### PR TITLE
Fix: Embed Tests - Handle superfast switching to next month bug

### DIFF
--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     timeout-minutes: 20
-    name:  Embed and booking flow(for non-embed as well)
+    name: Embed and booking flow(for non-embed as well)
     strategy:
       matrix:
         node: ["14.x"]

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,4 +1,4 @@
-name: E2E test - embed
+name: E2E test
 on:
   pull_request_target: # So we can test on forks
     branches:
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     timeout-minutes: 20
-    name: Testing Embeds
+    name:  Embed and booking flow(for non-embed as well)
     strategy:
       matrix:
         node: ["14.x"]

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,7 +1,5 @@
 name: E2E test - embed
 on:
-  push:
-    branches: [ tests/ci-embed ]
   pull_request_target: # So we can test on forks
     branches:
       - main

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -70,6 +70,12 @@ export async function waitFor(fn: () => Promise<unknown> | unknown, opts: { time
 }
 
 export async function selectFirstAvailableTimeSlotNextMonth(page: Page) {
+  // Let current month dates fully render.
+  // There is a bug where if we don't let current month fully render and quickly click go to next month, current month get's rendered
+  // This doesn't seem to be replicable with the speed of a person, only during automation.
+  // It would also allow correct snapshot to be taken for current month.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(1000);
   await page.click('[data-testid="incrementMonth"]');
   // @TODO: Find a better way to make test wait for full month change render to end
   // so it can click up on the right day, also when resolve remove other todos
@@ -82,6 +88,12 @@ export async function selectFirstAvailableTimeSlotNextMonth(page: Page) {
 }
 
 export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
+  // Let current month dates fully render.
+  // There is a bug where if we don't let current month fully render and quickly click go to next month, current month get's rendered
+  // This doesn't seem to be replicable with the speed of a person, only during automation.
+  // It would also allow correct snapshot to be taken for current month.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(1000);
   await page.click('[data-testid="incrementMonth"]');
   // @TODO: Find a better way to make test wait for full month change render to end
   // so it can click up on the right day, also when resolve remove other todos
@@ -95,7 +107,9 @@ export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
 
 export async function bookFirstEvent(page: Page) {
   // Click first event type
+
   await page.click('[data-testid="event-type-link"]');
+
   await selectFirstAvailableTimeSlotNextMonth(page);
   await bookTimeSlot(page);
 

--- a/packages/embeds/embed-core/playwright/config/playwright.config.ts
+++ b/packages/embeds/embed-core/playwright/config/playwright.config.ts
@@ -6,13 +6,14 @@ require("dotenv").config({ path: "../../../../../.env" });
 const outputDir = path.join("../results");
 const testDir = path.join("../tests");
 const quickMode = process.env.QUICK === "true";
+const CI = process.env.CI;
 const config: PlaywrightTestConfig = {
-  forbidOnly: !!process.env.CI,
-  retries: quickMode ? 0 : 1,
+  forbidOnly: !!CI,
+  retries: quickMode && !CI ? 0 : 1,
   workers: 1,
   timeout: 60_000,
   reporter: [
-    [process.env.CI ? "github" : "list"],
+    [CI ? "github" : "list"],
     [
       "html",
       { outputFolder: path.join(__dirname, "..", "reports", "playwright-html-report"), open: "never" },
@@ -33,13 +34,13 @@ const config: PlaywrightTestConfig = {
     command: "yarn run-p 'embed-dev' 'embed-web-start'",
     port: 3100,
     timeout: 60_000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !CI,
   },
   use: {
     baseURL: "http://localhost:3100",
     locale: "en-US",
     trace: "retain-on-failure",
-    headless: !!process.env.CI || !!process.env.PLAYWRIGHT_HEADLESS,
+    headless: !!CI || !!process.env.PLAYWRIGHT_HEADLESS,
   },
   projects: [
     {

--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -60,8 +60,11 @@ export const getEmbedIframe = async ({ page, pathname }: { page: Page; pathname:
 
 async function selectFirstAvailableTimeSlotNextMonth(frame: Frame, page: Page) {
   await frame.click('[data-testid="incrementMonth"]');
+
   // @TODO: Find a better way to make test wait for full month change render to end
-  // so it can click up on the right day, also when resolve remove other todos
+  // so it can click up on the right day, also when done, resolve other todos as well
+  // The problem is that the Month Text changes instantly but we don't know when the corresponding dates are visible
+
   // Waiting for full month increment
   await frame.waitForTimeout(2000);
   expect(await page.screenshot()).toMatchSnapshot("availability-page-2.png");

--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -66,7 +66,7 @@ async function selectFirstAvailableTimeSlotNextMonth(frame: Frame, page: Page) {
   // The problem is that the Month Text changes instantly but we don't know when the corresponding dates are visible
 
   // Waiting for full month increment
-  await frame.waitForTimeout(2000);
+  await frame.waitForTimeout(1000);
   expect(await page.screenshot()).toMatchSnapshot("availability-page-2.png");
   // TODO: Find out why the first day is always booked on tests
   await frame.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();
@@ -81,7 +81,14 @@ export async function bookFirstEvent(username: string, frame: Frame, page: Page)
       return !!url.pathname.match(new RegExp(`/${username}/.*$`));
     },
   });
+
+  // Let current month dates fully render.
+  // There is a bug where if we don't let current month fully render and quickly click go to next month, current month get's rendered
+  // This doesn't seem to be replicable with the speed of a person, only during automation.
+  // It would also allow correct snapshot to be taken for current month.
+  await frame.waitForTimeout(1000);
   expect(await page.screenshot()).toMatchSnapshot("availability-page-1.png");
+
   await selectFirstAvailableTimeSlotNextMonth(frame, page);
   await frame.waitForNavigation({
     url(url) {

--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -63,7 +63,7 @@ async function selectFirstAvailableTimeSlotNextMonth(frame: Frame, page: Page) {
   // @TODO: Find a better way to make test wait for full month change render to end
   // so it can click up on the right day, also when resolve remove other todos
   // Waiting for full month increment
-  await frame.waitForTimeout(1000);
+  await frame.waitForTimeout(2000);
   expect(await page.screenshot()).toMatchSnapshot("availability-page-2.png");
   // TODO: Find out why the first day is always booked on tests
   await frame.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();


### PR DESCRIPTION
- There is a bug in booking flow where if someone switches from current month to next month lighting fast, then Next month actually renders current month dates. This was causing tests to fail on CI. Not focussing on fixing the bug, as @emrysal is already working on a revamp of the date picker. Also, it would be almost impossible for a user to  practically replicate it. The bug wasn't replicable on local reliably, because I use dev server for that and that itself is slow compared to built code running on CI.
- Also fixes retry not working in CI.

Note: 
I later noticed that the same issue seems to be happening for non Embed E2E booking tests. Not sure if it's related to end of the month or something went into main that is causing it. I have fixed it in the same for those tests as well for now.
