### PR TITLE
Fixed: Office 365 integration redirection URL issue

### DIFF
--- a/pages/api/integrations/office365calendar/add.ts
+++ b/pages/api/integrations/office365calendar/add.ts
@@ -21,13 +21,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             }
         });
 
-        const hostname = 'x-forwarded-host' in req.headers ? 'https://' + req.headers['x-forwarded-host'] : 'host' in req.headers ? (req.secure ? 'https://' : 'http://') + req.headers['host'] : '';
-        if ( ! hostname || ! req.headers.referer.startsWith(hostname)) {
-            throw new Error('Unable to determine external url, check server settings');
-        }
-
         function generateAuthUrl() {
-            return 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=code&scope=' + scopes.join(' ') + '&client_id=' + process.env.MS_GRAPH_CLIENT_ID + '&redirect_uri=' + hostname + '/api/integrations/office365calendar/callback';
+            return 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=code&scope=' + scopes.join(' ') + '&client_id=' + process.env.MS_GRAPH_CLIENT_ID + '&redirect_uri=' + process.env.BASE_URL + '/api/integrations/office365calendar/callback';
         }
 
         res.status(200).json({url: generateAuthUrl() });

--- a/pages/api/integrations/office365calendar/callback.ts
+++ b/pages/api/integrations/office365calendar/callback.ts
@@ -11,9 +11,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!session) { res.status(401).json({message: 'You must be logged in to do this'}); return; }
 
     const toUrlEncoded = payload => Object.keys(payload).map( (key) => key + '=' + encodeURIComponent(payload[ key ]) ).join('&');
-    const hostname = 'x-forwarded-host' in req.headers ? 'https://' + req.headers['x-forwarded-host'] : 'host' in req.headers ? (req.secure ? 'https://' : 'http://') + req.headers['host'] : '';
 
-    const body = toUrlEncoded({ client_id: process.env.MS_GRAPH_CLIENT_ID, grant_type: 'authorization_code', code, scope: scopes.join(' '), redirect_uri: hostname + '/api/integrations/office365calendar/callback', client_secret: process.env.MS_GRAPH_CLIENT_SECRET });
+    const body = toUrlEncoded({ client_id: process.env.MS_GRAPH_CLIENT_ID, grant_type: 'authorization_code', code, scope: scopes.join(' '), redirect_uri: process.env.BASE_URL + '/api/integrations/office365calendar/callback', client_secret: process.env.MS_GRAPH_CLIENT_SECRET });
 
     const response = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', { method: 'POST', headers: {
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',


### PR DESCRIPTION
Used envirement `BASE_URL` instead of header's `x-forwarded-host` or `host`

Steps to reproduce
1. Host calendso on Heroku and setup environment variables
2. Try to add an office 365 account
3. redirection URL not used HTTPS, also not used original domain but used localhost
4. Microsoft return redirection error