### PR TITLE
Redirect to /even-types after deleting an event type

### DIFF
--- a/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/v2/eventtype/EventTypeSingleLayout.tsx
@@ -1,4 +1,5 @@
 import { TFunction } from "next-i18next";
+import { useRouter } from "next/router";
 import { EventTypeSetupInfered, FormValues } from "pages/v2/event-types/[type]";
 import { useMemo, useState } from "react";
 import { Loader } from "react-feather";
@@ -110,6 +111,7 @@ function EventTypeSingleLayout({
 }: Props) {
   const utils = trpc.useContext();
   const { t } = useLocale();
+  const router = useRouter();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const hasPermsToDelete = currentUserMembership?.role !== "MEMBER" || !currentUserMembership;
@@ -118,6 +120,7 @@ function EventTypeSingleLayout({
     onSuccess: async () => {
       await utils.invalidateQueries(["viewer.eventTypes"]);
       showToast(t("event_type_deleted_successfully"), "success");
+      await router.push("/event-types");
       setDeleteDialogOpen(false);
     },
     onError: (err) => {


### PR DESCRIPTION
## What does this PR do?

Redirect to /event-types after deleting an event type.

Fixes #4694

**Environment**: Staging(main branch) / Production

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to /event-types
- Click on an event type to go to event type settings
- Click on trash icon to delete even type 
- Click 'Yes, delete event type'
- See that you are redirected back to /event-types

