### PR TITLE
Fix awaiting approval translation

### DIFF
--- a/packages/emails/src/templates/OrganizerRequestEmail.tsx
+++ b/packages/emails/src/templates/OrganizerRequestEmail.tsx
@@ -8,7 +8,7 @@ export const OrganizerRequestEmail = (props: React.ComponentProps<typeof Organiz
         ? "event_awaiting_approval_recurring"
         : "event_awaiting_approval"
     }
-    subtitle="someone_requested_an_event"
+    subtitle={<>{props.calEvent.organizer.language.translate("someone_requested_an_event")}</>}
     headerType="calendarCircle"
     subject="event_awaiting_approval_subject"
     callToAction={

--- a/packages/emails/templates/organizer-request-email.ts
+++ b/packages/emails/templates/organizer-request-email.ts
@@ -32,7 +32,7 @@ export default class OrganizerRequestEmail extends OrganizerScheduledEmail {
   protected getTextBody(title = "event_awaiting_approval"): string {
     return super.getTextBody(
       title,
-      "someone_requested_an_event",
+      `${this.calEvent.organizer.language.translate("someone_requested_an_event")}`,
       "",
       `${this.calEvent.organizer.language.translate("confirm_or_reject_request")}
 ${process.env.NEXT_PUBLIC_WEBAPP_URL} + ${


### PR DESCRIPTION
Translates two strings that weren't previously translated

Before:
![](https://user-images.githubusercontent.com/8019099/177204273-2e6d696a-819f-4d8f-abad-3e5736c7bb57.png)
After:
![Screenshot 2022-07-05 at 11 54 57](https://user-images.githubusercontent.com/25907159/177312523-8fd33edb-adf4-4ac9-bc80-430606f62c39.png)

Fixes #3225 

