### PR TITLE
Fix round-robin

### DIFF
--- a/pages/api/book/event.ts
+++ b/pages/api/book/event.ts
@@ -140,12 +140,9 @@ const getUserNameWithBookingCounts = async (eventTypeId: number, selectedUserNam
   const users = await prisma.user.findMany({
     where: {
       username: { in: selectedUserNames },
-      bookings: {
+      eventTypes: {
         some: {
-          startTime: {
-            gt: new Date(),
-          },
-          eventTypeId,
+          id: eventTypeId,
         },
       },
     },


### PR DESCRIPTION
## What does this PR do?

### Before 
If users did not yet have a booking made under the round robin, they could never be selected.

### After
What you really want here is to grab all users that have this eventType

### Note
You might want to change the variable `getUserNameWithBookingCounts` to something that describes the above instead.