### PR TITLE
Proposal to turn off eslint during 'yarn / next build'

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -78,6 +78,9 @@ plugins.push(withAxiom);
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   i18n,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   experimental: {
     images: {
       unoptimized: true,


### PR DESCRIPTION
## What does this PR do?

Disables eslint on `yarn build` as this duplicates our dedicated eslint check and the error that is produced is not helpful from GH (if anything, it causes confusion). [https://nextjs.org/docs/api-reference/next.config.js/ignoring-eslint](https://nextjs.org/docs/api-reference/next.config.js/ignoring-eslint)

As per the NextJS docs:

> If you'd like Next.js to produce production code even when your application has ESLint errors, you can disable the built-in linting step completely. This is not recommended **unless you already have ESLint configured to run in a separate part of your workflow** (for example, in CI or a pre-commit hook).