### PR TITLE
Change event types pages to use the slug instead

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -1062,15 +1062,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   const eventType = await prisma.eventType.findFirst({
     where: {
-      userId: user.id,
-      OR: [
-        {
-          slug: typeParam,
-        },
-        {
-          id: parseInt(typeParam),
-        },
-      ],
+      AND: [{ userId: user.id }, { slug: typeParam }],
     },
     select: {
       id: true,
@@ -1090,7 +1082,6 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       periodEndDate: true,
       periodCountCalendarDays: true,
       requiresConfirmation: true,
-      userId: true,
     },
   });
 
@@ -1098,12 +1089,6 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     return {
       notFound: true,
     };
-  }
-
-  if (eventType.userId != session.user.id) {
-    return {
-      notFound: true,
-    } as const;
   }
 
   const credentials = await prisma.credential.findMany({

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -223,7 +223,7 @@ const EventTypesPage = (props: inferSSRProps<typeof getServerSideProps>) => {
                   className={classNames("hover:bg-neutral-50", item.$disabled && "pointer-events-none")}
                   tabIndex={item.$disabled ? -1 : undefined}>
                   <div className={"flex items-center px-4 py-4 sm:px-6"}>
-                    <Link href={"/event-types/" + item.id}>
+                    <Link href={"/event-types/" + item.slug}>
                       <a className="flex-1 min-w-0 sm:flex sm:items-center sm:justify-between hover:bg-neutral-50">
                         <span className="truncate">
                           <div className="flex text-sm">


### PR DESCRIPTION
Now, the event types page links to `event-types/slug` instead of `event-types/id`, and when you're on the individual event type page, it uses the following Prisma query:
```
where: {
      AND: [{ userId: user.id }, { slug: typeParam }],
},
```