### PR TITLE
Add user empty-name fallback

### DIFF
--- a/pages/[user]/[type].tsx
+++ b/pages/[user]/[type].tsx
@@ -179,7 +179,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   return {
     props: {
       profile: {
-        name: user.name,
+        name: user.name || user.username,
         image: user.avatar,
         slug: user.username,
         theme: user.theme,

--- a/pages/team/[slug]/[type].tsx
+++ b/pages/team/[slug]/[type].tsx
@@ -94,7 +94,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   return {
     props: {
       profile: {
-        name: team.name,
+        name: team.name || team.slug,
         slug: team.slug,
         image: team.logo,
         theme: null,


### PR DESCRIPTION
## What does this PR do?

When the username is `NULL` in the database, such as [cal.com/jamiefalls](//cal.com/jamiefalls/30min), a literal 'null' string gets output into the page's `<title />` and `<meta name="og:title" />` elements. This PR adds a fallback so that if the username is empty, the profile's slug will be displayed instead. (In this case, 'null' would change to 'jamiefalls'.)

Fixes # [n/a]

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Working on tests for this.

<!-- - [ ] Test A
- [ ] Test B -->

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
