### PR TITLE
#4724: Fix TimeZoneDropdown Position

### DIFF
--- a/apps/web/components/booking/TimeOptions.tsx
+++ b/apps/web/components/booking/TimeOptions.tsx
@@ -33,7 +33,7 @@ const TimeOptions: FC<Props> = ({ onToggle24hClock, onSelectTimeZone, timeFormat
   };
 
   return selectedTimeZone !== "" ? (
-    <div className="max-w-80 dark:border-darkgray-300 dark:bg-darkgray-200 absolute z-10 w-full rounded-sm border border-gray-200 bg-white px-4 pt-4 pb-3 shadow-sm">
+    <div className="md:max-w-80 dark:border-darkgray-300 dark:bg-darkgray-200 absolute z-10 -ml-4 w-full rounded-sm border border-gray-200 bg-white px-4 pt-4 pb-3 shadow-sm sm:-ml-8 md:ml-0">
       <div className="mb-4 flex">
         <div className="text-sm font-medium text-gray-600 dark:text-white">{t("time_options")}</div>
         <div className="ml-auto flex items-center">

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -241,7 +241,7 @@ function TimezoneDropdown({
   };
 
   return (
-    <Collapsible.Root open={isTimeOptionsOpen} onOpenChange={setIsTimeOptionsOpen} className="flex">
+    <Collapsible.Root open={isTimeOptionsOpen} onOpenChange={setIsTimeOptionsOpen} className="flex flex-col">
       <Collapsible.Trigger className="min-w-32 dark:text-darkgray-600 mb-2 -ml-2 px-2 text-left text-gray-600">
         <p className="text-sm font-medium">
           <Icon.FiGlobe className="mr-[10px] ml-[2px] -mt-[2px] inline-block h-4 w-4" />


### PR DESCRIPTION
## What does this PR do?

Adjusts Tailwind classNames to fix the TimeZoneDropdown positioning.

Summary:
- Change the flex direction to flex-col so the Dropdown sits underneath the trigger instead of the right.
- Add Tailwind classNames so that the Dropdown is 100vw on viewports <768px width. Styling for viewports with 768px width and higher are unchanged.

Fixes #4724 
Related #4764 

Loom Video: https://www.loom.com/share/de31c79bcc434d229e2c35085e58516e

**Environment**: Staging(main branch)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works


## Other Comments
I just noticed that @Jaibles also mentions styling issues in his original issue (#4724). I think it would be better to create a separate issue/PR.
> Requires confirmation and duration text size are also a size bigger than the other items and should be aligned.

![localhost_3000_free_issue-4724 (1)](https://user-images.githubusercontent.com/8443215/193180688-97ebb869-9ee4-4e6b-8170-b5875ca6f923.png)
