### PR TITLE
Fix event edit link styling issue in Safari

### DIFF
--- a/apps/web/pages/v2/event-types/index.tsx
+++ b/apps/web/pages/v2/event-types/index.tsx
@@ -317,7 +317,6 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
                             <DropdownMenuContent>
                               <DropdownMenuItem>
                                 <DropdownItem
-                                  type="button"
                                   href={"/event-types/" + type.id}
                                   disabled={type.$disabled}
                                   StartIcon={Icon.FiEdit2}>
@@ -432,7 +431,6 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
                       ) : null}
                       <DropdownMenuItem className="outline-none">
                         <Button
-                          type="button"
                           href={"/event-types/" + type.id}
                           color="minimal"
                           className="w-full"


### PR DESCRIPTION
Before

<img width="872" alt="CleanShot 2022-09-13 at 00 03 06@2x" src="https://user-images.githubusercontent.com/82475733/189766563-8db52776-8f4a-41ad-8b5e-24875ff3690e.png">

After

<img width="869" alt="CleanShot 2022-09-13 at 00 02 36@2x" src="https://user-images.githubusercontent.com/82475733/189766509-a7bdceb7-1a52-4f2d-9007-3d8200c6b73c.png">

Fixes  #4377
