### PR TITLE
Fix uninstalled status of giphy and hubspot

### DIFF
--- a/packages/app-store/giphy/_metadata.ts
+++ b/packages/app-store/giphy/_metadata.ts
@@ -6,6 +6,7 @@ export const metadata = {
   name: "Giphy",
   description: _package.description,
   category: "other",
+  installed: true,
   // If using static next public folder, can then be referenced from the base URL (/).
   imageSrc: "/api/app-store/giphy/icon.svg",
   logo: "/api/app-store/giphy/icon.svg",

--- a/packages/app-store/hubspotothercalendar/_metadata.ts
+++ b/packages/app-store/hubspotothercalendar/_metadata.ts
@@ -5,6 +5,7 @@ import _package from "./package.json";
 export const metadata = {
   name: "HubSpot CRM",
   description: _package.description,
+  installed: !!process.env.HUBSPOT_CLIENT_ID,
   type: "hubspot_other_calendar",
   imageSrc: "/api/app-store/hubspotothercalendar/icon.svg",
   variant: "other_calendar",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Fixes uninstalled status of Hubspot and Giphy apps
- Hubspot needs to check environment variables, Giphy is always installed.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
