### PR TITLE
Bugfix: dynamic import rainbow

### DIFF
--- a/apps/web/components/Gates.tsx
+++ b/apps/web/components/Gates.tsx
@@ -1,7 +1,6 @@
+import dynamic from "next/dynamic";
 import { Dispatch, useState, useEffect } from "react";
 import { JSONObject } from "superjson/dist/types";
-
-import RainbowGate from "@calcom/app-store/rainbow/components/RainbowKit";
 
 export type Gate = undefined | "rainbow"; // Add more like ` | "geolocation" | "payment"`
 
@@ -15,6 +14,8 @@ type GateProps = {
   metadata: JSONObject;
   dispatch: Dispatch<Partial<GateState>>;
 };
+
+const RainbowGate = dynamic(() => import("@calcom/app-store/rainbow/components/RainbowKit"));
 
 // To add a new Gate just add the gate logic to the switch statement
 const Gates: React.FC<GateProps> = ({ children, gates, metadata, dispatch }) => {

--- a/apps/web/components/v2/eventtype/EventAppsTab.tsx
+++ b/apps/web/components/v2/eventtype/EventAppsTab.tsx
@@ -5,6 +5,7 @@ import { Controller } from "react-hook-form";
 import { FormattedNumber, IntlProvider } from "react-intl";
 
 import { SelectGifInput } from "@calcom/app-store/giphy/components";
+import RainbowInstallForm from "@calcom/app-store/rainbow/components/RainbowInstallForm";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Icon } from "@calcom/ui";
 import { Alert, Button, EmptyScreen, Select, Switch, TextField } from "@calcom/ui/v2";
@@ -46,13 +47,19 @@ export const EventAppsTab = ({
   currency,
   eventType,
   hasGiphyIntegration,
+  hasRainbowIntegration,
 }: Pick<
   EventTypeSetupInfered,
-  "eventType" | "hasPaymentIntegration" | "hasGiphyIntegration" | "currency"
+  "eventType" | "hasPaymentIntegration" | "hasGiphyIntegration" | "hasRainbowIntegration" | "currency"
 >) => {
   const formMethods = useFormContext<FormValues>();
   const [showGifSelection, setShowGifSelection] = useState(
     hasGiphyIntegration && !!eventType.metadata["giphyThankYouPage"]
+  );
+  const [showRainbowSection, setShowRainbowSection] = useState(
+    hasRainbowIntegration &&
+      !!eventType.metadata["blockchainId"] &&
+      !!eventType.metadata["smartContractAddress"]
   );
   const [requirePayment, setRequirePayment] = useState(eventType.price > 0);
   const recurringEventDefined = eventType.recurringEvent?.count !== undefined;
@@ -169,6 +176,29 @@ export const EventAppsTab = ({
               onChange={(url: string) => {
                 formMethods.setValue("giphyThankYouPage", url);
               }}
+            />
+          )}
+        </AppCard>
+      )}
+      {hasRainbowIntegration && (
+        <AppCard
+          name="Rainbow"
+          description={t("confirmation_page_rainbow")}
+          logo="/api/app-store/rainbow/icon.svg"
+          switchOnClick={(e) => {
+            if (!e) {
+              formMethods.setValue("blockchainId", 1);
+              formMethods.setValue("smartContractAddress", "");
+            }
+
+            setShowRainbowSection(e);
+          }}
+          switchChecked={showRainbowSection}>
+          {showRainbowSection && (
+            <RainbowInstallForm
+              formMethods={formMethods}
+              blockchainId={(eventType.metadata.blockchainId as number) || 1}
+              smartContractAddress={(eventType.metadata.smartContractAddress as string) || ""}
             />
           )}
         </AppCard>

--- a/apps/web/pages/v2/event-types/[type]/index.tsx
+++ b/apps/web/pages/v2/event-types/[type]/index.tsx
@@ -80,6 +80,8 @@ export type FormValues = {
   };
   successRedirectUrl: string;
   giphyThankYouPage: string;
+  blockchainId: number;
+  smartContractAddress: string;
 };
 
 const querySchema = z.object({
@@ -178,6 +180,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
         eventType={eventType}
         hasPaymentIntegration={props.hasPaymentIntegration}
         hasGiphyIntegration={props.hasGiphyIntegration}
+        hasRainbowIntegration={props.hasRainbowIntegration}
       />
     ),
     workflows: (
@@ -210,6 +213,8 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
             seatsPerTimeSlot,
             recurringEvent,
             locations,
+            blockchainId,
+            smartContractAddress,
             ...input
           } = values;
 
@@ -226,6 +231,8 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
             seatsPerTimeSlot,
             metadata: {
               ...(giphyThankYouPage ? { giphyThankYouPage } : {}),
+              ...(smartContractAddress ? { smartContractAddress } : {}),
+              ...(blockchainId ? { blockchainId } : { blockchainId: 1 }),
             },
           });
         }}
@@ -418,6 +425,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   const hasGiphyIntegration = !!credentials.find((credential) => credential.type === "giphy_other");
 
+  const hasRainbowIntegration = !!credentials.find((credential) => credential.type === "rainbow_web3");
+
   // backwards compat
   if (eventType.users.length === 0 && !eventType.team) {
     const fallbackUser = await prisma.user.findUnique({
@@ -465,6 +474,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       teamMembers,
       hasPaymentIntegration,
       hasGiphyIntegration,
+      hasRainbowIntegration,
       currency,
       currentUserMembership,
     },

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1187,5 +1187,6 @@
   "add_new_form": "Add new form",
   "form_description": "Create your form to route a booker",
   "copy_link_to_form": "Copy link to form",
-  "pending_payment": "Pending payment"
+  "pending_payment": "Pending payment",
+  "confirmation_page_rainbow": "Token gate your event with tokens or NFTs on Ethereum, Polygon, and more."
 }


### PR DESCRIPTION
## What does this PR do?

Previous issue was Rainbow was not dynamically imported so Walletconnect RPCs were sending requests on behalf of users who didn't have Rainbow app installed.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/8162609/189775227-13bac542-125b-410d-aecf-f8a6274a9d0b.png">

With the fix it now dynamically imports RainbowKit so users who don't have RainbowKit app installed (or even enabled) will not see these requests come through:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/8162609/189775351-2e4ded0c-ceb2-462a-808c-e47da62000d9.png">

Also I tested to make sure it loads properly when Rainbow app is installed and enabled ✅

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
