### PR TITLE
Fix for a bug when updating an event type

### DIFF
--- a/pages/availability/event/[type].tsx
+++ b/pages/availability/event/[type].tsx
@@ -38,7 +38,7 @@ export default function EventType(props) {
             }
         });
 
-        console.log(response);
+        router.push('/availability');
     }
 
     async function deleteEventTypeHandler(event) {


### PR DESCRIPTION
- Due to the lack of router object, after clicking "Update" on the Event Type - a response would be printed to the console, but without being routed back to the availability page.

Illustration of the issue: 
![Google Chrome — CleanShotX | 2021-04-20 at 00 18 39](https://user-images.githubusercontent.com/16905768/115320186-4a9f4a00-a179-11eb-8278-a9d8589840ef.gif)
