### PR TITLE
Small fixes to darkmode on teams page & event type select

### DIFF
--- a/components/team/screens/Team.tsx
+++ b/components/team/screens/Team.tsx
@@ -16,10 +16,10 @@ const Team = ({ team }) => {
       "flex flex-col",
       "space-y-4",
       "p-4",
-      "bg-white dark:bg-opacity-8",
+      "bg-white dark:bg-neutral-900 dark:border-0 dark:bg-opacity-8",
       "border border-neutral-200",
       "hover:cursor-pointer",
-      "hover:border-black hover:border-2 dark:border-neutral-700 dark:hover:border-neutral-600",
+      "hover:border-black dark:border-neutral-700 dark:hover:border-neutral-600",
       "rounded-sm",
       "hover:shadow-md"
     );

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -115,7 +115,7 @@ export default function User(props): User {
             {eventTypes.length == 0 && (
               <div className="shadow overflow-hidden rounded-sm">
                 <div className="p-8 text-center text-gray-400 dark:text-white">
-                  <h2 className="font-semibold text-3xl text-gray-600">Uh oh!</h2>
+                  <h2 className="font-semibold text-3xl text-gray-600 dark:text-white">Uh oh!</h2>
                   <p className="max-w-md mx-auto">This user hasn&apos;t set up any event types yet.</p>
                 </div>
               </div>


### PR DESCRIPTION
Also removed `hover:border-2` as it was jumping (which it does not do on [user].tsx)