### PR TITLE
hotfix: organizer needs to confirm booking, not attendee

### DIFF
--- a/apps/web/lib/emails/templates/attendee-request-email.ts
+++ b/apps/web/lib/emails/templates/attendee-request-email.ts
@@ -55,7 +55,7 @@ ${this.calEvent.attendees[0].language.translate("booking_submitted", {
   name: this.calEvent.attendees[0].name,
 })}
 ${this.calEvent.attendees[0].language.translate("user_needs_to_confirm_or_reject_booking", {
-  user: this.calEvent.attendees[0].name,
+  user: this.calEvent.organizer.name,
 })}
 ${this.getWhat()}
 ${this.getWhen()}


### PR DESCRIPTION
## What does this PR do?
Fixes bug recently introduced in #2048 where the name of the guest/attendee would appear as the one needing to confirm booking, not the organizer.
Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)