### PR TITLE
Hotfix: fixed callback URL for team invite email

### DIFF
--- a/apps/web/pages/api/teams/[team]/invite.ts
+++ b/apps/web/pages/api/teams/[team]/invite.ts
@@ -90,7 +90,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         from: session.user.name,
         to: usernameOrEmail,
         teamName: team.name,
-        joinLink: `${BASE_URL}/auth/signup?token=${token}&callbackUrl=${BASE_URL + "/settings/teams"}`,
+        joinLink: `${BASE_URL}/auth/signup?token=${token}&callbackUrl=/settings/teams}`,
       };
 
       await sendTeamInviteEmail(teamInviteEvent);


### PR DESCRIPTION
## What does this PR do?

Fixes the callback URL for team invitation email

Fixes #2974 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Invite a user to a team who doesn't have a cal account yet. Once the user accepts the invitation in th email, adds the essential signup details, they should be redirected to the correct URL.