### PR TITLE
Added NEXTAUTH_URL back to .env.example as it is required on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ DATABASE_URL='postgresql://<user>:<pass>@<db-host>:<db-port>/<db-name>'
 GOOGLE_API_CREDENTIALS='secret'
 BASE_URL='http://localhost:3000'
 
+# @see: https://github.com/calendso/calendso/issues/263
+# Required for Vercel hosting - set NEXTAUTH_URL to equal your BASE_URL
+# NEXTAUTH_URL='http://localhost:3000'
+
 # Remove this var if you don't want Calendso to collect anonymous usage
 NEXT_PUBLIC_TELEMETRY_KEY=js.2pvs2bbpqq1zxna97wcml.oi2jzirnbj1ev4tc57c5r
 


### PR DESCRIPTION
Addresses #263 - Vercel does not seem to allow dynamic updates to `process.env` - an alternative solution is needed