### PR TITLE
fix(readme): specify nodejs version in prereq section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To get a local copy up and running, please follow these simple steps.
 
 Here is what you need to be able to run Cal.
 
-- Node.js
+- Node.js (Version: >=14.x <15)
 - PostgreSQL
 - Yarn _(recommended)_
 


### PR DESCRIPTION
## What does this PR do?

Updates the Prerequisites section in the readme to add the allowed nodejs versions required to run Cal.com.

## Type of change

Adding the nodejs versions' boundaries allowed.

## How should this be tested?

It's just a readme update, so It's fine.
