### PR TITLE
Blank success page in January bookings

### DIFF
--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -64,7 +64,7 @@ export default function Success(props: inferSSRProps<typeof getServerSideProps>)
     const event = createEvent({
       start: [
         date.toDate().getUTCFullYear(),
-        date.toDate().getUTCMonth(),
+        date.toDate().getUTCMonth() + 1,
         date.toDate().getUTCDate(),
         date.toDate().getUTCHours(),
         date.toDate().getUTCMinutes(),

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -64,7 +64,7 @@ export default function Success(props: inferSSRProps<typeof getServerSideProps>)
     const event = createEvent({
       start: [
         date.toDate().getUTCFullYear(),
-        date.toDate().getUTCMonth() + 1,
+        (date.toDate().getUTCMonth() as number) + 1,
         date.toDate().getUTCDate(),
         date.toDate().getUTCHours(),
         date.toDate().getUTCMinutes(),


### PR DESCRIPTION
## What does this PR do?

Adds +1 to the `date.toDate().getUTCMonth()` to make it 1 to 12 instead of 0 to 11 beacause the expected values are 1 to 12

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [X] Create a booking in January 2022 and see if you can view the success page

