### PR TITLE
Suggestion: let prettier sort imports order

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,4 +7,6 @@ module.exports = {
   semi: true,
   printWidth: 110,
   arrowParens: "always",
+  importOrder: ["^@ee/(.*)$", "^@lib/(.*)$", "^@components/(.*)$", "^[./]"],
+  importOrderSeparation: true,
 };

--- a/components/ActiveLink.tsx
+++ b/components/ActiveLink.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from "next/router";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import React, { Children } from "react";
 
 const ActiveLink = ({ children, activeClassName, ...props }) => {

--- a/components/Dialog.tsx
+++ b/components/Dialog.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import React from "react";
 
 type DialogProps = React.ComponentProps<typeof DialogPrimitive["Root"]>;
 export function Dialog(props: DialogProps) {

--- a/components/DonateBanner.tsx
+++ b/components/DonateBanner.tsx
@@ -1,4 +1,5 @@
 import { GiftIcon } from "@heroicons/react/outline";
+
 export default function DonateBanner() {
   if (location.hostname.endsWith(".cal.com")) {
     return null;

--- a/components/EmptyScreen.tsx
+++ b/components/EmptyScreen.tsx
@@ -1,5 +1,6 @@
-import { SVGComponent } from "@lib/types/SVGComponent";
 import React from "react";
+
+import { SVGComponent } from "@lib/types/SVGComponent";
 
 export default function EmptyScreen({
   Icon,

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -1,5 +1,6 @@
-import Cropper from "react-easy-crop";
 import { useCallback, useRef, useState } from "react";
+import Cropper from "react-easy-crop";
+
 import Slider from "./Slider";
 
 export default function ImageUploader({ target, id, buttonMsg, handleAvatarChange, imageRef }) {

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,7 +1,8 @@
 /* legacy and soon deprecated, please refactor to use <Dialog> only */
-import { Fragment, ReactNode } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { CheckIcon, InformationCircleIcon } from "@heroicons/react/outline";
+import { Fragment, ReactNode } from "react";
+
 import classNames from "@lib/classNames";
 
 export default function Modal(props: {

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,6 +1,7 @@
-import Link from "next/link";
 import { CodeIcon, CreditCardIcon, KeyIcon, UserGroupIcon, UserIcon } from "@heroicons/react/solid";
+import Link from "next/link";
 import { useRouter } from "next/router";
+
 import classNames from "@lib/classNames";
 
 export default function SettingsShell(props) {

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -1,10 +1,5 @@
-import Link from "next/link";
-import React, { Fragment, useEffect, useState } from "react";
-import { useRouter } from "next/router";
-import { signOut, useSession } from "next-auth/client";
 // TODO: replace headlessui with radix-ui
 import { Menu, Transition } from "@headlessui/react";
-import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
 import { SelectorIcon } from "@heroicons/react/outline";
 import {
   CalendarIcon,
@@ -15,12 +10,20 @@ import {
   LogoutIcon,
   PuzzleIcon,
 } from "@heroicons/react/solid";
-import Logo from "./Logo";
-import classNames from "@lib/classNames";
-import { Toaster } from "react-hot-toast";
-import Avatar from "@components/ui/Avatar";
 import { User } from "@prisma/client";
+import { signOut, useSession } from "next-auth/client";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import React, { Fragment, useEffect, useState } from "react";
+import { Toaster } from "react-hot-toast";
+
+import classNames from "@lib/classNames";
+import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
+
 import { HeadSeo } from "@components/seo/head-seo";
+import Avatar from "@components/ui/Avatar";
+
+import Logo from "./Logo";
 
 export default function Shell(props) {
   const router = useRouter();

--- a/components/Slider.tsx
+++ b/components/Slider.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
+import React from "react";
 
 const Slider = ({ value, min, max, step, label, changeHandler }) => (
   <SliderPrimitive.Root

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import React from "react";
 
 export function Tooltip({
   children,

--- a/components/booking/AvailableTimes.tsx
+++ b/components/booking/AvailableTimes.tsx
@@ -1,10 +1,12 @@
+import { ExclamationIcon } from "@heroicons/react/solid";
+import { SchedulingType } from "@prisma/client";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useSlots } from "@lib/hooks/useSlots";
-import { ExclamationIcon } from "@heroicons/react/solid";
 import React from "react";
+
+import { useSlots } from "@lib/hooks/useSlots";
+
 import Loader from "@components/Loader";
-import { SchedulingType } from "@prisma/client";
 
 const AvailableTimes = ({
   date,

--- a/components/booking/DatePicker.tsx
+++ b/components/booking/DatePicker.tsx
@@ -1,11 +1,12 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/solid";
-import { useEffect, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import getSlots from "@lib/slots";
 import dayjsBusinessDays from "dayjs-business-days";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { useEffect, useState } from "react";
+
 import classNames from "@lib/classNames";
+import getSlots from "@lib/slots";
 
 dayjs.extend(dayjsBusinessDays);
 dayjs.extend(utc);

--- a/components/booking/TimeOptions.tsx
+++ b/components/booking/TimeOptions.tsx
@@ -1,9 +1,11 @@
 // TODO: replace headlessui with radix-ui
 import { Switch } from "@headlessui/react";
-import TimezoneSelect from "react-timezone-select";
 import { useEffect, useState } from "react";
-import { is24h, timeZone } from "../../lib/clock";
+import TimezoneSelect from "react-timezone-select";
+
 import classNames from "@lib/classNames";
+
+import { is24h, timeZone } from "../../lib/clock";
 
 const TimeOptions = (props) => {
   const [selectedTimeZone, setSelectedTimeZone] = useState("");

--- a/components/booking/pages/AvailabilityPage.tsx
+++ b/components/booking/pages/AvailabilityPage.tsx
@@ -1,24 +1,26 @@
 // Get router variables
-import { useRouter } from "next/router";
-import { useEffect, useState, useMemo } from "react";
+import { ChevronDownIcon, ChevronUpIcon, ClockIcon, CreditCardIcon, GlobeIcon } from "@heroicons/react/solid";
 import { EventType } from "@prisma/client";
+import * as Collapsible from "@radix-ui/react-collapsible";
 import dayjs, { Dayjs } from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import utc from "dayjs/plugin/utc";
-import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
-import { ChevronDownIcon, ChevronUpIcon, ClockIcon, CreditCardIcon, GlobeIcon } from "@heroicons/react/solid";
-import DatePicker from "@components/booking/DatePicker";
-import { isBrandingHidden } from "@lib/isBrandingHidden";
-import PoweredByCalendso from "@components/ui/PoweredByCalendso";
-import { timeZone } from "@lib/clock";
-import AvailableTimes from "@components/booking/AvailableTimes";
-import TimeOptions from "@components/booking/TimeOptions";
-import * as Collapsible from "@radix-ui/react-collapsible";
-import { HeadSeo } from "@components/seo/head-seo";
-import { asStringOrNull } from "@lib/asStringOrNull";
-import useTheme from "@lib/hooks/useTheme";
-import AvatarGroup from "@components/ui/AvatarGroup";
+import { useRouter } from "next/router";
+import { useEffect, useState, useMemo } from "react";
 import { FormattedNumber, IntlProvider } from "react-intl";
+
+import { asStringOrNull } from "@lib/asStringOrNull";
+import { timeZone } from "@lib/clock";
+import useTheme from "@lib/hooks/useTheme";
+import { isBrandingHidden } from "@lib/isBrandingHidden";
+import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
+
+import AvailableTimes from "@components/booking/AvailableTimes";
+import DatePicker from "@components/booking/DatePicker";
+import TimeOptions from "@components/booking/TimeOptions";
+import { HeadSeo } from "@components/seo/head-seo";
+import AvatarGroup from "@components/ui/AvatarGroup";
+import PoweredByCalendso from "@components/ui/PoweredByCalendso";
 
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);

--- a/components/booking/pages/BookingPage.tsx
+++ b/components/booking/pages/BookingPage.tsx
@@ -1,5 +1,3 @@
-import Head from "next/head";
-import { useRouter } from "next/router";
 import {
   CalendarIcon,
   ClockIcon,
@@ -8,26 +6,32 @@ import {
   LocationMarkerIcon,
 } from "@heroicons/react/solid";
 import { EventTypeCustomInputType } from "@prisma/client";
-import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
-import { useCallback, useEffect, useState } from "react";
 import dayjs from "dayjs";
-import "react-phone-number-input/style.css";
-import PhoneInput from "react-phone-number-input";
-import { LocationType } from "@lib/location";
-import { Button } from "@components/ui/Button";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { stringify } from "querystring";
+import { useCallback, useEffect, useState } from "react";
+import { FormattedNumber, IntlProvider } from "react-intl";
 import { ReactMultiEmail } from "react-multi-email";
+import PhoneInput from "react-phone-number-input";
+import "react-phone-number-input/style.css";
+
+import { createPaymentLink } from "@ee/lib/stripe/client";
+
 import { asStringOrNull } from "@lib/asStringOrNull";
 import { timeZone } from "@lib/clock";
 import useTheme from "@lib/hooks/useTheme";
-import AvatarGroup from "@components/ui/AvatarGroup";
+import { LocationType } from "@lib/location";
+import createBooking from "@lib/mutations/bookings/create-booking";
 import { parseZone } from "@lib/parseZone";
-import { createPaymentLink } from "@ee/lib/stripe/client";
-import { FormattedNumber, IntlProvider } from "react-intl";
+import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
+import { BookingCreateBody } from "@lib/types/booking";
+
+import AvatarGroup from "@components/ui/AvatarGroup";
+import { Button } from "@components/ui/Button";
+
 import { BookPageProps } from "../../../pages/[user]/book";
 import { TeamBookingPageProps } from "../../../pages/team/[slug]/book";
-import { stringify } from "querystring";
-import createBooking from "@lib/mutations/bookings/create-booking";
-import { BookingCreateBody } from "@lib/types/booking";
 
 type BookingPageProps = BookPageProps | TeamBookingPageProps;
 

--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -1,7 +1,8 @@
-import { DialogClose, DialogContent } from "@components/Dialog";
-import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { ExclamationIcon } from "@heroicons/react/outline";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import React, { PropsWithChildren } from "react";
+
+import { DialogClose, DialogContent } from "@components/Dialog";
 import { Button } from "@components/ui/Button";
 
 export type ConfirmationDialogContentProps = {

--- a/components/error/error-page.tsx
+++ b/components/error/error-page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { HttpError } from "@lib/core/http/error";
 
 type Props = {

--- a/components/eventtype/EventTypeDescription.tsx
+++ b/components/eventtype/EventTypeDescription.tsx
@@ -1,4 +1,3 @@
-import { SchedulingType } from "@prisma/client";
 import {
   ClockIcon,
   CreditCardIcon,
@@ -6,10 +5,12 @@ import {
   UserIcon,
   UsersIcon,
 } from "@heroicons/react/solid";
-import React from "react";
+import { SchedulingType } from "@prisma/client";
 import { Prisma } from "@prisma/client";
-import classNames from "@lib/classNames";
+import React from "react";
 import { FormattedNumber, IntlProvider } from "react-intl";
+
+import classNames from "@lib/classNames";
 
 const eventTypeData = Prisma.validator<Prisma.EventTypeArgs>()({
   select: {

--- a/components/security/ChangePasswordSection.tsx
+++ b/components/security/ChangePasswordSection.tsx
@@ -1,6 +1,8 @@
 import React, { SyntheticEvent, useState } from "react";
-import Modal from "@components/Modal";
+
 import { ErrorCode } from "@lib/auth";
+
+import Modal from "@components/Modal";
 
 const errorMessages: { [key: string]: string } = {
   [ErrorCode.IncorrectPassword]: "Current password is incorrect",

--- a/components/security/DisableTwoFactorModal.tsx
+++ b/components/security/DisableTwoFactorModal.tsx
@@ -1,7 +1,10 @@
 import { SyntheticEvent, useState } from "react";
-import Button from "@components/ui/Button";
-import { Dialog, DialogContent } from "@components/Dialog";
+
 import { ErrorCode } from "@lib/auth";
+
+import { Dialog, DialogContent } from "@components/Dialog";
+import Button from "@components/ui/Button";
+
 import TwoFactorAuthAPI from "./TwoFactorAuthAPI";
 import TwoFactorModalHeader from "./TwoFactorModalHeader";
 

--- a/components/security/EnableTwoFactorModal.tsx
+++ b/components/security/EnableTwoFactorModal.tsx
@@ -1,7 +1,10 @@
 import React, { SyntheticEvent, useState } from "react";
-import Button from "@components/ui/Button";
-import { Dialog, DialogContent } from "@components/Dialog";
+
 import { ErrorCode } from "@lib/auth";
+
+import { Dialog, DialogContent } from "@components/Dialog";
+import Button from "@components/ui/Button";
+
 import TwoFactorAuthAPI from "./TwoFactorAuthAPI";
 import TwoFactorModalHeader from "./TwoFactorModalHeader";
 

--- a/components/security/TwoFactorAuthSection.tsx
+++ b/components/security/TwoFactorAuthSection.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import Button from "@components/ui/Button";
+
 import Badge from "@components/ui/Badge";
-import EnableTwoFactorModal from "./EnableTwoFactorModal";
+import Button from "@components/ui/Button";
+
 import DisableTwoFactorModal from "./DisableTwoFactorModal";
+import EnableTwoFactorModal from "./EnableTwoFactorModal";
 
 const TwoFactorAuthSection = ({ twoFactorEnabled }: { twoFactorEnabled: boolean }) => {
   const [enabled, setEnabled] = useState(twoFactorEnabled);

--- a/components/security/TwoFactorModalHeader.tsx
+++ b/components/security/TwoFactorModalHeader.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { ShieldCheckIcon } from "@heroicons/react/solid";
+import React from "react";
 
 const TwoFactorModalHeader = ({ title, description }: { title: string; description: string }) => {
   return (

--- a/components/seo/head-seo.tsx
+++ b/components/seo/head-seo.tsx
@@ -1,8 +1,9 @@
+import merge from "lodash.merge";
 import { NextSeo, NextSeoProps } from "next-seo";
 import React from "react";
-import { getBrowserInfo } from "@lib/core/browser/browser.utils";
+
 import { getSeoImage, seoConfig } from "@lib/config/next-seo.config";
-import merge from "lodash.merge";
+import { getBrowserInfo } from "@lib/core/browser/browser.utils";
 
 export type HeadSeoProps = {
   title: string;

--- a/components/team/EditTeam.tsx
+++ b/components/team/EditTeam.tsx
@@ -1,17 +1,20 @@
-import React, { useEffect, useRef, useState } from "react";
 import { ArrowLeftIcon, PlusIcon, TrashIcon } from "@heroicons/react/outline";
-import ErrorAlert from "@components/ui/alerts/Error";
-import { UsernameInput } from "@components/ui/UsernameInput";
-import MemberList from "./MemberList";
-import Avatar from "@components/ui/Avatar";
-import ImageUploader from "@components/ImageUploader";
-import { Dialog, DialogTrigger } from "@components/Dialog";
-import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
-import Modal from "@components/Modal";
-import MemberInvitationModal from "@components/team/MemberInvitationModal";
-import Button from "@components/ui/Button";
+import React, { useEffect, useRef, useState } from "react";
+
 import { Member } from "@lib/member";
 import { Team } from "@lib/team";
+
+import { Dialog, DialogTrigger } from "@components/Dialog";
+import ImageUploader from "@components/ImageUploader";
+import Modal from "@components/Modal";
+import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
+import MemberInvitationModal from "@components/team/MemberInvitationModal";
+import Avatar from "@components/ui/Avatar";
+import Button from "@components/ui/Button";
+import { UsernameInput } from "@components/ui/UsernameInput";
+import ErrorAlert from "@components/ui/alerts/Error";
+
+import MemberList from "./MemberList";
 
 export default function EditTeam(props: { team: Team | undefined | null; onCloseEdit: () => void }) {
   const [members, setMembers] = useState([]);

--- a/components/team/MemberInvitationModal.tsx
+++ b/components/team/MemberInvitationModal.tsx
@@ -1,7 +1,9 @@
 import { UsersIcon } from "@heroicons/react/outline";
 import { useState } from "react";
-import Button from "@components/ui/Button";
+
 import { Team } from "@lib/team";
+
+import Button from "@components/ui/Button";
 
 export default function MemberInvitationModal(props: { team: Team | undefined | null; onExit: () => void }) {
   const [errorMessage, setErrorMessage] = useState("");

--- a/components/team/MemberList.tsx
+++ b/components/team/MemberList.tsx
@@ -1,5 +1,6 @@
-import MemberListItem from "./MemberListItem";
 import { Member } from "@lib/member";
+
+import MemberListItem from "./MemberListItem";
 
 export default function MemberList(props: {
   members: Member[];

--- a/components/team/MemberListItem.tsx
+++ b/components/team/MemberListItem.tsx
@@ -1,11 +1,14 @@
 import { DotsHorizontalIcon, UserRemoveIcon } from "@heroicons/react/outline";
-import Dropdown, { DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/Dropdown";
 import { useState } from "react";
+
+import { Member } from "@lib/member";
+
 import { Dialog, DialogTrigger } from "@components/Dialog";
 import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
 import Avatar from "@components/ui/Avatar";
-import { Member } from "@lib/member";
 import Button from "@components/ui/Button";
+
+import Dropdown, { DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/Dropdown";
 
 export default function MemberListItem(props: {
   member: Member;

--- a/components/team/TeamList.tsx
+++ b/components/team/TeamList.tsx
@@ -1,5 +1,6 @@
-import TeamListItem from "./TeamListItem";
 import { Team } from "@lib/team";
+
+import TeamListItem from "./TeamListItem";
 
 export default function TeamList(props: {
   teams: Team[];

--- a/components/team/TeamListItem.tsx
+++ b/components/team/TeamListItem.tsx
@@ -5,15 +5,18 @@ import {
   PencilAltIcon,
   TrashIcon,
 } from "@heroicons/react/outline";
-import Dropdown, { DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/Dropdown";
-import { useState } from "react";
-import { Tooltip } from "@components/Tooltip";
 import Link from "next/link";
+import { useState } from "react";
+
+import showToast from "@lib/notification";
+
 import { Dialog, DialogTrigger } from "@components/Dialog";
+import { Tooltip } from "@components/Tooltip";
 import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
 import Avatar from "@components/ui/Avatar";
 import Button from "@components/ui/Button";
-import showToast from "@lib/notification";
+
+import Dropdown, { DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/Dropdown";
 
 interface Team {
   id: number;

--- a/components/team/screens/Team.tsx
+++ b/components/team/screens/Team.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import Text from "@components/ui/Text";
-import Link from "next/link";
-import Avatar from "@components/ui/Avatar";
 import { ArrowRightIcon } from "@heroicons/react/outline";
-import classnames from "classnames";
 import { ArrowLeftIcon } from "@heroicons/react/solid";
+import classnames from "classnames";
+import Link from "next/link";
+import React from "react";
+
+import Avatar from "@components/ui/Avatar";
 import Button from "@components/ui/Button";
+import Text from "@components/ui/Text";
 
 const Team = ({ team }) => {
   const Member = ({ member }) => {

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,7 +1,8 @@
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import * as Tooltip from "@radix-ui/react-tooltip";
-import { defaultAvatarSrc } from "@lib/profile";
+
 import classNames from "@lib/classNames";
+import { defaultAvatarSrc } from "@lib/profile";
 
 export type AvatarProps = {
   className?: string;

--- a/components/ui/AvatarGroup.tsx
+++ b/components/ui/AvatarGroup.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import Avatar from "@components/ui/Avatar";
+
 import classNames from "@lib/classNames";
+
+import Avatar from "@components/ui/Avatar";
+
 // import * as Tooltip from "@radix-ui/react-tooltip";
 
 export type AvatarGroupProps = {

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,5 +1,6 @@
-import classNames from "@lib/classNames";
 import React from "react";
+
+import classNames from "@lib/classNames";
 
 export type BadgeProps = {
   variant: "default" | "success" | "gray";

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,7 +1,8 @@
-import classNames from "@lib/classNames";
-import { SVGComponent } from "@lib/types/SVGComponent";
 import Link, { LinkProps } from "next/link";
 import React, { forwardRef } from "react";
+
+import classNames from "@lib/classNames";
+import { SVGComponent } from "@lib/types/SVGComponent";
 
 export type ButtonProps = {
   color?: "primary" | "secondary" | "minimal" | "warn";

--- a/components/ui/Schedule/Schedule.tsx
+++ b/components/ui/Schedule/Schedule.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import Text from "@components/ui/Text";
 import { PlusIcon, TrashIcon } from "@heroicons/react/outline";
-import dayjs, { Dayjs } from "dayjs";
 import classnames from "classnames";
+import dayjs, { Dayjs } from "dayjs";
+import React from "react";
+
+import Text from "@components/ui/Text";
 
 export const SCHEDULE_FORM_ID = "SCHEDULE_FORM_ID";
 export const toCalendsoAvailabilityFormat = (schedule: Schedule) => {

--- a/components/ui/Scheduler.tsx
+++ b/components/ui/Scheduler.tsx
@@ -1,12 +1,13 @@
+import { TrashIcon } from "@heroicons/react/outline";
+import { Availability } from "@prisma/client";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import React, { useEffect, useState } from "react";
 import TimezoneSelect from "react-timezone-select";
-import { TrashIcon } from "@heroicons/react/outline";
+
 import { WeekdaySelect } from "./WeekdaySelect";
 import SetTimesModal from "./modal/SetTimesModal";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import { Availability } from "@prisma/client";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import * as PrimitiveSwitch from "@radix-ui/react-switch";
 import * as Label from "@radix-ui/react-label";
+import * as PrimitiveSwitch from "@radix-ui/react-switch";
+import { useState } from "react";
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ");

--- a/components/ui/Text/Body/Body.tsx
+++ b/components/ui/Text/Body/Body.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Body: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Body/index.ts
+++ b/components/ui/Text/Body/index.ts
@@ -1,2 +1,3 @@
 import Body from "./Body";
+
 export default Body;

--- a/components/ui/Text/Caption/Caption.tsx
+++ b/components/ui/Text/Caption/Caption.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Caption: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Caption/index.ts
+++ b/components/ui/Text/Caption/index.ts
@@ -1,2 +1,3 @@
 import Caption from "./Caption";
+
 export default Caption;

--- a/components/ui/Text/Caption2/Caption2.tsx
+++ b/components/ui/Text/Caption2/Caption2.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Caption2: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Caption2/index.ts
+++ b/components/ui/Text/Caption2/index.ts
@@ -1,2 +1,3 @@
 import Caption2 from "./Caption2";
+
 export default Caption2;

--- a/components/ui/Text/Footnote/Footnote.tsx
+++ b/components/ui/Text/Footnote/Footnote.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Footnote: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Footnote/index.ts
+++ b/components/ui/Text/Footnote/index.ts
@@ -1,2 +1,3 @@
 import Footnote from "./Footnote";
+
 export default Footnote;

--- a/components/ui/Text/Headline/Headline.tsx
+++ b/components/ui/Text/Headline/Headline.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Headline: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Headline/index.ts
+++ b/components/ui/Text/Headline/index.ts
@@ -1,2 +1,3 @@
 import Headline from "./Headline";
+
 export default Headline;

--- a/components/ui/Text/Largetitle/Largetitle.tsx
+++ b/components/ui/Text/Largetitle/Largetitle.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Largetitle: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Largetitle/index.ts
+++ b/components/ui/Text/Largetitle/index.ts
@@ -1,2 +1,3 @@
 import Largetitle from "./Largetitle";
+
 export default Largetitle;

--- a/components/ui/Text/Overline/Overline.tsx
+++ b/components/ui/Text/Overline/Overline.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Overline: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Overline/index.ts
+++ b/components/ui/Text/Overline/index.ts
@@ -1,2 +1,3 @@
 import Overline from "./Overline";
+
 export default Overline;

--- a/components/ui/Text/Subheadline/Subheadline.tsx
+++ b/components/ui/Text/Subheadline/Subheadline.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Subheadline: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Subheadline/index.ts
+++ b/components/ui/Text/Subheadline/index.ts
@@ -1,2 +1,3 @@
 import Subheadline from "./Subheadline";
+
 export default Subheadline;

--- a/components/ui/Text/Subtitle/Subtitle.tsx
+++ b/components/ui/Text/Subtitle/Subtitle.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Subtitle: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Subtitle/index.ts
+++ b/components/ui/Text/Subtitle/index.ts
@@ -1,2 +1,3 @@
 import Subtitle from "./Subtitle";
+
 export default Subtitle;

--- a/components/ui/Text/Text.tsx
+++ b/components/ui/Text/Text.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Body from "./Body";
 import Caption from "./Caption";
 import Caption2 from "./Caption2";

--- a/components/ui/Text/Title/Title.tsx
+++ b/components/ui/Text/Title/Title.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Title: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Title/index.ts
+++ b/components/ui/Text/Title/index.ts
@@ -1,2 +1,3 @@
 import Title from "./Title";
+
 export default Title;

--- a/components/ui/Text/Title2/Title2.tsx
+++ b/components/ui/Text/Title2/Title2.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Title2: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Title2/index.ts
+++ b/components/ui/Text/Title2/index.ts
@@ -1,2 +1,3 @@
 import Title2 from "./Title2";
+
 export default Title2;

--- a/components/ui/Text/Title3/Title3.tsx
+++ b/components/ui/Text/Title3/Title3.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
+
 import { TextProps } from "../Text";
 
 const Title3: React.FunctionComponent<TextProps> = (props: TextProps) => {

--- a/components/ui/Text/Title3/index.ts
+++ b/components/ui/Text/Title3/index.ts
@@ -1,2 +1,3 @@
 import Title3 from "./Title3";
+
 export default Title3;

--- a/components/ui/Text/index.ts
+++ b/components/ui/Text/index.ts
@@ -1,39 +1,40 @@
+import Body from "./Body";
+import Caption from "./Caption";
+import Caption2 from "./Caption2";
+import Footnote from "./Footnote";
+import Headline from "./Headline";
+import Largetitle from "./Largetitle";
+import Overline from "./Overline";
+import Subheadline from "./Subheadline";
+import Subtitle from "./Subtitle";
 import Text from "./Text";
+import Title from "./Title";
+import Title2 from "./Title2";
+import Title3 from "./Title3";
+
 export { Text };
 export default Text;
 
-import Title from "./Title";
 export { Title };
 
-import Title2 from "./Title2";
 export { Title2 };
 
-import Title3 from "./Title3";
 export { Title3 };
 
-import Largetitle from "./Largetitle";
 export { Largetitle };
 
-import Subtitle from "./Subtitle";
 export { Subtitle };
 
-import Headline from "./Headline";
 export { Headline };
 
-import Subheadline from "./Subheadline";
 export { Subheadline };
 
-import Caption from "./Caption";
 export { Caption };
 
-import Caption2 from "./Caption2";
 export { Caption2 };
 
-import Footnote from "./Footnote";
 export { Footnote };
 
-import Overline from "./Overline";
 export { Overline };
 
-import Body from "./Body";
 export { Body };

--- a/components/ui/form/CheckedSelect.tsx
+++ b/components/ui/form/CheckedSelect.tsx
@@ -1,8 +1,9 @@
-import Select from "@components/ui/form/Select";
 import { XIcon, CheckIcon } from "@heroicons/react/outline";
 import React, { ForwardedRef, useEffect, useState } from "react";
-import Avatar from "@components/ui/Avatar";
 import { OptionsType } from "react-select/lib/types";
+
+import Avatar from "@components/ui/Avatar";
+import Select from "@components/ui/form/Select";
 
 export type CheckedSelectProps = {
   defaultValue?: [];

--- a/components/ui/form/PhoneInput.tsx
+++ b/components/ui/form/PhoneInput.tsx
@@ -1,6 +1,7 @@
-import "react-phone-number-input/style.css";
-import { default as BasePhoneInput } from "react-phone-number-input";
 import React from "react";
+import { default as BasePhoneInput } from "react-phone-number-input";
+import "react-phone-number-input/style.css";
+
 import classNames from "@lib/classNames";
 
 export const PhoneInput = (props) => (

--- a/components/ui/form/Select.tsx
+++ b/components/ui/form/Select.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from "react";
 import Select, { components, NamedProps } from "react-select";
+
 import classNames from "@lib/classNames";
 
 export const SelectComp = (props: PropsWithChildren<NamedProps>) => (

--- a/components/ui/form/radio-area/RadioAreaGroup.tsx
+++ b/components/ui/form/radio-area/RadioAreaGroup.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren, useState } from "react";
+
 import classNames from "@lib/classNames";
 
 type RadioAreaProps = React.InputHTMLAttributes<HTMLInputElement> & {

--- a/components/ui/form/radio-area/Select.tsx
+++ b/components/ui/form/radio-area/Select.tsx
@@ -1,8 +1,10 @@
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import { ChevronDownIcon } from "@heroicons/react/solid";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import React from "react";
-import { RadioArea, RadioAreaGroup } from "@components/ui/form/radio-area/RadioAreaGroup";
+
 import classNames from "@lib/classNames";
+
+import { RadioArea, RadioAreaGroup } from "@components/ui/form/radio-area/RadioAreaGroup";
 
 type OptionProps = React.OptionHTMLAttributes<HTMLOptionElement> & {
   description?: string;

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,4 +1,2 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-namespace */
 import "./commands";

--- a/ee/components/stripe/Payment.tsx
+++ b/ee/components/stripe/Payment.tsx
@@ -1,10 +1,13 @@
-import React, { useState } from "react";
-import { stringify } from "querystring";
 import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
-import Button from "@components/ui/Button";
 import { useRouter } from "next/router";
-import useDarkMode from "@lib/core/browser/useDarkMode";
+import { stringify } from "querystring";
+import React, { useState } from "react";
+
 import { PaymentData } from "@ee/lib/stripe/server";
+
+import useDarkMode from "@lib/core/browser/useDarkMode";
+
+import Button from "@components/ui/Button";
 
 const CARD_OPTIONS = {
   iconStyle: "solid" as const,

--- a/ee/components/stripe/PaymentPage.tsx
+++ b/ee/components/stripe/PaymentPage.tsx
@@ -1,8 +1,4 @@
-import PaymentComponent from "@ee/components/stripe/Payment";
-import getStripe from "@ee/lib/stripe/client";
-import { PaymentPageProps } from "@ee/pages/payment/[uid]";
 import { CreditCardIcon } from "@heroicons/react/solid";
-import useTheme from "@lib/hooks/useTheme";
 import { Elements } from "@stripe/react-stripe-js";
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
@@ -11,6 +7,12 @@ import utc from "dayjs/plugin/utc";
 import Head from "next/head";
 import React, { FC, useEffect, useState } from "react";
 import { FormattedNumber, IntlProvider } from "react-intl";
+
+import PaymentComponent from "@ee/components/stripe/Payment";
+import getStripe from "@ee/lib/stripe/client";
+import { PaymentPageProps } from "@ee/pages/payment/[uid]";
+
+import useTheme from "@lib/hooks/useTheme";
 
 dayjs.extend(utc);
 dayjs.extend(toArray);

--- a/ee/lib/stripe/server.ts
+++ b/ee/lib/stripe/server.ts
@@ -1,11 +1,13 @@
-import { CalendarEvent, Person } from "@lib/calendarClient";
-import EventOrganizerRefundFailedMail from "@lib/emails/EventOrganizerRefundFailedMail";
-import EventPaymentMail from "@lib/emails/EventPaymentMail";
-import prisma from "@lib/prisma";
 import { PaymentType } from "@prisma/client";
 import Stripe from "stripe";
 import { JsonValue } from "type-fest";
 import { v4 as uuidv4 } from "uuid";
+
+import { CalendarEvent, Person } from "@lib/calendarClient";
+import EventOrganizerRefundFailedMail from "@lib/emails/EventOrganizerRefundFailedMail";
+import EventPaymentMail from "@lib/emails/EventPaymentMail";
+import prisma from "@lib/prisma";
+
 import { createPaymentLink } from "./client";
 
 export type PaymentData = Stripe.Response<Stripe.PaymentIntent> & {

--- a/ee/pages/api/integrations/stripepayment/add.ts
+++ b/ee/pages/api/integrations/stripepayment/add.ts
@@ -1,7 +1,8 @@
-import { getSession } from "@lib/auth";
-import prisma from "@lib/prisma";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { stringify } from "querystring";
+
+import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
 
 const client_id = process.env.STRIPE_CLIENT_ID;
 

--- a/ee/pages/api/integrations/stripepayment/callback.ts
+++ b/ee/pages/api/integrations/stripepayment/callback.ts
@@ -1,8 +1,10 @@
 import { Prisma } from "@prisma/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import stripe, { StripeData } from "@ee/lib/stripe/server";
+
 import { getSession } from "@lib/auth";
 import prisma from "@lib/prisma";
-import stripe, { StripeData } from "@ee/lib/stripe/server";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;

--- a/ee/pages/api/integrations/stripepayment/webhook.ts
+++ b/ee/pages/api/integrations/stripepayment/webhook.ts
@@ -1,11 +1,13 @@
+import { buffer } from "micro";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getErrorFromUnknown } from "pages/_error";
+import Stripe from "stripe";
+
+import stripe from "@ee/lib/stripe/server";
+
 import { CalendarEvent } from "@lib/calendarClient";
 import EventManager from "@lib/events/EventManager";
 import prisma from "@lib/prisma";
-import stripe from "@ee/lib/stripe/server";
-import { buffer } from "micro";
-import type { NextApiRequest, NextApiResponse } from "next";
-import Stripe from "stripe";
-import { getErrorFromUnknown } from "pages/_error";
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 

--- a/ee/pages/payment/[uid].tsx
+++ b/ee/pages/payment/[uid].tsx
@@ -1,8 +1,10 @@
+import { GetServerSidePropsContext } from "next";
+
 import { PaymentData } from "@ee/lib/stripe/server";
+
 import { asStringOrThrow } from "@lib/asStringOrNull";
 import prisma from "@lib/prisma";
 import { inferSSRProps } from "@lib/types/inferSSRProps";
-import { GetServerSidePropsContext } from "next";
 
 export type PaymentPageProps = inferSSRProps<typeof getServerSideProps>;
 

--- a/lib/CalEventParser.ts
+++ b/lib/CalEventParser.ts
@@ -1,6 +1,7 @@
-import { CalendarEvent } from "./calendarClient";
-import { v5 as uuidv5 } from "uuid";
 import short from "short-uuid";
+import { v5 as uuidv5 } from "uuid";
+
+import { CalendarEvent } from "./calendarClient";
 import { stripHtml } from "./emails/helpers";
 
 const translator = short();

--- a/lib/app-providers.tsx
+++ b/lib/app-providers.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { createTelemetryClient, TelemetryProvider } from "@lib/telemetry";
 import { Provider } from "next-auth/client";
+import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Hydrate } from "react-query/hydration";
+
+import { createTelemetryClient, TelemetryProvider } from "@lib/telemetry";
 
 export const queryClient = new QueryClient();
 

--- a/lib/calendarClient.ts
+++ b/lib/calendarClient.ts
@@ -1,12 +1,14 @@
-import EventOrganizerMail from "./emails/EventOrganizerMail";
-import EventOrganizerRescheduledMail from "./emails/EventOrganizerRescheduledMail";
-import prisma from "./prisma";
 import { Prisma, Credential } from "@prisma/client";
-import CalEventParser from "./CalEventParser";
+
 import { EventResult } from "@lib/events/EventManager";
 import logger from "@lib/logger";
-import { CalDavCalendar } from "./integrations/CalDav/CalDavCalendarAdapter";
+
+import CalEventParser from "./CalEventParser";
+import EventOrganizerMail from "./emails/EventOrganizerMail";
+import EventOrganizerRescheduledMail from "./emails/EventOrganizerRescheduledMail";
 import { AppleCalendar } from "./integrations/Apple/AppleCalendarAdapter";
+import { CalDavCalendar } from "./integrations/CalDav/CalDavCalendarAdapter";
+import prisma from "./prisma";
 
 const log = logger.getChildLogger({ prefix: ["[lib] calendarClient"] });
 

--- a/lib/clock.ts
+++ b/lib/clock.ts
@@ -1,7 +1,7 @@
 // handles logic related to user clock display using 24h display / timeZone options.
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/lib/config/next-seo.config.ts
+++ b/lib/config/next-seo.config.ts
@@ -1,4 +1,5 @@
 import { DefaultSeoProps } from "next-seo";
+
 import { HeadSeoProps } from "@components/seo/head-seo";
 
 const seoImages = {

--- a/lib/emails/EventAttendeeMail.ts
+++ b/lib/emails/EventAttendeeMail.ts
@@ -1,9 +1,9 @@
 import dayjs, { Dayjs } from "dayjs";
-import EventMail from "./EventMail";
-
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+import EventMail from "./EventMail";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -160,6 +160,6 @@ export default class EventAttendeeMail extends EventMail {
    * @private
    */
   protected getInviteeStart(): Dayjs {
-    return <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
+    return dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
   }
 }

--- a/lib/emails/EventMail.ts
+++ b/lib/emails/EventMail.ts
@@ -1,8 +1,9 @@
+import nodemailer from "nodemailer";
+
 import CalEventParser from "../CalEventParser";
-import { stripHtml } from "./helpers";
 import { CalendarEvent, ConferenceData } from "../calendarClient";
 import { serverConfig } from "../serverConfig";
-import nodemailer from "nodemailer";
+import { stripHtml } from "./helpers";
 
 export interface EntryPoint {
   entryPointType?: string;

--- a/lib/emails/EventOrganizerMail.ts
+++ b/lib/emails/EventOrganizerMail.ts
@@ -1,11 +1,11 @@
-import { createEvent } from "ics";
 import dayjs, { Dayjs } from "dayjs";
-import EventMail from "./EventMail";
-
-import utc from "dayjs/plugin/utc";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
 import toArray from "dayjs/plugin/toArray";
-import localizedFormat from "dayjs/plugin/localizedFormat";
+import utc from "dayjs/plugin/utc";
+import { createEvent } from "ics";
+
+import EventMail from "./EventMail";
 import { stripHtml } from "./helpers";
 
 dayjs.extend(utc);
@@ -217,6 +217,6 @@ export default class EventOrganizerMail extends EventMail {
    * @private
    */
   protected getOrganizerStart(): Dayjs {
-    return <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    return dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
   }
 }

--- a/lib/emails/EventOrganizerRefundFailedMail.ts
+++ b/lib/emails/EventOrganizerRefundFailedMail.ts
@@ -1,11 +1,11 @@
 import dayjs, { Dayjs } from "dayjs";
-
-import utc from "dayjs/plugin/utc";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
 import toArray from "dayjs/plugin/toArray";
-import localizedFormat from "dayjs/plugin/localizedFormat";
-import EventOrganizerMail from "@lib/emails/EventOrganizerMail";
+import utc from "dayjs/plugin/utc";
+
 import { CalendarEvent } from "@lib/calendarClient";
+import EventOrganizerMail from "@lib/emails/EventOrganizerMail";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -27,7 +27,7 @@ export default class EventOrganizerRefundFailedMail extends EventOrganizerMail {
   }
 
   protected getBodyText(): string {
-    const organizerStart: Dayjs = <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    const organizerStart: Dayjs = dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
     return `The refund for the event ${this.calEvent.type} with ${
       this.calEvent.attendees[0].name
     } on ${organizerStart.format("LT dddd, LL")} failed. Please check with your payment provider and ${
@@ -57,7 +57,7 @@ export default class EventOrganizerRefundFailedMail extends EventOrganizerMail {
   }
 
   protected getSubject(): string {
-    const organizerStart: Dayjs = <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    const organizerStart: Dayjs = dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
     return `Refund failed: ${this.calEvent.attendees[0].name} - ${organizerStart.format("LT dddd, LL")} - ${
       this.calEvent.type
     }`;

--- a/lib/emails/EventOrganizerRequestMail.ts
+++ b/lib/emails/EventOrganizerRequestMail.ts
@@ -1,9 +1,9 @@
 import dayjs, { Dayjs } from "dayjs";
-
-import utc from "dayjs/plugin/utc";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
 import toArray from "dayjs/plugin/toArray";
-import localizedFormat from "dayjs/plugin/localizedFormat";
+import utc from "dayjs/plugin/utc";
+
 import EventOrganizerMail from "@lib/emails/EventOrganizerMail";
 
 dayjs.extend(utc);
@@ -42,7 +42,7 @@ export default class EventOrganizerRequestMail extends EventOrganizerMail {
   }
 
   protected getSubject(): string {
-    const organizerStart: Dayjs = <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    const organizerStart: Dayjs = dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
     return `New event request: ${this.calEvent.attendees[0].name} - ${organizerStart.format(
       "LT dddd, LL"
     )} - ${this.calEvent.type}`;

--- a/lib/emails/EventOrganizerRequestReminderMail.ts
+++ b/lib/emails/EventOrganizerRequestReminderMail.ts
@@ -1,9 +1,9 @@
 import dayjs, { Dayjs } from "dayjs";
-
-import utc from "dayjs/plugin/utc";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
 import toArray from "dayjs/plugin/toArray";
-import localizedFormat from "dayjs/plugin/localizedFormat";
+import utc from "dayjs/plugin/utc";
+
 import EventOrganizerRequestMail from "@lib/emails/EventOrganizerRequestMail";
 
 dayjs.extend(utc);
@@ -17,7 +17,7 @@ export default class EventOrganizerRequestReminderMail extends EventOrganizerReq
   }
 
   protected getSubject(): string {
-    const organizerStart: Dayjs = <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    const organizerStart: Dayjs = dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
     return `Event request is still waiting: ${this.calEvent.attendees[0].name} - ${organizerStart.format(
       "LT dddd, LL"
     )} - ${this.calEvent.type}`;

--- a/lib/emails/EventOrganizerRescheduledMail.ts
+++ b/lib/emails/EventOrganizerRescheduledMail.ts
@@ -1,4 +1,5 @@
 import dayjs, { Dayjs } from "dayjs";
+
 import EventOrganizerMail from "./EventOrganizerMail";
 
 export default class EventOrganizerRescheduledMail extends EventOrganizerMail {
@@ -48,7 +49,7 @@ export default class EventOrganizerRescheduledMail extends EventOrganizerMail {
    * @protected
    */
   protected getNodeMailerPayload(): Record<string, unknown> {
-    const organizerStart: Dayjs = <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
+    const organizerStart: Dayjs = dayjs(this.calEvent.startTime).tz(this.calEvent.organizer.timeZone);
 
     return {
       icalEvent: {

--- a/lib/emails/EventPaymentMail.ts
+++ b/lib/emails/EventPaymentMail.ts
@@ -1,10 +1,11 @@
 import dayjs, { Dayjs } from "dayjs";
-import EventMail, { AdditionInformation } from "./EventMail";
-
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
 import { CalendarEvent } from "@lib/calendarClient";
+
+import EventMail, { AdditionInformation } from "./EventMail";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -160,6 +161,6 @@ export default class EventPaymentMail extends EventMail {
    * @private
    */
   protected getInviteeStart(): Dayjs {
-    return <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
+    return dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
   }
 }

--- a/lib/emails/EventRejectionMail.ts
+++ b/lib/emails/EventRejectionMail.ts
@@ -1,9 +1,9 @@
 import dayjs, { Dayjs } from "dayjs";
-import EventMail from "./EventMail";
-
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+import EventMail from "./EventMail";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -86,6 +86,6 @@ export default class EventRejectionMail extends EventMail {
    * @private
    */
   protected getInviteeStart(): Dayjs {
-    return <Dayjs>dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
+    return dayjs(this.calEvent.startTime).tz(this.calEvent.attendees[0].timeZone);
   }
 }

--- a/lib/emails/VideoEventAttendeeMail.ts
+++ b/lib/emails/VideoEventAttendeeMail.ts
@@ -1,8 +1,9 @@
+import { AdditionInformation } from "@lib/emails/EventMail";
+
 import { CalendarEvent } from "../calendarClient";
+import { VideoCallData } from "../videoClient";
 import EventAttendeeMail from "./EventAttendeeMail";
 import { getFormattedMeetingId, getIntegrationName } from "./helpers";
-import { VideoCallData } from "../videoClient";
-import { AdditionInformation } from "@lib/emails/EventMail";
 
 export default class VideoEventAttendeeMail extends EventAttendeeMail {
   videoCallData: VideoCallData;

--- a/lib/emails/VideoEventOrganizerMail.ts
+++ b/lib/emails/VideoEventOrganizerMail.ts
@@ -1,8 +1,9 @@
-import { CalendarEvent } from "../calendarClient";
-import EventOrganizerMail from "./EventOrganizerMail";
-import { VideoCallData } from "../videoClient";
-import { getFormattedMeetingId, getIntegrationName } from "./helpers";
 import { AdditionInformation } from "@lib/emails/EventMail";
+
+import { CalendarEvent } from "../calendarClient";
+import { VideoCallData } from "../videoClient";
+import EventOrganizerMail from "./EventOrganizerMail";
+import { getFormattedMeetingId, getIntegrationName } from "./helpers";
 
 export default class VideoEventOrganizerMail extends EventOrganizerMail {
   videoCallData: VideoCallData;

--- a/lib/emails/invitation.ts
+++ b/lib/emails/invitation.ts
@@ -1,5 +1,6 @@
-import { serverConfig } from "../serverConfig";
 import nodemailer from "nodemailer";
+
+import { serverConfig } from "../serverConfig";
 
 export default function createInvitationEmail(data: any, options: any = {}) {
   return sendEmail(data, {

--- a/lib/emails/sendMail.ts
+++ b/lib/emails/sendMail.ts
@@ -1,5 +1,6 @@
-import { serverConfig } from "../serverConfig";
 import nodemailer, { SentMessageInfo } from "nodemailer";
+
+import { serverConfig } from "../serverConfig";
 
 const sendEmail = ({ to, subject, text, html = null }): Promise<string | SentMessageInfo> =>
   new Promise((resolve, reject) => {

--- a/lib/events/EventManager.ts
+++ b/lib/events/EventManager.ts
@@ -1,13 +1,14 @@
-import { CalendarEvent, createEvent, updateEvent } from "@lib/calendarClient";
 import { Credential } from "@prisma/client";
 import async from "async";
-import { createMeeting, updateMeeting } from "@lib/videoClient";
-import prisma from "@lib/prisma";
-import { LocationType } from "@lib/location";
-import { v5 as uuidv5 } from "uuid";
 import merge from "lodash.merge";
+import { v5 as uuidv5 } from "uuid";
+
+import { CalendarEvent, createEvent, updateEvent } from "@lib/calendarClient";
 import EventAttendeeMail from "@lib/emails/EventAttendeeMail";
 import EventAttendeeRescheduledMail from "@lib/emails/EventAttendeeRescheduledMail";
+import { LocationType } from "@lib/location";
+import prisma from "@lib/prisma";
+import { createMeeting, updateMeeting } from "@lib/videoClient";
 
 export interface EventResult {
   type: string;

--- a/lib/hooks/useSlots.ts
+++ b/lib/hooks/useSlots.ts
@@ -1,10 +1,13 @@
-import { useState, useEffect } from "react";
-import getSlots from "@lib/slots";
 import { User, SchedulingType } from "@prisma/client";
 import dayjs, { Dayjs } from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
 import utc from "dayjs/plugin/utc";
+import { useState, useEffect } from "react";
+
+import getSlots from "@lib/slots";
+
 import { FreeBusyTime } from "@components/ui/Schedule/Schedule";
+
 dayjs.extend(isBetween);
 dayjs.extend(utc);
 

--- a/lib/integrations/Apple/AppleCalendarAdapter.ts
+++ b/lib/integrations/Apple/AppleCalendarAdapter.ts
@@ -1,5 +1,7 @@
-import { IntegrationCalendar, CalendarApiAdapter, CalendarEvent } from "../../calendarClient";
-import { symmetricDecrypt } from "@lib/crypto";
+import { Credential } from "@prisma/client";
+import dayjs from "dayjs";
+import ICAL from "ical.js";
+import { createEvent, DurationObject, Attendee, Person } from "ics";
 import {
   createAccount,
   fetchCalendars,
@@ -9,13 +11,13 @@ import {
   updateCalendarObject,
   deleteCalendarObject,
 } from "tsdav";
-import { Credential } from "@prisma/client";
-import ICAL from "ical.js";
-import { createEvent, DurationObject, Attendee, Person } from "ics";
-import dayjs from "dayjs";
 import { v4 as uuidv4 } from "uuid";
-import { stripHtml } from "../../emails/helpers";
+
+import { symmetricDecrypt } from "@lib/crypto";
 import logger from "@lib/logger";
+
+import { IntegrationCalendar, CalendarApiAdapter, CalendarEvent } from "../../calendarClient";
+import { stripHtml } from "../../emails/helpers";
 
 const log = logger.getChildLogger({ prefix: ["[[lib] apple calendar"] });
 

--- a/lib/integrations/CalDav/CalDavCalendarAdapter.ts
+++ b/lib/integrations/CalDav/CalDavCalendarAdapter.ts
@@ -1,5 +1,7 @@
-import { CalendarApiAdapter, CalendarEvent, IntegrationCalendar } from "../../calendarClient";
-import { symmetricDecrypt } from "@lib/crypto";
+import { Credential } from "@prisma/client";
+import dayjs from "dayjs";
+import ICAL from "ical.js";
+import { Attendee, createEvent, DurationObject, Person } from "ics";
 import {
   createAccount,
   createCalendarObject,
@@ -9,13 +11,13 @@ import {
   getBasicAuthHeaders,
   updateCalendarObject,
 } from "tsdav";
-import { Credential } from "@prisma/client";
-import ICAL from "ical.js";
-import { Attendee, createEvent, DurationObject, Person } from "ics";
-import dayjs from "dayjs";
 import { v4 as uuidv4 } from "uuid";
-import { stripHtml } from "../../emails/helpers";
+
+import { symmetricDecrypt } from "@lib/crypto";
 import logger from "@lib/logger";
+
+import { CalendarApiAdapter, CalendarEvent, IntegrationCalendar } from "../../calendarClient";
+import { stripHtml } from "../../emails/helpers";
 
 const log = logger.getChildLogger({ prefix: ["[lib] caldav"] });
 

--- a/lib/integrations/getIntegrations.ts
+++ b/lib/integrations/getIntegrations.ts
@@ -1,5 +1,6 @@
-import { validJson } from "@lib/jsonUtils";
 import { Prisma } from "@prisma/client";
+
+import { validJson } from "@lib/jsonUtils";
 
 const credentialData = Prisma.validator<Prisma.CredentialArgs>()({
   select: { id: true, type: true, key: true },

--- a/lib/mutations/event-types/create-event-type.ts
+++ b/lib/mutations/event-types/create-event-type.ts
@@ -1,6 +1,7 @@
+import { EventType } from "@prisma/client";
+
 import * as fetch from "@lib/core/http/fetch-wrapper";
 import { CreateEventType } from "@lib/types/event-type";
-import { EventType } from "@prisma/client";
 
 const createEventType = async (data: CreateEventType) => {
   const response = await fetch.post<CreateEventType, EventType>("/api/availability/eventtype", data);

--- a/lib/mutations/event-types/update-event-type.ts
+++ b/lib/mutations/event-types/update-event-type.ts
@@ -1,6 +1,7 @@
+import { EventType } from "@prisma/client";
+
 import * as fetch from "@lib/core/http/fetch-wrapper";
 import { EventTypeInput } from "@lib/types/event-type";
-import { EventType } from "@prisma/client";
 
 const updateEventType = async (data: EventTypeInput) => {
   const response = await fetch.patch<EventTypeInput, EventType>("/api/availability/eventtype", data);

--- a/lib/queries/event-types/get-event-types.ts
+++ b/lib/queries/event-types/get-event-types.ts
@@ -1,5 +1,6 @@
-import * as fetch from "@lib/core/http/fetch-wrapper";
 import { EventType } from "@prisma/client";
+
+import * as fetch from "@lib/core/http/fetch-wrapper";
 
 type GetEventsResponse = { message: string; data: EventType[] };
 const getEventTypes = async () => {

--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -1,6 +1,7 @@
 import dayjs, { Dayjs } from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -94,7 +95,7 @@ const getSlotsBetweenBoundary = (frequency: number, { lowerBound, upperBound }: 
   const slots: Dayjs[] = [];
   for (let minutes = 0; lowerBound + minutes <= upperBound - frequency; minutes += frequency) {
     slots.push(
-      <Dayjs>dayjs
+      dayjs
         .utc()
         .startOf("d")
         .add(lowerBound + minutes, "minutes")

--- a/lib/teams/getTeam.ts
+++ b/lib/teams/getTeam.ts
@@ -1,4 +1,5 @@
 import { Team } from "@prisma/client";
+
 import prisma from "@lib/prisma";
 import { defaultAvatarSrc } from "@lib/profile";
 

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
 import { jitsuClient, JitsuClient } from "@jitsu/sdk-js";
+import React, { useContext } from "react";
 
 /**
  * Enumeration of all event types that are being sent

--- a/lib/types/booking.ts
+++ b/lib/types/booking.ts
@@ -1,5 +1,6 @@
-import { LocationType } from "@lib/location";
 import { Booking } from "@prisma/client";
+
+import { LocationType } from "@lib/location";
 
 export type BookingCreateBody = {
   email: string;

--- a/lib/videoClient.ts
+++ b/lib/videoClient.ts
@@ -1,17 +1,19 @@
-import prisma from "./prisma";
-import { CalendarEvent } from "./calendarClient";
-import VideoEventOrganizerMail from "./emails/VideoEventOrganizerMail";
-import VideoEventAttendeeMail from "./emails/VideoEventAttendeeMail";
-import { v5 as uuidv5 } from "uuid";
+import { Credential } from "@prisma/client";
 import short from "short-uuid";
-import EventAttendeeRescheduledMail from "./emails/EventAttendeeRescheduledMail";
-import EventOrganizerRescheduledMail from "./emails/EventOrganizerRescheduledMail";
-import { EventResult } from "@lib/events/EventManager";
-import logger from "@lib/logger";
+import { v5 as uuidv5 } from "uuid";
+
+import CalEventParser from "@lib/CalEventParser";
 import { AdditionInformation, EntryPoint } from "@lib/emails/EventMail";
 import { getIntegrationName } from "@lib/emails/helpers";
-import CalEventParser from "@lib/CalEventParser";
-import { Credential } from "@prisma/client";
+import { EventResult } from "@lib/events/EventManager";
+import logger from "@lib/logger";
+
+import { CalendarEvent } from "./calendarClient";
+import EventAttendeeRescheduledMail from "./emails/EventAttendeeRescheduledMail";
+import EventOrganizerRescheduledMail from "./emails/EventOrganizerRescheduledMail";
+import VideoEventAttendeeMail from "./emails/VideoEventAttendeeMail";
+import VideoEventOrganizerMail from "./emails/VideoEventOrganizerMail";
+import prisma from "./prisma";
 
 const log = logger.getChildLogger({ prefix: ["[lib] videoClient"] });
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "2.0.4",
     "@types/bcryptjs": "^2.4.2",
     "@types/jest": "^27.0.1",
     "@types/lodash.debounce": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "typescript": "^4.4.3"
   },
   "lint-staged": {
-    "./{*,{pages,components,lib}/**/*}.{js,ts,jsx,tsx}": [
+    "./{*,{ee,pages,components,lib}/**/*}.{js,ts,jsx,tsx}": [
       "prettier --write",
       "eslint"
     ]

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,8 +1,9 @@
-import { ChevronRightIcon } from "@heroicons/react/solid";
 import { BookOpenIcon, CheckIcon, CodeIcon, DocumentTextIcon } from "@heroicons/react/outline";
+import { ChevronRightIcon } from "@heroicons/react/solid";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
-import Link from "next/link";
+
 import { HeadSeo } from "@components/seo/head-seo";
 
 const links = [

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -1,13 +1,15 @@
-import Avatar from "@components/ui/Avatar";
-import { HeadSeo } from "@components/seo/head-seo";
-import useTheme from "@lib/hooks/useTheme";
 import { ArrowRightIcon } from "@heroicons/react/outline";
-import prisma from "@lib/prisma";
-import { inferSSRProps } from "@lib/types/inferSSRProps";
 import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import React from "react";
+
+import useTheme from "@lib/hooks/useTheme";
+import prisma from "@lib/prisma";
+import { inferSSRProps } from "@lib/types/inferSSRProps";
+
 import EventTypeDescription from "@components/eventtype/EventTypeDescription";
+import { HeadSeo } from "@components/seo/head-seo";
+import Avatar from "@components/ui/Avatar";
 
 export default function User(props: inferSSRProps<typeof getServerSideProps>) {
   const { isReady } = useTheme(props.user.theme);

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -1,8 +1,10 @@
 import { User } from "@prisma/client";
+import { GetServerSidePropsContext } from "next";
+
 import { asStringOrNull } from "@lib/asStringOrNull";
 import prisma from "@lib/prisma";
 import { inferSSRProps } from "@lib/types/inferSSRProps";
-import { GetServerSidePropsContext } from "next";
+
 import AvailabilityPage from "@components/booking/pages/AvailabilityPage";
 
 export default function Type(props: inferSSRProps<typeof getServerSideProps>) {

--- a/pages/[user]/book.tsx
+++ b/pages/[user]/book.tsx
@@ -1,11 +1,13 @@
-import BookingPage from "@components/booking/pages/BookingPage";
-import { asStringOrThrow } from "@lib/asStringOrNull";
-import prisma from "@lib/prisma";
-import { inferSSRProps } from "@lib/types/inferSSRProps";
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { GetServerSidePropsContext } from "next";
+
+import { asStringOrThrow } from "@lib/asStringOrNull";
+import prisma from "@lib/prisma";
+import { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import BookingPage from "@components/booking/pages/BookingPage";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,10 @@
-import "../styles/globals.css";
-import AppProviders from "@lib/app-providers";
-import type { AppProps as NextAppProps } from "next/app";
 import { DefaultSeo } from "next-seo";
+import type { AppProps as NextAppProps } from "next/app";
+
+import AppProviders from "@lib/app-providers";
 import { seoConfig } from "@lib/config/next-seo.config";
+
+import "../styles/globals.css";
 
 // Workaround for https://github.com/vercel/next.js/issues/8592
 export type AppProps = NextAppProps & {

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -2,12 +2,14 @@
  * Typescript class based component for custom-error
  * @link https://nextjs.org/docs/advanced-features/custom-error-page
  */
-import React from "react";
 import { NextPage, NextPageContext } from "next";
 import NextError, { ErrorProps } from "next/error";
+import React from "react";
+
 import { HttpError } from "@lib/core/http/error";
-import { ErrorPage } from "@components/error/error-page";
 import logger from "@lib/logger";
+
+import { ErrorPage } from "@components/error/error-page";
 
 // Adds HttpException to the list of possible error types.
 type AugmentedError = (NonNullable<NextPageContext["err"]> & HttpError) | null;

--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -1,9 +1,10 @@
 import NextAuth from "next-auth";
 import Providers from "next-auth/providers";
-import prisma from "@lib/prisma";
-import { ErrorCode, Session, verifyPassword } from "@lib/auth";
 import { authenticator } from "otplib";
+
+import { ErrorCode, Session, verifyPassword } from "@lib/auth";
 import { symmetricDecrypt } from "@lib/crypto";
+import prisma from "@lib/prisma";
 
 export default NextAuth({
   session: {

--- a/pages/api/auth/changepw.ts
+++ b/pages/api/auth/changepw.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { ErrorCode, hashPassword, verifyPassword } from "../../../lib/auth";
+
 import { getSession } from "@lib/auth";
+
+import { ErrorCode, hashPassword, verifyPassword } from "../../../lib/auth";
 import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/auth/forgot-password.ts
+++ b/pages/api/auth/forgot-password.ts
@@ -1,11 +1,13 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../lib/prisma";
-import dayjs from "dayjs";
 import { User, ResetPasswordRequest } from "@prisma/client";
-import sendEmail from "../../../lib/emails/sendMail";
-import { buildForgotPasswordMessage } from "../../../lib/forgot-password/messaging/forgot-password";
+import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import sendEmail from "../../../lib/emails/sendMail";
+import { buildForgotPasswordMessage } from "../../../lib/forgot-password/messaging/forgot-password";
+import prisma from "../../../lib/prisma";
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 

--- a/pages/api/auth/reset-password.ts
+++ b/pages/api/auth/reset-password.ts
@@ -1,12 +1,14 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../lib/prisma";
-import dayjs from "dayjs";
 import { User, ResetPasswordRequest } from "@prisma/client";
+import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { hashPassword } from "../../../lib/auth";
+import prisma from "../../../lib/prisma";
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
-import { hashPassword } from "../../../lib/auth";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,7 +1,8 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
 import { hashPassword } from "@lib/auth";
 import prisma from "@lib/prisma";
 import slugify from "@lib/slugify";
-import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/auth/two-factor/totp/disable.ts
+++ b/pages/api/auth/two-factor/totp/disable.ts
@@ -1,6 +1,7 @@
-import prisma from "@lib/prisma";
-import { ErrorCode, getSession, verifyPassword } from "@lib/auth";
 import { NextApiRequest, NextApiResponse } from "next";
+
+import { ErrorCode, getSession, verifyPassword } from "@lib/auth";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/auth/two-factor/totp/enable.ts
+++ b/pages/api/auth/two-factor/totp/enable.ts
@@ -1,8 +1,9 @@
-import prisma from "@lib/prisma";
-import { ErrorCode, getSession } from "@lib/auth";
 import { NextApiRequest, NextApiResponse } from "next";
 import { authenticator } from "otplib";
+
+import { ErrorCode, getSession } from "@lib/auth";
 import { symmetricDecrypt } from "@lib/crypto";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/auth/two-factor/totp/setup.ts
+++ b/pages/api/auth/two-factor/totp/setup.ts
@@ -1,9 +1,10 @@
-import prisma from "@lib/prisma";
-import { ErrorCode, getSession, verifyPassword } from "@lib/auth";
 import { NextApiRequest, NextApiResponse } from "next";
 import { authenticator } from "otplib";
 import qrcode from "qrcode";
+
+import { ErrorCode, getSession, verifyPassword } from "@lib/auth";
 import { symmetricEncrypt } from "@lib/crypto";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/availability/[user].ts
+++ b/pages/api/availability/[user].ts
@@ -1,9 +1,10 @@
-import { asStringOrNull } from "@lib/asStringOrNull";
-import { getBusyCalendarTimes } from "@lib/calendarClient";
-import prisma from "@lib/prisma";
 // import { getBusyVideoTimes } from "@lib/videoClient";
 import dayjs from "dayjs";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import { asStringOrNull } from "@lib/asStringOrNull";
+import { getBusyCalendarTimes } from "@lib/calendarClient";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const user = asStringOrNull(req.query.user);

--- a/pages/api/availability/calendar.ts
+++ b/pages/api/availability/calendar.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
-import prisma from "../../../lib/prisma";
+
 import { IntegrationCalendar, listCalendars } from "../../../lib/calendarClient";
+import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/availability/day.ts
+++ b/pages/api/availability/day.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/availability/eventtype.ts
+++ b/pages/api/availability/eventtype.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
 import prisma from "@lib/prisma";
 

--- a/pages/api/availability/week.ts
+++ b/pages/api/availability/week.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/book/confirm.ts
+++ b/pages/api/book/confirm.ts
@@ -1,10 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import { refund } from "@ee/lib/stripe/server";
+
 import { getSession } from "@lib/auth";
-import prisma from "../../../lib/prisma";
 import { CalendarEvent } from "@lib/calendarClient";
 import EventRejectionMail from "@lib/emails/EventRejectionMail";
 import EventManager from "@lib/events/EventManager";
-import { refund } from "@ee/lib/stripe/server";
+
+import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   const session = await getSession({ req: req });

--- a/pages/api/book/event.ts
+++ b/pages/api/book/event.ts
@@ -1,22 +1,23 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
 import { SchedulingType, Prisma } from "@prisma/client";
-import { CalendarEvent, getBusyCalendarTimes } from "@lib/calendarClient";
-import { v5 as uuidv5 } from "uuid";
-import short from "short-uuid";
-import { getBusyVideoTimes } from "@lib/videoClient";
-import { getEventName } from "@lib/event";
 import dayjs from "dayjs";
-import logger from "@lib/logger";
-import EventManager, { CreateUpdateResult, EventResult, PartialReference } from "@lib/events/EventManager";
-
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import isBetween from "dayjs/plugin/isBetween";
 import dayjsBusinessDays from "dayjs-business-days";
-import EventOrganizerRequestMail from "@lib/emails/EventOrganizerRequestMail";
+import isBetween from "dayjs/plugin/isBetween";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import type { NextApiRequest, NextApiResponse } from "next";
+import short from "short-uuid";
+import { v5 as uuidv5 } from "uuid";
+
 import { handlePayment } from "@ee/lib/stripe/server";
+
+import { CalendarEvent, getBusyCalendarTimes } from "@lib/calendarClient";
+import EventOrganizerRequestMail from "@lib/emails/EventOrganizerRequestMail";
+import { getEventName } from "@lib/event";
+import EventManager, { CreateUpdateResult, EventResult, PartialReference } from "@lib/events/EventManager";
+import logger from "@lib/logger";
+import prisma from "@lib/prisma";
 import { BookingCreateBody } from "@lib/types/booking";
+import { getBusyVideoTimes } from "@lib/videoClient";
 
 dayjs.extend(dayjsBusinessDays);
 dayjs.extend(utc);

--- a/pages/api/cancel.ts
+++ b/pages/api/cancel.ts
@@ -1,10 +1,12 @@
-import prisma from "@lib/prisma";
-import { CalendarEvent, deleteEvent } from "@lib/calendarClient";
-import { deleteMeeting } from "@lib/videoClient";
-import async from "async";
 import { BookingStatus } from "@prisma/client";
-import { asStringOrNull } from "@lib/asStringOrNull";
+import async from "async";
+
 import { refund } from "@ee/lib/stripe/server";
+
+import { asStringOrNull } from "@lib/asStringOrNull";
+import { CalendarEvent, deleteEvent } from "@lib/calendarClient";
+import prisma from "@lib/prisma";
+import { deleteMeeting } from "@lib/videoClient";
 
 export default async function handler(req, res) {
   // just bail if it not a DELETE

--- a/pages/api/cron/bookingReminder.ts
+++ b/pages/api/cron/bookingReminder.ts
@@ -1,9 +1,10 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
-import dayjs from "dayjs";
 import { ReminderType } from "@prisma/client";
-import EventOrganizerRequestReminderMail from "@lib/emails/EventOrganizerRequestReminderMail";
+import dayjs from "dayjs";
+import type { NextApiRequest, NextApiResponse } from "next";
+
 import { CalendarEvent } from "@lib/calendarClient";
+import EventOrganizerRequestReminderMail from "@lib/emails/EventOrganizerRequestReminderMail";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   const apiKey = req.query.apiKey;

--- a/pages/api/event-type/index.ts
+++ b/pages/api/event-type/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
 import prisma from "@lib/prisma";
 

--- a/pages/api/integrations.ts
+++ b/pages/api/integrations.ts
@@ -1,5 +1,6 @@
-import prisma from "../../lib/prisma";
 import { getSession } from "@lib/auth";
+
+import prisma from "../../lib/prisma";
 
 export default async function handler(req, res) {
   if (req.method === "GET") {

--- a/pages/api/integrations/apple/add.ts
+++ b/pages/api/integrations/apple/add.ts
@@ -1,9 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getSession } from "next-auth/client";
-import prisma from "../../../../lib/prisma";
+
 import { symmetricEncrypt } from "@lib/crypto";
-import logger from "@lib/logger";
 import { AppleCalendar } from "@lib/integrations/Apple/AppleCalendarAdapter";
+import logger from "@lib/logger";
+
+import prisma from "../../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {

--- a/pages/api/integrations/caldav/add.ts
+++ b/pages/api/integrations/caldav/add.ts
@@ -1,9 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
-import prisma from "../../../../lib/prisma";
 import { symmetricEncrypt } from "@lib/crypto";
-import logger from "@lib/logger";
 import { CalDavCalendar } from "@lib/integrations/CalDav/CalDavCalendarAdapter";
+import logger from "@lib/logger";
+
+import prisma from "../../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {

--- a/pages/api/integrations/googlecalendar/add.ts
+++ b/pages/api/integrations/googlecalendar/add.ts
@@ -1,6 +1,7 @@
-import { getSession } from "@lib/auth";
 import { google } from "googleapis";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS!;
 const scopes = [

--- a/pages/api/integrations/googlecalendar/callback.ts
+++ b/pages/api/integrations/googlecalendar/callback.ts
@@ -1,7 +1,9 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getSession } from "@lib/auth";
-import prisma from "../../../../lib/prisma";
 import { google } from "googleapis";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
+
+import prisma from "../../../../lib/prisma";
 
 const credentials = process.env.GOOGLE_API_CREDENTIALS!;
 

--- a/pages/api/integrations/office365calendar/add.ts
+++ b/pages/api/integrations/office365calendar/add.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../../lib/prisma";
 
 const scopes = ["User.Read", "Calendars.Read", "Calendars.ReadWrite", "offline_access"];

--- a/pages/api/integrations/office365calendar/callback.ts
+++ b/pages/api/integrations/office365calendar/callback.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../../lib/prisma";
 
 const scopes = ["offline_access", "Calendars.Read", "Calendars.ReadWrite"];

--- a/pages/api/integrations/zoomvideo/add.ts
+++ b/pages/api/integrations/zoomvideo/add.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../../lib/prisma";
 
 const client_id = process.env.ZOOM_CLIENT_ID;

--- a/pages/api/integrations/zoomvideo/callback.ts
+++ b/pages/api/integrations/zoomvideo/callback.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
+
 import prisma from "../../../../lib/prisma";
 
 const client_id = process.env.ZOOM_CLIENT_ID;

--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
+
 import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
 import { defaultAvatarSrc } from "@lib/profile";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/schedule/index.ts
+++ b/pages/api/schedule/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+
 import { getSession } from "@lib/auth";
 import prisma from "@lib/prisma";
 

--- a/pages/api/teams.ts
+++ b/pages/api/teams.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../lib/prisma";
+
 import { getSession } from "@lib/auth";
 import slugify from "@lib/slugify";
+
+import prisma from "../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/teams/[team]/index.ts
+++ b/pages/api/teams/[team]/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
+
 import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/teams/[team]/invite.ts
+++ b/pages/api/teams/[team]/invite.ts
@@ -1,8 +1,10 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../../lib/prisma";
-import createInvitationEmail from "../../../../lib/emails/invitation";
-import { getSession } from "@lib/auth";
 import { randomBytes } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
+
+import createInvitationEmail from "../../../../lib/emails/invitation";
+import prisma from "../../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/pages/api/teams/[team]/membership.ts
+++ b/pages/api/teams/[team]/membership.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../../lib/prisma";
+
 import { getSession } from "@lib/auth";
+
+import prisma from "../../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req });

--- a/pages/api/teams/[team]/profile.ts
+++ b/pages/api/teams/[team]/profile.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
 import { getSession } from "next-auth/client";
+
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/user/[id].ts
+++ b/pages/api/user/[id].ts
@@ -1,7 +1,8 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
-import { getSession } from "@lib/auth";
 import { pick } from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/user/membership.ts
+++ b/pages/api/user/membership.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../lib/prisma";
+
 import { getSession } from "@lib/auth";
+
+import prisma from "../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -1,7 +1,8 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@lib/prisma";
-import { getSession } from "@lib/auth";
 import { pick } from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getSession({ req: req });

--- a/pages/auth/error.tsx
+++ b/pages/auth/error.tsx
@@ -1,7 +1,8 @@
-import { useRouter } from "next/router";
 import { XIcon } from "@heroicons/react/outline";
-import { HeadSeo } from "@components/seo/head-seo";
 import Link from "next/link";
+import { useRouter } from "next/router";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 export default function Error() {
   const router = useRouter();

--- a/pages/auth/forgot-password/[id].tsx
+++ b/pages/auth/forgot-password/[id].tsx
@@ -1,12 +1,14 @@
-import { getCsrfToken } from "next-auth/client";
-import prisma from "@lib/prisma";
-import { HeadSeo } from "@components/seo/head-seo";
-import React, { useMemo } from "react";
-import debounce from "lodash.debounce";
-import dayjs from "dayjs";
 import { ResetPasswordRequest } from "@prisma/client";
-import Link from "next/link";
+import dayjs from "dayjs";
+import debounce from "lodash.debounce";
 import { GetServerSidePropsContext } from "next";
+import { getCsrfToken } from "next-auth/client";
+import Link from "next/link";
+import React, { useMemo } from "react";
+
+import prisma from "@lib/prisma";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 type Props = {
   id: string;

--- a/pages/auth/forgot-password/index.tsx
+++ b/pages/auth/forgot-password/index.tsx
@@ -1,9 +1,11 @@
-import { HeadSeo } from "@components/seo/head-seo";
+import debounce from "lodash.debounce";
+import { getCsrfToken } from "next-auth/client";
 import Link from "next/link";
 import React from "react";
-import { getCsrfToken } from "next-auth/client";
-import debounce from "lodash.debounce";
+
 import { getSession } from "@lib/auth";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 export default function ForgotPassword({ csrfToken }) {
   const [loading, setLoading] = React.useState(false);

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,9 +1,11 @@
-import { HeadSeo } from "@components/seo/head-seo";
-import Link from "next/link";
 import { getCsrfToken, signIn } from "next-auth/client";
-import { ErrorCode, getSession } from "@lib/auth";
-import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { ErrorCode, getSession } from "@lib/auth";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 const errorMessages: { [key: string]: string } = {
   [ErrorCode.SecondFactorRequired]:

--- a/pages/auth/logout.tsx
+++ b/pages/auth/logout.tsx
@@ -1,6 +1,7 @@
-import { HeadSeo } from "@components/seo/head-seo";
-import Link from "next/link";
 import { CheckIcon } from "@heroicons/react/outline";
+import Link from "next/link";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 export default function Logout() {
   return (

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -1,10 +1,12 @@
-import { HeadSeo } from "@components/seo/head-seo";
-import { useRouter } from "next/router";
 import { signIn } from "next-auth/client";
-import ErrorAlert from "@components/ui/alerts/Error";
+import { useRouter } from "next/router";
 import { useState } from "react";
-import { UsernameInput } from "@components/ui/UsernameInput";
+
 import prisma from "@lib/prisma";
+
+import { HeadSeo } from "@components/seo/head-seo";
+import { UsernameInput } from "@components/ui/UsernameInput";
+import ErrorAlert from "@components/ui/alerts/Error";
 
 export default function Signup(props) {
   const router = useRouter();

--- a/pages/availability/index.tsx
+++ b/pages/availability/index.tsx
@@ -1,13 +1,15 @@
+import { ClockIcon } from "@heroicons/react/outline";
+import { useSession } from "next-auth/client";
 import Link from "next/link";
-import prisma from "@lib/prisma";
-import Modal from "@components/Modal";
-import Shell from "@components/Shell";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
-import { useSession } from "next-auth/client";
-import { ClockIcon } from "@heroicons/react/outline";
-import Loader from "@components/Loader";
+
 import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
+
+import Loader from "@components/Loader";
+import Modal from "@components/Modal";
+import Shell from "@components/Shell";
 
 export default function Availability(props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/pages/availability/troubleshoot.tsx
+++ b/pages/availability/troubleshoot.tsx
@@ -1,10 +1,12 @@
-import Loader from "@components/Loader";
-import prisma from "@lib/prisma";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { GetServerSideProps } from "next";
-import { getSession } from "@lib/auth";
 import { useEffect, useState } from "react";
+
+import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
+
+import Loader from "@components/Loader";
 import Shell from "@components/Shell";
 
 dayjs.extend(utc);

--- a/pages/bookings/index.tsx
+++ b/pages/bookings/index.tsx
@@ -1,19 +1,21 @@
-import prisma from "@lib/prisma";
-import { useSession } from "next-auth/client";
-import Shell from "@components/Shell";
-import { useRouter } from "next/router";
-import dayjs from "dayjs";
-import { Fragment } from "react";
 // TODO: replace headlessui with radix-ui
 import { Menu, Transition } from "@headlessui/react";
-import { DotsHorizontalIcon } from "@heroicons/react/solid";
-import classNames from "@lib/classNames";
 import { ClockIcon, CalendarIcon, XIcon, CheckIcon, BanIcon } from "@heroicons/react/outline";
-import Loader from "@components/Loader";
-import { Button } from "@components/ui/Button";
-import { getSession } from "@lib/auth";
+import { DotsHorizontalIcon } from "@heroicons/react/solid";
 import { BookingStatus, User } from "@prisma/client";
+import dayjs from "dayjs";
+import { useSession } from "next-auth/client";
+import { useRouter } from "next/router";
+import { Fragment } from "react";
+
+import { getSession } from "@lib/auth";
+import classNames from "@lib/classNames";
+import prisma from "@lib/prisma";
+
 import EmptyScreen from "@components/EmptyScreen";
+import Loader from "@components/Loader";
+import Shell from "@components/Shell";
+import { Button } from "@components/ui/Button";
 
 export default function Bookings({ bookings }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/pages/cancel/[uid].tsx
+++ b/pages/cancel/[uid].tsx
@@ -1,12 +1,14 @@
 import { CalendarIcon, XIcon } from "@heroicons/react/solid";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { HeadSeo } from "@components/seo/head-seo";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { Button } from "@components/ui/Button";
+
 import prisma from "@lib/prisma";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
+
+import { HeadSeo } from "@components/seo/head-seo";
+import { Button } from "@components/ui/Button";
 
 dayjs.extend(utc);
 

--- a/pages/cancel/success.tsx
+++ b/pages/cancel/success.tsx
@@ -1,9 +1,10 @@
-import { HeadSeo } from "@components/seo/head-seo";
-import { useRouter } from "next/router";
 import { CheckIcon } from "@heroicons/react/outline";
-import { useSession } from "next-auth/client";
-import Button from "@components/ui/Button";
 import { ArrowRightIcon } from "@heroicons/react/solid";
+import { useSession } from "next-auth/client";
+import { useRouter } from "next/router";
+
+import { HeadSeo } from "@components/seo/head-seo";
+import Button from "@components/ui/Button";
 
 export default function CancelSuccess() {
   // Get router variables

--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -1,17 +1,6 @@
-import { useRouter } from "next/router";
-import Modal from "@components/Modal";
-import React, { useEffect, useRef, useState } from "react";
-import Select, { OptionTypeBase } from "react-select";
-import prisma from "@lib/prisma";
-import { EventTypeCustomInput, EventTypeCustomInputType, SchedulingType } from "@prisma/client";
-import { LocationType } from "@lib/location";
-import Shell from "@components/Shell";
-import { getSession } from "@lib/auth";
-import { Scheduler } from "@components/ui/Scheduler";
 // TODO: replace headlessui with radix-ui
 import { Disclosure, RadioGroup } from "@headlessui/react";
 import { PhoneIcon, XIcon } from "@heroicons/react/outline";
-import { HttpError } from "@lib/core/http/error";
 import {
   LocationMarkerIcon,
   LinkIcon,
@@ -24,34 +13,46 @@ import {
   UsersIcon,
   UserAddIcon,
 } from "@heroicons/react/solid";
-
+import { EventTypeCustomInput, EventTypeCustomInputType, SchedulingType } from "@prisma/client";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import throttle from "lodash.throttle";
+import { GetServerSidePropsContext } from "next";
+import { useRouter } from "next/router";
+import React, { useEffect, useRef, useState } from "react";
+import { DateRangePicker, OrientationShape, toMomentObject } from "react-dates";
 import "react-dates/initialize";
 import "react-dates/lib/css/_datepicker.css";
-import { DateRangePicker, OrientationShape, toMomentObject } from "react-dates";
-import Switch from "@components/ui/Switch";
-import { Dialog, DialogTrigger } from "@components/Dialog";
-import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
-import { GetServerSidePropsContext } from "next";
-import { useMutation } from "react-query";
-import { AdvancedOptions, EventTypeInput } from "@lib/types/event-type";
-import updateEventType from "@lib/mutations/event-types/update-event-type";
-import deleteEventType from "@lib/mutations/event-types/delete-event-type";
-import showToast from "@lib/notification";
-import CheckedSelect from "@components/ui/form/CheckedSelect";
-import { defaultAvatarSrc } from "@lib/profile";
-import * as RadioArea from "@components/ui/form/radio-area";
-import classNames from "@lib/classNames";
-import { inferSSRProps } from "@lib/types/inferSSRProps";
 import { FormattedNumber, IntlProvider } from "react-intl";
-import { asStringOrThrow } from "@lib/asStringOrNull";
-import Button from "@components/ui/Button";
-import getIntegrations, { hasIntegration } from "@lib/integrations/getIntegrations";
+import { useMutation } from "react-query";
+import Select, { OptionTypeBase } from "react-select";
 import Stripe from "stripe";
+
+import { asStringOrThrow } from "@lib/asStringOrNull";
+import { getSession } from "@lib/auth";
+import classNames from "@lib/classNames";
+import { HttpError } from "@lib/core/http/error";
+import getIntegrations, { hasIntegration } from "@lib/integrations/getIntegrations";
+import { LocationType } from "@lib/location";
+import deleteEventType from "@lib/mutations/event-types/delete-event-type";
+import updateEventType from "@lib/mutations/event-types/update-event-type";
+import showToast from "@lib/notification";
+import prisma from "@lib/prisma";
+import { defaultAvatarSrc } from "@lib/profile";
+import { AdvancedOptions, EventTypeInput } from "@lib/types/event-type";
+import { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import { Dialog, DialogTrigger } from "@components/Dialog";
+import Modal from "@components/Modal";
+import Shell from "@components/Shell";
+import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
+import Button from "@components/ui/Button";
+import { Scheduler } from "@components/ui/Scheduler";
+import Switch from "@components/ui/Switch";
 import CheckboxField from "@components/ui/form/CheckboxField";
+import CheckedSelect from "@components/ui/form/CheckedSelect";
+import * as RadioArea from "@components/ui/form/radio-area";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -1,7 +1,37 @@
+// TODO: replace headlessui with radix-ui
+import { Menu, Transition } from "@headlessui/react";
+import {
+  ChevronDownIcon,
+  DotsHorizontalIcon,
+  ExternalLinkIcon,
+  LinkIcon,
+  PlusIcon,
+  UsersIcon,
+} from "@heroicons/react/solid";
+import { SchedulingType } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import dayjs from "dayjs";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import React, { Fragment, useRef } from "react";
+import { useMutation } from "react-query";
+
+import { asStringOrNull } from "@lib/asStringOrNull";
+import { getSession } from "@lib/auth";
+import classNames from "@lib/classNames";
+import { HttpError } from "@lib/core/http/error";
+import { ONBOARDING_INTRODUCED_AT } from "@lib/getting-started";
+import { useToggleQuery } from "@lib/hooks/useToggleQuery";
+import createEventType from "@lib/mutations/event-types/create-event-type";
+import showToast from "@lib/notification";
+import prisma from "@lib/prisma";
+import { inferSSRProps } from "@lib/types/inferSSRProps";
+
 import { Dialog, DialogClose, DialogContent } from "@components/Dialog";
-import EventTypeDescription from "@components/eventtype/EventTypeDescription";
 import Shell from "@components/Shell";
 import { Tooltip } from "@components/Tooltip";
+import EventTypeDescription from "@components/eventtype/EventTypeDescription";
 import { Alert } from "@components/ui/Alert";
 import Avatar from "@components/ui/Avatar";
 import AvatarGroup from "@components/ui/AvatarGroup";
@@ -16,34 +46,6 @@ import Dropdown, {
 } from "@components/ui/Dropdown";
 import * as RadioArea from "@components/ui/form/radio-area";
 import UserCalendarIllustration from "@components/ui/svg/UserCalendarIllustration";
-// TODO: replace headlessui with radix-ui
-import { Menu, Transition } from "@headlessui/react";
-import {
-  ChevronDownIcon,
-  DotsHorizontalIcon,
-  ExternalLinkIcon,
-  LinkIcon,
-  PlusIcon,
-  UsersIcon,
-} from "@heroicons/react/solid";
-import { asStringOrNull } from "@lib/asStringOrNull";
-import { getSession } from "@lib/auth";
-import classNames from "@lib/classNames";
-import { HttpError } from "@lib/core/http/error";
-import { ONBOARDING_INTRODUCED_AT } from "@lib/getting-started";
-import { useToggleQuery } from "@lib/hooks/useToggleQuery";
-import createEventType from "@lib/mutations/event-types/create-event-type";
-import showToast from "@lib/notification";
-import prisma from "@lib/prisma";
-import { inferSSRProps } from "@lib/types/inferSSRProps";
-import { SchedulingType } from "@prisma/client";
-import dayjs from "dayjs";
-import Head from "next/head";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import React, { Fragment, useRef } from "react";
-import { useMutation } from "react-query";
-import { Prisma } from "@prisma/client";
 
 type PageProps = inferSSRProps<typeof getServerSideProps>;
 type EventType = PageProps["eventTypes"][number];

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -1,6 +1,4 @@
-import Head from "next/head";
-import prisma from "@lib/prisma";
-import { useSession } from "next-auth/client";
+import { ArrowRightIcon } from "@heroicons/react/outline";
 import {
   EventType,
   EventTypeCreateInput,
@@ -9,29 +7,34 @@ import {
   User,
   UserUpdateInput,
 } from "@prisma/client";
-import { NextPageContext } from "next";
-import React, { useEffect, useRef, useState } from "react";
-import { validJson } from "@lib/jsonUtils";
-import TimezoneSelect from "react-timezone-select";
-import Text from "@components/ui/Text";
-import ErrorAlert from "@components/ui/alerts/Error";
+import classnames from "classnames";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import debounce from "lodash.debounce";
+import { NextPageContext } from "next";
+import { useSession } from "next-auth/client";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { Integration } from "pages/integrations";
+import React, { useEffect, useRef, useState } from "react";
+import TimezoneSelect from "react-timezone-select";
+
+import { getSession } from "@lib/auth";
 import AddCalDavIntegration, {
   ADD_CALDAV_INTEGRATION_FORM_TITLE,
 } from "@lib/integrations/CalDav/components/AddCalDavIntegration";
+import { validJson } from "@lib/jsonUtils";
+import prisma from "@lib/prisma";
+
 import { Dialog, DialogClose, DialogContent, DialogHeader } from "@components/Dialog";
-import SchedulerForm, { SCHEDULE_FORM_ID } from "@components/ui/Schedule/Schedule";
-import { useRouter } from "next/router";
-import { Integration } from "pages/integrations";
-import { AddCalDavIntegrationRequest } from "../lib/integrations/CalDav/components/AddCalDavIntegration";
-import classnames from "classnames";
-import { ArrowRightIcon } from "@heroicons/react/outline";
-import { getSession } from "@lib/auth";
-import Button from "@components/ui/Button";
-import debounce from "lodash.debounce";
 import Loader from "@components/Loader";
+import Button from "@components/ui/Button";
+import SchedulerForm, { SCHEDULE_FORM_ID } from "@components/ui/Schedule/Schedule";
+import Text from "@components/ui/Text";
+import ErrorAlert from "@components/ui/alerts/Error";
+
+import { AddCalDavIntegrationRequest } from "../lib/integrations/CalDav/components/AddCalDavIntegration";
 import getEventTypes from "../lib/queries/event-types/get-event-types";
 
 dayjs.extend(utc);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
-import Loader from "@components/Loader";
 import { useRouter } from "next/router";
+
+import Loader from "@components/Loader";
 
 function RedirectPage() {
   const router = useRouter();

--- a/pages/integrations/[integration].tsx
+++ b/pages/integrations/[integration].tsx
@@ -1,10 +1,12 @@
-import prisma from "@lib/prisma";
-import { getIntegrationName, getIntegrationType } from "@lib/integrations";
-import Shell from "@components/Shell";
-import { useRouter } from "next/router";
 import { useSession } from "next-auth/client";
-import Loader from "@components/Loader";
+import { useRouter } from "next/router";
+
 import { getSession } from "@lib/auth";
+import { getIntegrationName, getIntegrationType } from "@lib/integrations";
+import prisma from "@lib/prisma";
+
+import Loader from "@components/Loader";
+import Shell from "@components/Shell";
 
 export default function Integration(props) {
   const router = useRouter();

--- a/pages/integrations/index.tsx
+++ b/pages/integrations/index.tsx
@@ -1,24 +1,26 @@
-import Link from "next/link";
-import prisma from "@lib/prisma";
-import Shell from "@components/Shell";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useSession } from "next-auth/client";
-import { CheckCircleIcon, ChevronRightIcon, PlusIcon, XCircleIcon } from "@heroicons/react/solid";
 import { InformationCircleIcon } from "@heroicons/react/outline";
-import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTrigger } from "@components/Dialog";
-import Switch from "@components/ui/Switch";
-import Loader from "@components/Loader";
-import AddCalDavIntegration, {
-  ADD_CALDAV_INTEGRATION_FORM_TITLE,
-} from "@lib/integrations/CalDav/components/AddCalDavIntegration";
+import { CheckCircleIcon, ChevronRightIcon, PlusIcon, XCircleIcon } from "@heroicons/react/solid";
+import { GetServerSidePropsContext } from "next";
+import { useSession } from "next-auth/client";
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import { getSession } from "@lib/auth";
 import AddAppleIntegration, {
   ADD_APPLE_INTEGRATION_FORM_TITLE,
 } from "@lib/integrations/Apple/components/AddAppleIntegration";
-import Button from "@components/ui/Button";
+import AddCalDavIntegration, {
+  ADD_CALDAV_INTEGRATION_FORM_TITLE,
+} from "@lib/integrations/CalDav/components/AddCalDavIntegration";
 import getIntegrations from "@lib/integrations/getIntegrations";
-import { GetServerSidePropsContext } from "next";
+import prisma from "@lib/prisma";
 import { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTrigger } from "@components/Dialog";
+import Loader from "@components/Loader";
+import Shell from "@components/Shell";
+import Button from "@components/ui/Button";
+import Switch from "@components/ui/Switch";
 
 export default function Home({ integrations }: inferSSRProps<typeof getServerSideProps>) {
   const [, loading] = useSession();

--- a/pages/payment/[uid].tsx
+++ b/pages/payment/[uid].tsx
@@ -1,5 +1,6 @@
 import PaymentPage from "@ee/components/stripe/PaymentPage";
 import { getServerSideProps } from "@ee/pages/payment/[uid]";
+
 import { inferSSRProps } from "@lib/types/inferSSRProps";
 
 export default function Payment(props: inferSSRProps<typeof getServerSideProps>) {

--- a/pages/reschedule/[uid].tsx
+++ b/pages/reschedule/[uid].tsx
@@ -1,6 +1,7 @@
 import { GetServerSidePropsContext } from "next";
-import prisma from "@lib/prisma";
+
 import { asStringOrNull } from "@lib/asStringOrNull";
+import prisma from "@lib/prisma";
 
 export default function Type() {
   // Just redirect to the schedule page to reschedule it.

--- a/pages/sandbox/Alert.tsx
+++ b/pages/sandbox/Alert.tsx
@@ -1,6 +1,7 @@
-import { Alert, AlertProps } from "@components/ui/Alert";
 import Head from "next/head";
 import React from "react";
+
+import { Alert, AlertProps } from "@components/ui/Alert";
 
 export default function AlertPage() {
   const list: AlertProps[] = [

--- a/pages/sandbox/Button.tsx
+++ b/pages/sandbox/Button.tsx
@@ -1,7 +1,8 @@
-import { Button, ButtonProps } from "@components/ui/Button";
 import { PlusIcon } from "@heroicons/react/solid";
 import Head from "next/head";
 import React from "react";
+
+import { Button, ButtonProps } from "@components/ui/Button";
 
 export default function ButtonPage() {
   const list: ButtonProps[] = [

--- a/pages/sandbox/RadioArea.tsx
+++ b/pages/sandbox/RadioArea.tsx
@@ -1,6 +1,7 @@
-import * as RadioArea from "@components/ui/form/radio-area";
 import Head from "next/head";
 import React, { useState } from "react";
+
+import * as RadioArea from "@components/ui/form/radio-area";
 
 const selectOptions = [
   {

--- a/pages/sandbox/preview-error-page.tsx
+++ b/pages/sandbox/preview-error-page.tsx
@@ -1,7 +1,9 @@
 import { NextPage } from "next";
-import { ErrorPage } from "@components/error/error-page";
 import React from "react";
+
 import { HttpError } from "@lib/core/http/error";
+
+import { ErrorPage } from "@components/error/error-page";
 
 const PreviewErrorPage: NextPage = () => {
   const statusCode = 403;

--- a/pages/sandbox/test-async-error.tsx
+++ b/pages/sandbox/test-async-error.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { HttpError } from "@lib/core/http/error";
 import { useQuery } from "react-query";
+
+import { HttpError } from "@lib/core/http/error";
 
 const TestAsyncErrorRoute: React.FC = () => {
   const { error, isLoading } = useQuery(["error-promise"], async () => {

--- a/pages/sandbox/test-error.tsx
+++ b/pages/sandbox/test-error.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { HttpError } from "@lib/core/http/error";
 
 type Props = {

--- a/pages/settings/billing.tsx
+++ b/pages/settings/billing.tsx
@@ -1,7 +1,8 @@
-import Shell from "@components/Shell";
-import SettingsShell from "@components/Settings";
-import prisma from "@lib/prisma";
 import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
+
+import SettingsShell from "@components/Settings";
+import Shell from "@components/Shell";
 
 export default function Billing() {
   return (

--- a/pages/settings/embed.tsx
+++ b/pages/settings/embed.tsx
@@ -1,9 +1,11 @@
-import prisma from "@lib/prisma";
-import Shell from "@components/Shell";
-import SettingsShell from "@components/Settings";
 import { useSession } from "next-auth/client";
-import Loader from "@components/Loader";
+
 import { getSession } from "@lib/auth";
+import prisma from "@lib/prisma";
+
+import Loader from "@components/Loader";
+import SettingsShell from "@components/Settings";
+import Shell from "@components/Shell";
 
 export default function Embed(props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/pages/settings/profile.tsx
+++ b/pages/settings/profile.tsx
@@ -1,21 +1,23 @@
+import crypto from "crypto";
 import { GetServerSidePropsContext } from "next";
 import { RefObject, useEffect, useRef, useState } from "react";
-import prisma from "@lib/prisma";
-import Modal from "@components/Modal";
-import Shell from "@components/Shell";
-import SettingsShell from "@components/Settings";
-import Avatar from "@components/ui/Avatar";
-import { getSession } from "@lib/auth";
 import Select from "react-select";
 import TimezoneSelect from "react-timezone-select";
-import { UsernameInput } from "@components/ui/UsernameInput";
-import ErrorAlert from "@components/ui/alerts/Error";
-import ImageUploader from "@components/ImageUploader";
-import crypto from "crypto";
+
+import { getSession } from "@lib/auth";
+import { isBrandingHidden } from "@lib/isBrandingHidden";
+import prisma from "@lib/prisma";
 import { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import ImageUploader from "@components/ImageUploader";
+import Modal from "@components/Modal";
+import SettingsShell from "@components/Settings";
+import Shell from "@components/Shell";
+import Avatar from "@components/ui/Avatar";
 import Badge from "@components/ui/Badge";
 import Button from "@components/ui/Button";
-import { isBrandingHidden } from "@lib/isBrandingHidden";
+import { UsernameInput } from "@components/ui/UsernameInput";
+import ErrorAlert from "@components/ui/alerts/Error";
 
 const themeOptions = [
   { value: "light", label: "Light" },

--- a/pages/settings/security.tsx
+++ b/pages/settings/security.tsx
@@ -1,11 +1,13 @@
-import React from "react";
-import prisma from "@lib/prisma";
-import Shell from "@components/Shell";
-import SettingsShell from "@components/Settings";
 import { getSession, useSession } from "next-auth/client";
+import React from "react";
+
+import prisma from "@lib/prisma";
+
 import Loader from "@components/Loader";
-import TwoFactorAuthSection from "@components/security/TwoFactorAuthSection";
+import SettingsShell from "@components/Settings";
+import Shell from "@components/Shell";
 import ChangePasswordSection from "@components/security/ChangePasswordSection";
+import TwoFactorAuthSection from "@components/security/TwoFactorAuthSection";
 
 export default function Security({ user }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/pages/settings/teams.tsx
+++ b/pages/settings/teams.tsx
@@ -1,19 +1,21 @@
+import { UsersIcon } from "@heroicons/react/outline";
+import { PlusIcon } from "@heroicons/react/solid";
 import { GetServerSideProps } from "next";
-import Shell from "@components/Shell";
-import SettingsShell from "@components/Settings";
-import { useEffect, useRef, useState } from "react";
 import type { Session } from "next-auth";
 import { useSession } from "next-auth/client";
-import { UsersIcon } from "@heroicons/react/outline";
-import TeamList from "@components/team/TeamList";
-import TeamListItem from "@components/team/TeamListItem";
-import Loader from "@components/Loader";
+import { useEffect, useRef, useState } from "react";
+
 import { getSession } from "@lib/auth";
-import EditTeam from "@components/team/EditTeam";
-import Button from "@components/ui/Button";
 import { Member } from "@lib/member";
 import { Team } from "@lib/team";
-import { PlusIcon } from "@heroicons/react/solid";
+
+import Loader from "@components/Loader";
+import SettingsShell from "@components/Settings";
+import Shell from "@components/Shell";
+import EditTeam from "@components/team/EditTeam";
+import TeamList from "@components/team/TeamList";
+import TeamListItem from "@components/team/TeamListItem";
+import Button from "@components/ui/Button";
 
 export default function Teams() {
   const noop = () => undefined;

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -1,21 +1,23 @@
-import { HeadSeo } from "@components/seo/head-seo";
-import Link from "next/link";
-import prisma from "@lib/prisma";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import { CheckIcon } from "@heroicons/react/outline";
 import { ClockIcon } from "@heroicons/react/solid";
+import { EventType } from "@prisma/client";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import toArray from "dayjs/plugin/toArray";
 import timezone from "dayjs/plugin/timezone";
+import toArray from "dayjs/plugin/toArray";
+import utc from "dayjs/plugin/utc";
 import { createEvent } from "ics";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { asStringOrNull } from "@lib/asStringOrNull";
 import { getEventName } from "@lib/event";
 import useTheme from "@lib/hooks/useTheme";
-import { asStringOrNull } from "@lib/asStringOrNull";
-import { inferSSRProps } from "@lib/types/inferSSRProps";
 import { isBrandingHidden } from "@lib/isBrandingHidden";
-import { EventType } from "@prisma/client";
+import prisma from "@lib/prisma";
+import { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import { HeadSeo } from "@components/seo/head-seo";
 
 dayjs.extend(utc);
 dayjs.extend(toArray);

--- a/pages/team/[slug].tsx
+++ b/pages/team/[slug].tsx
@@ -1,18 +1,20 @@
+import { ArrowRightIcon } from "@heroicons/react/solid";
 import { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
-import { HeadSeo } from "@components/seo/head-seo";
-import useTheme from "@lib/hooks/useTheme";
-import { ArrowRightIcon } from "@heroicons/react/solid";
-import prisma from "@lib/prisma";
-import Avatar from "@components/ui/Avatar";
-import Text from "@components/ui/Text";
 import React from "react";
-import { defaultAvatarSrc } from "@lib/profile";
-import EventTypeDescription from "@components/eventtype/EventTypeDescription";
-import Team from "@components/team/screens/Team";
+
+import useTheme from "@lib/hooks/useTheme";
 import { useToggleQuery } from "@lib/hooks/useToggleQuery";
+import prisma from "@lib/prisma";
+import { defaultAvatarSrc } from "@lib/profile";
+
+import EventTypeDescription from "@components/eventtype/EventTypeDescription";
+import { HeadSeo } from "@components/seo/head-seo";
+import Team from "@components/team/screens/Team";
+import Avatar from "@components/ui/Avatar";
 import AvatarGroup from "@components/ui/AvatarGroup";
 import Button from "@components/ui/Button";
+import Text from "@components/ui/Text";
 
 function TeamPage({ team }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { isReady } = useTheme();

--- a/pages/team/[slug]/[type].tsx
+++ b/pages/team/[slug]/[type].tsx
@@ -1,7 +1,9 @@
 import { Availability, EventType } from "@prisma/client";
-import prisma from "@lib/prisma";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+
 import { asStringOrNull } from "@lib/asStringOrNull";
+import prisma from "@lib/prisma";
+
 import AvailabilityPage from "@components/booking/pages/AvailabilityPage";
 
 export default function TeamType(props: InferGetServerSidePropsType<typeof getServerSideProps>) {

--- a/pages/team/[slug]/book.tsx
+++ b/pages/team/[slug]/book.tsx
@@ -1,9 +1,11 @@
-import BookingPage from "@components/booking/pages/BookingPage";
+import { GetServerSidePropsContext } from "next";
+import "react-phone-number-input/style.css";
+
 import { asStringOrThrow } from "@lib/asStringOrNull";
 import prisma from "@lib/prisma";
 import { inferSSRProps } from "@lib/types/inferSSRProps";
-import { GetServerSidePropsContext } from "next";
-import "react-phone-number-input/style.css";
+
+import BookingPage from "@components/booking/pages/BookingPage";
 
 export type TeamBookingPageProps = inferSSRProps<typeof getServerSideProps>;
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,7 +1,9 @@
-import { hashPassword } from "../lib/auth";
 import { Prisma, PrismaClient, UserPlan } from "@prisma/client";
 import dayjs from "dayjs";
 import { uuid } from "short-uuid";
+
+import { hashPassword } from "@lib/auth";
+
 const prisma = new PrismaClient();
 
 async function createBookingForEventType(opts: {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,7 +2,7 @@ import { Prisma, PrismaClient, UserPlan } from "@prisma/client";
 import dayjs from "dayjs";
 import { uuid } from "short-uuid";
 
-import { hashPassword } from "@lib/auth";
+import { hashPassword } from "../lib/auth";
 
 const prisma = new PrismaClient();
 

--- a/test/lib/parseZone.test.ts
+++ b/test/lib/parseZone.test.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+
 import { parseZone } from "@lib/parseZone";
 
 dayjs.extend(utc);

--- a/test/lib/prisma.test.ts
+++ b/test/lib/prisma.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "@jest/globals";
+
 import { whereAndSelect } from "@lib/prisma";
 
 it("can decorate using whereAndSelect", async () => {

--- a/test/lib/slots.test.ts
+++ b/test/lib/slots.test.ts
@@ -1,9 +1,10 @@
-import getSlots from "@lib/slots";
 import { expect, it } from "@jest/globals";
-import MockDate from "mockdate";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import MockDate from "mockdate";
+
+import getSlots from "@lib/slots";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,28 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
   integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
+"@babel/core@7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.10.tgz#07de050bbd8193fcd8a3c27918c0890613a94559"
+  integrity sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-compilation-targets" "^7.13.10"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helpers" "^7.13.10"
+    "@babel/parser" "^7.13.10"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/core@^7.1.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.15.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
@@ -42,7 +64,16 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.15.4", "@babel/generator@^7.7.2":
+"@babel/generator@7.13.9":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
+  integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
+  dependencies:
+    "@babel/types" "^7.13.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.15.4", "@babel/generator@^7.7.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
   integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
@@ -51,7 +82,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.15.4":
+"@babel/helper-compilation-targets@^7.13.10", "@babel/helper-compilation-targets@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz#cf6d94f30fbefc139123e27dd6b02f65aeedb7b9"
   integrity sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==
@@ -61,7 +92,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-function-name@^7.15.4":
+"@babel/helper-function-name@^7.12.13", "@babel/helper-function-name@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
   integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
@@ -98,7 +129,7 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-module-transforms@^7.15.4":
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz#962cc629a7f7f9a082dd62d0307fa75fe8788d7c"
   integrity sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==
@@ -141,14 +172,14 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-split-export-declaration@^7.15.4":
+"@babel/helper-split-export-declaration@^7.12.13", "@babel/helper-split-export-declaration@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
   integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
   integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
@@ -158,7 +189,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
-"@babel/helpers@^7.15.4":
+"@babel/helpers@^7.13.10", "@babel/helpers@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.15.4.tgz#5f40f02050a3027121a3cf48d497c05c555eaf43"
   integrity sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==
@@ -176,7 +207,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
+"@babel/parser@7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.10.tgz#8f8f9bf7b3afa3eabd061f7a5bcdf4fec3c48409"
+  integrity sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
   version "7.15.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.6.tgz#043b9aa3c303c0722e5377fef9197f4cf1796549"
   integrity sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
@@ -293,7 +329,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.15.4", "@babel/template@^7.3.3":
+"@babel/template@^7.12.13", "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
   integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
@@ -302,7 +338,22 @@
     "@babel/parser" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.7.2":
+"@babel/traverse@7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.0.tgz#6d95752475f86ee7ded06536de309a65fc8966cc"
+  integrity sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.0"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.13.0"
+    "@babel/types" "^7.13.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.7.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
   integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
@@ -317,6 +368,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/types@7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
+  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
@@ -325,7 +385,7 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+"@babel/types@^7.0.0", "@babel/types@^7.13.0", "@babel/types@^7.15.4", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.15.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
   integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
@@ -1356,6 +1416,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@trivago/prettier-plugin-sort-imports@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-2.0.4.tgz#2e5bbf80bd87e919202f791008a2fbcdbb2a566f"
+  integrity sha512-SCVUhQdbjn/Z4AY7b9JO00fZCeXxiVuarVxYP0n6cX2ijiQkE5HmGrOk32n0u385OebzQ9bZcrc51lAGLjXnFQ==
+  dependencies:
+    "@babel/core" "7.13.10"
+    "@babel/generator" "7.13.9"
+    "@babel/parser" "7.13.10"
+    "@babel/traverse" "7.13.0"
+    "@babel/types" "7.13.0"
+    "@types/lodash" "4.14.168"
+    javascript-natural-sort "0.7.1"
+    lodash "4.17.21"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -1472,6 +1546,11 @@
   version "4.14.173"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.173.tgz#9d3b674c67a26cf673756f6aca7b429f237f91ed"
   integrity sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==
+
+"@types/lodash@4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/lodash@^4.14.165":
   version "4.14.172"
@@ -4716,6 +4795,11 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
+
 jest-changed-files@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.1.1.tgz#9b3f67a34cc58e3e811e2e1e21529837653e4200"
@@ -5532,7 +5616,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.1.1, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.1.1, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
- Added a plugin to sort imports
- We should discuss if we want separators or not:
https://github.com/calendso/calendso/blob/ccb416df5f16816dfe8cf25ebd9260469a3c6019/.prettierrc.js#L11
- Sorted the imports of `pages/event-types/index.tsx` to demo it.
