### PR TITLE
Update README.md - adding video link to getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Calendso is currently in alpha. Watch **releases** of this repository to be noti
 
 To get a local copy up and running, please follow these simple steps.
 
+Here is a [awesome video on how to get calendso up]](https://www.youtube.com/watch?v=TaIQhG8AL0w) and running.
+
 ### Prerequisites
 
 Here is what you need to be able to run Calendso.


### PR DESCRIPTION
In discussion channel there was a comment that the link to the video would be helpfull to have it in the README.md

Did so, and added it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
