### PR TITLE
Allow apps to belong to multiple categories

### DIFF
--- a/apps/web/pages/apps/categories/[category].tsx
+++ b/apps/web/pages/apps/categories/[category].tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon } from "@heroicons/react/solid";
-import { InferGetStaticPropsType } from "next";
+import { InferGetStaticPropsType, GetStaticPropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -9,6 +9,8 @@ import prisma from "@calcom/prisma";
 
 import Shell from "@components/Shell";
 import AppCard from "@components/apps/AppCard";
+
+import { AppCategories } from ".prisma/client";
 
 export default function Apps({ apps: apps }: InferGetStaticPropsType<typeof getStaticProps>) {
   const { t } = useLocale();
@@ -63,11 +65,13 @@ export const getStaticPaths = async () => {
   };
 };
 
-export const getStaticProps = async (context) => {
+export const getStaticProps = async (context: GetStaticPropsContext) => {
+  const category = context.params?.category as AppCategories;
+
   const appQuery = await prisma.app.findMany({
     where: {
       categories: {
-        has: context.params.category,
+        has: category,
       },
     },
     select: {

--- a/apps/web/pages/apps/categories/[category].tsx
+++ b/apps/web/pages/apps/categories/[category].tsx
@@ -79,7 +79,6 @@ export const getStaticProps = async (context) => {
   const appStore = await getAppRegistry();
 
   const apps = appStore.filter((app) => appSlugs.includes(app.slug));
-  console.log("🚀 ~ file: [category].tsx ~ line 84 ~ getStaticProps ~ apps", apps);
 
   return {
     props: {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since we are moving away from local app metadata, this PR uses an app's categories stored in the db to render which app shows up under different categories. This also allows apps to be in multiple categories. 

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

For now we are going to be testing with Huddle01
- Go to the app store page. Under videos it should say there are four apps
- On the video's page Huddle01 should be listed as an app
- Under the web3 page Huddle01 should also be there

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
