### PR TITLE
Send email with Amazon SES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ EMAIL_SERVER_PORT=587
 EMAIL_SERVER_USER='<office365_emailAddress>'
 # Keep in mind that if you have 2FA enabled, you will need to provision an App Password.
 EMAIL_SERVER_PASSWORD='<office365_password>'
+
+AWS_ACCESS_KEY_ID='<aws_access_key>'
+AWS_SECRET_ACCESS_KEY='<aws_secret_key>'
+AWS_SES_REGION_NAME='<ses_region>'

--- a/lib/serverConfig.ts
+++ b/lib/serverConfig.ts
@@ -1,3 +1,5 @@
+const nodemailer = require("nodemailer");
+const aws = require("@aws-sdk/client-ses");
 
 function detectTransport(): string | any {
 
@@ -15,6 +17,19 @@ function detectTransport(): string | any {
         pass: process.env.EMAIL_SERVER_PASSWORD,
       },
       secure: (port === 465),
+    };
+
+    return transport;
+  }
+
+  if (process.env.AWS_ACCESS_KEY_ID) {
+    const ses = new aws.SES({
+      apiVersion: "2010-12-01",
+      region: process.env.AWS_SES_REGION_NAME,
+    });
+
+    const transport = {
+      SES: { ses, aws },
     };
 
     return transport;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
+    "@aws-sdk/client-ses": "^3.18.0",
     "@headlessui/react": "^1.0.0",
     "@heroicons/react": "^1.0.1",
     "@jitsu/sdk-js": "^2.0.1",


### PR DESCRIPTION
Hi!

The founder of NocoDB referred me to your Github. Love the project! 

My name is Handoyo from Lyrid (lyrid.io). I figured why don't just start to integrate this into my platform and test it internally for my scheduling. I am able to run it at: https://chat.lyr.id/hsutanto

I did make minor changes that are particular to us. We use SES to send our email and it appears nodemailer does have SES transport built-in. I just need to add the settings and tweak the serverConfig.ts to create SES transport. Voila, it is done.

This might be beneficial for the repo, so I am submitting PR for this.

I tested with the meeting scheduling link above that I deployed on Lyrid platform. You can try it yourself and we can schedule a chat if you're up for it! 

Thanks! Keep up the nice work!
Handoyo