### PR TITLE
Fix prisma client bundle making final bundle overgrow

### DIFF
--- a/apps/web/components/team/MemberListItem.tsx
+++ b/apps/web/components/team/MemberListItem.tsx
@@ -1,5 +1,6 @@
 import { UserRemoveIcon, PencilIcon } from "@heroicons/react/outline";
 import { ClockIcon, ExternalLinkIcon, DotsHorizontalIcon } from "@heroicons/react/solid";
+import { MembershipRole } from "@prisma/client";
 import Link from "next/link";
 import React, { useState } from "react";
 
@@ -25,7 +26,6 @@ import ModalContainer from "@components/ui/ModalContainer";
 
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamPill, { TeamRole } from "./TeamPill";
-import { MembershipRole } from ".prisma/client";
 
 interface Props {
   team: inferQueryOutput<"viewer.teams.get">;

--- a/apps/web/components/team/TeamListItem.tsx
+++ b/apps/web/components/team/TeamListItem.tsx
@@ -6,6 +6,7 @@ import {
   DotsHorizontalIcon,
   PencilIcon,
 } from "@heroicons/react/solid";
+import { MembershipRole } from "@prisma/client";
 import Link from "next/link";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -28,7 +29,6 @@ import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogCont
 import Avatar from "@components/ui/Avatar";
 
 import { TeamRole } from "./TeamPill";
-import { MembershipRole } from ".prisma/client";
 
 interface Props {
   team: inferQueryOutput<"viewer.teams.list">[number];

--- a/apps/web/components/team/TeamSettingsRightSidebar.tsx
+++ b/apps/web/components/team/TeamSettingsRightSidebar.tsx
@@ -1,4 +1,5 @@
 import { ClockIcon, ExternalLinkIcon, LinkIcon, LogoutIcon, TrashIcon } from "@heroicons/react/solid";
+import { MembershipRole } from "@prisma/client";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
@@ -13,8 +14,6 @@ import { trpc } from "@lib/trpc";
 import ConfirmationDialogContent from "@components/dialog/ConfirmationDialogContent";
 import CreateEventTypeButton from "@components/eventtype/CreateEventType";
 import LinkIconButton from "@components/ui/LinkIconButton";
-
-import { MembershipRole } from ".prisma/client";
 
 export default function TeamSettingsRightSidebar(props: { team: TeamWithMembers; role: MembershipRole }) {
   const { t } = useLocale();

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -1,10 +1,9 @@
+import { IdentityProvider } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { hashPassword } from "@lib/auth";
 import prisma from "@lib/prisma";
 import slugify from "@lib/slugify";
-
-import { IdentityProvider } from ".prisma/client";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/apps/web/pages/api/auth/two-factor/totp/setup.ts
+++ b/apps/web/pages/api/auth/two-factor/totp/setup.ts
@@ -1,3 +1,4 @@
+import { IdentityProvider } from "@prisma/client";
 import { NextApiRequest, NextApiResponse } from "next";
 import { authenticator } from "otplib";
 import qrcode from "qrcode";
@@ -5,8 +6,6 @@ import qrcode from "qrcode";
 import { ErrorCode, getSession, verifyPassword } from "@lib/auth";
 import { symmetricEncrypt } from "@lib/crypto";
 import prisma from "@lib/prisma";
-
-import { IdentityProvider } from ".prisma/client";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/apps/web/pages/settings/security.tsx
+++ b/apps/web/pages/settings/security.tsx
@@ -1,3 +1,4 @@
+import { IdentityProvider } from "@prisma/client";
 import React from "react";
 
 import SAMLConfiguration from "@ee/components/saml/Configuration";
@@ -10,8 +11,6 @@ import SettingsShell from "@components/SettingsShell";
 import Shell from "@components/Shell";
 import ChangePasswordSection from "@components/security/ChangePasswordSection";
 import TwoFactorAuthSection from "@components/security/TwoFactorAuthSection";
-
-import { IdentityProvider } from ".prisma/client";
 
 export default function Security() {
   const user = trpc.useQuery(["viewer.me"]).data;


### PR DESCRIPTION
## What does this PR do?

When running `yarn build`, several warning flags are shown (red) in some of the app pages.

![image](https://user-images.githubusercontent.com/66160623/159430022-3cc0c072-edc4-45df-bb77-10873835cb0c.png)
...
![image](https://user-images.githubusercontent.com/66160623/159430128-b8aa4a8e-7c16-433d-99a8-30661e3bbad4.png)
...
![image](https://user-images.githubusercontent.com/66160623/159430286-cce3ece7-f6db-4839-8315-3a088ea3bc9b.png)

When running the bundle analyzer we can see that chunk that drives the prisma/client module is loaded twice given a total bundle size close to 9MB. Check the screenshot #2235 

![image](https://user-images.githubusercontent.com/66160623/159421690-80ebfc8f-d485-44ea-a3b4-75d890857632.png)  

---
The prisma client is imported in two different ways that don't produce any difference except from triggering a second bundled chunk of itself. It is imported using the alias that references the package in the monorepo, `@prisma/client,` and by calling the generated module by prisma at `.prisma/client`. This PR unifies the two ways of calling the prisma client into one (the aliased form). As a result, the final bundle size is cutted to 3.5MB, around 60% of reduced size and there are no more red flags in the final build log.

![image](https://user-images.githubusercontent.com/66160623/159432431-b9f06ebc-0b61-4c99-a6ba-9d37003b69b3.png)

**NO RED FLAGS ANYMORE**

![image](https://user-images.githubusercontent.com/66160623/159432594-b2d17dce-0ee1-4775-b278-f169fd246205.png)
...
![image](https://user-images.githubusercontent.com/66160623/159432646-6baa6be9-e7d9-4f12-bdac-7d1da92a9c6a.png)
...
![image](https://user-images.githubusercontent.com/66160623/159432706-28cf498a-b1db-4132-bf42-c962543a2e6c.png)
...
![image](https://user-images.githubusercontent.com/66160623/159432781-ee95e4b9-4ab3-4fd1-bc2f-19ba113e9337.png)

Fixes #2235

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

I ran all the unit and e2e tests in development and in production which will use the optimized build and is the one that I should target. I also ran a few manual smoke tests to assure everything is working well. 

_In development_

- `yarn workspace @calcom/prisma db-reset && yarn dx`   _#in one terminal_
- `yarn workspace @calcom/web test-e2e`  _#in another terminal_

_In production_

- `yarn test-e2e`