### PR TITLE
Fix a typo in the server lib

### DIFF
--- a/packages/lib/server/defaultResponder.ts
+++ b/packages/lib/server/defaultResponder.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getServerErrorFromUnkown } from "./getServerErrorFromUnkown";
+import { getServerErrorFromUnknown } from "./getServerErrorFromUnknown";
 import { performance } from "./perfObserver";
 
 type Handle<T> = (req: NextApiRequest, res: NextApiResponse) => Promise<T>;
@@ -15,7 +15,7 @@ function defaultResponder<T>(f: Handle<T>) {
       ok = true;
       if (result) res.json(result);
     } catch (err) {
-      const error = getServerErrorFromUnkown(err);
+      const error = getServerErrorFromUnknown(err);
       res.statusCode = error.statusCode;
       res.json({ message: error.message });
     } finally {

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -24,7 +24,7 @@ function parseZodErrorIssues(issues: ZodIssue[]): string {
     .join("; ");
 }
 
-export function getServerErrorFromUnkown(cause: unknown): HttpError {
+export function getServerErrorFromUnknown(cause: unknown): HttpError {
   if (isZodError(cause)) {
     console.log("cause", cause);
     return new HttpError({

--- a/packages/lib/server/index.ts
+++ b/packages/lib/server/index.ts
@@ -1,5 +1,5 @@
 export { default as defaultHandler } from "./defaultHandler";
 export { default as defaultResponder } from "./defaultResponder";
-export { getServerErrorFromUnkown } from "./getServerErrorFromUnkown";
+export { getServerErrorFromUnknown } from "./getServerErrorFromUnknown";
 export { getTranslation } from "./i18n";
 export { default as perfObserver } from "./perfObserver";


### PR DESCRIPTION
## What does this PR do?

This PR corrects a typo by replacing `getServerErrorFromUnkown` -> `getServerErrorFromUnknown`.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
