### PR TITLE
Remove password reset data from response

### DIFF
--- a/pages/api/auth/forgot-password.ts
+++ b/pages/api/auth/forgot-password.ts
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       text: message,
     });
 
-    return res.status(201).json({ message: "Reset Requested", data: passwordRequest });
+    return res.status(201).json({ message: "Reset Requested" });
   } catch (reason) {
     console.error(reason);
     return res.status(500).json({ message: "Unable to create password reset request" });


### PR DESCRIPTION
The forgot-password flow creates a ResetPasswordRequest record and uses the generated primary key as a URL token. The issue is that the endpoint returns the entire record when initiating the flow, which allows an attacker to change the password of any account without receiving an email.