### PR TITLE
renamed booking_confirmed to booking_attempted

### DIFF
--- a/components/booking/pages/BookingPage.tsx
+++ b/components/booking/pages/BookingPage.tsx
@@ -211,7 +211,7 @@ const BookingPage = (props: BookingPageProps) => {
 
   const bookEvent = (booking: BookingFormValues) => {
     telemetry.withJitsu((jitsu) =>
-      jitsu.track(telemetryEventTypes.bookingConfirmed, collectPageParameters())
+      jitsu.track(telemetryEventTypes.bookingAttempted, collectPageParameters())
     );
 
     // "metadata" is a reserved key to allow for connecting external users without relying on the email address.

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -7,6 +7,7 @@ import React, { useContext } from "react";
  */
 export const telemetryEventTypes = {
   pageView: "page_view",
+  bookingAttempted: "booking_attempted",
   bookingConfirmed: "booking_confirmed",
   bookingCancelled: "booking_cancelled",
   importSubmitted: "import_submitted",


### PR DESCRIPTION
## What does this PR do?

renames `booking_confirmed` to `booking_attempted` 

- [ ] needs reintroduction of booking_confirmed on API layer when email confirmations are being sent
- [ ]  needs renaming of column on jitsu postgres from `booking_confirmed` to `booking_attempted` 