### PR TITLE
Include organizer in list of attendees with organizer: true

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -102,10 +102,10 @@ export default class GoogleCalendarService implements Calendar {
           dateTime: calEventRaw.endTime,
           timeZone: calEventRaw.organizer.timeZone,
         },
-        attendees: calEventRaw.attendees.map((attendee) => ({
+        attendees: [{...calEventRaw.organizer, organizer: true }, ... calEventRaw.attendees.map((attendee) => ({
           ...attendee,
           responseStatus: "accepted",
-        })),
+        }))],
         reminders: {
           useDefault: true,
         },


### PR DESCRIPTION
## What does this PR do?

If you create an event in gcal via most normal means, the organizer is in the list of attendees even though they are called out elsewhere in their API.  Tandem relies on this, so that's what is motivating me, but consistency is good too..  



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Tested that it updates Google Calendar as designed, and also that the full loop works.  

