### PR TITLE
[Hotfix] 404 apple-calendar setup page

### DIFF
--- a/packages/app-store/_pages/setup/_getStaticProps.tsx
+++ b/packages/app-store/_pages/setup/_getStaticProps.tsx
@@ -2,6 +2,9 @@ import { GetStaticPropsContext } from "next";
 
 export const AppSetupPageMap = {
   zapier: import("../../zapier/pages/setup/_getStaticProps"),
+  "apple-calendar": {
+    getStaticProps: null,
+  },
 };
 
 export const getStaticProps = async (ctx: GetStaticPropsContext) => {


### PR DESCRIPTION
Loom video of bug https://www.loom.com/share/c87a46485d40423ba71f1cfcffa15368

404 page -> https://app.cal.com/apps/apple-calendar/setup

Corresponding fix in main is merged as part of app-store PR https://github.com/calcom/cal.com/pull/2917
