### PR TITLE
fix: prisma schema directory in heroku config

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,6 @@
     "JWT_SECRET": "secret"
   },
   "scripts": {
-    "postdeploy": "cd apps/web && npx prisma migrate deploy"
+    "postdeploy": "cd packages/prisma && npx prisma migrate deploy"
   }
 }


### PR DESCRIPTION
## What does this PR do?

When deploying using the `Deploy to Heroku` button, the deployment failed to run the `postdeploy` script because `prisma.schema` wasn't in the `apps/web` directory

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] deploy to heroku from the pr repo

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
