### PR TITLE
Fixes zoom expiry date

### DIFF
--- a/lib/integrations/Zoom/ZoomVideoApiAdapter.ts
+++ b/lib/integrations/Zoom/ZoomVideoApiAdapter.ts
@@ -60,7 +60,7 @@ export interface ZoomEventResult {
 
 interface ZoomToken {
   scope: "meeting:write";
-  expires_in: number;
+  expiry_date: number;
   token_type: "bearer";
   access_token: string;
   refresh_token: string;
@@ -68,7 +68,7 @@ interface ZoomToken {
 
 const zoomAuth = (credential: Credential) => {
   const credentialKey = credential.key as unknown as ZoomToken;
-  const isExpired = (expiryDate: number) => expiryDate < +new Date();
+  const isExpired = (expiryDate: number) => expiryDate < Date.now();
   const authHeader =
     "Basic " +
     Buffer.from(process.env.ZOOM_CLIENT_ID + ":" + process.env.ZOOM_CLIENT_SECRET).toString("base64");
@@ -87,6 +87,9 @@ const zoomAuth = (credential: Credential) => {
     })
       .then(handleErrorsJson)
       .then(async (responseBody) => {
+        // set expiry date as offset from current time.
+        responseBody.expiry_date = Math.round(Date.now() + responseBody.expires_in * 1000);
+        delete responseBody.expires_in;
         // Store new tokens in database.
         await prisma.credential.update({
           where: {
@@ -96,14 +99,14 @@ const zoomAuth = (credential: Credential) => {
             key: responseBody,
           },
         });
+        credentialKey.expiry_date = responseBody.expiry_date;
         credentialKey.access_token = responseBody.access_token;
-        credentialKey.expires_in = Math.round(+new Date() / 1000 + responseBody.expires_in);
         return credentialKey.access_token;
       });
 
   return {
     getToken: () =>
-      !isExpired(credentialKey.expires_in)
+      !isExpired(credentialKey.expiry_date)
         ? Promise.resolve(credentialKey.access_token)
         : refreshAccessToken(credentialKey.refresh_token),
   };

--- a/lib/integrations/Zoom/ZoomVideoApiAdapter.ts
+++ b/lib/integrations/Zoom/ZoomVideoApiAdapter.ts
@@ -61,6 +61,7 @@ export interface ZoomEventResult {
 interface ZoomToken {
   scope: "meeting:write";
   expiry_date: number;
+  expires_in?: number; // deprecated, purely for backwards compatibility; superseeded by expiry_date.
   token_type: "bearer";
   access_token: string;
   refresh_token: string;
@@ -106,7 +107,7 @@ const zoomAuth = (credential: Credential) => {
 
   return {
     getToken: () =>
-      !isExpired(credentialKey.expiry_date)
+      !isExpired(credentialKey.expires_in || credentialKey.expiry_date)
         ? Promise.resolve(credentialKey.access_token)
         : refreshAccessToken(credentialKey.refresh_token),
   };

--- a/pages/api/integrations/zoomvideo/callback.ts
+++ b/pages/api/integrations/zoomvideo/callback.ts
@@ -30,7 +30,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
     }
   );
-  const json = await result.json();
+
+  const responseBody = await result.json();
+
+  responseBody.expiry_date = Math.round(Date.now() + responseBody.expires_in * 1000);
+  delete responseBody.expires_in;
 
   await prisma.user.update({
     where: {
@@ -40,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       credentials: {
         create: {
           type: "zoom_video",
-          key: json,
+          key: responseBody,
         },
       },
     },


### PR DESCRIPTION
Fixes #1314 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

* Connect Zoom integration before checking out this branch
* Observe `expires_in: 3599` in the "Credential" - zoom_video.
* Checkout this branch
* Create new booking with Zoom as a location
* Observe the `expires_in: 3599` is now replaced by `expiry_date`. This means the access token has been refreshed entirely. Note the expiry_date value.
* Create another booking (again using Zoom)
* Observe the expiry_date has not changed, the access_token has been re-used.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
