### PR TITLE
fix: refresh UserDropdown after update

### DIFF
--- a/pages/settings/profile.tsx
+++ b/pages/settings/profile.tsx
@@ -97,9 +97,10 @@ function SettingsView(props: ComponentProps<typeof Settings> & { localeProp: str
   const { t } = useLocale();
   const router = useRouter();
   const mutation = trpc.useMutation("viewer.updateProfile", {
-    onSuccess: () => {
+    onSuccess: async () => {
       showToast(t("your_user_profile_updated_successfully"), "success");
       setHasErrors(false); // dismiss any open errors
+      await utils.invalidateQueries(["viewer.me"]);
     },
     onError: (err) => {
       setHasErrors(true);


### PR DESCRIPTION
## What does this PR do?
Change username should refresh Userdropdown.

Fixes [# (issue)](https://github.com/calendso/calendso/issues/1351)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [X] Go to settings and change the username and then save. Updated username should be reflected on Userdropdown in sidebar.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and corrected any misspellings
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
