### PR TITLE
fixing the hyperlink for open startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,4 +436,4 @@ Special thanks to these amazing projects which help power Cal.com:
   
  <a href="https://jitsu.com/?utm_source=cal.com-gihub"><img height="40px" src="https://jitsu.com/img/powered-by-jitsu.png?gh=true" alt="Jitsu.com"></a>
 
-Cal.com is an [open startup](https://jitsu.com) and [Jitsu](https://github.com/jitsucom/jitsu) (an open-source Segment alternative) helps us to track most of the usage metrics.
+Cal.com is an [open startup](https://cal.com/open) and [Jitsu](https://github.com/jitsucom/jitsu) (an open-source Segment alternative) helps us to track most of the usage metrics.


### PR DESCRIPTION
## What does this PR do?
Very minor change – currently README.md links to jitsu.com where it should link to https://cal.com/open 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

Just click on `open startup` at the bottom of README.md

## Checklist
