### PR TITLE
Fix bug when dismissing modal on availability page

### DIFF
--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -42,7 +42,7 @@ export default function Availability(props) {
         setShowChangeTimesModal(!showChangeTimesModal);
     }
 
-    const closeSuccessModal = () => { router.replace(router.asPath); }
+    const closeSuccessModal = () => { setSuccessModalOpen(false); router.replace(router.asPath); }
 
     function convertMinsToHrsMins (mins) {
         let h = Math.floor(mins / 60);


### PR DESCRIPTION
Previously, pressing "Dismiss" on the modal shown on the availability page did not close the modal.

This PR simply sets the modal state to false, just like the other two instances in the project where a modal is closed.

![image](https://user-images.githubusercontent.com/23691775/117216522-e792f180-adcd-11eb-88d7-94a9fe63293a.png)
