### PR TITLE
Check STRIPE_PRIVATE_KEY exists before stripe call during disband

### DIFF
--- a/apps/web/server/routers/viewer/teams.tsx
+++ b/apps/web/server/routers/viewer/teams.tsx
@@ -149,7 +149,9 @@ export const viewerTeamsRouter = createProtectedRouter()
     async resolve({ ctx, input }) {
       if (!(await isTeamOwner(ctx.user?.id, input.teamId))) throw new TRPCError({ code: "UNAUTHORIZED" });
 
-      await downgradeTeamMembers(input.teamId);
+      if (process.env.STRIPE_PRIVATE_KEY) {
+        await downgradeTeamMembers(input.teamId);
+      }
 
       // delete all memberships
       await ctx.prisma.membership.deleteMany({


### PR DESCRIPTION
## What does this PR do?

Wraps downgradeTeamMembers in a check for STRIPE_PRIVATE_KEY so team disband does not fail when the Cal.com install does not have any connected Stripe accounts. 