### PR TITLE
fix reacreate of bookingReferences when rescheduling

### DIFF
--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -636,7 +636,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     })
   );
   await Promise.all(promises);
-
+  // Avoid passing referencesToCreate with id unique constrain values
   await prisma.booking.update({
     where: {
       uid: booking.uid,

--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -176,8 +176,9 @@ export default class EventManager {
       select: {
         id: true,
         references: {
+          // NOTE: id field removed from select as we don't require for deletingMany
+          // but was giving error on recreate for reschedule, probably because promise.all() didn't finished
           select: {
-            id: true,
             type: true,
             uid: true,
             meetingId: true,


### PR DESCRIPTION
## What does this PR do?

When rescheduling there is a time when we **deleteMany** bookingReferences, then we try to recreate them with same ids as before but new _bookingId_. My changes should now recreate new ones but without conflicting with previous ids, as it looked there was some id collision before DB was ready or ended deleteMany, as deleteMany appears to be being executed on Promise.all() await.

Fixes
![image](https://user-images.githubusercontent.com/4461358/160012279-c1e8fdae-9671-4815-ba8d-04201f6cbf56.png)


## Type of change



- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Try to reschedule a meeting that has zoom video or another that creates bookingReferences, now it should delete old bookingReferences but without id collision.


## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
