### PR TITLE
Add login event in Jitsu

### DIFF
--- a/apps/web/lib/telemetry.ts
+++ b/apps/web/lib/telemetry.ts
@@ -11,6 +11,7 @@ export const telemetryEventTypes = {
   bookingCancelled: "booking_cancelled",
   importSubmitted: "import_submitted",
   googleLogin: "google_login",
+  login: "login",
   samlLogin: "saml_login",
   samlConfig: "saml_config",
   embedView: "embed_view",

--- a/apps/web/pages/auth/login.tsx
+++ b/apps/web/pages/auth/login.tsx
@@ -105,6 +105,7 @@ export default function Login({
           form={form}
           className="space-y-6"
           handleSubmit={(values) => {
+            telemetry.withJitsu((jitsu) => jitsu.track(telemetryEventTypes.login, collectPageParameters()));
             signIn<"credentials">("credentials", { ...values, callbackUrl, redirect: false })
               .then((res) => {
                 if (!res) setErrorMessage(errorMessages[ErrorCode.InternalServerError]);


### PR DESCRIPTION
There was just a google_login event specifically to track logins through Google. I have added a new event `login` for now.
