### PR TITLE
Draft: re-enabled Zoom availability check, fixed signature of getAvailability

### DIFF
--- a/lib/videoClient.ts
+++ b/lib/videoClient.ts
@@ -89,7 +89,7 @@ interface VideoApiAdapter {
 
   deleteMeeting(uid: string): Promise<unknown>;
 
-  getAvailability(dateFrom, dateTo): Promise<any>;
+  getAvailability(): Promise<any>;
 }
 
 const ZoomVideo = (credential): VideoApiAdapter => {

--- a/pages/api/availability/[user].ts
+++ b/pages/api/availability/[user].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@lib/prisma";
 import { getBusyCalendarTimes } from "@lib/calendarClient";
-// import { getBusyVideoTimes } from "@lib/videoClient";
+import { getBusyVideoTimes } from "@lib/videoClient";
 import dayjs from "dayjs";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -31,12 +31,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     req.query.dateTo,
     selectedCalendars
   );
-  // const videoBusyTimes = await getBusyVideoTimes(
-  //   currentUser.credentials,
-  //   req.query.dateFrom,
-  //   req.query.dateTo
-  // );
-  // calendarBusyTimes.push(...videoBusyTimes);
+  const videoBusyTimes = await getBusyVideoTimes(
+    currentUser.credentials,
+    req.query.dateFrom,
+    req.query.dateTo
+  );
+  calendarBusyTimes.push(...videoBusyTimes);
 
   const bufferedBusyTimes = calendarBusyTimes.map((a) => ({
     start: dayjs(a.start).subtract(currentUser.bufferTime, "minute").toString(),


### PR DESCRIPTION
Recently, some people were encountering errors when querying a user's availability when the only integration added was Zoom.

The following error was thrown in the backend:
```
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at /var/task/.next/server/chunks/3798.js:225:92
    at Array.map (<anonymous>)
    at /var/task/.next/server/chunks/3798.js:223:38
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Promise.all (index 0)
    at async handler (/var/task/.next/server/pages/api/availability/[user].js:45:26)
    at async apiResolver (/var/task/node_modules/next/dist/next-server/server/api-utils.js:8:1)
    at async Server.handleApiRequest (/var/task/node_modules/next/dist/next-server/server/next-server.js:66:462)
2021-08-24T21:23:25.412Z	a0490d74-9f92-4216-bd6d-c9918d8789cb	ERROR	TypeError: Cannot read property 'start' of undefined
    at /var/task/.next/server/pages/api/availability/[user].js:48:59
    at Array.map (<anonymous>)
    at handler (/var/task/.next/server/pages/api/availability/[user].js:47:47)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async apiResolver (/var/task/node_modules/next/dist/next-server/server/api-utils.js:8:1)
    at async Server.handleApiRequest (/var/task/node_modules/next/dist/next-server/server/next-server.js:66:462)
    at async Object.fn (/var/task/node_modules/next/dist/next-server/server/next-server.js:58:580)
    at async Router.execute (/var/task/node_modules/next/dist/next-server/server/router.js:25:67)
    at async Server.run (/var/task/node_modules/next/dist/next-server/server/next-server.js:68:1042)
```

I wasn't able to reproduce this error yet, but I found a faulty function signature in `videoClient.ts`. In this file, `getAvailability` doesn't take arguments because the Zoom API doesn't offer date filtering of the user's events. So these arguments have been removed.

Please take this PR as a draft yet; it should be tested thoroughly and we should make sure the Zoom error is really gone before merging this PR and thus re-enabling the Zoom availability check.