### PR TITLE
prevent i18n flickering on pages

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,6 @@
 import { BookOpenIcon, CheckIcon, CodeIcon, DocumentTextIcon } from "@heroicons/react/outline";
 import { ChevronRightIcon } from "@heroicons/react/solid";
+import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
@@ -7,6 +8,8 @@ import React from "react";
 import { useLocale } from "@lib/hooks/useLocale";
 
 import { HeadSeo } from "@components/seo/head-seo";
+
+import { ssrInit } from "@server/lib/ssr";
 
 export default function Custom404() {
   const { t } = useLocale();
@@ -170,3 +173,13 @@ export default function Custom404() {
     </>
   );
 }
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const ssr = await ssrInit(context);
+
+  return {
+    props: {
+      trpcState: ssr.dehydrate(),
+    },
+  };
+};

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,7 @@
 import { BookOpenIcon, CheckIcon, CodeIcon, DocumentTextIcon } from "@heroicons/react/outline";
 import { ChevronRightIcon } from "@heroicons/react/solid";
-import { GetServerSidePropsContext } from "next";
+import { GetStaticPaths, GetStaticPropsContext } from "next";
+import { i18n } from "next-i18next.config";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
@@ -9,7 +10,7 @@ import { useLocale } from "@lib/hooks/useLocale";
 
 import { HeadSeo } from "@components/seo/head-seo";
 
-import { ssrInit } from "@server/lib/ssr";
+import { ssgInit } from "@server/lib/ssg";
 
 export default function Custom404() {
   const { t } = useLocale();
@@ -174,8 +175,18 @@ export default function Custom404() {
   );
 }
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const ssr = await ssrInit(context);
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: i18n.locales.map((locale) => ({
+      locale,
+      params: {},
+    })),
+    fallback: "blocking",
+  };
+};
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
+  const ssr = await ssgInit(context);
 
   return {
     props: {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,7 +1,6 @@
 import { BookOpenIcon, CheckIcon, CodeIcon, DocumentTextIcon } from "@heroicons/react/outline";
 import { ChevronRightIcon } from "@heroicons/react/solid";
-import { GetStaticPaths, GetStaticPropsContext } from "next";
-import { i18n } from "next-i18next.config";
+import { GetStaticPropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
@@ -174,16 +173,6 @@ export default function Custom404() {
     </>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: i18n.locales.map((locale) => ({
-      locale,
-      params: {},
-    })),
-    fallback: "blocking",
-  };
-};
 
 export const getStaticProps = async (context: GetStaticPropsContext) => {
   const ssr = await ssgInit(context);

--- a/pages/cancel/[uid].tsx
+++ b/pages/cancel/[uid].tsx
@@ -15,6 +15,8 @@ import CustomBranding from "@components/CustomBranding";
 import { HeadSeo } from "@components/seo/head-seo";
 import { Button } from "@components/ui/Button";
 
+import { ssrInit } from "@server/lib/ssr";
+
 export default function Type(props: inferSSRProps<typeof getServerSideProps>) {
   const { t } = useLocale();
   // Get router variables
@@ -145,6 +147,7 @@ export default function Type(props: inferSSRProps<typeof getServerSideProps>) {
 }
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const ssr = await ssrInit(context);
   const session = await getSession(context);
   const booking = await prisma.booking.findUnique({
     where: {
@@ -202,6 +205,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       booking: bookingObj,
       cancellationAllowed:
         (!!session?.user && session.user?.id === booking.user?.id) || booking.startTime >= new Date(),
+      trpcState: ssr.dehydrate(),
     },
   };
 };

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -22,6 +22,8 @@ import CustomBranding from "@components/CustomBranding";
 import { HeadSeo } from "@components/seo/head-seo";
 import Button from "@components/ui/Button";
 
+import { ssrInit } from "@server/lib/ssr";
+
 dayjs.extend(utc);
 dayjs.extend(toArray);
 dayjs.extend(timezone);
@@ -279,6 +281,7 @@ export default function Success(props: inferSSRProps<typeof getServerSideProps>)
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const ssr = await ssrInit(context);
   const typeId = parseInt(asStringOrNull(context.query.type) ?? "");
 
   if (isNaN(typeId)) {
@@ -358,6 +361,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       hideBranding: eventType.team ? eventType.team.hideBranding : isBrandingHidden(eventType.users[0]),
       profile,
       eventType,
+      trpcState: ssr.dehydrate(),
     },
   };
 }

--- a/server/lib/ssg.ts
+++ b/server/lib/ssg.ts
@@ -8,6 +8,12 @@ import prisma from "@lib/prisma";
 import { appRouter } from "@server/routers/_app";
 import { createSSGHelpers } from "@trpc/react/ssg";
 
+/**
+ * Initialize static site rendering tRPC helpers.
+ * Provides a method to prefetch tRPC-queries in a `getStaticProps`-function.
+ * Automatically prefetches i18n based on the passed in `context`-object to prevent i18n-flickering.
+ * Make sure to `return { props: { trpcState: ssr.dehydrate() } }` at the end.
+ */
 export async function ssgInit<TParams extends { locale?: string }>(opts: GetStaticPropsContext<TParams>) {
   const requestedLocale = opts.params?.locale || opts.locale || i18n.defaultLocale;
   const isSupportedLocale = i18n.locales.includes(requestedLocale);

--- a/server/lib/ssg.ts
+++ b/server/lib/ssg.ts
@@ -1,0 +1,37 @@
+import { GetStaticPropsContext } from "next";
+import { i18n } from "next-i18next.config";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import superjson from "superjson";
+
+import prisma from "@lib/prisma";
+
+import { appRouter } from "@server/routers/_app";
+import { createSSGHelpers } from "@trpc/react/ssg";
+
+export async function ssgInit<TParams extends { locale?: string }>(opts: GetStaticPropsContext<TParams>) {
+  const requestedLocale = opts.params?.locale || opts.locale || i18n.defaultLocale;
+  const isSupportedLocale = i18n.locales.includes(requestedLocale);
+  if (!isSupportedLocale) {
+    console.warn(`Requested unsupported locale "${requestedLocale}"`);
+  }
+  const locale = isSupportedLocale ? requestedLocale : i18n.defaultLocale;
+
+  const _i18n = await serverSideTranslations(locale, ["common"]);
+
+  const ssg = createSSGHelpers({
+    router: appRouter,
+    transformer: superjson,
+    ctx: {
+      prisma,
+      session: null,
+      user: null,
+      locale,
+      i18n: _i18n,
+    },
+  });
+
+  // always preload i18n
+  await ssg.fetchQuery("viewer.i18n");
+
+  return ssg;
+}

--- a/server/lib/ssr.ts
+++ b/server/lib/ssr.ts
@@ -7,7 +7,7 @@ import { createSSGHelpers } from "@trpc/react/ssg";
 import { appRouter } from "../routers/_app";
 
 /**
- * Initialize server-side rendering.
+ * Initialize server-side rendering tRPC helpers.
  * Provides a method to prefetch tRPC-queries in a `getServerSideProps`-function.
  * Automatically prefetches i18n based on the passed in `context`-object to prevent i18n-flickering.
  * Make sure to `return { props: { trpcState: ssr.dehydrate() } }` at the end.

--- a/server/lib/ssr.ts
+++ b/server/lib/ssr.ts
@@ -6,6 +6,12 @@ import { createSSGHelpers } from "@trpc/react/ssg";
 
 import { appRouter } from "../routers/_app";
 
+/**
+ * Initialize server-side rendering.
+ * Provides a method to prefetch tRPC-queries in a `getServerSideProps`-function.
+ * Automatically prefetches i18n based on the passed in `context`-object to prevent i18n-flickering.
+ * Make sure to `return { props: { trpcState: ssr.dehydrate() } }` at the end.
+ */
 export async function ssrInit(context: GetServerSidePropsContext) {
   const ctx = await createContext(context);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,25 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@components/*": ["components/*"],
-      "@lib/*": ["lib/*"],
-      "@server/*": ["server/*"],
-      "@ee/*": ["ee/*"]
+      "@components/*": [
+        "components/*"
+      ],
+      "@lib/*": [
+        "lib/*"
+      ],
+      "@server/*": [
+        "server/*"
+      ],
+      "@ee/*": [
+        "ee/*"
+      ]
     },
     "skipLibCheck": true,
     "strict": true,
@@ -21,10 +33,21 @@
     "isolatedModules": true,
     "useUnknownInCatchVariables": true,
     "jsx": "preserve",
-    "types": ["@types/jest", "jest-playwright-preset", "expect-playwright"],
+    "types": [
+      "@types/jest",
+      "jest-playwright-preset",
+      "expect-playwright"
+    ],
     "allowJs": true,
     "incremental": true
   },
-  "include": ["next-env.d.ts", "@types/*.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "@types/*.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
     "paths": {
-      "@components/*": [
-        "components/*"
-      ],
-      "@lib/*": [
-        "lib/*"
-      ],
-      "@server/*": [
-        "server/*"
-      ],
-      "@ee/*": [
-        "ee/*"
-      ]
+      "@components/*": ["components/*"],
+      "@lib/*": ["lib/*"],
+      "@server/*": ["server/*"],
+      "@ee/*": ["ee/*"]
     },
     "skipLibCheck": true,
     "strict": true,
@@ -33,21 +21,10 @@
     "isolatedModules": true,
     "useUnknownInCatchVariables": true,
     "jsx": "preserve",
-    "types": [
-      "@types/jest",
-      "jest-playwright-preset",
-      "expect-playwright"
-    ],
-    "allowJs": false,
+    "types": ["@types/jest", "jest-playwright-preset", "expect-playwright"],
+    "allowJs": true,
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "@types/*.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "@types/*.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What does this PR do?

Prevent i18n flickering on pages

- `/cancel`
- `/success`
- 404. **Note that this will have "flicker of English-content".** See https://github.com/vercel/next.js/discussions/12477 for more details, I don't know of a good solution for this as you can't even provide `getStaticPaths` on 404-pages.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [ ] Load 404 page
- [ ] Cancel an event
- [ ] Book an event

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
