### PR TITLE
HotFix - Background not being transparent for [user]/[type] in embed

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -286,7 +286,7 @@ const useDateSelected = ({ timeZone }: { timeZone?: string }) => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [router.query.date]);
 
   const setSelectedDate = (newDate: Date) => {
     router.replace(
@@ -314,6 +314,7 @@ const AvailabilityPage = ({ profile, eventType }: Props) => {
   const { contracts } = useContracts();
   const availabilityDatePickerEmbedStyles = useEmbedStyles("availabilityDatePicker");
   const shouldAlignCentrallyInEmbed = useEmbedNonStylesConfig("align") !== "left";
+
   const shouldAlignCentrally = !isEmbed || shouldAlignCentrallyInEmbed;
   const isBackgroundTransparent = useIsBackgroundTransparent();
 
@@ -350,6 +351,10 @@ const AvailabilityPage = ({ profile, eventType }: Props) => {
     }
   }, [telemetry]);
 
+  // Avoid embed styling flicker. Till embed status is confirmed, don't render.
+  if (isEmbed === null) {
+    return null;
+  }
   // Recurring event sidebar requires more space
   const maxWidth = isAvailableTimesVisible
     ? recurringEventCount

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -72,6 +72,12 @@ plugins.push(withTM);
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   i18n,
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   webpack: (config) => {
     config.resolve.fallback = {
       ...config.resolve.fallback, // if you miss it, all the other options in fallback, specified

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -72,12 +72,6 @@ plugins.push(withTM);
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   i18n,
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   webpack: (config) => {
     config.resolve.fallback = {
       ...config.resolve.fallback, // if you miss it, all the other options in fallback, specified

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -1,6 +1,8 @@
 import { UserPlan } from "@prisma/client";
 import dayjs from "dayjs";
 import { GetStaticPropsContext } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { JSONObject } from "superjson/dist/types";
 import { z } from "zod";
 
@@ -19,6 +21,14 @@ export type AvailabilityPageProps = inferSSRProps<typeof getStaticProps>;
 
 export default function Type(props: AvailabilityPageProps) {
   const { t } = useLocale();
+  const router = useRouter();
+  useEffect(() => {
+    // Embed background is handled in _document.tsx but this particular page(/[user][/type] is statically rendered and thus doesn't have `embed` param at that time)
+    // So, for static pages, handle the embed background here. Make sure to always keep it consistent with _document.tsx
+    if (typeof router.query.embed !== "undefined") {
+      document.body.style.background = "transparent";
+    }
+  }, [router.query.embed]);
 
   return props.away ? (
     <div className="h-screen dark:bg-neutral-900">

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -294,6 +294,7 @@ async function getDynamicGroupPageProps(context: GetStaticPropsContext) {
 const paramsSchema = z.object({ type: z.string(), user: z.string() });
 
 export const getStaticProps = async (context: GetStaticPropsContext) => {
+  console.log("STATIC CALL", context.params);
   const { user: userParam } = paramsSchema.parse(context.params);
   // dynamic groups are not generated at build time, but otherwise are probably cached until infinity.
   const isDynamicGroup = userParam.includes("+");

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -1,12 +1,13 @@
 import { UserPlan } from "@prisma/client";
 import dayjs from "dayjs";
-import { GetStaticPropsContext } from "next";
+import { GetStaticPropsContext, GetStaticPaths } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { JSONObject } from "superjson/dist/types";
 import { z } from "zod";
 
 import { locationHiddenFilter, LocationObject } from "@calcom/app-store/locations";
+import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getDefaultEvent, getGroupName, getUsernameList } from "@calcom/lib/defaultEvents";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -21,15 +22,14 @@ export type AvailabilityPageProps = inferSSRProps<typeof getStaticProps>;
 
 export default function Type(props: AvailabilityPageProps) {
   const { t } = useLocale();
-  const router = useRouter();
+  const isEmbed = useIsEmbed();
   useEffect(() => {
     // Embed background is handled in _document.tsx but this particular page(/[user][/type] is statically rendered and thus doesn't have `embed` param at that time)
     // So, for static pages, handle the embed background here. Make sure to always keep it consistent with _document.tsx
-    if (typeof router.query.embed !== "undefined") {
+    if (isEmbed) {
       document.body.style.background = "transparent";
     }
-  }, [router.query.embed]);
-
+  }, [isEmbed]);
   return props.away ? (
     <div className="h-screen dark:bg-neutral-900">
       <main className="mx-auto max-w-3xl px-4 py-24">
@@ -305,6 +305,6 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
   }
 };
 
-export const getStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return { paths: [], fallback: "blocking" };
 };

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -6,6 +6,7 @@ class MyDocument extends Document<Props> {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
     const isEmbed = ctx.req?.url?.includes("embed=");
+    console.log("isEmbed", isEmbed, ctx.req?.url);
     return { ...initialProps, isEmbed };
   }
 

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -6,14 +6,17 @@ class MyDocument extends Document<Props> {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
     const isEmbed = ctx.req?.url?.includes("embed=");
-    console.log("isEmbed", isEmbed, ctx.req?.url);
     return { ...initialProps, isEmbed };
   }
 
   render() {
     const props = this.props;
-    const { locale } = this.props.__NEXT_DATA__;
+    const { locale, gssp } = this.props.__NEXT_DATA__;
     const dir = locale === "ar" || locale === "he" ? "rtl" : "ltr";
+
+    // gssp -> getServerSideProps allow us to know that this page was rendered server side and thus would have ctx.req.url with embed query param(if it was there in the request)
+    // In that case only, we should consider embed to be enabled. For other cases it should be handled at client side and the component should ensure that flicker due to changing css doesn't occur
+    const isEmbedCorrectlyDetected = gssp && props.isEmbed;
 
     return (
       <Html lang={locale} dir={dir}>
@@ -29,8 +32,8 @@ class MyDocument extends Document<Props> {
 
         {/* Keep the embed hidden till parent initializes and gives it the appropriate styles */}
         <body
-          className={props.isEmbed ? "bg-transparent" : "bg-gray-100 dark:bg-neutral-900"}
-          style={props.isEmbed ? { display: "none" } : {}}>
+          className={isEmbedCorrectlyDetected ? "bg-transparent" : "bg-gray-100 dark:bg-neutral-900"}
+          style={isEmbedCorrectlyDetected ? { display: "none" } : {}}>
           <Main />
           <NextScript />
         </body>

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -229,7 +229,7 @@ export const useIsEmbed = () => {
   // We can't simply return isEmbed() from this method.
   // isEmbed() returns different values on server and browser, which messes up the hydration.
   // TODO: We can avoid using document.URL and instead use Router.
-  const [_isEmbed, setIsEmbed] = useState(false);
+  const [_isEmbed, setIsEmbed] = useState<boolean | null>(null);
   useEffect(() => {
     setIsEmbed(isEmbed());
   }, []);


### PR DESCRIPTION
## What does this PR do?

Fixes multiple issues related to booking flow

### Embed background on [user]/[type] page isn't transparent. Reported by @PeerRich on Twist DM for embed at https://w7th.com/work-with/ 
After:
<img width="1723" alt="Screenshot 2022-06-21 at 1 01 51 PM" src="https://user-images.githubusercontent.com/1780212/174742186-a0f99205-3932-42d2-9de5-ad0a8ee2455c.png">
Before:
<img width="1749" alt="Screenshot 2022-06-21 at 1 02 10 PM" src="https://user-images.githubusercontent.com/1780212/174742253-ccbaafc7-1343-4c8f-b7a5-1fa6a34cbe11.png">
_Note: - The issue isn't replicable on local because in dev mode, getStaticProps is always executed(and thus behave like SSR)_

### Border Fix
After: https://www.loom.com/share/3ecc903ec0e34bf9ba2fa02570719c4e
Before: https://www.loom.com/share/51291a10b1e044bca8342480f2b0f5e0

### Auto opening of Availability with ?date= parameter. Also shows that hydration error logs are gone now. These logs were visible in console in production but in UI in development mode.
After: https://www.loom.com/share/242f7c5f68fd4a69b852645128f53071
Before: https://www.loom.com/share/82ddc2a99de54c56bdcaf874b7ee38d9


**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- See the looms

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
