### PR TITLE
fix: remove redundant AND

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -99,7 +99,7 @@ async function getUserPageProps(context: GetStaticPropsContext) {
       slug,
       /* Free users can only display their first eventType */
       id: user.plan === UserPlan.FREE ? eventTypeIds[0] : undefined,
-      AND: [{ OR: [{ userId: user.id }, { users: { some: { id: user.id } } }] }],
+      OR: [{ userId: user.id }, { users: { some: { id: user.id } } }],
     },
     // Order is important to ensure that given a slug if there are duplicates, we choose the same event type consistently when showing in event-types list UI(in terms of ordering and disabled event types)
     // TODO: If we can ensure that there are no duplicates for a [slug, userId] combination in existing data, this requirement might be avoided.


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`AND` is unesscessary here as only I condition is provided inside it.

However the motivation before creating the PR was to fix
 >    // Order is important to ensure that given a slug if there are duplicates, we choose the same event type consistently when showing in event-types list UI(in terms of ordering and disabled event types)
    // TODO: If we can ensure that there are no duplicates for a [slug, userId] combination in existing data, this requirement might be avoided.
    
I find the comment bit misleading as there can be no duplicate combination for `[slug,userId]`. ([schema.prisma](https://github.com/calcom/cal.com/blob/main/packages/prisma/schema.prisma))
```ts
model EventType{
...
  id                      Int                     @id @default(autoincrement())
  users                   User[]                  @relation("user_eventtype")
  @@unique([userId, slug])
}
```
Due to which I tried to convert 
`const eventTypes = await prisma.eventType.findMany({`  
to 
`const eventTypes = await prisma.eventType.findUnique({`  
as there exist only 1 such pair.  
After some time I found out that it also returns true if user exists in the username is exist in users( see model EventType above)
Eg Alice and Bob both have a event-type with **15min** as `slug`.
the row where Alice is the owner (the event-type created by her) has  `users: ["alice","Bob"]` in column users( see model EventType above)
Current Behaviour: Navigating to `/bob/15min`  is resulted in the event-type where bob is the owner.
Suppise If Bob does not have this event created , It will result to the one Alice created (as Bob is included in **users** column of Alice craeted event)

The problem: 
- same link can be resolved in two different cases mentioned above. 
- There can be better solution than `findMany` , as we just need 1 row.

The first problem is  probably the expected behaviour.
 For the second I though of doing one of the following 
 - split into two queries, if record found where  `userId` in model EventType  matches the `id` of the username provided in slug.Then return the result of this and skip the next one.  The first condition fails then only perform next one.
 -  doing a prisma raw query that will do it in one sql statement.

If any of the above two sounds good, I will go ahead and include them or you can go ahead with merging the existing change if your happy with it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

