### PR TITLE
Adds autosync functionality with calendso/docker

### DIFF
--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -1,0 +1,28 @@
+name: Update Calendso Docker repository
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: calendso/docker
+          token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
+
+      - name: Pull and update calendso submodule recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "Github Actions - sync calendso/docker"
+          git add --all
+          git commit -m "Updated tracking branch to latest"
+          git push


### PR DESCRIPTION
**DO NOT MERGE AS IS, A SECRET NEEDS TO BE ADDED TO THIS REPO FIRST**

Adds a single GH workflow that automatically updates the submodule in the docker repo to reflect the latest changes in `calendso/calendso`; so it is always up-to-date.

I setup a test enviroment to check this workflow worked; See the demo in action @ https://github.com/emrysal/calendso-github-actions-test-parent & https://github.com/emrysal/calendso-github-actions-test-child