### PR TITLE
change docs to .dev temporarily

### DIFF
--- a/apps/swagger/pages/index.tsx
+++ b/apps/swagger/pages/index.tsx
@@ -38,7 +38,7 @@ export default function APIDocs() {
         docExpansion="none"
         operationsSorter="method"
         filter={true}
-        url={process.env.SWAGGER_DOCS_URL || "https://api.cal.com/docs"}
+        url={process.env.SWAGGER_DOCS_URL || "https://api.cal.dev/docs"}
       />
     </div>
   );


### PR DESCRIPTION
## What does this PR do?
changes swagger url to api.cal.dev/docs