### PR TITLE
fix/scroll-mobile-on-dialog

### DIFF
--- a/packages/ui/Dialog.tsx
+++ b/packages/ui/Dialog.tsx
@@ -75,7 +75,8 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
             : props.size == "lg"
             ? "p-6 sm:max-w-[70rem]"
             : "p-6 sm:max-w-[35rem]",
-          `${props.className}`
+          "h-[80vh] max-h-[560px] overflow-scroll overscroll-auto md:h-auto md:max-h-[inherit]",
+          `${props.className || ""}`
         )}
         ref={forwardedRef}>
         {children}

--- a/packages/ui/Dialog.tsx
+++ b/packages/ui/Dialog.tsx
@@ -69,14 +69,13 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
       <DialogPrimitive.Content
         {...props}
         className={classNames(
-          "fadeIn fixed left-1/2 top-1/2 z-[9998]  min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
+          "fadeIn fixed left-1/2 top-1/2 z-[9998] min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
           props.size == "xl"
             ? "p-0.5 sm:max-w-[98vw]"
             : props.size == "lg"
             ? "p-6 sm:max-w-[70rem]"
             : "p-6 sm:max-w-[35rem]",
-          "h-[80vh] max-h-[560px] overflow-scroll overscroll-auto md:h-auto md:max-h-[inherit]",
-          `${props.className || ""}`
+          `${props.className}`
         )}
         ref={forwardedRef}>
         {children}

--- a/packages/ui/Dialog.tsx
+++ b/packages/ui/Dialog.tsx
@@ -69,13 +69,14 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
       <DialogPrimitive.Content
         {...props}
         className={classNames(
-          "fadeIn fixed left-1/2 top-1/2 z-[9998] min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
+          "fadeIn fixed left-1/2 top-1/2 z-[9998]  min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
           props.size == "xl"
             ? "p-0.5 sm:max-w-[98vw]"
             : props.size == "lg"
             ? "p-6 sm:max-w-[70rem]"
             : "p-6 sm:max-w-[35rem]",
-          `${props.className}`
+          "h-[80vh] max-h-[560px] overflow-scroll overscroll-auto md:h-auto md:max-h-[inherit]",
+          `${props.className || ""}`
         )}
         ref={forwardedRef}>
         {children}


### PR DESCRIPTION
## What does this PR do?

There was an issue when seeing modals in mobile screen, user couldn’t scroll its content.
## Loom
Before:
https://www.loom.com/share/699517037b8f460cb164601791410396
After:
https://www.loom.com/share/e1eac739143445ea9c2e8b0cc2dcd3b7

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Try to add a new event with a mobile screen and its height its reduced by a keyboard or something

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
