### PR TITLE
Adds sort order to free event type 404

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -169,6 +169,14 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           },
         ],
       },
+      orderBy: [
+        {
+          position: "desc",
+        },
+        {
+          id: "asc",
+        },
+      ],
       select: {
         id: true,
       },


### PR DESCRIPTION
## What does this PR do?

Fixes 404 for sorted free event types 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] On a free account, create an event type and put it on first position
- [ ] Go to user page, first event should not return 404
