### PR TITLE
fix-isSelectedProp-for-settings-calendars-switches-4532

### DIFF
--- a/apps/web/components/v2/settings/CalendarSwitch.tsx
+++ b/apps/web/components/v2/settings/CalendarSwitch.tsx
@@ -12,6 +12,7 @@ export function CalendarSwitch(props: {
   externalId: string;
   title: string;
   defaultSelected: boolean;
+  isSelected: boolean;
 }) {
   const { t } = useLocale();
 
@@ -69,7 +70,7 @@ export function CalendarSwitch(props: {
         key={props.externalId}
         name="enabled"
         label={props.title}
-        defaultChecked={props.defaultSelected}
+        defaultChecked={props.isSelected}
         onCheckedChange={(isOn: boolean) => {
           mutation.mutate({ isOn });
         }}

--- a/apps/web/pages/v2/settings/my-account/calendars.tsx
+++ b/apps/web/pages/v2/settings/my-account/calendars.tsx
@@ -132,6 +132,7 @@ const CalendarsView = () => {
                                 externalId={cal.externalId}
                                 title={cal.name || "Nameless calendar"}
                                 type={item.integration.type}
+                                isSelected={cal.isSelected}
                                 defaultSelected={cal.externalId === data?.destinationCalendar?.externalId}
                               />
                             ))}


### PR DESCRIPTION
## What does this PR do?

- Fixes prop isSelected not being sent to Calendar Switch comp

Fixes #4532 

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] From settings/calendar, calendar switches should check/uncheck as in other pages.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
