### PR TITLE
Reversed order of custom inputs & notes

### DIFF
--- a/pages/api/book/event.ts
+++ b/pages/api/book/event.ts
@@ -284,10 +284,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   };
 
   const description =
-    reqBody.customInputs.reduce((str, input) => str + input.label + "\n" + input.value + "\n\n", "") +
-    t("additional_notes") +
-    ":\n" +
-    reqBody.notes;
+    reqBody.notes +
+    reqBody.customInputs.reduce(
+      (str, input) => str + "<br /><br />" + input.label + ":<br />" + input.value,
+      ""
+    );
 
   const evt: CalendarEvent = {
     type: eventType.title,


### PR DESCRIPTION
## What does this PR do?

This is a temporary fix for custom fields in the new email templates; in rich text ("\n" no longer works)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
