### PR TITLE
Disable confirm button for recurring events

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -815,7 +815,7 @@ const BookingPage = ({
                     <Button
                       type="submit"
                       data-testid={rescheduleUid ? "confirm-reschedule-button" : "confirm-book-button"}
-                      loading={mutation.isLoading}>
+                      loading={mutation.isLoading || recurringMutation.isLoading}>
                       {rescheduleUid ? t("reschedule") : t("confirm")}
                     </Button>
                     <Button color="secondary" type="button" onClick={() => router.back()}>


### PR DESCRIPTION
## What does this PR do?

When you book a recurring event the confirm button will now be disabled. Currently you can click the confirm button several times and you will see errors in the console

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

