### PR TITLE
Add user_settings table

### DIFF
--- a/prisma/migrations/20220110140654_add_user_settings_table/migration.sql
+++ b/prisma/migrations/20220110140654_add_user_settings_table/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "UserSettings" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- RenameIndex
+ALTER INDEX "DailyEventReference_bookingId_unique" RENAME TO "DailyEventReference_bookingId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,7 @@ model EventType {
   price                   Int                    @default(0)
   currency                String                 @default("usd")
   slotInterval            Int?
-  smartContractAddress               String?
+  smartContractAddress    String?
 
   @@unique([userId, slug])
 }
@@ -195,7 +195,7 @@ model DailyEventReference {
   dailyurl   String   @default("dailycallurl")
   dailytoken String   @default("dailytoken")
   booking    Booking? @relation(fields: [bookingId], references: [id])
-  bookingId  Int?
+  bookingId  Int?     @unique
 }
 
 model Booking {
@@ -326,4 +326,13 @@ model Webhook {
   active          Boolean                @default(true)
   eventTriggers   WebhookTriggerEvents[]
   user            User                   @relation(fields: [userId], references: [id])
+}
+
+model UserSettings {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  key       String
+  value     String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## What does this PR do?
Add the migration for the user_settings table.

The UserSettings table will allow us to store user-related configuration without polluting the user table with data that can be changed at any moment of time. An example is to turn on/off some sections of the page (like smart contracts) if the user provides (or not) certain information.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Migration should run in production


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
