### PR TITLE
Fixed issue with mixed up Google login

### DIFF
--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -150,7 +150,7 @@ export default NextAuth({
   },
   providers,
   callbacks: {
-    async jwt({ token, user, account, profile }) {
+    async jwt({ token, user, account }) {
       if (!user) {
         return token;
       }
@@ -165,7 +165,7 @@ export default NextAuth({
 
       // The arguments above are from the provider so we need to look up the
       // user based on those values in order to construct a JWT.
-      if (account && profile && account.type === "oauth" && account.provider) {
+      if (account && account.type === "oauth" && account.provider && account.providerAccountId) {
         let idP: IdentityProvider = IdentityProvider.GOOGLE;
         if (account.provider === "saml") {
           idP = IdentityProvider.SAML;
@@ -178,7 +178,7 @@ export default NextAuth({
                 identityProvider: idP,
               },
               {
-                identityProviderId: profile.id as string,
+                identityProviderId: account.providerAccountId as string,
               },
             ],
           },


### PR DESCRIPTION
## What does this PR do?

Fixes Google login: `profile.id` is undefined and this is causing the first record to be retrieved instead of the AND query failing. Switched to using `account.providerAccountId`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Test Google login with 2 accounts, login to each one of the individually and ensure it picks the right account each time

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
