### PR TITLE
Ensure users cannot delete teams they don’t own

### DIFF
--- a/pages/api/teams/[team]/index.ts
+++ b/pages/api/teams/[team]/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import prisma from "../../../../lib/prisma";
+import prisma from "@lib/prisma";
 import { getSession } from "@lib/auth";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -10,6 +10,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // DELETE /api/teams/{team}
   if (req.method === "DELETE") {
+    if (!session.user?.id) {
+      console.log("Received session token without a user id.");
+      return res.status(500).json({ message: "Something went wrong." });
+    }
+
+    const membership = await prisma.membership.findFirst({
+      where: {
+        userId: session.user.id,
+        teamId: parseInt(req.query.team as string),
+      },
+    });
+
+    if (!membership || membership.role !== "OWNER") {
+      console.log(`User ${session.user.id} tried deleting an organization they don't own.`);
+      return res.status(403).json({ message: "Forbidden." });
+    }
+
     await prisma.membership.delete({
       where: {
         userId_teamId: { userId: session.user.id, teamId: parseInt(req.query.team) },


### PR DESCRIPTION
Adds an explicit authorization check to ensure users cannot delete teams they don’t own. This technically wasn’t possible possible because prisma throws an error when you attempt to delete a record that doesn’t exist, but better to have a precondition than not