### PR TITLE
Hotfix: Embed ModalBox - Hidden Content

### DIFF
--- a/packages/embeds/embed-core/src/ModalBox/ModalBoxHtml.ts
+++ b/packages/embeds/embed-core/src/ModalBox/ModalBoxHtml.ts
@@ -10,30 +10,16 @@ const html = `<style>
   background-color:rgb(5,5,5, 0.8)
 }
 
-@media only screen and (min-width:600px) {
-  .modal-box {
-    margin:0 auto;
-    margin-top:20px;
-    margin-bottom:20px;
-    position:absolute;
-    width:100%;
-    top:50%;
-    left:50%;
-    transform: translateY(-50%) translateX(-50%);
-    overflow: auto;
-  }
-}
-
-@media only screen and (max-width:600px) {
-  .modal-box {
-  width: 100%;
-  height: 80%;
-  position:fixed;
-  top:50px;
-  left:0;
-  right: 0;
-  margin: 0;
-  }
+.modal-box {
+  margin:0 auto;
+  margin-top:20px;
+  margin-bottom:20px;
+  position:absolute;
+  width:100%;
+  top:50%;
+  left:50%;
+  transform: translateY(-50%) translateX(-50%);
+  overflow: auto;
 }
 
 .header {

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -469,11 +469,8 @@ export class Cal {
       if (this.modalBox) {
         // It ensures that if the iframe is so tall that it can't fit in the parent window without scroll. Then force the scroll by restricting the max-height to innerHeight
         // This case is reproducible when viewing in ModalBox on Mobile.
-        iframe.style.maxHeight = window.innerHeight + "px";
-        // Automatically setting the height of modal-box as per iframe creates problem in managing width of iframe.
-        // if (iframe.style.width !== "100%") {
-        //   this.modalBox!.shadowRoot!.querySelector(".modal-box")!.style.width = iframe.style.width;
-        // }
+        const spacingTopPlusBottom = 2 * 50; // 50 is the padding we want to keep to show close button comfortably. Make it same as top for bottom.
+        iframe.style.maxHeight = window.innerHeight - spacingTopPlusBottom + "px";
       }
     });
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # https://github.com/calcom/cal.com/issues/3476
There are 2 fixes here
- The below the fold content of modal-box is now visible
- Even on smaller width devices, the modal-box would be centered vertically, but taking the entire width(as width is pretty less). Earlier on smaller width devices, I had chosen an approach of attaching the modal-box at the top with a padding of 50px.
A demo of the fix showing the behaviour in many devices https://www.loom.com/share/43b0aad923e44c5bab4b7b75a224a706

Thanks to @sean-brydon for introducing me to Sizzy. Makes it much easier.

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
