### PR TITLE
Fixes connectionIntegration undefined bug

### DIFF
--- a/apps/web/components/integrations/ConnectIntegrations.tsx
+++ b/apps/web/components/integrations/ConnectIntegrations.tsx
@@ -2,6 +2,7 @@ import type { IntegrationOAuthCallbackState } from "pages/api/integrations/types
 import { useState } from "react";
 import { useMutation } from "react-query";
 
+import { NEXT_PUBLIC_BASE_URL } from "@lib/config/constants";
 import { AddAppleIntegrationModal } from "@lib/integrations/calendar/components/AddAppleIntegration";
 import { AddCalDavIntegrationModal } from "@lib/integrations/calendar/components/AddCalDavIntegration";
 
@@ -17,7 +18,7 @@ export default function ConnectIntegration(props: {
 
   const mutation = useMutation(async () => {
     const state: IntegrationOAuthCallbackState = {
-      returnTo: location.pathname + location.search,
+      returnTo: NEXT_PUBLIC_BASE_URL + location.pathname + location.search,
     };
     const stateStr = encodeURIComponent(JSON.stringify(state));
     const searchParams = `?state=${stateStr}`;

--- a/apps/web/components/integrations/ConnectIntegrations.tsx
+++ b/apps/web/components/integrations/ConnectIntegrations.tsx
@@ -2,7 +2,6 @@ import type { IntegrationOAuthCallbackState } from "pages/api/integrations/types
 import { useState } from "react";
 import { useMutation } from "react-query";
 
-import { BASE_URL } from "@lib/config/constants";
 import { AddAppleIntegrationModal } from "@lib/integrations/calendar/components/AddAppleIntegration";
 import { AddCalDavIntegrationModal } from "@lib/integrations/calendar/components/AddCalDavIntegration";
 
@@ -18,7 +17,7 @@ export default function ConnectIntegration(props: {
 
   const mutation = useMutation(async () => {
     const state: IntegrationOAuthCallbackState = {
-      returnTo: BASE_URL + location.pathname + location.search,
+      returnTo: location.pathname + location.search,
     };
     const stateStr = encodeURIComponent(JSON.stringify(state));
     const searchParams = `?state=${stateStr}`;

--- a/apps/web/lib/config/constants.ts
+++ b/apps/web/lib/config/constants.ts
@@ -3,3 +3,4 @@ export const WEBSITE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://cal.com";
 export const IS_PRODUCTION = process.env.NODE_ENV === "production";
 export const TRIAL_LIMIT_DAYS = 14;
 export const HOSTED_CAL_FEATURES = process.env.HOSTED_CAL_FEATURES || BASE_URL === "https://app.cal.com";
+export const NEXT_PUBLIC_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || `https://${process.env.VERCEL_URL}`;


### PR DESCRIPTION
## What does this PR do?
Fixes introduced bug by creating new const in config NEXT_PUBLIC_BASE_URL instead of just BASE_URL

In order to test you need to test an integration like google calendar, before BASE_URL would be undefined and so the callback returnTo would be invalid. Now that's fixed and it's the root of the site instead

~~Reverts back #1883~~ 