### PR TITLE
Fix EmailField style in ForgotPassword page

### DIFF
--- a/pages/auth/forgot-password/index.tsx
+++ b/pages/auth/forgot-password/index.tsx
@@ -98,7 +98,7 @@ export default function ForgotPassword({ csrfToken }: { csrfToken: string }) {
                 <input name="csrfToken" type="hidden" defaultValue={csrfToken} hidden />
 
                 <EmailField
-                  className="justify-center w-full"
+                  className="w-full"
                   onChange={handleChange}
                   id="email"
                   name="email"

--- a/pages/auth/forgot-password/index.tsx
+++ b/pages/auth/forgot-password/index.tsx
@@ -98,6 +98,7 @@ export default function ForgotPassword({ csrfToken }: { csrfToken: string }) {
                 <input name="csrfToken" type="hidden" defaultValue={csrfToken} hidden />
 
                 <EmailField
+                  className="justify-center w-full"
                   onChange={handleChange}
                   id="email"
                   name="email"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Now, the email field in the Forgot Password page (`/auth/forgot-password`) is fitting 100% of the width.

Fixes #1515 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Visit the Forgot Password page located at the route `/auth/forgot-password`.
- [x] Note that the email field fits 100% of the width.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
