### PR TITLE
Adds useUnknownInCatchVariables and disallows .js in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "@server/*": ["server/*"],
       "@ee/*": ["ee/*"]
     },
-    "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
@@ -20,9 +19,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "useUnknownInCatchVariables": true,
     "jsx": "preserve",
     "types": ["@types/jest", "jest-playwright-preset", "expect-playwright"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "lib/*.js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION

Added in TS 4.0: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables

Proposes `useUnknownInCatchVariables` in order to tell typescript to mark all cases of exceptions as `unknown`. this allows doing the following:

#### Before:
```typescript
try { } catch (err) { } // implicit any!
try { } catch (err: any) { } // fixed
```

#### After:
```typescript
try {} catch (err) {} // err is now of type unknown, and does not have to be hinted explicitly
```

### Disallows *.js

We have no more JavaScript files (at least, by extension) in our source - this PR addresses the exclusion for .js file we once put in due to md5.js

```bash
$ find . -type f -name ".js" | grep -v node_modules
# <no results>
```