### PR TITLE
added readme and license for /ee folder

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,42 @@
+The Calendso Enterprise Edition (EE) license (the “EE License”)
+Copyright (c) 2020-present Calendso, Inc
+
+With regard to the Calendso Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Calendso Subscription Terms available
+at https://calendso.com/terms (the “EE Terms”), or other agreements governing
+the use of the Software, as mutually agreed by you and Meet Technologies, Inc ("Calendso"),
+and otherwise have a valid Calendso Enterprise Edition subscription ("EE Subscription")
+for the correct number of hosts as defined in the EE Terms ("Hosts"). Subject to the foregoing sentence,
+you are free to modify this Software and publish patches to the Software. You agree
+that Calendso and/or its licensors (as applicable) retain all right, title and interest in
+and to all such modifications and/or patches, and all such modifications and/or
+patches may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid EE Subscription for the correct number of hosts.
+Notwithstanding the foregoing, you may copy and modify the Software for development
+and testing purposes, without requiring a subscription. You agree that Calendso and/or
+its licensors (as applicable) retain all right, title and interest in and to all such
+modifications. You are not granted any other rights beyond what is expressly stated herein.
+Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense,
+and/or sell the Software.
+
+This EE License applies only to the part of this Software that is not distributed under
+the MIT license. Any part of this Software distributed under the MIT license or which
+is served client-side as an image, font, cascading stylesheet (CSS), file which produces
+or is compiled, arranged, augmented, or combined into client-side JavaScript, in whole or
+in part, is copyrighted under the MIT license. The full text of this EE License shall
+be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the Calendso Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,5 +1,5 @@
 The Calendso Enterprise Edition (EE) license (the “EE License”)
-Copyright (c) 2020-present Calendso, Inc
+Copyright (c) 2020-present Meet Technologies, Inc
 
 With regard to the Calendso Software:
 

--- a/ee/README.md
+++ b/ee/README.md
@@ -1,0 +1,15 @@
+<!-- PROJECT LOGO -->
+<div align="right">
+  <a href="https://github.com/calendso/calendso">
+    <img src="https://calendso.com/calendso-logo.svg" alt="Logo" width="160" height="65">
+  </a><br/>
+  <a href="https://calendso.com">Website</a>
+</div>
+
+# Enterprise Edition
+
+Welcome to the Enterprise Edition ("/ee") of Calendso.com.
+
+The [/ee](https://github.com/calendso/calendso/tree/main/ee) subfolder is the place for all the **Pro** features from our [hosted](https://calendso.com/pricing) plan and [enterprise-grade](https://calendso.com/enterprise) features such as SSO, SAML, ADFS, OIDC, SCIM, SIEM, HRIS and much more.
+
+> _❗ WARNING: This repository is copyrighted (unlike our [main repo](https://github.com/calendso/calendso)). You are not allowed to use this code to host your own version of app.calendso.com without obtaining a proper [license](https://calendso.com/enterprise) first❗_


### PR DESCRIPTION
initial commit of open-sourcing our pro features and enterprise edition.

previously the source of our pro & ee features were in a private fork, however we've decided to move them into the open-source monorepo.