### PR TITLE
Update submodules to use https and specify branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "apps/api"]
 	path = apps/api
-	url = git@github.com:calcom/api.git
+	url = https://github.com/calcom/api.git
+	branch = main
 [submodule "apps/website"]
 	path = apps/website
-	url = git@github.com:calcom/website.git
+	url = https://github.com/calcom/website.git
+	branch = main


### PR DESCRIPTION
## What does this PR do?

This updates the submodules to use https (supporting more widely used github authentication methods) and specifies `branch = main` to help those who still have master as their default branch. This should fix the `calcom/docker` build issues, as documented in #2305

Fixes #2305

Tagging @zomars 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Clone calcom/cal.com and perform `git submodule update --init --remote --recursive`
- [ ] Clone calcom/docker and perform `git submodule update --init --remote --recursive`

## Checklist

