### PR TITLE
fix cron jobs env/secrets

### DIFF
--- a/.github/workflows/cron-bookingReminder.yml
+++ b/.github/workflows/cron-bookingReminder.yml
@@ -8,10 +8,13 @@ on:
     - cron: "0,15,30,45 * * * *"
 jobs:
   cron:
+    env:
+      APP_URL: ${{ secrets.APP_URL }}
+      CRON_API_KEY: ${{ secrets.CRON_API_KEY }}
     runs-on: ubuntu-latest
     steps:
       - name: cURL request
-        if: ${{ secrets.APP_URL && secrets.CRON_API_KEY }}
+        if: ${{ env.APP_URL && env.CRON_API_KEY }}
         run: |
           curl ${{ secrets.APP_URL }}/api/cron/bookingReminder \
             -X POST

--- a/.github/workflows/cron-downgradeUsers.yml
+++ b/.github/workflows/cron-downgradeUsers.yml
@@ -8,10 +8,13 @@ on:
     - cron: "0,15,30,45 * * * *"
 jobs:
   cron:
+    env:
+      APP_URL: ${{ secrets.APP_URL }}
+      CRON_API_KEY: ${{ secrets.CRON_API_KEY }}
     runs-on: ubuntu-latest
     steps:
       - name: cURL request
-        if: ${{ secrets.APP_URL && secrets.CRON_API_KEY }}
+        if: ${{ env.APP_URL && env.CRON_API_KEY }}
         run: |
           curl ${{ secrets.APP_URL }}/api/cron/downgradeUsers \
             -X POST


### PR DESCRIPTION
Seems like secrets first have to be stored as env vars in order to be used - see failing job [here](https://github.com/calendso/calendso/actions/runs/1381803375)