### PR TITLE
Brand color fix

### DIFF
--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -31,7 +31,7 @@ module.exports = {
           700: "#0d121d",
           800: "#0a0e17",
           900: "#080c13",
-          DEFAULT: "#111827",
+          DEFAULT: "var(--brand-color)",
         },
         brandcontrast: "var(--brand-text-color)",
         darkmodebrand: "var(--brand-color-dark-mode)",


### PR DESCRIPTION
## What does this PR do?

Brand color reference lost after switching to brand color shades for v2 components.

Fixes #3663 

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See #3663 
