### PR TITLE
Fixed Zoom Auth

### DIFF
--- a/pages/api/book/[user].ts
+++ b/pages/api/book/[user].ts
@@ -1,47 +1,48 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import prisma from "../../../lib/prisma";
-import { CalendarEvent, createEvent, updateEvent, getBusyCalendarTimes } from "../../../lib/calendarClient";
+import { CalendarEvent, createEvent, updateEvent } from "../../../lib/calendarClient";
 import async from "async";
 import { v5 as uuidv5 } from "uuid";
 import short from "short-uuid";
-import { createMeeting, updateMeeting, getBusyVideoTimes } from "../../../lib/videoClient";
+import { createMeeting, updateMeeting } from "../../../lib/videoClient";
 import EventAttendeeMail from "../../../lib/emails/EventAttendeeMail";
 import { getEventName } from "../../../lib/event";
 import { LocationType } from "../../../lib/location";
 import merge from "lodash.merge";
+
 const translator = short();
-import dayjs from "dayjs";
 
-const isAvailable = (busyTimes, time, length) => {
-  // Check for conflicts
-  let t = true;
-  busyTimes.forEach((busyTime) => {
-    const startTime = dayjs(busyTime.start);
-    const endTime = dayjs(busyTime.end);
-
-    // Check if start times are the same
-    if (dayjs(time).format("HH:mm") == startTime.format("HH:mm")) {
-      t = false;
-    }
-
-    // Check if time is between start and end times
-    if (dayjs(time).isBetween(startTime, endTime)) {
-      t = false;
-    }
-
-    // Check if slot end time is between start and end time
-    if (dayjs(time).add(length, "minutes").isBetween(startTime, endTime)) {
-      t = false;
-    }
-
-    // Check if startTime is between slot
-    if (startTime.isBetween(dayjs(time), dayjs(time).add(length, "minutes"))) {
-      t = false;
-    }
-  });
-
-  return t;
-};
+// Commented out because unused and thus throwing an error in linter.
+// const isAvailable = (busyTimes, time, length) => {
+//   // Check for conflicts
+//   let t = true;
+//   busyTimes.forEach((busyTime) => {
+//     const startTime = dayjs(busyTime.start);
+//     const endTime = dayjs(busyTime.end);
+//
+//     // Check if start times are the same
+//     if (dayjs(time).format("HH:mm") == startTime.format("HH:mm")) {
+//       t = false;
+//     }
+//
+//     // Check if time is between start and end times
+//     if (dayjs(time).isBetween(startTime, endTime)) {
+//       t = false;
+//     }
+//
+//     // Check if slot end time is between start and end time
+//     if (dayjs(time).add(length, "minutes").isBetween(startTime, endTime)) {
+//       t = false;
+//     }
+//
+//     // Check if startTime is between slot
+//     if (startTime.isBetween(dayjs(time), dayjs(time).add(length, "minutes"))) {
+//       t = false;
+//     }
+//   });
+//
+//   return t;
+// };
 
 interface GetLocationRequestFromIntegrationRequest {
   location: string;
@@ -63,10 +64,10 @@ const getLocationRequestFromIntegration = ({ location }: GetLocationRequestFromI
   return null;
 };
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   const { user } = req.query;
 
-  const currentUser = await prisma.user.findFirst({
+  let currentUser = await prisma.user.findFirst({
     where: {
       username: user,
     },
@@ -79,42 +80,62 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
   });
 
-  const selectedCalendars = await prisma.selectedCalendar.findMany({
+  // Commented out because unused and thus throwing an error in linter.
+  // const selectedCalendars = await prisma.selectedCalendar.findMany({
+  //   where: {
+  //     userId: currentUser.id,
+  //   },
+  // });
+  // Split credentials up into calendar credentials and video credentials
+  let calendarCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_calendar"));
+  let videoCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_video"));
+
+  // Commented out because unused and thus throwing an error in linter.
+  // const hasCalendarIntegrations =
+  //   currentUser.credentials.filter((cred) => cred.type.endsWith("_calendar")).length > 0;
+  // const hasVideoIntegrations =
+  //   currentUser.credentials.filter((cred) => cred.type.endsWith("_video")).length > 0;
+
+  // Commented out because unused and thus throwing an error in linter.
+  // const calendarAvailability = await getBusyCalendarTimes(
+  //   currentUser.credentials,
+  //   dayjs(req.body.start).startOf("day").utc().format(),
+  //   dayjs(req.body.end).endOf("day").utc().format(),
+  //   selectedCalendars
+  // );
+  // const videoAvailability = await getBusyVideoTimes(
+  //   currentUser.credentials,
+  //   dayjs(req.body.start).startOf("day").utc().format(),
+  //   dayjs(req.body.end).endOf("day").utc().format()
+  // );
+  // let commonAvailability = [];
+
+  // Commented out because unused and thus throwing an error in linter.
+  // if (hasCalendarIntegrations && hasVideoIntegrations) {
+  //   commonAvailability = calendarAvailability.filter((availability) =>
+  //     videoAvailability.includes(availability)
+  //   );
+  // } else if (hasVideoIntegrations) {
+  //   commonAvailability = videoAvailability;
+  // } else if (hasCalendarIntegrations) {
+  //   commonAvailability = calendarAvailability;
+  // }
+
+  // Now, get the newly stored credentials (new refresh token for example).
+  currentUser = await prisma.user.findFirst({
     where: {
-      userId: currentUser.id,
+      username: user,
+    },
+    select: {
+      id: true,
+      credentials: true,
+      timeZone: true,
+      email: true,
+      name: true,
     },
   });
-  // Split credentials up into calendar credentials and video credentials
-  const calendarCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_calendar"));
-  const videoCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_video"));
-
-  const hasCalendarIntegrations =
-    currentUser.credentials.filter((cred) => cred.type.endsWith("_calendar")).length > 0;
-  const hasVideoIntegrations =
-    currentUser.credentials.filter((cred) => cred.type.endsWith("_video")).length > 0;
-
-  const calendarAvailability = await getBusyCalendarTimes(
-    currentUser.credentials,
-    dayjs(req.body.start).startOf("day").utc().format(),
-    dayjs(req.body.end).endOf("day").utc().format(),
-    selectedCalendars
-  );
-  const videoAvailability = await getBusyVideoTimes(
-    currentUser.credentials,
-    dayjs(req.body.start).startOf("day").utc().format(),
-    dayjs(req.body.end).endOf("day").utc().format()
-  );
-  let commonAvailability = [];
-
-  if (hasCalendarIntegrations && hasVideoIntegrations) {
-    commonAvailability = calendarAvailability.filter((availability) =>
-      videoAvailability.includes(availability)
-    );
-  } else if (hasVideoIntegrations) {
-    commonAvailability = videoAvailability;
-  } else if (hasCalendarIntegrations) {
-    commonAvailability = calendarAvailability;
-  }
+  calendarCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_calendar"));
+  videoCredentials = currentUser.credentials.filter((cred) => cred.type.endsWith("_video"));
 
   const rescheduleUid = req.body.rescheduleUid;
 
@@ -170,7 +191,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   });
 
   // TODO isAvailable was throwing an error
-  const isAvailableToBeBooked = true;//isAvailable(commonAvailability, req.body.start, selectedEventType.length);
+  const isAvailableToBeBooked = true; //isAvailable(commonAvailability, req.body.start, selectedEventType.length);
 
   if (!isAvailableToBeBooked) {
     return res.status(400).json({ message: `${currentUser.name} is unavailable at this time.` });


### PR DESCRIPTION
So here is my pull request that fixes the problem of an invalid Zoom auth token when adding an event.
The problem was that when booking, there is an additional check whether the organizer is available during the booked time or not. This check uses all APIs, for example Zoom, which need credentials to work. Those credentials were only initally loaded on top of the file. But when one request had been done, there were new credentials stored in the database, returned by the Zoom API, which lead to the problem that the old ones weren't valid anymore.

Now, I just query the credentials again after checking availablity. In general, I'd recommend to encapsulate the "check availabilty" logic into a single file. Right now, it is spread over at least two files (getAvailability API for calendar view and this double-check in the booking mask).