### PR TITLE
Added named dialog to replace new=1

### DIFF
--- a/apps/web/components/Dialog.tsx
+++ b/apps/web/components/Dialog.tsx
@@ -1,11 +1,55 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import React, { ReactNode } from "react";
+import { useRouter } from "next/router";
+import React, { ReactNode, useState } from "react";
 
-export type DialogProps = React.ComponentProps<typeof DialogPrimitive["Root"]>;
+export type DialogProps = React.ComponentProps<typeof DialogPrimitive["Root"]> & {
+  name?: string;
+  clearQueryParamsOnClose?: string[];
+};
 export function Dialog(props: DialogProps) {
-  const { children, ...other } = props;
+  const router = useRouter();
+  const { children, name, ...dialogProps } = props;
+  // only used if name is set
+  const [open, setOpen] = useState(!!dialogProps.open);
+
+  if (name) {
+    const clearQueryParamsOnClose = ["dialog", ...(props.clearQueryParamsOnClose || [])];
+    dialogProps.onOpenChange = (open) => {
+      if (props.onOpenChange) {
+        props.onOpenChange(open);
+      }
+      // toggles "dialog" query param
+      if (open) {
+        router.query["dialog"] = name;
+      } else {
+        clearQueryParamsOnClose.forEach((queryParam) => {
+          delete router.query[queryParam];
+        });
+      }
+      router.push(
+        {
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+          },
+        },
+        undefined,
+        { shallow: true }
+      );
+      setOpen(open);
+    };
+    // handles initial state
+    if (!open && router.query["dialog"] === name) {
+      setOpen(true);
+    }
+    // allow overriding
+    if (!("open" in dialogProps)) {
+      dialogProps.open = open;
+    }
+  }
+
   return (
-    <DialogPrimitive.Root {...other}>
+    <DialogPrimitive.Root {...dialogProps}>
       <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-gray-500 bg-opacity-75 transition-opacity" />
       {children}
     </DialogPrimitive.Root>


### PR DESCRIPTION
## What does this PR do?

Instead of useToggleQuery this names a dialog build in; so instead of having to manually set up every useToggleQuery at every location, this integrates deeper with the Dialog to enable query-param control of the dialog whenever the name is set.

For example, this will allow:
https://app.cal.com/availability?dialog=new-schedule

```javascript
<Dialog name="new-schedule">...</Dialog>
```