### PR TITLE
Fix - Huddle01 installation (no success message and no redirect )

### DIFF
--- a/packages/app-store/huddle01video/api/add.ts
+++ b/packages/app-store/huddle01video/api/add.ts
@@ -39,5 +39,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     return res.status(500);
   }
-  return res.redirect("/apps/installed");
+  // need to return a json object with the response status
+  return res.status(200).json({ url: "/apps/installed" });
 }


### PR DESCRIPTION
## What does this PR do?

When installing Huddle01 user doesn't get any confirmation message or redirects. So, this PR resolves this issue, and now if a user installs the Huddle01 app it redirects them to the installed app page which is the same behavior for all other apps.

Fixes #3142 

Loom Video: https://www.loom.com/share/b46170687ebb42a2b45be9a34162b823

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Navigate to Apps, then select Huddle01. Then, click the Install App button, it should redirect to the installed apps page with Huddle01 coming up as an installed app.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
