### PR TITLE
Hotfix: Fixing Security Issues

### DIFF
--- a/apps/web/pages/api/book/request-reschedule.ts
+++ b/apps/web/pages/api/book/request-reschedule.ts
@@ -91,6 +91,8 @@ const handler = async (
       },
     });
 
+    if (bookingToReschedule.userId !== userOwner.id) throw new Error("UNAUTHORIZED");
+
     if (bookingToReschedule && userOwner) {
       let event: Partial<EventType> = {};
       if (bookingToReschedule.eventTypeId) {

--- a/apps/web/server/routers/viewer/availability.tsx
+++ b/apps/web/server/routers/viewer/availability.tsx
@@ -143,6 +143,17 @@ export const availabilityRouter = createProtectedRouter()
     async resolve({ input, ctx }) {
       const { user, prisma } = ctx;
 
+      const scheduleToDelete = await prisma.schedule.findFirst({
+        where: {
+          id: input.scheduleId,
+        },
+        select: {
+          userId: true,
+        },
+      });
+
+      if (scheduleToDelete?.userId !== user.id) throw new TRPCError({ code: "UNAUTHORIZED" });
+
       if (user.defaultScheduleId === input.scheduleId) {
         // unset default
         await prisma.user.update({
@@ -197,7 +208,12 @@ export const availabilityRouter = createProtectedRouter()
         where: {
           id: input.scheduleId,
         },
+        select: {
+          userId: true,
+        },
       });
+
+      if (userSchedule?.userId !== user.id) throw new TRPCError({ code: "UNAUTHORIZED" });
 
       if (!userSchedule || userSchedule.userId !== user.id) {
         throw new TRPCError({

--- a/apps/web/server/routers/viewer/teams.tsx
+++ b/apps/web/server/routers/viewer/teams.tsx
@@ -201,6 +201,8 @@ export const viewerTeamsRouter = createProtectedRouter()
     }),
     async resolve({ ctx, input }) {
       if (!(await isTeamAdmin(ctx.user?.id, input.teamId))) throw new TRPCError({ code: "UNAUTHORIZED" });
+      if (input.role === MembershipRole.OWNER && !(await isTeamOwner(ctx.user?.id, input.teamId)))
+        throw new TRPCError({ code: "UNAUTHORIZED" });
 
       const translation = await getTranslation(input.language ?? "en", "common");
 


### PR DESCRIPTION
## What does this PR do?

Fixes a security issue reported by Hamza (Slack) regarding:
- Non Owners being able to add Owners to teams.
- Being able to operate with availability schedules that don't belong to the logged in user 
- Changing the reschedule id for a different one belonging to a different user caused unexpected behaviors

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Being a non Owner of a team, modifying the request to invite a new member switching the role to Owner, will throw an "UNAUTHORIZED" error. 

<img width="640" alt="Cal_com___Cal_com" src="https://user-images.githubusercontent.com/467258/169673732-9980d73a-2f4c-4c24-8711-db8d0ab91528.png">

--- 

Updating or deleting a schedule with its ID that doesn't belong to the logged in user will throw an "UNAUTHORIZED" error.
 
<img width="699" alt="Availability___Cal_com" src="https://user-images.githubusercontent.com/467258/169675691-6b8b07b3-5d46-4ef1-b5e9-4a2e3f5a3058.png">

---

Now changing the reschedule id for one that does not belong to the logged in user throws an error

<img width="1014" alt="Bookings___Cal_com" src="https://user-images.githubusercontent.com/467258/169676188-5671072d-e90b-47b9-95a2-45c6a80bad4f.png">



