### PR TITLE
fix/bookings-order

### DIFF
--- a/apps/web/server/routers/viewer.tsx
+++ b/apps/web/server/routers/viewer.tsx
@@ -339,9 +339,9 @@ const loggedInViewerRouter = createProtectedRouter()
         typeof bookingListingByStatus,
         Prisma.BookingOrderByWithAggregationInput
       > = {
-        upcoming: { startTime: "desc" },
+        upcoming: { startTime: "asc" },
         past: { startTime: "desc" },
-        cancelled: { startTime: "desc" },
+        cancelled: { startTime: "asc" },
       };
       const passedBookingsFilter = bookingListingFilters[bookingListingByStatus];
       const orderBy = bookingListingOrderby[bookingListingByStatus];
@@ -390,7 +390,7 @@ const loggedInViewerRouter = createProtectedRouter()
         skip,
       });
 
-      const bookings = bookingsQuery.reverse().map((booking) => {
+      const bookings = bookingsQuery.map((booking) => {
         return {
           ...booking,
           startTime: booking.startTime.toISOString(),


### PR DESCRIPTION
## What does this PR do?

This PR removes unnecessary reverse array order before returning bookings list, since this order can be managed by prisma
order by option, and applies said order by correct value on orderBy filter.
Issue related mentioned on #1833 

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and corrected any misspellings
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
