### PR TITLE
fix for wrong day selected

### DIFF
--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -131,7 +131,7 @@ const getSlots = ({
   )
     .reduce((slots, boundary: Boundary) => [...slots, ...getSlotsBetweenBoundary(frequency, boundary)], [])
     .map((slot) =>
-      slot.month(inviteeDate.month()).date(inviteeDate.date()).utcOffset(inviteeDate.utcOffset())
+      slot.utcOffset(inviteeDate.utcOffset()).month(inviteeDate.month()).date(inviteeDate.date())
     );
 };
 

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -25,6 +25,7 @@ export default function Type(props): Type {
   const telemetry = useTelemetry();
 
   useEffect(() => {
+    handleToggle24hClock(localStorage.getItem("timeOption.is24hClock") === "true");
     telemetry.withJitsu((jitsu) => jitsu.track(telemetryEventTypes.pageView, collectPageParameters()));
   }, [telemetry]);
 


### PR DESCRIPTION
Fixed a bug that selected the following day on the booking page, when the selected time is smaller than the utc offset of the current timezone. Also fixed the reloading of the last 24h/12h selection