### PR TITLE
Fixed typo in CheckboxField and wrapped description in <label>

### DIFF
--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -73,6 +73,7 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
     if (selection) {
       locationFormMethods.setValue("locationType", selection?.value);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selection]);
 
   const locationFormSchema = z.object({

--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -136,7 +136,7 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                     onChange={(e) =>
                       locationFormMethods.setValue("displayLocationPublicly", e.target.checked)
                     }
-                    infomationIconText={t("display_location_info_badge")}></CheckboxField>
+                    informationIconText={t("display_location_info_badge")}></CheckboxField>
                 )}
               />
             </div>
@@ -182,7 +182,7 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                       : undefined
                   }
                   onChange={(e) => locationFormMethods.setValue("displayLocationPublicly", e.target.checked)}
-                  infomationIconText={t("display_location_info_badge")}></CheckboxField>
+                  informationIconText={t("display_location_info_badge")}></CheckboxField>
               )}
             />
           </div>

--- a/apps/web/components/ui/form/CheckboxField.tsx
+++ b/apps/web/components/ui/form/CheckboxField.tsx
@@ -6,46 +6,45 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
   label?: React.ReactNode;
   description: string;
   descriptionAsLabel?: boolean;
-  infomationIconText?: string;
+  informationIconText?: string;
 };
 
 const CheckboxField = forwardRef<HTMLInputElement, Props>(
-  ({ label, description, infomationIconText, descriptionAsLabel, ...rest }, ref) => {
+  ({ label, description, informationIconText, descriptionAsLabel, ...rest }, ref) => {
     return (
       <div className="block items-center sm:flex">
-        {label && !descriptionAsLabel && (
+        {label && (
           <div className="min-w-48 mb-4 sm:mb-0">
-            <label htmlFor={rest.id} className="flex text-sm font-medium text-neutral-700">
-              {label}
-            </label>
-          </div>
-        )}
-        {label && descriptionAsLabel && (
-          <div className="min-w-48 mb-4 sm:mb-0">
-            <span className="flex text-sm font-medium text-neutral-700">{label}</span>
+            {React.createElement(
+              descriptionAsLabel ? "div" : "label",
+              {
+                htmlFor: rest.id,
+                className: "flex text-sm font-medium text-neutral-700",
+              },
+              label
+            )}
           </div>
         )}
         <div className="w-full">
           <div className="relative flex items-start">
-            <div className="flex h-5 items-center">
-              <input
-                {...rest}
-                disabled={rest.disabled}
-                ref={ref}
-                type="checkbox"
-                className="text-primary-600 focus:ring-primary-500 h-4 w-4 rounded border-gray-300"
-              />
-            </div>
-            <div className="text-sm ltr:ml-3 rtl:mr-3">
-              {!label || descriptionAsLabel ? (
-                <label htmlFor={rest.id} className="text-neutral-700">
-                  {description}
-                </label>
-              ) : (
-                <p className="text-neutral-900">{description}</p>
-              )}
-            </div>
-            {infomationIconText && <InfoBadge content={infomationIconText}></InfoBadge>}
+            {React.createElement(
+              descriptionAsLabel ? "label" : "div",
+              {
+                className: "relative flex items-start",
+              },
+              <>
+                <div className="flex h-5 items-center">
+                  <input
+                    {...rest}
+                    ref={ref}
+                    type="checkbox"
+                    className="text-primary-600 focus:ring-primary-500 h-4 w-4 rounded border-gray-300"
+                  />
+                </div>
+                <span className="text-sm text-neutral-700 ltr:ml-3 rtl:mr-3">{description}</span>
+              </>
+            )}
+            {informationIconText && <InfoBadge content={informationIconText}></InfoBadge>}
           </div>
         </div>
       </div>

--- a/apps/web/components/ui/form/CheckboxField.tsx
+++ b/apps/web/components/ui/form/CheckboxField.tsx
@@ -1,5 +1,7 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
 
+import classNames from "@calcom/lib/classNames";
+
 import InfoBadge from "@components/ui/InfoBadge";
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
@@ -10,7 +12,8 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 };
 
 const CheckboxField = forwardRef<HTMLInputElement, Props>(
-  ({ label, description, informationIconText, descriptionAsLabel, ...rest }, ref) => {
+  ({ label, description, informationIconText, ...rest }, ref) => {
+    const descriptionAsLabel = !label || rest.descriptionAsLabel;
     return (
       <div className="block items-center sm:flex">
         {label && (
@@ -18,8 +21,12 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
             {React.createElement(
               descriptionAsLabel ? "div" : "label",
               {
-                htmlFor: rest.id,
                 className: "flex text-sm font-medium text-neutral-700",
+                ...(!descriptionAsLabel
+                  ? {
+                      htmlFor: rest.id,
+                    }
+                  : {}),
               },
               label
             )}
@@ -30,7 +37,10 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
             {React.createElement(
               descriptionAsLabel ? "label" : "div",
               {
-                className: "relative flex items-start",
+                className: classNames(
+                  "relative flex items-start",
+                  descriptionAsLabel ? "text-neutral-700" : "text-neutral-900"
+                ),
               },
               <>
                 <div className="flex h-5 items-center">
@@ -41,7 +51,7 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
                     className="text-primary-600 focus:ring-primary-500 h-4 w-4 rounded border-gray-300"
                   />
                 </div>
-                <span className="text-sm text-neutral-700 ltr:ml-3 rtl:mr-3">{description}</span>
+                <span className="text-sm ltr:ml-3 rtl:mr-3">{description}</span>
               </>
             )}
             {informationIconText && <InfoBadge content={informationIconText}></InfoBadge>}


### PR DESCRIPTION
## What does this PR do?

* Fixes a little typo - no usages I could find
* Simplifies the descriptionAsLabel by using `createElement`
* When the description is the label, it is wrapped inside of a label (in this situation, id is no longer a required attribute for the label to work properly, it works either way)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
