### PR TITLE
Fix emails and cal event descriptions as null

### DIFF
--- a/apps/web/pages/api/book/request-reschedule.ts
+++ b/apps/web/pages/api/book/request-reschedule.ts
@@ -174,14 +174,6 @@ const handler = async (
         }
       });
 
-      // Creating cancelled event as placeholders in calendars, remove when virtual calendar handles it
-      const eventManager = new EventManager({
-        credentials: userOwner.credentials,
-        destinationCalendar: userOwner.destinationCalendar,
-      });
-      builder.calendarEvent.title = `Cancelled: ${builder.calendarEvent.title}`;
-      await eventManager.updateAndSetCancelledPlaceholder(builder.calendarEvent, bookingToReschedule);
-
       // Send emails
       await sendRequestRescheduleEmail(builder.calendarEvent, {
         rescheduleLink: builder.rescheduleLink,

--- a/apps/web/pages/cancel/[uid].tsx
+++ b/apps/web/pages/cancel/[uid].tsx
@@ -101,8 +101,8 @@ export default function Type(props: inferSSRProps<typeof getServerSideProps>) {
                           className="mb-5 sm:mb-6"
                         />
                         <div className="space-x-2 text-center rtl:space-x-reverse">
-                          <Button color="secondary" onClick={() => router.back()}>
-                            {t("back_to_bookings")}
+                          <Button color="secondary" onClick={() => router.push("/reschedule/" + uid)}>
+                            {t("reschedule_this")}
                           </Button>
                           <Button
                             data-testid="cancel"

--- a/packages/core/builders/CalendarEvent/builder.ts
+++ b/packages/core/builders/CalendarEvent/builder.ts
@@ -5,6 +5,7 @@ import { v5 as uuidv5 } from "uuid";
 
 import { getTranslation } from "@calcom/lib/server/i18n";
 import prisma from "@calcom/prisma";
+import { CalendarEvent } from "@calcom/types/Calendar";
 
 import { CalendarEventClass } from "./class";
 
@@ -124,6 +125,7 @@ export class CalendarEventBuilder implements ICalendarEventBuilder {
               slug: true,
             },
           },
+          description: true,
           slug: true,
           teamId: true,
           title: true,
@@ -261,6 +263,10 @@ export class CalendarEventBuilder implements ICalendarEventBuilder {
 
   public setDescription(description: CalendarEventClass["description"]) {
     this.calendarEvent.description = description;
+  }
+
+  public setNotes(notes: CalendarEvent["additionalNotes"]) {
+    this.calendarEvent.additionalNotes = notes;
   }
 
   public setCancellationReason(cancellationReason: CalendarEventClass["cancellationReason"]) {

--- a/packages/core/builders/CalendarEvent/class.ts
+++ b/packages/core/builders/CalendarEvent/class.ts
@@ -21,6 +21,7 @@ class CalendarEventClass implements CalendarEvent {
   cancellationReason?: string | null;
   rejectionReason?: string | null;
   hideCalendarNotes?: boolean;
+  additionalNotes?: string | null | undefined;
 
   constructor(initProps?: CalendarEvent) {
     // If more parameters are given we update this

--- a/packages/core/builders/CalendarEvent/director.ts
+++ b/packages/core/builders/CalendarEvent/director.ts
@@ -27,6 +27,8 @@ export class CalendarEventDirector {
       this.builder.setLocation(this.existingBooking.location);
       this.builder.setUId(this.existingBooking.uid);
       this.builder.setCancellationReason(this.cancellationReason);
+      this.builder.setDescription(this.builder.eventType.description);
+      this.builder.setNotes(this.existingBooking.description);
       this.builder.buildRescheduleLink(this.existingBooking.uid);
     } else {
       throw new Error("buildForRescheduleEmail.missing.params.required");

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -46,6 +46,9 @@ ${organizer + attendees}
 };
 
 export const getAdditionalNotes = (calEvent: CalendarEvent) => {
+  if (!calEvent.additionalNotes) {
+    return "";
+  }
   return `
 ${calEvent.organizer.language.translate("additional_notes")}:
 ${calEvent.additionalNotes}
@@ -53,6 +56,9 @@ ${calEvent.additionalNotes}
 };
 
 export const getDescription = (calEvent: CalendarEvent) => {
+  if (!calEvent.description) {
+    return "";
+  }
   return `\n${calEvent.attendees[0].language.translate("description")}
     ${calEvent.description}
     `;


### PR DESCRIPTION
## What does this PR do?

- Returns button for reschedule on /cancel page
- Prevents emails or calendar event created with Description/Additional Notes with undefined or null text
- No longer updates old calendar event on reschedule with Cancelled: title

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Book or reschedule, and email and calendar event be created without any null or undefined text.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
