### PR TITLE
Remove team member bug fix

### DIFF
--- a/server/routers/viewer/teams.tsx
+++ b/server/routers/viewer/teams.tsx
@@ -159,7 +159,7 @@ export const viewerTeamsRouter = createProtectedRouter()
 
       await ctx.prisma.membership.delete({
         where: {
-          userId_teamId: { userId: ctx.user?.id, teamId: input.teamId },
+          userId_teamId: { userId: input.memberId, teamId: input.teamId },
         },
       });
     },


### PR DESCRIPTION
Not sure how this slipped by, but this needs merging asap.

It's a single line change, removing a team member explicitly and exclusively removes yourself from your own team.