### PR TITLE
temp remove <Tips> card from sidebar till 2.1

### DIFF
--- a/packages/ui/v2/core/Shell.tsx
+++ b/packages/ui/v2/core/Shell.tsx
@@ -32,8 +32,7 @@ import pkg from "../../../../apps/web/package.json";
 import ErrorBoundary from "../../ErrorBoundary";
 import { KBarRoot, KBarContent, KBarTrigger } from "../../Kbar";
 import Logo from "../../Logo";
-import Tips from "../modules/tips/Tips";
-import Card from "./Card";
+// TODO: re-introduce in 2.1 import Tips from "../modules/tips/Tips";
 import HeadSeo from "./head-seo";
 
 /* TODO: Migate this */
@@ -590,7 +589,9 @@ function SideBar() {
         <Navigation />
       </div>
 
+      {/* TODO @Peer_Rich: reintroduce in 2.1 
       <Tips />
+      */}
 
       <TrialBanner />
       <div data-testid="user-dropdown-trigger">


### PR DESCRIPTION
temporally removing Tips from sidebar.

the Tips card in sidebar needs another round of fixes, which we don't have the time for, will fix for 2.1
<img width="292" alt="CleanShot 2022-08-29 at 14 03 47@2x" src="https://user-images.githubusercontent.com/8019099/187196993-37763c59-1f62-4e6d-a8f6-f40abc416f6d.png">
