### PR TITLE
Show error message when workflow id is invalid

### DIFF
--- a/apps/web/ee/pages/workflows/[workflow].tsx
+++ b/apps/web/ee/pages/workflows/[workflow].tsx
@@ -78,6 +78,8 @@ function WorkflowPage() {
 
   const {
     data: workflow,
+    isError,
+    error,
     isLoading,
     dataUpdatedAt,
   } = trpc.useQuery([
@@ -153,15 +155,21 @@ function WorkflowPage() {
           <Alert className="border " severity="warning" title={t("pro_feature_workflows")} />
         ) : (
           <>
-            {isAllDataLoaded ? (
-              <WorkflowDetailsPage
-                form={form}
-                workflowId={+workflowId}
-                selectedEventTypes={selectedEventTypes}
-                setSelectedEventTypes={setSelectedEventTypes}
-              />
+            {!isError ? (
+              <>
+                {isAllDataLoaded ? (
+                  <WorkflowDetailsPage
+                    form={form}
+                    workflowId={+workflowId}
+                    selectedEventTypes={selectedEventTypes}
+                    setSelectedEventTypes={setSelectedEventTypes}
+                  />
+                ) : (
+                  <Loader />
+                )}
+              </>
             ) : (
-              <Loader />
+              <Alert severity="error" title="Something went wrong" message={error.message} />
             )}
           </>
         )}

--- a/apps/web/server/routers/viewer/workflows.tsx
+++ b/apps/web/server/routers/viewer/workflows.tsx
@@ -82,6 +82,11 @@ export const workflowsRouter = createProtectedRouter()
           },
         },
       });
+      if (!workflow) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+        });
+      }
       return workflow;
     },
   })


### PR DESCRIPTION
## What does this PR do?

Show error message when workflow id does not belong to user or workflow does not exist. Currently, it just keeps loading.

![Screenshot 2022-07-20 at 18 38 41](https://user-images.githubusercontent.com/30310907/180094405-d392ea9d-9659-4754-b188-ebf500c42623.png)

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to workflows/id
  - use workflow id that belongs to different user 
  - use a workflow id that does not exist
- You should see the error message from the screenshot above

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
