### PR TITLE
fix for email

### DIFF
--- a/apps/web/lib/emails/templates/attendee-request-email.ts
+++ b/apps/web/lib/emails/templates/attendee-request-email.ts
@@ -88,7 +88,7 @@ ${this.getAdditionalNotes()}
         ${emailScheduledBodyHeaderContent(
           this.calEvent.organizer.language.translate("booking_submitted"),
           this.calEvent.organizer.language.translate("user_needs_to_confirm_or_reject_booking", {
-            user: this.calEvent.attendees[0].name,
+            user: this.calEvent.organizer.name,
           })
         )}
         ${emailSchedulingBodyDivider()}


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where the booker gets the email stating that they need to confirm the booking instead of the organizer.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Make a booking to an event-type which needs to be confirmed from the organizer. The email should state that the organizer needs to confirm the booking, not the booker.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

