### PR TITLE
Web3 hotfixes to latest main

### DIFF
--- a/ee/components/web3/CryptoSection.tsx
+++ b/ee/components/web3/CryptoSection.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useState } from "react";
 import React from "react";
 import Web3 from "web3";
 import { AbiItem } from "web3-utils";
-import verifyAccount, { AUTH_MESSAGE } from "web3/utils/verifyAccount";
 
 import { useLocale } from "@lib/hooks/useLocale";
 import showToast from "@lib/notification";
@@ -12,6 +11,7 @@ import { Button } from "@components/ui/Button";
 
 import { useContracts } from "../../../contexts/contractsContext";
 import genericAbi from "../../../web3/abis/abiWithGetBalance.json";
+import verifyAccount, { AUTH_MESSAGE } from "../../../web3/utils/verifyAccount";
 
 interface Window {
   ethereum: any;

--- a/pages/api/book/event.ts
+++ b/pages/api/book/event.ts
@@ -8,7 +8,6 @@ import utc from "dayjs/plugin/utc";
 import type { NextApiRequest, NextApiResponse } from "next";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
-import verifyAccount from "web3/utils/verifyAccount";
 
 import { handlePayment } from "@ee/lib/stripe/server";
 
@@ -33,6 +32,8 @@ import sendPayload from "@lib/webhooks/sendPayload";
 import getSubscribers from "@lib/webhooks/subscriptions";
 
 import { getTranslation } from "@server/lib/i18n";
+
+import verifyAccount from "../../../web3/utils/verifyAccount";
 
 dayjs.extend(dayjsBusinessTime);
 dayjs.extend(utc);

--- a/pages/event-types/[type].tsx
+++ b/pages/event-types/[type].tsx
@@ -564,16 +564,17 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                 form={formMethods}
                 handleSubmit={async (values) => {
                   const { periodDates, periodCountCalendarDays, smartContractAddress, ...input } = values;
-                  const metadata = {
-                    smartContractAddress: smartContractAddress,
-                  };
                   updateMutation.mutate({
                     ...input,
-                    metadata,
                     periodStartDate: periodDates.startDate,
                     periodEndDate: periodDates.endDate,
                     periodCountCalendarDays: periodCountCalendarDays === "1",
                     id: eventType.id,
+                    metadata: smartContractAddress
+                      ? {
+                          smartContractAddress,
+                        }
+                      : undefined,
                   });
                 }}
                 className="space-y-6">
@@ -1034,7 +1035,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                                       </div>
                                     )}
                                     {period.type === "RANGE" && (
-                                      <div className="inline-flex rtl:space-x-reverse space-x-2 ltr:ml-2 rtl:mr-2">
+                                      <div className="inline-flex space-x-2 rtl:space-x-reverse ltr:ml-2 rtl:mr-2">
                                         <Controller
                                           name="periodDates"
                                           control={formMethods.control}
@@ -1130,7 +1131,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                                           defaultChecked={requirePayment}
                                         />
                                       </div>
-                                      <div className="ltr:ml-3 rtl:mr-3 text-sm">
+                                      <div className="text-sm ltr:ml-3 rtl:mr-3">
                                         <p className="text-neutral-900">
                                           {t("require_payment")} (0.5% +{" "}
                                           <IntlProvider locale="en">
@@ -1197,7 +1198,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                   </>
                   {/* )} */}
                 </Collapsible>
-                <div className="flex justify-end mt-4 rtl:space-x-reverse space-x-2">
+                <div className="flex justify-end mt-4 space-x-2 rtl:space-x-reverse">
                   <Button href="/event-types" color="secondary" tabIndex={-1}>
                     {t("cancel")}
                   </Button>

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightIcon } from "@heroicons/react/outline";
-import { zodResolver } from "@hookform/resolvers/zod/dist/zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Prisma } from "@prisma/client";
 import classnames from "classnames";
 import dayjs from "dayjs";
@@ -534,7 +534,7 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
 
               {error && <Alert severity="error" {...error} />}
 
-              <section className="flex w-full rtl:space-x-reverse space-x-2">
+              <section className="flex w-full space-x-2 rtl:space-x-reverse">
                 {steps.map((s, index) => {
                   return index <= currentStep ? (
                     <div


### PR DESCRIPTION
* web3 folder is unknown to TS, so this fixes the path in line with the other imports
* zodResolver was included incorrectly which caused a big break whilst patching @hookform/resolvers
* Slight mod to smartContractAddress and metadata in update event type so in case of non-web3, metadata = undefined instead of `metadata: { smartContractAddress: undefined }`