### PR TITLE
fix query to list API keys

### DIFF
--- a/apps/web/server/routers/viewer/apiKeys.tsx
+++ b/apps/web/server/routers/viewer/apiKeys.tsx
@@ -11,9 +11,16 @@ export const apiKeysRouter = createProtectedRouter()
       return await ctx.prisma.apiKey.findMany({
         where: {
           userId: ctx.user.id,
-          NOT: {
-            appId: "zapier",
-          },
+          OR: [
+            {
+              NOT: {
+                appId: "zapier",
+              },
+            },
+            {
+              appId: null,
+            },
+          ],
         },
         orderBy: { createdAt: "desc" },
       });


### PR DESCRIPTION
## What does this PR do?

Now API keys are shown again. 

Fixes #2689 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to settings -> security 
2. Generate a new key 
3. And see that the new key is listed now