### PR TITLE
Add delete tooltip to event detail

### DIFF
--- a/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
@@ -206,6 +206,7 @@ function EventTypeSingleLayout({
               size="icon"
               StartIcon={Icon.FiTrash}
               combined
+              tooltip={t("delete")}
               disabled={!hasPermsToDelete}
               onClick={() => setDeleteDialogOpen(true)}
             />


### PR DESCRIPTION
closes #4249

before

<img width="482" alt="image" src="https://user-images.githubusercontent.com/82475733/188975425-185813d4-4aea-4fb8-a7cb-5bbc1c6429bb.png">


after

<img width="530" alt="image" src="https://user-images.githubusercontent.com/82475733/188975205-fa869014-173e-4672-a49a-c6ebcf55af84.png">
