### PR TITLE
Fix user dropdown text overflow

### DIFF
--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -328,15 +328,14 @@ function UserDropdown({ small }: { small?: boolean }) {
   return (
     <Dropdown>
       <DropdownMenuTrigger asChild>
-        <div className="flex items-center space-x-2 cursor-pointer group">
-          <Avatar
-            imageSrc={user?.avatar || ""}
-            alt={user?.username || "Nameless User"}
-            className={classNames(small ? "w-8 h-8" : "w-10 h-10", "bg-gray-300 rounded-full flex-shrink-0")}
-          />
+        <div className="flex items-center space-x-2 cursor-pointer group w-full">
+          <span
+            className={classNames(small ? "w-8 h-8" : "w-10 h-10", "bg-gray-300 rounded-full flex-shrink-0")}>
+            <Avatar imageSrc={user?.avatar || ""} alt={user?.username || "Nameless User"} />
+          </span>
           {!small && (
-            <>
-              <span className="flex-grow text-sm">
+            <span className="flex flex-grow items-center truncate">
+              <span className="flex-grow text-sm truncate">
                 <span className="block font-medium text-gray-900 truncate">
                   {user?.username || "Nameless User"}
                 </span>
@@ -348,7 +347,7 @@ function UserDropdown({ small }: { small?: boolean }) {
                 className="flex-shrink-0 w-5 h-5 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />
-            </>
+            </span>
           )}
         </div>
       </DropdownMenuTrigger>


### PR DESCRIPTION
## What does this PR do?
Long username will overflow in sidebar. This PR will truncate overflow username.
Before: 
![image](https://user-images.githubusercontent.com/12154828/145329348-8114b8a5-6e57-466c-8002-db6a6b247194.png)
After:
![image](https://user-images.githubusercontent.com/12154828/145329359-bb61a054-f0ed-408b-aeab-7fd13386b6b1.png)


Fixes https://github.com/calendso/calendso/issues/1278

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Test A: Go to settings and set a long username. The overflow text should be hidden and avatar and dropdown icon should be displayed as normal.
- [x] Test B: Set back short username, it should be displayed as before.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and corrected any misspellings
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
