### PR TITLE
feat: Add support for multiple google calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Contributions are what make the open source community such an amazing place to b
 2. In the search box, type calendar and select the Google Calendar API search result.
 3. Enable the selected API.
 4. Next, go to the [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent) from the side pane. Select the app type (Internal or External) and enter the basic app details on the first page.
-5. In the second page on Scopes, select Add or Remove Scopes. Search for Calendar.event and select the scope with scope value `.../auth/calendar.events` and select Update.
+5. In the second page on Scopes, select Add or Remove Scopes. Search for Calendar.event and select the scope with scope value `.../auth/calendar.events`, `.../auth/calendar.readonly`, `.../auth/calendar` and select Update.
 6. In the third page (Test Users), add the Google account(s) you'll using. Make sure the details are correct on the last page of the wizard and your consent screen will be configured.
 7. Now select [Credentials](https://console.cloud.google.com/apis/credentials) from the side pane and then select Create Credentials. Select the OAuth Client ID option.
 8. Select Web Application as the Application Type.

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -139,20 +139,33 @@ const GoogleCalendar = (credential) => {
     return {
         getAvailability: (dateFrom, dateTo) => new Promise( (resolve, reject) => {
             const calendar = google.calendar({ version: 'v3', auth: myGoogleAuth });
-            calendar.freebusy.query({
-                requestBody: {
-                    timeMin: dateFrom,
-                    timeMax: dateTo,
-                    items: [ {
-                        "id": "primary"
-                    } ]
-                }
-            }, (err, apires) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve(apires.data.calendars.primary.busy)
-            });
+            calendar.calendarList
+              .list()
+              .then(cals => {
+                const items = cals.data.items.filter(
+                  item => !/calendar.google.com/.test(item.id)
+                );
+                calendar.freebusy.query({
+                  requestBody: {
+                      timeMin: dateFrom,
+                      timeMax: dateTo,
+                      items: items
+                  }
+                }, (err, apires) => {
+                    if (err) {
+                        reject(err);
+                    }
+                    resolve(
+                      Object.values(apires.data.calendars).flatMap(
+                        (item) => item["busy"]
+                      )
+                    )
+                });
+              })
+              .catch((err) => {
+                reject(err);
+              });
+
         }),
         createEvent: (event: CalendarEvent) => new Promise( (resolve, reject) => {
             const payload = {

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -142,14 +142,11 @@ const GoogleCalendar = (credential) => {
             calendar.calendarList
               .list()
               .then(cals => {
-                const items = cals.data.items.filter(
-                  item => !/calendar.google.com/.test(item.id)
-                );
                 calendar.freebusy.query({
                   requestBody: {
                       timeMin: dateFrom,
                       timeMax: dateTo,
-                      items: items
+                      items: cals.data.items
                   }
                 }, (err, apires) => {
                     if (err) {

--- a/pages/api/integrations/googlecalendar/add.ts
+++ b/pages/api/integrations/googlecalendar/add.ts
@@ -4,7 +4,7 @@ import prisma from '../../../../lib/prisma';
 const {google} = require('googleapis');
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS;
-const scopes = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events'];
+const scopes = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events', 'https://www.googleapis.com/auth/calendar'];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'GET') {


### PR DESCRIPTION
Hello Team, 

I'm adding support to verify if you are busy in more than one calendar in this PR. 

**Purpose**
I'm using two google accounts (work and personal). I shared my work calendar to my personal account, but calendso only supports verifying if you are busy in the primary calendar.

**Changes**
Readme: Updating the documentation about the scopes
calendarClient: adding the support verifying more than one calendar
googlecalendar/add.ts: Update the scopes

**Images**

![Screenshot_1](https://user-images.githubusercontent.com/7839474/117048868-b41e6d00-acd0-11eb-8018-7c1f7fd25182.png)

![Screenshot_2](https://user-images.githubusercontent.com/7839474/117048882-b7195d80-acd0-11eb-8de3-a1a71199ea5f.png)

https://github.com/calendso/calendso/issues/15