### PR TITLE
availability timezone fix

### DIFF
--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -159,8 +159,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     availability && availability.length
       ? availability.map((schedule) => ({
           ...schedule,
-          startTime: schedule.startTime.getHours() * 60 + schedule.startTime.getHours(),
-          endTime: schedule.endTime.getHours() * 60 + schedule.endTime.getHours(),
+          startTime: schedule.startTime.getHours() * 60 + schedule.startTime.getMinutes(),
+          endTime: schedule.endTime.getHours() * 60 + schedule.endTime.getMinutes(),
         }))
       : null;
 

--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -159,8 +159,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     availability && availability.length
       ? availability.map((schedule) => ({
           ...schedule,
-          startTime: schedule.startTime.getUTCHours() * 60 + schedule.startTime.getUTCMinutes(),
-          endTime: schedule.endTime.getUTCHours() * 60 + schedule.endTime.getUTCMinutes(),
+          startTime: schedule.startTime.getHours() * 60 + schedule.startTime.getHours(),
+          endTime: schedule.endTime.getHours() * 60 + schedule.endTime.getHours(),
         }))
       : null;
 


### PR DESCRIPTION
- @emrysal said the the `startTime`/`endTime` is stored as UTC in the DB
- If availability is stored as UTC we shouldn't do further conversion on it when getting the hours
