### PR TITLE
csrfToken->getCsrfToken is required by webpack5 (fixes #123, thanks @jacobocode)

### DIFF
--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { csrfToken } from 'next-auth/client';
+import { getCsrfToken } from 'next-auth/client';
 
 export default function Login({ csrfToken }) {
   return (
@@ -13,7 +13,7 @@ export default function Login({ csrfToken }) {
                 Sign in to your account
             </h2>
         </div>
-    
+
         <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
             <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
                 <form className="space-y-6" method="post" action="/api/auth/callback/credentials">
@@ -26,7 +26,7 @@ export default function Login({ csrfToken }) {
                             <input id="email" name="email" type="email" autoComplete="email" placeholder="john.doe@example.com" required className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
                         </div>
                     </div>
-            
+
                     <div>
                         <label htmlFor="password" className="block text-sm font-medium text-gray-700">
                             Password
@@ -35,7 +35,7 @@ export default function Login({ csrfToken }) {
                             <input id="password" name="password" type="password" autoComplete="current-password" placeholder="•••••••••••••" required className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
                         </div>
                     </div>
-            
+
                     <div>
                         <button type="submit" className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                             Sign in
@@ -44,12 +44,12 @@ export default function Login({ csrfToken }) {
                 </form>
             </div>
         </div>
-    </div>  
+    </div>
   )
 }
 
-Login.getInitialProps = async (context) => {
+Login.getInitialProps = async ({ req, res }) => {
   return {
-    csrfToken: await csrfToken(context)
+    csrfToken: await getCsrfToken({ req })
   }
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
