### PR TITLE
[WIP] Allow user to select NONE or ONE calendar for  Event Type

### DIFF
--- a/pages/api/availability/eventtype.ts
+++ b/pages/api/availability/eventtype.ts
@@ -59,6 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       periodEndDate: req.body.periodEndDate,
       periodCountCalendarDays: req.body.periodCountCalendarDays,
       minimumBookingNotice: req.body.minimumBookingNotice,
+      selectedCalendar: req.body.calendar,
     };
 
     if (req.method == "POST") {

--- a/pages/api/availability/eventtypecalendar.ts
+++ b/pages/api/availability/eventtypecalendar.ts
@@ -1,0 +1,80 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSession } from "@lib/auth";
+import prisma from "../../../lib/prisma";
+import { IntegrationCalendar, listCalendars } from "../../../lib/calendarClient";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getSession({ req: req });
+
+  if (!session) {
+    res.status(401).json({ message: "Not authenticated" });
+    return;
+  }
+
+  const currentUser = await prisma.user.findFirst({
+    where: {
+      id: session.user.id,
+    },
+    select: {
+      credentials: {
+        select: {
+          id: true,
+          type: true,
+          key: true,
+          externalAccount: true,
+        },
+      },
+      timeZone: true,
+      id: true,
+    },
+  });
+
+  if (req.method == "POST") {
+    await prisma.eventTypeSelectedCalendar.create({
+      data: {
+        eventType: {
+          connect: {
+            id: req.body.eventTypeId,
+          },
+        },
+        integration: req.body.integration,
+        externalId: req.body.externalId,
+      },
+    });
+    res.status(200).json({ message: "Calendar Selection Saved" });
+  }
+
+  if (req.method == "DELETE") {
+    await prisma.eventTypeSelectedCalendar.delete({
+      where: {
+        eventTypeId_integration_externalId: {
+          eventTypeId: req.body.eventTypeId,
+          externalId: req.body.externalId,
+          integration: req.body.integration,
+        },
+      },
+    });
+
+    res.status(200).json({ message: "Calendar Selection Saved" });
+  }
+
+  if (req.method == "GET") {
+    const eventTypeSelectedCalendarIds = await prisma.eventTypeSelectedCalendar.findMany({
+      where: {
+        eventTypeId: parseInt(req.query.eventTypeId as string),
+      },
+      select: {
+        externalId: true,
+      },
+    });
+
+    const calendars: IntegrationCalendar[] = await listCalendars(currentUser.credentials);
+    const eventTypeSelectableCalendars = calendars.map((cal) => {
+      return {
+        selected: eventTypeSelectedCalendarIds.findIndex((s) => s.externalId === cal.externalId) > -1,
+        ...cal,
+      };
+    });
+    res.status(200).json(eventTypeSelectableCalendars);
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,15 @@ model EventType {
   periodCountCalendarDays Boolean?
   requiresConfirmation Boolean @default(false)
   minimumBookingNotice Int @default(120)
+  selectedCalendar      EventTypeSelectedCalendar?
+}
+
+model EventTypeSelectedCalendar {
+  id            Int     @default(autoincrement()) @id
+  eventType     EventType   @relation(fields: [eventTypeId], references: [id])
+  eventTypeId   Int
+  integration   String
+  externalId    String
 }
 
 model Credential {


### PR DESCRIPTION
Allows separating meeting types in different calendars, ex: work, personal, sport.

See screenshot:
<img width="546" alt="calendso-select-calendar-for-eventtype" src="https://user-images.githubusercontent.com/1281163/131592229-a9e7e936-d8da-44c0-b56e-7f2daffc9dd7.png">
