### PR TITLE
fix: user bio width when booking a team member

### DIFF
--- a/components/team/screens/Team.tsx
+++ b/components/team/screens/Team.tsx
@@ -45,7 +45,7 @@ const Team = ({ team }) => {
             <Avatar displayName={member.user.name} imageSrc={member.user.avatar} className="w-12 h-12" />
             <section className="space-y-2">
               <Text variant="title">{member.user.name}</Text>
-              <Text variant="subtitle" className="w-6/8">
+              <Text variant="subtitle" className="w-6/8 max-w-md">
                 {member.user.bio}
               </Text>
             </section>


### PR DESCRIPTION
## What does this PR do?

Currently when viewing team members to book a meeting withe them, their bio is unrestricted in width, this can lead to user bio's taking up the entire screen and being very disproportional to other users.  This PR adds a max width to the bio so that the bio will begin to wrap instead of filling as much space as it can.
(Apologies again for large images)

This is the current handling of a long description. 
![2021-12-06-223814_3764x588_scrot](https://user-images.githubusercontent.com/10099540/144934859-07d9cbe9-fe03-4b83-b491-50736583a04d.png)


This is after adding a max width to the bio
![2021-12-06-224210_813x755_scrot](https://user-images.githubusercontent.com/10099540/144934905-bfb308ce-4225-40f9-ae55-d1be51b301d9.png)




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

This is a visual change really, I am happy to look into doing some automated testing of this, but will need some direction for visual testing. 
To test manually, load up a team booking page and go into the members view.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
