### PR TITLE
App Store Zoom InstallAppButton

### DIFF
--- a/packages/app-store/components.tsx
+++ b/packages/app-store/components.tsx
@@ -19,6 +19,7 @@ export const InstallAppButtonMap = {
   googlecalendar: dynamic(() => import("./googlecalendar/components/InstallAppButton")),
   office365calendar: dynamic(() => import("./office365calendar/components/InstallAppButton")),
   stripepayment: dynamic(() => import("./stripepayment/components/InstallAppButton")),
+  zoomvideo: dynamic(() => import("./zoomvideo/components/InstallAppButton")),
 };
 
 export const InstallAppButton = (

--- a/packages/app-store/zoomvideo/components/InstallAppButton.tsx
+++ b/packages/app-store/zoomvideo/components/InstallAppButton.tsx
@@ -1,0 +1,18 @@
+import type { InstallAppButtonProps } from "@calcom/app-store/types";
+
+import useAddAppMutation from "../../_utils/useAddAppMutation";
+
+export default function InstallAppButton(props: InstallAppButtonProps) {
+  const mutation = useAddAppMutation("zoom_video");
+
+  return (
+    <>
+      {props.render({
+        onClick() {
+          mutation.mutate("");
+        },
+        loading: mutation.isLoading,
+      })}
+    </>
+  );
+}

--- a/packages/app-store/zoomvideo/components/index.ts
+++ b/packages/app-store/zoomvideo/components/index.ts
@@ -1,0 +1,1 @@
+export { default as InstallAppButton } from "./InstallAppButton";


### PR DESCRIPTION
## What does this PR do?

Implements Zoom `InstallAppButton` to test the developer experience.

<img width="519" alt="Cal_com___Cal_com" src="https://user-images.githubusercontent.com/467258/159618505-a39bc840-b9f5-4309-b583-5dde9f4ee5e7.png">

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How should this be tested?

Go to Zoom App page and see the install button enabled and functional.

## Feedback

It was super easy to implement and get into the system, very well thought that Apps can provide this from components on their own folder. Going a step forward, is there any chance apps can include anything else on their page to provide flexibility there? Like including a video, a gif, screenshots of its usage like apps have in Apple AppStore? Just a thought. Maybe enabling creating a MDX, markdown with React components, could be flexible enough, and in the process of submitting an app, someone on our side could check certain standard to avoid any crazy stuff.
