### PR TITLE
fixed month buttons on booking page for darkmode

### DIFF
--- a/packages/ui/booker/DatePicker.tsx
+++ b/packages/ui/booker/DatePicker.tsx
@@ -160,21 +160,23 @@ const DatePicker = ({
           </strong>{" "}
           <span className="text-bookinglight">{new Date(new Date().setMonth(month)).getFullYear()}</span>
         </span>
-        <div>
+        <div className="text-black dark:text-white">
           {isLoading && <Spinner />}
           <button
             onClick={() => changeMonth(month - 1)}
             className={classNames(
-              "group p-1 hover:text-black ltr:mr-2 rtl:ml-2 dark:hover:text-white",
-              month <= new Date().getMonth() &&
-                "text-bookinglighter disabled:text-bookinglighter dark:text-gray-600"
+              "group p-1 opacity-50 hover:opacity-100 ltr:mr-2 rtl:ml-2",
+              month <= new Date().getMonth() && "disabled:text-bookinglighter hover:opacity-50"
             )}
             disabled={month <= new Date().getMonth()}
             data-testid="decrementMonth">
             <ChevronLeftIcon className="h-5 w-5" />
           </button>
-          <button className="group p-1" onClick={() => changeMonth(month + 1)} data-testid="incrementMonth">
-            <ChevronRightIcon className="h-5 w-5 group-hover:text-black dark:group-hover:text-white" />
+          <button
+            className="group p-1 opacity-50 hover:opacity-100"
+            onClick={() => changeMonth(month + 1)}
+            data-testid="incrementMonth">
+            <ChevronRightIcon className="h-5 w-5" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
before:

<img width="231" alt="image" src="https://user-images.githubusercontent.com/8019099/174436830-b7273171-93ee-4bdc-a57b-1855b11d4f3f.png">

after:

default

<img width="164" alt="image" src="https://user-images.githubusercontent.com/8019099/174436892-6e077281-1be4-41cb-8011-5c2ba7cb81ce.png">

hover:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/8019099/174436905-6cfc1a29-7bcf-4b98-873a-ff371eb95213.png">

disabled:

<img width="162" alt="image" src="https://user-images.githubusercontent.com/8019099/174436927-c42bb971-50ff-4ffe-90b0-7bd4ef718f64.png">
