### PR TITLE
added url to event-types preview

### DIFF
--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -142,7 +142,6 @@ const EventTypeList = ({ readOnly, types, profile }: EventTypeListProps): JSX.El
                     <div>
                       <span className="font-medium truncate text-neutral-900">{type.title} </span>
                       <small className="text-neutral-500">{`/${profile.slug}/${type.slug}`}</small>
-
                       {type.hidden && (
                         <span className="ml-2 inline items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-yellow-100 text-yellow-800">
                           {t("hidden")}

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -140,7 +140,10 @@ const EventTypeList = ({ readOnly, types, profile }: EventTypeListProps): JSX.El
                     className="flex-grow text-sm truncate"
                     title={`${type.title} ${type.description ? `– ${type.description}` : ""}`}>
                     <div>
-                      <span className="font-medium truncate text-neutral-900">{type.title}</span>
+                      <span className="font-medium truncate text-neutral-900">
+                        {type.title}{" "}
+                        <small className="text-neutral-500">{`/${profile.slug}/${type.slug}`}</small>
+                      </span>
                       {type.hidden && (
                         <span className="ml-2 inline items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-yellow-100 text-yellow-800">
                           {t("hidden")}

--- a/pages/event-types/index.tsx
+++ b/pages/event-types/index.tsx
@@ -140,10 +140,9 @@ const EventTypeList = ({ readOnly, types, profile }: EventTypeListProps): JSX.El
                     className="flex-grow text-sm truncate"
                     title={`${type.title} ${type.description ? `– ${type.description}` : ""}`}>
                     <div>
-                      <span className="font-medium truncate text-neutral-900">
-                        {type.title}{" "}
-                        <small className="text-neutral-500">{`/${profile.slug}/${type.slug}`}</small>
-                      </span>
+                      <span className="font-medium truncate text-neutral-900">{type.title} </span>
+                      <small className="text-neutral-500">{`/${profile.slug}/${type.slug}`}</small>
+
                       {type.hidden && (
                         <span className="ml-2 inline items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-yellow-100 text-yellow-800">
                           {t("hidden")}


### PR DESCRIPTION
## What does this PR do?

- adds slug to event-type

asked by a customer:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/8019099/148360994-bf670da1-d458-4e55-b6ed-99dd3805ecad.png">

after:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/8019099/148360947-81c2d32c-a6a8-408d-9cc5-9040a09f720a.png">

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [ ] visit event-types on desktop
- [ ] visit event-types on mobile

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
