### PR TITLE
Prepares the email system for Calendso Teams

### DIFF
--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -1,5 +1,4 @@
 import EventOrganizerMail from "./emails/EventOrganizerMail";
-import EventAttendeeMail from "./emails/EventAttendeeMail";
 import EventOrganizerRescheduledMail from "./emails/EventOrganizerRescheduledMail";
 import EventAttendeeRescheduledMail from "./emails/EventAttendeeRescheduledMail";
 import prisma from "./prisma";
@@ -120,6 +119,10 @@ export interface CalendarEvent {
   startTime: string;
   endTime: string;
   description?: string;
+  team?: {
+    name: string;
+    members: string[];
+  };
   location?: string;
   organizer: Person;
   attendees: Person[];
@@ -574,24 +577,10 @@ const createEvent = async (
       entryPoints: maybeEntryPoints,
     });
 
-    const attendeeMail = new EventAttendeeMail(calEvent, uid, {
-      hangoutLink: maybeHangoutLink,
-      conferenceData: maybeConferenceData,
-      entryPoints: maybeEntryPoints,
-    });
-
     try {
       await organizerMail.sendEmail();
     } catch (e) {
       console.error("organizerMail.sendEmail failed", e);
-    }
-
-    if (!creationResult || !creationResult.disableConfirmationEmail) {
-      try {
-        await attendeeMail.sendEmail();
-      } catch (e) {
-        console.error("attendeeMail.sendEmail failed", e);
-      }
     }
   }
 

--- a/lib/emails/EventAttendeeMail.ts
+++ b/lib/emails/EventAttendeeMail.ts
@@ -65,7 +65,13 @@ export default class EventAttendeeMail extends EventMail {
       </tr>
       <tr>
         <td>Who</td>
-        <td>${this.calEvent.organizer.name}<br /><small>${this.calEvent.organizer.email}</small></td>
+        <td>
+          ${this.calEvent.team?.name || this.calEvent.organizer.name}<br />
+          <small>
+            ${this.calEvent.organizer.email && !this.calEvent.team ? this.calEvent.organizer.email : ""}
+            ${this.calEvent.team ? this.calEvent.team.members.join(", ") : ""}
+          </small>
+        </td>
       </tr>
       <tr>
         <td>Where</td>
@@ -122,6 +128,10 @@ export default class EventAttendeeMail extends EventMail {
     return ``;
   }
 
+  protected getAdditionalFooter(): string {
+    return this.parser.getChangeEventFooterHtml();
+  }
+
   /**
    * Returns the payload object for the nodemailer.
    *
@@ -133,7 +143,7 @@ export default class EventAttendeeMail extends EventMail {
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
       replyTo: this.calEvent.organizer.email,
       subject: `Confirmed: ${this.calEvent.type} with ${
-        this.calEvent.organizer.name
+        this.calEvent.team?.name || this.calEvent.organizer.name
       } on ${this.getInviteeStart().format("LT dddd, LL")}`,
       html: this.getHtmlRepresentation(),
       text: this.getPlainTextRepresentation(),

--- a/lib/emails/EventAttendeeRescheduledMail.ts
+++ b/lib/emails/EventAttendeeRescheduledMail.ts
@@ -13,8 +13,8 @@ export default class EventAttendeeRescheduledMail extends EventAttendeeMail {
       Hi ${this.calEvent.attendees[0].name},<br />
       <br />
       Your ${this.calEvent.type} with ${
-        this.calEvent.organizer.name
-      } has been rescheduled to ${this.getInviteeStart().format("h:mma")} 
+        this.calEvent.team?.name || this.calEvent.organizer.name
+      } has been rescheduled to ${this.getInviteeStart().format("h:mma")}
       (${this.calEvent.attendees[0].timeZone}) on ${this.getInviteeStart().format("dddd, LL")}.<br />
       ` +
       this.getAdditionalFooter() +

--- a/lib/emails/EventMail.ts
+++ b/lib/emails/EventMail.ts
@@ -69,7 +69,7 @@ export default abstract class EventMail {
   /**
    * Sends the email to the event attendant and returns a Promise.
    */
-  public sendEmail(): Promise<any> {
+  public sendEmail() {
     new Promise((resolve, reject) =>
       nodemailer
         .createTransport(this.getMailerOptions().transport)
@@ -90,7 +90,7 @@ export default abstract class EventMail {
    *
    * @protected
    */
-  protected getMailerOptions(): any {
+  protected getMailerOptions() {
     return {
       transport: serverConfig.transport,
       from: serverConfig.from,
@@ -134,13 +134,5 @@ export default abstract class EventMail {
    */
   protected getCancelLink(): string {
     return this.parser.getCancelLink();
-  }
-
-  /**
-   * Defines a footer that will be appended to the email.
-   * @protected
-   */
-  protected getAdditionalFooter(): string {
-    return this.parser.getChangeEventFooterHtml();
   }
 }

--- a/lib/emails/EventOrganizerMail.ts
+++ b/lib/emails/EventOrganizerMail.ts
@@ -50,8 +50,10 @@ export default class EventOrganizerMail extends EventMail {
     return "A new event has been scheduled.";
   }
 
-  protected getBodyText(): string {
-    return "You and any other attendees have been emailed with this information.";
+  protected getAdditionalFooter(): string {
+    return `<p style="color: #4b5563; margin-top: 20px;">Need to make a change? <a href=${
+      process.env.BASE_URL + "/bookings"
+    } style="color: #161e2e;">Manage my bookings</a></p>`;
   }
 
   protected getImage(): string {
@@ -94,7 +96,6 @@ export default class EventOrganizerMail extends EventMail {
   >
     ${this.getImage()}
     <h1 style="font-weight: 500; color: #161e2e;">${this.getBodyHeader()}</h1>
-    <p style="color: #4b5563; margin-bottom: 30px;">${this.getBodyText()}</p>
     <hr />
     <table style="border-spacing: 20px; color: #161e2e; margin-bottom: 10px;">
       <colgroup>


### PR DESCRIPTION
"Manage my bookings" forces the user to authenticate in order to cancel or reschedule a booking. For all intends and purposes a booking UID should be considered a secret; This change allows for a more credible audit trail of whom scheduled or cancelled a meeting - currently there is no way of knowing if an event has been scheduled by the invitee or by the organizer. With Collective teams due, this problem would be multiplied. The UID is to be known by the invitee _only_. See below how this is fixed:

![image](https://user-images.githubusercontent.com/1046695/132142246-2b9b1340-b7d8-4507-8d1b-9ee54c7346f1.png)

Through this PR, collective team emails are supported; like below:

![image](https://user-images.githubusercontent.com/1046695/132142412-314ceb57-430f-47a4-b19f-8debd977648c.png)

Moved attendee email out of the calendarClient into the EventManager. This ensures the email is always sent unless a specific integration disables a confirmation email. As a result of this I was able to rip out the legacyEmailer out of the booking page. It's not the greatest implementation yet but it will get us talking about future improvements, mainly the introduction of a native createEvent adapter.

Fully backwards compatible, so good to go as is.