### PR TITLE
Hotfix: Fixing app types variants (fixes Hubspot)

### DIFF
--- a/packages/lib/deriveAppDictKeyFromType.ts
+++ b/packages/lib/deriveAppDictKeyFromType.ts
@@ -21,6 +21,7 @@ export function deriveAppDictKeyFromType(appType: string, dict: Record<string, u
     return appTypeVariant2;
   }
 
+  // Transform as last resort removing all underscores, applies to `hubspot_other_calendar` to be `hubsporothercalendar`
   const appTypeVariant3 = appType.replace(/_/g, "");
   handlers = dict[appTypeVariant3];
   if (handlers) {

--- a/packages/lib/deriveAppDictKeyFromType.ts
+++ b/packages/lib/deriveAppDictKeyFromType.ts
@@ -21,6 +21,12 @@ export function deriveAppDictKeyFromType(appType: string, dict: Record<string, u
     return appTypeVariant2;
   }
 
+  const appTypeVariant3 = appType.replace(/_/g, "");
+  handlers = dict[appTypeVariant3];
+  if (handlers) {
+    return appTypeVariant3;
+  }
+
   return appType;
 
   // const categories = ["video", "other", "calendar", "web3", "payment", "messaging"];


### PR DESCRIPTION
## What does this PR do?

HubSpot App from the appstore was not showing the install button. This fixes that and other eventual apps in the same situation.

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Go to https://localhost:3000/apps/hubspot and check the install button is present.
