### PR TITLE
RoundRobin Booking Error in a particular case

### DIFF
--- a/apps/web/pages/[user]/book.tsx
+++ b/apps/web/pages/[user]/book.tsx
@@ -77,7 +77,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   if (!users.length) return { notFound: true };
   const [user] = users;
   const eventTypeRaw =
-    usernameList && usernameList.length > 1
+    usernameList.length > 1
       ? getDefaultEvent(eventTypeSlug)
       : await prisma.eventType.findUnique({
           where: {

--- a/apps/web/pages/[user]/book.tsx
+++ b/apps/web/pages/[user]/book.tsx
@@ -77,7 +77,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   if (!users.length) return { notFound: true };
   const [user] = users;
   const eventTypeRaw =
-    usernameList.length > 1
+    usernameList && usernameList.length > 1
       ? getDefaultEvent(eventTypeSlug)
       : await prisma.eventType.findUnique({
           where: {

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -223,7 +223,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const reqBody = req.body as BookingCreateBody;
 
   // handle dynamic user
-  const dynamicUserList = getUsernameList(reqBody.user);
+  const dynamicUserList = getUsernameList(reqBody?.user);
   const eventTypeSlug = reqBody.eventTypeSlug;
   const eventTypeId = reqBody.eventTypeId;
   const tAttendees = await getTranslation(reqBody.language ?? "en", "common");

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -223,7 +223,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const reqBody = req.body as BookingCreateBody;
 
   // handle dynamic user
-  const dynamicUserList = getUsernameList(reqBody.user as string);
+  const dynamicUserList = getUsernameList(reqBody.user);
   const eventTypeSlug = reqBody.eventTypeSlug;
   const eventTypeId = reqBody.eventTypeId;
   const tAttendees = await getTranslation(reqBody.language ?? "en", "common");

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -139,9 +139,9 @@ export const getUsernameSlugLink = ({ users, slug }: UsernameSlugLinkProps): str
   return slugLink;
 };
 
-export const getUsernameList = (users: string | string[] | undefined): string[] | undefined => {
+export const getUsernameList = (users: string | string[] | undefined): string[] => {
   if (!users) {
-    return;
+    return [];
   }
   if (!(users instanceof Array)) {
     users = [users];

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -147,6 +147,8 @@ export const getUsernameList = (users: string | string[] | undefined): string[] 
     users = [users];
   }
   const allUsers: string[] = [];
+  // Multiple users can come in case of a team round-robin booking and in that case dynamic link won't be a user.
+  // So, even though this code handles even if individual user is dynamic link, that isn't a possibility right now.
   users.forEach((user) => {
     allUsers.push(
       ...user

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -139,15 +139,27 @@ export const getUsernameSlugLink = ({ users, slug }: UsernameSlugLinkProps): str
   return slugLink;
 };
 
-export const getUsernameList = (users: string): string[] => {
-  return users
-    ?.toLowerCase()
-    .replace(/ /g, "+")
-    .replace(/%20/g, "+")
-    .split("+")
-    .filter((el) => {
-      return el.length != 0;
-    });
+export const getUsernameList = (users: string | string[] | undefined): string[] | undefined => {
+  if (!users) {
+    return;
+  }
+  if (!(users instanceof Array)) {
+    users = [users];
+  }
+  const allUsers: string[] = [];
+  users.forEach((user) => {
+    allUsers.push(
+      ...user
+        ?.toLowerCase()
+        .replace(/ /g, "+")
+        .replace(/%20/g, "+")
+        .split("+")
+        .filter((el) => {
+          return el.length != 0;
+        })
+    );
+  });
+  return allUsers;
 };
 
 export default defaultEvents;


### PR DESCRIPTION
## What does this PR do?

Fixes the issue when someone tries to book a team event(round robin) and multiple members are available at that time.
In this case meeting is booked with more than 1 person and `getUsernameList` breaks

The issue would only come if all the conditions are met:
- Team Event
- Round Robin
- Chosen a timeslot where 2 or more persons are available.
- 
Refer: https://calendso.slack.com/archives/C01NXDSRY9W/p1649718021648189

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Book Round Robin with a time slot when at least 2 of the members are available. Error was coming earlier. Now it is fixed.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
