### PR TITLE
Hotfix: Hide useless windows scrollbar on windows when they are not even required

### DIFF
--- a/packages/embeds/embed-core/src/ModalBox/ModalBoxHtml.ts
+++ b/packages/embeds/embed-core/src/ModalBox/ModalBoxHtml.ts
@@ -20,7 +20,7 @@ const html = `<style>
     top:50%;
     left:50%;
     transform: translateY(-50%) translateX(-50%);
-    overflow: scroll;
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)
Mac is good. It doesn't show scroll bar when not required (by default).
Windows is bad. Make it be like Mac

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Open embed popup on windows to observe useless scrollbars which would be gone now.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
