### PR TITLE
Categories strip fix

### DIFF
--- a/packages/ui/v2/core/apps/AllApps.tsx
+++ b/packages/ui/v2/core/apps/AllApps.tsx
@@ -70,7 +70,7 @@ export default function AllApps({ apps }: AllAppsPropsType) {
           })}
         </h2>
         {leftVisible && (
-          <div className="absolute top-[34px] flex lg:left-1/2 lg:top-0">
+          <div className="absolute top-9 flex md:left-1/2 md:-top-1">
             <div className="flex h-12 w-5 items-center justify-end bg-white">
               <ChevronLeft className="h-4 w-4 text-gray-500" />
             </div>
@@ -112,7 +112,7 @@ export default function AllApps({ apps }: AllAppsPropsType) {
           ))}
         </ul>
         {rightVisible && (
-          <div className="absolute right-0 top-[34px] flex lg:right-12 lg:top-0">
+          <div className="absolute top-9 right-0 flex md:-top-1">
             <div className="flex h-12 w-5 bg-gradient-to-r from-transparent to-white" />
             <div className="flex h-12 w-5 items-center justify-end bg-white">
               <ChevronRight className="h-4 w-4 text-gray-500" />


### PR DESCRIPTION
## What does this PR do?

Yet a final tweak for categories strip in all apps

 Loom Video: https://www.loom.com/share/7b773e85df83453d8482143c73f7852b

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to `/apps` page and scroll to see all apps, where al the categories are listed. Change resolutions and reload, scrolling the categories strip should show arrows correctly positioned at end and beginning of strip to indicate more options are available.