### PR TITLE
Fix NaN values when creating event type under your name

### DIFF
--- a/components/eventtype/CreateEventType.tsx
+++ b/components/eventtype/CreateEventType.tsx
@@ -51,7 +51,9 @@ export default function CreateEventTypeButton(props: Props) {
 
   // URL encoded params
   const teamId: number | undefined =
-    typeof router.query.teamId === "string" ? parseInt(router.query.teamId) : undefined;
+    typeof router.query.teamId === "string" && router.query.teamId
+      ? parseInt(router.query.teamId)
+      : undefined;
   const pageSlug = router.query.eventPage || props.options[0].slug;
   const hasTeams = !!props.options.find((option) => option.teamId);
 
@@ -123,13 +125,7 @@ export default function CreateEventTypeButton(props: Props) {
           onClick={() => openModal(props.options[0])}
           data-testid="new-event-type"
           StartIcon={PlusIcon}
-          {...(props.canAddEvents
-            ? {
-                href: modalOpen.hrefOn,
-              }
-            : {
-                disabled: true,
-              })}>
+          {...(props.canAddEvents ? { href: modalOpen.hrefOn } : { disabled: true })}>
           {t("new_event_type_btn")}
         </Button>
       ) : (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When you try to create an event type under your name, the query param `teamId` is `""` (empty string) so, parsing this to number the result is `NaN`. Then, `NaN` values were shown in the sections where there is a _conditional rendering_. 

Fixes #1623

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Login
- [x] Enter to Event Types tab (`/event-types`)
- [x] Click on "New event type" button and select your name
- [x] Now, there are no NaN values showing on the modal

![image](https://user-images.githubusercontent.com/39246879/151248828-8ea5466b-e0c9-4dea-9225-f35cebdc1deb.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
