### PR TITLE
Fix cancellation success page for unauthorized users

### DIFF
--- a/pages/cancel/success.tsx
+++ b/pages/cancel/success.tsx
@@ -40,7 +40,7 @@ export default function CancelSuccess() {
                     <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-headline">
                       {t("cancellation_successful")}
                     </h3>
-                    {!loading && !session.user && (
+                    {!loading && !session && (
                       <div className="mt-2">
                         <p className="text-sm text-gray-500">{t("free_to_pick_another_event_type")}</p>
                       </div>
@@ -49,8 +49,8 @@ export default function CancelSuccess() {
                 </div>
                 <div className="mt-5 sm:mt-6 text-center">
                   <div className="mt-5">
-                    {!loading && !session.user && <Button href={eventPage}>Pick another</Button>}
-                    {!loading && session.user && (
+                    {!loading && !session && <Button href={eventPage}>Pick another</Button>}
+                    {!loading && session && (
                       <Button data-testid="back-to-bookings" href="/bookings" EndIcon={ArrowRightIcon}>
                         {t("back_to_bookings")}
                       </Button>


### PR DESCRIPTION
## What does this PR do?

`session` itself is null when the user is anonymous, see https://github.com/calendso/calendso/blob/4cd7a4ce5b3812bfdb05dbb8f936e9c308570d86/components/Shell.tsx#L58

Prior to this change the page fails as it tries to access a property of `null`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Go to the cancellation link as an anonymous user, hit "cancel"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
