### PR TITLE
Adjust chevron color in DatePicker to make it more intuitive

### DIFF
--- a/components/booking/DatePicker.tsx
+++ b/components/booking/DatePicker.tsx
@@ -171,10 +171,13 @@ const DatePicker = ({
         <span className="w-1/2 text-gray-600 dark:text-white">
           {dayjs().month(selectedMonth).format("MMMM YYYY")}
         </span>
-        <div className="w-1/2 text-right text-gray-400">
+        <div className="w-1/2 text-right text-gray-600 dark:text-gray-400">
           <button
             onClick={decrementMonth}
-            className={"mr-4 " + (selectedMonth <= dayjs().tz(inviteeTimeZone).month() && "text-gray-600")}
+            className={
+              "mr-4 " +
+              (selectedMonth <= dayjs().tz(inviteeTimeZone).month() && "text-gray-400 dark:text-gray-600")
+            }
             disabled={selectedMonth <= dayjs().tz(inviteeTimeZone).month()}>
             <ChevronLeftIcon className="w-5 h-5" />
           </button>

--- a/components/booking/DatePicker.tsx
+++ b/components/booking/DatePicker.tsx
@@ -171,10 +171,10 @@ const DatePicker = ({
         <span className="w-1/2 text-gray-600 dark:text-white">
           {dayjs().month(selectedMonth).format("MMMM YYYY")}
         </span>
-        <div className="w-1/2 text-right">
+        <div className="w-1/2 text-right text-gray-400">
           <button
             onClick={decrementMonth}
-            className={"mr-4 " + (selectedMonth <= dayjs().tz(inviteeTimeZone).month() && "text-gray-400")}
+            className={"mr-4 " + (selectedMonth <= dayjs().tz(inviteeTimeZone).month() && "text-gray-600")}
             disabled={selectedMonth <= dayjs().tz(inviteeTimeZone).month()}>
             <ChevronLeftIcon className="w-5 h-5" />
           </button>


### PR DESCRIPTION
I noticed that the chevron color (for selecting months) is reversed (brighter for disabled button; lighter for active button). In this PR I adjusted the colors to make it look more intuitive (see before and after pics) 

**BEFORE** 
<img width="202" alt="Screenshot 2021-07-30 at 15 18 31" src="https://user-images.githubusercontent.com/4049052/127652179-0892821a-4564-4d90-8e1e-004beccf7885.png">
<img width="207" alt="Screenshot 2021-07-30 at 15 18 44" src="https://user-images.githubusercontent.com/4049052/127652190-792ce6ea-abb3-40d3-9656-5ab0baa5bff1.png">


**AFTER**
<img width="205" alt="Screenshot 2021-07-30 at 15 19 07" src="https://user-images.githubusercontent.com/4049052/127652212-4d01b150-a256-497e-9bea-9a3ecd86a036.png">
<img width="206" alt="Screenshot 2021-07-30 at 15 19 11" src="https://user-images.githubusercontent.com/4049052/127652220-2ece84ee-7996-4549-abe2-e6e7dd6b2cad.png">
