### PR TITLE
Remove '{}' to prevent overwriting .env.appStore value

### DIFF
--- a/.env.appStore.example
+++ b/.env.appStore.example
@@ -21,7 +21,8 @@ DAILY_SCALE_PLAN=''
 #   - GOOGLE CALENDAR/MEET/LOGIN
 # Needed to enable Google Calendar integration and Login with Google
 # @see https://github.com/calendso/calendso#obtaining-the-google-api-credentials
-GOOGLE_API_CREDENTIALS='{}'
+GOOGLE_API_CREDENTIALS=
+
 # To enable Login with Google you need to:
 # 1. Set `GOOGLE_API_CREDENTIALS` above
 # 2. Set `GOOGLE_LOGIN_ENABLED` to `true`


### PR DESCRIPTION
I lost my `GOOGLE_API_CREDENTIALS` variable - env-check:app-store seems to overwrite the existing value within .env.appStore if you specify a specific value within the .example file.