### PR TITLE
fix: HTTP 404 when trying to access `/user/book` route with username containing uppercase letters

### DIFF
--- a/apps/web/pages/[user]/book.tsx
+++ b/apps/web/pages/[user]/book.tsx
@@ -26,7 +26,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const ssr = await ssrInit(context);
   const user = await prisma.user.findUnique({
     where: {
-      username: asStringOrThrow(context.query.user),
+      username: asStringOrThrow(context.query.user).toLowerCase(),
     },
     select: {
       id: true,


### PR DESCRIPTION
## What does this PR do?

Fix HTTP 404 when trying to access `/user/book` route with username containing uppercase letters

Fixes #2010, #2011

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Go to https://cal.com/ANY_UPPERCASE_USERNAME/book?type=...&date=...
2. Should not return HTTP 404 error

