### PR TITLE
Fix reschedule not happening in calendar if two calendars are there

### DIFF
--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -678,8 +678,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     results = updateManager.results;
     referencesToCreate = updateManager.referencesToCreate;
-
-    if (results.length > 0 && results.every((res) => !res.success)) {
+    if (results.length > 0 && results.some((res) => !res.success)) {
       const error = {
         errorCode: "BookingReschedulingMeetingFailed",
         message: "Booking Rescheduling failed",

--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -132,15 +132,19 @@ export const updateEvent = async (
 ): Promise<EventResult> => {
   const uid = getUid(calEvent);
   const calendar = getCalendar(credential);
-  let success = true;
-
+  let success = false;
+  if (bookingRefUid === "") {
+    log.error("updateEvent failed", "bookingRefUid is empty", calEvent, credential);
+  }
   const updatedResult =
     calendar && bookingRefUid
-      ? await calendar.updateEvent(bookingRefUid, calEvent).catch((e) => {
-          log.error("updateEvent failed", e, calEvent);
-          success = false;
-          return undefined;
-        })
+      ? await calendar
+          .updateEvent(bookingRefUid, calEvent)
+          .then(() => (success = true))
+          .catch((e) => {
+            log.error("updateEvent failed", e, calEvent);
+            return undefined;
+          })
       : undefined;
 
   return {

--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -345,8 +345,13 @@ export default class EventManager {
     booking: PartialBooking
   ): Promise<Array<EventResult>> {
     return async.mapLimit(this.calendarCredentials, 5, async (credential: Credential) => {
+      // HACK:
+      // Right now if two calendars are connected and a booking is created it has two bookingReferences, one is having uid null and the other is having valid uid.
+      // I don't know why yet - But we should work on fixing that. But even after the fix as there can be multiple references in an existing booking the following ref.uid check would still be required
+      // We should ignore the one with uid null, the other one is valid.
+      // Also, we should store(if not already) that which is the calendarCredential for the valid bookingReference, instead of going through all credentials one by one
       const bookingRefUid = booking
-        ? booking.references.filter((ref) => ref.type === credential.type)[0]?.uid
+        ? booking.references.filter((ref) => ref.type === credential.type && !!ref.uid)[0]?.uid
         : null;
 
       return updateEvent(credential, event, bookingRefUid);


### PR DESCRIPTION
## What does this PR do?

**Problem**
- You have two calendars connected(both from Google Calendar)
- You book an event-type. This is what you would see in DB for booking table 
![image](https://user-images.githubusercontent.com/1780212/167830877-047c58ad-bfd7-4e69-b3c5-8bbc97f22afc.png)
- Now when you reschedule it, it won't be able to update the calendar because the first(hardcoded) `bookingReference` is picked right now and the first one has null uid
- There is one problem still left with this HACK.As there are more than 1 credential of Google Calendar, one update calendar request would fail and show up in logs(@zomars @emrysal  any suggestions here) and other would pass. I don't know which `uid` belongs to which Google Calendar Credentials

**How PR fixes it**
Instead of picking the first one, it's picking the first valid one(with non-null uid)


**Better Fix - In future**
Ideally, the booking should just refer to its destination calendar and also `destinationCalendar` should know which credential it belongs to.

__Also, there was bug in logging such cases. Also, fixed that__

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
