### PR TITLE
Fixes deployed previews

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const withTM = require("next-transpile-modules")(["react-timezone-select"]);
 
-// TODO: Revisit this later with getStaticProps in App
-if (process.env.NEXTAUTH_URL) {
-  process.env.BASE_URL = process.env.NEXTAUTH_URL.replace("/api/auth", "");
+// So we can test deploy previews preview
+if (process.env.VERCEL_URL && !process.env.BASE_URL) {
+  process.env.BASE_URL = process.env.VERCEL_URL;
+}
+if (process.env.BASE_URL) {
+  process.env.NEXTAUTH_URL = process.env.BASE_URL + "/api/auth";
 }
 
 if (!process.env.EMAIL_FROM) {
@@ -12,9 +15,6 @@ if (!process.env.EMAIL_FROM) {
     "\x1b[0m",
     "EMAIL_FROM environment variable is not set, this may indicate mailing is currently disabled. Please refer to the .env.example file."
   );
-}
-if (process.env.BASE_URL) {
-  process.env.NEXTAUTH_URL = process.env.BASE_URL + "/api/auth";
 }
 
 const validJson = (jsonString) => {


### PR DESCRIPTION
Allows us to use Vercel previews as a staging environment

For this to work we need to do this on Vercel:
- Unset  `BASE_URL` for previews
- Enable "Automatically expose System Environment Variables"