### PR TITLE
changed api docs link

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -16,7 +16,7 @@ const links = [
     title: "API Reference",
     description: "A complete API reference for our libraries",
     icon: CodeIcon,
-    href: "https://api.docs.calendso.com",
+    href: "https://developer.calendso.com/api",
   },
   {
     title: "Blog",

--- a/pages/settings/embed.tsx
+++ b/pages/settings/embed.tsx
@@ -69,7 +69,7 @@ export default function Embed(props) {
               Leverage our API for full control and customizability.
             </p>
           </div>
-          <a href="https://api.docs.calendso.com" className="btn btn-primary">
+          <a href="https://developer.calendso.com/api" className="btn btn-primary">
             Browse our API documentation
           </a>
         </div>


### PR DESCRIPTION
our new api docs is now on swagger, available on: https://developer.calendso.com/api