### PR TITLE
fix: calendar spacings for mobile on availability page

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -176,7 +176,7 @@ const SlotPicker = ({
       <DatePicker
         isLoading={isLoading}
         className={classNames(
-          "mt-8 w-full px-4 sm:mt-0 sm:min-w-[455px] md:px-5",
+          "mt-8 w-full px-4 pb-4 sm:mt-0 sm:min-w-[455px] md:px-5",
           selectedDate
             ? "sm:dark:border-darkgray-200 border-gray-200 sm:w-1/2 sm:border-r sm:p-4 sm:pr-6 md:w-1/3"
             : "sm:p-4"


### PR DESCRIPTION
## What does this PR do?

it fixes a small visual issue for the availability page for mobile devices
Before:
<img width="433" alt="Screenshot 2022-09-28 at 11 18 15" src="https://user-images.githubusercontent.com/8544449/192683974-bc2e7ac6-b0c2-4027-bfea-73275d548f90.png">
After: 
<img width="433" alt="Screenshot 2022-09-28 at 11 17 58" src="https://user-images.githubusercontent.com/8544449/192684001-76a3ace1-e18c-47f6-bba8-2fc7d83c26a3.png">

 Loom Video: https://www.loom.com/share/e53bccb5c7814e468b2052349c583831

**Environment**: Staging(main branch) / Production

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Login on a mobile device
- [ ] Create an event
- [ ] Preview the event
- [ ] See the is small padding on the bottom of the calendar

Thanks for creating this great project. If there are more issues available to contribute, I would be happy to. Cheers!