### PR TITLE
Fixes google meet url not appearing calendar invite

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -14,8 +14,6 @@ import type {
   NewCalendarEventType,
 } from "@calcom/types/Calendar";
 
-import { updateEvent } from "../../wipemycalother/lib/calendarManager";
-
 const GOOGLE_API_CREDENTIALS = process.env.GOOGLE_API_CREDENTIALS || "";
 
 export default class GoogleCalendarService implements Calendar {
@@ -75,7 +73,6 @@ export default class GoogleCalendarService implements Calendar {
   };
 
   async createEvent(calEventRaw: CalendarEvent): Promise<NewCalendarEventType> {
-    console.log({ calEventRaw });
     return new Promise((resolve, reject) =>
       this.auth.getToken().then((myGoogleAuth) => {
         const payload: calendar_v3.Schema$Event = {

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -14,6 +14,8 @@ import type {
   NewCalendarEventType,
 } from "@calcom/types/Calendar";
 
+import { updateEvent } from "../../wipemycalother/lib/calendarManager";
+
 const GOOGLE_API_CREDENTIALS = process.env.GOOGLE_API_CREDENTIALS || "";
 
 export default class GoogleCalendarService implements Calendar {
@@ -72,21 +74,22 @@ export default class GoogleCalendarService implements Calendar {
     };
   };
 
-  async createEvent(event: CalendarEvent): Promise<NewCalendarEventType> {
+  async createEvent(calEventRaw: CalendarEvent): Promise<NewCalendarEventType> {
+    console.log({ calEventRaw });
     return new Promise((resolve, reject) =>
       this.auth.getToken().then((myGoogleAuth) => {
         const payload: calendar_v3.Schema$Event = {
-          summary: event.title,
-          description: getRichDescription(event),
+          summary: calEventRaw.title,
+          description: getRichDescription(calEventRaw),
           start: {
-            dateTime: event.startTime,
-            timeZone: event.organizer.timeZone,
+            dateTime: calEventRaw.startTime,
+            timeZone: calEventRaw.organizer.timeZone,
           },
           end: {
-            dateTime: event.endTime,
-            timeZone: event.organizer.timeZone,
+            dateTime: calEventRaw.endTime,
+            timeZone: calEventRaw.organizer.timeZone,
           },
-          attendees: event.attendees.map((attendee) => ({
+          attendees: calEventRaw.attendees.map((attendee) => ({
             ...attendee,
             responseStatus: "accepted",
           })),
@@ -95,23 +98,21 @@ export default class GoogleCalendarService implements Calendar {
           },
         };
 
-        if (event.location) {
-          payload["location"] = getLocation(event);
+        if (calEventRaw.location) {
+          payload["location"] = getLocation(calEventRaw);
         }
 
-        if (event.conferenceData && event.location === "integrations:google:meet") {
-          payload["conferenceData"] = event.conferenceData;
+        if (calEventRaw.conferenceData && calEventRaw.location === "integrations:google:meet") {
+          payload["conferenceData"] = calEventRaw.conferenceData;
         }
-
         const calendar = google.calendar({
           version: "v3",
-          auth: myGoogleAuth,
         });
         calendar.events.insert(
           {
             auth: myGoogleAuth,
-            calendarId: event.destinationCalendar?.externalId
-              ? event.destinationCalendar.externalId
+            calendarId: calEventRaw.destinationCalendar?.externalId
+              ? calEventRaw.destinationCalendar.externalId
               : "primary",
             requestBody: payload,
             conferenceDataVersion: 1,
@@ -121,6 +122,22 @@ export default class GoogleCalendarService implements Calendar {
               console.error("There was an error contacting google calendar service: ", err);
               return reject(err);
             }
+
+            calendar.events.patch({
+              // Update the same event but this time we know the hangout link
+              calendarId: calEventRaw.destinationCalendar?.externalId
+                ? calEventRaw.destinationCalendar.externalId
+                : "primary",
+              auth: myGoogleAuth,
+              eventId: event.data.id || "",
+              requestBody: {
+                description: getRichDescription({
+                  ...calEventRaw,
+                  additionInformation: { hangoutLink: event.data.hangoutLink || "" },
+                }),
+              },
+            });
+
             return resolve({
               uid: "",
               ...event.data,


### PR DESCRIPTION
## What does this PR do?

Previously the description was being generated before we even have the hangout url. There's no really easy way to create the description with this URL - So we update the created event with the correct description after it has been created.

<img width="418" alt="CleanShot 2022-04-28 at 10 02 11@2x" src="https://user-images.githubusercontent.com/55134778/165717449-e43c1168-0e77-4766-9472-d3e2f7f14250.png">

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Book a meeting with google meet as location type 
- [ ] Check calendar

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
