### PR TITLE
Fix DatePicker not working on next months and onwards

### DIFF
--- a/components/booking/DatePicker.tsx
+++ b/components/booking/DatePicker.tsx
@@ -68,7 +68,7 @@ function DatePicker({
     setSelectedMonth((selectedMonth ?? 0) - 1);
   };
 
-  const inviteeDate = (): Dayjs => (date || dayjs()).month(selectedMonth);
+  const inviteeDate = (): Dayjs => dayjs().month(selectedMonth);
 
   useEffect(() => {
     // Create placeholder elements for empty days in first week


### PR DESCRIPTION
## What does this PR do?

When you try to book a slot for the next month or onward the `DatePicker` doesn't correctly cause it takes the initial date as the one chosen.
Here i added the [issue](https://github.com/calendso/calendso/issues/1331) with the problem.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How should this be tested?

I did this fix very quickly and without to much knowledge of the codebase, probably im missing something, but basically the selected date doesn't have to be related with the status of the date picker.

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
