### PR TITLE
hotfix/zoom-passwordless-meeting

### DIFF
--- a/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
@@ -15,7 +15,7 @@ import { getZoomAppKeys } from "./getZoomAppKeys";
 const zoomEventResultSchema = z.object({
   id: z.number(),
   join_url: z.string(),
-  password: z.string(),
+  password: z.string().optional().default(""),
 });
 
 export type ZoomEventResult = z.infer<typeof zoomEventResultSchema>;


### PR DESCRIPTION
## What does this PR do?

Sets zoom response with password optinal and empty string as default value

Fixes #3397

**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)