### PR TITLE
Correct License banner instructions. 

### DIFF
--- a/ee/components/LicenseBanner.tsx
+++ b/ee/components/LicenseBanner.tsx
@@ -32,7 +32,7 @@ export default function LicenseBanner() {
                 <span className="inline">
                   Accept our license by changing the .env variable{" "}
                   <span className="bg-gray-50 bg-opacity-20 px-1">NEXT_PUBLIC_LICENSE_CONSENT</span> to
-                  &apos;I agree&apos;.
+                  &apos;agree&apos;.
                 </span>
               </p>
             </div>

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -1,3 +1,3 @@
 {
-  "new-event-type-btn": "New event type"
+  "new-event-type-btn": "New Event Type"
 }

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -1,3 +1,3 @@
 {
-  "new-event-type-btn": "New Event Type"
+  "new-event-type-btn": "New event type"
 }


### PR DESCRIPTION
Instructions read "Accept our license by changing the .env variable NEXT_PUBLIC_LICENSE_CONSENT to I agree"
NEXT_PUBLIC_LICENSE_CONSENT variable is set to only accept "agree" - removed the I from "I agree" in the banners instructions. 