### PR TITLE
Fix: duplicate team name no prompt

### DIFF
--- a/pages/api/teams.ts
+++ b/pages/api/teams.ts
@@ -23,7 +23,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     if (nameCollisions > 0) {
-      return res.status(409).json({ errorCode: "TeamNameCollision", message: "Team name already take." });
+      return res
+        .status(409)
+        .json({ errorCode: "TeamNameCollision", message: "Team username already taken." });
     }
 
     const createTeam = await prisma.team.create({

--- a/pages/settings/teams.tsx
+++ b/pages/settings/teams.tsx
@@ -13,6 +13,7 @@ import Shell from "@components/Shell";
 import EditTeam from "@components/team/EditTeam";
 import TeamList from "@components/team/TeamList";
 import TeamListItem from "@components/team/TeamListItem";
+import { Alert } from "@components/ui/Alert";
 import Button from "@components/ui/Button";
 
 export default function Teams() {
@@ -24,6 +25,8 @@ export default function Teams() {
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
   const [editTeamEnabled, setEditTeamEnabled] = useState(false);
   const [teamToEdit, setTeamToEdit] = useState<Team | null>();
+  const [hasErrors, setHasErrors] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const nameRef = useRef<HTMLInputElement>() as React.MutableRefObject<HTMLInputElement>;
 
   const handleErrors = async (resp: Response) => {
@@ -48,6 +51,11 @@ export default function Teams() {
     loadData();
   }, []);
 
+  useEffect(() => {
+    setHasErrors(false);
+    setErrorMessage("");
+  }, [showCreateTeamModal]);
+
   if (loading) {
     return <Loader />;
   }
@@ -60,10 +68,16 @@ export default function Teams() {
       headers: {
         "Content-Type": "application/json",
       },
-    }).then(() => {
-      loadData();
-      setShowCreateTeamModal(false);
-    });
+    })
+      .then(handleErrors)
+      .then(() => {
+        loadData();
+        setShowCreateTeamModal(false);
+      })
+      .catch((err) => {
+        setHasErrors(true);
+        setErrorMessage(err.message);
+      });
   };
 
   const editTeam = (team: Team) => {
@@ -162,6 +176,7 @@ export default function Teams() {
                     <label htmlFor="name" className="block text-sm font-medium text-gray-700">
                       {t("name")}
                     </label>
+                    {hasErrors && <Alert className="mt-1 mb-2" severity="error" message={errorMessage} />}
                     <input
                       ref={nameRef}
                       type="text"


### PR DESCRIPTION
## What does this PR do?
When creating a new team, if the team name already existed, show error message instead of silently doing nothing and closing the modal. Apparantly, there are multiple places can be shown for this error message, this PR choose to show it on the modal as below because it raise the awareness for user before he can taking any further action. Also this behavior is consistent with editing an team name to another name already existed, that is showing an alert message rather than using showToast as showToast is being used for successful message most of time from my observation.
![image](https://user-images.githubusercontent.com/12154828/145024297-891ccb3b-ad1d-4f34-b3d9-bccf5ae1e889.png)

Fixes # (issue)
https://github.com/calendso/calendso/issues/1122

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A: If a team name already existed, show error message.
- [x] Test B: If a team name not exist, create new team.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
