### PR TITLE
#4533: Show correct time format on booking page

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -224,7 +224,7 @@ function TimezoneDropdown({
   const [isTimeOptionsOpen, setIsTimeOptionsOpen] = useState(false);
 
   useEffect(() => {
-    handleToggle24hClock(getIs24hClockFromLocalStorage() === true);
+    handleToggle24hClock(!!getIs24hClockFromLocalStorage());
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -24,7 +24,7 @@ import useTheme from "@calcom/lib/hooks/useTheme";
 import notEmpty from "@calcom/lib/notEmpty";
 import { getRecurringFreq } from "@calcom/lib/recurringStrings";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
-import { detectBrowserTimeFormat } from "@calcom/lib/timeFormat";
+import { detectBrowserTimeFormat, getIs24hClockFromLocalStorage } from "@calcom/lib/timeFormat";
 import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { Icon } from "@calcom/ui/Icon";
@@ -225,7 +225,7 @@ function TimezoneDropdown({
   const [isTimeOptionsOpen, setIsTimeOptionsOpen] = useState(false);
 
   useEffect(() => {
-    handleToggle24hClock(localStorage.getItem("timeOption.is24hClock") === "true");
+    handleToggle24hClock(getIs24hClockFromLocalStorage() === "true");
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -224,7 +224,7 @@ function TimezoneDropdown({
   const [isTimeOptionsOpen, setIsTimeOptionsOpen] = useState(false);
 
   useEffect(() => {
-    handleToggle24hClock(getIs24hClockFromLocalStorage() === "true");
+    handleToggle24hClock(getIs24hClockFromLocalStorage() === true);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -25,7 +25,6 @@ import notEmpty from "@calcom/lib/notEmpty";
 import { getRecurringFreq } from "@calcom/lib/recurringStrings";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import { detectBrowserTimeFormat, getIs24hClockFromLocalStorage } from "@calcom/lib/timeFormat";
-import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { Icon } from "@calcom/ui/Icon";
 import DatePicker from "@calcom/ui/v2/modules/booker/DatePicker";

--- a/apps/web/lib/clock.ts
+++ b/apps/web/lib/clock.ts
@@ -1,6 +1,10 @@
 // handles logic related to user clock display using 24h display / timeZone options.
 import dayjs from "@calcom/dayjs";
-import { isBrowserLocale24h } from "@calcom/lib/timeFormat";
+import {
+  getIs24hClockFromLocalStorage,
+  isBrowserLocale24h,
+  setIs24hClockInLocalStorage,
+} from "@calcom/lib/timeFormat";
 import { localStorage } from "@calcom/lib/webstorage";
 
 interface TimeOptions {
@@ -20,8 +24,8 @@ const initClock = () => {
     return;
   }
   // This only sets browser locale if there's no preference on localStorage.
-  if (!localStorage.getItem("timeOption.is24hClock")) set24hClock(isBrowserLocale24h());
-  timeOptions.is24hClock = localStorage.getItem("timeOption.is24hClock") === "true";
+  if (!getIs24hClockFromLocalStorage()) set24hClock(isBrowserLocale24h());
+  timeOptions.is24hClock = getIs24hClockFromLocalStorage() === "true";
   timeOptions.inviteeTimeZone = localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess();
 };
 
@@ -32,7 +36,7 @@ const is24h = (is24hClock?: boolean) => {
 };
 
 const set24hClock = (is24hClock: boolean) => {
-  localStorage.setItem("timeOption.is24hClock", is24hClock.toString());
+  setIs24hClockInLocalStorage(is24hClock ? "true" : "false");
   timeOptions.is24hClock = is24hClock;
 };
 

--- a/apps/web/lib/clock.ts
+++ b/apps/web/lib/clock.ts
@@ -24,8 +24,8 @@ const initClock = () => {
     return;
   }
   // This only sets browser locale if there's no preference on localStorage.
-  if (!getIs24hClockFromLocalStorage()) set24hClock(isBrowserLocale24h());
-  timeOptions.is24hClock = getIs24hClockFromLocalStorage() === "true";
+  if (getIs24hClockFromLocalStorage() === null) set24hClock(isBrowserLocale24h());
+  timeOptions.is24hClock = getIs24hClockFromLocalStorage() === true;
   timeOptions.inviteeTimeZone = localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess();
 };
 
@@ -36,7 +36,7 @@ const is24h = (is24hClock?: boolean) => {
 };
 
 const set24hClock = (is24hClock: boolean) => {
-  setIs24hClockInLocalStorage(is24hClock ? "true" : "false");
+  setIs24hClockInLocalStorage(is24hClock);
   timeOptions.is24hClock = is24hClock;
 };
 

--- a/apps/web/lib/clock.ts
+++ b/apps/web/lib/clock.ts
@@ -25,7 +25,7 @@ const initClock = () => {
   }
   // This only sets browser locale if there's no preference on localStorage.
   if (getIs24hClockFromLocalStorage() === null) set24hClock(isBrowserLocale24h());
-  timeOptions.is24hClock = getIs24hClockFromLocalStorage() === true;
+  timeOptions.is24hClock = !!getIs24hClockFromLocalStorage();
   timeOptions.inviteeTimeZone = localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess();
 };
 

--- a/apps/web/pages/settings/profile.tsx
+++ b/apps/web/pages/settings/profile.tsx
@@ -230,7 +230,7 @@ function SettingsView(props: ComponentProps<typeof Settings> & { localeProp: str
     // Write time format to localStorage if available
     // Embed isn't applicable to profile pages. So ignore the rule
     // eslint-disable-next-line @calcom/eslint/avoid-web-storage
-    setIs24hClockInLocalStorage(selectedTimeFormat.value === 12 ? "false" : "true");
+    setIs24hClockInLocalStorage(selectedTimeFormat.value === 24);
 
     // TODO: Add validation
 

--- a/apps/web/pages/settings/profile.tsx
+++ b/apps/web/pages/settings/profile.tsx
@@ -17,6 +17,7 @@ import TimezoneSelect, { ITimezone } from "react-timezone-select";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import showToast from "@calcom/lib/notification";
+import { setIs24hClockInLocalStorage } from "@calcom/lib/timeFormat";
 import prisma from "@calcom/prisma";
 import { TRPCClientErrorLike } from "@calcom/trpc/client";
 import { trpc } from "@calcom/trpc/react";
@@ -229,7 +230,7 @@ function SettingsView(props: ComponentProps<typeof Settings> & { localeProp: str
     // Write time format to localStorage if available
     // Embed isn't applicable to profile pages. So ignore the rule
     // eslint-disable-next-line @calcom/eslint/avoid-web-storage
-    window.localStorage.setItem("timeOption.is24hClock", selectedTimeFormat.value === 12 ? "false" : "true");
+    setIs24hClockInLocalStorage(selectedTimeFormat.value === 12 ? "false" : "true");
 
     // TODO: Add validation
 

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -26,7 +26,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { getEveryFreqFor } from "@calcom/lib/recurringStrings";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
-import { isBrowserLocale24h } from "@calcom/lib/timeFormat";
+import { getIs24hClockFromLocalStorage, isBrowserLocale24h } from "@calcom/lib/timeFormat";
 import { localStorage } from "@calcom/lib/webstorage";
 import prisma from "@calcom/prisma";
 import Button from "@calcom/ui/Button";
@@ -203,7 +203,7 @@ export default function Success(props: SuccessProps) {
       // TODO: Add payment details
     });
     setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
-    setIs24h(!!localStorage.getItem("timeOption.is24hClock"));
+    setIs24h(!!getIs24hClockFromLocalStorage());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventType, needsConfirmation]);
 

--- a/apps/web/pages/v2/settings/my-account/general.tsx
+++ b/apps/web/pages/v2/settings/my-account/general.tsx
@@ -111,7 +111,7 @@ const GeneralView = ({ localeProp }: GeneralViewProps) => {
     <Form
       form={formMethods}
       handleSubmit={(values) => {
-        setIs24hClockInLocalStorage(values.timeFormat.value === 12 ? "false" : "true");
+        setIs24hClockInLocalStorage(values.timeFormat.value === 24);
 
         mutation.mutate({
           ...values,

--- a/apps/web/pages/v2/settings/my-account/general.tsx
+++ b/apps/web/pages/v2/settings/my-account/general.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useForm, Controller } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { setIs24hClockInLocalStorage } from "@calcom/lib/timeFormat";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/v2/core/Button";
 import Meta from "@calcom/ui/v2/core/Meta";
@@ -110,6 +111,8 @@ const GeneralView = ({ localeProp }: GeneralViewProps) => {
     <Form
       form={formMethods}
       handleSubmit={(values) => {
+        setIs24hClockInLocalStorage(values.timeFormat.value === 12 ? "false" : "true");
+
         mutation.mutate({
           ...values,
           locale: values.locale.value,

--- a/apps/web/pages/v2/success.tsx
+++ b/apps/web/pages/v2/success.tsx
@@ -26,7 +26,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { getEveryFreqFor } from "@calcom/lib/recurringStrings";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
-import { isBrowserLocale24h } from "@calcom/lib/timeFormat";
+import { getIs24hClockFromLocalStorage, isBrowserLocale24h } from "@calcom/lib/timeFormat";
 import { localStorage } from "@calcom/lib/webstorage";
 import prisma from "@calcom/prisma";
 import Button from "@calcom/ui/Button";
@@ -201,7 +201,7 @@ export default function Success(props: SuccessProps) {
       // TODO: Add payment details
     });
     setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
-    setIs24h(!!localStorage.getItem("timeOption.is24hClock"));
+    setIs24h(!!getIs24hClockFromLocalStorage());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventType, needsConfirmation]);
 

--- a/packages/features/ee/payments/components/PaymentPage.tsx
+++ b/packages/features/ee/payments/components/PaymentPage.tsx
@@ -11,7 +11,7 @@ import { sdkActionManager, useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
-import { isBrowserLocale24h } from "@calcom/lib/timeFormat";
+import { getIs24hClockFromLocalStorage, isBrowserLocale24h } from "@calcom/lib/timeFormat";
 import { Icon } from "@calcom/ui/Icon";
 
 import type { PaymentPageProps } from "../pages/payment";
@@ -26,7 +26,7 @@ const PaymentPage: FC<PaymentPageProps> = (props) => {
   useEffect(() => {
     let embedIframeWidth = 0;
     setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
-    setIs24h(!!localStorage.getItem("timeOption.is24hClock"));
+    setIs24h(!!getIs24hClockFromLocalStorage());
     if (isEmbed) {
       requestAnimationFrame(function fixStripeIframe() {
         // HACK: Look for stripe iframe and center position it just above the embed content

--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -6,8 +6,16 @@
  */
 import { localStorage } from "@calcom/lib/webstorage";
 
+const is24hLocalstorageKey = "timeOption.is24hClock";
+
+export const setIs24hClockInLocalStorage = (is24h: "true" | "false") =>
+  localStorage.setItem(is24hLocalstorageKey, is24h);
+
+export const getIs24hClockFromLocalStorage = () =>
+  localStorage.getItem(is24hLocalstorageKey) as "true" | "false" | null;
+
 export const isBrowserLocale24h = () => {
-  const localStorageTimeFormat = localStorage.getItem("timeOption.is24hClock");
+  const localStorageTimeFormat = getIs24hClockFromLocalStorage();
   // If time format is already stored in the browser then retrieve and return early
   if (localStorageTimeFormat === "true") {
     return true;
@@ -19,10 +27,10 @@ export const isBrowserLocale24h = () => {
   if (typeof window !== "undefined" && navigator) locale = window.navigator?.language;
 
   if (!new Intl.DateTimeFormat(locale, { hour: "numeric" }).format(0).match(/M/)) {
-    localStorage.setItem("timeOption.is24hClock", "false");
+    setIs24hClockInLocalStorage("false");
     return false;
   } else {
-    localStorage.setItem("timeOption.is24hClock", "true");
+    setIs24hClockInLocalStorage("true");
     return true;
   }
 };

--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -8,18 +8,22 @@ import { localStorage } from "@calcom/lib/webstorage";
 
 const is24hLocalstorageKey = "timeOption.is24hClock";
 
-export const setIs24hClockInLocalStorage = (is24h: "true" | "false") =>
-  localStorage.setItem(is24hLocalstorageKey, is24h);
+export const setIs24hClockInLocalStorage = (is24h: boolean) =>
+  localStorage.setItem(is24hLocalstorageKey, is24h.toString());
 
-export const getIs24hClockFromLocalStorage = () =>
-  localStorage.getItem(is24hLocalstorageKey) as "true" | "false" | null;
+export const getIs24hClockFromLocalStorage = () => {
+  const is24hFromLocalstorage = localStorage.getItem(is24hLocalstorageKey);
+  if (is24hFromLocalstorage === null) return null;
+
+  return is24hFromLocalstorage === "false" ? false : true;
+};
 
 export const isBrowserLocale24h = () => {
   const localStorageTimeFormat = getIs24hClockFromLocalStorage();
   // If time format is already stored in the browser then retrieve and return early
-  if (localStorageTimeFormat === "true") {
+  if (localStorageTimeFormat === true) {
     return true;
-  } else if (localStorageTimeFormat === "false") {
+  } else if (localStorageTimeFormat === false) {
     return false;
   }
 
@@ -27,10 +31,10 @@ export const isBrowserLocale24h = () => {
   if (typeof window !== "undefined" && navigator) locale = window.navigator?.language;
 
   if (!new Intl.DateTimeFormat(locale, { hour: "numeric" }).format(0).match(/M/)) {
-    setIs24hClockInLocalStorage("false");
+    setIs24hClockInLocalStorage(false);
     return false;
   } else {
-    setIs24hClockInLocalStorage("true");
+    setIs24hClockInLocalStorage(true);
     return true;
   }
 };

--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -15,7 +15,7 @@ export const getIs24hClockFromLocalStorage = () => {
   const is24hFromLocalstorage = localStorage.getItem(is24hLocalstorageKey);
   if (is24hFromLocalstorage === null) return null;
 
-  return is24hFromLocalstorage === "false" ? false : true;
+  return is24hFromLocalstorage === "true";
 };
 
 export const isBrowserLocale24h = () => {


### PR DESCRIPTION
## What does this PR do?

Store timeformat preferences in localstorage when changing profile. This way you see the correct format on the booking page. 

I've also abstracted the reuse of the localstorage key for time format into a small util function, to prevent typos in the future.

Fixes #4533

https://www.loom.com/share/5e2c10f918a749fcb11ef157268d7ded

**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Verify that when you update the time format in your settings the format on the bookings page updates accordingly. 