### PR TITLE
Hotfix: Fix Cancellation 500 error if one of the new video apps are installed

### DIFF
--- a/packages/types/VideoApiAdapter.d.ts
+++ b/packages/types/VideoApiAdapter.d.ts
@@ -9,14 +9,17 @@ export interface VideoCallData {
   url: string;
 }
 
-export interface VideoApiAdapter {
-  createMeeting(event: CalendarEvent): Promise<VideoCallData>;
+// VideoApiAdapter is defined by the Video App. The App currently can choose to not define it. So, consider in type that VideoApiAdapter can be undefined.
+export type VideoApiAdapter =
+  | {
+      createMeeting(event: CalendarEvent): Promise<VideoCallData>;
 
-  updateMeeting(bookingRef: PartialReference, event: CalendarEvent): Promise<VideoCallData>;
+      updateMeeting(bookingRef: PartialReference, event: CalendarEvent): Promise<VideoCallData>;
 
-  deleteMeeting(uid: string): Promise<unknown>;
+      deleteMeeting(uid: string): Promise<unknown>;
 
-  getAvailability(dateFrom?: string, dateTo?: string): Promise<EventBusyDate[]>;
-}
+      getAvailability(dateFrom?: string, dateTo?: string): Promise<EventBusyDate[]>;
+    }
+  | undefined;
 
 export type VideoApiAdapterFactory = (credential: Credential) => VideoApiAdapter;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes 500 errors on cancellation, causing emails to be not sent but cancellation to happen.
_The error occurred when either of Riverside, Whereby, or Around apps was installed. The root cause being the Apps don't define VideoApiAdapter._

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Add Riverside App and see that whenever cancellating a booking, you would see 500 error. After the fix it would be gone
## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
