### PR TITLE
fixed dark mode team page

### DIFF
--- a/apps/web/components/ui/AvatarGroup.tsx
+++ b/apps/web/components/ui/AvatarGroup.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import classNames from "@lib/classNames";
 
-import Avatar from "@components/ui/Avatar";
 import { AvatarSSR } from "@components/ui/AvatarSSR";
 
 export type AvatarGroupProps = {

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -62,7 +62,7 @@ function TeamPage({ team }: TeamPageProps) {
               </div>
               <div className="mt-1 self-center">
                 <AvatarGroup
-                  border="border-2 border-white"
+                  border="border-2 border-white dark:border-darkgray-100"
                   truncateAfter={4}
                   className="flex flex-shrink-0"
                   size={10}
@@ -110,7 +110,7 @@ function TeamPage({ team }: TeamPageProps) {
               </div>
             </div>
 
-            <aside className="mt-8 text-center dark:text-white">
+            <aside className="mt-8 mb-16 flex justify-center text-center dark:text-white">
               <Button
                 color="minimal"
                 EndIcon={Icon.FiArrowRight}

--- a/packages/ui/v2/modules/event-types/EventTypeDescription.tsx
+++ b/packages/ui/v2/modules/event-types/EventTypeDescription.tsx
@@ -31,7 +31,7 @@ export const EventTypeDescription = ({ eventType, className }: EventTypeDescript
     <>
       <div className={classNames("dark:text-darkgray-800 text-neutral-500", className)}>
         {eventType.description && (
-          <h2 className="dark:text-darkgray-800 max-w-[280px] overflow-hidden text-ellipsis py-2 text-sm leading-none text-gray-600 opacity-60 sm:max-w-[500px]">
+          <h2 className="dark:text-darkgray-800 max-w-[280px] overflow-hidden text-ellipsis py-2 text-sm text-gray-600 opacity-60 sm:max-w-[500px]">
             {eventType.description.substring(0, 100)}
             {eventType.description.length > 100 && "..."}
           </h2>


### PR DESCRIPTION
before
<img width="910" alt="CleanShot 2022-09-08 at 23 02 08@2x" src="https://user-images.githubusercontent.com/8019099/189225284-b9237fe1-08fa-4644-b56a-e4aed7c3dff2.png">


after
<img width="919" alt="CleanShot 2022-09-08 at 23 01 54@2x" src="https://user-images.githubusercontent.com/8019099/189225251-34679666-1228-48f7-a741-cea71b50fa35.png">

___

before
<img width="954" alt="CleanShot 2022-09-08 at 22 54 06@2x" src="https://user-images.githubusercontent.com/8019099/189223991-2b89aa0e-99a6-4bd3-9f19-3a1e257aa756.png">


after
<img width="868" alt="CleanShot 2022-09-08 at 22 53 53@2x" src="https://user-images.githubusercontent.com/8019099/189223972-ec23f239-a8ab-4205-93db-f4a0b1606d10.png">


__


before
<img width="176" alt="CleanShot 2022-09-08 at 22 53 28@2x" src="https://user-images.githubusercontent.com/8019099/189223886-069fbdab-7708-4f5d-9c4e-acef85e32bc2.png">

after
<img width="239" alt="CleanShot 2022-09-08 at 22 53 13@2x" src="https://user-images.githubusercontent.com/8019099/189223802-cc638458-6fe8-4740-8885-d8fadb64138f.png">
