### PR TITLE
Make the caldav queries run in parallel when querying availability

### DIFF
--- a/lib/integrations/CalDav/CalDavCalendarAdapter.ts
+++ b/lib/integrations/CalDav/CalDavCalendarAdapter.ts
@@ -203,15 +203,15 @@ export class CalDavCalendar implements CalendarApiAdapter {
         .map((e) => e.externalId);
 
       const events = [];
+      await Promise.all(
+        selectedCalendarIds.map(async (calId) => {
+          const calEvents = await this.getEvents(calId, dateFrom, dateTo);
 
-      for (const calId of selectedCalendarIds) {
-        const calEvents = await this.getEvents(calId, dateFrom, dateTo);
-
-        for (const ev of calEvents) {
-          events.push({ start: ev.startDate, end: ev.endDate });
-        }
-      }
-
+          for (const ev of calEvents) {
+            events.push({ start: ev.startDate, end: ev.endDate });
+          }
+        })
+      );
       return events;
     } catch (reason) {
       console.error(reason);

--- a/lib/integrations/CalDav/CalDavCalendarAdapter.ts
+++ b/lib/integrations/CalDav/CalDavCalendarAdapter.ts
@@ -198,6 +198,9 @@ export class CalDavCalendar implements CalendarApiAdapter {
     selectedCalendars: IntegrationCalendar[]
   ): Promise<EventBusyDate[]> {
     try {
+      if (selectedCalendars.length == 0) {
+        selectedCalendars = await this.listCalendars();
+      }
       const selectedCalendarIds = selectedCalendars
         .filter((e) => e.integration === this.integrationName)
         .map((e) => e.externalId);


### PR DESCRIPTION
Ref  #479 