### PR TITLE
fixed booking navbar, fixed bookings buttons, fixed /success dark mode

### DIFF
--- a/apps/web/components/ui/TableActions.tsx
+++ b/apps/web/components/ui/TableActions.tsx
@@ -72,7 +72,7 @@ const TableActions: FC<Props> = ({ actions }) => {
   });
   return (
     <>
-      <div className="hidden space-x-2 rtl:space-x-reverse lg:block">
+      <div className="hidden space-x-2 rtl:space-x-reverse lg:flex">
         {actions.map((action) => {
           const button = (
             <Button

--- a/apps/web/pages/v2/success.tsx
+++ b/apps/web/pages/v2/success.tsx
@@ -261,7 +261,7 @@ export default function Success(props: SuccessProps) {
   const locationToDisplay = getSuccessPageLocationMessage(location, t);
 
   return (
-    <div className={isEmbed ? "" : "h-screen bg-neutral-100 dark:bg-neutral-900"} data-testid="success-page">
+    <div className={isEmbed ? "" : "h-screen"} data-testid="success-page">
       {userIsOwner && !isEmbed && (
         <div className="mt-2 ml-4 -mb-4">
           <Link href={eventType.recurringEvent?.count ? "/bookings/recurring" : "/bookings/upcoming"}>
@@ -289,7 +289,7 @@ export default function Success(props: SuccessProps) {
               <div
                 className={classNames(
                   "inline-block transform overflow-hidden rounded-lg border sm:my-8 sm:max-w-xl",
-                  isBackgroundTransparent ? "" : "bg-white dark:border-neutral-700 dark:bg-gray-800",
+                  isBackgroundTransparent ? "" : "dark:bg-darkgray-100 bg-white dark:border-neutral-700",
                   "px-8 pt-5 pb-4 text-left align-bottom transition-all sm:w-full sm:py-8 sm:align-middle"
                 )}
                 role="dialog"
@@ -333,7 +333,7 @@ export default function Success(props: SuccessProps) {
                   <div className="mt-3">
                     <p className="text-neutral-600 dark:text-gray-300">{getTitle()}</p>
                   </div>
-                  <div className="border-bookinglightest text-bookingdark mt-8 grid grid-cols-3 border-t pt-8 text-left dark:border-gray-900 dark:text-gray-300">
+                  <div className="border-bookinglightest text-bookingdark dark:border-darkgray-300 mt-8 grid grid-cols-3 border-t pt-8 text-left dark:text-gray-300">
                     <div className="font-medium">{t("what")}</div>
                     <div className="col-span-2 mb-6 last:mb-0">{eventName}</div>
                     <div className="font-medium">{t("when")}</div>
@@ -561,7 +561,7 @@ export default function Success(props: SuccessProps) {
                 {session === null && !(userIsOwner || props.hideBranding) && (
                   <>
                     <hr className="border-bookinglightest" />
-                    <div className="border-bookinglightest text-booking-lighter pt-8 text-center text-xs dark:border-gray-900 dark:text-white">
+                    <div className="border-bookinglightest text-booking-lighter dark:border-darkgray-300 pt-8 text-center text-xs dark:text-white">
                       <a href="https://cal.com/signup">{t("create_booking_link_with_calcom")}</a>
 
                       <form
@@ -577,7 +577,7 @@ export default function Success(props: SuccessProps) {
                           name="email"
                           id="email"
                           defaultValue={router.query.email}
-                          className="focus:border-brand border-bookinglightest mt-0 block w-full rounded-sm border-gray-300 shadow-sm focus:ring-black dark:border-gray-900 dark:bg-black dark:text-white sm:text-sm"
+                          className="focus:border-brand border-bookinglightest dark:border-darkgray-300 mt-0 block w-full rounded-sm border-gray-300 shadow-sm focus:ring-black dark:bg-black dark:text-white sm:text-sm"
                           placeholder="rick.astley@cal.com"
                         />
                         <Button size="lg" type="submit" className="min-w-max" color="primary">

--- a/packages/ui/v2/core/layouts/AppsLayout.tsx
+++ b/packages/ui/v2/core/layouts/AppsLayout.tsx
@@ -22,7 +22,7 @@ export default function AppsLayout({
 }: { children: React.ReactNode } & ComponentProps<typeof Shell>) {
   return (
     <Shell {...rest}>
-      <div className="flex flex-col p-2 md:p-0 xl:flex-row ">
+      <div className="flex flex-col xl:flex-row ">
         <div className="block lg:hidden">
           <HorizontalTabs tabs={tabs} />
         </div>

--- a/packages/ui/v2/core/layouts/BookingLayout.tsx
+++ b/packages/ui/v2/core/layouts/BookingLayout.tsx
@@ -43,7 +43,7 @@ export default function BookingLayout({
 }: { children: React.ReactNode } & ComponentProps<typeof Shell>) {
   return (
     <Shell {...rest}>
-      <div className="flex flex-col p-2 md:p-0 xl:flex-row ">
+      <div className="flex flex-col xl:flex-row ">
         <div className="hidden xl:block">
           <VerticalTabs tabs={tabs} sticky />
         </div>

--- a/packages/ui/v2/core/navigation/tabs/VerticalTabItem.tsx
+++ b/packages/ui/v2/core/navigation/tabs/VerticalTabItem.tsx
@@ -66,7 +66,7 @@ const VerticalTabItem: FC<VerticalTabItemProps> = ({ name, href, tabName, info, 
               onClick={onClick}
               className={classNames(
                 props.textClassNames || "text-sm font-medium leading-none text-gray-600",
-                "group flex h-14 w-64 flex-row items-center rounded-md px-3 py-[10px] hover:bg-gray-100 group-hover:text-gray-700  [&[aria-current='page']]:bg-gray-200 [&[aria-current='page']]:text-gray-900",
+                "group flex w-64 flex-row items-center rounded-md px-3 py-[10px] hover:bg-gray-100 group-hover:text-gray-700  [&[aria-current='page']]:bg-gray-200 [&[aria-current='page']]:text-gray-900",
                 props.disabled && "pointer-events-none !opacity-30",
                 (isChild || !props.icon) && "ml-7 mr-5 w-auto",
                 !info ? "h-9" : "h-14",


### PR DESCRIPTION
before
<img width="1218" alt="CleanShot 2022-09-07 at 10 04 27@2x" src="https://user-images.githubusercontent.com/8019099/188824543-46e3233c-8e6c-4f37-8625-59d73b29cdde.png">


after
<img width="1240" alt="CleanShot 2022-09-07 at 10 03 52@2x" src="https://user-images.githubusercontent.com/8019099/188824393-4df331c2-79bc-41c1-ac75-e240258dee47.png">


<img width="936" alt="CleanShot 2022-09-07 at 10 02 51@2x" src="https://user-images.githubusercontent.com/8019099/188824357-adef01ee-4f7a-43a7-ae73-50009693c91f.png">
