### PR TITLE
Mobile tweaks app store

### DIFF
--- a/apps/web/components/v2/apps/CalendarListContainer.tsx
+++ b/apps/web/components/v2/apps/CalendarListContainer.tsx
@@ -163,7 +163,7 @@ function ConnectedCalendarsList(props: Props) {
                     logo={item.integration.logo}
                     description={item.primary?.externalId || "No external Id"}
                     actions={
-                      <div className="w-32">
+                      <div className="flex w-32 justify-end">
                         <DisconnectIntegration
                           credentialId={item.credentialId}
                           trashIcon

--- a/apps/web/pages/v2/apps/installed/[category].tsx
+++ b/apps/web/pages/v2/apps/installed/[category].tsx
@@ -100,7 +100,7 @@ const IntegrationsList = ({ data }: { data: inferQueryOutput<"viewer.integration
           logo={item.logo}
           description={item.description}
           actions={
-            <div className="flex w-32 justify-center">
+            <div className="flex w-32 justify-end">
               <ConnectOrDisconnectIntegrationButton
                 credentialIds={item.credentialIds}
                 type={item.type}

--- a/packages/ui/v2/core/apps/AllApps.tsx
+++ b/packages/ui/v2/core/apps/AllApps.tsx
@@ -61,7 +61,7 @@ export default function AllApps({ apps }: AllAppsPropsType) {
 
   return (
     <div className="mb-16">
-      <div className="mb-4 flex flex-col justify-between lg:flex-row lg:items-center">
+      <div className="relative mb-4 flex flex-col justify-between lg:flex-row lg:items-center">
         <h2 className="text-lg font-semibold text-gray-900 ">
           {t("explore_apps", {
             category:
@@ -70,7 +70,7 @@ export default function AllApps({ apps }: AllAppsPropsType) {
           })}
         </h2>
         {leftVisible && (
-          <div className="absolute left-1/2 flex">
+          <div className="absolute top-[34px] flex lg:left-1/2 lg:top-0">
             <div className="flex h-12 w-5 items-center justify-end bg-white">
               <ChevronLeft className="h-4 w-4 text-gray-500" />
             </div>
@@ -112,7 +112,7 @@ export default function AllApps({ apps }: AllAppsPropsType) {
           ))}
         </ul>
         {rightVisible && (
-          <div className="absolute right-12 flex">
+          <div className="absolute right-0 top-[34px] flex lg:right-12 lg:top-0">
             <div className="flex h-12 w-5 bg-gradient-to-r from-transparent to-white" />
             <div className="flex h-12 w-5 items-center justify-end bg-white">
               <ChevronRight className="h-4 w-4 text-gray-500" />

--- a/packages/ui/v2/core/layouts/InstalledAppsLayout.tsx
+++ b/packages/ui/v2/core/layouts/InstalledAppsLayout.tsx
@@ -47,7 +47,7 @@ export default function InstalledAppsLayout({
   }
   return (
     <Shell {...rest}>
-      <div className="mt-10 flex flex-col p-2 md:p-0 xl:flex-row">
+      <div className="flex flex-col p-2 md:p-0 xl:flex-row">
         <div className="hidden xl:block">
           <VerticalTabs tabs={actualTabs} sticky />
         </div>


### PR DESCRIPTION
## What does this PR do?

Fixing a few things pointed out by @PeerRich regarding mobile:
 - Top margin between shell and content on installed apps page
 - Remove icon from installed apps to be aligned to the right

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/467258/190730521-feaeea4c-8782-4f03-ba76-b878aeb62271.png">

 - Arrows on App Store to show more categories

https://user-images.githubusercontent.com/467258/190730560-62503ab9-1fd9-43cd-a400-fdc244c0c775.mov

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to App Store and Installed Apps on Mobile and check the fixed items in description.