### PR TITLE
added brand color to dark mode timepicker

### DIFF
--- a/components/booking/AvailableTimes.tsx
+++ b/components/booking/AvailableTimes.tsx
@@ -84,7 +84,7 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
               <div key={slot.time.format()}>
                 <Link href={bookingUrl}>
                   <a
-                    className="block py-4 mb-2 font-medium bg-white border rounded-sm dark:bg-gray-600 text-primary-500 dark:text-neutral-200 border-brand dark:border-transparent hover:text-white hover:bg-brand hover:text-brandcontrast dark:hover:border-black dark:hover:bg-black"
+                    className="block py-4 mb-2 font-medium bg-white border rounded-sm dark:bg-gray-600 text-primary-500 dark:text-neutral-200 border-brand dark:border-transparent hover:text-white hover:bg-brand hover:text-brandcontrast dark:hover:border-black dark:hover:bg-brand dark:hover:text-brandcontrast"
                     data-testid="time">
                     {slot.time.format(timeFormat)}
                   </a>

--- a/components/booking/AvailableTimes.tsx
+++ b/components/booking/AvailableTimes.tsx
@@ -3,8 +3,9 @@ import { SchedulingType } from "@prisma/client";
 import { Dayjs } from "dayjs";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, { FC } from "react";
+import React, { FC, useEffect, useState } from "react";
 
+import classNames from "@lib/classNames";
 import { useLocale } from "@lib/hooks/useLocale";
 import { useSlots } from "@lib/hooks/useSlots";
 
@@ -43,6 +44,12 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
     minimumBookingNotice,
     eventTypeId,
   });
+
+  const [brand, setBrand] = useState("#292929");
+
+  useEffect(() => {
+    setBrand(getComputedStyle(document.documentElement).getPropertyValue("--brand-color").trim());
+  }, []);
 
   return (
     <div className="flex flex-col mt-8 text-center sm:pl-4 sm:mt-0 sm:w-1/3 md:-mb-5">
@@ -84,7 +91,10 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
               <div key={slot.time.format()}>
                 <Link href={bookingUrl}>
                   <a
-                    className="block py-4 mb-2 font-medium bg-white border rounded-sm dark:bg-gray-600 text-primary-500 dark:text-neutral-200 border-brand dark:border-transparent hover:text-white hover:bg-brand hover:text-brandcontrast dark:hover:border-black dark:hover:bg-brand dark:hover:text-brandcontrast"
+                    className={classNames(
+                      "block py-4 mb-2 font-medium bg-white border rounded-sm dark:bg-gray-600 text-primary-500 dark:text-neutral-200 dark:border-transparent hover:text-white hover:bg-brand hover:text-brandcontrast dark:hover:border-black dark:hover:bg-brand dark:hover:text-brandcontrast",
+                      brand === "#fff" || brand === "#fffff" ? "border-brandcontrast" : "border-brand"
+                    )}
                     data-testid="time">
                     {slot.time.format(timeFormat)}
                   </a>

--- a/components/booking/AvailableTimes.tsx
+++ b/components/booking/AvailableTimes.tsx
@@ -93,7 +93,7 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
                   <a
                     className={classNames(
                       "block py-4 mb-2 font-medium bg-white border rounded-sm dark:bg-gray-600 text-primary-500 dark:text-neutral-200 dark:border-transparent hover:text-white hover:bg-brand hover:text-brandcontrast dark:hover:border-black dark:hover:bg-brand dark:hover:text-brandcontrast",
-                      brand === "#fff" || brand === "#fffff" ? "border-brandcontrast" : "border-brand"
+                      brand === "#fff" || brand === "#ffffff" ? "border-brandcontrast" : "border-brand"
                     )}
                     data-testid="time">
                     {slot.time.format(timeFormat)}

--- a/components/ui/form/PhoneInput.tsx
+++ b/components/ui/form/PhoneInput.tsx
@@ -8,7 +8,7 @@ export const PhoneInput = (props: PhoneInputProps) => (
   <BasePhoneInput
     {...props}
     className={classNames(
-      "shadow-sm rounded-md block w-full py-px px-3 border border-1 border-gray-300 ring-black focus-within:ring-1 focus-within:border-brand dark:border-gray-900 dark:text-white dark:bg-[#292929]",
+      "shadow-sm rounded-sm block w-full py-px px-3 border border-1 border-gray-300 ring-black focus-within:ring-1 focus-within:border-brand dark:border-black dark:text-white dark:bg-black",
       props.className
     )}
     onChange={() => {

--- a/components/ui/form/PhoneInput.tsx
+++ b/components/ui/form/PhoneInput.tsx
@@ -8,7 +8,7 @@ export const PhoneInput = (props: PhoneInputProps) => (
   <BasePhoneInput
     {...props}
     className={classNames(
-      "shadow-sm rounded-md block w-full py-px px-3 border border-1 border-gray-300 ring-black focus-within:ring-1 focus-within:border-brand dark:border-gray-900 dark:text-brandcontrast dark:bg-brand",
+      "shadow-sm rounded-md block w-full py-px px-3 border border-1 border-gray-300 ring-black focus-within:ring-1 focus-within:border-brand dark:border-gray-900 dark:text-white dark:bg-[#292929]",
       props.className
     )}
     onChange={() => {

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -417,7 +417,7 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
   }
 
   return (
-    <div className="min-h-screen bg-brand text-brandcontrast">
+    <div className="min-h-screen bg-brand">
       <Head>
         <title>Cal.com - {t("getting_started")}</title>
         <link rel="icon" href="/favicon.ico" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,7 +12,7 @@
   @apply text-sm border-0 focus:ring-0;
 }
 .dark .PhoneInputInput {
-  @apply bg-brand;
+  @apply bg-black;
 }
 .PhoneInputCountrySelect {
   @apply text-black;


### PR DESCRIPTION
## What does this PR do?

- Quick follow up to PR#1289 which was merged a little too quickly.
- Fixes minor visual bugs missed in the PR#1289
- Adds logic to show dark border on timeselector when brand color is `#fff`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [x] Choose #ffffff as the brand color when background is dark
- [x] Choose #292929 as the brand color when background is light
- [x] Choose any random hex as the brand color and see if the text is visible

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
