### PR TITLE
fixed event-type layout

### DIFF
--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -60,6 +60,7 @@ function useRedirectToLoginIfUnauthenticated() {
 }
 
 export default function Shell(props: {
+  centered?: boolean;
   title?: string;
   heading: ReactNode;
   subtitle?: ReactNode;
@@ -122,7 +123,7 @@ export default function Shell(props: {
     <>
       <HeadSeo
         title={pageTitle ?? "Cal.com"}
-        description={props.subtitle ? props.subtitle : "Cal.com"}
+        description={props.subtitle ? props.subtitle?.toString() : ""}
         nextSeoProps={{
           nofollow: true,
           noindex: true,
@@ -133,10 +134,8 @@ export default function Shell(props: {
       </div>
 
       <div className="h-screen flex overflow-hidden bg-gray-100">
-        {/* Static sidebar for desktop */}
         <div className="hidden md:flex md:flex-shrink-0">
           <div className="flex flex-col w-56">
-            {/* Sidebar component, swap this element with another sidebar if you like */}
             <div className="flex flex-col h-0 flex-1 border-r border-gray-200 bg-white">
               <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
                 <Link href="/event-types">
@@ -199,7 +198,7 @@ export default function Shell(props: {
                 </div>
               </div>
             </nav>
-            <div className="py-8">
+            <div className={classNames(props.centered && "md:max-w-5xl mx-auto", "py-8")}>
               <div className="block sm:flex justify-between px-4 sm:px-6 md:px-8 min-h-[80px]">
                 <div className="mb-8 w-full">
                   <h1 className="font-cal text-xl font-bold text-gray-900 tracking-wide mb-1">

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -62,7 +62,7 @@ function useRedirectToLoginIfUnauthenticated() {
 export default function Shell(props: {
   title?: string;
   heading: ReactNode;
-  subtitle: string;
+  subtitle?: ReactNode;
   children: ReactNode;
   CTA?: ReactNode;
 }) {
@@ -122,7 +122,7 @@ export default function Shell(props: {
     <>
       <HeadSeo
         title={pageTitle ?? "Cal.com"}
-        description={props.subtitle}
+        description={props.subtitle ? props.subtitle : "Cal.com"}
         nextSeoProps={{
           nofollow: true,
           noindex: true,

--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -322,9 +322,10 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
   return (
     <div>
       <Shell
+        centered
         title={`${eventType.title} | Event Type`}
         heading={
-          <div className="relative group md:max-w-5xl mx-auto" onClick={() => setEditIcon(false)}>
+          <div className="relative group -mb-2" onClick={() => setEditIcon(false)}>
             <input
               ref={titleRef}
               type="text"
@@ -343,7 +344,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
             )}
           </div>
         }
-        subtitle={<div className="-mt-1 md:max-w-5xl mx-auto pl-2">{eventType.description}</div> || ""}>
+        subtitle={eventType.description || ""}>
         <div className="block sm:flex md:max-w-5xl mx-auto">
           <div className="w-full mr-2 sm:w-9/12">
             <div className="p-4 py-6 -mx-4 bg-white border rounded-sm border-neutral-200 sm:mx-0 sm:px-8">

--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -343,7 +343,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
             )}
           </div>
         }
-        subtitle={eventType.description || ""}>
+        subtitle={<div className="-mt-1 md:max-w-5xl mx-auto pl-2">{eventType.description}</div> || ""}>
         <div className="block sm:flex md:max-w-5xl mx-auto">
           <div className="w-full mr-2 sm:w-9/12">
             <div className="p-4 py-6 -mx-4 bg-white border rounded-sm border-neutral-200 sm:mx-0 sm:px-8">


### PR DESCRIPTION
introducing:

`<Shell centered />` props whenever we need to center the content area (currently `md:max-w-5xl mx-auto`)

___

a recent minor change broke the event-type detail page:

before

![image](https://user-images.githubusercontent.com/8019099/136758432-f8555226-26e8-4d3c-9513-ef2fe8230fd2.png)


after
![image](https://user-images.githubusercontent.com/8019099/136758322-925e712a-f9c7-4d1d-a466-7ed28a565aef.png)

