### PR TITLE
Added 3 digit hex compatibility for Custom Brand colors

### DIFF
--- a/apps/web/components/CustomBranding.tsx
+++ b/apps/web/components/CustomBranding.tsx
@@ -179,6 +179,7 @@ function normalizeHexCode(hex: string | null, dark: boolean) {
   if (!hex) {
     return !dark ? brandColor : darkBrandColor;
   }
+  hex = hex.replace("#", "");
   if (hex.length === 3) {
     hex = hex
       .split("")

--- a/apps/web/components/CustomBranding.tsx
+++ b/apps/web/components/CustomBranding.tsx
@@ -175,6 +175,21 @@ function hexToRGB(hex: string) {
   return [parseInt(color.slice(0, 2), 16), parseInt(color.slice(2, 4), 16), parseInt(color.slice(4, 6), 16)];
 }
 
+function normalizeHexCode(hex: string | null, dark: boolean) {
+  if (!hex) {
+    return !dark ? brandColor : darkBrandColor;
+  }
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map(function (hex) {
+        return hex + hex;
+      })
+      .join("");
+  }
+  return hex;
+}
+
 function getContrastingTextColor(bgColor: string | null, dark: boolean): string {
   bgColor = bgColor == "" || bgColor == null ? (dark ? darkBrandColor : brandColor) : bgColor;
   const rgb = hexToRGB(bgColor);
@@ -204,6 +219,9 @@ const BrandColor = ({
   lightVal: string | undefined | null;
   darkVal: string | undefined | null;
 }) => {
+  // convert to 6 digit equivalent if 3 digit code is entered
+  lightVal = normalizeHexCode(lightVal, false);
+  darkVal = normalizeHexCode(darkVal, true);
   // ensure acceptable hex-code
   lightVal = isValidHexCode(lightVal)
     ? lightVal?.indexOf("#") === 0


### PR DESCRIPTION
## What does this PR do?

Adds compatibility for 3 digit hex codes in Custom Brand Colors

Before:
![image](https://user-images.githubusercontent.com/52925846/158332674-1286fd77-3448-4726-8595-759551adffa0.png)


After:
![image](https://user-images.githubusercontent.com/52925846/158332609-67c900d5-e277-42f3-8428-f6accaa6d2d8.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Enter 3 digit valid hex code (eg: `000`, `08c`) in the brand color and confirm that the color picker is picking the correct/desired value. Now, save the changes. The respective text color should be picked accurately now (as opposed to earlier where it was picking dark text by default).

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
