### PR TITLE
Fix/availability time zone day change

### DIFF
--- a/apps/web/lib/slots.ts
+++ b/apps/web/lib/slots.ts
@@ -64,32 +64,9 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
   const slots: Dayjs[] = [];
 
   const slotsTimeFrameAvailable = [] as Array<WorkingHoursTimeFrame>;
+
   // Here we split working hour in chunks for every frequency available that can fit in whole working hours
-  const computedLocalWorkingHours: WorkingHoursTimeFrame[] = [];
-  let tempComputeTimeFrame: WorkingHoursTimeFrame | undefined;
-  const computeLength = localWorkingHours.length - 1;
-  const makeTimeFrame = (item: typeof localWorkingHours[0]): WorkingHoursTimeFrame => ({
-    startTime: item.startTime,
-    endTime: item.endTime,
-  });
   localWorkingHours.forEach((item, index) => {
-    if (!tempComputeTimeFrame) {
-      tempComputeTimeFrame = makeTimeFrame(item);
-    } else {
-      // please check the comment in splitAvailableTime func for the added 1 minute
-      if (tempComputeTimeFrame.endTime + 1 === item.startTime) {
-        // to deal with time that across the day, e.g. from 11:59 to to 12:01
-        tempComputeTimeFrame.endTime = item.endTime;
-      } else {
-        computedLocalWorkingHours.push(tempComputeTimeFrame);
-        tempComputeTimeFrame = makeTimeFrame(item);
-      }
-    }
-    if (index == computeLength) {
-      computedLocalWorkingHours.push(tempComputeTimeFrame);
-    }
-  });
-  computedLocalWorkingHours.forEach((item, index) => {
     slotsTimeFrameAvailable.push(...splitAvailableTime(item.startTime, item.endTime, frequency, eventLength));
   });
 

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -166,6 +166,10 @@ it("adds buffer time with custom slot interval", async () => {
   ).toHaveLength(239);
 });
 
+/**
+ * 25 its the expected result here since invitee timezone
+ * overlaps with userOwner from 7:00 to 23:00
+ */
 it("test for event of 45 min with a timezone in -7:00", async () => {
   expect(
     getSlots({

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -165,3 +165,21 @@ it("adds buffer time with custom slot interval", async () => {
     })
   ).toHaveLength(239);
 });
+
+it("test for event of 45 min with a timezone in -7:00", async () => {
+  expect(
+    getSlots({
+      inviteeDate: dayjs().tz("America/Los_Angeles").startOf("day"),
+      frequency: 45,
+      minimumBookingNotice: 0,
+      workingHours: [
+        {
+          days: Array.from(Array(7).keys()),
+          startTime: MINUTES_DAY_START,
+          endTime: MINUTES_DAY_END,
+        },
+      ],
+      eventLength: 45,
+    })
+  ).toHaveLength(25);
+});

--- a/packages/lib/availability.ts
+++ b/packages/lib/availability.ts
@@ -120,34 +120,35 @@ export function getWorkingHours(
       });
     }
 
-    /**
-     * We need to merge consecutive workingHours
-     * this means that [{startTime: 9:30, endTime: 10:30}, {startTime: 10:30, endTime: 11:00}]
-     * becomes a single element in the array [{startTime: 9:30, endTime: 11:00}]
-     * This is due sometimes when hours involved a day change in UTC, working hours
-     * got splitted by a day end unpurposely
-     */
-    const mergedConsecutiveHours = workingHours.reduce((accumulator, current) => {
-      const previousElement = accumulator[accumulator.length - 1];
-      if (previousElement && previousElement.endTime + 1 === current.startTime && accumulator.length > 0) {
-        // We don't push, but we modify previousElement
-        let copyPrevious = accumulator.pop();
-        if (copyPrevious) {
-          copyPrevious["endTime"] = current.endTime;
-          accumulator.push(copyPrevious);
-        }
-      } else {
-        accumulator.push(current);
-      }
-
-      return accumulator;
-    }, [] as { startTime: number; endTime: number; days: number[] }[]);
-    return mergedConsecutiveHours;
-  }, []);
+    return workingHours;
+  }, [] as WorkingHours[]);
 
   workingHours.sort((a, b) => a.startTime - b.startTime);
 
-  return workingHours;
+  /**
+   * We need to merge consecutive workingHours
+   * this means that [{startTime: 9:30, endTime: 10:30}, {startTime: 10:30, endTime: 11:00}]
+   * becomes a single element in the array [{startTime: 9:30, endTime: 11:00}]
+   * This is because when a day change is involved, working hours
+   * get splitted unpurposely
+   */
+  const mergedConsecutiveHours = workingHours.reduce((accumulator, current) => {
+    const previousElement = accumulator[accumulator.length - 1];
+    if (previousElement && previousElement.endTime + 1 === current.startTime && accumulator.length > 0) {
+      // We don't push, but we modify previousElement
+      let copyPrevious = accumulator.pop();
+      if (copyPrevious) {
+        copyPrevious["endTime"] = current.endTime;
+        accumulator.push(copyPrevious);
+      }
+    } else {
+      accumulator.push(current);
+    }
+
+    return accumulator;
+  }, [] as { startTime: number; endTime: number; days: number[] }[]);
+
+  return mergedConsecutiveHours;
 }
 
 export function availabilityAsString(availability: Availability, locale: string) {


### PR DESCRIPTION
## What does this PR do?
When calculating working hours, availability creates a new row in the array when day change occurs, this should not be the case because when calculating hours a time slot could be omitted due to day change.

Fixes # (issue)


## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Create an event with availability with a timezone that goes through 2 days on UTC time(e.g. -07:00 works) and with an event duration of 45 min.
- [ ] Take a look on availability time slot on 16:30 should be there as this was previously omitted.

## Checklist

