### PR TITLE
Fix event type button on team settings

### DIFF
--- a/components/eventtype/CreateEventType.tsx
+++ b/components/eventtype/CreateEventType.tsx
@@ -81,18 +81,21 @@ export default function CreateEventTypeButton(props: Props) {
 
   // inject selection data into url for correct router history
   const openModal = (option: EventTypeParent) => {
-    router.push({
-      pathname: router.pathname,
-      query: {
-        ...router.query,
-        new: "1",
-        eventPage: option.slug,
-        ...(option.teamId
-          ? {
-              teamId: option.teamId,
-            }
-          : {}),
-      },
+    // setTimeout fixes a bug where the url query params are removed immediately after opening the modal
+    setTimeout(() => {
+      router.push({
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          new: "1",
+          eventPage: option.slug,
+          ...(option.teamId
+            ? {
+                teamId: option.teamId,
+              }
+            : {}),
+        },
+      });
     });
   };
 
@@ -108,7 +111,6 @@ export default function CreateEventTypeButton(props: Props) {
     <Dialog
       open={modalOpen.isOn}
       onOpenChange={(isOpen) => {
-        router.push(isOpen ? modalOpen.hrefOn : modalOpen.hrefOff);
         if (!isOpen) closeModal();
       }}>
       {!hasTeams || props.isIndividualTeam ? (


### PR DESCRIPTION
## What does this PR do?
Somehow a bug occurs that was not caught locally, the second time the modal is opened the query params are stripped causing the team context to be missing, in turn causing the user to mistakingly create an event for themselves instead of a team. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update