### PR TITLE
Adds iframe to developer.cal.com (swagger-ui) into docs/public-api.mdx

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -3,4 +3,14 @@ const withNextra = require("nextra")({
   themeConfig: "./theme.config.js",
   unstable_staticImage: true,
 });
-module.exports = withNextra();
+module.exports = withNextra({
+  async rewrites() {
+    return [
+      // This redirects requests recieved at / the root to the /api/ folder.
+      {
+        source: "/api",
+        destination: "https://developer.cal.com/",
+      },
+    ];
+  },
+});

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -9,7 +9,7 @@ module.exports = withNextra({
       // This redirects requests recieved at / the root to the /api/ folder.
       {
         source: "/api",
-        destination: "https://developer.cal.com/",
+        destination: "/public-api",
       },
     ];
   },

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -6,7 +6,7 @@ const withNextra = require("nextra")({
 module.exports = withNextra({
   async rewrites() {
     return [
-      // This redirects requests recieved at / the root to the /api/ folder.
+      // This redirects requests recieved at /api to /public-api to workaround nextjs default use of /api.
       {
         source: "/api",
         destination: "/public-api",

--- a/apps/docs/pages/meta.json
+++ b/apps/docs/pages/meta.json
@@ -6,6 +6,7 @@
   "event-types": "Event Types",
   "teams": "Teams",
   "integrations": "Integrations",
+  "public-api": "API",
   "webhooks": "Webhooks",
   "settings": "Settings",
   "import": "Import",

--- a/apps/docs/pages/public-api.mdx
+++ b/apps/docs/pages/public-api.mdx
@@ -1,7 +1,5 @@
 import Bleed from 'nextra-theme-docs/bleed'
 
----
----
 <Bleed full>
   <iframe src="https://developer.cal.com"
      width="100%"

--- a/apps/docs/pages/public-api.mdx
+++ b/apps/docs/pages/public-api.mdx
@@ -4,6 +4,6 @@ import Bleed from 'nextra-theme-docs/bleed'
   <iframe src="https://developer.cal.com"
      width="100%"
      height="900px"
-     title="Swagger UI"
+     title="Swagger UI - Cal.com Public API"
    ></iframe>
 </Bleed>

--- a/apps/docs/pages/public-api.mdx
+++ b/apps/docs/pages/public-api.mdx
@@ -1,0 +1,11 @@
+import Bleed from 'nextra-theme-docs/bleed'
+
+---
+---
+<Bleed full>
+  <iframe src="https://developer.cal.com"
+     width="100%"
+     height="900px"
+     title="Swagger UI"
+   ></iframe>
+</Bleed>


### PR DESCRIPTION
## What does this PR do?
Adds new swagger ui at https://docs.cal.com/api



## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Open docs, go to /api, see iframe with swagger ui from developer.cal.com


## Checklist
