### PR TITLE
Fix confirmation emails for attendees

### DIFF
--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -71,7 +71,7 @@ export default class AttendeeScheduledEmail extends BaseEmail {
         name: this.calEvent.team?.name || this.calEvent.organizer.name,
         date: this.getFormattedDate(),
       })}`,
-      html: renderEmail("AttendeeRescheduledEmail", {
+      html: renderEmail("AttendeeScheduledEmail", {
         calEvent: this.calEvent,
         attendee: this.attendee,
       }),


### PR DESCRIPTION
## What does this PR do?

Sending attendees the right confirmation email when booking an event. Currently, the attendee receives the email for rescheduled bookings. 

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Book an event 
- Check confirmation email of attendee