### PR TITLE
Hotfix: Cancelling recurring vs single event

### DIFF
--- a/apps/web/lib/parseDate.ts
+++ b/apps/web/lib/parseDate.ts
@@ -5,6 +5,7 @@ import dayjs, { Dayjs } from "@calcom/dayjs";
 import { RecurringEvent } from "@calcom/types/Calendar";
 
 import { detectBrowserTimeFormat } from "@lib/timeFormat";
+import { inferQueryOutput } from "@lib/trpc";
 
 import { parseZone } from "./parseZone";
 
@@ -45,4 +46,16 @@ export const parseRecurringDates = (
     return processDate(dayjs(r).tz(timeZone), i18n);
   });
   return [dateStrings, rule.all()];
+};
+
+type BookingItem = inferQueryOutput<"viewer.bookings">["bookings"][number];
+
+export const extractRecurringDates = (
+  bookings: BookingItem[],
+  timeZone: string | undefined,
+  i18n: I18n
+): [string[], Date[]] => {
+  const dateStrings = bookings.map((booking) => processDate(dayjs(booking.startTime).tz(timeZone), i18n));
+  const allDates = dateStrings.map((dateString) => dayjs(dateString).tz(timeZone).toDate());
+  return [dateStrings, allDates];
 };

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -286,6 +286,8 @@
   "cannot_cancel_booking": "You cannot cancel this booking",
   "reschedule_instead": "Instead, you could also reschedule it.",
   "event_is_in_the_past": "The event is in the past",
+  "cancelling_event_recurring": "The event is one instance of a recurring event.",
+  "cancelling_all_recurring": "These are all remaining instances in the recurring event.",
   "error_with_status_code_occured": "An error with status code {{status}} occurred.",
   "booking_already_cancelled": "This booking was already cancelled",
   "go_back_home": "Go back home",

--- a/apps/web/server/routers/viewer.tsx
+++ b/apps/web/server/routers/viewer.tsx
@@ -428,11 +428,6 @@ const loggedInViewerRouter = createProtectedRouter()
         skip,
       });
 
-      const groupedRecurringBookings = await prisma.booking.groupBy({
-        by: [Prisma.BookingScalarFieldEnum.recurringEventId],
-        _count: true,
-      });
-
       let bookings = bookingsQuery.map((booking) => {
         return {
           ...booking,
@@ -473,7 +468,6 @@ const loggedInViewerRouter = createProtectedRouter()
 
       return {
         bookings,
-        groupedRecurringBookings,
         nextCursor,
       };
     },


### PR DESCRIPTION
## What does this PR do?

When cancelling a single event in a recurring event series, it was cancelling all events, not a single instance.
This also covers a fix to show correctly the remaining events in a series taking into account cancelled/rejected events, as well as just cancelling remaining events in the future, not all events in a series, to reflect the correct state to past events that were accepted that probably did happen.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Confirm a recurring event upon creation or use the mocked ones. Try to cancel one instance from "Upcoming" tab, and see that you only get an email to just one instance, as well as the correct cancel page with the correct information for just that instance. Also, in "Recurring" tab for bookings, once cancelled, the number of remaining events should be correct as well as show upon hovering the dotted line, the correct remaining event instances dates.