### PR TITLE
Basic validation for New Event Type to prevent unexpected behaviour

### DIFF
--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -61,8 +61,9 @@ export default function Availability(props) {
             }
         });
 
-        console.log(response);
-        Router.reload();
+        if (enteredTitle && enteredLength) {
+            Router.reload();
+        }
     }
 
     async function updateStartEndTimesHandler(event) {
@@ -217,6 +218,7 @@ export default function Availability(props) {
                                             </div>
                                         </div>
                                     </div>
+                                    {/* TODO: Add an error message when required input fields empty*/}
                                     <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
                                         <button type="submit" className="btn btn-primary">
                                             Create


### PR DESCRIPTION
Previously, when creating a new event type, the user was still allowed to create a new event type, even if the event length's field was empty. This would cause a prisma error, since it would receive NaN and no event would have been added, but the page still reloaded. Therefore, a very basic validation to address this, at least in the short-term.

GIF below illustrates the issue: 
![CleanShotX | 2021-04-20 at 01 36 11](https://user-images.githubusercontent.com/16905768/115320119-22175000-a179-11eb-8b8f-2f7a2ce9e9c0.gif)

