### PR TITLE
Fixes a crash caused by too many redraws

### DIFF
--- a/lib/hooks/useLocale.ts
+++ b/lib/hooks/useLocale.ts
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next";
-import { useEffect } from "react";
 
 type LocaleProps = {
   localeProp: string;
@@ -8,9 +7,9 @@ type LocaleProps = {
 export const useLocale = (props: LocaleProps) => {
   const { i18n, t } = useTranslation("common");
 
-  useEffect(() => {
-    (async () => await i18n.changeLanguage(props.localeProp))();
-  }, [i18n, props.localeProp]);
+  if (i18n.language !== props.localeProp) {
+    i18n.changeLanguage(props.localeProp);
+  }
 
   return {
     i18n,


### PR DESCRIPTION
`i18n.changeLanguage` triggers a full redraw of the component, causing i18n.changeLanguage to trigger in an infinite loop. This is not a hard crash on good hardware but it causes a variety of strange issues throughout (like blank pages, dropdowns not working).

By adding a check whether the current locale is equal to the given prop locale - no need for useEffect.