### PR TITLE
Temporarily disables forgot password test

### DIFF
--- a/apps/web/playwright/auth/forgot-password.test.ts
+++ b/apps/web/playwright/auth/forgot-password.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("Can reset forgotten password", async ({ browser }) => {
+  test.fixme(true, "TODO: This test is failing randomly, disabled for now");
   // Create a new incognito browser context
   const context = await browser.newContext({
     extraHTTPHeaders: {


### PR DESCRIPTION
## What does this PR do?

Temporarily disables forgot password test due to be failing randomly. Will re-enable once it's refactored and proven to be stable enough.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
