### PR TITLE
Hotfix: Success page layout broken due to duplicate "When"

### DIFF
--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -299,15 +299,15 @@ export default function Success(props: SuccessProps) {
                           <div className="font-medium">{t("what")}</div>
                           <div className="col-span-2 mb-6">{eventName}</div>
                           <div className="font-medium">{t("when")}</div>
-                          <div className="col-span-2 mb-6">
+                          {/* <div className="col-span-2 mb-6">
                             {date.format("MMMM DD, YYYY")}
                             <br />
                             {date.format("LT")} - {date.add(props.eventType.length, "m").format("LT")}{" "}
                             <span className="text-bookinglight">
                               ({localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()})
                             </span>
-                          </div>
-                          <div className="col-span-2">
+                          </div> */}
+                          <div className="col-span-2 mb-6">
                             <RecurringBookings
                               isReschedule={reschedule === "true"}
                               eventType={props.eventType}


### PR DESCRIPTION
**Before**:
<img width="787" alt="Screenshot 2022-05-10 at 1 41 03 PM" src="https://user-images.githubusercontent.com/1780212/167581010-f436e0c0-29f2-41ce-afb0-79c9b4ac7f13.png">

**After**:
<img width="595" alt="Screenshot 2022-05-10 at 1 41 30 PM" src="https://user-images.githubusercontent.com/1780212/167581098-6ecd5071-714f-4773-b673-6009e44487c6.png">

