### PR TITLE
Fixing wrong text color

### DIFF
--- a/apps/web/components/ui/Text/Largetitle/Largetitle.tsx
+++ b/apps/web/components/ui/Text/Largetitle/Largetitle.tsx
@@ -1,14 +1,13 @@
-import classnames from "classnames";
 import React from "react";
+import { twMerge } from "tailwind-merge";
 
 import { TextProps } from "../Text";
 
 const Largetitle: React.FunctionComponent<TextProps> = (props: TextProps) => {
-  const classes = classnames(
-    "font-cal tracking-wider text-3xl text-gray-900 dark:text-white mb-2",
+  const classes = twMerge(
+    "font-cal tracking-wider text-gray-900 text-3xl dark:text-white mb-2",
     props?.className
   );
-
   return <p className={classes}>{props?.text || props.children}</p>;
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -100,6 +100,7 @@
     "short-uuid": "^4.2.0",
     "stripe": "^8.191.0",
     "superjson": "1.8.1",
+    "tailwind-merge": "^1.2.0",
     "tsdav": "2.0.0",
     "tslog": "^3.2.1",
     "uuid": "^8.3.2",


### PR DESCRIPTION
## What does this PR do?

Fixes
![image](https://user-images.githubusercontent.com/467258/159348331-ce7b6711-efb6-41f9-afcd-e9d6c08ec9c7.png)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Use onboarding credentials to see title in the right color for dark background

## Considerations

It introduces a new package @dcastil/tailwind-merge