### PR TITLE
ensure callbackUrl exists when submitting login form

### DIFF
--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,8 +1,16 @@
 import { HeadSeo } from "@components/seo/head-seo";
 import Link from "next/link";
 import { getCsrfToken, getSession } from "next-auth/client";
-
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 export default function Login({ csrfToken }) {
+  const router = useRouter();
+  useEffect(() => {
+    if (!router.query?.callbackUrl) {
+      window.history.replaceState(null, document.title, "?callbackUrl=/");
+    }
+  }, [router.query]);
+
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <HeadSeo title="Login" description="Login" />


### PR DESCRIPTION
Hickity hack hack very dumb-ish.

So when submitting the login form, a callbackUrl needs to be present.
I say this is dumb because using replaceState without consider other possible query parameters present in the url.
So if say, has a ?ref=<something> the ref will be ignore. 

Using the [signIn](https://next-auth.js.org/getting-started/client#signin) method provided by NextAuth requires a re-architecture of the login to use an onSubmit method, state variables, and handling error states. 