### PR TITLE
Hotfix: Fix Event Type crash when no attendees

### DIFF
--- a/apps/web/pages/event-types/[type].tsx
+++ b/apps/web/pages/event-types/[type].tsx
@@ -369,7 +369,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
 
     fetchTokens();
 
-    !hashedUrl && setHashedUrl(generateHashedLink(eventType.users[0].id));
+    !hashedUrl && setHashedUrl(generateHashedLink(eventType.users[0]?.id ?? team?.id));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -2184,6 +2184,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       successRedirectUrl: true,
       team: {
         select: {
+          id: true,
           slug: true,
           members: {
             where: {


### PR DESCRIPTION
## What does this PR do?

Currently if an event type has no attendees (users relation)  it crashes due to the hashURL trying to target `users[0].id` if this is not found we now default to `team.id` which would always exist. 

*It should not be possible for none teams to ever have an event type where `users[0] === null`  

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Remove a attendee from team event type
- [ ] application will no longer crash

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
