### PR TITLE
Default to slug when Full Name isn't set

### DIFF
--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -384,7 +384,7 @@ const CreateNewEventDialog = ({ profiles, canAddEvents }: { profiles: Profile[];
                   size={6}
                   className="inline mr-2"
                 />
-                {profile.name}
+                {profile.name ? profile.name : profile.slug}
               </DropdownMenuItem>
             ))}
           </DropdownMenuContent>


### PR DESCRIPTION
When Full Name isn't set and a new team is created,
The part of the now drop-down add new event type (previously button)
that's supposed to be personal or non-team
appears as an empty div.
This commit makes it default to slug / username in such a case.