### PR TITLE
Fixed bug with creating new outlook events

### DIFF
--- a/apps/web/lib/integrations/calendar/services/Office365CalendarService.ts
+++ b/apps/web/lib/integrations/calendar/services/Office365CalendarService.ts
@@ -35,7 +35,7 @@ export default class Office365CalendarService implements Calendar {
         ? `${event.destinationCalendar.externalId}/`
         : "";
 
-      const response = await fetch(`https://graph.microsoft.com/v1.0/me/calendar/${calendarId}events`, {
+      const response = await fetch(`https://graph.microsoft.com/v1.0/me/calendar/events`, {
         method: "POST",
         headers: {
           Authorization: "Bearer " + accessToken,


### PR DESCRIPTION
## What does this PR do?

Changed the API call to MS Graph to create new calendar events.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Setup
- Connect your account to Outlook
- On the Integration page set a calendar to create events on
- Edit an event type so the destination calendar is Outlook

Testing - Changes should be reflected on Outlook
- Create a booking
- Reschedule the booking
- Delete the booking

