### PR TITLE
Fix: Remove 0s from team page

### DIFF
--- a/components/team/screens/Team.tsx
+++ b/components/team/screens/Team.tsx
@@ -68,7 +68,7 @@ const Team = ({ team }) => {
   return (
     <div>
       <Members members={team.members} />
-      {team.eventTypes.length && (
+      {team.eventTypes.length > 0 && (
         <aside className="text-center dark:text-white mt-8">
           <Button color="secondary" href={`/team/${team.slug}`} shallow={true} StartIcon={ArrowLeftIcon}>
             Go back

--- a/pages/team/[slug].tsx
+++ b/pages/team/[slug].tsx
@@ -65,7 +65,7 @@ function TeamPage({ team }: inferSSRProps<typeof getServerSideProps>) {
             <Text variant="headline">{teamName}</Text>
           </div>
           {(showMembers.isOn || !team.eventTypes.length) && <Team team={team} />}
-          {!showMembers.isOn && team.eventTypes.length > 1 && (
+          {!showMembers.isOn && team.eventTypes.length > 0 && (
             <div className="mx-auto max-w-3xl">
               {eventTypes}
 

--- a/pages/team/[slug].tsx
+++ b/pages/team/[slug].tsx
@@ -65,7 +65,7 @@ function TeamPage({ team }: inferSSRProps<typeof getServerSideProps>) {
             <Text variant="headline">{teamName}</Text>
           </div>
           {(showMembers.isOn || !team.eventTypes.length) && <Team team={team} />}
-          {!showMembers.isOn && team.eventTypes.length && (
+          {!showMembers.isOn && team.eventTypes.length > 1 && (
             <div className="mx-auto max-w-3xl">
               {eventTypes}
 


### PR DESCRIPTION
If a team has no event types, two zeroes appear on the members list page:
<img width="49" alt="Screenshot 2021-09-30 at 10 17 51" src="https://user-images.githubusercontent.com/25907159/135424850-79aca39b-6753-4c7e-bf62-562fdac5dddc.png">

Turns out I just had to change the length checks to length is greater than 0 and it disappears