### PR TITLE
dynamic import rainbow (only if installed)

### DIFF
--- a/apps/web/components/Gates.tsx
+++ b/apps/web/components/Gates.tsx
@@ -1,7 +1,6 @@
+import dynamic from "next/dynamic";
 import { Dispatch, useState, useEffect } from "react";
 import { JSONObject } from "superjson/dist/types";
-
-import RainbowGate from "@calcom/app-store/rainbow/components/RainbowKit";
 
 export type Gate = undefined | "rainbow"; // Add more like ` | "geolocation" | "payment"`
 
@@ -15,6 +14,8 @@ type GateProps = {
   metadata: JSONObject;
   dispatch: Dispatch<Partial<GateState>>;
 };
+
+const RainbowGate = dynamic(() => import("@calcom/app-store/rainbow/components/RainbowKit"));
 
 // To add a new Gate just add the gate logic to the switch statement
 const Gates: React.FC<GateProps> = ({ children, gates, metadata, dispatch }) => {


### PR DESCRIPTION
## What does this PR do?

Previous issue was Rainbow was not dynamically imported so Walletconnect RPCs were sending requests on behalf of users who didn't have Rainbow app installed.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/8162609/189775227-13bac542-125b-410d-aecf-f8a6274a9d0b.png">

With the fix it now dynamically imports RainbowKit so users who don't have RainbowKit app installed (or even enabled) will not see these requests come through:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/8162609/189775351-2e4ded0c-ceb2-462a-808c-e47da62000d9.png">

Also I tested to make sure it loads properly when Rainbow app is installed and enabled ✅

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)