### PR TITLE
i18n static `[user]`

### DIFF
--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -19,28 +19,12 @@ import HelpMenuItemDynamic from "@ee/lib/intercom/HelpMenuItemDynamic";
 
 import classNames from "@lib/classNames";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
-import { trpc } from "@lib/trpc";
 
 import { HeadSeo } from "@components/seo/head-seo";
 import Avatar from "@components/ui/Avatar";
 
+import { useMeQuery } from "../lib/hooks/useMeQuery";
 import Logo from "./Logo";
-
-function useMeQuery() {
-  const [session] = useSession();
-  const meQuery = trpc.useQuery(["viewer.me"], {
-    // refetch max once per 5s
-    staleTime: 5000,
-  });
-
-  useEffect(() => {
-    // refetch if sesion changes
-    meQuery.refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session]);
-
-  return meQuery;
-}
 
 function useRedirectToLoginIfUnauthenticated() {
   const [session, loading] = useSession();

--- a/lib/app-providers.tsx
+++ b/lib/app-providers.tsx
@@ -1,7 +1,4 @@
 import { IdProvider } from "@radix-ui/react-id";
-import { httpBatchLink } from "@trpc/client/links/httpBatchLink";
-import { loggerLink } from "@trpc/client/links/loggerLink";
-import { withTRPC } from "@trpc/next";
 import { Provider } from "next-auth/client";
 import { AppProps } from "next/dist/shared/lib/router/router";
 import React from "react";
@@ -22,35 +19,4 @@ const AppProviders = (props: AppProps) => {
   );
 };
 
-export default withTRPC({
-  config() {
-    /**
-     * If you want to use SSR, you need to use the server's full URL
-     * @link https://trpc.io/docs/ssr
-     */
-    return {
-      /**
-       * @link https://trpc.io/docs/links
-       */
-      links: [
-        // adds pretty logs to your console in development and logs errors in production
-        loggerLink({
-          enabled: (opts) =>
-            process.env.NODE_ENV === "development" ||
-            (opts.direction === "down" && opts.result instanceof Error),
-        }),
-        httpBatchLink({
-          url: `/api/trpc`,
-        }),
-      ],
-      /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
-       */
-      // queryClientConfig: { defaultOptions: { queries: { staleTime: 6000 } } },
-    };
-  },
-  /**
-   * @link https://trpc.io/docs/ssr
-   */
-  ssr: false,
-})(AppProviders);
+export default AppProviders;

--- a/lib/core/i18n/i18n.utils.ts
+++ b/lib/core/i18n/i18n.utils.ts
@@ -75,3 +75,5 @@ export type OptionType = {
 export const localeOptions: OptionType[] = i18n.locales.map((locale) => {
   return { value: locale, label: localeLabels[locale] };
 });
+
+export const defaultLocale = i18n.defaultLocale;

--- a/lib/hooks/useMeQuery.tsx
+++ b/lib/hooks/useMeQuery.tsx
@@ -1,0 +1,20 @@
+import { useSession } from "next-auth/client";
+import { useEffect } from "react";
+
+import { trpc } from "@lib/trpc";
+
+export function useMeQuery() {
+  const [session] = useSession();
+  const meQuery = trpc.useQuery(["viewer.me"], {
+    // refetch max once per 5s
+    staleTime: 5000,
+  });
+
+  useEffect(() => {
+    // refetch if sesion changes
+    meQuery.refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
+
+  return meQuery;
+}

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 module.exports = {
   i18n: {
+    localeDetection: false,
     defaultLocale: "en",
     locales: ["en", "fr", "it", "ru", "es", "de", "pt", "ro"],
   },

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -124,7 +124,7 @@ export async function getStaticProps(context: GetStaticPropsContext<{ user: stri
     props: {
       trpcState: ssg.dehydrate(),
       username,
-      ...(await serverSideTranslations(user?.locale ?? defaultLocale, ["common"])),
+      ...(await serverSideTranslations(user.locale ?? defaultLocale, ["common"])),
     },
     revalidate: 1,
   };

--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -99,7 +99,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
       const paths = [
         {
           params: {
-            username: user.username,
+            user: user.username,
           },
           locale: defaultLocale,
         },
@@ -108,7 +108,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
       if (user.locale && user.locale !== defaultLocale) {
         paths.push({
           params: {
-            username: user.username,
+            user: user.username,
           },
           locale: user.locale,
         });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -28,10 +28,10 @@ function useViewerLocale() {
   const meQuery = useMeQuery();
   const viewerPreferredLanguage = meQuery.data?.locale ?? navigatorLanguage();
 
-  // switch locale to `navigator.language` on first mount
+  // switch locale to viewer language on first mount
   useEffect(() => {
     const currentLocale = router.locale;
-    console.log("locale witch check", { currentLocale, viewerPreferredLanguage });
+    // console.debug("locale check", { currentLocale, viewerPreferredLanguage });
 
     if (currentLocale === viewerPreferredLanguage) {
       return;
@@ -49,9 +49,9 @@ function useViewerLocale() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewerPreferredLanguage]);
 
-  useEffect(() => {
-    console.log("locale switch:", router.locale);
-  }, [router.locale]);
+  // useEffect(() => {
+  //   console.debug("locale switch:", router.locale);
+  // }, [router.locale]);
 }
 
 function MyApp(props: AppProps) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 import AppProviders from "@lib/app-providers";
 import { seoConfig } from "@lib/config/next-seo.config";
 
+import { useMeQuery } from "../lib/hooks/useMeQuery";
 import "../styles/globals.css";
 
 // Workaround for https://github.com/vercel/next.js/issues/8592
@@ -15,14 +16,21 @@ export type AppProps = NextAppProps & {
   err?: Error;
 };
 
-function useViewerLanguage() {
+function navigatorLanguage() {
+  return process.browser ? navigator.language : "en";
+}
+function useViewerLocale() {
   const router = useRouter();
+
+  const meQuery = useMeQuery();
+  const viewerPreferredLanguage = meQuery.data?.locale ?? navigatorLanguage();
 
   // switch locale to `navigator.language` on first mount
   useEffect(() => {
     const currentLocale = router.locale;
+    console.log("locale witch check", { currentLocale, viewerPreferredLanguage });
 
-    if (currentLocale === navigator.language) {
+    if (currentLocale === viewerPreferredLanguage) {
       return;
     }
     router.replace(
@@ -32,22 +40,28 @@ function useViewerLanguage() {
       },
       undefined,
       {
-        locale: navigator.language,
+        locale: viewerPreferredLanguage,
       }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [viewerPreferredLanguage]);
 
   useEffect(() => {
     console.log("locale switch:", router.locale);
   }, [router.locale]);
 }
 
+function UseViewerLocale() {
+  useViewerLocale();
+  return null;
+}
+
 function MyApp(props: AppProps) {
   const { Component, pageProps, err } = props;
-  useViewerLanguage();
+
   return (
     <AppProviders {...props}>
+      <UseViewerLocale />
       <DefaultSeo {...seoConfig.defaultNextSeo} />
       <Component {...pageProps} err={err} />
     </AppProviders>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,6 @@
+import { httpBatchLink } from "@trpc/client/links/httpBatchLink";
+import { loggerLink } from "@trpc/client/links/loggerLink";
+import { withTRPC } from "@trpc/next";
 import { appWithTranslation } from "next-i18next";
 import { DefaultSeo } from "next-seo";
 import type { AppProps as NextAppProps } from "next/app";
@@ -51,21 +54,46 @@ function useViewerLocale() {
   }, [router.locale]);
 }
 
-function UseViewerLocale() {
-  useViewerLocale();
-  return null;
-}
-
 function MyApp(props: AppProps) {
   const { Component, pageProps, err } = props;
-
+  useViewerLocale();
   return (
     <AppProviders {...props}>
-      <UseViewerLocale />
       <DefaultSeo {...seoConfig.defaultNextSeo} />
       <Component {...pageProps} err={err} />
     </AppProviders>
   );
 }
 
-export default appWithTranslation(MyApp);
+export default withTRPC({
+  config() {
+    /**
+     * If you want to use SSR, you need to use the server's full URL
+     * @link https://trpc.io/docs/ssr
+     */
+    return {
+      /**
+       * @link https://trpc.io/docs/links
+       */
+      links: [
+        // adds pretty logs to your console in development and logs errors in production
+        loggerLink({
+          enabled: (opts) =>
+            process.env.NODE_ENV === "development" ||
+            (opts.direction === "down" && opts.result instanceof Error),
+        }),
+        httpBatchLink({
+          url: `/api/trpc`,
+        }),
+      ],
+      /**
+       * @link https://react-query.tanstack.com/reference/QueryClient
+       */
+      // queryClientConfig: { defaultOptions: { queries: { staleTime: 6000 } } },
+    };
+  },
+  /**
+   * @link https://trpc.io/docs/ssr
+   */
+  ssr: false,
+})(appWithTranslation(MyApp));

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,7 @@ export type AppProps = NextAppProps & {
 };
 
 function navigatorLanguage() {
-  return process.browser ? navigator.language : "en";
+  return process.browser ? navigator.language.split("-")[0] : "en";
 }
 function useViewerLocale() {
   const router = useRouter();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,8 @@
 import { appWithTranslation } from "next-i18next";
 import { DefaultSeo } from "next-seo";
 import type { AppProps as NextAppProps } from "next/app";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 import AppProviders from "@lib/app-providers";
 import { seoConfig } from "@lib/config/next-seo.config";
@@ -13,8 +15,37 @@ export type AppProps = NextAppProps & {
   err?: Error;
 };
 
+function useViewerLanguage() {
+  const router = useRouter();
+
+  // switch locale to `navigator.language` on first mount
+  useEffect(() => {
+    const currentLocale = router.locale;
+
+    if (currentLocale === navigator.language) {
+      return;
+    }
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: router.query,
+      },
+      undefined,
+      {
+        locale: navigator.language,
+      }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    console.log("locale switch:", router.locale);
+  }, [router.locale]);
+}
+
 function MyApp(props: AppProps) {
   const { Component, pageProps, err } = props;
+  useViewerLanguage();
   return (
     <AppProviders {...props}>
       <DefaultSeo {...seoConfig.defaultNextSeo} />

--- a/pages/settings/profile.tsx
+++ b/pages/settings/profile.tsx
@@ -93,7 +93,13 @@ function HideBrandingInput(props: {
 
 export default function Settings(props: Props) {
   const { locale } = useLocale({ localeProp: props.localeProp });
-  const mutation = trpc.useMutation("viewer.updateProfile");
+
+  const utils = trpc.useContext();
+  const mutation = trpc.useMutation("viewer.updateProfile", {
+    async onSettled() {
+      await utils.invalidateQuery(["viewer.me"]);
+    },
+  });
 
   const [successModalOpen, setSuccessModalOpen] = useState(false);
   const usernameRef = useRef<HTMLInputElement>(null);

--- a/server/createContext.ts
+++ b/server/createContext.ts
@@ -2,12 +2,12 @@
 import * as trpc from "@trpc/server";
 import { Maybe } from "@trpc/server";
 import * as trpcNext from "@trpc/server/adapters/next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { getSession, Session } from "@lib/auth";
+import { getOrSetUserLocaleFromHeaders } from "@lib/core/i18n/i18n.utils";
 import prisma from "@lib/prisma";
 import { defaultAvatarSrc } from "@lib/profile";
-import { getOrSetUserLocaleFromHeaders } from "@lib/core/i18n/i18n.utils";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 async function getUserFromSession(session: Maybe<Session>) {
   if (!session?.user?.id) {
@@ -32,6 +32,7 @@ async function getUserFromSession(session: Maybe<Session>) {
       createdDate: true,
       hideBranding: true,
       avatar: true,
+      locale: true,
     },
   });
 


### PR DESCRIPTION
Still needs some more exploration but the goal is to

- Being able to statically render 1 language per user (the one they have as preference with fallback on en)
- On mount, the client switches the language based on the viewer’s browser settings + user settings if they’re logged in

Will have a “flash of english content” for people browsing, but it should do the job.