### PR TITLE
Fixes #225 by correctly applying the timezone whilst keeping the original date in UTC

### DIFF
--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -1,24 +1,33 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import prisma from '../lib/prisma';
+import {useEffect, useState} from "react";
 import { useRouter } from 'next/router';
 import { CheckIcon } from '@heroicons/react/outline';
 import { ClockIcon, CalendarIcon, LocationMarkerIcon } from '@heroicons/react/solid';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import toArray from 'dayjs/plugin/toArray';
+import timezone from 'dayjs/plugin/timezone';
 import { createEvent } from 'ics';
 
 dayjs.extend(utc);
+dayjs.extend(toArray);
+dayjs.extend(timezone);
 
 export default function Success(props) {
     const router = useRouter();
-    const { date, location } = router.query;
+    const { location } = router.query;
+
+    const [ is24h, setIs24h ] = useState(false);
+    const [ date, setDate ] = useState(dayjs.utc(router.query.date));
+
+    useEffect( () => {
+        setDate(date.tz(localStorage.getItem('timeOption.preferredTimeZone') || dayjs.tz.guess()));
+        setIs24h(!!localStorage.getItem('timeOption.is24hClock'));
+    }, []);
 
     function eventLink(): string {
-
-        const start = Array.prototype.concat(...date.split('T').map(
-            (parts) => parts.split('-').length > 1 ? parts.split('-').map( (n) => parseInt(n, 10) ) : parts.split(':').map( (n) => parseInt(n, 10) )
-        ));
 
         let optional = {};
         if (location) {
@@ -26,7 +35,7 @@ export default function Success(props) {
         }
 
         const event = createEvent({
-           start,
+           start: date.utc().toArray().slice(0, 6),
            startInputType: 'utc',
            title: props.eventType.title + ' with ' + props.user.name,
            description: props.eventType.description,
@@ -78,7 +87,7 @@ export default function Success(props) {
                                         </p>}
                                         <p className="text-gray-500">
                                             <CalendarIcon className="inline-block w-4 h-4 mr-1 -mt-1" />
-                                            {dayjs(date).format("hh:mma, dddd DD MMMM YYYY")}
+                                            {date.format((is24h ? 'H:mm' : 'h:mma') + ", dddd DD MMMM YYYY")}
                                         </p>
                                     </div>
                                 </div>
@@ -86,17 +95,17 @@ export default function Success(props) {
                             <div className="mt-5 sm:mt-6 text-center">
                                 <span className="font-medium text-gray-500">Add to your calendar</span>
                                 <div className="flex mt-2">
-                                    <Link href={`https://calendar.google.com/calendar/r/eventedit?dates=${dayjs(date).format('YYYYMMDDTHHmmss[Z]')}/${dayjs(date).add(props.eventType.length, 'minute').format('YYYYMMDDTHHmmss[Z]')}&text=${props.eventType.title} with ${props.user.name}&details=${props.eventType.description}` + ( location ? "&location=" + encodeURIComponent(location) : '')}>
+                                    <Link href={`https://calendar.google.com/calendar/r/eventedit?dates=${date.utc().format('YYYYMMDDTHHmmss[Z]')}/${date.add(props.eventType.length, 'minute').utc().format('YYYYMMDDTHHmmss[Z]')}&text=${props.eventType.title} with ${props.user.name}&details=${props.eventType.description}` + ( location ? "&location=" + encodeURIComponent(location) : '')}>
                                         <a className="mx-2 btn-wide btn-white">
                                             <svg className="inline-block w-4 h-4 mr-1 -mt-1" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Google</title><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></svg>
                                         </a>
                                     </Link>
-                                    <Link href={encodeURI("https://outlook.live.com/calendar/0/deeplink/compose?body=" + props.eventType.description + "&enddt=" + dayjs(date).add(props.eventType.length, 'minute').format() + "&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=" + dayjs(date).format() + "&subject=" + props.eventType.title + " with " + props.user.name) + (location ? "&location=" + location : '')}>
+                                    <Link href={encodeURI("https://outlook.live.com/calendar/0/deeplink/compose?body=" + props.eventType.description + "&enddt=" + date.add(props.eventType.length, 'minute').format() + "&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=" + date.format() + "&subject=" + props.eventType.title + " with " + props.user.name) + (location ? "&location=" + location : '')}>
                                         <a className="mx-2 btn-wide btn-white">
                                             <svg className="inline-block w-4 h-4 mr-1 -mt-1" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Microsoft Outlook</title><path d="M7.88 12.04q0 .45-.11.87-.1.41-.33.74-.22.33-.58.52-.37.2-.87.2t-.85-.2q-.35-.21-.57-.55-.22-.33-.33-.75-.1-.42-.1-.86t.1-.87q.1-.43.34-.76.22-.34.59-.54.36-.2.87-.2t.86.2q.35.21.57.55.22.34.31.77.1.43.1.88zM24 12v9.38q0 .46-.33.8-.33.32-.8.32H7.13q-.46 0-.8-.33-.32-.33-.32-.8V18H1q-.41 0-.7-.3-.3-.29-.3-.7V7q0-.41.3-.7Q.58 6 1 6h6.5V2.55q0-.44.3-.75.3-.3.75-.3h12.9q.44 0 .75.3.3.3.3.75V10.85l1.24.72h.01q.1.07.18.18.07.12.07.25zm-6-8.25v3h3v-3zm0 4.5v3h3v-3zm0 4.5v1.83l3.05-1.83zm-5.25-9v3h3.75v-3zm0 4.5v3h3.75v-3zm0 4.5v2.03l2.41 1.5 1.34-.8v-2.73zM9 3.75V6h2l.13.01.12.04v-2.3zM5.98 15.98q.9 0 1.6-.3.7-.32 1.19-.86.48-.55.73-1.28.25-.74.25-1.61 0-.83-.25-1.55-.24-.71-.71-1.24t-1.15-.83q-.68-.3-1.55-.3-.92 0-1.64.3-.71.3-1.2.85-.5.54-.75 1.3-.25.74-.25 1.63 0 .85.26 1.56.26.72.74 1.23.48.52 1.17.81.69.3 1.56.3zM7.5 21h12.39L12 16.08V17q0 .41-.3.7-.29.3-.7.3H7.5zm15-.13v-7.24l-5.9 3.54Z"/></svg>
                                         </a>
                                     </Link>
-                                    <Link href={encodeURI("https://outlook.office.com/calendar/0/deeplink/compose?body=" + props.eventType.description + "&enddt=" + dayjs(date).add(props.eventType.length, 'minute').format() + "&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=" + dayjs(date).format() + "&subject=" + props.eventType.title + " with " + props.user.name) + (location ? "&location=" + location : '')}>
+                                    <Link href={encodeURI("https://outlook.office.com/calendar/0/deeplink/compose?body=" + props.eventType.description + "&enddt=" + date.add(props.eventType.length, 'minute').format() + "&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=" + date.format() + "&subject=" + props.eventType.title + " with " + props.user.name) + (location ? "&location=" + location : '')}>
                                         <a className="mx-2 btn-wide btn-white">
                                             <svg className="inline-block w-4 h-4 mr-1 -mt-1" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Microsoft Office</title><path d="M21.53 4.306v15.363q0 .807-.472 1.433-.472.627-1.253.85l-6.888 1.974q-.136.037-.29.055-.156.019-.293.019-.396 0-.72-.105-.321-.106-.656-.292l-4.505-2.544q-.248-.137-.391-.366-.143-.23-.143-.515 0-.434.304-.738.304-.305.739-.305h5.831V4.964l-4.38 1.563q-.533.187-.856.658-.322.472-.322 1.03v8.078q0 .496-.248.912-.25.416-.683.651l-2.072 1.13q-.286.148-.571.148-.497 0-.844-.347-.348-.347-.348-.844V6.563q0-.62.33-1.19.328-.571.874-.881L11.07.285q.248-.136.534-.21.285-.075.57-.075.211 0 .38.031.166.031.364.093l6.888 1.899q.384.11.7.329.317.217.547.52.23.305.353.67.125.367.125.764zm-1.588 15.363V4.306q0-.273-.16-.478-.163-.204-.423-.28l-3.388-.93q-.397-.111-.794-.23-.397-.117-.794-.216v19.68l4.976-1.427q.26-.074.422-.28.161-.204.161-.477z"/></svg>
                                         </a>


### PR DESCRIPTION
https://github.com/emrysal/calendso/blob/69f34976585ec368f1a2754ffc74b291611c97aa/pages/success.tsx#L77

Even though the `date` variable within `${dayjs(date).format('YYYYMMDDTHHmmss[Z]')}` contains the 'Z' character, Dayjs happily ignores this as an indication of UTC. The appropriate implementation would have been `${dayjs.utc(date).format('YYYYMMDDTHHmmss[Z]')}` which is roughly what this PR implements. 

However, due to the recent usage of localStorage on the /book pages, I implemented that too in addition to cleaning up the code a bit, but essentially this fix is a oneliner.