### PR TITLE
Adds Meta component to handle layout headings/metadata

### DIFF
--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -11,6 +11,7 @@ import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/
 import DynamicIntercomProvider from "@calcom/features/ee/support/lib/intercom/providerDynamic";
 import { ContractsProvider } from "@calcom/features/ee/web3/contexts/contractsContext";
 import { trpc } from "@calcom/trpc/react";
+import { MetaProvider } from "@calcom/ui/v2/core/Meta";
 
 import usePublicPage from "@lib/hooks/usePublicPage";
 
@@ -80,7 +81,7 @@ const AppProviders = (props: AppPropsWithChildren) => {
                 storageKey={storageKey}
                 forcedTheme={forcedTheme}
                 attribute="class">
-                {props.children}
+                <MetaProvider>{props.children}</MetaProvider>
               </ThemeProvider>
             </TooltipProvider>
           </CustomI18nextProvider>

--- a/apps/web/pages/v2/settings/admin/apps.tsx
+++ b/apps/web/pages/v2/settings/admin/apps.tsx
@@ -1,8 +1,10 @@
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 
 function AdminAppsView() {
   return (
     <>
+      <Meta title="apps" description="apps_description" />
       <h1>App listing</h1>
     </>
   );

--- a/apps/web/pages/v2/settings/admin/impersonation.tsx
+++ b/apps/web/pages/v2/settings/admin/impersonation.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import Button from "@calcom/ui/Button";
 import { TextField } from "@calcom/ui/form/fields";
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 
 function AdminView() {
@@ -12,6 +13,7 @@ function AdminView() {
 
   return (
     <>
+      <Meta title="impersonation" description="impersonation_description" />
       <form
         className="mb-6 w-full sm:w-1/2"
         onSubmit={(e) => {

--- a/apps/web/pages/v2/settings/admin/index.tsx
+++ b/apps/web/pages/v2/settings/admin/index.tsx
@@ -1,8 +1,10 @@
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 
 function AdminAppsView() {
   return (
     <>
+      <Meta title="admin" description="admin_description" />
       <h1>Admin index</h1>
     </>
   );

--- a/apps/web/pages/v2/settings/admin/users.tsx
+++ b/apps/web/pages/v2/settings/admin/users.tsx
@@ -1,8 +1,10 @@
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 
 function AdminUsersView() {
   return (
     <>
+      <Meta title="users" description="users_description" />
       <h1>Users listing</h1>
     </>
   );

--- a/apps/web/pages/v2/settings/my-account/appearance.tsx
+++ b/apps/web/pages/v2/settings/my-account/appearance.tsx
@@ -1,24 +1,17 @@
 import { GetServerSidePropsContext } from "next";
 import { Trans } from "next-i18next";
-import { useRouter } from "next/router";
-import { title } from "process";
-import { useMemo, useState } from "react";
-import { useForm, Controller } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import prisma from "@calcom/prisma";
 import { trpc } from "@calcom/trpc/react";
-import { Icon } from "@calcom/ui";
-import Avatar from "@calcom/ui/v2/core/Avatar";
 import Badge from "@calcom/ui/v2/core/Badge";
 import { Button } from "@calcom/ui/v2/core/Button";
-import Loader from "@calcom/ui/v2/core/Loader";
+import Meta from "@calcom/ui/v2/core/Meta";
 import Switch from "@calcom/ui/v2/core/Switch";
-import TimezoneSelect from "@calcom/ui/v2/core/TimezoneSelect";
 import ColorPicker from "@calcom/ui/v2/core/colorpicker";
 import Select from "@calcom/ui/v2/core/form/Select";
-import { TextField, Form, Label } from "@calcom/ui/v2/core/form/fields";
+import { Form } from "@calcom/ui/v2/core/form/fields";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 import showToast from "@calcom/ui/v2/core/notifications";
 
@@ -54,6 +47,7 @@ const AppearanceView = (props: inferSSRProps<typeof getServerSideProps>) => {
           theme: values.theme.value,
         });
       }}>
+      <Meta title="appearance" description="appearance_description" />
       <Controller
         name="theme"
         control={formMethods.control}

--- a/apps/web/pages/v2/settings/my-account/calendars.tsx
+++ b/apps/web/pages/v2/settings/my-account/calendars.tsx
@@ -7,6 +7,7 @@ import { trpc } from "@calcom/trpc/react";
 import { Icon } from "@calcom/ui";
 import Badge from "@calcom/ui/v2/core/Badge";
 import EmptyScreen from "@calcom/ui/v2/core/EmptyScreen";
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 import { List, ListItem, ListItemText, ListItemTitle } from "@calcom/ui/v2/modules/List";
 import DestinationCalendarSelector from "@calcom/ui/v2/modules/event-types/DestinationCalendarSelector";
@@ -29,95 +30,102 @@ const CalendarsView = () => {
   });
 
   return (
-    <QueryCell
-      query={query}
-      success={({ data }) => {
-        console.log("🚀 ~ file: calendars.tsx ~ line 28 ~ CalendarsView ~ data", data);
-        return data.connectedCalendars.length ? (
-          <div>
-            <div className="mt-4 rounded-md border-neutral-200 bg-white p-2 sm:mx-0 sm:p-10 md:border md:p-6 xl:mt-0">
-              <div className="mt-4 rounded-md  border-neutral-200 bg-white p-2 sm:mx-0 sm:p-10 md:border md:p-2 xl:mt-0">
-                <Icon.FiCalendar className="h-5 w-5" />
+    <>
+      <Meta title="calendars" description="calendars_description" />
+      <QueryCell
+        query={query}
+        success={({ data }) => {
+          console.log("🚀 ~ file: calendars.tsx ~ line 28 ~ CalendarsView ~ data", data);
+          return data.connectedCalendars.length ? (
+            <div>
+              <div className="mt-4 rounded-md border-neutral-200 bg-white p-2 sm:mx-0 sm:p-10 md:border md:p-6 xl:mt-0">
+                <div className="mt-4 rounded-md  border-neutral-200 bg-white p-2 sm:mx-0 sm:p-10 md:border md:p-2 xl:mt-0">
+                  <Icon.FiCalendar className="h-5 w-5" />
+                </div>
+                <h4 className="leading-20 mt-2 text-xl font-semibold text-black">{t("add_to_calendar")}</h4>
+                <p className="pb-2 text-sm text-gray-600">
+                  <Trans i18nKey="add_to_calendar_description">
+                    Where to add events when you re booked. You can override this on a per-event basis in
+                    advanced settings in the event type.
+                  </Trans>
+                </p>
+                <DestinationCalendarSelector
+                  hidePlaceholder
+                  value={data.destinationCalendar?.externalId}
+                  onChange={mutation.mutate}
+                  isLoading={mutation.isLoading}
+                />
               </div>
-              <h4 className="leading-20 mt-2 text-xl font-semibold text-black">{t("add_to_calendar")}</h4>
-              <p className="pb-2 text-sm text-gray-600">
-                <Trans i18nKey="add_to_calendar_description">
-                  Where to add events when you re booked. You can override this on a per-event basis in
-                  advanced settings in the event type.
-                </Trans>
-              </p>
-              <DestinationCalendarSelector
-                hidePlaceholder
-                value={data.destinationCalendar?.externalId}
-                onChange={mutation.mutate}
-                isLoading={mutation.isLoading}
-              />
-            </div>
 
-            <h4 className="leading-20 mt-12 text-xl font-semibold text-black">{t("check_for_conflicts")}</h4>
-            <p className="pb-2 text-sm text-gray-600">{t("select_calendars")}</p>
-            <List>
-              {data.connectedCalendars.map((item) => (
-                <Fragment key={item.credentialId}>
-                  {item.calendars && (
-                    <ListItem expanded className="flex-col">
-                      <div className="flex w-full flex-1 items-center space-x-3 pb-5 pl-1 pt-1 rtl:space-x-reverse">
-                        {
-                          // eslint-disable-next-line @next/next/no-img-element
-                          item.integration.logo && (
-                            <img
-                              className="h-10 w-10"
-                              src={item.integration.logo}
-                              alt={item.integration.title}
-                            />
-                          )
-                        }
-                        <div className="flex-grow truncate pl-2">
-                          <ListItemTitle component="h3" className="mb-1 space-x-2">
-                            <Link href={"/apps/" + item.integration.slug}>
-                              {item.integration.name || item.integration.title}
-                            </Link>
-                            {data?.destinationCalendar?.credentialId === item.credentialId && (
-                              <Badge variant="green">Default</Badge>
-                            )}
-                          </ListItemTitle>
-                          <ListItemText component="p">{item.integration.description}</ListItemText>
+              <h4 className="leading-20 mt-12 text-xl font-semibold text-black">
+                {t("check_for_conflicts")}
+              </h4>
+              <p className="pb-2 text-sm text-gray-600">{t("select_calendars")}</p>
+              <List>
+                {data.connectedCalendars.map((item) => (
+                  <Fragment key={item.credentialId}>
+                    {item.calendars && (
+                      <ListItem expanded className="flex-col">
+                        <div className="flex w-full flex-1 items-center space-x-3 pb-5 pl-1 pt-1 rtl:space-x-reverse">
+                          {
+                            // eslint-disable-next-line @next/next/no-img-element
+                            item.integration.logo && (
+                              <img
+                                className="h-10 w-10"
+                                src={item.integration.logo}
+                                alt={item.integration.title}
+                              />
+                            )
+                          }
+                          <div className="flex-grow truncate pl-2">
+                            <ListItemTitle component="h3" className="mb-1 space-x-2">
+                              <Link href={"/apps/" + item.integration.slug}>
+                                {item.integration.name || item.integration.title}
+                              </Link>
+                              {data?.destinationCalendar?.credentialId === item.credentialId && (
+                                <Badge variant="green">Default</Badge>
+                              )}
+                            </ListItemTitle>
+                            <ListItemText component="p">{item.integration.description}</ListItemText>
+                          </div>
+                          <div>
+                            <DisconnectIntegration credentialId={item.credentialId} label={t("disconnect")} />
+                          </div>
                         </div>
-                        <div>
-                          <DisconnectIntegration credentialId={item.credentialId} label={t("disconnect")} />
+                        <div className="w-full border-t border-gray-200">
+                          <p className="px-2 pt-4 text-sm text-neutral-500">
+                            {t("toggle_calendars_conflict")}
+                          </p>
+                          <ul className="space-y-2 px-2 pt-4">
+                            {item.calendars.map((cal) => (
+                              <CalendarSwitch
+                                key={cal.externalId}
+                                externalId={cal.externalId}
+                                title={cal.name || "Nameless calendar"}
+                                type={item.integration.type}
+                                defaultSelected={cal.externalId === data?.destinationCalendar?.externalId}
+                              />
+                            ))}
+                          </ul>
                         </div>
-                      </div>
-                      <div className="w-full border-t border-gray-200">
-                        <p className="px-2 pt-4 text-sm text-neutral-500">{t("toggle_calendars_conflict")}</p>
-                        <ul className="space-y-2 px-2 pt-4">
-                          {item.calendars.map((cal) => (
-                            <CalendarSwitch
-                              key={cal.externalId}
-                              externalId={cal.externalId}
-                              title={cal.name || "Nameless calendar"}
-                              type={item.integration.type}
-                              defaultSelected={cal.externalId === data?.destinationCalendar?.externalId}
-                            />
-                          ))}
-                        </ul>
-                      </div>
-                    </ListItem>
-                  )}
-                </Fragment>
-              ))}
-            </List>
-          </div>
-        ) : (
-          <EmptyScreen
-            Icon={Icon.FiCalendar}
-            headline="No calendar installed"
-            description="You have not yet connected any of your calendars"
-            buttonText="Add a calendar"
-            buttonOnClick={() => console.log("Button Clicked")}
-          />
-        );
-      }}
-    />
+                      </ListItem>
+                    )}
+                  </Fragment>
+                ))}
+              </List>
+            </div>
+          ) : (
+            <EmptyScreen
+              Icon={Icon.FiCalendar}
+              headline="No calendar installed"
+              description="You have not yet connected any of your calendars"
+              buttonText="Add a calendar"
+              buttonOnClick={() => console.log("Button Clicked")}
+            />
+          );
+        }}
+      />
+    </>
   );
 };
 

--- a/apps/web/pages/v2/settings/my-account/conferencing.tsx
+++ b/apps/web/pages/v2/settings/my-account/conferencing.tsx
@@ -9,6 +9,7 @@ import Dropdown, {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@calcom/ui/v2/core/Dropdown";
+import Meta from "@calcom/ui/v2/core/Meta";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 import DisconnectIntegration from "@calcom/ui/v2/modules/integrations/DisconnectIntegration";
 
@@ -27,6 +28,7 @@ const ConferencingLayout = (props: inferSSRProps<typeof getServerSideProps>) => 
 
   return (
     <div className="m-4 rounded-md border-neutral-200 bg-white sm:mx-0  md:border xl:mt-0">
+      <Meta title="conferencing" description="conferencing_description" />
       {apps.map((app) => (
         <div
           key={app.title}

--- a/apps/web/pages/v2/settings/my-account/general.tsx
+++ b/apps/web/pages/v2/settings/my-account/general.tsx
@@ -8,6 +8,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import prisma from "@calcom/prisma";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/v2/core/Button";
+import Meta from "@calcom/ui/v2/core/Meta";
 import TimezoneSelect from "@calcom/ui/v2/core/TimezoneSelect";
 import Select from "@calcom/ui/v2/core/form/Select";
 import { Form, Label } from "@calcom/ui/v2/core/form/fields";
@@ -101,6 +102,7 @@ const GeneralView = ({ localeProp, t, user }: GeneralViewProps) => {
           weekStart: values.weekStart.value,
         });
       }}>
+      <Meta title="general" description="general_description" />
       <Controller
         name="locale"
         control={formMethods.control}

--- a/apps/web/pages/v2/settings/my-account/profile.tsx
+++ b/apps/web/pages/v2/settings/my-account/profile.tsx
@@ -2,8 +2,8 @@ import crypto from "crypto";
 import { GetServerSidePropsContext } from "next";
 import { signOut } from "next-auth/react";
 import { Trans } from "next-i18next";
-import { useState, useRef } from "react";
-import { useForm, Controller } from "react-hook-form";
+import { useRef, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import prisma from "@calcom/prisma";
@@ -11,8 +11,9 @@ import { trpc } from "@calcom/trpc/react";
 import { Icon } from "@calcom/ui";
 import Avatar from "@calcom/ui/v2/core/Avatar";
 import { Button } from "@calcom/ui/v2/core/Button";
-import { Dialog, DialogTrigger, DialogContent } from "@calcom/ui/v2/core/Dialog";
-import { TextField, Form, Label } from "@calcom/ui/v2/core/form/fields";
+import { Dialog, DialogContent, DialogTrigger } from "@calcom/ui/v2/core/Dialog";
+import Meta from "@calcom/ui/v2/core/Meta";
+import { Form, Label, TextField } from "@calcom/ui/v2/core/form/fields";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 import showToast from "@calcom/ui/v2/core/notifications";
 
@@ -71,6 +72,7 @@ const ProfileView = (props: inferSSRProps<typeof getServerSideProps>) => {
         handleSubmit={(values) => {
           mutation.mutate(values);
         }}>
+        <Meta title="profile" description="profile_description" />
         <div className="flex items-center">
           {/* TODO upload new avatar */}
           <Controller

--- a/apps/web/pages/v2/settings/security/password.tsx
+++ b/apps/web/pages/v2/settings/security/password.tsx
@@ -1,11 +1,12 @@
 import { IdentityProvider } from "@prisma/client";
 import { Trans } from "next-i18next";
-import { useForm, Controller } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/v2/core/Button";
-import { TextField, Form } from "@calcom/ui/v2/core/form/fields";
+import Meta from "@calcom/ui/v2/core/Meta";
+import { Form, TextField } from "@calcom/ui/v2/core/form/fields";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 import showToast from "@calcom/ui/v2/core/notifications";
 
@@ -28,6 +29,7 @@ const PasswordView = () => {
 
   return (
     <>
+      <Meta title="password" description="password_description" />
       {user && user.identityProvider !== IdentityProvider.CAL ? (
         <div>
           <div className="mt-6">

--- a/apps/web/pages/v2/settings/security/two-factor-auth.tsx
+++ b/apps/web/pages/v2/settings/security/two-factor-auth.tsx
@@ -4,6 +4,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import Badge from "@calcom/ui/v2/core/Badge";
 import Loader from "@calcom/ui/v2/core/Loader";
+import Meta from "@calcom/ui/v2/core/Meta";
 import Switch from "@calcom/ui/v2/core/Switch";
 import { getLayout } from "@calcom/ui/v2/core/layouts/AdminLayout";
 
@@ -23,6 +24,7 @@ const TwoFactorAuthView = () => {
 
   return (
     <>
+      <Meta title="2fa" description="2fa_description" />
       <div className="mt-6 flex items-start space-x-4">
         <Switch
           checked={user?.twoFactorEnabled}

--- a/packages/ui/v2/core/Meta.tsx
+++ b/packages/ui/v2/core/Meta.tsx
@@ -1,0 +1,56 @@
+import Head from "next/head";
+import React, { createContext, useContext, useState } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
+type MetaType = {
+  title: string;
+  description: string;
+};
+
+const initialMeta = {
+  title: "",
+  description: "",
+};
+
+const MetaContext = createContext({
+  meta: initialMeta,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setMeta: (newMeta: Partial<MetaType>) => {},
+});
+
+export function useMeta() {
+  return useContext(MetaContext);
+}
+
+export function MetaProvider({ children }: { children: React.ReactNode }) {
+  const [value, setValue] = useState(initialMeta);
+  const setMeta = (newMeta: Partial<MetaType>) => {
+    setValue((v) => ({ ...v, ...newMeta }));
+  };
+
+  return <MetaContext.Provider value={{ meta: value, setMeta }}>{children}</MetaContext.Provider>;
+}
+
+/**
+ * The purpose of this component is to simplify title and description handling.
+ * Similarly to `next/head`'s `Head` component this allow us to update the metadata for a page
+ * from any children, also exposes the metadata via the `useMeta` hook in case we need them
+ * elsewhere (ie. on a Heading, Title, Subtitle, etc.)
+ * @example <Meta title="Password" description="Manage settings for your account passwords" />
+ */
+export default function Meta({ title, description }: MetaType) {
+  const { t } = useLocale();
+  const { setMeta, meta } = useMeta();
+  /* @TODO: maybe find a way to have this data on first render to prevent flicker */
+  if (meta.title !== title || meta.description !== description) {
+    setMeta({ title, description });
+  }
+
+  return (
+    <Head>
+      <title>{t(title)} | Cal.com</title>
+      <meta name="description" content={t(description)} />
+    </Head>
+  );
+}

--- a/packages/ui/v2/core/layouts/SettingsLayout.tsx
+++ b/packages/ui/v2/core/layouts/SettingsLayout.tsx
@@ -1,6 +1,9 @@
 import React, { ComponentProps } from "react";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
 import { Icon } from "../../../Icon";
+import { useMeta } from "../Meta";
 import Shell from "../Shell";
 import { VerticalTabItem } from "../navigation/tabs";
 import VerticalTabs from "../navigation/tabs/VerticalTabs";
@@ -88,9 +91,35 @@ export default function SettingsLayout({
           />
         </VerticalTabs>
       }>
-      <div className="flex-1 [&>*]:flex-1">{children}</div>
+      <div className="flex-1 [&>*]:flex-1">
+        <ShellHeader />
+        {children}
+      </div>
     </Shell>
   );
 }
 
 export const getLayout = (page: React.ReactElement) => <SettingsLayout>{page}</SettingsLayout>;
+
+function ShellHeader() {
+  const { meta } = useMeta();
+  const { t, isLocaleReady } = useLocale();
+  return (
+    <header className="block justify-between px-4 pt-8 sm:flex sm:px-6 md:px-8">
+      <div className="mb-8 w-full">
+        {meta.title && isLocaleReady ? (
+          <h1 className="font-cal mb-1 text-xl font-bold capitalize tracking-wide text-gray-900">
+            {t(meta.title)}
+          </h1>
+        ) : (
+          <div className="mb-1 h-6 w-24 animate-pulse rounded-md bg-gray-200" />
+        )}
+        {meta.description && isLocaleReady ? (
+          <p className="text-sm text-neutral-500 ltr:mr-4 rtl:ml-4">{t(meta.description)}</p>
+        ) : (
+          <div className="mb-1 h-6 w-32 animate-pulse rounded-md bg-gray-200" />
+        )}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
To be merged after #4018 

## What does this PR do?

- Adds a `Meta` component that allows to update metadata from any page children
- Exposes metadata via a `useMeta` hook, this can be used to sync page metadata and display it in UI (Like Headings, subtitles, etc.)
- Adds `Meta` to pages in `/v2/settings`
- Adds example usage in `SettingsLayout` as `ShellHeader`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to `/v2/settings/my-account/profile`
- [ ] Navigate between settings pages and see how headings change
