### PR TITLE
Fixes 'How to use Additional Inputs as Variables' dialog in workflows

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1267,5 +1267,10 @@
   "seats": "seats",
   "every_app_published": "Every app published on the Cal.com App Store is open source and thoroughly tested via peer reviews. Nevertheless, Cal.com, Inc. does not endorse or certify these apps unless they are published by Cal.com. If you encounter inappropriate content or behaviour please report it.",
   "report_app": "Report app",
-  "team_name_required": "Team name required"
+  "team_name_required": "Team name required",
+  "how_additional_inputs_as_variables": "How to use Additional Inputs as Variables",
+  "format": "Format",
+  "uppercase_for_letters": "Use uppercase for all letters",
+  "replace_whitespaces_underscores": "Replace whitespaces with underscores",
+  "ingore_special_characters": "Ignore special characters in your Additonal Input label. Use only letters and numbers"
 }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1272,5 +1272,5 @@
   "format": "Format",
   "uppercase_for_letters": "Use uppercase for all letters",
   "replace_whitespaces_underscores": "Replace whitespaces with underscores",
-  "ingore_special_characters": "Ignore special characters in your Additonal Input label. Use only letters and numbers"
+  "ignore_special_characters": "Ignore special characters in your Additonal Input label. Use only letters and numbers"
 }

--- a/packages/features/ee/workflows/components/v2/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/v2/WorkflowStepContainer.tsx
@@ -481,10 +481,10 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
           </ConfirmationDialogContent>
         </Dialog>
         <Dialog open={isAdditionalInputsDialogOpen} onOpenChange={setIsAdditionalInputsDialogOpen}>
-          <DialogContent useOwnActionButtons type="creation" className="sm:max-w-[600px] md:h-[570px]">
-            <div className="-m-3 h-[440px] overflow-x-hidden overflow-y-scroll sm:m-0">
+          <DialogContent useOwnActionButtons type="creation" className="sm:max-w-[610px] md:h-[570px]">
+            <div className="-m-3 h-[430px] overflow-x-hidden overflow-y-scroll sm:m-0">
               <h1 className="w-full text-xl font-semibold ">{t("how_additional_inputs_as_variables")}</h1>
-              <div className="mt-7 rounded-md bg-gray-50 p-3 sm:p-5">
+              <div className="mb-7 mt-7 rounded-md bg-gray-50 p-3 sm:p-4">
                 <p className="test-sm font-medium">{t("format")}</p>
                 <ul className="mt-2 ml-5 list-disc text-gray-900">
                   <li>{t("uppercase_for_letters")}</li>
@@ -526,7 +526,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 </div>
               </div>
             </div>
-            <div className="mt-3 -mb-7 flex flex-row-reverse gap-x-2">
+            <div className="flex flex-row-reverse">
               <DialogClose asChild>
                 <Button color="primary" type="button">
                   {t("close")}

--- a/packages/features/ee/workflows/components/v2/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/v2/WorkflowStepContainer.tsx
@@ -489,7 +489,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 <ul className="mt-2 ml-5 list-disc text-gray-900">
                   <li>{t("uppercase_for_letters")}</li>
                   <li>{t("replace_whitespaces_underscores")}</li>
-                  <li>{t("ingore_special_characters")}</li>
+                  <li>{t("ignore_special_characters")}</li>
                 </ul>
                 <div className="mt-6">
                   <p className="test-sm w-full font-medium">{t("example_1")}</p>


### PR DESCRIPTION
## What does this PR do?

This PR adds missing translations and fixes dialog width so that the variable is not cut off.

Before: 
![Screenshot 2022-09-30 at 14 13 47](https://user-images.githubusercontent.com/30310907/193267568-62e69480-7a26-49f5-a9b4-54988ff5c970.png)

After: 
![Screenshot 2022-09-30 at 14 13 38](https://user-images.githubusercontent.com/30310907/193267576-cad63ce0-d14f-4349-8ee5-a9cef5da8d68.png)