### PR TITLE
Exchange Integration

### DIFF
--- a/components/integrations/ConnectIntegrations.tsx
+++ b/components/integrations/ConnectIntegrations.tsx
@@ -4,6 +4,7 @@ import { useMutation } from "react-query";
 
 import { AddAppleIntegrationModal } from "@lib/integrations/calendar/components/AddAppleIntegration";
 import { AddCalDavIntegrationModal } from "@lib/integrations/calendar/components/AddCalDavIntegration";
+import { AddExchangeIntegrationModal } from "@lib/integrations/calendar/components/AddExchangeIntegration";
 
 import { ButtonBaseProps } from "@components/ui/Button";
 
@@ -40,7 +41,7 @@ export default function ConnectIntegration(props: {
     <>
       {props.render({
         onClick() {
-          if (["caldav_calendar", "apple_calendar"].includes(type)) {
+          if (["caldav_calendar", "apple_calendar", "exchange_calendar"].includes(type)) {
             // special handlers
             setIsModalOpen(true);
             return;
@@ -57,6 +58,10 @@ export default function ConnectIntegration(props: {
 
       {type === "apple_calendar" && (
         <AddAppleIntegrationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
+      )}
+
+      {type === "exchange_calendar" && (
+        <AddExchangeIntegrationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
       )}
     </>
   );

--- a/lib/integrations.ts
+++ b/lib/integrations.ts
@@ -12,6 +12,8 @@ export function getIntegrationName(name: string) {
       return "Stripe";
     case "apple_calendar":
       return "Apple Calendar";
+    case "exchange_calendar":
+      return "Exchange Calendar";
     case "daily_video":
       return "Daily";
   }

--- a/lib/integrations/calendar/CalendarManager.ts
+++ b/lib/integrations/calendar/CalendarManager.ts
@@ -13,6 +13,7 @@ import { CalendarServiceType, EventBusyDate } from "./constants/types";
 import { Calendar, CalendarEvent } from "./interfaces/Calendar";
 import AppleCalendarService from "./services/AppleCalendarService";
 import CalDavCalendarService from "./services/CalDavCalendarService";
+import ExchangeCalendarService from "./services/ExchangeCalendarService";
 import GoogleCalendarService from "./services/GoogleCalendarService";
 import Office365CalendarService from "./services/Office365CalendarService";
 
@@ -21,6 +22,7 @@ const CALENDARS: Record<string, CalendarServiceType> = {
   [CALENDAR_INTEGRATIONS_TYPES.caldav]: CalDavCalendarService,
   [CALENDAR_INTEGRATIONS_TYPES.google]: GoogleCalendarService,
   [CALENDAR_INTEGRATIONS_TYPES.office365]: Office365CalendarService,
+  [CALENDAR_INTEGRATIONS_TYPES.exchange]: ExchangeCalendarService,
 };
 
 const log = logger.getChildLogger({ prefix: ["CalendarManager"] });

--- a/lib/integrations/calendar/components/AddExchangeIntegration.tsx
+++ b/lib/integrations/calendar/components/AddExchangeIntegration.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogProps,
+} from "@components/Dialog";
+import { Form, TextField } from "@components/form/fields";
+import { Alert } from "@components/ui/Alert";
+import Button from "@components/ui/Button";
+
+export const ADD_APPLE_INTEGRATION_FORM_TITLE = "addExchangeIntegration";
+
+export function AddExchangeIntegrationModal(props: DialogProps) {
+  const form = useForm({
+    defaultValues: {
+      username: "",
+      password: "",
+      url: process.env.EXCHANGE_DEFAULT_EWS_URL || "",
+    },
+  });
+  const [errorMessage, setErrorMessage] = useState("");
+  return (
+    <Dialog {...props}>
+      <DialogContent>
+        <DialogHeader
+          title="Connect to Exchange Server"
+          subtitle="Your credentials will be stored and encrypted."
+        />
+
+        <Form
+          form={form}
+          onSubmit={form.handleSubmit(async (values) => {
+            setErrorMessage("");
+            const res = await fetch("/api/integrations/exchange/add", {
+              method: "POST",
+              body: JSON.stringify(values),
+              headers: {
+                "Content-Type": "application/json",
+              },
+            });
+            const json = await res.json();
+            if (!res.ok) {
+              setErrorMessage(json?.message || "Something went wrong");
+            } else {
+              props.onOpenChange?.(false);
+            }
+          })}>
+          <fieldset className="space-y-2" disabled={form.formState.isSubmitting}>
+            <TextField
+              required
+              type="text"
+              {...form.register("url")}
+              label="Exchange EWS URL"
+              placeholder="https://example.com/Ews/Exchange.asmx"
+            />
+            <TextField
+              required
+              type="text"
+              {...form.register("username")}
+              label="E-Mail"
+              placeholder="rickroll@example.com"
+            />
+            <TextField
+              required
+              type="password"
+              {...form.register("password")}
+              label="Password"
+              placeholder="•••••••••••••"
+              autoComplete="password"
+            />
+          </fieldset>
+
+          {errorMessage && <Alert severity="error" title={errorMessage} className="my-4" />}
+          <DialogFooter>
+            <DialogClose
+              onClick={() => {
+                props.onOpenChange?.(false);
+              }}
+              asChild>
+              <Button type="button" color="secondary" tabIndex={-1}>
+                Cancel
+              </Button>
+            </DialogClose>
+
+            <Button type="submit" loading={form.formState.isSubmitting}>
+              Save
+            </Button>
+          </DialogFooter>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/integrations/calendar/constants/generals.ts
+++ b/lib/integrations/calendar/constants/generals.ts
@@ -5,6 +5,7 @@ export const APPLE_CALENDAR_URL = "https://caldav.icloud.com";
 export const CALENDAR_INTEGRATIONS_TYPES = {
   apple: "apple_calendar",
   caldav: "caldav_calendar",
+  exchange: "exchange_calendar",
   google: "google_calendar",
   office365: "office365_calendar",
 };

--- a/lib/integrations/calendar/services/ExchangeCalendarService.ts
+++ b/lib/integrations/calendar/services/ExchangeCalendarService.ts
@@ -1,0 +1,223 @@
+import { Credential } from "@prisma/client";
+import {
+  ExchangeService,
+  Appointment,
+  ExchangeVersion,
+  WebCredentials,
+  Uri,
+  DateTime,
+  MessageBody,
+  Attendee,
+  PropertySet,
+  SendInvitationsMode,
+  ItemId,
+  FolderId,
+  SendInvitationsOrCancellationsMode,
+  DeleteMode,
+  ConflictResolutionMode,
+  CalendarView,
+  WellKnownFolderName,
+  FolderView,
+  LegacyFreeBusyStatus,
+} from "ews-javascript-api";
+
+import { symmetricDecrypt } from "@lib/crypto";
+import { CALENDAR_INTEGRATIONS_TYPES } from "@lib/integrations/calendar/constants/generals";
+import logger from "@lib/logger";
+
+import { EventBusyDate, NewCalendarEventType } from "../constants/types";
+import { Calendar, CalendarEvent, IntegrationCalendar } from "../interfaces/Calendar";
+
+export default class ExchangeCalendarService implements Calendar {
+  private url = "";
+  private integrationName = "";
+  private log: typeof logger;
+  private readonly exchangeVersion: ExchangeVersion;
+  private credentials: Record<string, string>;
+
+  constructor(credential: Credential) {
+    this.integrationName = CALENDAR_INTEGRATIONS_TYPES.exchange;
+
+    this.log = logger.getChildLogger({ prefix: [`[[lib] ${this.integrationName}`] });
+
+    const decryptedCredential = JSON.parse(
+      symmetricDecrypt(credential.key?.toString() || "", process.env.CALENDSO_ENCRYPTION_KEY || "")
+    );
+    const username = decryptedCredential.username;
+    const url = decryptedCredential.url;
+    const password = decryptedCredential.password;
+
+    this.url = url;
+
+    this.credentials = {
+      username,
+      password,
+    };
+    this.exchangeVersion = ExchangeVersion.Exchange2013;
+  }
+
+  async createEvent(event: CalendarEvent): Promise<NewCalendarEventType> {
+    try {
+      const appointment = new Appointment(this.getExchangeService()); // service instance of ExchangeService
+      appointment.Subject = event.title;
+      appointment.Start = DateTime.Parse(event.startTime); // moment string
+      appointment.End = DateTime.Parse(event.endTime); // moment string
+      appointment.Location = event.location || "Location not defined!";
+      appointment.Body = new MessageBody(event.description || ""); // you can not use any special character or escape the content
+
+      for (let i = 0; i < event.attendees.length; i++) {
+        appointment.RequiredAttendees.Add(new Attendee(event.attendees[i].email));
+      }
+
+      await appointment.Save(SendInvitationsMode.SendToAllAndSaveCopy);
+
+      return {
+        uid: appointment.Id.UniqueId,
+        id: appointment.Id.UniqueId,
+        password: "",
+        type: "",
+        url: "",
+        additionalInfo: [],
+      };
+    } catch (reason) {
+      this.log.error(reason);
+      throw reason;
+    }
+  }
+
+  async updateEvent(uid: string, event: CalendarEvent): Promise<any> {
+    try {
+      const appointment = await Appointment.Bind(
+        this.getExchangeService(),
+        new ItemId(uid),
+        new PropertySet()
+      );
+      appointment.Subject = event.title;
+      appointment.Start = DateTime.Parse(event.startTime); // moment string
+      appointment.End = DateTime.Parse(event.endTime); // moment string
+      appointment.Location = event.location || "Location not defined!";
+      appointment.Body = new MessageBody(event.description || ""); // you can not use any special character or escape the content
+      for (let i = 0; i < event.attendees.length; i++) {
+        appointment.RequiredAttendees.Add(new Attendee(event.attendees[i].email));
+      }
+      appointment.Update(
+        ConflictResolutionMode.AlwaysOverwrite,
+        SendInvitationsOrCancellationsMode.SendToAllAndSaveCopy
+      );
+    } catch (reason) {
+      this.log.error(reason);
+      throw reason;
+    }
+  }
+
+  async deleteEvent(uid: string): Promise<void> {
+    try {
+      const appointment = await Appointment.Bind(
+        this.getExchangeService(),
+        new ItemId(uid),
+        new PropertySet()
+      );
+      // Delete the appointment. Note that the item ID will change when the item is moved to the Deleted Items folder.
+      appointment.Delete(DeleteMode.MoveToDeletedItems);
+    } catch (reason) {
+      this.log.error(reason);
+      throw reason;
+    }
+  }
+
+  async getAvailability(
+    dateFrom: string,
+    dateTo: string,
+    selectedCalendars: IntegrationCalendar[]
+  ): Promise<EventBusyDate[]> {
+    try {
+      const externalCalendars = await this.listCalendars();
+      const calendarsToGetAppointmentsFrom = [];
+      for (let i = 0; i < selectedCalendars.length; i++) {
+        //Only select vaild calendars! (We get all all active calendars on the instance! even from different users!)
+        for (let k = 0; k < externalCalendars.length; k++) {
+          if (selectedCalendars[i].externalId == externalCalendars[k].externalId) {
+            calendarsToGetAppointmentsFrom.push(selectedCalendars[i]);
+          }
+        }
+      }
+
+      const finaleRet = [];
+      for (let i = 0; i < calendarsToGetAppointmentsFrom.length; i++) {
+        const calendarFolderId = new FolderId(calendarsToGetAppointmentsFrom[i].externalId);
+        const localReturn = await this.getExchangeService()
+          .FindAppointments(
+            calendarFolderId,
+            new CalendarView(DateTime.Parse(dateFrom), DateTime.Parse(dateTo))
+          )
+          .then(function (params) {
+            const ret: EventBusyDate[] = [];
+
+            for (let k = 0; k < params.Items.length; k++) {
+              if (params.Items[k].LegacyFreeBusyStatus != LegacyFreeBusyStatus.Free) {
+                //Dont use this appointment if "ShowAs" was set to "free"
+                ret.push({
+                  start: new Date(params.Items[k].Start.ToISOString()),
+                  end: new Date(params.Items[k].End.ToISOString()),
+                });
+              }
+            }
+            return ret;
+          });
+        finaleRet.push(...localReturn);
+      }
+
+      return finaleRet;
+    } catch (reason) {
+      this.log.error(reason);
+      throw reason;
+    }
+  }
+
+  async listCalendars(): Promise<IntegrationCalendar[]> {
+    try {
+      const allFolders: IntegrationCalendar[] = [];
+      return this.getExchangeService()
+        .FindFolders(WellKnownFolderName.MsgFolderRoot, new FolderView(1000))
+        .then(async (res) => {
+          for (const k in res.Folders) {
+            const f = res.Folders[k];
+            if (f.FolderClass == "IPF.Appointment") {
+              //Select parent folder for all calendars
+              allFolders.push({
+                externalId: f.Id.UniqueId,
+                name: f.DisplayName ?? "",
+                primary: true, //The first one is prime
+                integration: this.integrationName,
+              });
+              return await this.getExchangeService()
+                .FindFolders(f.Id, new FolderView(1000))
+                .then((res) => {
+                  //Find all calendars inside calendar folder
+                  res.Folders.forEach((fs) => {
+                    allFolders.push({
+                      externalId: fs.Id.UniqueId,
+                      name: fs.DisplayName ?? "",
+                      primary: false,
+                      integration: this.integrationName,
+                    });
+                  });
+                  return allFolders;
+                });
+            }
+          }
+          return allFolders;
+        });
+    } catch (reason) {
+      this.log.error(reason);
+      throw reason;
+    }
+  }
+
+  private getExchangeService(): ExchangeService {
+    const exch1 = new ExchangeService(this.exchangeVersion);
+    exch1.Credentials = new WebCredentials(this.credentials.username, this.credentials.password);
+    exch1.Url = new Uri(this.url);
+    return exch1;
+  }
+}

--- a/lib/integrations/getIntegrations.ts
+++ b/lib/integrations/getIntegrations.ts
@@ -22,6 +22,7 @@ export type Integration = {
     | "daily_video"
     | "caldav_calendar"
     | "apple_calendar"
+    | "exchange_calendar"
     | "stripe_payment";
   title: string;
   imageSrc: string;
@@ -75,6 +76,14 @@ export const ALL_INTEGRATIONS = [
     type: "apple_calendar",
     title: "Apple Calendar",
     imageSrc: "integrations/apple-calendar.svg",
+    description: "For personal and business calendars",
+    variant: "calendar",
+  },
+  {
+    installed: true,
+    type: "exchange_calendar",
+    title: "Exchange Calendar",
+    imageSrc: "integrations/outlook.svg",
     description: "For personal and business calendars",
     variant: "calendar",
   },

--- a/pages/api/integrations/exchange/add.ts
+++ b/pages/api/integrations/exchange/add.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@lib/auth";
+import { symmetricEncrypt } from "@lib/crypto";
+import { getCalendar } from "@lib/integrations/calendar/CalendarManager";
+import logger from "@lib/logger";
+import prisma from "@lib/prisma";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    // Check that user is authenticated
+    const session = await getSession({ req });
+
+    if (!session?.user?.id) {
+      res.status(401).json({ message: "You must be logged in to do this" });
+      return;
+    }
+
+    const { username, password, url } = req.body;
+    // Get user
+    const user = await prisma.user.findFirst({
+      rejectOnNotFound: true,
+      where: {
+        id: session?.user?.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const data = {
+      type: "exchange_calendar",
+      key: symmetricEncrypt(
+        JSON.stringify({ username, password, url }),
+        process.env.CALENDSO_ENCRYPTION_KEY!
+      ),
+      userId: user.id,
+    };
+
+    try {
+      const dav = getCalendar({
+        id: 0,
+        ...data,
+      });
+      await dav?.listCalendars();
+      await prisma.credential.create({
+        data,
+      });
+    } catch (reason) {
+      logger.error("Could not add this caldav account", reason);
+      return res.status(500).json({ message: "Could not add this caldav account" });
+    }
+
+    return res.status(200).json({});
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,12 +2914,24 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+biskviit@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/biskviit/-/biskviit-1.0.1.tgz#037a0cd4b71b9e331fd90a1122de17dc49e420a7"
+  integrity sha1-A3oM1LcbnjMf2QoRIt4X3EnkIKc=
+  dependencies:
+    psl "^1.1.7"
+
 bl@~0.8.1:
   version "0.8.2"
   resolved "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
   integrity sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=
   dependencies:
     readable-stream "~1.0.26"
+
+bluebird@^3.5.5:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bmp-js@^0.1.0:
   version "0.1.0"
@@ -3960,6 +3972,13 @@ encode-utf8@^1.0.3:
   resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
   integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
+encoding@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 encoding@0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
@@ -4283,6 +4302,20 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+ews-javascript-api@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ews-javascript-api/-/ews-javascript-api-0.10.3.tgz#9e91cbc4599d992650c766b946f70166baf8a82a"
+  integrity sha512-sH5ZZfCvn7fuKzBuWAS7/MBna1xRtSbLz994aGaqHfjrL9Q0diqS710G0qgjbBALikpP2PX8FVTly6aQ1fAGlA==
+  dependencies:
+    base64-js "^1.3.1"
+    moment "^2.24.0"
+    moment-timezone "^0.5.26"
+    uuid "^3.3.3"
+    xmldom "^0.1.27"
+  optionalDependencies:
+    bluebird "^3.5.5"
+    fetch "^1.1.0"
+
 exec-sh@^0.3.2:
   version "0.3.6"
   resolved "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
@@ -4484,6 +4517,14 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
+
+fetch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fetch/-/fetch-1.1.0.tgz#0a8279f06be37f9f0ebb567560a30a480da59a2e"
+  integrity sha1-CoJ58Gvjf58Ou1Z1YKMKSA2lmi4=
+  dependencies:
+    biskviit "1.0.1"
+    encoding "0.1.12"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -5083,7 +5124,7 @@ iconv-lite@0.4.19:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6794,6 +6835,18 @@ mockdate@^3.0.5:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
   integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
 
+moment-timezone@^0.5.26:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.24.0:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -7833,7 +7886,7 @@ prr@~1.0.1:
   resolved "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-psl@^1.1.33:
+psl@^1.1.33, psl@^1.1.7:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -9601,6 +9654,11 @@ util@0.12.4, util@^0.12.0:
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
 
+uuid@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -9879,6 +9937,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom@^0.1.27:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xtend@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This will add Exchange Integration with all available calendar appointment features like -> add, change, delete and also getAvailability.

Note: I Added a .env var to define a default value (so not every user as to but is able to change):
```
# Used for the Exchange EWS integration
EXCHANGE_DEFAULT_EWS_URL=
```
For some reason this value is not pulled into the input field (it is set as default value at AddExchangeIntegration.tsx line 30 ). Maybe someone knows why and can fix this before merge?

The last commit (fix select event-types bug) is not really related to to exchange but will fix an issue with the radio buttons at /event-types (was not  able to select them).

Code is maybe not the cleanest so change and fix as you wish :)
Hope you like it.
Best regards!

PS: Fixed things so you get all your exchange calendars and be able to choose from them, also don't use appointments set to "free" at "show as"