### PR TITLE
Fix - Email Notes

### DIFF
--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -326,7 +326,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       (str, input) => str + "<br /><br />" + input.label + ":<br />" + input.value,
       ""
     );
-
   const evt: CalendarEvent = {
     type: eventType.title,
     title: getEventName(eventNameObject), //this needs to be either forced in english, or fetched for each attendee and organizer separately
@@ -530,6 +529,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (rescheduleUid) {
     // Use EventManager to conditionally use all needed integrations.
     const updateManager = await eventManager.update(evt, rescheduleUid);
+    // This gets overridden when updating the event - to check if notes have been hidden or not. We just reset this back
+    // to the default description when we are sending the emails.
+    evt.description = description;
 
     results = updateManager.results;
     referencesToCreate = updateManager.referencesToCreate;
@@ -563,6 +565,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } else if (!eventType.requiresConfirmation && !eventType.price) {
     // Use EventManager to conditionally use all needed integrations.
     const createManager = await eventManager.create(evt);
+
+    // This gets overridden when creating the event - to check if notes have been hidden or not. We just reset this back
+    // to the default description when we are sending the emails.
+    evt.description = description;
 
     results = createManager.results;
     referencesToCreate = createManager.referencesToCreate;


### PR DESCRIPTION
## What does this PR do?
Currently if you select the option to hide notes. The only way to view them notes is by logging into the app. 
It has been requested that the notes still show in the email invitations.

![CleanShot 2022-04-02 at 17 14 46](https://user-images.githubusercontent.com/55134778/161391711-adf31794-e920-4450-8be9-635b1cf98e1f.png)

![CleanShot 2022-04-02 at 17 14 55](https://user-images.githubusercontent.com/55134778/161391712-97e582a7-a6d2-4a1f-933a-23fc1ae8d249.png)


Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->



## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Enable hide notes 
- [ ] Create a booking
- [ ] Check calendar - notes hidden
- [ ] However, email invitation should display notes
- [ ] 

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works

