### PR TITLE
use untransformed selectedDate as timezone already applied

### DIFF
--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -49,7 +49,7 @@ export default function Type(props: inferSSRProps<typeof getServerSideProps>) {
       return;
     }
 
-    const formattedDate = selectedDate.utc().format("YYYY-MM-DD");
+    const formattedDate = selectedDate.format("YYYY-MM-DD");
 
     router.replace(
       {


### PR DESCRIPTION
Converting to UTC causes incorrect date when time is "tomorrow" in user's selected timezone.