### PR TITLE
Fix mobile styling for Rainbowkit gate

### DIFF
--- a/packages/app-store/rainbow/components/RainbowKit.tsx
+++ b/packages/app-store/rainbow/components/RainbowKit.tsx
@@ -113,7 +113,7 @@ const BalanceCheck: React.FC<RainbowGateProps> = ({ chainId, setToken, tokenAddr
   return (
     <main className="mx-auto max-w-3xl py-24 px-4">
       <div className="rounded-md border border-neutral-200 dark:border-neutral-700 dark:hover:border-neutral-600">
-        <div className="hover:border-brand dark:bg-darkgray-100 flex min-h-[120px] grow border-b border-neutral-200 bg-white p-4 text-center first:rounded-t-md last:rounded-b-md last:border-b-0 hover:bg-white dark:border-neutral-700 dark:hover:border-neutral-600 md:flex-row md:text-left ">
+        <div className="hover:border-brand dark:bg-darkgray-100 flex min-h-[120px] grow flex-col border-b border-neutral-200 bg-white p-6 text-center first:rounded-t-md last:rounded-b-md last:border-b-0 hover:bg-white dark:border-neutral-700 dark:hover:border-neutral-600 md:flex-row md:text-left">
           <span className="mb-4 grow md:mb-0">
             <h2 className="mb-2 grow font-semibold text-neutral-900 dark:text-white">Token Gate</h2>
             {isLoading && (


### PR DESCRIPTION
## What does this PR do?

Previously:

<img width="562" alt="Screen Shot 2022-09-06 at 7 20 55 AM" src="https://user-images.githubusercontent.com/8162609/188661272-56754842-8c23-4843-aa60-1d73540cdb17.png">

Fix:

<img width="562" alt="Screen Shot 2022-09-06 at 7 26 45 AM" src="https://user-images.githubusercontent.com/8162609/188661282-ef4a1d3c-fa6e-451a-8d2d-95ef5ac29c59.png">

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

On an event that has web3 events enabled, on route `http://localhost:3000/admin/[event]` you will see the change in effect by changing browser window size.
