### PR TITLE
fix: add success modal on event-type update

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import Modal from "../../components/Modal";
 import React, { useEffect, useRef, useState } from "react";
 import Select, { OptionBase } from "react-select";
 import prisma from "@lib/prisma";
@@ -104,6 +105,7 @@ export default function EventTypePage({
   availability,
 }: Props): JSX.Element {
   const router = useRouter();
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
 
   const inputOptions: OptionBase[] = [
     { value: EventTypeCustomInputType.Text, label: "Text" },
@@ -235,7 +237,7 @@ export default function EventTypePage({
       },
     });
 
-    router.push("/event-types");
+    setSuccessModalOpen(true);
   }
 
   async function deleteEventTypeHandler(event) {
@@ -266,6 +268,10 @@ export default function EventTypePage({
     setSelectedInputOption(inputOptions[0]);
     setShowAddCustomModal(false);
     setSelectedCustomInput(undefined);
+  };
+
+  const closeSuccessModal = () => {
+    setSuccessModalOpen(false);
   };
 
   const updateLocations = (e) => {
@@ -850,6 +856,12 @@ export default function EventTypePage({
                   </button>
                 </div>
               </form>
+              <Modal
+                heading="Event Type updated successfully"
+                description="Your event type has been updated successfully."
+                open={successModalOpen}
+                handleClose={closeSuccessModal}
+              />
             </div>
           </div>
           <div className="w-full sm:w-2/12 ml-2 px-4 mt-8 sm:mt-0 min-w-32">


### PR DESCRIPTION
The User is redirected to the `/event-types` page after editing and successfully updating an event-type. The user doesn't know if the update was successful.

Added a success modal similar to how `/availability` and `/settings` pages behave after update.