### PR TITLE
Resolved errors on the pages/event-types/[type].tsx page

### DIFF
--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -1,0 +1,42 @@
+import { DialogClose, DialogContent } from "@components/Dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ExclamationIcon } from "@heroicons/react/outline";
+import React from "react";
+
+export default function ConfirmationDialogContent({
+  title,
+  alert,
+  confirmBtnText,
+  cancelBtnText,
+  onConfirm,
+  children,
+}) {
+  confirmBtnText = confirmBtnText || "Confirm";
+  cancelBtnText = cancelBtnText || "Cancel";
+
+  return (
+    <DialogContent>
+      <div className="flex">
+        {alert && (
+          <div className="mr-3 mt-0.5">
+            {alert === "danger" && (
+              <div className="text-center p-2 rounded-full mx-auto bg-red-100">
+                <ExclamationIcon className="w-5 h-5 text-red-600" />
+              </div>
+            )}
+          </div>
+        )}
+        <div>
+          <DialogPrimitive.Title className="text-xl font-bold text-gray-900">{title}</DialogPrimitive.Title>
+          <DialogPrimitive.Description className="text-neutral-500">{children}</DialogPrimitive.Description>
+        </div>
+      </div>
+      <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+        <DialogClose onClick={onConfirm} className="btn btn-primary">
+          {confirmBtnText}
+        </DialogClose>
+        <DialogClose className="btn btn-white mx-2">{cancelBtnText}</DialogClose>
+      </div>
+    </DialogContent>
+  );
+}


### PR DESCRIPTION
* Fixes redirect to /availability on save & delete -> go to /event-types instead.
* Implements Confirmation Dialog (And ConfirmationDialogContent component for reusability)

![image](https://user-images.githubusercontent.com/1046695/128942988-b87a20dd-188d-477b-b924-387096f552aa.png)

* Moves the hidden switch to the right side menu

![image](https://user-images.githubusercontent.com/1046695/128943100-a070889f-6ef7-49b8-abcc-9459f3604bfa.png)

* Split the EventTypeInput into two parts, of which advanced options are only included when advanced options is "Disclosed". 
