### PR TITLE
Removed calendar scope, we shouldn't need it.

### DIFF
--- a/pages/api/integrations/googlecalendar/add.ts
+++ b/pages/api/integrations/googlecalendar/add.ts
@@ -4,7 +4,7 @@ import prisma from '../../../../lib/prisma';
 const {google} = require('googleapis');
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS;
-const scopes = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events', 'https://www.googleapis.com/auth/calendar'];
+const scopes = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events'];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'GET') {


### PR DESCRIPTION
@jfernandogt Regarding the Google Verification process, and looking at the documentation and through tests I concluded `https://www.googleapis.com/auth/calendar.readonly` covers the GET calendarlist action. As you explicitly added this scope I'm tagging you in this PR.

The access gained with `https://www.googleapis.com/auth/calendar` is too broad, so the verification process would defacto fail if we were to keep this scope in the repository.