### PR TITLE
Add more typescript types

### DIFF
--- a/lib/emails/invitation.ts
+++ b/lib/emails/invitation.ts
@@ -9,17 +9,20 @@ export type Invitation = {
   token?: string;
 };
 
-export function createInvitationEmail(data: any, options: any = {}) {
-  return sendEmail(data, {
-    provider: {
-      transport: serverConfig.transport,
-      from: serverConfig.from,
-    },
-    ...options,
-  });
+type EmailProvider = {
+  from: string;
+  transport: any;
+};
+
+export function createInvitationEmail(data: Invitation) {
+  const provider = {
+    transport: serverConfig.transport,
+    from: serverConfig.from,
+  } as EmailProvider;
+  return sendEmail(data, provider);
 }
 
-const sendEmail = (invitation: Invitation, { provider }) =>
+const sendEmail = (invitation: Invitation, provider: EmailProvider): Promise<void> =>
   new Promise((resolve, reject) => {
     const { transport, from } = provider;
 

--- a/lib/emails/invitation.ts
+++ b/lib/emails/invitation.ts
@@ -2,7 +2,14 @@ import nodemailer from "nodemailer";
 
 import { serverConfig } from "../serverConfig";
 
-export default function createInvitationEmail(data: any, options: any = {}) {
+export type Invitation = {
+  from?: string;
+  toEmail: string;
+  teamName: string;
+  token?: string;
+};
+
+export function createInvitationEmail(data: any, options: any = {}) {
   return sendEmail(data, {
     provider: {
       transport: serverConfig.transport,
@@ -12,10 +19,11 @@ export default function createInvitationEmail(data: any, options: any = {}) {
   });
 }
 
-const sendEmail = (invitation: any, { provider }) =>
+const sendEmail = (invitation: Invitation, { provider }) =>
   new Promise((resolve, reject) => {
     const { transport, from } = provider;
 
+    const invitationHtml = html(invitation);
     nodemailer.createTransport(transport).sendMail(
       {
         from: `Cal.com <${from}>`,
@@ -23,8 +31,8 @@ const sendEmail = (invitation: any, { provider }) =>
         subject:
           (invitation.from ? invitation.from + " invited you" : "You have been invited") +
           ` to join ${invitation.teamName}`,
-        html: html(invitation),
-        text: text(invitation),
+        html: invitationHtml,
+        text: text(invitationHtml),
       },
       (error) => {
         if (error) {
@@ -36,7 +44,7 @@ const sendEmail = (invitation: any, { provider }) =>
     );
   });
 
-const html = (invitation: any) => {
+export function html(invitation: Invitation): string {
   let url: string = process.env.BASE_URL + "/settings/teams";
   if (invitation.token) {
     url = `${process.env.BASE_URL}/auth/signup?token=${invitation.token}&callbackUrl=${url}`;
@@ -82,10 +90,9 @@ const html = (invitation: any) => {
     </table>
   `
   );
-};
+}
 
 // just strip all HTML and convert <br /> to \n
-const text = (evt: any) =>
-  html(evt)
-    .replace("<br />", "\n")
-    .replace(/<[^>]+>/g, "");
+export function text(htmlStr: string): string {
+  return htmlStr.replace("<br />", "\n").replace(/<[^>]+>/g, "");
+}

--- a/pages/api/teams/[team]/invite.ts
+++ b/pages/api/teams/[team]/invite.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSession } from "@lib/auth";
 
-import createInvitationEmail from "../../../../lib/emails/invitation";
+import { createInvitationEmail } from "../../../../lib/emails/invitation";
 import prisma from "../../../../lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/test/lib/emails/invitation.test.ts
+++ b/test/lib/emails/invitation.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "@jest/globals";
+
+
+import { html, text, Invitation } from "@lib/emails/invitation";
+
+
+it("email text rendering should strip tags and add new lines", () => {
+  const result = text('<p>hello world</p><br /><div>welcome to the brave <span>new</span> world')
+  expect(result).toEqual('hello world\nwelcome to the brave new world')
+})
+
+it("email html should render invite email", () => {
+  const invitation = {
+    from: 'Huxley',
+    toEmail: 'hello@example.com',
+    teamName: 'Calendar Lovers',
+    token: 'invite-token'
+  } as Invitation
+  const result = html(invitation)
+  expect(result).toContain('<br />Huxley invited you to join the team \"Calendar Lovers\" in Cal.com.<br />')
+  expect(result).toContain('/auth/signup?token=invite-token&')
+  expect(result).toContain('If you prefer not to use \"hello@example.com\" as your Cal.com email or already have a Cal.com account, please request another invitation to that email.')
+})

--- a/test/lib/emails/invitation.test.ts
+++ b/test/lib/emails/invitation.test.ts
@@ -1,23 +1,21 @@
 import { expect, it } from "@jest/globals";
-
-
 import { html, text, Invitation } from "@lib/emails/invitation";
 
 
 it("email text rendering should strip tags and add new lines", () => {
-  const result = text('<p>hello world</p><br /><div>welcome to the brave <span>new</span> world')
-  expect(result).toEqual('hello world\nwelcome to the brave new world')
+  const result = text('<p>hello world</p><br /><div>welcome to the brave <span>new</span> world');
+  expect(result).toEqual('hello world\nwelcome to the brave new world');
 })
 
 it("email html should render invite email", () => {
   const invitation = {
-    from: 'Huxley',
-    toEmail: 'hello@example.com',
-    teamName: 'Calendar Lovers',
-    token: 'invite-token'
-  } as Invitation
-  const result = html(invitation)
-  expect(result).toContain('<br />Huxley invited you to join the team \"Calendar Lovers\" in Cal.com.<br />')
-  expect(result).toContain('/auth/signup?token=invite-token&')
-  expect(result).toContain('If you prefer not to use \"hello@example.com\" as your Cal.com email or already have a Cal.com account, please request another invitation to that email.')
+    from: "Huxley",
+    toEmail: "hello@example.com",
+    teamName: "Calendar Lovers",
+    token: "invite-token"
+  } as Invitation;
+  const result = html(invitation);
+  expect(result).toContain('<br />Huxley invited you to join the team \"Calendar Lovers\" in Cal.com.<br />');
+  expect(result).toContain('/auth/signup?token=invite-token&');
+  expect(result).toContain('If you prefer not to use \"hello@example.com\" as your Cal.com email or already have a Cal.com account, please request another invitation to that email.');
 })

--- a/test/lib/emails/invitation.test.ts
+++ b/test/lib/emails/invitation.test.ts
@@ -1,21 +1,23 @@
 import { expect, it } from "@jest/globals";
+
 import { html, text, Invitation } from "@lib/emails/invitation";
 
-
 it("email text rendering should strip tags and add new lines", () => {
-  const result = text('<p>hello world</p><br /><div>welcome to the brave <span>new</span> world');
-  expect(result).toEqual('hello world\nwelcome to the brave new world');
-})
+  const result = text("<p>hello world</p><br /><div>welcome to the brave <span>new</span> world");
+  expect(result).toEqual("hello world\nwelcome to the brave new world");
+});
 
 it("email html should render invite email", () => {
   const invitation = {
     from: "Huxley",
     toEmail: "hello@example.com",
     teamName: "Calendar Lovers",
-    token: "invite-token"
+    token: "invite-token",
   } as Invitation;
   const result = html(invitation);
-  expect(result).toContain('<br />Huxley invited you to join the team \"Calendar Lovers\" in Cal.com.<br />');
-  expect(result).toContain('/auth/signup?token=invite-token&');
-  expect(result).toContain('If you prefer not to use \"hello@example.com\" as your Cal.com email or already have a Cal.com account, please request another invitation to that email.');
-})
+  expect(result).toContain('<br />Huxley invited you to join the team "Calendar Lovers" in Cal.com.<br />');
+  expect(result).toContain("/auth/signup?token=invite-token&");
+  expect(result).toContain(
+    'If you prefer not to use "hello@example.com" as your Cal.com email or already have a Cal.com account, please request another invitation to that email.'
+  );
+});


### PR DESCRIPTION
- add types to the invitation functionality
- refactored email generation. Html generation was called twice before (for both html and text) and now it's called once
- added two simple unit tests
- removed some unused arguments from `createInvitationEmail`