### PR TITLE
Updated office365 button to UTC

### DIFF
--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -183,9 +183,9 @@ export default function Success(props) {
                               "https://outlook.office.com/calendar/0/deeplink/compose?body=" +
                                 props.eventType.description +
                                 "&enddt=" +
-                                date.add(props.eventType.length, "minute").format() +
+                                date.add(props.eventType.length, "minute").utc().format() +
                                 "&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=" +
-                                date.format() +
+                                date.utc().format() +
                                 "&subject=" +
                                 eventName
                             ) + (location ? "&location=" + location : "")


### PR DESCRIPTION
Fixes issue with office365 not accepting timezone postfixes, causing all kinds of weird dates to be displayed whilst trying to open the deeplink as an invitee (wrong dates, wrong times).