### PR TITLE
fix .env instruction for new dotenv stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here is what you need to be able to run Cal.
 1. Copy `apps/web/.env.example` to `apps/web/.env`
 
    ```sh
-   cp apps/web/.env.example apps/web/.env
+   cp .env.example apps/web/.env
    cp packages/prisma/.env.example packages/prisma/.env
    ```
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Small fix: Fixes the instruction script for copying .env.examples which were updated/refactored in a recent PR ([The Dotenv Refactor (](https://github.com/calcom/cal.com/commit/ec58a9dd70804aa5ab9a45a6c7bc91d0e0d67963)https://github.com/calcom/cal.com/pull/2275[)](https://github.com/calcom/cal.com/commit/ec58a9dd70804aa5ab9a45a6c7bc91d0e0d67963)), but the instruction to copy .env files was not. In specific, .env.example now lives in the root directory, but the instruction script expects it to be in apps/web/ and accordingly fails. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A: run the cp command that I have added 
- [ ] Test B

## Checklist

