### PR TITLE
Dynamic link description on Availability page & Booking page

### DIFF
--- a/apps/web/components/eventtype/EventTypeDescriptionSafeHTML.tsx
+++ b/apps/web/components/eventtype/EventTypeDescriptionSafeHTML.tsx
@@ -1,11 +1,13 @@
 export type EventTypeDescriptionSafeProps = {
-  eventType: { description: string | null };
+  eventType: { description: string | null; isDynamic?: boolean };
 };
 
 export const EventTypeDescriptionSafeHTML = ({ eventType }: EventTypeDescriptionSafeProps) => {
   const props: JSX.IntrinsicElements["div"] = { suppressHydrationWarning: true };
   // @ts-expect-error: @see packages/prisma/middleware/eventTypeDescriptionParseAndSanitize.ts
   if (eventType.description) props.dangerouslySetInnerHTML = { __html: eventType.descriptionAsSafeHTML };
+  // Dynamic link description is not set/pulled from the DB, hence we can allow it here as is
+  if (eventType.isDynamic) props.dangerouslySetInnerHTML = { __html: eventType.description || "" };
   return <div {...props} />;
 };
 


### PR DESCRIPTION
## What does this PR do?

Allows Dynamic event description on the Availability and Booking pages

Before:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/52925846/189281014-fe6da46e-359c-4c19-9748-64cbfbd7aa1e.png">

After:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/52925846/189280932-3eb26597-db60-4916-88f8-d7ff38baeb65.png">


**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
