### PR TITLE
Fix translation subtitle bug - (Fixes #3225) 

### DIFF
--- a/apps/web/pages/api/email.ts
+++ b/apps/web/pages/api/email.ts
@@ -48,7 +48,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   res.setHeader("Content-Type", "text/html");
   res.setHeader("Cache-Control", "no-cache, no-store, private, must-revalidate");
   res.write(
-    renderEmail("OrganizerRequestReminderEmail", {
+    renderEmail("OrganizerRequestEmail", {
       attendee: evt.attendees[0],
       calEvent: evt,
     })

--- a/packages/emails/src/templates/OrganizerRequestEmail.tsx
+++ b/packages/emails/src/templates/OrganizerRequestEmail.tsx
@@ -1,27 +1,30 @@
 import { CallToAction, CallToActionTable } from "../components";
 import { OrganizerScheduledEmail } from "./OrganizerScheduledEmail";
 
-export const OrganizerRequestEmail = (props: React.ComponentProps<typeof OrganizerScheduledEmail>) => (
-  <OrganizerScheduledEmail
-    title={
-      props.title || props.calEvent.recurringEvent?.count
-        ? "event_awaiting_approval_recurring"
-        : "event_awaiting_approval"
-    }
-    subtitle="someone_requested_an_event"
-    headerType="calendarCircle"
-    subject="event_awaiting_approval_subject"
-    callToAction={
-      <CallToActionTable>
-        <CallToAction
-          label={props.calEvent.organizer.language.translate("confirm_or_reject_request")}
-          href={
-            process.env.NEXT_PUBLIC_WEBAPP_URL +
-            (props.calEvent.recurringEvent?.count ? "/bookings/recurring" : "/bookings/upcoming")
-          }
-        />
-      </CallToActionTable>
-    }
-    {...props}
-  />
-);
+export const OrganizerRequestEmail = (props: React.ComponentProps<typeof OrganizerScheduledEmail>) => {
+  const t = props.calEvent.organizer.language.translate;
+  return (
+    <OrganizerScheduledEmail
+      title={
+        props.title || props.calEvent.recurringEvent?.count
+          ? "event_awaiting_approval_recurring"
+          : "event_awaiting_approval"
+      }
+      subtitle={<>{t("someone_requested_an_event")}</>}
+      headerType="calendarCircle"
+      subject="event_awaiting_approval_subject"
+      callToAction={
+        <CallToActionTable>
+          <CallToAction
+            label={t("confirm_or_reject_request")}
+            href={
+              process.env.NEXT_PUBLIC_WEBAPP_URL +
+              (props.calEvent.recurringEvent?.count ? "/bookings/recurring" : "/bookings/upcoming")
+            }
+          />
+        </CallToActionTable>
+      }
+      {...props}
+    />
+  );
+};

--- a/packages/emails/src/templates/OrganizerScheduledEmail.tsx
+++ b/packages/emails/src/templates/OrganizerScheduledEmail.tsx
@@ -9,8 +9,8 @@ export const OrganizerScheduledEmail = (
     newSeat?: boolean;
   } & Partial<React.ComponentProps<typeof BaseScheduledEmail>>
 ) => {
-  let subject;
-  let title;
+  let subject: string;
+  let title: string;
 
   if (props.newSeat) {
     subject = "new_seat_subject";

--- a/packages/emails/templates/organizer-request-email.ts
+++ b/packages/emails/templates/organizer-request-email.ts
@@ -30,12 +30,12 @@ export default class OrganizerRequestEmail extends OrganizerScheduledEmail {
   }
 
   protected getTextBody(title = "event_awaiting_approval"): string {
+    const t = this.calEvent.organizer.language.translate;
     return super.getTextBody(
       title,
-      "someone_requested_an_event",
+      `${t("someone_requested_an_event")}`,
       "",
-      `${this.calEvent.organizer.language.translate("confirm_or_reject_request")}
-${process.env.NEXT_PUBLIC_WEBAPP_URL} + ${
+      `${t("confirm_or_reject_request")}${process.env.NEXT_PUBLIC_WEBAPP_URL} + ${
         this.calEvent.recurringEvent?.count ? "/bookings/recurring" : "/bookings/upcoming"
       }`
     );


### PR DESCRIPTION
## Add translation wrapper for subtitle

Subtitle for `OrganizerRequestEmail` component was a string whereas was supposed to be wrapped in the `calEvent.organizer.language.translate` function.

Fixes #3225
<img width="1422" alt="Screenshot 2022-07-05 at 12 53 18" src="https://user-images.githubusercontent.com/47124762/177313521-62e1f031-a7ca-4b02-a230-611500d46bd9.png">

