### PR TITLE
Fixes password prompt race condition

### DIFF
--- a/apps/web/pages/v2/settings/my-account/profile.tsx
+++ b/apps/web/pages/v2/settings/my-account/profile.tsx
@@ -1,5 +1,4 @@
 import crypto from "crypto";
-import { reset } from "mockdate";
 import { signOut } from "next-auth/react";
 import { useRef, useState, BaseSyntheticEvent, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";

--- a/apps/web/pages/v2/settings/my-account/profile.tsx
+++ b/apps/web/pages/v2/settings/my-account/profile.tsx
@@ -1,6 +1,7 @@
 import crypto from "crypto";
+import { reset } from "mockdate";
 import { signOut } from "next-auth/react";
-import { useRef, useState, BaseSyntheticEvent } from "react";
+import { useRef, useState, BaseSyntheticEvent, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { ErrorCode } from "@calcom/lib/auth";
@@ -124,15 +125,26 @@ const ProfileView = () => {
     deleteMeMutation.mutate({ password, totpCode });
   };
 
-  const formMethods = useForm({
-    defaultValues: {
-      avatar: user?.avatar || "",
-      username: user?.username || "",
-      name: user?.name || "",
-      email: user?.email || "",
-      bio: user?.bio || "",
-    },
-  });
+  const formMethods = useForm<{
+    avatar?: string;
+    username?: string;
+    name?: string;
+    email?: string;
+    bio?: string;
+  }>();
+
+  const { reset } = formMethods;
+
+  useEffect(() => {
+    if (user)
+      reset({
+        avatar: user?.avatar || "",
+        username: user?.username || "",
+        name: user?.name || "",
+        email: user?.email || "",
+        bio: user?.bio || "",
+      });
+  }, [reset, user]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const passwordRef = useRef<HTMLInputElement>(null!);


### PR DESCRIPTION
## What does this PR do?

FormMethods is created with default values that can sometimes be "" due to the user not being loaded. Because tests run very fast this can cause the form to be submitted before the default value had a chance to update from the initial draw. When this happens the form value != the email and the password prompt is shown.