### PR TITLE
#4110: Made vertical tabs in bookings and event types pages sticky.

### DIFF
--- a/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
@@ -243,7 +243,7 @@ function EventTypeSingleLayout({
       <ClientSuspense fallback={<Loader />}>
         <div className="flex flex-col xl:flex-row xl:space-x-8">
           <div className="hidden xl:block">
-            <VerticalTabs tabs={EventTypeTabs} />
+            <VerticalTabs tabs={EventTypeTabs} sticky />
           </div>
           <div className="p-2 md:p-0 xl:hidden">
             <HorizontalTabs tabs={EventTypeTabs} />

--- a/packages/ui/v2/core/layouts/BookingLayout.tsx
+++ b/packages/ui/v2/core/layouts/BookingLayout.tsx
@@ -42,7 +42,7 @@ export default function BookingLayout({
     <Shell {...rest}>
       <div className="flex flex-col p-2 md:p-0 xl:flex-row ">
         <div className="hidden xl:block">
-          <VerticalTabs tabs={tabs} />
+          <VerticalTabs tabs={tabs} sticky />
         </div>
         <div className="block xl:hidden">
           <HorizontalTabs tabs={tabs} />

--- a/packages/ui/v2/core/navigation/tabs/VerticalTabs.tsx
+++ b/packages/ui/v2/core/navigation/tabs/VerticalTabs.tsx
@@ -1,16 +1,22 @@
 import { FC } from "react";
 
+import { classNames } from "@calcom/lib";
+
 import VerticalTabItem, { VerticalTabItemProps } from "./VerticalTabItem";
 
 export interface NavTabProps {
   tabs: VerticalTabItemProps[];
   children?: React.ReactNode;
   className?: string;
+  sticky?: boolean;
 }
 
-const NavTabs: FC<NavTabProps> = ({ tabs, className = "", ...props }) => {
+const NavTabs: FC<NavTabProps> = ({ tabs, className = "", sticky, ...props }) => {
   return (
-    <nav className={`no-scrollbar flex flex-col space-y-1 ${className}`} aria-label="Tabs" {...props}>
+    <nav
+      className={classNames(`no-scrollbar flex flex-col space-y-1 ${className}`, sticky && "sticky top-0")}
+      aria-label="Tabs"
+      {...props}>
       {props.children}
       {tabs.map((tab, idx) => (
         <VerticalTabItem {...tab} key={idx} />


### PR DESCRIPTION
## What does this PR do?

Made sidebars in booking and event types pages sticky. For this I added an extra prop `sticky` to the `VerticalTabs` component, so this sticky behaviour is opt-in, rather than the default. 

Fixes #4110

Loom Video: https://www.loom.com/share/463d5c756ed24073beecfc05a4e22351

**Environment**: Staging(main branch)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Verify that on both of the pages (bookings and event-types) the sticky bar behaviour is correct.
- [ ] Verify that on both of the pages the sticky bar behaviour doesn't break anything on tablet and mobile (it shouldn't be used there, we use horizontal tabs instead of the vertical tabs there)
