### PR TITLE
Fixes "Time slot initially unavailable becomes available by browsing?"

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -98,7 +98,9 @@ const getCachedResults = (
     /** We extract external Ids so we don't cache too much */
     const selectedCalendarIds = passedSelectedCalendars.map((sc) => sc.externalId);
     /** We create a unque hash key based on the input data */
-    const cacheKey = createHash("md5").update(JSON.stringify({ id, selectedCalendarIds })).digest("hex");
+    const cacheKey = createHash("md5")
+      .update(JSON.stringify({ id, selectedCalendarIds, dateFrom, dateTo }))
+      .digest("hex");
     /** Check if we already have cached data and return */
     const cachedAvailability = cache.get(cacheKey);
     if (cachedAvailability) return cachedAvailability;


### PR DESCRIPTION
* Ensures that a startTime is given in UTC and then properly translated to invitee timezone time regardless of server time:
e.g. `2022-07-06T04:00:00.000Z 2022-07-06T04:00:00-04:00`

* Cache key got hit on calls for different times due missing `dateTo` and `dateFrom` - these are both strings at this point so `format()` is not needed.