### PR TITLE
hotfix for images hosted elsewhere and link stored in DB

### DIFF
--- a/pages/api/user/avatar.ts
+++ b/pages/api/user/avatar.ts
@@ -23,16 +23,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     .digest("hex");
   const img = user?.avatar;
   if (img) {
-    const decoded = img
-      .toString()
-      .replace("data:image/png;base64,", "")
-      .replace("data:image/jpeg;base64,", "");
-    const imageResp = Buffer.from(decoded, "base64");
-    res.writeHead(200, {
-      "Content-Type": "image/png",
-      "Content-Length": imageResp.length,
-    });
-    res.end(imageResp);
+    if (!img.includes("data:image")) {
+      res.writeHead(302, {
+        Location: img,
+      });
+      res.end();
+    } else {
+      const decoded = img
+        .toString()
+        .replace("data:image/png;base64,", "")
+        .replace("data:image/jpeg;base64,", "");
+      const imageResp = Buffer.from(decoded, "base64");
+      res.writeHead(200, {
+        "Content-Type": "image/png",
+        "Content-Length": imageResp.length,
+      });
+      res.end(imageResp);
+    }
   } else {
     res.writeHead(302, {
       Location: defaultAvatarSrc({ md5: emailMd5 }),

--- a/pages/api/user/avatar.ts
+++ b/pages/api/user/avatar.ts
@@ -22,28 +22,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     .update(user?.email as string)
     .digest("hex");
   const img = user?.avatar;
-  if (img) {
-    if (!img.includes("data:image")) {
-      res.writeHead(302, {
-        Location: img,
-      });
-      res.end();
-    } else {
-      const decoded = img
-        .toString()
-        .replace("data:image/png;base64,", "")
-        .replace("data:image/jpeg;base64,", "");
-      const imageResp = Buffer.from(decoded, "base64");
-      res.writeHead(200, {
-        "Content-Type": "image/png",
-        "Content-Length": imageResp.length,
-      });
-      res.end(imageResp);
-    }
-  } else {
+  if (!img) {
     res.writeHead(302, {
       Location: defaultAvatarSrc({ md5: emailMd5 }),
     });
     res.end();
+  } else if (!img.includes("data:image")) {
+    res.writeHead(302, {
+      Location: img,
+    });
+    res.end();
+  } else {
+    const decoded = img
+      .toString()
+      .replace("data:image/png;base64,", "")
+      .replace("data:image/jpeg;base64,", "");
+    const imageResp = Buffer.from(decoded, "base64");
+    res.writeHead(200, {
+      "Content-Type": "image/png",
+      "Content-Length": imageResp.length,
+    });
+    res.end(imageResp);
   }
 }


### PR DESCRIPTION
## What does this PR do?

Provides a hotfix for images hosted elsewhere and link stored in our DB

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] If the image is hosted elsewhere and the link stored in the db, the `/[user]/avatar.png` should now show the image instead of the error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
