### PR TITLE
fix: owners can't be edited by admins

### DIFF
--- a/apps/web/server/routers/viewer/teams.tsx
+++ b/apps/web/server/routers/viewer/teams.tsx
@@ -175,13 +175,22 @@ export const viewerTeamsRouter = createProtectedRouter()
     }),
     async resolve({ ctx, input }) {
       if (!(await isTeamAdmin(ctx.user?.id, input.teamId))) throw new TRPCError({ code: "UNAUTHORIZED" });
-
+      // Only a team owner can remove another team owner.
+      if (
+        (await isTeamOwner(input.memberId, input.teamId)) &&
+        !(await isTeamOwner(ctx.user?.id, input.teamId))
+      )
+        throw new TRPCError({ code: "UNAUTHORIZED" });
       if (ctx.user?.id === input.memberId)
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "You can not remove yourself from a team you own.",
         });
-
+      // if (input.memberId)
+      // throw new TRPCError({
+      //   code: "FORBIDDEN",
+      //   message: "You can not remove yourself from a team you own.",
+      // });
       await ctx.prisma.membership.delete({
         where: {
           userId_teamId: { userId: input.memberId, teamId: input.teamId },
@@ -351,7 +360,9 @@ export const viewerTeamsRouter = createProtectedRouter()
     }),
     async resolve({ ctx, input }) {
       if (!(await isTeamAdmin(ctx.user?.id, input.teamId))) throw new TRPCError({ code: "UNAUTHORIZED" });
-
+      // Only owners can award owner role.
+      if (input.role === MembershipRole.OWNER && !(await isTeamOwner(ctx.user?.id, input.teamId)))
+        throw new TRPCError({ code: "UNAUTHORIZED" });
       const memberships = await ctx.prisma.membership.findMany({
         where: {
           teamId: input.teamId,

--- a/apps/web/server/routers/viewer/teams.tsx
+++ b/apps/web/server/routers/viewer/teams.tsx
@@ -186,11 +186,6 @@ export const viewerTeamsRouter = createProtectedRouter()
           code: "FORBIDDEN",
           message: "You can not remove yourself from a team you own.",
         });
-      // if (input.memberId)
-      // throw new TRPCError({
-      //   code: "FORBIDDEN",
-      //   message: "You can not remove yourself from a team you own.",
-      // });
       await ctx.prisma.membership.delete({
         where: {
           userId_teamId: { userId: input.memberId, teamId: input.teamId },


### PR DESCRIPTION
## What does this PR do?
Makes owners not be removable or downgraded on their teams by other admins.
Fixes # (issue)
7, 8, 9
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

More info in private twist thread https://twist.com/a/195135/ch/554218/t/3526268/
