### PR TITLE
Added button to add integrations

### DIFF
--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
-import {useContext, useEffect, useState} from "react";
-import { useRouter } from "next/router";
-import { signOut, useSession } from 'next-auth/client';
-import { MenuIcon, XIcon } from '@heroicons/react/outline';
+import {useEffect, useState} from "react";
+import {useRouter} from "next/router";
+import {signOut, useSession} from 'next-auth/client';
+import {MenuIcon, XIcon} from '@heroicons/react/outline';
 import {collectPageParameters, telemetryEventTypes, useTelemetry} from "../lib/telemetry";
 
 export default function Shell(props) {
@@ -133,7 +133,7 @@ export default function Shell(props) {
                     </div>
                     }
                 </nav>
-                <header className="py-10">
+                <header className={props.noPaddingBottom ? "pt-10" : "py-10"}>
                     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         <h1 className="text-3xl font-bold text-white">
                             {props.heading}

--- a/pages/integrations/index.tsx
+++ b/pages/integrations/index.tsx
@@ -2,10 +2,10 @@ import Head from 'next/head';
 import Link from 'next/link';
 import prisma from '../../lib/prisma';
 import Shell from '../../components/Shell';
-import { useState } from 'react';
-import { useSession, getSession } from 'next-auth/client';
-import { CheckCircleIcon, XCircleIcon, ChevronRightIcon, PlusIcon } from '@heroicons/react/solid';
-import { InformationCircleIcon } from '@heroicons/react/outline';
+import {useState} from 'react';
+import {getSession, useSession} from 'next-auth/client';
+import {CheckCircleIcon, ChevronRightIcon, PlusIcon, XCircleIcon} from '@heroicons/react/solid';
+import {InformationCircleIcon} from '@heroicons/react/outline';
 
 export default function Home({ integrations }) {
     const [session, loading] = useSession();
@@ -32,7 +32,13 @@ export default function Home({ integrations }) {
                 <link rel="icon" href="/favicon.ico" />
             </Head>
 
-            <Shell heading="Integrations">
+            <Shell heading="Integrations" noPaddingBottom>
+                <div className="text-right py-2">
+                    <button onClick={toggleAddModal} type="button"
+                            className="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Add new integration
+                    </button>
+                </div>
                 <div className="bg-white shadow overflow-hidden rounded-lg">
                     {integrations.filter( (ig) => ig.credential ).length !== 0 ? <ul className="divide-y divide-gray-200">
                         {integrations.filter(ig => ig.credential).map( (ig) => (<li>


### PR DESCRIPTION
In this PR I added a button to add a new integration in the integrations list. Previously, you could only have one integration at a time since the "add your first" link disappeared when one integration was added.

The Shell component now has a flag called "noPaddingBottom" which changes the Shell header's padding from y-10 to top-10 in order to keep the old arrangement before the button was added.

Screenshot of the new feature:
![image](https://user-images.githubusercontent.com/14024119/121595901-12144200-ca3f-11eb-815f-edd4762cd557.png)
