### PR TITLE
Dynamic group booking fix to accept "+" in URL and updated Head SEO for dynamic booking

### DIFF
--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -43,6 +43,11 @@ export default function User(props: inferSSRProps<typeof getServerSideProps>) {
   const router = useRouter();
   const isSingleUser = props.users.length === 1;
   const isDynamicGroup = props.users.length > 1;
+  const dynamicNames = isDynamicGroup
+    ? props.users.map((user) => {
+        return user.name || "";
+      })
+    : [];
   const dynamicUsernames = isDynamicGroup
     ? props.users.map((user) => {
         return user.username || "";
@@ -106,11 +111,11 @@ export default function User(props: inferSSRProps<typeof getServerSideProps>) {
     <>
       <Theme />
       <HeadSeo
-        title={isDynamicGroup ? dynamicUsernames.join(", ") : nameOrUsername}
+        title={isDynamicGroup ? dynamicNames.join(", ") : nameOrUsername}
         description={
           isDynamicGroup ? `Book events with ${dynamicUsernames.join(", ")}` : (user.bio as string) || ""
         }
-        name={isDynamicGroup ? dynamicUsernames.join(", ") : nameOrUsername}
+        name={isDynamicGroup ? dynamicNames.join(", ") : nameOrUsername}
         username={isDynamicGroup ? dynamicUsernames.join(", ") : (user.username as string) || ""}
         // avatar={user.avatar || undefined}
       />

--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -106,10 +106,12 @@ export default function User(props: inferSSRProps<typeof getServerSideProps>) {
     <>
       <Theme />
       <HeadSeo
-        title={nameOrUsername}
-        description={(user.bio as string) || ""}
-        name={nameOrUsername}
-        username={(user.username as string) || ""}
+        title={isDynamicGroup ? dynamicUsernames.join(", ") : nameOrUsername}
+        description={
+          isDynamicGroup ? `Book events with ${dynamicUsernames.join(", ")}` : (user.bio as string) || ""
+        }
+        name={isDynamicGroup ? dynamicUsernames.join(", ") : nameOrUsername}
+        username={isDynamicGroup ? dynamicUsernames.join(", ") : (user.username as string) || ""}
         // avatar={user.avatar || undefined}
       />
       <div className="h-screen dark:bg-neutral-900">

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -141,6 +141,8 @@ export const getUsernameSlugLink = ({ users, slug }: UsernameSlugLinkProps): str
 export const getUsernameList = (users: string): string[] => {
   return users
     .toLowerCase()
+    .replace(" ", "+")
+    .replace("%20", "+")
     .split("+")
     .filter((el) => {
       return el.length != 0;


### PR DESCRIPTION
## What does this PR do?

`+` means a space only in `application/x-www-form-urlencoded` content, such as the query part of a URL (converting it to `%20`) and so it doesn't work for dynamic group booking currently, as `+` expected in the logic is expecting it encoded with %2b.
This PR converts `" "` or `%20` to `+` so that we can still accept `+` from the URL and allow it to do what we intended it to do in the first place
It also considers dynamic group booking for HeadSEO details

[ref: [Vercel](https://github.com/vercel/community/discussions/133)]
[ref: [Stackoverflow](https://stackoverflow.com/questions/2678551/when-should-space-be-encoded-to-plus-or-20/)]


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Visit `/rick+pro` or `/rick+free` in staging and it should show the dynamic group booking page. Proceed with the booking normally.
