### PR TITLE
Fixes redirect to upcoming bookings after canceling booking

### DIFF
--- a/apps/web/pages/cancel/success.tsx
+++ b/apps/web/pages/cancel/success.tsx
@@ -15,6 +15,7 @@ export default function CancelSuccess() {
   const { title, name, eventPage, recurring } = router.query;
   let team: string | string[] | number | undefined = router.query.team;
   const { data: session, status } = useSession();
+  const isRecurringEvent = recurring === "true" ? true : false;
   const loading = status === "loading";
   // If team param passed wrongly just assume it be a non team case.
   if (team instanceof Array || typeof team === "undefined") {
@@ -63,7 +64,7 @@ export default function CancelSuccess() {
                     {!loading && session?.user && (
                       <Button
                         data-testid="back-to-bookings"
-                        href={recurring !== "" ? "/bookings/recurring" : "/bookings"}
+                        href={isRecurringEvent ? "/bookings/recurring" : "/bookings"}
                         StartIcon={ArrowLeftIcon}>
                         {t("back_to_bookings")}
                       </Button>


### PR DESCRIPTION
## What does this PR do?

Fixes bug, that it always redirect to bookings/recurring after canceling a booking.

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Cancel a not recurring event and see that you will be redirected to bookings/upcoming after clicking 'Back to bookings'
- Cancel a recurring event and see that you will be redirected to bookings/recurring after clicking 'Back to bookings'

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
