### PR TITLE
Add session info to Beacon

### DIFF
--- a/apps/web/components/Shell.tsx
+++ b/apps/web/components/Shell.tsx
@@ -494,7 +494,17 @@ function UserDropdown({ small }: { small?: boolean }) {
   const { t } = useLocale();
   const query = useMeQuery();
   const user = query.data;
-
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    const Beacon = window.Beacon;
+    // window.Beacon is defined when user actually opens up HelpScout and username is available here. On every re-render update session info, so that it is always latest.
+    Beacon &&
+      Beacon("session-data", {
+        username: user?.username || "Unknown",
+        screenResolution: `${screen.width}x${screen.height}`,
+      });
+  });
   const mutation = trpc.useMutation("viewer.away", {
     onSettled() {
       utils.invalidateQueries("viewer.me");


### PR DESCRIPTION
Adds following session info to HelpScout Beaon
- **screenResolution** - For debugging responsiveness related issues
- **username** - To allow to quickly start debugging issues.
<img width="1120" alt="Screenshot 2022-07-22 at 2 43 48 PM" src="https://user-images.githubusercontent.com/1780212/180406682-a66f3bf0-cf3b-4f83-abad-e543066c7f57.png">