### PR TITLE
Fix: event types skeleton is off #4540

### DIFF
--- a/apps/web/components/v2/eventtype/SkeletonLoader.tsx
+++ b/apps/web/components/v2/eventtype/SkeletonLoader.tsx
@@ -6,7 +6,7 @@ function SkeletonLoader() {
     <SkeletonContainer>
       <div className="mb-4 flex items-center">
         <SkeletonAvatar className="h-8 w-8" />
-        <div className="space-y-1">
+        <div className="flex flex-col space-y-1">
           <SkeletonText className="h-4 w-16" />
           <SkeletonText className="h-4 w-24" />
         </div>


### PR DESCRIPTION
## What does this PR do?

Fix User and URL skeleton alignment in the event types tab.

Fixes # #4540

![CleanShot 2022-09-17 at 13 15 10@2x](https://user-images.githubusercontent.com/47124762/190854723-e84c2fd3-1e8c-43ec-ad5d-0266ea987dac.png)
![CleanShot 2022-09-17 at 13 18 43@2x](https://user-images.githubusercontent.com/47124762/190854725-c634b464-1144-4e98-a34b-af9fb6b8fb95.png)

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
