### PR TITLE
fixed Dialog action buttons

### DIFF
--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -33,11 +33,11 @@ export default function ConfirmationDialogContent(props: PropsWithChildren<Confi
         </div>
       </div>
       <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse gap-x-2">
-        <DialogClose as={Button} color="primary" onClick={onConfirm}>
-          {confirmBtnText}
+        <DialogClose onClick={onConfirm}>
+          <Button color="primary">{confirmBtnText}</Button>
         </DialogClose>
-        <DialogClose as={Button} color="secondary">
-          {cancelBtnText}
+        <DialogClose>
+          <Button color="secondary">{cancelBtnText}</Button>
         </DialogClose>
       </div>
     </DialogContent>

--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -33,10 +33,10 @@ export default function ConfirmationDialogContent(props: PropsWithChildren<Confi
         </div>
       </div>
       <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse gap-x-2">
-        <DialogClose onClick={onConfirm}>
+        <DialogClose onClick={onConfirm} asChild>
           <Button color="primary">{confirmBtnText}</Button>
         </DialogClose>
-        <DialogClose>
+        <DialogClose asChild>
           <Button color="secondary">{cancelBtnText}</Button>
         </DialogClose>
       </div>


### PR DESCRIPTION
seems like a Radix update may have broken action buttons in Dialogs:
![image](https://user-images.githubusercontent.com/8019099/133071924-8797b394-3ee2-4842-9205-bab49383b1ec.png)

looks like `as={Button}` is not working.

fixed by adding `<Button />` as children:

![image](https://user-images.githubusercontent.com/8019099/133071953-372cc762-d7ac-4554-8a76-053379b8b873.png)
