### PR TITLE
Bugfix: Send email when no integrations are present as well

### DIFF
--- a/pages/api/book/[user].ts
+++ b/pages/api/book/[user].ts
@@ -141,8 +141,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   });
 
-  // If one of the integrations allows email confirmations, send it.
-  if (!results.every((result) => result.disableConfirmationEmail)) {
+  // If one of the integrations allows email confirmations or no integrations are added, send it.
+  if (currentUser.credentials.length === 0 || !results.every((result) => result.disableConfirmationEmail)) {
     await createConfirmBookedEmail(
       evt, hashUID
     );


### PR DESCRIPTION
The new booking persistence feature lead to the problem that no confirmation emails were sent when there were no integrations added. This is now fixed.