### PR TITLE
Improve password peek positioning accross app and website.

### DIFF
--- a/packages/ui/v2/core/form/fields.tsx
+++ b/packages/ui/v2/core/form/fields.tsx
@@ -202,12 +202,12 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputF
       {addOnLeading || addOnSuffix ? (
         <div
           className={classNames(
-            " mb-1 flex items-center rounded-md focus-within:outline-none focus-within:ring-2 focus-within:ring-neutral-800 focus-within:ring-offset-1",
+            "relative mb-1 flex items-center rounded-md focus-within:outline-none focus-within:ring-2 focus-within:ring-neutral-800 focus-within:ring-offset-1",
             addOnSuffix && "group flex-row-reverse"
           )}>
           <div
             className={classNames(
-              "h-9 border border-gray-300",
+              "addon-wrapper h-9 border border-gray-300",
               addOnFilled && "bg-gray-100",
               addOnLeading && "rounded-l-md border-r-0 px-3",
               addOnSuffix && "rounded-r-md border-l-0 px-3"
@@ -250,40 +250,39 @@ export const PasswordField = forwardRef<HTMLInputElement, InputFieldProps>(funct
   props,
   ref
 ) {
-  /*const { t } = useLocale();
+  const { t } = useLocale();
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const toggleIsPasswordVisible = useCallback(
     () => setIsPasswordVisible(!isPasswordVisible),
     [isPasswordVisible, setIsPasswordVisible]
   );
   const textLabel = isPasswordVisible ? t("hide_password") : t("show_password");
-*/
+
   return (
-    <div className="relative">
+    <div className="relative [&_.group:hover_.addon-wrapper]:border-gray-400 [&_.group:focus-within_.addon-wrapper]:border-neutral-300">
       <InputField
-        type={/* isPasswordVisible ? "text" : */ "password"}
-        placeholder={/* isPasswordVisible ? "0hMy4P4ssw0rd" : */ "•••••••••••••"}
+        type={isPasswordVisible ? "text" : "password"}
+        placeholder={isPasswordVisible ? "0hMy4P4ssw0rd" : "•••••••••••••"}
         ref={ref}
         {...props}
-        className={classNames("mb-0 pr-10", props.className)}
+        className={classNames("mb-0 border-r-0 pr-10", props.className)}
+        addOnFilled={false}
+        addOnSuffix={
+          <Tooltip content={textLabel}>
+            <button
+              className="absolute right-3 bottom-0 h-9 text-gray-900"
+              type="button"
+              onClick={() => toggleIsPasswordVisible()}>
+              {isPasswordVisible ? (
+                <EyeOff className="h-4 stroke-[2.5px]" />
+              ) : (
+                <Eye className="h-4 stroke-[2.5px]" />
+              )}
+              <span className="sr-only">{textLabel}</span>
+            </button>
+          </Tooltip>
+        }
       />
-
-      {/*<Tooltip content={textLabel}>
-        <button
-          className={classNames(
-            "absolute right-3 h-9 text-gray-900",
-            props.hintErrors ? "top-[22px]" : "bottom-0"
-          )}
-          type="button"
-          onClick={() => toggleIsPasswordVisible()}>
-          {isPasswordVisible ? (
-            <EyeOff className="h-4 stroke-[2.5px]" />
-          ) : (
-            <Eye className="h-4 stroke-[2.5px]" />
-          )}
-          <span className="sr-only">{textLabel}</span>
-        </button>
-          </Tooltip>*/}
     </div>
   );
 });


### PR DESCRIPTION
## What does this PR do?

Improves general positioning of the password peek tooltip. Redid the styling a bit so we can use the addonSuffix, which ensures that the element is positioned within the input wrapper, making absolute positioning a lot easier :) 

This issue mainly fixes the positioning on `cal.com/signup`, but also impacts the password elements on eg `/settings/security/password` and `/auth/setup`. Tested all 3 of these, see screenshots. Added @leog  as a reviewer since he recently also fixed the auth/setup page, and want to inform him of this change as well :) 

### Proof that it's fixed:

#### Settings page

<img width="1225" alt="CleanShot 2022-10-03 at 21 29 28@2x" src="https://user-images.githubusercontent.com/2969573/193663439-3c3a6cae-4577-4518-8736-3116effeb692.png">

#### /signup page

<img width="1256" alt="CleanShot 2022-10-03 at 21 42 42@2x" src="https://user-images.githubusercontent.com/2969573/193664775-6232a05d-7682-4319-b900-0b8ce4410d65.png">

#### Auth/setup page

<img width="557" alt="CleanShot 2022-10-03 at 21 28 52@2x" src="https://user-images.githubusercontent.com/2969573/193663451-2c013b9d-f3eb-4174-81bc-607db2afdbdb.png">

**Environment**: Staging(main branch) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Check pages where password input field is used, and ensure that the peek icon is positioned correctly (see 3 pages mentioned at the top of this issue)