### PR TITLE
fix: check for overlapping appointments

### DIFF
--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -149,6 +149,11 @@ export default function Type(props) {
           if (dayjs(times[i]).add(props.eventType.length, 'minutes').isBetween(startTime, endTime)) {
               times.splice(i, 1);
           }
+
+          // Check if startTime is between slot 
+          if(startTime.isBetween(dayjs(times[i]), dayjs(times[i]).add(props.eventType.length, 'minutes'))) {
+            times.splice(i, 1);
+          }
       });
     }
 

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -144,6 +144,11 @@ export default function Type(props) {
           if (dayjs(times[i]).isBetween(startTime, endTime)) {
               times.splice(i, 1);
           }
+
+          // Check if slot end time is between start and end time
+          if (dayjs(times[i]).add(props.eventType.length, 'minutes').isBetween(startTime, endTime)) {
+              times.splice(i, 1);
+          }
       });
     }
 


### PR DESCRIPTION
I had a case where a 45 minute slot was available for 5:45pm but my 6:00pm was already booked. This PR fixes the situation where the slot end time could be in one of the busy slots.

Please give any suggestions. I love calendso and would love to contribute more.

**Edit**
The second commit is for the situations where my slot starts at let's say 5:30 pm and ends at 6:00pm, but I am busy from 5:40 to 5:50, then none of the previous checks will work.

**Suggestion -**
I think we should get slots after checking the busy schedule
But this can be done at a later stage.