### PR TITLE
fix: makes prisma.schema auto-generate uuids instead on webhooks

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -385,7 +385,7 @@ enum WebhookTriggerEvents {
 }
 
 model Webhook {
-  id              String                 @id @unique
+  id              String                 @unique @default(uuid()) @db.Uuid
   userId          Int?
   eventTypeId     Int?
   subscriberUrl   String


### PR DESCRIPTION
## What does this PR do?
Makes webhook.id be of type uuid, and also auto-generated by default.

So we can skip asking for it as input when creating webhooks via API or otherwise.



```diff
-  id              String                 @id @unique
+  id              String                 @db.Uuid @unique @default(uuid())
```

We could also use gen_random_uuid() if our AWS RDS postgres databases have the crypto extension.

> ## Enable extensions for native database functions
> Some native database functions are part an extension. For example, gen_random_uuid() is part of the [pgcrypto](https://www.postgresql.org/docs/10/pgcrypto.html) module
> https://www.prisma.io/docs/concepts/components/prisma-schema/features-without-psl-equivalent#enable-extensions-for-native-database-functions
https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference