### PR TITLE
docs(readme): prisma db push is not in preview anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You will also need Google API credentials. You can get this from the [Google API
 
 5. Set up the database using the Prisma schema (found in `prisma/schema.prisma`)
    ```sh
-   npx prisma db push --preview-feature
+   npx prisma db push
    ```
 6. Run (in development mode)
    ```sh


### PR DESCRIPTION
`npx prisma db push` is Generally available [since Prisma 2.22.0](https://github.com/prisma/prisma/releases/tag/2.22.0)

![image](https://user-images.githubusercontent.com/2574275/124147861-5ff4f680-da8f-11eb-9828-54b35387ebce.png)
