### PR TITLE
chore: update correct link for docs

### DIFF
--- a/apps/docs/theme.config.js
+++ b/apps/docs/theme.config.js
@@ -1,6 +1,6 @@
 export default {
-  github: 'https://github.com/calcom/docs',
-  docsRepositoryBase: 'https://github.com/calcom/docs/blob/master',
+  github: 'https://github.com/calcom/cal.com',
+  docsRepositoryBase: 'https://github.com/calcom/cal.com/blob/main/apps/docs/pages',
   titleSuffix: ' | Cal.com',
   logo: (
     <h4 className="m-0">


### PR DESCRIPTION
## What does this PR do?

Fix correct links for docs `nextra`'s `theme.config.js` since `docs` has been moved to monorepo.

## Type of change

A chore.

## How should this be tested?

- [x] Check if clicking the Github icon on the top right works.
- [x] Check if clicking the "Edit this page on Github" buttons across pages work. 


