### PR TITLE
Add missing embed fingerprint

### DIFF
--- a/packages/embeds/vite.config.js
+++ b/packages/embeds/vite.config.js
@@ -3,6 +3,7 @@ require("dotenv").config({ path: path.join(__dirname, "..", "..", ".env") });
 process.env.EMBED_PUBLIC_VERCEL_URL = process.env.VERCEL_URL;
 process.env.EMBED_PUBLIC_WEBAPP_URL = process.env.NEXT_PUBLIC_WEBAPP_URL;
 process.env.EMBED_PUBLIC_EMBED_LIB_URL = process.env.NEXT_PUBLIC_EMBED_LIB_URL;
+process.env.EMBED_PUBLIC_EMBED_FINGER_PRINT = process.env.NEXT_PUBLIC_EMBED_FINGER_PRINT;
 
 // Problem: typeof process.env.EMBED_PUBLIC_EMBED_LIB_URL is "undefined"(truthy) if process.env.NEXT_PUBLIC_EMBED_LIB_URL is undefined(falsy)
 // This is probably because environment variables are always string, so this weird automatic conversion to string happens


### PR DESCRIPTION
Add missing fingerprint that can tell us exactly for which commit the embed.js has been generated.