### PR TITLE
Adds prisma helper function for whereAndSelect

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,9 +1,9 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 let prisma: PrismaClient;
-const globalAny:any = global;
+const globalAny: any = global;
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === "production") {
   prisma = new PrismaClient();
 } else {
   if (!globalAny.prisma) {
@@ -11,5 +11,19 @@ if (process.env.NODE_ENV === 'production') {
   }
   prisma = globalAny.prisma;
 }
+
+const whereAndSelect = (modelQuery, criteria: Record<string, unknown>, pluckedAttributes: string[]) =>
+  modelQuery({
+    where: criteria,
+    select: pluckedAttributes.reduce(
+      (select: { [string]: boolean }, attr: string) => ({
+        ...select,
+        [attr]: true,
+      }),
+      {}
+    ),
+  });
+
+export { whereAndSelect };
 
 export default prisma;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -12,16 +12,25 @@ if (process.env.NODE_ENV === "production") {
   prisma = globalAny.prisma;
 }
 
+const pluck = (select: Record<string, boolean>, attr: string) => {
+  const parts = attr.split(".");
+  const alwaysAttr = parts[0];
+  const pluckedValue =
+    parts.length > 1
+      ? {
+          select: pluck(select[alwaysAttr] ? select[alwaysAttr].select : {}, parts.slice(1).join(".")),
+        }
+      : true;
+  return {
+    ...select,
+    [alwaysAttr]: pluckedValue,
+  };
+};
+
 const whereAndSelect = (modelQuery, criteria: Record<string, unknown>, pluckedAttributes: string[]) =>
   modelQuery({
     where: criteria,
-    select: pluckedAttributes.reduce(
-      (select: { [string]: boolean }, attr: string) => ({
-        ...select,
-        [attr]: true,
-      }),
-      {}
-    ),
+    select: pluckedAttributes.reduce(pluck, {}),
   });
 
 export { whereAndSelect };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test": "node node_modules/.bin/jest",
     "build": "next build",
     "start": "next start",
     "postinstall": "prisma generate",

--- a/test/lib/prisma.test.ts
+++ b/test/lib/prisma.test.ts
@@ -1,20 +1,23 @@
 
-import {it, expect} from '@jest/globals';
-import {whereAndSelect} from "@lib/prisma";
+import { it, expect } from '@jest/globals';
+import { whereAndSelect } from "@lib/prisma";
 
-it('can decorate using whereAndSelect', async () => {
-  whereAndSelect( (queryObj) => {
-    expect(queryObj).toStrictEqual({ where: { id: 1 }, select: { example: true } });
+it("can decorate using whereAndSelect", async () => {
+  whereAndSelect(
+    (queryObj) => {
+      expect(queryObj).toStrictEqual({ where: { id: 1 }, select: { example: true } });
     },
     { id: 1 },
     [
-      "example"
-    ])
+      "example",
+    ]
+  );
 });
 
-it('can do nested selects using . seperator', async () => {
+it("can do nested selects using . seperator", async () => {
 
-  whereAndSelect( (queryObj) => {
+  whereAndSelect(
+    (queryObj) => {
       expect(queryObj).toStrictEqual({
         where: {
           uid: 1,
@@ -27,7 +30,7 @@ it('can do nested selects using . seperator', async () => {
               name: true,
             },
           },
-        }
+        },
       });
     },
     { uid: 1 },
@@ -35,11 +38,13 @@ it('can do nested selects using . seperator', async () => {
       "description",
       "attendees.email",
       "attendees.name",
-    ])
-})
+    ]
+  );
+});
 
-it('can handle nesting deeply', async () => {
-  whereAndSelect( (queryObj) => {
+it("can handle nesting deeply", async () => {
+  whereAndSelect(
+    (queryObj) => {
       expect(queryObj).toStrictEqual({
         where: {
           uid: 1,
@@ -50,13 +55,13 @@ it('can handle nesting deeply', async () => {
             select: {
               email: {
                 select: {
-                  nested: true
+                  nested: true,
                 }
               },
               name: true,
             },
           },
-        }
+        },
       });
     },
     { uid: 1 },
@@ -64,11 +69,13 @@ it('can handle nesting deeply', async () => {
       "description",
       "attendees.email.nested",
       "attendees.name",
-    ])
+    ]
+  );
 });
 
-it('can handle nesting multiple', async () => {
-  whereAndSelect( (queryObj) => {
+it("can handle nesting multiple", async () => {
+  whereAndSelect(
+    (queryObj) => {
       expect(queryObj).toStrictEqual({
         where: {
           uid: 1,
@@ -97,5 +104,6 @@ it('can handle nesting multiple', async () => {
       "attendees.name",
       "bookings.id",
       "bookings.name",
-    ])
+    ]
+  );
 });

--- a/test/lib/prisma.test.ts
+++ b/test/lib/prisma.test.ts
@@ -1,0 +1,101 @@
+
+import {it, expect} from '@jest/globals';
+import {whereAndSelect} from "@lib/prisma";
+
+it('can decorate using whereAndSelect', async () => {
+  whereAndSelect( (queryObj) => {
+    expect(queryObj).toStrictEqual({ where: { id: 1 }, select: { example: true } });
+    },
+    { id: 1 },
+    [
+      "example"
+    ])
+});
+
+it('can do nested selects using . seperator', async () => {
+
+  whereAndSelect( (queryObj) => {
+      expect(queryObj).toStrictEqual({
+        where: {
+          uid: 1,
+        },
+        select: {
+          description: true,
+          attendees: {
+            select: {
+              email: true,
+              name: true,
+            },
+          },
+        }
+      });
+    },
+    { uid: 1 },
+    [
+      "description",
+      "attendees.email",
+      "attendees.name",
+    ])
+})
+
+it('can handle nesting deeply', async () => {
+  whereAndSelect( (queryObj) => {
+      expect(queryObj).toStrictEqual({
+        where: {
+          uid: 1,
+        },
+        select: {
+          description: true,
+          attendees: {
+            select: {
+              email: {
+                select: {
+                  nested: true
+                }
+              },
+              name: true,
+            },
+          },
+        }
+      });
+    },
+    { uid: 1 },
+    [
+      "description",
+      "attendees.email.nested",
+      "attendees.name",
+    ])
+});
+
+it('can handle nesting multiple', async () => {
+  whereAndSelect( (queryObj) => {
+      expect(queryObj).toStrictEqual({
+        where: {
+          uid: 1,
+        },
+        select: {
+          description: true,
+          attendees: {
+            select: {
+              email: true,
+              name: true,
+            },
+          },
+          bookings: {
+            select: {
+              id: true,
+              name: true,
+            }
+          }
+        }
+      });
+    },
+    { uid: 1 },
+    [
+      "description",
+      "attendees.email",
+      "attendees.name",
+      "bookings.id",
+      "bookings.name",
+    ])
+});


### PR DESCRIPTION
This PR is documented in https://gist.github.com/emrysal/b7b3be83c84c7ca463a128b48cf4eef7

Does not change any existing code, and is fully backwards compatible, but provides a utility that allows the codebase to shrink by condensing a common Prisma usecase.