### PR TITLE
(Conditionally) remove HTML from event description

### DIFF
--- a/lib/CalEventParser.ts
+++ b/lib/CalEventParser.ts
@@ -86,4 +86,13 @@ export default class CalEventParser {
     eventCopy.description = this.getRichDescriptionHtml();
     return eventCopy;
   }
+
+  /**
+   * Returns a calendar event with rich description as plain text.
+   */
+  public asRichEventPlain(): CalendarEvent {
+    const eventCopy: CalendarEvent = { ...this.calEvent };
+    eventCopy.description = this.getRichDescription();
+    return eventCopy;
+  }
 }

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -513,8 +513,7 @@ const createEvent = async (credential: Credential, calEvent: CalendarEvent): Pro
    * We need HTML there. Google Calendar understands newlines and Apple Calendar cannot show HTML, so no HTML should
    * be used for Google and Apple Calendar.
    */
-  const richEvent: CalendarEvent =
-    credential.type === "office365_calendar" ? parser.asRichEvent() : parser.asRichEventPlain();
+  const richEvent: CalendarEvent = parser.asRichEventPlain();
 
   const creationResult = credential ? await calendars([credential])[0].createEvent(richEvent) : null;
 
@@ -561,8 +560,7 @@ const updateEvent = async (
 ): Promise<unknown> => {
   const parser: CalEventParser = new CalEventParser(calEvent);
   const newUid: string = parser.getUid();
-  const richEvent: CalendarEvent =
-    credential.type === "office365_calendar" ? parser.asRichEvent() : parser.asRichEventPlain();
+  const richEvent: CalendarEvent = parser.asRichEventPlain();
 
   const updateResult = credential
     ? await calendars([credential])[0].updateEvent(uidToUpdate, richEvent)

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -508,7 +508,13 @@ const listCalendars = (withCredentials) =>
 const createEvent = async (credential: Credential, calEvent: CalendarEvent): Promise<unknown> => {
   const parser: CalEventParser = new CalEventParser(calEvent);
   const uid: string = parser.getUid();
-  const richEvent: CalendarEvent = parser.asRichEventPlain();
+  /*
+   * Matching the credential type is a workaround because the office calendar simply strips away newlines (\n and \r).
+   * We need HTML there. Google Calendar understands newlines and Apple Calendar cannot show HTML, so no HTML should
+   * be used for Google and Apple Calendar.
+   */
+  const richEvent: CalendarEvent =
+    credential.type === "office365_calendar" ? parser.asRichEvent() : parser.asRichEventPlain();
 
   const creationResult = credential ? await calendars([credential])[0].createEvent(richEvent) : null;
 

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -561,7 +561,8 @@ const updateEvent = async (
 ): Promise<unknown> => {
   const parser: CalEventParser = new CalEventParser(calEvent);
   const newUid: string = parser.getUid();
-  const richEvent: CalendarEvent = parser.asRichEventPlain();
+  const richEvent: CalendarEvent =
+    credential.type === "office365_calendar" ? parser.asRichEvent() : parser.asRichEventPlain();
 
   const updateResult = credential
     ? await calendars([credential])[0].updateEvent(uidToUpdate, richEvent)

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -508,7 +508,7 @@ const listCalendars = (withCredentials) =>
 const createEvent = async (credential: Credential, calEvent: CalendarEvent): Promise<unknown> => {
   const parser: CalEventParser = new CalEventParser(calEvent);
   const uid: string = parser.getUid();
-  const richEvent: CalendarEvent = parser.asRichEvent();
+  const richEvent: CalendarEvent = parser.asRichEventPlain();
 
   const creationResult = credential ? await calendars([credential])[0].createEvent(richEvent) : null;
 
@@ -555,7 +555,7 @@ const updateEvent = async (
 ): Promise<unknown> => {
   const parser: CalEventParser = new CalEventParser(calEvent);
   const newUid: string = parser.getUid();
-  const richEvent: CalendarEvent = parser.asRichEvent();
+  const richEvent: CalendarEvent = parser.asRichEventPlain();
 
   const updateResult = credential
     ? await calendars([credential])[0].updateEvent(uidToUpdate, richEvent)

--- a/lib/emails/helpers.ts
+++ b/lib/emails/helpers.ts
@@ -25,9 +25,11 @@ export function getFormattedMeetingId(videoCallData: VideoCallData): string {
 }
 
 export function stripHtml(html: string): string {
+  const aMailToRegExp = /<a[\s\w="_:#;]*href="mailto:([^<>"]*)"[\s\w="_:#;]*>([^<>]*)<\/a>/g;
   const aLinkRegExp = /<a[\s\w="_:#;]*href="([^<>"]*)"[\s\w="_:#;]*>([^<>]*)<\/a>/g;
   return html
     .replace(/<br\s?\/>/g, "\n")
+    .replace(aMailToRegExp, "$1")
     .replace(aLinkRegExp, "$2: $1")
     .replace(/<[^>]+>/g, "");
 }

--- a/lib/emails/helpers.ts
+++ b/lib/emails/helpers.ts
@@ -25,5 +25,9 @@ export function getFormattedMeetingId(videoCallData: VideoCallData): string {
 }
 
 export function stripHtml(html: string): string {
-  return html.replace("<br />", "\n").replace(/<[^>]+>/g, "");
+  const aLinkRegExp = /<a[\s\w="_:#;]*href="([^<>"]*)"[\s\w="_:#;]*>([^<>]*)<\/a>/g;
+  return html
+    .replace("<br />", "\n")
+    .replace(aLinkRegExp, "$2: $1")
+    .replace(/<[^>]+>/g, "");
 }

--- a/lib/emails/helpers.ts
+++ b/lib/emails/helpers.ts
@@ -27,7 +27,7 @@ export function getFormattedMeetingId(videoCallData: VideoCallData): string {
 export function stripHtml(html: string): string {
   const aLinkRegExp = /<a[\s\w="_:#;]*href="([^<>"]*)"[\s\w="_:#;]*>([^<>]*)<\/a>/g;
   return html
-    .replace("<br />", "\n")
+    .replace(/<br\s?\/>/g, "\n")
     .replace(aLinkRegExp, "$2: $1")
     .replace(/<[^>]+>/g, "");
 }


### PR DESCRIPTION
Good evening,

Earlier, we were encountering the problem that users of certain calendar tools, such as Apple Calendar, were seeing raw HTML tags in their event description, because obviously HTML seems not to be supported in those tools.

**So just remove that HTML stuff, replace `<br />` with `\n` and we're good to go, huh?**

Well, then the web version of Outlook Calendar doesn't support newline characters. It just strips them out. **Even the Windows-related `\r` newline character.**
It looks like this:
![image](https://user-images.githubusercontent.com/14024119/126570005-afdd0c0b-e348-4e39-a78b-84f14ffeaf9a.png)

Meanwhile, Google Calendar pretty much likes newline characters in plain text events:
![image](https://user-images.githubusercontent.com/14024119/126570089-73301ad5-6703-4cc9-910c-bd6b462caf84.png)

**So what do we do?**
I decided to conditionally use either the HTML-based version (for Outlook events) or the newline-based version (for everything else) of the event text when creating it. See the code (line 511 and following in calendarClient.ts) for more information.

Works in Outlook:
![image](https://user-images.githubusercontent.com/14024119/126570742-9a5eced5-a23c-440e-a6a3-6072485a865d.png)

And in Google:
![image](https://user-images.githubusercontent.com/14024119/126570775-fb71ccc4-f114-41f7-83e2-08607a90982f.png)

**But there's still an unsolved problem:**
Apple Calendar is just a tool that uses other integrations, such as Google or Outlook Calendar (or iCloud). So this PR doesn't solve the Apple Calendar issues, since we don't know which software the user is using.

We have the following options:
1. Just **always** throw away the HTML, leading to a quite "ugly" event description in Outlook Web, but saving the view for Apple Calendar.
2. Keep the conditional HTML usage: @Malte-D Could you test this PR with your Apple Calendar? I don't have a Mac right now. Maybe Outlook parses the HTML correctly and delivers a "working" version to Apple Calendar? Needs investigation!
3. Make an "opt-in" to let the user decide whether to use HTML descriptions or not.

Right now, this PR contains option 2. Please share your opinion about that with me. :)