### PR TITLE
fix: add login link on forgot password page

### DIFF
--- a/pages/auth/forgot-password/index.tsx
+++ b/pages/auth/forgot-password/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import React from "react";
 import { getCsrfToken } from "next-auth/client";
 import debounce from "lodash.debounce";
@@ -136,6 +137,15 @@ export default function Page({ csrfToken }) {
                     )}
                     Request Password Reset
                   </button>
+                </div>
+                <div className="space-y-2">
+                  <Link href="/auth/login">
+                    <button
+                      type="button"
+                      className="w-full flex justify-center py-2 px-4 text-sm font-medium text-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                      Login
+                    </button>
+                  </Link>
                 </div>
               </form>
             </>


### PR DESCRIPTION
From a UI/UX perspective, it's always recommended to have a link to the login from the forgot password page (even though one can use the back button).

Before:
![Screenshot 2021-06-29 at 11 35 31](https://user-images.githubusercontent.com/34626017/123766777-a4399880-d8cf-11eb-99d4-14dcaf21f56c.png)

After:
![Screenshot 2021-06-29 at 11 45 23](https://user-images.githubusercontent.com/34626017/123766792-a865b600-d8cf-11eb-802a-5b75cf2826b2.png)
