### PR TITLE
Dynamic group link for more than 2 user fixed

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -261,9 +261,15 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   eventTypeObject.schedule = null;
   eventTypeObject.availability = [];
 
+  const dynamicNames = isDynamicGroup
+    ? users.map((user) => {
+        return user.name || "";
+      })
+    : [];
+
   const profile = isDynamicGroup
     ? {
-        name: getGroupName(usernameList),
+        name: getGroupName(dynamicNames),
         image: null,
         slug: typeParam,
         theme: null,

--- a/apps/web/pages/[user]/book.tsx
+++ b/apps/web/pages/[user]/book.tsx
@@ -168,9 +168,15 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   const isDynamicGroupBooking = users.length > 1;
 
+  const dynamicNames = isDynamicGroupBooking
+    ? users.map((user) => {
+        return user.name || "";
+      })
+    : [];
+
   const profile = isDynamicGroupBooking
     ? {
-        name: getGroupName(usernameList),
+        name: getGroupName(dynamicNames),
         image: null,
         slug: eventTypeSlug,
         theme: null,

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -126,11 +126,10 @@ export const getGroupName = (usernameList: string[]): string => {
 export const getUsernameSlugLink = ({ users, slug }: UsernameSlugLinkProps): string => {
   let slugLink = ``;
   if (users.length > 1) {
-    let combinedUsername = ``;
-    for (let i = 0; i < users.length - 1; i++) {
-      combinedUsername = `${users[i].username}+`;
+    let combinedUsername = `${users[0].username}`;
+    for (let i = 1; i < users.length; i++) {
+      combinedUsername = `${combinedUsername}+${users[i].username}`;
     }
-    combinedUsername = `${combinedUsername}${users[users.length - 1].username}`;
     slugLink = `/${combinedUsername}/${slug}`;
   } else {
     slugLink = `/${users[0].username}/${slug}`;

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -140,8 +140,8 @@ export const getUsernameSlugLink = ({ users, slug }: UsernameSlugLinkProps): str
 export const getUsernameList = (users: string): string[] => {
   return users
     .toLowerCase()
-    .replace(" ", "+")
-    .replace("%20", "+")
+    .replace(/ /g, "+")
+    .replace(/%20/g, "+")
     .split("+")
     .filter((el) => {
       return el.length != 0;


### PR DESCRIPTION
## What does this PR do?

- Dynamic group booking only supports 2 users currently because of the use of replace added in PR #2414. This PR adds support for more than 2 users by building on that PR logic.
- This PR also fixes the dynamic group link logic which earlier only allowed 2 users, but now provides the expected link with all the users as part of the booking.
- This PR updates the availability and booking pages to use Name instead of usernames of the dynamic group for title

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [x] Try booking `/pro+rick+free+usa` in staging

