### PR TITLE
Webhook tweaks + Support added for "Custom payload templates" / x-www-form-urlencoded / json

### DIFF
--- a/lib/webhooks/sendPayload.tsx
+++ b/lib/webhooks/sendPayload.tsx
@@ -1,38 +1,63 @@
+import { compile } from "handlebars";
+
 import { CalendarEvent } from "@lib/calendarClient";
 
-const sendPayload = (
+type ContentType = "application/json" | "application/x-www-form-urlencoded";
+
+function applyTemplate(template: string, data: Omit<CalendarEvent, "language">, contentType: ContentType) {
+  const compiled = compile(template)(data);
+  if (contentType === "application/json") {
+    return jsonParse(compiled);
+  }
+  return compiled;
+}
+
+function jsonParse(jsonString: string) {
+  try {
+    return JSON.parse(jsonString);
+  } catch (e) {
+    // don't do anything.
+  }
+  return false;
+}
+
+const sendPayload = async (
   triggerEvent: string,
   createdAt: string,
   subscriberUrl: string,
-  payload: CalendarEvent
-): Promise<string | Response> =>
-  new Promise((resolve, reject) => {
-    if (!subscriberUrl || !payload) {
-      return reject(new Error("Missing required elements to send webhook payload."));
-    }
-    const body = {
-      triggerEvent: triggerEvent,
-      createdAt: createdAt,
-      payload: payload,
-    };
+  data: Omit<CalendarEvent, "language">,
+  template?: string | null
+) => {
+  if (!subscriberUrl || !data) {
+    throw new Error("Missing required elements to send webhook payload.");
+  }
 
-    fetch(subscriberUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    })
-      .then((response) => {
-        if (!response.ok) {
-          reject(new Error(`Response code ${response.status}`));
-          return;
-        }
-        resolve(response);
-      })
-      .catch((err) => {
-        reject(err);
+  const contentType =
+    !template || jsonParse(template) ? "application/json" : "application/x-www-form-urlencoded";
+
+  const body = template
+    ? applyTemplate(template, data, contentType)
+    : JSON.stringify({
+        triggerEvent: triggerEvent,
+        createdAt: createdAt,
+        payload: data,
       });
+
+  const response = await fetch(subscriberUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": contentType,
+    },
+    body,
   });
+
+  const text = await response.text();
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    message: text,
+  };
+};
 
 export default sendPayload;

--- a/lib/webhooks/subscriptions.tsx
+++ b/lib/webhooks/subscriptions.tsx
@@ -2,7 +2,7 @@ import { WebhookTriggerEvents } from "@prisma/client";
 
 import prisma from "@lib/prisma";
 
-const getSubscriberUrls = async (userId: number, triggerEvent: WebhookTriggerEvents): Promise<string[]> => {
+const getSubscribers = async (userId: number, triggerEvent: WebhookTriggerEvents) => {
   const allWebhooks = await prisma.webhook.findMany({
     where: {
       userId: userId,
@@ -17,11 +17,11 @@ const getSubscriberUrls = async (userId: number, triggerEvent: WebhookTriggerEve
     },
     select: {
       subscriberUrl: true,
+      payloadTemplate: true,
     },
   });
-  const subscriberUrls = allWebhooks.map(({ subscriberUrl }) => subscriberUrl);
 
-  return subscriberUrls;
+  return allWebhooks;
 };
 
-export default getSubscriberUrls;
+export default getSubscribers;

--- a/pages/integrations/index.tsx
+++ b/pages/integrations/index.tsx
@@ -1,10 +1,4 @@
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  PencilAltIcon,
-  SwitchHorizontalIcon,
-  TrashIcon,
-} from "@heroicons/react/outline";
+import { ChevronRightIcon, PencilAltIcon, SwitchHorizontalIcon, TrashIcon } from "@heroicons/react/outline";
 import { ClipboardIcon } from "@heroicons/react/solid";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import Image from "next/image";
@@ -13,7 +7,6 @@ import { Controller, useForm, useWatch } from "react-hook-form";
 
 import { QueryCell } from "@lib/QueryCell";
 import classNames from "@lib/classNames";
-import { getErrorFromUnknown } from "@lib/errors";
 import { useLocale } from "@lib/hooks/useLocale";
 import showToast from "@lib/notification";
 import { inferQueryOutput, trpc } from "@lib/trpc";
@@ -61,7 +54,7 @@ function WebhookListItem(props: { webhook: TWebhook; onEditWebhook: () => void }
             </span>
           </div>
           <div className="flex mt-2">
-            <span className="flex flex-col space-y-1 sm:space-y-0 text-xs sm:flex-row sm:space-x-2">
+            <span className="flex flex-col space-y-1 text-xs sm:space-y-0 sm:flex-row sm:space-x-2">
               {props.webhook.eventTriggers.map((eventTrigger, ind) => (
                 <span
                   key={ind}
@@ -124,13 +117,9 @@ function WebhookTestDisclosure() {
 
   return (
     <Collapsible open={open} onOpenChange={() => setOpen(!open)}>
-      <CollapsibleTrigger type="button" className={"cursor-pointer flex w-full text-sm"}>
-        {t("webhook_test")}{" "}
-        {open ? (
-          <ChevronUpIcon className="w-5 h-5 text-gray-700" />
-        ) : (
-          <ChevronDownIcon className="w-5 h-5 text-gray-700" />
-        )}
+      <CollapsibleTrigger type="button" className={"cursor-pointer flex w-full"}>
+        <ChevronRightIcon className={`${open ? "transform rotate-90" : ""} w-5 h-5 text-neutral-500`} />
+        <span className="text-sm font-medium text-gray-700">{t("webhook_test")}</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <InputGroupBox className="px-0 space-y-0 border-0">
@@ -190,24 +179,17 @@ function WebhookDialogForm(props: {
     <Form
       data-testid="WebhookDialogForm"
       form={form}
-      onSubmit={(event) => {
-        form
-          .handleSubmit(async (values) => {
-            if (values.id) {
-              await utils.client.mutation("viewer.webhook.edit", values);
-              await utils.invalidateQueries(["viewer.webhook.list"]);
-              showToast(t("webhook_updated_successfully"), "success");
-            } else {
-              await utils.client.mutation("viewer.webhook.create", values);
-              await utils.invalidateQueries(["viewer.webhook.list"]);
-              showToast(t("webhook_created_successfully"), "success");
-            }
-
-            props.handleClose();
-          })(event)
-          .catch((err) => {
-            showToast(`${getErrorFromUnknown(err).message}`, "error");
-          });
+      handleSubmit={async (event) => {
+        if (event.id) {
+          await utils.client.mutation("viewer.webhook.edit", event);
+          await utils.invalidateQueries(["viewer.webhook.list"]);
+          showToast(t("webhook_updated_successfully"), "success");
+        } else {
+          await utils.client.mutation("viewer.webhook.create", event);
+          await utils.invalidateQueries(["viewer.webhook.list"]);
+          showToast(t("webhook_created_successfully"), "success");
+        }
+        props.handleClose();
       }}
       className="space-y-4">
       <input type="hidden" {...form.register("id")} />

--- a/prisma/migrations/20211120211639_add_payload_template/migration.sql
+++ b/prisma/migrations/20211120211639_add_payload_template/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Webhook" ADD COLUMN     "payloadTemplate" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,7 @@ model User {
   plan                UserPlan           @default(PRO)
   Schedule            Schedule[]
   webhooks            Webhook[]
-  brandColor          String            @default("#292929")
+  brandColor          String             @default("#292929")
 
   @@map(name: "users")
 }
@@ -301,11 +301,12 @@ enum WebhookTriggerEvents {
 }
 
 model Webhook {
-  id            String                 @id @unique
-  userId        Int
-  subscriberUrl String
-  createdAt     DateTime               @default(now())
-  active        Boolean                @default(true)
-  eventTriggers WebhookTriggerEvents[]
-  user          User                   @relation(fields: [userId], references: [id])
+  id              String                 @id @unique
+  userId          Int
+  subscriberUrl   String
+  payloadTemplate String?
+  createdAt       DateTime               @default(now())
+  active          Boolean                @default(true)
+  eventTriggers   WebhookTriggerEvents[]
+  user            User                   @relation(fields: [userId], references: [id])
 }

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -79,6 +79,7 @@
   "webhook_created_successfully": "Webhook created successfully!",
   "webhook_updated_successfully": "Webhook updated successfully!",
   "webhook_removed_successfully": "Webhook removed successfully!",
+  "payload_template": "Payload Template",
   "dismiss": "Dismiss",
   "no_data_yet": "No data yet",
   "ping_test": "Ping test",


### PR DESCRIPTION
* Added support for webhook success status codes between >= 200 && < 300, allowing for responses like 201, or 204.
* Amended the Form implementation to the new Form component tweaks (handleSubmit)
* sendPayload added for handling PING calls (no more custom fetch call)
* When non-JSON payloads are given, sendPayload supports x-www-form-urlencoded (Allowing URL query strings like data=ABC&data_2=DEF)
* Updated styling of the webhook test to be in line with the "Advanced options" collapsible in event types.

![image](https://user-images.githubusercontent.com/1046695/142741693-f1f6c866-746c-4bc2-9216-d3af378e3f39.png)

By default. the calendar event is used as the format, and the payload values. Custom payload templates allow mapping to a custom format if you do not have full control over the receiving side. All CalendarEvent fields are available, using handlebars to transpile.

```json
{
  "customJsonFieldForAttendeeName": "{{attendees.[0].name}}"
}
```

**Todo**
* Write some documentation on available variables
* Write integration guide for Twilio.

**Screenshots**
![phone](https://user-images.githubusercontent.com/1046695/142741519-c488341e-4106-49b7-97a6-cbb8a7dabec2.png)
![image](https://user-images.githubusercontent.com/1046695/142741537-48220d38-fcaf-4961-a616-68fbe057fb8e.png)
![webhook](https://user-images.githubusercontent.com/1046695/142741557-d68366c0-bf89-4248-9ff4-d41cf8f17749.png)