### PR TITLE
Remove subtitle in dialog for adding new schedule

### DIFF
--- a/apps/web/components/availability/NewScheduleButton.tsx
+++ b/apps/web/components/availability/NewScheduleButton.tsx
@@ -46,20 +46,17 @@ export function NewScheduleButton({ name = "new-schedule" }: { name?: string }) 
         </Button>
       </DialogTrigger>
       <DialogContent>
-        <div className="mb-4">
+        <div className="mb-8">
           <h3 className="text-lg font-bold leading-6 text-gray-900" id="modal-title">
             {t("add_new_schedule")}
           </h3>
-          <div>
-            <p className="text-sm text-gray-500">{t("new_event_type_to_book_description")}</p>
-          </div>
         </div>
         <Form
           form={form}
           handleSubmit={(values) => {
             createMutation.mutate(values);
           }}>
-          <div className="mt-3 space-y-4">
+          <div className="mt-3 space-y-2">
             <label htmlFor="label" className="block text-sm font-medium text-gray-700">
               {t("name")}
             </label>


### PR DESCRIPTION
## What does this PR do?

Removes wrong subtitle in the dialog for adding a new schedule. 

Before: 
<img width="594" alt="Screenshot 2022-05-30 at 15 13 12" src="https://user-images.githubusercontent.com/30310907/171034402-63332216-352f-4ed5-8a11-b9e26e9dc19f.png">

After:
<img width="653" alt="Screenshot 2022-05-30 at 18 48 14" src="https://user-images.githubusercontent.com/30310907/171034447-84e8d88e-5e47-4057-a22f-4f302406d0f4.png">

**Environment**: Staging(main branch) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)