### PR TITLE
Fix name not shown in password reset email

### DIFF
--- a/packages/emails/src/templates/ForgotPasswordEmail.tsx
+++ b/packages/emails/src/templates/ForgotPasswordEmail.tsx
@@ -16,7 +16,7 @@ export const ForgotPasswordEmail = (
   return (
     <BaseEmailHtml subject={props.language("reset_password_subject")}>
       <p>
-        <>{props.language("hi_user_name", { user: props.user.name })}!</>
+        <>{props.language("hi_user_name", { name: props.user.name })}!</>
       </p>
       <p style={{ fontWeight: 400, lineHeight: "24px" }}>
         <>{props.language("someone_requested_password_reset")}</>

--- a/packages/emails/templates/forgot-password-email.ts
+++ b/packages/emails/templates/forgot-password-email.ts
@@ -36,7 +36,7 @@ export default class ForgotPasswordEmail extends BaseEmail {
   protected getTextBody(): string {
     return `
 ${this.passwordEvent.language("reset_password_subject")}
-${this.passwordEvent.language("hi_user_name", { user: this.passwordEvent.user.name })},
+${this.passwordEvent.language("hi_user_name", { name: this.passwordEvent.user.name })},
 ${this.passwordEvent.language("someone_requested_password_reset")}
 ${this.passwordEvent.language("change_password")}: ${this.passwordEvent.resetLink}
 ${this.passwordEvent.language("password_reset_instructions")}


### PR DESCRIPTION
## What does this PR do?

Fixes issue that name isn't shown in password reset email. 

Before:
![Screenshot 2022-06-27 at 11 37 48](https://user-images.githubusercontent.com/30310907/175909538-56c3cabb-abfe-44f2-b1ff-8ac47714a915.png)

After: 
![Screenshot 2022-06-27 at 11 38 52](https://user-images.githubusercontent.com/30310907/175909751-9bc3926e-91cb-4e35-91ee-4abdefdf8eeb.png)

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
