### PR TITLE
Fix getBusyTimes when called w/o calendars

### DIFF
--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -219,7 +219,7 @@ const calendars = (withCredentials): [] => withCredentials.map( (cred) => {
 const getBusyTimes = (withCredentials, dateFrom, dateTo) => Promise.all(
     calendars(withCredentials).map( c => c.getAvailability(dateFrom, dateTo) )
 ).then(
-    (results) => results.reduce( (acc, availability) => acc.concat(availability) )
+    (results) => results.reduce( (acc, availability) => acc.concat(availability), [])
 );
 
 const createEvent = (credential, evt: CalendarEvent) => calendars([ credential ])[0].createEvent(evt);


### PR DESCRIPTION
`getBusyTimes` depends on there being a non-zero number of calendars, a more sensible base-case is returning an empty array