### PR TITLE
CAL-295 added BASE_URL in nextjs config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,4 +58,7 @@ module.exports = withTM({
       },
     ];
   },
+  publicRuntimeConfig: {
+    BASE_URL: process.env.BASE_URL || "http://localhost:3000",
+  },
 });


### PR DESCRIPTION
* Adds `BASE_URL` to `publicRuntimeConfig` inside next.config.js 