### PR TITLE
Fixes the slow performance due to the Dayjs timezone plugin

### DIFF
--- a/apps/web/server/routers/viewer/slots.tsx
+++ b/apps/web/server/routers/viewer/slots.tsx
@@ -62,9 +62,10 @@ const checkForAvailability = ({
   const slotStartTimeWithBeforeBuffer = time.subtract(beforeBufferTime, "minutes").utc();
   const slotEndTimeWithAfterBuffer = time.add(eventLength + afterBufferTime, "minutes").utc();
 
-  return busy.every((busyTime): boolean => {
-    const startTime = dayjs(busyTime.start);
-    const endTime = dayjs(busyTime.end);
+  return busy.every((busyTime) => {
+    const startTime = dayjs.utc(busyTime.start);
+    const endTime = dayjs.utc(busyTime.end);
+
     // Check if start times are the same
     if (time.utc().isBetween(startTime, endTime, null, "[)")) {
       return false;

--- a/apps/web/server/routers/viewer/slots.tsx
+++ b/apps/web/server/routers/viewer/slots.tsx
@@ -4,7 +4,6 @@ import { z } from "zod";
 import type { CurrentSeats } from "@calcom/core/getUserAvailability";
 import { getUserAvailability } from "@calcom/core/getUserAvailability";
 import dayjs, { Dayjs } from "@calcom/dayjs";
-import { yyyymmdd } from "@calcom/lib/date-fns";
 import { availabilityUserSelect } from "@calcom/prisma";
 import { stringToDayjs } from "@calcom/prisma/zod-utils";
 import { TimeRange } from "@calcom/types/schedule";

--- a/apps/web/server/routers/viewer/slots.tsx
+++ b/apps/web/server/routers/viewer/slots.tsx
@@ -59,15 +59,15 @@ const checkForAvailability = ({
     return true;
   }
 
-  const slotEndTime = time.add(eventLength, "minutes");
-  const slotStartTimeWithBeforeBuffer = time.subtract(beforeBufferTime, "minutes");
-  const slotEndTimeWithAfterBuffer = time.add(eventLength + afterBufferTime, "minutes");
+  const slotEndTime = time.add(eventLength, "minutes").utc();
+  const slotStartTimeWithBeforeBuffer = time.subtract(beforeBufferTime, "minutes").utc();
+  const slotEndTimeWithAfterBuffer = time.add(eventLength + afterBufferTime, "minutes").utc();
 
   return busy.every((busyTime): boolean => {
     const startTime = dayjs(busyTime.start);
     const endTime = dayjs(busyTime.end);
     // Check if start times are the same
-    if (time.isBetween(startTime, endTime, null, "[)")) {
+    if (time.utc().isBetween(startTime, endTime, null, "[)")) {
       return false;
     }
     // Check if slot end time is between start and end time


### PR DESCRIPTION
## What does this PR do?

The `dayjs.tz()` function returns an instance with abysmal performance on the `isBetween` and `isBefore` (and `isAfter`) calls. We do however need this elsewhere in the code to properly run `startOf` - this just modifies the code that has the performance hit (`isBetween` takes ~4ms to execute, x the amount of slots, x the busy times). By running this within utc mode the speed of `isBetween` (& friends) goes to 0.00Xms.

Performance can be improved elsewhere too - but this is the primary offender.