### PR TITLE
Hotfix: Embed - Avoid global variables leak by making the entire code IIFE

### DIFF
--- a/packages/embeds/embed-core/vite.config.js
+++ b/packages/embeds/embed-core/vite.config.js
@@ -2,8 +2,8 @@ import viteBaseConfig from "../vite.config";
 
 const path = require("path");
 const { defineConfig } = require("vite");
-
 module.exports = defineConfig((configEnv) => {
+  /** @type {import('vite').UserConfig} */
   const config = {
     ...viteBaseConfig,
     base: "/embed/",
@@ -19,6 +19,17 @@ module.exports = defineConfig((configEnv) => {
           preview: path.resolve(__dirname, "preview.html"),
           embed: path.resolve(__dirname, "src/embed.ts"),
         },
+        plugins: [
+          {
+            generateBundle: (code, bundle) => {
+              // Note: banner/footer doesn't work because it doesn't enclose the entire library code, some variables are still left out.
+              // Ideally IIFE mode should be used to solve this problem but it has 2 known problems
+              // 1. It doesn't work with rollupOptions.input.preview(as it is an app and app doesn't support it, only libraries)
+              // 2. Having IIFE mode somehow adds the CSS imported in embed, directly to the parent page. It is supposed to be used as a string and then that string is used as CSS in shadow dom
+              bundle["embed.js"].code = `!function(){${bundle["embed.js"].code}}()`;
+            },
+          },
+        ],
         output: {
           entryFileNames: "[name].js",
           //FIXME: Can't specify UMD as import because preview is an app which doesn't support `format` and this setting apply to both input


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)
As reported on helpscout, there was a clash of the same global variable name(var `b` in this case) which was accidentally exposed by embed. This causes embed.js to cause run time error.
Now, the entire library code is wrapped in IIFE.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Simply goto http://localhost:3100 and check if b variable is exposed or any other variables are exposed globally.

