### PR TITLE
Allows tree shaking unused modules

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -84,6 +84,15 @@ const nextConfig = {
       fs: false,
     };
 
+    /**
+     * TODO: Find more possible barrels for this project.
+     *  @see https://github.com/vercel/next.js/issues/12557#issuecomment-1196931845
+     **/
+    config.module.rules.push({
+      test: [/lib\/.*.tsx?/i],
+      sideEffects: false,
+    });
+
     return config;
   },
   async rewrites() {

--- a/packages/app-store-cli/package.json
+++ b/packages/app-store-cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/app-store-cli",
+  "sideEffects": false,
   "version": "0.0.0",
   "bin": "dist/cli.js",
   "engines": {

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/app-store",
+  "sideEffects": false,
   "version": "0.0.0",
   "main": "./index.ts",
   "files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/config",
+  "sideEffects": false,
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/core",
+  "sideEffects": false,
   "description": "Cal.com core functionality",
   "version": "0.0.0",
   "private": true,

--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/emails",
+  "sideEffects": false,
   "version": "0.0.0",
   "private": true,
   "scripts": {},

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/embed-core",
+  "sideEffects": false,
   "version": "1.1.2",
   "description": "This is the vanilla JS core script that embeds Cal Link",
   "main": "./dist/embed/embed.js",

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@calcom/embed-core",
-  "sideEffects": false,
   "version": "1.1.2",
   "description": "This is the vanilla JS core script that embeds Cal Link",
   "main": "./dist/embed/embed.js",

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/embed-react",
+  "sideEffects": false,
   "version": "1.0.9",
   "description": "Embed Cal Link as a React Component",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/embed-snippet",
+  "sideEffects": false,
   "version": "1.0.4",
   "main": "./dist/snippet.umd.js",
   "module": "./dist/snippet.es.js",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/eslint-plugin-eslint",
+  "sideEffects": false,
   "version": "0.1.0",
   "main": "./src/index.js",
   "dependencies": {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/features",
+  "sideEffects": false,
   "description": "Cal.com's main collocation of features",
   "authors": "Cal.com, Inc.",
   "version": "1.0.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/lib",
+  "sideEffects": false,
   "version": "0.0.0",
   "main": "./index.ts",
   "types": "./index.ts",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/trpc",
+  "sideEffects": false,
   "description": "Shared tRPC library for Cal.com",
   "authors": "zomars",
   "version": "1.0.0",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/tsconfig",
+  "sideEffects": false,
   "version": "0.0.0",
   "private": true,
   "main": "index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@calcom/ui",
+  "sideEffects": false,
   "version": "0.0.0",
   "main": "./index.tsx",
   "types": "./index.tsx",


### PR DESCRIPTION
## What does this PR do?

- Marks all packages as "side effect" free which all SHOULD be unless I'm mistaken
- This will allow correct behavior for [webpack tree shaking](https://webpack.js.org/guides/tree-shaking/)
- Noticed some minor gains in some pages locally (up to 20kb of bundle size reduction)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Before checking out this branch: `yarn build`
- [ ] After checking out this branch `yarn build`
- [ ] Compare overall bundle size
- [ ] `yarn test-e2e`
