### PR TITLE
Fix availability free-busy data pull, location change and status in CALDAV | new branch (attempt#2)

### DIFF
--- a/packages/lib/sanitizeCalendarObject.ts
+++ b/packages/lib/sanitizeCalendarObject.ts
@@ -1,0 +1,12 @@
+import { DAVObject } from "tsdav";
+
+export const sanitizeCalendarObject = (obj: DAVObject) => {
+  return obj.data
+    .replaceAll("\r\n", "\r")
+    .replaceAll("\r", "\r\n")
+    .replaceAll(/(: \r\n|:\r\n|\r\n:|\r\n :)/gm, ":")
+    .replaceAll(/(; \r\n|;\r\n|\r\n;|\r\n ;)/gm, ";")
+    .replaceAll(/(= \r\n|=\r\n|\r\n=|\r\n =)/gm, "=");
+};
+
+export default sanitizeCalendarObject;


### PR DESCRIPTION
## What does this PR do?


- Fixes the incompatibility between the `ICALstring` returned in the calendar objects by TSDAV's `fetchCalendarObjects` and the expected input from `ICAL.parse()`
- Adds a sanitizer for calendar object data retrieved by TSdav for further processing
- Fixes Location Change reflecting on the connected CalDAV
- Fixes Reschedule change reflecting on the connected CalDAV
- Fixes Freebusy data consideration to allow booking over events with 'TRANSPARENT' (free) status

Fixes #3589  #2988  #2236  #1588 

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
