### PR TITLE
fix: use default user image for nameless users

### DIFF
--- a/apps/web/components/Shell.tsx
+++ b/apps/web/components/Shell.tsx
@@ -380,10 +380,12 @@ function UserDropdown({ small }: { small?: boolean }) {
             <img
               className="rounded-full"
               src={
-                (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL) +
-                "/" +
-                user?.username +
-                "/avatar.png"
+                user?.username
+                  ? (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL) +
+                    "/" +
+                    user.username +
+                    "/avatar.png"
+                  : "cal-com-icon.svg"
               }
               alt={user?.username || "Nameless User"}
             />


### PR DESCRIPTION
## What does this PR do?

- Fixes #2013. Anything would be better than letting the alt text overflow IMO. My questions:
  - Which image should be used here? I put `cal-com-icon.svg` there but it doesn't feel like the correct one. 
  - Would the maintainer consider switching to `next/image` for this `<img>` tag? It is the recommended component for next.js apps now and would stop the linter from complaining 😄 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [x] Test A: Run apps/web with a user who doesn't have a username
- [x] Test B: Run apps/web with a user who has a username

## Checklist
