### PR TITLE
Added og-image to booking pages

### DIFF
--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -20,6 +20,8 @@ export default function User(props) {
             <Head>
                 <title>{props.user.name || props.user.username} | Calendso</title>
                 <link rel="icon" href="/favicon.ico" />
+                <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "**") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+                <meta property="og:title" content={"Book " + (props.user.name || props.user.username) + " via Calendso"}/>
             </Head>
 
             <main className="max-w-2xl mx-auto my-24">

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -20,7 +20,7 @@ export default function User(props) {
             <Head>
                 <title>{props.user.name || props.user.username} | Calendso</title>
                 <link rel="icon" href="/favicon.ico" />
-                <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "**").replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+                <meta property="og:image" content={"https://og-image-one-pi.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "**").replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
                 <meta property="og:title" content={"Book " + (props.user.name || props.user.username) + " via Calendso"}/>
             </Head>
 

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -20,7 +20,7 @@ export default function User(props) {
             <Head>
                 <title>{props.user.name || props.user.username} | Calendso</title>
                 <link rel="icon" href="/favicon.ico" />
-                <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "**") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+                <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "**").replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
                 <meta property="og:title" content={"Book " + (props.user.name || props.user.username) + " via Calendso"}/>
             </Head>
 

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -96,7 +96,7 @@ export default function Type(props) {
           Calendso
         </title>
         <link rel="icon" href="/favicon.ico" />
-        <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "** <br>" + props.eventType.description).replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+        <meta property="og:image" content={"https://og-image-one-pi.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "** <br>" + props.eventType.description).replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
         <meta property="og:title" content={"Book " + (props.user.name || props.user.username)  + " via Calendso"}/>
         <meta property="og:description" content={props.eventType.description}/>
       </Head>

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -96,6 +96,9 @@ export default function Type(props) {
           Calendso
         </title>
         <link rel="icon" href="/favicon.ico" />
+        <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "** <br>" + props.eventType.description) + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+        <meta property="og:title" content={"Book " + (props.user.name || props.user.username)  + " via Calendso"}/>
+        <meta property="og:description" content={props.eventType.description}/>
       </Head>
       <main
         className={

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -96,7 +96,7 @@ export default function Type(props) {
           Calendso
         </title>
         <link rel="icon" href="/favicon.ico" />
-        <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "** <br>" + props.eventType.description) + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
+        <meta property="og:image" content={"https://og-image-inctrrupl-calend-so.vercel.app/" + encodeURIComponent("Book **" + (props.user.name || props.user.username) + "** <br>" + props.eventType.description).replace(/'/g, "%27") + ".png?md=1&images=https%3A%2F%2Fcalendso.com%2Fcalendso-logo-white.svg&images=" + encodeURIComponent(props.user.avatar)} />
         <meta property="og:title" content={"Book " + (props.user.name || props.user.username)  + " via Calendso"}/>
         <meta property="og:description" content={props.eventType.description}/>
       </Head>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8019099/122978859-da868d80-d38e-11eb-81e6-7aa2c2c9dba5.png)

using https://github.com/calendso/og-image to show dynamic og-image of booking links with avatar and title of booking. 

Preview for calendso/malte
![Bildschirmfoto 2021-06-22 um 17 50 52](https://user-images.githubusercontent.com/5464426/122958148-e53b2580-d382-11eb-8cc8-af579d71bd3d.png)

And for calendso/malte/chat
![Bildschirmfoto 2021-06-22 um 17 59 38](https://user-images.githubusercontent.com/5464426/122960608-d99c2e80-d383-11eb-979d-b12a2fbf5bc1.png)

