### PR TITLE
Fixes 500 error on avatar endpoint when user doesn't exist

### DIFF
--- a/apps/web/pages/api/user/avatar.ts
+++ b/apps/web/pages/api/user/avatar.ts
@@ -8,7 +8,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   //   const username = req.url?.substring(1, req.url.lastIndexOf("/"));
   const username = req.query.username as string;
   const user = await prisma.user.findUnique({
-    rejectOnNotFound: true,
     where: {
       username: username,
     },
@@ -20,9 +19,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const emailMd5 = crypto
     .createHash("md5")
-    .update(user.email as string)
+    .update((user?.email as string) || "guest@example.com")
     .digest("hex");
-  const img = user.avatar;
+  const img = user?.avatar;
   if (!img) {
     res.writeHead(302, {
       Location: defaultAvatarSrc({ md5: emailMd5 }),


### PR DESCRIPTION
## What does this PR do?

Super quick one!
Currently, we throw an error when the avatar endpoint is called for a user who doesn't exists. In this PR, we add a fallback gravatar so that we don't get any 500 errors because of it and this 500 error is handled more gracefully.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] try accessing `non_existing_username/avatar.png` endpoint, it should provide a fallback gravatar instead of a 500 `no user exists` error

