### PR TITLE
Fixes contextual translation error (NL)

### DIFF
--- a/public/static/locales/nl/common.json
+++ b/public/static/locales/nl/common.json
@@ -431,7 +431,7 @@
   "add_new_event_type": "Een nieuw type afspraak toevoegen",
   "new_event_type_to_book_description": "Maak een nieuw afspraak type voor bezoekers om tijden mee te reserveren.",
   "length": "Lengte",
-  "minimum_booking_notice": "Minimale voorbereidingstijd",
+  "minimum_booking_notice": "Minimum vooruitboeken",
   "delete_event_type_description": "Weet u zeker dat u dit evenement wilt verwijderen? Iedereen met wie u deze link heeft gedeeld zal hem niet meer kunnen gebruiken om te boeken.",
   "delete_event_type": "Verwijder Evenement",
   "confirm_delete_event_type": "Ja, verwijder evenement",


### PR DESCRIPTION
Currently it translates as "Minimum preparation time" - contextually this could be right but in our case it isn't. Re-translated as "Minimum forward notice" - it's the closest I could come up with and used by booking.nl (Dutch version of Booking.com) - so I reckon that's best.