### PR TITLE
Added 100vh fix for ios to make sure it always fills the screen height

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -99,7 +99,7 @@ html.todesktop nav a[aria-current="page"]{
 
 html.todesktop nav a svg{
   color: #0272F7 !important
-} 
+}
 */
 
 
@@ -153,11 +153,11 @@ button[role="switch"][data-state="checked"] {
 }
 /* TODO: avoid global specific css */
 /* button[role="switch"][data-state="checked"] span {
-  transform: translateX(16px); 
+  transform: translateX(16px);
 } */
 
 /* DateRangePicker */
-/* 
+/*
   TODO:: Remove on V2 launch
  */
 .react-daterange-picker > .react-daterange-picker__wrapper {
@@ -480,5 +480,19 @@ hr {
   }
   to {
     opacity: 1;
+  }
+}
+
+/**
+ * Makes sure h-screen works on mobile Safari. By default h-screen
+ * does not take into account the height of the address bar, causing
+ * weird behaviour when scrolling — sometimes the height will be correct
+ * and sometimes it won't, depending on whether the address bar is
+ * in 'collapsed' state or not.
+ * @see: https://benborgers.com/posts/tailwind-h-screen
+ */
+@supports (-webkit-touch-callout: none) {
+  .h-screen {
+    height: -webkit-fill-available;
   }
 }


### PR DESCRIPTION
## What does this PR do?
By default 100vh on ios sometimes will and sometimes won't take into account the address bar height, causing on eg the event types or bookings pages the content to be behind our bottom nav. This fix makes sure it always has the correct height. 

## Before video
https://user-images.githubusercontent.com/2969573/193221162-6692ea2b-674a-4719-8c8f-3f92b75869e4.MP4

## After video
https://user-images.githubusercontent.com/2969573/193221263-d30d907f-f095-4c5a-a111-a270cf930b6a.MP4



**Environment**: Staging(main branch)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Verify that there's no weird scrolling behaviour anymore on eg event types and booking pages where content lies behind the bottom nav