### PR TITLE
Fix: Disclosure form submission

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -619,7 +619,7 @@ export default function EventTypePage({
                         />
                         <span className="text-neutral-700 text-sm font-medium">Show advanced settings</span>
                       </Disclosure.Button>
-                      <Disclosure.Panel className="space-y-4">
+                      <Disclosure.Panel className={`${open ? "" : "hidden"} space-y-4`} static>
                         <div className="block sm:flex items-center">
                           <div className="min-w-44 mb-4 sm:mb-0">
                             <label


### PR DESCRIPTION
The disclosure component from Headless UI works nice, but when the content is hidden, the form inputs from the Disclosure panel are removed from the DOM causing errors on form submission. The form expects some inputs, but they don't exist as the Disclosure removes them from the DOM on collapse.

I've added `static` attribute to the Disclosure panel (based on Headless UI docs) to always have the panel present even if the disclosure is collapsed or not. Additionally, the button `Show advanced Settings` will only toggle `hidden` class on the panel.