### PR TITLE
Removes reference to no longer available Heroku free tier from Vercel doc page

### DIFF
--- a/apps/docs/pages/self-hosting/vercel.mdx
+++ b/apps/docs/pages/self-hosting/vercel.mdx
@@ -6,7 +6,7 @@ title: Vercel
 
 ## Requirements
 
-You need a PostgresDB database hosted somewhere. [Heroku](https://www.heroku.com) and [Supabase](https://supabase.com/) offer great free options.
+You need a PostgresDB database hosted somewhere. [Supabase](https://supabase.com/) offers a great free option.
 
 ## Getting Started
 


### PR DESCRIPTION
## What does this PR do?

Removes reference to Heroku's unfortunately now terminated free database tier from the[ Vercel page](https://developer.cal.com/self-hosting/vercel) in the self-deployment docs. See announcement: https://blog.heroku.com/next-chapter


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] This change requires a documentation update
