### PR TITLE
Fixes overflow for long calendar names

### DIFF
--- a/apps/web/components/DestinationCalendarSelector.tsx
+++ b/apps/web/components/DestinationCalendarSelector.tsx
@@ -53,11 +53,14 @@ const DestinationCalendarSelector = ({
       })),
     })) ?? [];
   return (
-    <div className="relative">
+    <div className="relative" title={`${t("select_destination_calendar")}: ${selectedOption?.label || ""}`}>
       {/* There's no easy way to customize the displayed value for a Select, so we fake it. */}
       {!hidePlaceholder && (
-        <div className="pointer-events-none absolute z-10">
-          <Button size="sm" color="secondary" className="m-[1px] rounded-sm border-transparent">
+        <div className="pointer-events-none absolute z-10 w-full">
+          <Button
+            size="sm"
+            color="secondary"
+            className="m-[1px] w-[calc(100%_-_40px)] overflow-hidden overflow-ellipsis whitespace-nowrap rounded-sm border-none leading-5">
             {t("select_destination_calendar")}: {selectedOption?.label || ""}
           </Button>
         </div>


### PR DESCRIPTION
## What does this PR do?

- Adds title attribute for overflowed text
- Fixes overflowed text for long calendar names 

Before:

![image](https://user-images.githubusercontent.com/3504472/159832652-68cb777e-d50d-4303-8e39-3afb37aab038.png)
 

After:

![image](https://user-images.githubusercontent.com/3504472/159832729-926c5c22-1396-4690-a540-d4cce2505c64.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Add a very long calendar name and see the primary calendar selector

