### PR TITLE
fix: double slash in copying event link

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -908,9 +908,13 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
               </a>
               <button
                 onClick={() => {
+                  var hostname = if(window.location.hostname.endsWith("/")){
+                    window.location.hostname
+                  }else{
+                    window.location.hostname+"/"
+                  }
                   navigator.clipboard.writeText(
-                    window.location.hostname +
-                      "/" +
+                    hostname +
                       (team ? "team/" + team.slug : eventType.users[0].username) +
                       "/" +
                       eventType.slug


### PR DESCRIPTION
fix #642 