### PR TITLE
No way to exit 'Create a new team screen'

### DIFF
--- a/apps/web/pages/v2/settings/teams/new/[[...step]].tsx
+++ b/apps/web/pages/v2/settings/teams/new/[[...step]].tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { z } from "zod";
@@ -7,6 +8,7 @@ import { z } from "zod";
 import AddNewTeamMembers from "@calcom/features/ee/teams/components/v2/AddNewTeamMembers";
 import CreateNewTeam from "@calcom/features/ee/teams/components/v2/CreateNewTeam";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Icon } from "@calcom/ui/Icon";
 
 import { StepCard } from "@components/getting-started/components/StepCard";
 import { Steps } from "@components/getting-started/components/Steps";
@@ -72,7 +74,13 @@ const CreateNewTeamPage = () => {
         <title>{t("create_new_team")}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-
+      <div className="mt-2 ml-4 -mb-4">
+        <Link href="/settings">
+          <a className="mt-2 inline-flex px-1 py-2 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-transparent dark:hover:text-white">
+            <Icon.FiChevronLeft className="h-5 w-5" /> {t("Exit")}
+          </a>
+        </Link>
+      </div>
       <div className="mx-auto px-4 py-24">
         <div className="relative">
           <div className="sm:mx-auto sm:w-full sm:max-w-[600px]">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds a "Exit" button to help users exit the "Create a new team screen".

Fixes #4523

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Demo
https://www.loom.com/share/ef01acdebbff4d78a87e5a0ba9254589

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Visit the settings page
- [ ] Click on Add a new team
