### PR TITLE
Add Links to Public Pages

### DIFF
--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -66,6 +66,7 @@ export default function Shell(props) {
                                             {
                                                 profileDropdownExpanded && (
                                                     <div className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="user-menu">
+                                                        <Link href={"/" + session.user.username}><a target="_blank" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Your Public Page</a></Link>
                                                         <Link href="/settings/profile"><a className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Your Profile</a></Link>
                                                         <Link href="/settings/password"><a className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Login &amp; Security</a></Link>
                                                         <button onClick={logoutHandler} className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Sign out</button>

--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -40,4 +40,18 @@ export default NextAuth({
             }
         })
     ],
+    callbacks: {
+        async jwt(token, user, account, profile, isNewUser) {
+            // Add username to the token right after signin
+            if (user?.username) {
+                token.username = user.username
+            }
+            return token;
+        },
+        async session(session, token) {
+            session.user = session.user || {}
+            session.user.username = token.username;
+            return session;
+        },
+    },
 });

--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -158,7 +158,7 @@ export default function Availability(props) {
                                                     {eventType.length} minutes
                                                 </td>
                                                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                                    {eventType.hidden && <Link href={"/" + props.user.username + "/" + eventType.slug}><a className="text-blue-600 hover:text-blue-900 mr-2">View</a></Link>}
+                                                    <Link href={"/" + props.user.username + "/" + eventType.slug}><a target="_blank" className="text-blue-600 hover:text-blue-900 mr-2">View</a></Link>
                                                     <Link href={"/availability/event/" + eventType.id}><a className="text-blue-600 hover:text-blue-900">Edit</a></Link>
                                                 </td>
                                             </tr>


### PR DESCRIPTION
This PR adds a Link to the public, shareable pages in the User-Dropdown:
<img width="267" alt="Bildschirmfoto 2021-05-05 um 22 04 06" src="https://user-images.githubusercontent.com/142237/117202241-e40f6280-aded-11eb-8a7b-bc13846de87d.png">

It also permanently enables the already existing "View" Link in the Availability-Section, because having this link always visible helps users to find their shareable Link.
<img width="1259" alt="Bildschirmfoto 2021-05-05 um 22 04 19" src="https://user-images.githubusercontent.com/142237/117202480-25077700-adee-11eb-9e96-5c4d2f3ab1ae.png">

Both links open the View in a new Tab, because the public page does not contain the Menu anymore and the user leaves the application context.