### PR TITLE
Fix the text of the requiresConfirmation option

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -672,7 +672,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                               <div className="ml-3 text-sm">
                                 <p className="text-neutral-900">
                                   The booking needs to be manually confirmed before it is pushed to the
-                                  integrations and a integrations and a confirmation mail is sent.
+                                  integrations and a confirmation mail is sent.
                                 </p>
                               </div>
                             </div>


### PR DESCRIPTION
There was a grammatical error, probably an accidental remnant from a previous edit.