### PR TITLE
Show user avatar in new event type dropdown

### DIFF
--- a/apps/web/components/eventtype/CreateEventType.tsx
+++ b/apps/web/components/eventtype/CreateEventType.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import type { z } from "zod";
 
 import classNames from "@calcom/lib/classNames";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import showToast from "@calcom/lib/notification";
 import { createEventTypeInput } from "@calcom/prisma/zod/custom/eventtype";
@@ -338,7 +339,7 @@ function CreateEventTeamsItem(props: {
       onSelect={() => props.openModal(props.option)}>
       <Avatar
         alt={props.option.name || ""}
-        imageSrc={props.option.image}
+        imageSrc={props.option.image || WEBAPP_URL + "/" + props.option.slug + "/avatar.png"}
         size={6}
         className="inline ltr:mr-2 rtl:ml-2"
       />


### PR DESCRIPTION
Before:
<img width="350" alt="Screenshot 2022-09-14 at 16 58 48" src="https://user-images.githubusercontent.com/25907159/190216759-1f6e232f-4ccd-46d2-8a23-2921765aa49f.png">

After with both user and team profile pic set in the DB:
<img width="350" alt="Screenshot 2022-09-14 at 16 59 20" src="https://user-images.githubusercontent.com/25907159/190216861-e3a67109-8ce6-4666-81af-4166cd36dd99.png">

After with user profile picture unset in the DB (Gravatar):
<img width="345" alt="Screenshot 2022-09-14 at 17 00 01" src="https://user-images.githubusercontent.com/25907159/190216981-6a0df4d7-84a9-4fcb-8701-e3636817ef19.png">