### PR TITLE
fix/availability-tz-offset

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -31,7 +31,6 @@ import {
 } from "@calcom/embed-core/embed-iframe";
 import classNames from "@calcom/lib/classNames";
 import { CAL_URL, WEBAPP_URL } from "@calcom/lib/constants";
-import { yyyymmdd } from "@calcom/lib/date-fns";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { getRecurringFreq } from "@calcom/lib/recurringStrings";
 import { localStorage } from "@calcom/lib/webstorage";
@@ -125,8 +124,8 @@ const useSlots = ({
       {
         eventTypeId,
         startTime: startTime?.toISOString() || "",
-        timeZone,
         endTime: endTime?.toISOString() || "",
+        timeZone,
       },
     ],
     { enabled: !!startTime && !!endTime }
@@ -182,7 +181,6 @@ const SlotPicker = ({
   }, [router.isReady, month, date, timeZone]);
 
   const { i18n, isLocaleReady } = useLocale();
-
   const { slots: _1 } = useSlots({
     eventTypeId: eventType.id,
     startTime: selectedDate?.startOf("day"),
@@ -224,7 +222,7 @@ const SlotPicker = ({
       {selectedDate && (
         <AvailableTimes
           isLoading={isLoading}
-          slots={slots[yyyymmdd(selectedDate.toDate())]}
+          slots={slots[selectedDate.format("YYYY-MM-DD")]}
           date={selectedDate}
           timeFormat={timeFormat}
           eventTypeId={eventType.id}

--- a/apps/web/lib/slots.ts
+++ b/apps/web/lib/slots.ts
@@ -42,7 +42,13 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
   const startOfInviteeDay = inviteeDate.startOf("day");
   // checks if the start date is in the past
 
-  if (inviteeDate.isBefore(startDate, "hour")) {
+  /**
+   *  TODO: change "day" for "hour" to stop displaying 1 day before today
+   * This is displaying a day as available as sometimes difference between two dates is < 24 hrs.
+   * But when doing timezones an available day for an owner can be 2 days available in other users tz.
+   *
+   * */
+  if (inviteeDate.isBefore(startDate, "day")) {
     return [];
   }
 

--- a/apps/web/lib/slots.ts
+++ b/apps/web/lib/slots.ts
@@ -41,7 +41,8 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
   const startOfDay = dayjs.utc().startOf("day");
   const startOfInviteeDay = inviteeDate.startOf("day");
   // checks if the start date is in the past
-  if (inviteeDate.isBefore(startDate, "day")) {
+
+  if (inviteeDate.isBefore(startDate, "hour")) {
     return [];
   }
 

--- a/apps/web/server/routers/viewer/slots.tsx
+++ b/apps/web/server/routers/viewer/slots.tsx
@@ -198,8 +198,8 @@ export const slotsRouter = createRouter().query("getSchedule", {
         periodDays: eventType.periodDays,
       });
 
-    // AFAIK startTime and endTime already have timezone info on them
-    let time = dayjs(startTime);
+    let time = input.timeZone === "Etc/GMT" ? startTime.utc() : startTime.tz(input.timeZone);
+
     do {
       // get slots retrieves the available times for a given day
       const times = getSlots({
@@ -209,7 +209,6 @@ export const slotsRouter = createRouter().query("getSchedule", {
         minimumBookingNotice: eventType.minimumBookingNotice,
         frequency: eventType.slotInterval || eventType.length,
       });
-
       // if ROUND_ROBIN - slots stay available on some() - if normal / COLLECTIVE - slots only stay available on every()
       const filterStrategy =
         !eventType.schedulingType || eventType.schedulingType === SchedulingType.COLLECTIVE
@@ -223,7 +222,7 @@ export const slotsRouter = createRouter().query("getSchedule", {
           )
         );
 
-      slots[yyyymmdd(time.toDate())] = filteredTimes.map((time) => ({
+      slots[time.format("YYYY-MM-DD")] = filteredTimes.map((time) => ({
         time: time.toISOString(),
         users: eventType.users.map((user) => user.username || ""),
         // Conditionally add the attendees and booking id to slots object if there is already a booking during that time


### PR DESCRIPTION
## What does this PR do?

Changes yyyymmdd(dayjs.toDate()) for a simplified dayjs.format(YYYY-MM-DD), since doing .toDate() always returns localised time and ignores any tz in the Date object. This was generating a conflict between doing .toDate() on server (UTC) and client .toDate() to user's selected TZ on input.

Fixes #3184

**Environment**: Staging(main branch) and Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
1. Setup an availability like this image -> https://user-images.githubusercontent.com/4461358/176308580-aeba174d-3db5-428d-abe3-b9ae5c3f4b37.png
2. Go to any 60min long event for the owner account, change timezone to Europe/Belgrade
3. Slots should display accordingly.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
