### PR TITLE
Fixing border in installed apps

### DIFF
--- a/apps/web/components/v2/apps/IntegrationListItem.tsx
+++ b/apps/web/components/v2/apps/IntegrationListItem.tsx
@@ -32,7 +32,7 @@ function IntegrationListItem(props: {
     <ListItem
       expanded={!!props.children}
       className={classNames(
-        "my-0 flex-col rounded-md border transition-colors duration-500",
+        "my-0 flex-col border transition-colors duration-500 first:rounded-t-md last:rounded-b-md",
         highlight ? "bg-yellow-100" : ""
       )}>
       <div className={classNames("flex w-full flex-1 items-center space-x-2 p-4 rtl:space-x-reverse")}>

--- a/apps/web/pages/v2/apps/installed/[category].tsx
+++ b/apps/web/pages/v2/apps/installed/[category].tsx
@@ -91,7 +91,7 @@ interface IntegrationsContainerProps {
 
 const IntegrationsList = ({ data }: { data: inferQueryOutput<"viewer.integrations"> }) => {
   return (
-    <List>
+    <List noBorderTreatment>
       {data.items.map((item) => (
         <IntegrationListItem
           name={item.name}


### PR DESCRIPTION
## What does this PR do?

Borders within the list of installed apps were not looking great aside from the Calendar category. Now fixed.

Before:
<kbd><img src="https://user-images.githubusercontent.com/467258/192876398-0daf54b7-671f-4aab-9d6a-c87c5a5e6833.png" /></kbd>

After:
<kbd><img src="https://user-images.githubusercontent.com/467258/192876466-6b2b5f8b-7d34-4b39-8272-19fe4ca4c2ac.png" /></kbd>

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to Installed Apps, Conferencing category, see the app list borders correctly shown.