### PR TITLE
fix: text-black when state open radix button

### DIFF
--- a/packages/ui/v2/core/Button.tsx
+++ b/packages/ui/v2/core/Button.tsx
@@ -40,7 +40,7 @@ export type ButtonProps = ButtonBaseProps &
 
 const variantClassName = {
   primary:
-    "border border-transparent text-white bg-brand-500 hover:bg-brand-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500",
+    "border border-transparent text-white radix-state-open:text-black bg-brand-500 hover:bg-brand-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500",
   secondary: "border border-gray-200 text-brand-900 bg-white hover:bg-gray-100",
   minimal:
     "text-gray-700 bg-transparent hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:bg-gray-100 focus:ring-brand-900 dark:text-darkgray-900 hover:dark:text-gray-50",
@@ -118,7 +118,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
           <svg
             className={classNames(
               "mx-4 h-5 w-5 animate-spin",
-              color === "primary" ? "radix-state-open:text-black text-white dark:text-black" : "text-black"
+              color === "primary" ? "text-white dark:text-black" : "text-black"
             )}
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/packages/ui/v2/core/Button.tsx
+++ b/packages/ui/v2/core/Button.tsx
@@ -118,7 +118,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
           <svg
             className={classNames(
               "mx-4 h-5 w-5 animate-spin",
-              color === "primary" ? "text-white dark:text-black" : "text-black"
+              color === "primary" ? "radix-state-open:text-black text-white dark:text-black" : "text-black"
             )}
             xmlns="http://www.w3.org/2000/svg"
             fill="none"


### PR DESCRIPTION
## What does this PR do?
Adds classname `radix-open-state:text-black` to shared component button.

Fixes #4497

![image](https://user-images.githubusercontent.com/6601142/190537791-42543c6c-eeb9-4f05-aea1-6e1947c53d78.png)
