### PR TITLE
Fix for unintended webhook data being sent

### DIFF
--- a/apps/web/pages/api/cancel.ts
+++ b/apps/web/pages/api/cancel.ts
@@ -134,7 +134,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // Send Webhook call if hooked to BOOKING.CANCELLED
   const subscriberOptions = {
     userId: bookingToDelete.userId,
-    eventTypeId: bookingToDelete.eventTypeId as number,
+    eventTypeId: (bookingToDelete.eventTypeId as number) || 0,
     triggerEvent: eventTrigger,
   };
   const subscribers = await getSubscribers(subscriberOptions);


### PR DESCRIPTION
## What does this PR do?

- Adds a fallback value to the deleted eventTypes during cancellation to ensure unintended webhook calls aren't sent out

Fixes #2043 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Create a new webhook on one account.
2. Log in to another account and either create a new event-type (as you would need to delete this later for testing purposes)
3. Create a test booking on the new event
4. Delete the event-type
5. Now cancel the earlier booking
   Now you shouldn't have received a webhook trigger with the details relating to the cancelled event on the account with the webhook integrated.


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->