### PR TITLE
Fixes CLS when loading Avatars

### DIFF
--- a/packages/ui/v2/core/Avatar.tsx
+++ b/packages/ui/v2/core/Avatar.tsx
@@ -18,20 +18,24 @@ export type AvatarProps = {
 };
 
 const sizesPropsBySize = {
-  sm: "w-6",
-  md: "w-8",
-  lg: "w-16",
-};
+  sm: "w-6", // 24px
+  md: "w-8", // 32px
+  lg: "w-16", // 64px
+} as const;
 
 export default function Avatar(props: AvatarProps) {
   const { imageSrc, gravatarFallbackMd5, size, alt, title } = props;
-  const rootClass = classNames("rounded-full", sizesPropsBySize[props.size], "h-auto");
+  const sizeClassname = sizesPropsBySize[props.size];
+  const rootClass = classNames("rounded-full aspect-square", sizeClassname, "h-auto");
   const avatar = (
-    <AvatarPrimitive.Root className={classNames("relative inline-block overflow-hidden ")}>
+    <AvatarPrimitive.Root
+      className={classNames(
+        sizeClassname,
+        "relative inline-block aspect-square overflow-hidden rounded-full bg-gray-300"
+      )}>
       <AvatarPrimitive.Image src={imageSrc ?? undefined} alt={alt} className={rootClass} />
       <AvatarPrimitive.Fallback delayMs={600}>
         {gravatarFallbackMd5 && (
-          // eslint-disable-next-line @next/next/no-img-element
           <img src={defaultAvatarSrc({ md5: gravatarFallbackMd5 })} alt={alt} className={rootClass} />
         )}
       </AvatarPrimitive.Fallback>

--- a/packages/ui/v2/core/Avatar.tsx
+++ b/packages/ui/v2/core/Avatar.tsx
@@ -25,7 +25,7 @@ const sizesPropsBySize = {
 
 export default function Avatar(props: AvatarProps) {
   const { imageSrc, gravatarFallbackMd5, size, alt, title } = props;
-  const sizeClassname = sizesPropsBySize[props.size];
+  const sizeClassname = sizesPropsBySize[size];
   const rootClass = classNames("rounded-full aspect-square", sizeClassname, "h-auto");
   const avatar = (
     <AvatarPrimitive.Root


### PR DESCRIPTION
## What does this PR do?

Fixes Cumulative Layout Shift when loading Avatars

| Before | After |
|---|---|
| ![avatar-cls-before](https://user-images.githubusercontent.com/3504472/186749868-8fcbeade-bb4d-4350-bbaa-c1a9cda9acd0.gif) | ![avatar-cls-after](https://user-images.githubusercontent.com/3504472/186749875-ab546ad5-695d-43be-bd20-f2b183c6882f.gif) |

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
