### PR TITLE
Fix for incorrect <hr /> color as result of Tailwind upgrade

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -355,6 +355,10 @@ body {
   background-color: #f3f4f6;
 }
 
+hr {
+  @apply border-gray-200;
+}
+
 .text-white-important {
   color: white !important;
 }


### PR DESCRIPTION
It appears as a result of the Tailwind upgrade the `<hr />` tag's were affected site wide, rendering as black instead of light gray. This PR simply adds a global @apply to the hr tag to fix.