### PR TITLE
Favour the user's default calendar notification settings without overriding

### DIFF
--- a/lib/integrations/GoogleCalendar/GoogleCalendarApiAdapter.ts
+++ b/lib/integrations/GoogleCalendar/GoogleCalendarApiAdapter.ts
@@ -166,8 +166,7 @@ export const GoogleCalendarApiAdapter = (credential: Credential): CalendarApiAda
             },
             attendees: event.attendees,
             reminders: {
-              useDefault: false,
-              overrides: [{ method: "email", minutes: 10 }],
+              useDefault: true,
             },
           };
 


### PR DESCRIPTION


If people want emails for every event on their calendar, they can set that up.