### PR TITLE
Fix input on trial accounts

### DIFF
--- a/apps/web/pages/event-types/[type].tsx
+++ b/apps/web/pages/event-types/[type].tsx
@@ -1679,9 +1679,9 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                                           <>
                                             <div className="block sm:flex">
                                               <div className="flex-auto">
-                                                {eventType.users.some(
-                                                  (user) => user.plan === ("PRO" || "TRIAL")
-                                                ) || eventType.users.some((user) => user.plan === "TRIAL") ? (
+                                                {eventType.users.some((user) =>
+                                                  ["PRO", "TRIAL"].includes(user.plan)
+                                                ) ? (
                                                   <div className="flex-auto">
                                                     <label
                                                       htmlFor="beforeBufferTime"

--- a/apps/web/pages/event-types/[type].tsx
+++ b/apps/web/pages/event-types/[type].tsx
@@ -1681,7 +1681,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
                                               <div className="flex-auto">
                                                 {eventType.users.some(
                                                   (user) => user.plan === ("PRO" || "TRIAL")
-                                                ) ? (
+                                                ) || eventType.users.some((user) => user.plan === "TRIAL") ? (
                                                   <div className="flex-auto">
                                                     <label
                                                       htmlFor="beforeBufferTime"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds the pro input for seats on event types for trail accounts

![image](https://user-images.githubusercontent.com/65426560/180807305-c8b1810d-0c43-4fc8-a9a3-a189be0d08b8.png)


Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Log into a trial account and edit an event type
- Go to the seats option, you should be able to type a number
- Log into a pro account and edit an event type
- Go to the seats option and you should still be able to see the same type of input

