### PR TITLE
removes trial banner on tablet and smaller

### DIFF
--- a/ee/components/TrialBanner.tsx
+++ b/ee/components/TrialBanner.tsx
@@ -19,7 +19,7 @@ const TrialBanner = () => {
 
   return (
     <div
-      className="p-4 m-4 text-sm font-medium text-center text-gray-600 bg-yellow-200 rounded-md"
+      className="hidden p-4 m-4 text-sm font-medium text-center text-gray-600 bg-yellow-200 rounded-md sm:block"
       data-testid="trial-banner">
       <div className="mb-2 text-left">{t("trial_days_left", { days: trialDaysLeft })}</div>
       <Button


### PR DESCRIPTION
## What does this PR do?

removes trial banner for tablet & mobile 


before:
![image](https://user-images.githubusercontent.com/8019099/149582027-a4aa391f-d5ab-4cbc-9181-cb97c6af0cea.png)

