### PR TITLE
Show success page if booking was deleted on calendar

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -18,6 +18,10 @@ import type { PartialReference } from "@calcom/types/EventManager";
 
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 
+interface GoogleCalError extends Error {
+  code?: number;
+}
+
 export default class GoogleCalendarService implements Calendar {
   private url = "";
   private integrationName = "";
@@ -229,7 +233,7 @@ export default class GoogleCalendarService implements Calendar {
           sendNotifications: true,
           sendUpdates: "all",
         },
-        function (err, event) {
+        function (err: GoogleCalError | null, event) {
           if (err) {
             if (err.code === 410) resolve();
             console.error("There was an error contacting google calendar service: ", err);

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -231,7 +231,7 @@ export default class GoogleCalendarService implements Calendar {
         },
         function (err, event) {
           if (err) {
-            if (err.code === 410) resolve(err.data);
+            if (err.code === 410) resolve();
             console.error("There was an error contacting google calendar service: ", err);
             return reject(err);
           }

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -231,6 +231,7 @@ export default class GoogleCalendarService implements Calendar {
         },
         function (err, event) {
           if (err) {
+            if (err.code === 410) resolve(err.data);
             console.error("There was an error contacting google calendar service: ", err);
             return reject(err);
           }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

If a user deletes a booking on their Google cal and then on Cal.com it will now show a success page rather than an error 500.

From Google cal API docs "For already deleted events, no further action is necessary." https://developers.google.com/calendar/api/guides/errors#410_gone

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Connect a Google calendar
- Create a booking
- Delete the booking on your Google calendar first 
- On cal.com go to the booking page and cancel the booking
	- It should show the success page

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
