### PR TITLE
Ensure credential objects come oldest first

### DIFF
--- a/pages/api/book/confirm.ts
+++ b/pages/api/book/confirm.ts
@@ -63,7 +63,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
     select: {
       id: true,
-      credentials: true,
+      credentials: {
+        orderBy: { id: "desc" as Prisma.SortOrder },
+      },
       timeZone: true,
       email: true,
       name: true,


### PR DESCRIPTION
Given the credentials are loaded based on userId, sort is not consistent.
Without this, events are booked on whichever calendar credential is loaded first. 
https://github.com/calendso/calendso/blob/813eaa83b7b4813c1854d20680f96d56e1016af0/lib/events/EventManager.ts#L240-L244