### PR TITLE
Changed button text on Select calendars modal

### DIFF
--- a/pages/integrations/index.tsx
+++ b/pages/integrations/index.tsx
@@ -193,7 +193,7 @@ export default function Home({ integrations }: Props) {
         </div>
         <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
           <DialogClose as="button" className="btn btn-white mx-2">
-            Cancel
+            Confirm
           </DialogClose>
         </div>
       </DialogContent>


### PR DESCRIPTION
Changed button text on "Select calendars" modal in App Store. See #530.
As I already explained there I think from a user standpoint it's much more clear when the button says "Confirm" instead of "Cancel". With "Cancel" being the button's text it could give the impression that the calendars the user selected will not be saved even though they are.

Before change
![image](https://user-images.githubusercontent.com/41294690/130981856-c3b583ae-fa28-4804-bc15-5198e161467e.png)

After change
![image](https://user-images.githubusercontent.com/41294690/131189106-b075f522-5464-44d3-bf6f-da67d3027fed.png)