### PR TITLE
Removed sub-account scopes from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,15 +236,12 @@ Contributions are what make the open source community such an amazing place to b
 9. Set the Redirect URL for OAuth `<CALENDSO URL>/api/integrations/zoomvideo/callback` replacing CALENDSO URL with the URI at which your application runs.
 10. Also add the redirect URL given above as a whitelist URL and enable "Subdomain check". Make sure, it says "saved" below the form.
 11. You don't need to provide basic information about your app. Instead click at "Scopes" and then at "+ Add Scopes". Search for and check the following scopes:
-    1. account:master
-    2. account:read:admin
-    3. account:write:admin
-    4. meeting:master
-    5. meeting:read:admin
-    6. meeting:write:admin
-    7. user:master
-    8. user:read:admin
-    9. user:write:admin
+    1. account:read:admin
+    2. account:write:admin
+    3. meeting:read:admin
+    4. meeting:write:admin
+    5. user:read:admin
+    6. user:write:admin
 12. Click "Done".
 13. You're good to go. Now you can easily add your Zoom integration in the Calendso settings.
 


### PR DESCRIPTION
Originally, we stated in the README that users would need to add some scopes ending with ":master" to their Zoom app. It turned out that those scopes are not needed and thus can be removed from the README.

All needed functionalities can be achieved using the admin scopes.