### PR TITLE
Fix/remove date selector telementry

### DIFF
--- a/components/booking/pages/AvailabilityPage.tsx
+++ b/components/booking/pages/AvailabilityPage.tsx
@@ -61,7 +61,6 @@ const AvailabilityPage = ({ profile, eventType, workingHours }: Props) => {
   }, [telemetry]);
 
   const changeDate = (newDate: Dayjs) => {
-    telemetry.withJitsu((jitsu) => jitsu.track(telemetryEventTypes.dateSelected, collectPageParameters()));
     router.replace(
       {
         query: {

--- a/components/booking/pages/BookingPage.tsx
+++ b/components/booking/pages/BookingPage.tsx
@@ -112,9 +112,6 @@ const BookingPage = (props: BookingPageProps) => {
   }, [router.query.guest]);
 
   const telemetry = useTelemetry();
-  useEffect(() => {
-    telemetry.withJitsu((jitsu) => jitsu.track(telemetryEventTypes.timeSelected, collectPageParameters()));
-  }, [telemetry]);
 
   const locationInfo = (type: LocationType) => locations.find((location) => location.type === type);
 

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -7,7 +7,6 @@ import React, { useContext } from "react";
  */
 export const telemetryEventTypes = {
   pageView: "page_view",
-  timeSelected: "time_selected",
   bookingConfirmed: "booking_confirmed",
   bookingCancelled: "booking_cancelled",
 };

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -7,7 +7,6 @@ import React, { useContext } from "react";
  */
 export const telemetryEventTypes = {
   pageView: "page_view",
-  dateSelected: "date_selected",
   timeSelected: "time_selected",
   bookingConfirmed: "booking_confirmed",
   bookingCancelled: "booking_cancelled",


### PR DESCRIPTION
## What does this PR do?

removing `date_selected` and `time_selected` from telemetry as we never used this event and it spams our db.