### PR TITLE
Fix pre-fill feature bug where name was missing in some user's sessions

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -181,6 +181,7 @@ export default NextAuth({
       if (account && account.type === "credentials") {
         return {
           id: user.id,
+          name: user.name,
           username: user.username,
           email: user.email,
         };
@@ -213,6 +214,7 @@ export default NextAuth({
 
         return {
           id: existingUser.id,
+          name: existingUser.name,
           username: existingUser.username,
           email: existingUser.email,
         };
@@ -226,6 +228,7 @@ export default NextAuth({
         user: {
           ...session.user,
           id: token.id as number,
+          name: token.name,
           username: token.username as string,
         },
       };


### PR DESCRIPTION
## What does this PR do?
Adds user.name to several code-paths in next-auth where it was missing causing a bug where name is not available to session.
 issue on new prefill feature
Fixes #2164 has already been fixed with recent hotfix #2166
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- [ ] Try to login and see someone else booking, both name and email should be pre-filled
- [ ] On your own booking, doesn't prefill.
