### PR TITLE
Update README to reflect nodejs >=14.x <17 version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To get a local copy up and running, please follow these simple steps.
 
 Here is what you need to be able to run Cal.
 
-- Node.js (Version: >=14.x <15)
+- Node.js (Version: >=14.x <17)
 - PostgreSQL
 - Yarn _(recommended)_
 


### PR DESCRIPTION
## What does this PR do?

TSIA

Fixes # (issue)
Updates doc to reflect changes from https://github.com/calcom/cal.com/pull/2711

## Type of change
Documentation update

## How should this be tested?
Compare with engines.node value in top-level package.json