### PR TITLE
mv `ONBOARDING_INTRODUCED_AT` to new file

### DIFF
--- a/lib/getting-started.tsx
+++ b/lib/getting-started.tsx
@@ -1,0 +1,3 @@
+import dayjs from "dayjs";
+
+export const ONBOARDING_INTRODUCED_AT = dayjs("September 1 2021").toISOString();

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -24,7 +24,7 @@ import prisma from "@lib/prisma";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import { useMutation } from "react-query";
 import createEventType from "@lib/mutations/event-types/create-event-type";
-import { ONBOARDING_INTRODUCED_AT } from "../getting_started/index";
+import { ONBOARDING_INTRODUCED_AT } from "@lib/getting-started";
 
 const EventTypesPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { user, types } = props;

--- a/pages/getting_started/index.tsx
+++ b/pages/getting_started/index.tsx
@@ -50,8 +50,6 @@ const DEFAULT_EVENT_TYPES = [
   },
 ];
 
-export const ONBOARDING_INTRODUCED_AT = dayjs("September 1 2021").toISOString();
-
 type OnboardingProps = {
   user: User;
   integrations?: Record<string, string>[];


### PR DESCRIPTION
otherwise will the `/event-types`-route probably unnecessarily import the whole `getting_started`-page