### PR TITLE
Removed team from profile url

### DIFF
--- a/pages/settings/profile.tsx
+++ b/pages/settings/profile.tsx
@@ -196,7 +196,7 @@ function SettingsView(props: ComponentProps<typeof Settings> & { localeProp: str
                   name="username"
                   addOnLeading={
                     <span className="inline-flex items-center px-3 text-gray-500 border border-r-0 border-gray-300 rounded-l-sm bg-gray-50 sm:text-sm">
-                      {process.env.NEXT_PUBLIC_APP_URL}/{"team/"}
+                      {process.env.NEXT_PUBLIC_APP_URL}/
                     </span>
                   }
                   ref={usernameRef}


### PR DESCRIPTION
## What does this PR do?

Removes team from Profile URL
![image](https://user-images.githubusercontent.com/52925846/146799217-7c94ed34-5331-495d-a245-d879dfeceb38.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
