### PR TITLE
send back a specific message per field

### DIFF
--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -7,10 +7,19 @@ export default async function handler(req, res) {
     }
 
     const data = req.body;
-
     const { username, email, password } = data;
 
-    if (!email || !email.includes('@') || !password || password.trim().length < 7) {
+    if (!username) {
+        res.status(422).json({message: 'Invalid username'});
+        return;
+    }
+
+    if (!email || !email.includes('@')) {
+        res.status(422).json({message: 'Invalid email'});
+        return;
+    }
+
+    if (!password || password.trim().length < 7) {
         res.status(422).json({message: 'Invalid input - password should be at least 7 characters long.'});
         return;
     }


### PR DESCRIPTION
When I was creating a user, I kept getting `invalid password`, when the reason was that I wasn't sending the username. This sends back a specific message per field.