### PR TITLE
Fixes fetch depth

### DIFF
--- a/.github/workflows/check-if-ui-has-changed.yml
+++ b/.github/workflows/check-if-ui-has-changed.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }} # So we can test on forks
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Install dependencies
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow


### PR DESCRIPTION
## What does this PR do?

Chromatic support team 

Looking at your Github Action setup, I see a possible issue. At [line 25](https://github.com/calcom/cal.com/blob/d78a53a419021c934ee532a31482da2868730e55/.github/workflows/check-if-ui-has-changed.yml#L25) of your check-if-ui-has-changed.yml file, fetch-depth is set to '2'. If that is the config file used for your Github Action, Chromatic requires a setting of 0 to see the entire git history (you can read more about that [here](https://www.chromatic.com/docs/github-actions#support-for-codeactionscheckoutv2code-and-above)). Could you please try updating that setting and see if that helps with the ancestor issue?


~ Bryan