### PR TITLE
Fixed infinite event-type page loop after onboarding

### DIFF
--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -130,7 +130,6 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
       throw new Error((await res.json()).message);
     }
     const responseData = await res.json();
-    console.log("response data ready");
     return responseData.data;
   };
 
@@ -318,6 +317,7 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
                     handleSkipStep();
                   } else {
                     await response.json().catch((e) => {
+                      console.log("Error: response.json invalid: " + e);
                       setSubmitting(false);
                     });
                   }

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -130,6 +130,7 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
       throw new Error((await res.json()).message);
     }
     const responseData = await res.json();
+    console.log("response data ready");
     return responseData.data;
   };
 
@@ -242,7 +243,7 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
     if (!props.eventTypes || props.eventTypes.length === 0) {
       const eventTypes = await getEventTypes();
       if (eventTypes.length === 0) {
-        Promise.all(
+        await Promise.all(
           DEFAULT_EVENT_TYPES.map(async (event) => {
             return await createEventType(event);
           })

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -318,7 +318,6 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
                     handleSkipStep();
                   } else {
                     await response.json().catch((e) => {
-                      console.log("Error: response.json invalid: " + e);
                       setSubmitting(false);
                     });
                   }


### PR DESCRIPTION
## What does this PR do?

- Adds the missing await for the promise object so that it waits for the default event types to be created before `pages/event-types` is loaded

Fixes #1773 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Register a new test account and complete the onboarding

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
