### PR TITLE
#4445: Fix to prevent bookings with long titles or a lot of content from overflowing on the page

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -262,7 +262,7 @@ function BookingListItem(booking: BookingItemProps) {
       </Dialog>
 
       <tr className="flex flex-col hover:bg-neutral-50 sm:flex-row">
-        <td className="hidden align-top ltr:pl-6 rtl:pr-6 sm:table-cell sm:w-48" onClick={onClick}>
+        <td className="hidden align-top ltr:pl-6 rtl:pr-6 sm:table-cell sm:min-w-[10rem]" onClick={onClick}>
           <div className="cursor-pointer py-4">
             <div className="text-sm leading-6 text-gray-900">{startTime}</div>
             <div className="text-sm text-gray-500">
@@ -296,7 +296,7 @@ function BookingListItem(booking: BookingItemProps) {
             </div>
           </div>
         </td>
-        <td className={"flex-1 px-4" + (isRejected ? " line-through" : "")} onClick={onClick}>
+        <td className={"w-full px-4" + (isRejected ? " line-through" : "")} onClick={onClick}>
           {/* Time and Badges for mobile */}
           <div className="w-full pt-4 pb-2 sm:hidden">
             <div className="flex w-full items-center justify-between sm:hidden">
@@ -335,7 +335,7 @@ function BookingListItem(booking: BookingItemProps) {
             <div
               title={booking.title}
               className={classNames(
-                "max-w-10/12 sm:max-w-56 truncate text-sm font-medium leading-6 text-neutral-900 md:max-w-max",
+                "max-w-10/12 sm:max-w-56 text-sm font-medium leading-6 text-neutral-900 md:max-w-full",
                 isCancelled ? "line-through" : ""
               )}>
               {booking.title}
@@ -366,7 +366,7 @@ function BookingListItem(booking: BookingItemProps) {
             )}
           </div>
         </td>
-        <td className="whitespace-nowrap py-4 pl-4 text-right text-sm font-medium ltr:pr-4 rtl:pl-4 sm:pl-0">
+        <td className="py-4 pl-4 text-right text-sm font-medium ltr:pr-4 rtl:pl-4 sm:pl-0">
           {isUpcoming && !isCancelled ? (
             <>
               {isPending && user?.id === booking.user?.id && <TableActions actions={pendingActions} />}

--- a/apps/web/pages/v2/bookings/[status].tsx
+++ b/apps/web/pages/v2/bookings/[status].tsx
@@ -90,7 +90,7 @@ export default function Bookings() {
 
   return (
     <BookingLayout heading={t("bookings")} subtitle={t("bookings_description")}>
-      <div className="flex w-full flex-1 flex-col" ref={animationParentRef}>
+      <div className="flex w-full flex-col" ref={animationParentRef}>
         {query.status === "error" && (
           <Alert severity="error" title={t("something_went_wrong")} message={query.error.message} />
         )}
@@ -103,7 +103,7 @@ export default function Bookings() {
              */}
 
             <div className="overflow-hidden rounded-md border border-gray-200">
-              <table className="w-full">
+              <table className="w-full max-w-full table-fixed">
                 <tbody className="divide-y divide-gray-200 bg-white" data-testid="bookings">
                   {query.data.pages.map((page, index) => (
                     <Fragment key={index}>


### PR DESCRIPTION
## What does this PR do?

Fixes overflowing on booking page when event has a long title or there's a lot of other content on the page. We removed the truncation (...) of the text and made the text go to the next line. 

Fixes #4445

### Before: 
<img width="1453" alt="CleanShot 2022-09-29 at 20 34 58@2x" src="https://user-images.githubusercontent.com/2969573/193209962-ebaec8a5-e545-4310-818b-6f3e6bca3c30.png">
<img width="1151" alt="CleanShot 2022-09-29 at 20 35 18@2x" src="https://user-images.githubusercontent.com/2969573/193209971-ae0480ae-7dad-42a5-97e6-7f40af206e95.png">
<img width="442" alt="CleanShot 2022-09-29 at 20 35 35@2x" src="https://user-images.githubusercontent.com/2969573/193209976-c6b4539b-c15d-4979-90ba-17dd4b093ad0.png">

### New situation
<img width="1504" alt="CleanShot 2022-09-30 at 08 59 26@2x" src="https://user-images.githubusercontent.com/2969573/193210096-281faf40-734f-4050-a5b1-4a9a5e815ce4.png">
<img width="1066" alt="CleanShot 2022-09-30 at 08 59 52@2x" src="https://user-images.githubusercontent.com/2969573/193210145-53241d82-69ab-482b-a617-8c8a4fc3f1c7.png">
<img width="372" alt="CleanShot 2022-09-30 at 09 00 14@2x" src="https://user-images.githubusercontent.com/2969573/193210230-804d7597-5d7c-435b-aff4-aa96f7db06ac.png">


**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Ensure that content on /booking isn't overflowing anymore with different types of titles. Also check multiple tabs on this page.