### PR TITLE
Always disconnect + remove redundant success message

### DIFF
--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -343,15 +343,13 @@ async function main() {
       },
     ]
   );
-
-  await prisma.$disconnect();
 }
 
 main()
-  .then(() => {
-    console.log("🌱 Seeded db");
-  })
   .catch((e) => {
     console.error(e);
     process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
   });


### PR DESCRIPTION
## What does this PR do?

This removes a redundant console.log which prints `success` - which used to be how we reported success but is now redundant by Prisma. Also, the connection was not closed when an error was encountered.

This is how it looks like after this PR:
![image](https://user-images.githubusercontent.com/1046695/155199373-9f6645f6-eb9d-4574-b240-be80bdc601e9.png)
