### PR TITLE
Show button even when no event types

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -501,8 +501,7 @@ const EventTypesPage = () => {
         heading={t("event_types_page_title")}
         subtitle={t("event_types_page_subtitle")}
         CTA={
-          query.data &&
-          query.data.eventTypeGroups.length !== 0 && (
+          query.data && (
             <CreateEventTypeButton
               canAddEvents={query.data.viewer.canAddEvents}
               options={query.data.profiles}


### PR DESCRIPTION
`<EmptyScreen>` does not contain the event type create button and we historically disable that, so this enables the create event type button even if the event type count is 0