### PR TITLE
feat: slot optimization

### DIFF
--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -38,24 +38,27 @@ const isSlotAvailable = ({
     }
 
     // Check if time is between start and end times
-    if (slotStartTime.isBetween(busyTimeStart, busyTimeEnd)) {
+    else if (slotStartTime.isBetween(busyTimeStart, busyTimeEnd)) {
       slotAvailability.available = false;
       slotAvailability.offset = busyTimeEnd.diff(slotStartTime, 'minute');
     }
 
     // Check if slot end time is between start and end time
-    if (slotEndTime.isBetween(busyTimeStart, busyTimeEnd)) {
+    else if (slotEndTime.isBetween(busyTimeStart, busyTimeEnd)) {
       slotAvailability.available = false;
-      slotAvailability.offset = busyTimeEnd.diff(slotEndTime, 'minute');
+      slotAvailability.offset = busyTimeEnd.diff(slotStartTime, 'minute');
     }
 
     // Check if startTime is between slot 
-    if (busyTimeStart.isBetween(slotStartTime, slotEndTime)) {
+    else if (busyTimeStart.isBetween(slotStartTime, slotEndTime)) {
       slotAvailability.available = false;
-      slotAvailability.offset = busyTimeEnd.diff(slotStartTime, 'minute')
+      slotAvailability.offset = busyTimeEnd.diff(slotStartTime, 'minute');
     }
 
-    if (!slotAvailability.available) return slotAvailability;
+    if (!slotAvailability.available) {
+      if(slotAvailability.offset === 0) slotAvailability.offset = 5;
+      return slotAvailability
+    };
   }
   return slotAvailability;
 }
@@ -83,7 +86,6 @@ const getSlots = ({
       minutes <= dayEndTime - eventLength;
     ) {
       const slot = lowerBound.add(minutes, "minutes");
-
 
       if (slot > now) {
         const slotAvailablilty = isSlotAvailable({ slotStartTime: slot, slotEndTime: slot.add(eventLength, 'minutes'), busyTimes });

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -113,7 +113,7 @@ export default function Type(props) {
             setLoading(true);
             const res = await fetch(`/api/availability/${user}?dateFrom=${lowerBound.utc().format()}&dateTo=${upperBound.utc().format()}`);
             const busyTimes = await res.json();
-            if (busyTimes.length > 0) setBusy(busyTimes);
+            setBusy(busyTimes);
             setLoading(false);
         }
         changeDate();
@@ -127,36 +127,9 @@ export default function Type(props) {
         selectedDate: selectedDate,
         dayStartTime: props.user.startTime,
         dayEndTime: props.user.endTime,
+        busyTimes: busy,
       })
-    , [selectedDate, selectedTimeZone])
-
-    // Check for conflicts
-    for(let i = times.length - 1; i >= 0; i -= 1) {
-      busy.forEach(busyTime => {
-          let startTime = dayjs(busyTime.start);
-          let endTime = dayjs(busyTime.end);
-
-          // Check if start times are the same
-          if (dayjs(times[i]).format('HH:mm') == startTime.format('HH:mm')) {
-              times.splice(i, 1);
-          }
-
-          // Check if time is between start and end times
-          if (dayjs(times[i]).isBetween(startTime, endTime)) {
-              times.splice(i, 1);
-          }
-
-          // Check if slot end time is between start and end time
-          if (dayjs(times[i]).add(props.eventType.length, 'minutes').isBetween(startTime, endTime)) {
-              times.splice(i, 1);
-          }
-
-          // Check if startTime is between slot 
-          if(startTime.isBetween(dayjs(times[i]), dayjs(times[i]).add(props.eventType.length, 'minutes'))) {
-            times.splice(i, 1);
-          }
-      });
-    }
+    , [selectedDate, selectedTimeZone, busy])
 
     // Display available times
     const availableTimes = times.map((time) =>


### PR DESCRIPTION
The current implementation will cut off an entire slot if I'm busy for just 5 minutes at the starting of a slot.
For example, if I'm busy till 5:15pm and slot starts at 5:10pm for a 45 minute booking, then next slot should be 5:15pm instead of 5:55pm.

This PR attempts to fix that. Please give suggestions if changes are required.