### PR TITLE
Attempt to fix telemetry loop

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -26,9 +26,9 @@ const middleware: NextMiddleware = async (req) => {
   if (req.cookies.has("calcom-v2-early-access") && V2_WHITELIST.some((p) => url.pathname.startsWith(p))) {
     // rewrite to the current subdomain under the pages/sites folder
     url.pathname = `/v2${url.pathname}`;
+    return NextResponse.rewrite(url);
   }
-
-  return NextResponse.rewrite(url);
+  return NextResponse.next();
 };
 
 export default collectEvents({

--- a/apps/web/pages/api/collect-events.ts
+++ b/apps/web/pages/api/collect-events.ts
@@ -1,8 +1,8 @@
-import { nextEventsCollectApi } from "next-collect/server";
+import { collectApiHandler } from "next-collect/server";
 
 import { extendEventData, nextCollectBasicSettings } from "@calcom/lib/telemetry";
 
-export default nextEventsCollectApi({
+export default collectApiHandler({
   ...nextCollectBasicSettings,
   cookieName: "__clnds",
   extend: extendEventData,


### PR DESCRIPTION
* Fixes deprecation notice
* Attempt at NextResponse.next() instead of rewrite to stop triggering middleware too much (potentially, it's a guess)