### PR TITLE
type-safe `getSession()`

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,11 +1,11 @@
-import { hash, compare } from 'bcryptjs';
+import { hash, compare } from "bcryptjs";
 
-export async function hashPassword(password) {
-    const hashedPassword = await hash(password, 12);
-    return hashedPassword;
+export async function hashPassword(password: string) {
+  const hashedPassword = await hash(password, 12);
+  return hashedPassword;
 }
 
-export async function verifyPassword(password, hashedPassword) {
-    const isValid = await compare(password, hashedPassword);
-    return isValid;
+export async function verifyPassword(password: string, hashedPassword: string) {
+  const isValid = await compare(password, hashedPassword);
+  return isValid;
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,6 @@
-import { hash, compare } from "bcryptjs";
+import { compare, hash } from "bcryptjs";
+import { DefaultSession } from "next-auth";
+import { getSession as getSessionInner, GetSessionOptions } from "next-auth/client";
 
 export async function hashPassword(password: string) {
   const hashedPassword = await hash(password, 12);
@@ -8,4 +10,20 @@ export async function hashPassword(password: string) {
 export async function verifyPassword(password: string, hashedPassword: string) {
   const isValid = await compare(password, hashedPassword);
   return isValid;
+}
+
+type DefaultSessionUser = NonNullable<DefaultSession["user"]>;
+type CalendsoSessionUser = DefaultSessionUser & {
+  id: number;
+  username: string;
+};
+export interface CalendsoSession extends DefaultSession {
+  user?: CalendsoSessionUser;
+}
+
+export async function getSession(options: GetSessionOptions): Promise<CalendsoSession | null> {
+  const session = await getSessionInner(options);
+
+  // that these are equal are unsured in `[...nextauth]`'s callback
+  return session as CalendsoSession;
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -24,6 +24,6 @@ export interface CalendsoSession extends DefaultSession {
 export async function getSession(options: GetSessionOptions): Promise<CalendsoSession | null> {
   const session = await getSessionInner(options);
 
-  // that these are equal are unsured in `[...nextauth]`'s callback
+  // that these are equal are ensured in `[...nextauth]`'s callback
   return session as CalendsoSession;
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,7 +17,7 @@ type CalendsoSessionUser = DefaultSessionUser & {
   id: number;
   username: string;
 };
-export interface CalendsoSession extends DefaultSession {
+interface Session extends DefaultSession {
   user?: CalendsoSessionUser;
 }
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.6.1",
     "@types/nodemailer": "^6.4.4",

--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -1,59 +1,73 @@
-import NextAuth from 'next-auth';
-import Providers from 'next-auth/providers';
-import prisma from '../../../lib/prisma';
-import {verifyPassword} from "../../../lib/auth";
+import NextAuth from "next-auth";
+import Providers from "next-auth/providers";
+import prisma from "../../../lib/prisma";
+import { CalendsoSession, verifyPassword } from "../../../lib/auth";
 
 export default NextAuth({
-    session: {
-        jwt: true
+  session: {
+    jwt: true,
+  },
+  pages: {
+    signIn: "/auth/login",
+    signOut: "/auth/logout",
+    error: "/auth/error", // Error code passed in query string as ?error=
+  },
+  providers: [
+    Providers.Credentials({
+      name: "Calendso",
+      credentials: {
+        email: { label: "Email Address", type: "email", placeholder: "john.doe@example.com" },
+        password: { label: "Password", type: "password", placeholder: "Your super secure password" },
+      },
+      async authorize(credentials) {
+        const user = await prisma.user.findFirst({
+          where: {
+            email: credentials.email,
+          },
+        });
+
+        if (!user) {
+          throw new Error("No user found");
+        }
+        if (!user.password) {
+          throw new Error("Incorrect password");
+        }
+
+        const isValid = await verifyPassword(credentials.password, user.password);
+
+        if (!isValid) {
+          throw new Error("Incorrect password");
+        }
+
+        return {
+          id: user.id,
+          username: user.username,
+          email: user.email,
+          name: user.name,
+          image: user.avatar,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt(token, user) {
+      // Add username to the token right after signin
+      if (user?.username) {
+        token.id = user.id;
+        token.username = user.username;
+      }
+      return token;
     },
-    pages: {
-        signIn: '/auth/login',
-        signOut: '/auth/logout',
-        error: '/auth/error', // Error code passed in query string as ?error=
-    },
-    providers: [
-        Providers.Credentials({
-            name: 'Calendso',
-            credentials: {
-                email: { label: "Email Address", type: "email", placeholder: "john.doe@example.com" },
-                password: { label: "Password", type: "password", placeholder: "Your super secure password" }
-            },
-            async authorize(credentials) {
-                const user = await prisma.user.findFirst({
-                    where: {
-                        email: credentials.email
-                    }
-                });
-
-                if (!user) {
-                    throw new Error('No user found');
-                }
-
-                const isValid = await verifyPassword(credentials.password, user.password);
-
-                if (!isValid) {
-                    throw new Error('Incorrect password');
-                }
-
-                return {id: user.id, username: user.username, email: user.email, name: user.name, image: user.avatar};
-            }
-        })
-    ],
-    callbacks: {
-        async jwt(token, user, account, profile, isNewUser) {
-            // Add username to the token right after signin
-            if (user?.username) {
-                token.id = user.id;
-                token.username = user.username;
-            }
-            return token;
+    async session(session, token) {
+      const calendsoSession: CalendsoSession = {
+        ...session,
+        user: {
+          ...session.user,
+          id: token.id as number,
+          username: token.username as string,
         },
-        async session(session, token) {
-            session.user = session.user || {}
-            session.user.id = token.id;
-            session.user.username = token.username;
-            return session;
-        },
+      };
+      return calendsoSession;
     },
+  },
 });

--- a/pages/api/auth/changepw.ts
+++ b/pages/api/auth/changepw.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { hashPassword, verifyPassword } from '../../../lib/auth';
-import { getSession } from 'next-auth/client';
-import prisma from '../../../lib/prisma';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { hashPassword, verifyPassword } from "../../../lib/auth";
+import { getSession } from "@lib/auth";
+import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const session = await getSession({req: req});

--- a/pages/api/availability/calendar.ts
+++ b/pages/api/availability/calendar.ts
@@ -1,7 +1,7 @@
-import type {NextApiRequest, NextApiResponse} from 'next';
-import {getSession} from 'next-auth/client';
-import prisma from '../../../lib/prisma';
-import {IntegrationCalendar, listCalendars} from "../../../lib/calendarClient";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../lib/prisma";
+import { IntegrationCalendar, listCalendars } from "../../../lib/calendarClient";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const session = await getSession({req: req});

--- a/pages/api/availability/day.ts
+++ b/pages/api/availability/day.ts
@@ -1,6 +1,6 @@
-import type {NextApiRequest, NextApiResponse} from 'next';
-import {getSession} from 'next-auth/client';
-import prisma from '../../../lib/prisma';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const session = await getSession({req: req});

--- a/pages/api/integrations.ts
+++ b/pages/api/integrations.ts
@@ -1,5 +1,5 @@
-import prisma from '../../lib/prisma';
-import { getSession } from 'next-auth/client';
+import prisma from "../../lib/prisma";
+import { getSession } from "@lib/auth";
 
 export default async function handler(req, res) {
     if (req.method === 'GET') {

--- a/pages/api/integrations/googlecalendar/add.ts
+++ b/pages/api/integrations/googlecalendar/add.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { getSession } from 'next-auth/client';
-import prisma from '../../../../lib/prisma';
-const {google} = require('googleapis');
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../../lib/prisma";
+const { google } = require("googleapis");
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS;
 const scopes = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events'];

--- a/pages/api/integrations/googlecalendar/callback.ts
+++ b/pages/api/integrations/googlecalendar/callback.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { getSession } from 'next-auth/client';
-import prisma from '../../../../lib/prisma';
-const {google} = require('googleapis');
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../../lib/prisma";
+const { google } = require("googleapis");
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS;
 

--- a/pages/api/integrations/office365calendar/add.ts
+++ b/pages/api/integrations/office365calendar/add.ts
@@ -1,6 +1,6 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { getSession } from 'next-auth/client';
-import prisma from '../../../../lib/prisma';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../../lib/prisma";
 
 const scopes = ['User.Read', 'Calendars.Read', 'Calendars.ReadWrite', 'offline_access'];
 

--- a/pages/api/integrations/office365calendar/callback.ts
+++ b/pages/api/integrations/office365calendar/callback.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { getSession } from 'next-auth/client';
-import prisma from '../../../../lib/prisma';
-const scopes = ['offline_access', 'Calendars.Read', 'Calendars.ReadWrite'];
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../../lib/prisma";
+const scopes = ["offline_access", "Calendars.Read", "Calendars.ReadWrite"];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const { code } = req.query;

--- a/pages/api/integrations/zoomvideo/add.ts
+++ b/pages/api/integrations/zoomvideo/add.ts
@@ -1,6 +1,6 @@
-import type {NextApiRequest, NextApiResponse} from 'next';
-import {getSession} from 'next-auth/client';
-import prisma from '../../../../lib/prisma';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../../lib/prisma";
 
 const client_id = process.env.ZOOM_CLIENT_ID;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcryptjs@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
+  integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"


### PR DESCRIPTION
- As part of #473 I saw a lot of occurrences of an error using `getSession()`
- Seems like we're manually extending the jwt + session to include some more stuff
- Here I added a specific `CalendsoSession` that adheres to what is defined in `[...nextauth.ts]`


Possibly there's a nicer way to extend the session in the first place, but this fixes some of the typing issues.