### PR TITLE
fix/3928-reschedule-unexpected-error

### DIFF
--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -33,6 +33,12 @@ export function getServerErrorFromUnknown(cause: unknown): HttpError {
       cause,
     });
   }
+  if (cause instanceof SyntaxError) {
+    return new HttpError({
+      statusCode: 500,
+      message: "Unexpected error, please reach out for our customer support.",
+    });
+  }
   if (cause instanceof PrismaClientKnownRequestError) {
     return new HttpError({ statusCode: 400, message: cause.message, cause });
   }
@@ -50,5 +56,8 @@ export function getServerErrorFromUnknown(cause: unknown): HttpError {
     return new Error(cause, { cause });
   }
 
-  return new HttpError({ statusCode: 500, message: `Unhandled error of type '${typeof cause}'` });
+  return new HttpError({
+    statusCode: 500,
+    message: `Unhandled error of type '${typeof cause}'. Please reach out for our customer support.`,
+  });
 }


### PR DESCRIPTION
## What does this PR do?

Fixes api/book/event error handling. Now if a syntax error is received in defaultResponder message should be custom and not retrieved to user. Also improved default error message.

Fixes #3928

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

- [ ] On api/book/event you can use JSON.parse("Error parsing") to be thrown on any part of the code and it should be handled properly.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works

