### PR TITLE
add `<QueryCell />` to remove bespoke loading/error/empty/success logic

### DIFF
--- a/lib/hooks/QueryCell.tsx
+++ b/lib/hooks/QueryCell.tsx
@@ -27,7 +27,7 @@ interface QueryCellOptions<TData, TError extends ErrorLike> {
   empty?: (query: QueryObserverSuccessResult<TData, TError>) => JSX.Element;
 }
 
-export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
+export function QueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
   const { query } = opts;
 
   if (query.status === "success") {
@@ -51,8 +51,4 @@ export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOpt
   }
   // impossible state
   return null;
-}
-
-export function QueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
-  return useQueryCell(opts);
 }

--- a/lib/hooks/useQueryCell.tsx
+++ b/lib/hooks/useQueryCell.tsx
@@ -1,0 +1,62 @@
+import {
+  QueryObserverIdleResult,
+  QueryObserverLoadingErrorResult,
+  QueryObserverLoadingResult,
+  QueryObserverRefetchErrorResult,
+  QueryObserverSuccessResult,
+  UseQueryResult,
+} from "react-query";
+
+import Loader from "@components/Loader";
+import { Alert } from "@components/ui/Alert";
+
+type ErrorLike = {
+  message: string;
+};
+interface QueryCellBaseOptions<TData, TError extends ErrorLike> {
+  query: UseQueryResult<TData, TError>;
+  success: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
+  error?: (
+    result: QueryObserverLoadingErrorResult<TData, TError> | QueryObserverRefetchErrorResult<TData, TError>
+  ) => JSX.Element;
+  loading?: (query: QueryObserverLoadingResult<TData, TError>) => JSX.Element;
+  idle?: (query: QueryObserverIdleResult<TData, TError>) => JSX.Element;
+}
+interface QueryCellArrayOptionsOptions<TData, TError extends ErrorLike>
+  extends QueryCellBaseOptions<TData, TError> {
+  empty?: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
+}
+type QueryCellOptions<TData, TError extends ErrorLike> = TData extends Array<unknown>
+  ? QueryCellArrayOptionsOptions<TData, TError>
+  : QueryCellBaseOptions<TData, TError>;
+
+export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
+  const { query } = opts;
+
+  if (query.status === "success") {
+    const _opts = opts as QueryCellArrayOptionsOptions<TData, TError>;
+    if (Array.isArray(query.data) && query.data.length === 0 && _opts.empty) {
+      return _opts.empty(query);
+    }
+    return opts.success(query);
+  }
+  if (query.status === "error") {
+    return (
+      opts.error?.(query) ?? (
+        <Alert severity="error" title="Something went wrong" message={query.error.message} />
+      )
+    );
+  }
+  if (query.status === "loading") {
+    return opts.loading?.(query) ?? <Loader />;
+  }
+  if (query.status === "idle") {
+    return null;
+  }
+  // impossible state
+  return null;
+}
+
+export function QueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
+  return useQueryCell(opts);
+}

--- a/lib/hooks/useQueryCell.tsx
+++ b/lib/hooks/useQueryCell.tsx
@@ -15,7 +15,7 @@ type ErrorLike = {
 };
 interface QueryCellOptions<TData, TError extends ErrorLike> {
   query: UseQueryResult<TData, TError>;
-  success: (query: QueryObserverSuccessResult<TData>) => JSX.Element;
+  success: (query: QueryObserverSuccessResult<TData, TError>) => JSX.Element;
   error?: (
     query: QueryObserverLoadingErrorResult<TData, TError> | QueryObserverRefetchErrorResult<TData, TError>
   ) => JSX.Element;
@@ -24,7 +24,7 @@ interface QueryCellOptions<TData, TError extends ErrorLike> {
   /**
    * If there's no data (`null`, `undefined`, or `[]`), render this component
    */
-  empty?: (query: QueryObserverSuccessResult<TData>) => JSX.Element;
+  empty?: (query: QueryObserverSuccessResult<TData, TError>) => JSX.Element;
 }
 
 export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {

--- a/lib/hooks/useQueryCell.tsx
+++ b/lib/hooks/useQueryCell.tsx
@@ -13,7 +13,7 @@ import { Alert } from "@components/ui/Alert";
 type ErrorLike = {
   message: string;
 };
-interface QueryCellBaseOptions<TData, TError extends ErrorLike> {
+interface QueryCellOptions<TData, TError extends ErrorLike> {
   query: UseQueryResult<TData, TError>;
   success: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
   error?: (
@@ -21,22 +21,18 @@ interface QueryCellBaseOptions<TData, TError extends ErrorLike> {
   ) => JSX.Element;
   loading?: (query: QueryObserverLoadingResult<TData, TError>) => JSX.Element;
   idle?: (query: QueryObserverIdleResult<TData, TError>) => JSX.Element;
-}
-interface QueryCellArrayOptionsOptions<TData, TError extends ErrorLike>
-  extends QueryCellBaseOptions<TData, TError> {
+  /**
+   * If there's no data (`null`, `undefined`, or `[]`), render this component
+   */
   empty?: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
 }
-type QueryCellOptions<TData, TError extends ErrorLike> = TData extends Array<unknown>
-  ? QueryCellArrayOptionsOptions<TData, TError>
-  : QueryCellBaseOptions<TData, TError>;
 
 export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {
   const { query } = opts;
 
   if (query.status === "success") {
-    const _opts = opts as QueryCellArrayOptionsOptions<TData, TError>;
-    if (Array.isArray(query.data) && query.data.length === 0 && _opts.empty) {
-      return _opts.empty(query);
+    if (opts.empty && (query.data == null || (Array.isArray(query.data) && query.data.length === 0))) {
+      return opts.empty(query);
     }
     return opts.success(query);
   }

--- a/lib/hooks/useQueryCell.tsx
+++ b/lib/hooks/useQueryCell.tsx
@@ -15,16 +15,16 @@ type ErrorLike = {
 };
 interface QueryCellOptions<TData, TError extends ErrorLike> {
   query: UseQueryResult<TData, TError>;
-  success: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
+  success: (query: QueryObserverSuccessResult<TData>) => JSX.Element;
   error?: (
-    result: QueryObserverLoadingErrorResult<TData, TError> | QueryObserverRefetchErrorResult<TData, TError>
+    query: QueryObserverLoadingErrorResult<TData, TError> | QueryObserverRefetchErrorResult<TData, TError>
   ) => JSX.Element;
   loading?: (query: QueryObserverLoadingResult<TData, TError>) => JSX.Element;
   idle?: (query: QueryObserverIdleResult<TData, TError>) => JSX.Element;
   /**
    * If there's no data (`null`, `undefined`, or `[]`), render this component
    */
-  empty?: (result: QueryObserverSuccessResult<TData>) => JSX.Element;
+  empty?: (query: QueryObserverSuccessResult<TData>) => JSX.Element;
 }
 
 export function useQueryCell<TData, TError extends ErrorLike>(opts: QueryCellOptions<TData, TError>) {

--- a/pages/bookings/[status].tsx
+++ b/pages/bookings/[status].tsx
@@ -1,7 +1,7 @@
 import { CalendarIcon } from "@heroicons/react/outline";
 import { useRouter } from "next/router";
 
-import { QueryCell } from "@lib/hooks/useQueryCell";
+import { QueryCell } from "@lib/hooks/QueryCell";
 import { inferQueryInput, trpc } from "@lib/trpc";
 
 import BookingsShell from "@components/BookingsShell";

--- a/pages/bookings/[status].tsx
+++ b/pages/bookings/[status].tsx
@@ -1,14 +1,13 @@
 import { CalendarIcon } from "@heroicons/react/outline";
 import { useRouter } from "next/router";
 
+import { QueryCell } from "@lib/hooks/useQueryCell";
 import { inferQueryInput, trpc } from "@lib/trpc";
 
 import BookingsShell from "@components/BookingsShell";
 import EmptyScreen from "@components/EmptyScreen";
-import Loader from "@components/Loader";
 import Shell from "@components/Shell";
 import BookingListItem from "@components/booking/BookingListItem";
-import { Alert } from "@components/ui/Alert";
 
 type BookingListingStatus = inferQueryInput<"viewer.bookings">["status"];
 
@@ -16,7 +15,6 @@ export default function Bookings() {
   const router = useRouter();
   const status = router.query?.status as BookingListingStatus;
   const query = trpc.useQuery(["viewer.bookings", { status }]);
-  const bookings = query.data;
 
   return (
     <Shell heading="Bookings" subtitle="See upcoming and past events booked through your event type links.">
@@ -24,28 +22,27 @@ export default function Bookings() {
         <div className="-mx-4 sm:mx-auto flex flex-col">
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-              {query.status === "error" && (
-                <Alert severity="error" title="Something went wrong" message={query.error.message} />
-              )}
-              {query.status === "loading" && <Loader />}
-              {bookings &&
-                (bookings.length === 0 ? (
-                  <EmptyScreen
-                    Icon={CalendarIcon}
-                    headline="No upcoming bookings, yet"
-                    description="You have no upcoming bookings. As soon as someone books a time with you it will show up here."
-                  />
-                ) : (
+              <QueryCell
+                query={query}
+                success={({ data }) => (
                   <div className="my-6 border border-gray-200 overflow-hidden border-b rounded-sm">
                     <table className="min-w-full divide-y divide-gray-200">
                       <tbody className="bg-white divide-y divide-gray-200" data-testid="bookings">
-                        {bookings.map((booking) => (
+                        {data.map((booking) => (
                           <BookingListItem key={booking.id} {...booking} />
                         ))}
                       </tbody>
                     </table>
                   </div>
-                ))}
+                )}
+                empty={() => (
+                  <EmptyScreen
+                    Icon={CalendarIcon}
+                    headline={`No upcoming bookings, yet`}
+                    description="You have no upcoming bookings. As soon as someone books a time with you it will show up here."
+                  />
+                )}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Inspired by redwoodjs cells - https://redwoodjs.com/docs/cells
- Abstracts away the repetitive loading/error state of queries with a simple render function
  - `error` and `loading` is automatically handled for you but can be customised per query
  - `success` is mandatory and will have inferred the right type of the resolved query
  - `empty` is optional to use when the result return no data or empty array - if no `empty()` is provided we use `success`

### Example usage

https://github.com/calendso/calendso/blob/fbfa192e142a09bc5546690e6993b6be4da350c5/pages/bookings/%5Bstatus%5D.tsx#L25-L45