### PR TITLE
onChange callback got removed in eslint cleanups

### DIFF
--- a/pages/[user]/book.tsx
+++ b/pages/[user]/book.tsx
@@ -238,6 +238,9 @@ export default function Book(props: any): JSX.Element {
                         id="phone"
                         required
                         className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                        onChange={() => {
+                          /* DO NOT REMOVE: Callback required by PhoneInput, comment added to satisfy eslint:no-empty-function */
+                        }}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Triggered eslint:no-empty-function, this PR circumvents this by adding a comment as part of the function body.

Bug introduced in https://github.com/calendso/calendso/pull/311 - I did review this but it was nigh impossible to expect this would break @PeerRich - no way the author could have predicted this either.