### PR TITLE
Fix E2E Tests and Fix broken success page and non existing user URL

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -141,7 +141,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     },
   });
 
-  if (!users) {
+  if (!users || !users.length) {
     return {
       notFound: true,
     };

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -487,10 +487,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   const profile = {
     name: eventType.team?.name || eventType.users[0]?.name || null,
-    email: eventType.team ? null : eventType.users[0].email,
+    email: eventType.team ? null : eventType.users[0].email || null,
     theme: (!eventType.team?.name && eventType.users[0]?.theme) || null,
-    brandColor: eventType.team ? null : eventType.users[0].brandColor,
-    darkBrandColor: eventType.team ? null : eventType.users[0].darkBrandColor,
+    brandColor: eventType.team ? null : eventType.users[0].brandColor || null,
+    darkBrandColor: eventType.team ? null : eventType.users[0].darkBrandColor || null,
   };
 
   return {

--- a/apps/web/playwright/auth/delete-account.test.ts
+++ b/apps/web/playwright/auth/delete-account.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("Can delete user account", async ({ page }) => {
+  //FIXME: This test depends on seed.
   // Login to account to delete
   await page.goto(`/auth/login`);
   // Click input[name="email"]

--- a/apps/web/playwright/booking-pages.test.ts
+++ b/apps/web/playwright/booking-pages.test.ts
@@ -77,11 +77,11 @@ test.describe("pro user", () => {
   test.use({ storageState: "playwright/artifacts/proStorageState.json" });
 
   test.beforeEach(async ({ page }) => {
+    await deleteAllBookingsByEmail("pro@example.com");
     await page.goto("/pro");
   });
 
-  test.afterAll(async () => {
-    // delete test bookings
+  test.afterEach(async () => {
     await deleteAllBookingsByEmail("pro@example.com");
   });
 

--- a/apps/web/playwright/dynamic-booking-pages.test.ts
+++ b/apps/web/playwright/dynamic-booking-pages.test.ts
@@ -12,6 +12,8 @@ test.describe("dynamic booking", () => {
   test.use({ storageState: "playwright/artifacts/proStorageState.json" });
 
   test.beforeEach(async ({ page }) => {
+    await deleteAllBookingsByEmail("pro@example.com");
+    await deleteAllBookingsByEmail("free@example.com");
     await page.goto("/pro+free");
   });
 

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -72,7 +72,7 @@ export async function selectFirstAvailableTimeSlotNextMonth(page: Page) {
   // @TODO: Find a better way to make test wait for full month change render to end
   // so it can click up on the right day, also when resolve remove other todos
   // Waiting for full month increment
-  await page.waitForTimeout(400);
+  await page.waitForTimeout(1000);
   // TODO: Find out why the first day is always booked on tests
   await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();
   await page.click('[data-testid="time"]');
@@ -83,7 +83,7 @@ export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
   // @TODO: Find a better way to make test wait for full month change render to end
   // so it can click up on the right day, also when resolve remove other todos
   // Waiting for full month increment
-  await page.waitForTimeout(400);
+  await page.waitForTimeout(1000);
   // TODO: Find out why the first day is always booked on tests
   await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();
   await page.locator('[data-testid="time"]').nth(1).click();


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes Tests Timing out
- Fixes the issue where if the user isn't logged in and he books a dynamic meeting link and reaches the success page which gives 500.  [Try booking pro+free when you are logged out.]
- User tries to access a non-existing user's cal link - [https://cal.com/abc/2](https://cal.com/abc/2) (Gives 500)
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests Fix

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't checked if new and existing unit tests pass locally with my changes
