### PR TITLE
Improved team layout when blocks have unequal content length.

### DIFF
--- a/apps/web/components/team/screens/Team.tsx
+++ b/apps/web/components/team/screens/Team.tsx
@@ -13,46 +13,48 @@ type TeamType = TeamPageProps["team"];
 type MembersType = TeamType["members"];
 type MemberType = MembersType[number];
 
-const Team = ({ team }: TeamPageProps) => {
+const Member = ({ member, teamName }: { member: MemberType; teamName: string }) => {
   const { t } = useLocale();
 
-  const Member = ({ member }: { member: MemberType }) => {
-    return (
-      <Link key={member.id} href={`/${member.username}`}>
-        <div className="sm:min-w-80 sm:max-w-80 dark:bg-darkgray-200 dark:hover:bg-darkgray-300 group flex h-full flex-col space-y-2 rounded-md bg-white p-4  hover:cursor-pointer hover:bg-gray-50 ">
-          <Avatar
-            size="md"
-            alt={member.name || ""}
-            imageSrc={WEBAPP_URL + "/" + member.username + "/avatar.png"}
-          />
-          <section className="line-clamp-4 mt-2 w-full space-y-1">
-            <p className="font-medium text-neutral-900 dark:text-white">{member.name}</p>
-            <p className="line-clamp-3 overflow-ellipsis text-sm font-normal text-neutral-500 dark:text-white">
-              {member.bio || t("user_from_team", { user: member.name, team: team.name })}
-            </p>
-          </section>
-        </div>
-      </Link>
-    );
-  };
+  return (
+    <Link key={member.id} href={`/${member.username}`}>
+      <div className="sm:min-w-80 sm:max-w-80 dark:bg-darkgray-200 dark:hover:bg-darkgray-300 group flex min-h-full w-[90%] flex-col space-y-2 rounded-md bg-white p-4  hover:cursor-pointer hover:bg-gray-50 ">
+        <Avatar
+          size="md"
+          alt={member.name || ""}
+          imageSrc={WEBAPP_URL + "/" + member.username + "/avatar.png"}
+        />
+        <section className="line-clamp-4 mt-2 w-full space-y-1">
+          <p className="font-medium text-neutral-900 dark:text-white">{member.name}</p>
+          <p className="line-clamp-3 overflow-ellipsis text-sm font-normal text-neutral-500 dark:text-white">
+            {member.bio || t("user_from_team", { user: member.name, team: teamName })}
+          </p>
+        </section>
+      </div>
+    </Link>
+  );
+};
 
-  const Members = ({ members }: { members: MembersType }) => {
-    if (!members || members.length === 0) {
-      return null;
-    }
+const Members = ({ members, teamName }: { members: MembersType; teamName: string }) => {
+  const { t } = useLocale();
 
-    return (
-      <section className="lg:min-w-lg mx-auto flex min-w-full max-w-5xl flex-wrap justify-center gap-x-6 gap-y-6">
-        {members.map((member) => {
-          return member.username !== null && <Member key={member.id} member={member} />;
-        })}
-      </section>
-    );
-  };
+  if (!members || members.length === 0) {
+    return null;
+  }
 
   return (
+    <section className="lg:min-w-lg mx-auto flex min-w-full max-w-5xl flex-wrap justify-center gap-x-6 gap-y-6">
+      {members.map((member) => {
+        return member.username !== null && <Member key={member.id} member={member} teamName={teamName} />;
+      })}
+    </section>
+  );
+};
+
+const Team = ({ team }: TeamPageProps) => {
+  return (
     <div>
-      <Members members={team.members} />
+      <Members members={team.members} teamName={team.name} />
     </div>
   );
 };

--- a/apps/web/components/team/screens/Team.tsx
+++ b/apps/web/components/team/screens/Team.tsx
@@ -1,10 +1,7 @@
 import Link from "next/link";
 import { TeamPageProps } from "pages/team/[slug]";
-import React from "react";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
-import Button from "@calcom/ui/Button";
-import { Icon } from "@calcom/ui/Icon";
 import { Avatar } from "@calcom/ui/v2";
 
 import { useLocale } from "@lib/hooks/useLocale";
@@ -13,7 +10,7 @@ type TeamType = TeamPageProps["team"];
 type MembersType = TeamType["members"];
 type MemberType = MembersType[number];
 
-const Member = ({ member, teamName }: { member: MemberType; teamName: string }) => {
+const Member = ({ member, teamName }: { member: MemberType; teamName: string | null }) => {
   const { t } = useLocale();
 
   return (
@@ -35,9 +32,7 @@ const Member = ({ member, teamName }: { member: MemberType; teamName: string }) 
   );
 };
 
-const Members = ({ members, teamName }: { members: MembersType; teamName: string }) => {
-  const { t } = useLocale();
-
+const Members = ({ members, teamName }: { members: MembersType; teamName: string | null }) => {
   if (!members || members.length === 0) {
     return null;
   }


### PR DESCRIPTION
## What does this PR do?

Was just looking at the [cal.com team page](https://cal.com/team/cal?members=1) and noticed that the layout was a bit skewed when some people had more content than others. While working on this I also noticed that the component kept on rerendering when clicking around on this page. This happened because all the components were defined inside the render, fixed that as well in this PR. 

**Before:** 
<img width="1235" alt="CleanShot 2022-09-29 at 16 17 04@2x" src="https://user-images.githubusercontent.com/2969573/193056123-9924216e-94ae-44b8-8821-f46b31e283e2.png">
<img width="450" alt="CleanShot 2022-09-29 at 16 17 21@2x" src="https://user-images.githubusercontent.com/2969573/193056186-7abd2fa2-6e17-4c67-ab47-2c13a3a98493.png">

**After this PR:**
<img width="1095" alt="CleanShot 2022-09-29 at 16 18 13@2x" src="https://user-images.githubusercontent.com/2969573/193056417-e5c428e6-ea02-4edf-80fa-69e59705c6aa.png">
<img width="482" alt="CleanShot 2022-09-29 at 16 18 31@2x" src="https://user-images.githubusercontent.com/2969573/193056493-9299bf3b-a0d0-4931-9b07-5bcf885ecb62.png">


**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
