### PR TITLE
fix: add translation in getServerSideProps

### DIFF
--- a/apps/web/pages/getting-started/[[...step]].tsx
+++ b/apps/web/pages/getting-started/[[...step]].tsx
@@ -1,4 +1,5 @@
 import { GetServerSidePropsContext } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { z } from "zod";
@@ -180,6 +181,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   return {
     props: {
+      ...(await serverSideTranslations(context.locale ?? "", ["common"])),
       user: {
         ...user,
         emailMd5: crypto.createHash("md5").update(user.email).digest("hex"),


### PR DESCRIPTION
## What does this PR do?
in on-boarding page, text's are translated after a flash. this PR fixes that.

before:
[i8n-fix-before.webm](https://user-images.githubusercontent.com/84864519/189656353-7f2b6c3f-1fc7-43fa-9278-18b7bc270904.webm)

after:
[i8n-fix-after.webm](https://user-images.githubusercontent.com/84864519/189656406-4c8f41b0-d5a6-4f74-bc2d-89cf9f8e15bf.webm)


 

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)