### PR TITLE
Contains multiple fixes centered around Zoom

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -206,6 +206,7 @@ function BookingListItem(booking: BookingItemProps) {
     [recurringStrings, recurringDates] = parseRecurringDates(
       {
         startDate: booking.startTime,
+        timeZone: user?.timeZone,
         recurringEvent: parseRecurringEvent(booking.eventType.recurringEvent),
         recurringCount: booking.recurringCount,
       },

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -329,6 +329,7 @@ const BookingPage = ({
     [recurringStrings, recurringDates] = parseRecurringDates(
       {
         startDate: date,
+        timeZone: timeZone(),
         recurringEvent: eventType.recurringEvent,
         recurringCount: parseInt(recurringEventCount.toString()),
       },

--- a/apps/web/lib/parseDate.ts
+++ b/apps/web/lib/parseDate.ts
@@ -23,9 +23,15 @@ export const parseDate = (date: string | null | Dayjs, i18n: I18n) => {
 export const parseRecurringDates = (
   {
     startDate,
+    timeZone,
     recurringEvent,
     recurringCount,
-  }: { startDate: string | null | Dayjs; recurringEvent: RecurringEvent | null; recurringCount: number },
+  }: {
+    startDate: string | null | Dayjs;
+    timeZone?: string;
+    recurringEvent: RecurringEvent | null;
+    recurringCount: number;
+  },
   i18n: I18n
 ): [string[], Date[]] => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,7 +42,7 @@ export const parseRecurringDates = (
     dtstart: dayjs(startDate).toDate(),
   });
   const dateStrings = rule.all().map((r) => {
-    return processDate(dayjs(r), i18n);
+    return processDate(dayjs(r).tz(timeZone), i18n);
   });
   return [dateStrings, rule.all()];
 };

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -336,8 +336,8 @@ async function handler(req: NextApiRequest) {
     description: eventType.description,
     additionalNotes,
     customInputs,
-    startTime: reqBody.start,
-    endTime: reqBody.end,
+    startTime: dayjs(reqBody.start).utc().format(),
+    endTime: dayjs(reqBody.end).utc().format(),
     organizer: {
       name: organizerUser.name || "Nameless",
       email: organizerUser.email || "Email-less",
@@ -490,8 +490,8 @@ async function handler(req: NextApiRequest) {
     const newBookingData: Prisma.BookingCreateInput = {
       uid,
       title: evt.title,
-      startTime: dayjs(evt.startTime).toDate(),
-      endTime: dayjs(evt.endTime).toDate(),
+      startTime: dayjs.utc(evt.startTime).toDate(),
+      endTime: dayjs.utc(evt.endTime).toDate(),
       description: evt.additionalNotes,
       customInputs: isPrismaObjOrUndefined(evt.customInputs),
       status: isConfirmedByDefault ? BookingStatus.ACCEPTED : BookingStatus.PENDING,

--- a/apps/web/server/routers/viewer.tsx
+++ b/apps/web/server/routers/viewer.tsx
@@ -89,6 +89,7 @@ const loggedInViewerRouter = createProtectedRouter()
         bufferTime: user.bufferTime,
         locale: user.locale,
         timeFormat: user.timeFormat,
+        timeZone: user.timeZone,
         avatar: user.avatar,
         createdDate: user.createdDate,
         trialEndsAt: user.trialEndsAt,


### PR DESCRIPTION
Fixes:

* parseRecurringDates parsed based on browser time, not organizer time or attendee time. 99% of the time correct, not always.
* Zoom start and end times MUST be given in UTC (<date>+01:00 is parsed as UTC) - we don't care; I fixed the issue by casting the overall event start and end time to UTC.
* Added organizer timeZone to user.me query to use later in parseRecurringDates on the booking page (note, not having that there before likely means that there is more depending on browser time than I fixed in this PR 🤷)

Features:
* Zoom supports recurring events; which I had a look at and mapped with.