### PR TITLE
Fix link ignoring app url on even-type

### DIFF
--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -995,10 +995,10 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
               <button
                 onClick={() => {
                   navigator.clipboard.writeText(
-                    "https://cal.com/" +
-                      (team ? "team/" + team.slug : eventType.users[0].username) +
-                      "/" +
-                      eventType.slug
+                    (`${process.env.NEXT_PUBLIC_APP_URL}/` ?? "https://cal.com/") +
+                    (team ? "team/" + team.slug : eventType.users[0].username) +
+                    "/" +
+                    eventType.slug
                   );
                   showToast("Link copied!", "success");
                 }}


### PR DESCRIPTION
Right now, on self-hosted cal.com when clicking on Copy Link under /event-types/[id], the link will always have the domain cal.com. This PR fixes the issue, instead depending on NEXT_PUBLIC_APP_URL and only reverting to cal.com when this variable is not specified.

![image](https://user-images.githubusercontent.com/29983481/134737668-22d2d707-fd91-48a0-a06b-dcccfbe123d2.png)
