### PR TITLE
change prerequistic of node.js from min 14.x to 15.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To get a local copy up and running, please follow these simple steps.
 
 Here is what you need to be able to run Cal.
 
-- Node.js (Version: >=14.x <17)
+- Node.js (Version: >=15.x <17)
 - PostgreSQL
 - Yarn _(recommended)_
 


### PR DESCRIPTION
## What does this PR do?
Changes in README to increase node.js minimum version to 15.x as next-axiom has requirement of version  `"node": ">=15"`
reference: [line 11-13](https://github.com/axiomhq/next-axiom/blob/main/package.json)

![yarn install failing as next-axiom requires min node.js version 15.x](https://user-images.githubusercontent.com/52914487/181682605-a1783bec-da2d-4e10-be95-2a37415edcb2.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Follow the local installation instructions using node version < 15.0.
the screenshot uploaded above will appear as install dependencies

