### PR TITLE
Display most recent bookings on Past/Cancelled

### DIFF
--- a/apps/web/server/routers/viewer.tsx
+++ b/apps/web/server/routers/viewer.tsx
@@ -345,8 +345,8 @@ const loggedInViewerRouter = createProtectedRouter()
         Prisma.BookingOrderByWithAggregationInput
       > = {
         upcoming: { startTime: "asc" },
-        past: { startTime: "asc" },
-        cancelled: { startTime: "asc" },
+        past: { startTime: "desc" },
+        cancelled: { startTime: "desc" },
       };
       const passedBookingsFilter = bookingListingFilters[bookingListingByStatus];
       const orderBy = bookingListingOrderby[bookingListingByStatus];


### PR DESCRIPTION
## What does this PR do?
Currently Canceled and Past bookings show oldest first. Switching order to show most recent booking.

Fixes #2528 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Load Past/Canceled bookings

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works

