### PR TITLE
Hotfix: Fix Broken webhooks

### DIFF
--- a/packages/features/webhooks/components/WebhookForm.tsx
+++ b/packages/features/webhooks/components/WebhookForm.tsx
@@ -53,7 +53,9 @@ const WebhookForm = (props: {
   const triggerOptions = [...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2["core"]];
   if (apps) {
     for (const app of apps) {
-      triggerOptions.push(...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]);
+      if (WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]) {
+        triggerOptions.push(...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]);
+      }
     }
   }
   const translatedTriggerOptions = triggerOptions.map((option) => ({ ...option, label: t(option.label) }));


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)
Bug: when you try to create a new webhook when Giphy or any other App is installed.
<img width="708" alt="Screenshot 2022-10-04 at 12 08 40 AM" src="https://user-images.githubusercontent.com/1780212/193653333-23e768d2-685d-450d-ac06-128c10e28fda.png">
Reported by @shirazdole 

We have tests for webhook and they didn't catch the bug because the setup doesn't have an app installed.

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Make sure that you have Giphy app installed and go and try to add a webhook

