### PR TITLE
fix/zoom-passwordless-meeting

### DIFF
--- a/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
@@ -15,7 +15,7 @@ import { getZoomAppKeys } from "./getZoomAppKeys";
 const zoomEventResultSchema = z.object({
   id: z.number(),
   join_url: z.string(),
-  password: z.string(),
+  password: z.string().optional().default(""),
 });
 
 export type ZoomEventResult = z.infer<typeof zoomEventResultSchema>;


### PR DESCRIPTION
## What does this PR do?

Added optional to password to zoom response

Fixes #3397

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Free accounts meetings are password enforced, only users who use paid zoom can generate meetings without a password.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works

