### PR TITLE
Add restrictions to protect the owners and change their roles

### DIFF
--- a/apps/web/components/Shell.tsx
+++ b/apps/web/components/Shell.tsx
@@ -34,6 +34,7 @@ import HelpMenuItem from "@ee/components/support/HelpMenuItem";
 import classNames from "@lib/classNames";
 import { WEBAPP_URL } from "@lib/config/constants";
 import { shouldShowOnboarding } from "@lib/getting-started";
+import useMeQuery from "@lib/hooks/useMeQuery";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@lib/telemetry";
 import { trpc } from "@lib/trpc";
 
@@ -45,16 +46,6 @@ import ImpersonatingBanner from "@components/ui/ImpersonatingBanner";
 import pkg from "../package.json";
 import { useViewerI18n } from "./I18nLanguageHandler";
 import Logo from "./Logo";
-
-export function useMeQuery() {
-  const meQuery = trpc.useQuery(["viewer.me"], {
-    retry(failureCount) {
-      return failureCount > 3;
-    },
-  });
-
-  return meQuery;
-}
 
 function useRedirectToLoginIfUnauthenticated(isPublic = false) {
   const { data: session, status } = useSession();

--- a/apps/web/components/availability/Schedule.tsx
+++ b/apps/web/components/availability/Schedule.tsx
@@ -14,9 +14,9 @@ import Dropdown, { DropdownMenuTrigger, DropdownMenuContent } from "@calcom/ui/D
 
 import { defaultDayRange } from "@lib/availability";
 import { weekdayNames } from "@lib/core/i18n/weekday";
+import useMeQuery from "@lib/hooks/useMeQuery";
 import { TimeRange } from "@lib/types/schedule";
 
-import { useMeQuery } from "@components/Shell";
 import Select from "@components/ui/form/Select";
 
 dayjs.extend(utc);

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -12,9 +12,9 @@ import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader } from "
 import { TextArea } from "@calcom/ui/form/fields";
 
 import { HttpError } from "@lib/core/http/error";
+import useMeQuery from "@lib/hooks/useMeQuery";
 import { inferQueryOutput, trpc } from "@lib/trpc";
 
-import { useMeQuery } from "@components/Shell";
 import { RescheduleDialog } from "@components/dialog/RescheduleDialog";
 import TableActions, { ActionType } from "@components/ui/TableActions";
 

--- a/apps/web/components/team/MemberChangeRoleModal.tsx
+++ b/apps/web/components/team/MemberChangeRoleModal.tsx
@@ -5,7 +5,6 @@ import React, { SyntheticEvent, useEffect } from "react";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import Button from "@calcom/ui/Button";
 
-import { TeamWithMembers } from "@lib/queries/teams";
 import { trpc } from "@lib/trpc";
 
 import ModalContainer from "@components/ui/ModalContainer";
@@ -20,7 +19,7 @@ const options: MembershipRoleOption[] = [{ value: "MEMBER" }, { value: "ADMIN" }
 
 export default function MemberChangeRoleModal(props: {
   isOpen: boolean;
-  team: TeamWithMembers;
+  currentMember: MembershipRole;
   memberId: number;
   teamId: number;
   initialRole: MembershipRole;
@@ -50,8 +49,6 @@ export default function MemberChangeRoleModal(props: {
     },
   });
 
-  const memberRole = props.team?.membership.role;
-
   function changeRole(e: SyntheticEvent) {
     e.preventDefault();
 
@@ -79,7 +76,7 @@ export default function MemberChangeRoleModal(props: {
             {/*<option value="OWNER">{t("owner")}</option> - needs dialog to confirm change of ownership */}
             <Select
               isSearchable={false}
-              options={memberRole !== MembershipRole.OWNER ? options.slice(0, 2) : options}
+              options={props.currentMember !== MembershipRole.OWNER ? options.slice(0, 2) : options}
               value={role}
               onChange={(option) => option && setRole(option)}
               id="role"

--- a/apps/web/components/team/MemberChangeRoleModal.tsx
+++ b/apps/web/components/team/MemberChangeRoleModal.tsx
@@ -5,6 +5,7 @@ import React, { SyntheticEvent, useEffect } from "react";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import Button from "@calcom/ui/Button";
 
+import { TeamWithMembers } from "@lib/queries/teams";
 import { trpc } from "@lib/trpc";
 
 import ModalContainer from "@components/ui/ModalContainer";
@@ -15,10 +16,11 @@ type MembershipRoleOption = {
   label?: string;
 };
 
-const options: MembershipRoleOption[] = [{ value: "MEMBER" }, { value: "ADMIN" }];
+const options: MembershipRoleOption[] = [{ value: "MEMBER" }, { value: "ADMIN" }, { value: "OWNER" }];
 
 export default function MemberChangeRoleModal(props: {
   isOpen: boolean;
+  team: TeamWithMembers;
   memberId: number;
   teamId: number;
   initialRole: MembershipRole;
@@ -48,6 +50,8 @@ export default function MemberChangeRoleModal(props: {
     },
   });
 
+  const memberRole = props.team?.membership.role;
+
   function changeRole(e: SyntheticEvent) {
     e.preventDefault();
 
@@ -57,7 +61,6 @@ export default function MemberChangeRoleModal(props: {
       role: role.value,
     });
   }
-
   return (
     <ModalContainer isOpen={props.isOpen} onExit={props.onExit}>
       <>
@@ -76,7 +79,7 @@ export default function MemberChangeRoleModal(props: {
             {/*<option value="OWNER">{t("owner")}</option> - needs dialog to confirm change of ownership */}
             <Select
               isSearchable={false}
-              options={options}
+              options={memberRole !== MembershipRole.OWNER ? options.slice(0, 2) : options}
               value={role}
               onChange={(option) => option && setRole(option)}
               id="role"

--- a/apps/web/components/team/MemberInvitationModal.tsx
+++ b/apps/web/components/team/MemberInvitationModal.tsx
@@ -16,6 +16,7 @@ import Select from "@components/ui/form/Select";
 type MemberInvitationModalProps = {
   isOpen: boolean;
   team: TeamWithMembers | null;
+  currentMember: MembershipRole;
   onExit: () => void;
 };
 
@@ -47,8 +48,6 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       setErrorMessage(err.message);
     },
   });
-
-  const memberRole = props.team?.membership.role;
 
   function inviteMember(e: SyntheticEvent) {
     e.preventDefault();
@@ -102,7 +101,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
               </label>
               <Select
                 defaultValue={options[0]}
-                options={memberRole !== MembershipRole.OWNER ? options.slice(0, 2) : options}
+                options={props.currentMember !== MembershipRole.OWNER ? options.slice(0, 2) : options}
                 id="role"
                 name="role"
                 className="mt-1 block w-full rounded-sm border-gray-300 shadow-sm sm:text-sm"

--- a/apps/web/components/team/MemberInvitationModal.tsx
+++ b/apps/web/components/team/MemberInvitationModal.tsx
@@ -24,7 +24,7 @@ type MembershipRoleOption = {
   label?: string;
 };
 
-const _options: MembershipRoleOption[] = [{ value: "MEMBER" }, { value: "ADMIN" }];
+const _options: MembershipRoleOption[] = [{ value: "MEMBER" }, { value: "ADMIN" }, { value: "OWNER" }];
 
 export default function MemberInvitationModal(props: MemberInvitationModalProps) {
   const [errorMessage, setErrorMessage] = useState("");
@@ -47,6 +47,8 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       setErrorMessage(err.message);
     },
   });
+
+  const memberRole = props.team?.membership.role;
 
   function inviteMember(e: SyntheticEvent) {
     e.preventDefault();
@@ -100,7 +102,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
               </label>
               <Select
                 defaultValue={options[0]}
-                options={options}
+                options={memberRole !== MembershipRole.OWNER ? options.slice(0, 2) : options}
                 id="role"
                 name="role"
                 className="mt-1 block w-full rounded-sm border-gray-300 shadow-sm sm:text-sm"

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -21,10 +21,10 @@ import { trpc, inferQueryOutput } from "@lib/trpc";
 
 import { Tooltip } from "@components/Tooltip";
 import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
+import { useCurrentUser } from "@components/team/currentUser";
 import Avatar from "@components/ui/Avatar";
 import ModalContainer from "@components/ui/ModalContainer";
 
-import { useMeQuery } from "../Shell";
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamPill, { TeamRole } from "./TeamPill";
 
@@ -54,12 +54,6 @@ export default function MemberListItem(props: Props) {
     const { members } = props.team;
     const owners = members.filter((member) => member["role"] === MembershipRole.OWNER && member["accepted"]);
     return owners.length;
-  };
-
-  const useCurrentUser = () => {
-    const query = useMeQuery();
-    const user = query.data;
-    return user?.id;
   };
 
   const currentUser = useCurrentUser();

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -1,8 +1,8 @@
-import { UserRemoveIcon, PencilIcon } from "@heroicons/react/outline";
-import { ClockIcon, ExternalLinkIcon, DotsHorizontalIcon } from "@heroicons/react/solid";
+import { PencilIcon, UserRemoveIcon } from "@heroicons/react/outline";
+import { ClockIcon, DotsHorizontalIcon, ExternalLinkIcon } from "@heroicons/react/solid";
 import { MembershipRole } from "@prisma/client";
 import Link from "next/link";
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import showToast from "@calcom/lib/notification";
@@ -17,11 +17,11 @@ import Dropdown, {
 import TeamAvailabilityModal from "@ee/components/team/availability/TeamAvailabilityModal";
 
 import { getPlaceholderAvatar } from "@lib/getPlaceholderAvatar";
-import { trpc, inferQueryOutput } from "@lib/trpc";
+import useCurrentUserId from "@lib/hooks/useCurrentUserId";
+import { inferQueryOutput, trpc } from "@lib/trpc";
 
 import { Tooltip } from "@components/Tooltip";
 import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
-import { useCurrentUser } from "@components/team/currentUser";
 import Avatar from "@components/ui/Avatar";
 import ModalContainer from "@components/ui/ModalContainer";
 
@@ -56,7 +56,7 @@ export default function MemberListItem(props: Props) {
     return owners.length;
   };
 
-  const currentUser = useCurrentUser();
+  const currentUserId = useCurrentUserId();
 
   const name =
     props.member.name ||
@@ -133,7 +133,7 @@ export default function MemberListItem(props: Props) {
               {((props.team.membership.role === MembershipRole.OWNER &&
                 (props.member.role !== MembershipRole.OWNER ||
                   ownersInTeam() > 1 ||
-                  props.member.id !== currentUser)) ||
+                  props.member.id !== currentUserId)) ||
                 (props.team.membership.role === MembershipRole.ADMIN &&
                   props.member.role !== MembershipRole.OWNER)) && (
                 <>
@@ -195,7 +195,7 @@ export default function MemberListItem(props: Props) {
           <div className="space-x-2 border-t py-5 rtl:space-x-reverse">
             <Button onClick={() => setShowTeamAvailabilityModal(false)}>{t("done")}</Button>
             {props.team.membership.role !== MembershipRole.MEMBER && (
-              <Link href={`/settings/teams/${props.team.id}/availability`}>
+              <Link href={`/settings/teams/${props.team.id}/availability`} passHref>
                 <Button color="secondary">{t("Open Team Availability")}</Button>
               </Link>
             )}

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -184,7 +184,7 @@ export default function MemberListItem(props: Props) {
       {showChangeMemberRoleModal && (
         <MemberChangeRoleModal
           isOpen={showChangeMemberRoleModal}
-          team={props.team}
+          currentMember={props.team.membership.role}
           teamId={props.team?.id}
           memberId={props.member.id}
           initialRole={props.member.role as MembershipRole}

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -52,7 +52,7 @@ export default function MemberListItem(props: Props) {
 
   const ownersInTeam = () => {
     const { members } = props.team;
-    const owners = members.filter((member) => member["role"] === "OWNER");
+    const owners = members.filter((member) => member["role"] === MembershipRole.OWNER);
     return owners.length;
   };
 
@@ -137,8 +137,10 @@ export default function MemberListItem(props: Props) {
               </DropdownMenuItem>
               <DropdownMenuSeparator className="h-px bg-gray-200" />
               {((props.team.membership.role === MembershipRole.OWNER &&
-                (props.member.role !== "OWNER" || (ownersInTeam() > 1 && props.member.id === currentUser))) ||
-                (props.team.membership.role === MembershipRole.ADMIN && props.member.role !== "OWNER")) && (
+                (props.member.role !== MembershipRole.OWNER ||
+                  (ownersInTeam() > 1 && props.member.id === currentUser))) ||
+                (props.team.membership.role === MembershipRole.ADMIN &&
+                  props.member.role !== MembershipRole.OWNER)) && (
                 <>
                   <DropdownMenuItem>
                     <Button

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -52,7 +52,7 @@ export default function MemberListItem(props: Props) {
 
   const ownersInTeam = () => {
     const { members } = props.team;
-    const owners = members.filter((member) => member["role"] === MembershipRole.OWNER);
+    const owners = members.filter((member) => member["role"] === MembershipRole.OWNER && member["accepted"]);
     return owners.length;
   };
 
@@ -138,7 +138,8 @@ export default function MemberListItem(props: Props) {
               <DropdownMenuSeparator className="h-px bg-gray-200" />
               {((props.team.membership.role === MembershipRole.OWNER &&
                 (props.member.role !== MembershipRole.OWNER ||
-                  (ownersInTeam() > 1 && props.member.id === currentUser))) ||
+                  ownersInTeam() > 1 ||
+                  props.member.id !== currentUser)) ||
                 (props.team.membership.role === MembershipRole.ADMIN &&
                   props.member.role !== MembershipRole.OWNER)) && (
                 <>

--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -24,6 +24,7 @@ import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogCont
 import Avatar from "@components/ui/Avatar";
 import ModalContainer from "@components/ui/ModalContainer";
 
+import { useMeQuery } from "../Shell";
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamPill, { TeamRole } from "./TeamPill";
 
@@ -48,6 +49,20 @@ export default function MemberListItem(props: Props) {
       showToast(err.message, "error");
     },
   });
+
+  const ownersInTeam = () => {
+    const { members } = props.team;
+    const owners = members.filter((member) => member["role"] === "OWNER");
+    return owners.length;
+  };
+
+  const useCurrentUser = () => {
+    const query = useMeQuery();
+    const user = query.data;
+    return user?.id;
+  };
+
+  const currentUser = useCurrentUser();
 
   const name =
     props.member.name ||
@@ -121,8 +136,9 @@ export default function MemberListItem(props: Props) {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator className="h-px bg-gray-200" />
-              {(props.team.membership.role === MembershipRole.OWNER ||
-                props.team.membership.role === MembershipRole.ADMIN) && (
+              {((props.team.membership.role === MembershipRole.OWNER &&
+                (props.member.role !== "OWNER" || (ownersInTeam() > 1 && props.member.id === currentUser))) ||
+                (props.team.membership.role === MembershipRole.ADMIN && props.member.role !== "OWNER")) && (
                 <>
                   <DropdownMenuItem>
                     <Button
@@ -165,6 +181,7 @@ export default function MemberListItem(props: Props) {
       {showChangeMemberRoleModal && (
         <MemberChangeRoleModal
           isOpen={showChangeMemberRoleModal}
+          team={props.team}
           teamId={props.team?.id}
           memberId={props.member.id}
           initialRole={props.member.role as MembershipRole}

--- a/apps/web/components/team/currentUser.tsx
+++ b/apps/web/components/team/currentUser.tsx
@@ -1,7 +1,0 @@
-import { useMeQuery } from "@components/Shell";
-
-export const useCurrentUser = () => {
-  const query = useMeQuery();
-  const user = query.data;
-  return user?.id;
-};

--- a/apps/web/components/team/currentUser.tsx
+++ b/apps/web/components/team/currentUser.tsx
@@ -1,0 +1,7 @@
+import { useMeQuery } from "@components/Shell";
+
+export const useCurrentUser = () => {
+  const query = useMeQuery();
+  const user = query.data;
+  return user?.id;
+};

--- a/apps/web/ee/components/TrialBanner.tsx
+++ b/apps/web/ee/components/TrialBanner.tsx
@@ -4,8 +4,7 @@ import Button from "@calcom/ui/Button";
 
 import { TRIAL_LIMIT_DAYS } from "@lib/config/constants";
 import { useLocale } from "@lib/hooks/useLocale";
-
-import { useMeQuery } from "@components/Shell";
+import useMeQuery from "@lib/hooks/useMeQuery";
 
 const TrialBanner = () => {
   const { t } = useLocale();

--- a/apps/web/ee/pages/settings/teams/[id]/availability.tsx
+++ b/apps/web/ee/pages/settings/teams/[id]/availability.tsx
@@ -5,10 +5,11 @@ import { Alert } from "@calcom/ui/Alert";
 import TeamAvailabilityScreen from "@ee/components/team/availability/TeamAvailabilityScreen";
 
 import { getPlaceholderAvatar } from "@lib/getPlaceholderAvatar";
+import useMeQuery from "@lib/hooks/useMeQuery";
 import { trpc } from "@lib/trpc";
 
 import Loader from "@components/Loader";
-import Shell, { useMeQuery } from "@components/Shell";
+import Shell from "@components/Shell";
 import Avatar from "@components/ui/Avatar";
 
 export function TeamAvailabilityPage() {

--- a/apps/web/lib/hooks/useCurrentUserId.ts
+++ b/apps/web/lib/hooks/useCurrentUserId.ts
@@ -1,0 +1,9 @@
+import useMeQuery from "./useMeQuery";
+
+export const useCurrentUserId = () => {
+  const query = useMeQuery();
+  const user = query.data;
+  return user?.id;
+};
+
+export default useCurrentUserId;

--- a/apps/web/lib/hooks/useMeQuery.ts
+++ b/apps/web/lib/hooks/useMeQuery.ts
@@ -1,0 +1,13 @@
+import { trpc } from "../trpc";
+
+export function useMeQuery() {
+  const meQuery = trpc.useQuery(["viewer.me"], {
+    retry(failureCount) {
+      return failureCount > 3;
+    },
+  });
+
+  return meQuery;
+}
+
+export default useMeQuery;

--- a/apps/web/lib/queries/teams/index.ts
+++ b/apps/web/lib/queries/teams/index.ts
@@ -72,7 +72,7 @@ export async function getTeamWithMembers(id?: number, slug?: string) {
       ...obj.user,
       isMissingSeat: obj.user.plan === UserPlan.FREE,
       role: membership?.role,
-      accepted: membership?.role === "OWNER" ? true : membership?.accepted,
+      accepted: membership?.accepted,
     };
   });
 

--- a/apps/web/pages/settings/billing.tsx
+++ b/apps/web/pages/settings/billing.tsx
@@ -5,9 +5,10 @@ import { useIntercom } from "react-use-intercom";
 import Button from "@calcom/ui/Button";
 
 import { useLocale } from "@lib/hooks/useLocale";
+import useMeQuery from "@lib/hooks/useMeQuery";
 
 import SettingsShell from "@components/SettingsShell";
-import Shell, { useMeQuery } from "@components/Shell";
+import Shell from "@components/Shell";
 
 type CardProps = { title: string; description: string; className?: string; children: ReactNode };
 const Card = ({ title, description, className = "", children }: CardProps): JSX.Element => (

--- a/apps/web/pages/settings/teams/[id]/index.tsx
+++ b/apps/web/pages/settings/teams/[id]/index.tsx
@@ -145,6 +145,7 @@ export function TeamSettingsPage() {
             <MemberInvitationModal
               isOpen={showMemberInvitationModal}
               team={team}
+              currentMember={team.membership.role}
               onExit={() => setShowMemberInvitationModal(false)}
             />
           )}

--- a/apps/web/pages/settings/teams/index.tsx
+++ b/apps/web/pages/settings/teams/index.tsx
@@ -8,12 +8,13 @@ import { Alert } from "@calcom/ui/Alert";
 import Button from "@calcom/ui/Button";
 
 import { useLocale } from "@lib/hooks/useLocale";
+import useMeQuery from "@lib/hooks/useMeQuery";
 import { trpc } from "@lib/trpc";
 
 import EmptyScreen from "@components/EmptyScreen";
 import Loader from "@components/Loader";
 import SettingsShell from "@components/SettingsShell";
-import Shell, { useMeQuery } from "@components/Shell";
+import Shell from "@components/Shell";
 import TeamCreateModal from "@components/team/TeamCreateModal";
 import TeamList from "@components/team/TeamList";
 

--- a/apps/web/server/routers/viewer/teams.tsx
+++ b/apps/web/server/routers/viewer/teams.tsx
@@ -65,7 +65,7 @@ export const viewerTeamsRouter = createProtectedRouter()
 
       return memberships.map((membership) => ({
         role: membership.role,
-        accepted: membership.role === "OWNER" ? true : membership.accepted,
+        accepted: membership.accepted,
         ...teams.find((team) => team.id === membership.teamId),
       }));
     },


### PR DESCRIPTION
## What does this PR do?

Adds restrictions so that an Owner can downgrade his role only if he isn't the only Owner. Additionally, an Owner can only modify the roles of other members who aren't Owners. Admins can only modify members with the same or lesser roles. It was considered that only an Owner can appoint another owner.

Fixes #2089 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- The changes were tested in a team with at least two members.

## Checklist

- [X] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and corrected any misspellings
- [X] I have checked if my changes generate no new warnings
