### PR TITLE
Fix prisma setup on e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "turbo run start --scope=\"@calcom/web\"",
     "test": "turbo run test",
     "test-playwright": "yarn playwright test",
-    "test-e2e": "turbo run test-e2e",
+    "test-e2e": "turbo run test-e2e --concurrency=1",
     "type-check": "turbo run type-check"
   },
   "devDependencies": {


### PR DESCRIPTION
## What does this PR do?
Fix the issue of running the setup steps for prisma (reset and deploy) in parallel as both tasks are listed as separate dependencies in the e2e turbo task but they failed because running both concurrently is not possible.  Turbo defaults to parallel execution always unless the --concurrency=1 flag is provided which in this case will run the listed tasks RTL in serial mode.

Fixes #2069

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- `yarn test e2e`

## Checklist

## Notes

_As for now, there are two e2e tests that are failing (at least in development) but this was true also prior to this PR and it is unrelated to these proposed changes. They should be addressed in a different issue/PR_  
