### PR TITLE
Fix book event form schema validation

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -197,14 +197,16 @@ const BookingPage = ({
     };
   };
 
-  const bookingFormSchema = z.object({
-    name: z.string().min(1),
-    email: z.string().email(),
-  });
+  const bookingFormSchema = z
+    .object({
+      name: z.string().min(1),
+      email: z.string().email(),
+    })
+    .passthrough();
 
   const bookingForm = useForm<BookingFormValues>({
     defaultValues: defaultValues(),
-    resolver: zodResolver(bookingFormSchema), // Since this isnt set to strict we only validate the fields in the schema
+    resolver: zodResolver(bookingFormSchema), // Since this isn't set to strict we only validate the fields in the schema
   });
 
   const selectedLocation = useWatch({


### PR DESCRIPTION
## What does this PR do?

Recently schema validation was implemented in booking form, but it filters out all others fields not present in the schema, added passthrough method so it delivers all unknown fields received in schema validator.


- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Book an event with additional fields, it should now save notes value on DB
## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
