### PR TITLE
Missing dayjs().isBetween plugin + format Z explicitly

### DIFF
--- a/pages/api/book/[user].ts
+++ b/pages/api/book/[user].ts
@@ -14,12 +14,14 @@ import logger from "../../../lib/logger";
 
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import isBetween from "dayjs/plugin/isBetween";
 import dayjsBusinessDays from "dayjs-business-days";
 import { Exception } from "handlebars";
 import EventOrganizerRequestMail from "@lib/emails/EventOrganizerRequestMail";
 
 dayjs.extend(dayjsBusinessDays);
 dayjs.extend(utc);
+dayjs.extend(isBetween);
 dayjs.extend(timezone);
 
 const translator = short();
@@ -28,7 +30,6 @@ const log = logger.getChildLogger({ prefix: ["[api] book:user"] });
 function isAvailable(busyTimes, time, length) {
   // Check for conflicts
   let t = true;
-
   if (Array.isArray(busyTimes) && busyTimes.length > 0) {
     busyTimes.forEach((busyTime) => {
       const startTime = dayjs(busyTime.start);
@@ -312,8 +313,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const calendarAvailability = await getBusyCalendarTimes(
       currentUser.credentials,
-      dayjs(req.body.start).startOf("day").utc().format(),
-      dayjs(req.body.end).endOf("day").utc().format(),
+      dayjs(req.body.start).startOf("day").utc().format("YYYY-MM-DDTHH:mm:ss[Z]"),
+      dayjs(req.body.end).endOf("day").utc().format("YYYY-MM-DDTHH:mm:ss[Z]"),
       selectedCalendars
     );
     const videoAvailability = await getBusyVideoTimes(
@@ -412,7 +413,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     try {
       isAvailableToBeBooked = isAvailable(commonAvailability, req.body.start, selectedEventType.length);
-    } catch {
+    } catch (e) {
+      console.log(e);
       log.debug({
         message: "Unable set isAvailableToBeBooked. Using true. ",
       });


### PR DESCRIPTION
Quite straightforward; isAvailable was breaking whilst creating new bookings whilst testing https://github.com/calendso/calendso/pull/397.

One error is that
```javascript
// Can work with 2021-07-01T00:00:00+00:00
const filter = "?$filter=start/dateTime ge '" + dateFrom + "' and end/dateTime le '" + dateTo + "'";
// this however, encodes the + as a space and this breaks the query. 
const filter = "?startdatetime=" + dateFrom + "&enddatetime=" + dateTo; 
```

I have fixed this by enforcing `Z`.

Another bug was that `isBetween` was missing (used in getting conflicts) - this is unrelated - I don't know why this wasn't an issue before.

This PR is required for #397 to work.
