### PR TITLE
Adding email validation to booking

### DIFF
--- a/pages/[user]/book.tsx
+++ b/pages/[user]/book.tsx
@@ -65,7 +65,7 @@ export default function Book(props) {
                                 <div className="mb-4">
                                     <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email address</label>
                                     <div className="mt-1">
-                                        <input type="text" name="email" id="email" className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="you@example.com" />
+                                        <input type="email" name="email" id="email" className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="you@example.com" />
                                     </div>
                                 </div>
                                 <div className="mb-4">

--- a/pages/[user]/book.tsx
+++ b/pages/[user]/book.tsx
@@ -59,13 +59,13 @@ export default function Book(props) {
                                 <div className="mb-4">
                                     <label htmlFor="name" className="block text-sm font-medium text-gray-700">Your name</label>
                                     <div className="mt-1">
-                                        <input type="text" name="name" id="name" className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="John Doe" />
+                                        <input type="text" name="name" id="name" required className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="John Doe" />
                                     </div>
                                 </div>
                                 <div className="mb-4">
                                     <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email address</label>
                                     <div className="mt-1">
-                                        <input type="email" name="email" id="email" className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="you@example.com" />
+                                        <input type="email" name="email" id="email" required className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" placeholder="you@example.com" />
                                     </div>
                                 </div>
                                 <div className="mb-4">


### PR DESCRIPTION
Closes #43 

Changed `<input>` `type` attribute in `book.tsx` from `"text"` to `"email"`, which will automatically perform email validation. [This is well supported on all browsers.](https://caniuse.com/mdn-html_elements_input_input-email)

Also double checked that email validation is performed on `login.tsx` ([line in Github](https://github.com/calendso/calendso/blob/main/pages/auth/login.tsx#L26)), which also uses `type="email"`.

EDIT: Added `required` attribute to all input fields as well, as mentioned in the closed duplicate issue #127 

Made `name` and `email` required, did not make `notes` required, as it eventually gets put into an optional field. (`description` on `CalendarEvent`)