### PR TITLE
Saves app id to zoom credential

### DIFF
--- a/packages/app-store/zoomvideo/api/callback.ts
+++ b/packages/app-store/zoomvideo/api/callback.ts
@@ -35,6 +35,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         create: {
           type: "zoom_video",
           key: responseBody,
+          appId: "zoom",
         },
       },
     },


### PR DESCRIPTION
## What does this PR do?

AppId wasn't saved to zoom credential. This fixes the issue that when we delete zoom it doesn't change locations to Cal Video

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
