### PR TITLE
fix VSCode auto importing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.run": "onSave"
+  "eslint.run": "onSave",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
## What does this PR do?

Automatic imports previously resolved to relative paths (".../../components") instead of respecting tsconfig path ("@components"). This is just a quality of life improvement for developers when using intellisense to automaticly import suggestions. Previously needed to clean up manually with the wrong import, or just write it the long way 🤮.

## Type of change

Dev env only
