### PR TITLE
add control for setting minimum advance time

### DIFF
--- a/components/booking/DatePicker.tsx
+++ b/components/booking/DatePicker.tsx
@@ -23,6 +23,7 @@ const DatePicker = ({
   periodEndDate,
   periodDays,
   periodCountCalendarDays,
+  minimumAdvance,
 }) => {
   const [calendar, setCalendar] = useState([]);
   const [selectedMonth, setSelectedMonth] = useState<number>();
@@ -87,6 +88,7 @@ const DatePicker = ({
           const periodRangeStartDay = dayjs(periodStartDate).tz(organizerTimeZone).endOf("day");
           const periodRangeEndDay = dayjs(periodEndDate).tz(organizerTimeZone).endOf("day");
           return (
+            date.endOf("day").isBefore(dayjs().add(minimumAdvance, "day").endOf("day")) ||
             date.endOf("day").isBefore(dayjs().tz(inviteeTimeZone)) ||
             date.endOf("day").isBefore(periodRangeStartDay) ||
             date.endOf("day").isAfter(periodRangeEndDay) ||
@@ -102,6 +104,7 @@ const DatePicker = ({
         case "unlimited":
         default:
           return (
+            date.endOf("day").isBefore(dayjs().add(minimumAdvance, "day").endOf("day")) ||
             date.endOf("day").isBefore(dayjs().tz(inviteeTimeZone)) ||
             !getSlots({
               inviteeDate: date,

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -161,6 +161,7 @@ export default function Type(props): Type {
                 periodEndDate={props.eventType?.periodEndDate}
                 periodDays={props.eventType?.periodDays}
                 periodCountCalendarDays={props.eventType?.periodCountCalendarDays}
+                minimumAdvance={props.eventType.minimumAdvance}
                 weekStart={props.user.weekStart}
                 onDatePicked={changeDate}
                 workingHours={props.workingHours}
@@ -238,6 +239,7 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
       "periodStartDate",
       "periodEndDate",
       "periodCountCalendarDays",
+      "minimumAdvance",
     ]
   );
 

--- a/pages/api/availability/eventtype.ts
+++ b/pages/api/availability/eventtype.ts
@@ -14,10 +14,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       title: req.body.title,
       slug: req.body.slug,
       description: req.body.description,
-      length: parseInt(req.body.length),
+      length: parseInt(req.body.length, 10),
       hidden: req.body.hidden,
       locations: req.body.locations,
       eventName: req.body.eventName,
+      minimumAdvance: parseInt(req.body.minimumAdvance, 10),
       customInputs: !req.body.customInputs
         ? undefined
         : {

--- a/pages/availability/event/[type].tsx
+++ b/pages/availability/event/[type].tsx
@@ -55,6 +55,7 @@ type EventTypeInput = {
   slug: string;
   description: string;
   length: number;
+  minimumAdvance: number;
   hidden: boolean;
   locations: unknown;
   eventName: string;
@@ -171,6 +172,7 @@ export default function EventTypePage({
   const slugRef = useRef<HTMLInputElement>();
   const descriptionRef = useRef<HTMLTextAreaElement>();
   const lengthRef = useRef<HTMLInputElement>();
+  const minimumAdvanceRef = useRef<HTMLInputElement>();
   const isHiddenRef = useRef<HTMLInputElement>();
   const eventNameRef = useRef<HTMLInputElement>();
   const periodDaysRef = useRef<HTMLInputElement>();
@@ -187,6 +189,7 @@ export default function EventTypePage({
     const enteredSlug: string = slugRef.current.value;
     const enteredDescription: string = descriptionRef.current.value;
     const enteredLength: number = parseInt(lengthRef.current.value);
+    const enteredMinimumAdvance: number = parseInt(minimumAdvanceRef.current.value, 10);
     const enteredIsHidden: boolean = isHiddenRef.current.checked;
     const enteredEventName: string = eventNameRef.current.value;
 
@@ -213,6 +216,7 @@ export default function EventTypePage({
       slug: enteredSlug,
       description: enteredDescription,
       length: enteredLength,
+      minimumAdvance: enteredMinimumAdvance,
       hidden: enteredIsHidden,
       locations,
       eventName: enteredEventName,
@@ -555,6 +559,49 @@ export default function EventTypePage({
                         className="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"
                         placeholder="A quick video meeting."
                         defaultValue={eventType.description}></textarea>
+                    </div>
+                  </div>
+                  <div className="mb-4">
+                    <label htmlFor="length" className="block text-sm font-medium text-gray-700">
+                      Length
+                    </label>
+                    <div className="mt-1 relative rounded-md shadow-sm">
+                      <input
+                        ref={lengthRef}
+                        type="number"
+                        name="length"
+                        id="length"
+                        required
+                        className="focus:ring-blue-500 focus:border-blue-500 block w-full pr-20 sm:text-sm border-gray-300 rounded-md"
+                        placeholder="15"
+                        defaultValue={eventType.length}
+                      />
+                      <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 text-sm">
+                        minutes
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mb-4">
+                    <label htmlFor="minimumAdvance" className="block text-sm font-medium text-gray-700">Minimum advance</label>
+                    <div>
+                      <p className="text-sm text-gray-500">
+                        Set the minimum number of days before people can book.
+                      </p>
+                    </div>
+                    <div className="mt-1 relative rounded-md shadow-sm">
+                      <input
+                        ref={minimumAdvanceRef}
+                        type="number"
+                        name="minimumAdvance"
+                        id="minimumAdvance"
+                        required
+                        className="focus:ring-blue-500 focus:border-blue-500 block w-full pr-20 sm:text-sm border-gray-300 rounded-md"
+                        placeholder="1"
+                        defaultValue={eventType.minimumAdvance}
+                      />
+                      <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 text-sm">
+                        days
+                      </div>
                     </div>
                   </div>
                   <div className="mb-4">
@@ -991,6 +1038,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ req, query
       periodStartDate: true,
       periodEndDate: true,
       periodCountCalendarDays: true,
+      minimumAdvance: true,
     },
   });
 

--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -19,6 +19,7 @@ export default function Availability(props) {
     const descriptionRef = useRef<HTMLTextAreaElement>();
     const lengthRef = useRef<HTMLInputElement>();
     const isHiddenRef = useRef<HTMLInputElement>();
+    const minimumAdvanceRef = useRef<HTMLInputElement>();
 
     const startHoursRef = useRef<HTMLInputElement>();
     const startMinsRef = useRef<HTMLInputElement>();
@@ -57,12 +58,13 @@ export default function Availability(props) {
         const enteredDescription = descriptionRef.current.value;
         const enteredLength = lengthRef.current.value;
         const enteredIsHidden = isHiddenRef.current.checked;
+        const enteredMinimumAdvance = minimumAdvanceRef.current.value;
 
         // TODO: Add validation
 
         const response = await fetch('/api/availability/eventtype', {
             method: 'POST',
-            body: JSON.stringify({title: enteredTitle, slug: enteredSlug, description: enteredDescription, length: enteredLength, hidden: enteredIsHidden}),
+            body: JSON.stringify({title: enteredTitle, slug: enteredSlug, description: enteredDescription, length: enteredLength, hidden: enteredIsHidden, minimumAdvance: enteredMinimumAdvance}),
             headers: {
                 'Content-Type': 'application/json'
             }
@@ -270,6 +272,20 @@ export default function Availability(props) {
                                                 <input ref={lengthRef} type="number" name="length" id="length" required className="focus:ring-blue-500 focus:border-blue-500 block w-full pr-20 sm:text-sm border-gray-300 rounded-md" placeholder="15" />
                                                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 text-sm">
                                                     minutes
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div className="mb-4">
+                                            <label htmlFor="minimumAdvance" className="block text-sm font-medium text-gray-700">Minimum advance</label>
+                                            <div>
+                                                <p className="text-sm text-gray-500">
+                                                    Set the minimum number of days before people can book.
+                                                </p>
+                                            </div>
+                                            <div className="mt-1 relative rounded-md shadow-sm">
+                                                <input ref={minimumAdvanceRef} type="number" name="minimumAdvance" id="minimumAdvance" required className="focus:ring-blue-500 focus:border-blue-500 block w-full pr-20 sm:text-sm border-gray-300 rounded-md" placeholder="1" />
+                                                <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 text-sm">
+                                                    days
                                                 </div>
                                             </div>
                                         </div>

--- a/prisma/migrations/20210720115926_minimum_advance/migration.sql
+++ b/prisma/migrations/20210720115926_minimum_advance/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventType" ADD COLUMN     "minimumAdvance" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model EventType {
   periodEndDate DateTime?
   periodDays Int?
   periodCountCalendarDays Boolean?
+  minimumAdvance Int @default(1)
 }
 
 model Credential {


### PR DESCRIPTION
Hey folks!

This is one of the features we required for launching the feedback hub here at On Deck. The idea is that users can specify a how much of advance they want to have per event type (in days). Then, in booking view those days will be grayed out.

Feel free to ignore this PR if it's not something you planned on adding!

Cheers,
Egor

