### PR TITLE
Fix deleted event when on different cal (404)

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -241,7 +241,7 @@ export default class GoogleCalendarService implements Calendar {
             /* 410 is when an event is already deleted on the Google cal before on cal.com
             404 is when the event is on a different calendar */
             console.error("There was an error contacting google calendar service: ", err);
-            if (err.code === (410 || 404)) return resolve();
+            if (err.code === 410 || err.code === 404) return resolve();
             return reject(err);
           }
           return resolve(event?.data);


### PR DESCRIPTION
Was reviewing changes earlier today and noticed this went in; (410 || 404) means that 410 is always a truthy value, so the check will never check 404. This logic was equivalent to `err.code === 410` - unfortunately this rather neat looking shortcut doesn't work.