### PR TITLE
fix: truncate event type description instead of title

### DIFF
--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -121,7 +121,7 @@ export default function Availability(props) {
                 </div>
                 <div className="flex flex-col mb-8">
                     <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-                        <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                        <div className="py-2 align-middle inline-block max-w-full min-w-full sm:px-6 lg:px-8">
                             <div className="shadow overflow-hidden border-b border-gray-200 rounded-lg">
                                 <table className="min-w-full divide-y divide-gray-200">
                                     <thead className="bg-gray-50">
@@ -143,7 +143,7 @@ export default function Availability(props) {
                                     <tbody className="bg-white divide-y divide-gray-200">
                                         {props.types.map((eventType) =>
                                             <tr>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 align-top">
                                                     {eventType.title}
                                                     {eventType.hidden &&
                                                         <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
@@ -151,13 +151,13 @@ export default function Availability(props) {
                                                         </span>
                                                     }
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                <td className="px-6 py-4 text-sm text-gray-500 align-top">
                                                     {eventType.description}
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 align-top">
                                                     {eventType.length} minutes
                                                 </td>
-                                                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium align-top">
                                                     <Link href={"/" + props.user.username + "/" + eventType.slug}><a target="_blank" className="text-blue-600 hover:text-blue-900 mr-2">View</a></Link>
                                                     <Link href={"/availability/event/" + eventType.id}><a className="text-blue-600 hover:text-blue-900">Edit</a></Link>
                                                 </td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,8 +103,8 @@ export default function Home(props) {
                         <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
                           <div className="truncate">
                             <div className="flex text-sm">
-                              <p className="font-medium text-blue-600 truncate">{type.title}</p>
-                              <p className="ml-1 flex-shrink-0 font-normal text-gray-500">
+                              <p className="flex-shrink-0 font-medium text-blue-600 truncate">{type.title}</p>
+                              <p className="ml-1 font-normal text-gray-500 truncate">
                                 in {type.description}
                               </p>
                             </div>


### PR DESCRIPTION
Hey folks,

When event type description is long enough title collapses and description does not truncate properly (no ellipsis).

![schedule beondeck com_](https://user-images.githubusercontent.com/900311/125603395-42e3fb9d-4917-4110-bae5-af2e693ea52c.png)

Same problem occurred in the event type table as well:
![localhost_3003_auth_login (1)](https://user-images.githubusercontent.com/900311/125613901-bfb19c5e-f1a5-4666-a1d7-c0ec06d844d4.png)

Fixed by allowing overflow of the description and setting a max width for the table container.
![localhost_3003_auth_login](https://user-images.githubusercontent.com/900311/125613981-bc5cfb29-8cb4-4ed5-852d-e3dc67bae803.png)
