### PR TITLE
fixed dropdown component styling, added new shadow-dropdown

### DIFF
--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -151,6 +151,9 @@ module.exports = {
           900: "#f3f4f6",
         },
       },
+      boxShadow: {
+        dropdown: "0px 2px 6px -1px rgba(0, 0, 0, 0.08)",
+      },
       fontFamily: {
         cal: ['"Cal Sans"', "sans-serif"],
         mono: ["Roboto Mono", "monospace"],

--- a/packages/ui/v2/core/Dropdown.tsx
+++ b/packages/ui/v2/core/Dropdown.tsx
@@ -34,7 +34,7 @@ export const DropdownMenuContent = forwardRef<HTMLDivElement, DropdownMenuConten
         portalled={props.portalled}
         align={align}
         {...props}
-        className="w-50 relative z-10 mt-1 -ml-0 origin-top-right rounded-md bg-white text-sm ring-1 ring-black ring-opacity-5 focus:outline-none"
+        className="shadow-dropdown w-50 relative z-10 mt-1 -ml-0 origin-top-right rounded-md border border-gray-200 bg-white text-sm"
         ref={forwardedRef}>
         {children}
       </DropdownMenuPrimitive.Content>
@@ -124,12 +124,12 @@ export const DropdownItem = (props: DropdownItemProps) => {
     <ButtonOrLink
       {...props}
       className={classNames(
-        "inline-flex items-center px-3 py-[10px] text-gray-600",
+        "inline-flex items-center px-3 py-2 text-gray-700 hover:text-gray-900",
         props.color === "destructive" ? "hover:bg-red-100 hover:text-red-700" : " hover:bg-gray-100"
       )}>
       <>
         {StartIcon && <StartIcon />}
-        <div className="mx-2 text-black">{props.children}</div>
+        <div className="mx-2">{props.children}</div>
         {EndIcon && <EndIcon />}
       </>
     </ButtonOrLink>


### PR DESCRIPTION
before

<img width="270" alt="CleanShot 2022-09-06 at 19 42 38@2x" src="https://user-images.githubusercontent.com/8019099/188703592-4a94a784-3724-4517-9854-ad50ebd2dc07.png">


after

<img width="291" alt="CleanShot 2022-09-06 at 19 42 13@2x" src="https://user-images.githubusercontent.com/8019099/188703511-9c13716d-3191-4243-9b95-537c795d4c6d.png">
