### PR TITLE
copy of #561 ensure callbackUrl exists when submitting login form

### DIFF
--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -2,8 +2,16 @@ import { HeadSeo } from "@components/seo/head-seo";
 import Link from "next/link";
 import { getCsrfToken } from "next-auth/client";
 import { getSession } from "@lib/auth";
-
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 export default function Login({ csrfToken }) {
+  const router = useRouter();
+  useEffect(() => {
+    if (!router.query?.callbackUrl) {
+      window.history.replaceState(null, document.title, "?callbackUrl=/");
+    }
+  }, [router.query]);
+
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <HeadSeo title="Login" description="Login" />


### PR DESCRIPTION
as requested by @KATT i moved it into our branch https://github.com/calendso/calendso/pull/561#pullrequestreview-745483031

OG PR by @femyeda:

> Hickity hack hack very dumb-ish.
> 
> So when submitting the login form, a callbackUrl needs to be present.
> I say this is dumb because using replaceState without consider other possible query parameters present in the url.
> So if say, has a ?ref= the ref will be ignore.
> 
> Using the signIn method provided by NextAuth requires a re-architecture of the login to use an onSubmit method, state variables, and handling error states.