### PR TITLE
Fix next-auth issues

### DIFF
--- a/pages/auth/forgot-password/index.tsx
+++ b/pages/auth/forgot-password/index.tsx
@@ -1,10 +1,10 @@
 import Head from "next/head";
 import Link from "next/link";
 import React from "react";
-import { getCsrfToken } from "next-auth/client";
+import { getCsrfToken, getSession } from "next-auth/client";
 import debounce from "lodash.debounce";
 
-export default function Page({ csrfToken }) {
+export default function ForgotPassword({ csrfToken }) {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
   const [success, setSuccess] = React.useState(false);
@@ -156,8 +156,17 @@ export default function Page({ csrfToken }) {
   );
 }
 
-Page.getInitialProps = async ({ req }) => {
+ForgotPassword.getInitialProps = async (context) => {
+  const { req, res } = context;
+  const session = await getSession({ req });
+
+  if (session) {
+    res.writeHead(302, { Location: "/" });
+    res.end();
+    return;
+  }
+
   return {
-    csrfToken: await getCsrfToken({ req }),
+    csrfToken: await getCsrfToken(context),
   };
 };

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
-import { getCsrfToken } from "next-auth/client";
+import { getCsrfToken, getSession } from "next-auth/client";
 
 export default function Login({ csrfToken }) {
   return (
@@ -79,8 +79,17 @@ export default function Login({ csrfToken }) {
   );
 }
 
-Login.getInitialProps = async ({ req }) => {
+Login.getInitialProps = async (context) => {
+  const { req, res } = context;
+  const session = await getSession({ req });
+
+  if (session) {
+    res.writeHead(302, { Location: "/" });
+    res.end();
+    return;
+  }
+
   return {
-    csrfToken: await getCsrfToken({ req }),
+    csrfToken: await getCsrfToken(context),
   };
 };

--- a/pages/auth/logout.tsx
+++ b/pages/auth/logout.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 import { CheckIcon } from "@heroicons/react/outline";
+import { getSession, signOut } from "next-auth/client";
 
 export default function Logout() {
   return (
@@ -43,3 +44,14 @@ export default function Logout() {
     </div>
   );
 }
+
+Logout.getInitialProps = async (context) => {
+  const { req } = context;
+  const session = await getSession({ req });
+
+  if (session) {
+    signOut({ redirect: false });
+  }
+
+  return { session: undefined };
+};


### PR DESCRIPTION
- [x] Fixed: When logged in, a user can still navigate to `/auth/login` or `/auth/forgot-password`. The user should not be allowed to do that, instead, he should be redirected to the root protected route.

- [x] Fixed: When the user signs out, he is redirected to `auth/logout` which points to`auth/login` but the user's session is still active. If he navigates to a protected route, he can still access the protected route, since the session was not correctly destroyed. 