### PR TITLE
fix order of past bookings

### DIFF
--- a/apps/web/server/routers/viewer.tsx
+++ b/apps/web/server/routers/viewer.tsx
@@ -344,7 +344,7 @@ const loggedInViewerRouter = createProtectedRouter()
         Prisma.BookingOrderByWithAggregationInput
       > = {
         upcoming: { startTime: "asc" },
-        past: { startTime: "desc" },
+        past: { startTime: "asc" },
         cancelled: { startTime: "asc" },
       };
       const passedBookingsFilter = bookingListingFilters[bookingListingByStatus];


### PR DESCRIPTION
## What does this PR do?
Changes order from past bookings from desc to asc like cancelled and upcoming.
Fixes # (issue)
Reported on twist by @Jaibles 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Login with user
- [ ] Go to past bookings, order should be correct now

<img width="947" alt="image" src="https://user-images.githubusercontent.com/6601142/162297950-58424a21-013d-40d0-8e3f-809f5c76bdda.png">

