### PR TITLE
Design improvements for v2 security settings pages

### DIFF
--- a/apps/web/pages/v2/settings/security/password.tsx
+++ b/apps/web/pages/v2/settings/security/password.tsx
@@ -52,40 +52,44 @@ const PasswordView = () => {
             const { oldPassword, newPassword } = values;
             mutation.mutate({ oldPassword, newPassword });
           }}>
-          <div className="flex space-x-4">
-            <Controller
-              name="oldPassword"
-              control={formMethods.control}
-              render={({ field: { value } }) => (
-                <TextField
-                  name="oldPassword"
-                  label={t("old_password")}
-                  value={value}
-                  type="password"
-                  onChange={(e) => {
-                    formMethods.setValue("oldPassword", e?.target.value);
-                  }}
-                />
-              )}
-            />
-            <Controller
-              name="newPassword"
-              control={formMethods.control}
-              render={({ field: { value } }) => (
-                <TextField
-                  name="newPassword"
-                  label={t("new_password")}
-                  value={value}
-                  type="password"
-                  placeholder={t("secure_password")}
-                  onChange={(e) => {
-                    formMethods.setValue("newPassword", e?.target.value);
-                  }}
-                />
-              )}
-            />
+          <div className="max-w-[38rem] sm:flex sm:space-x-4">
+            <div className="flex-grow">
+              <Controller
+                name="oldPassword"
+                control={formMethods.control}
+                render={({ field: { value } }) => (
+                  <TextField
+                    name="oldPassword"
+                    label={t("old_password")}
+                    value={value}
+                    type="password"
+                    onChange={(e) => {
+                      formMethods.setValue("oldPassword", e?.target.value);
+                    }}
+                  />
+                )}
+              />
+            </div>
+            <div className="flex-grow">
+              <Controller
+                name="newPassword"
+                control={formMethods.control}
+                render={({ field: { value } }) => (
+                  <TextField
+                    name="newPassword"
+                    label={t("new_password")}
+                    value={value}
+                    type="password"
+                    placeholder={t("secure_password")}
+                    onChange={(e) => {
+                      formMethods.setValue("newPassword", e?.target.value);
+                    }}
+                  />
+                )}
+              />
+            </div>
           </div>
-          <p>
+          <p className="text-sm text-gray-600">
             <Trans i18nKey="valid_password">
               Password must be at least at least 7 characters, mix of uppercase & lowercase letters, and
               contain at least 1 number

--- a/apps/web/pages/v2/settings/security/two-factor-auth.tsx
+++ b/apps/web/pages/v2/settings/security/two-factor-auth.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
@@ -34,12 +34,12 @@ const TwoFactorAuthView = () => {
         />
         <div>
           <div className="flex">
-            <p>{t("two_factor_auth")}</p>
+            <p className="font-semibold">{t("two_factor_auth")}</p>
             <Badge className="ml-2 text-xs" variant={user?.twoFactorEnabled ? "success" : "gray"}>
               {user?.twoFactorEnabled ? t("enabled") : t("disabled")}
             </Badge>
           </div>
-          <p>Add an extra layer of security to your account.</p>
+          <p className="text-sm text-gray-600">Add an extra layer of security to your account.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## What does this PR do?

Improves design of settings/security V2 pages.

Fixes ' 2fa: color and size of text 'Add an extra...' is wrong' of https://github.com/calcom/cal.com/issues/4009
Fixes 'Password change in settings: input fields too small, text under input fields could be smaller and in lighter gray' of https://github.com/calcom/cal.com/issues/4009

---

Before:
<img width="810" alt="Screenshot 2022-09-01 at 21 57 15" src="https://user-images.githubusercontent.com/30310907/188042859-7b2b3777-862d-4f0c-a730-f9e55f25bb31.png">

After:
<img width="619" alt="Screenshot 2022-09-01 at 21 56 18" src="https://user-images.githubusercontent.com/30310907/188042899-72a5cdcf-f005-4762-9f73-80f447645a65.png">

---

Before: 
<img width="461" alt="Screenshot 2022-09-01 at 21 57 18" src="https://user-images.githubusercontent.com/30310907/188042915-27bb063c-5a15-4b7c-86ef-f22e4191c6b5.png">

After:
<img width="338" alt="Screenshot 2022-09-01 at 21 56 40" src="https://user-images.githubusercontent.com/30310907/188042936-f6bc4dd1-5566-4f76-beda-8b3506a30050.png">


