### PR TITLE
get rid of circular references in `viewer.eventTypes`

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import { seoConfig } from "@lib/config/next-seo.config";
 import I18nLanguageHandler from "@components/I18nLanguageHandler";
 
 import type { AppRouter } from "@server/routers/_app";
-import { httpBatchLink } from "@trpc/client/links/httpBatchLink";
+import { httpLink } from "@trpc/client/links/httpLink";
 import { loggerLink } from "@trpc/client/links/loggerLink";
 import { withTRPC } from "@trpc/next";
 import type { TRPCClientErrorLike } from "@trpc/react";
@@ -44,7 +44,7 @@ export default withTRPC<AppRouter>({
             process.env.NODE_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),
         }),
-        httpBatchLink({
+        httpLink({
           url: `/api/trpc`,
         }),
       ],

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -375,7 +375,7 @@ const EventTypesPage = () => {
                 ))}
 
               {data.eventTypeGroups.length === 0 && (
-                <CreateFirstEventTypeView profiles={data.profiles} canAddEvents={data.canAddEvents} />
+                <CreateFirstEventTypeView profiles={data.profiles} canAddEvents={data.viewer.canAddEvents} />
               )}
             </>
           )}

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -331,7 +331,10 @@ const EventTypesPage = () => {
         CTA={
           query.data &&
           query.data.eventTypeGroups.length !== 0 && (
-            <CreateNewEventButton canAddEvents={query.data.canAddEvents} profiles={query.data.profiles} />
+            <CreateNewEventButton
+              canAddEvents={query.data.viewer.canAddEvents}
+              profiles={query.data.profiles}
+            />
           )
         }>
         <QueryCell

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -356,23 +356,22 @@ const EventTypesPage = () => {
                   className="mb-4"
                 />
               )}
-              {data.eventTypeGroups &&
-                data.eventTypeGroups.map((group) => (
-                  <Fragment key={group.profile.slug}>
-                    {/* hide list heading when there is only one (current user) */}
-                    {(data.eventTypeGroups.length !== 1 || group.teamId) && (
-                      <EventTypeListHeading
-                        profile={group.profile}
-                        membershipCount={group.metadata.membershipCount}
-                      />
-                    )}
-                    <EventTypeList
-                      types={group.eventTypes}
+              {data.eventTypeGroups.map((group) => (
+                <Fragment key={group.profile.slug}>
+                  {/* hide list heading when there is only one (current user) */}
+                  {(data.eventTypeGroups.length !== 1 || group.teamId) && (
+                    <EventTypeListHeading
                       profile={group.profile}
-                      readOnly={group.metadata.readOnly}
+                      membershipCount={group.metadata.membershipCount}
                     />
-                  </Fragment>
-                ))}
+                  )}
+                  <EventTypeList
+                    types={group.eventTypes}
+                    profile={group.profile}
+                    readOnly={group.metadata.readOnly}
+                  />
+                </Fragment>
+              ))}
 
               {data.eventTypeGroups.length === 0 && (
                 <CreateFirstEventTypeView profiles={data.profiles} canAddEvents={data.viewer.canAddEvents} />

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -338,7 +338,7 @@ const EventTypesPage = () => {
           query={query}
           success={({ data }) => (
             <>
-              {data.user.plan === "FREE" && !data.canAddEvents && (
+              {data.viewer.plan === "FREE" && !data.viewer.canAddEvents && (
                 <Alert
                   severity="warning"
                   title={<>{t("plan_upgrade")}</>}

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -357,19 +357,19 @@ const EventTypesPage = () => {
                 />
               )}
               {data.eventTypeGroups &&
-                data.eventTypeGroups.map((input) => (
-                  <Fragment key={input.profile.slug}>
+                data.eventTypeGroups.map((group) => (
+                  <Fragment key={group.profile.slug}>
                     {/* hide list heading when there is only one (current user) */}
-                    {(data.eventTypeGroups.length !== 1 || input.teamId) && (
+                    {(data.eventTypeGroups.length !== 1 || group.teamId) && (
                       <EventTypeListHeading
-                        profile={input.profile}
-                        membershipCount={input.metadata.membershipCount}
+                        profile={group.profile}
+                        membershipCount={group.metadata.membershipCount}
                       />
                     )}
                     <EventTypeList
-                      types={input.eventTypes}
-                      profile={input.profile}
-                      readOnly={input.metadata.readOnly}
+                      types={group.eventTypes}
+                      profile={group.profile}
+                      readOnly={group.metadata.readOnly}
                     />
                   </Fragment>
                 ))}

--- a/server/routers/viewer.tsx
+++ b/server/routers/viewer.tsx
@@ -239,8 +239,10 @@ const loggedInViewerRouter = createProtectedRouter()
       const canAddEvents = user.plan !== "FREE" || eventTypeGroups[0].eventTypes.length < 1;
 
       return {
-        canAddEvents,
-        user,
+        viewer: {
+          canAddEvents,
+          plan: user.plan,
+        },
         // don't display event teams without event types,
         eventTypeGroups: eventTypeGroups.filter((groupBy) => !!groupBy.eventTypes?.length),
         // so we can show a dropdown when the user has teams


### PR DESCRIPTION
Simplifies the response in `viewer.eventTypes` to avoid circular references