### PR TITLE
Fix with ical convert to zone

### DIFF
--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -248,12 +248,16 @@ export default abstract class BaseCalendarService implements Calendar {
         const vcalendar = new ICAL.Component(jcalData);
         const vevent = vcalendar.getFirstSubcomponent("vevent");
         const event = new ICAL.Event(vevent);
-        const timezoneComp = vcalendar.getFirstSubcomponent("vtimezone");
-        const tzid: string = timezoneComp?.getFirstPropertyValue("tzid") ?? "UTC";
+        const vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
+        if (vtimezone) {
+          const zone = new ICAL.Timezone(vtimezone);
+          event.startDate = event.startDate.convertToZone(zone);
+          event.endDate = event.endDate.convertToZone(zone);
+        }
 
         return {
-          start: dayjs.tz(event.startDate.toJSDate(), tzid).toISOString(),
-          end: dayjs.tz(event.endDate.toJSDate(), tzid).toISOString(),
+          start: dayjs(event.startDate.toJSDate()).toISOString(),
+          end: dayjs(event.endDate.toJSDate()).toISOString(),
         };
       });
 


### PR DESCRIPTION
## What does this PR do?

Implements timezones to ical events

Fixes #2361 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Connect calendars with different timezone than UTC
2. Create some events for today
3. Go to troubleshoot for availabilities.
4. Find your correct timestamp for your event timezone and if hover on bold time should be correct time for UTC

## Checklist


- I haven't added tests that prove my fix is effective or that my feature works
