### PR TITLE
fix: Fixed password peek alignment which wasnot correct in all places.

### DIFF
--- a/packages/ui/v2/core/form/fields.tsx
+++ b/packages/ui/v2/core/form/fields.tsx
@@ -264,12 +264,12 @@ export const PasswordField = forwardRef<HTMLInputElement, InputFieldProps>(funct
         placeholder="•••••••••••••"
         ref={ref}
         {...props}
-        className={classNames("pr-10", props.className)}
+        className={classNames("mb-0 pr-10", props.className)}
       />
 
       <Tooltip content={textLabel}>
         <button
-          className="absolute bottom-2 right-3 h-9 text-gray-900"
+          className="absolute bottom-0 right-3 h-9 text-gray-900"
           type="button"
           onClick={() => toggleIsPasswordVisible()}>
           {isPasswordVisible ? (


### PR DESCRIPTION
## What does this PR do?

I noticed that a recent change broke the alignment of the password peek icon on the login page. I did a small tweak to the password field component just now to fix it in both instances. The fix removes any margin applied to the password input field. I don't think we need to have them specifically on the input field (you'd rather add them on the wrapping components instead of giving components that can be used in a lot of places a margin), but if we ever want to add them back I'd suggest adding them to the place where I've now put `mb-0`.

## Old broken situation
<img width="703" alt="Screenshot 2022-09-18 at 21 51 20" src="https://user-images.githubusercontent.com/2969573/190925754-64432e1f-7fb0-4c57-91b5-ad1de22ebfba.png">

## New situation
<img width="734" alt="Screenshot 2022-09-18 at 21 46 02" src="https://user-images.githubusercontent.com/2969573/190925743-28d17a06-0e47-4876-9e40-a1a8be5ace49.png">
<img width="914" alt="Screenshot 2022-09-18 at 21 45 50" src="https://user-images.githubusercontent.com/2969573/190925744-4d7a670f-a870-4b72-ac10-6427ed666177.png">


**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Ensure all password fields like amazing ❤️
