### PR TITLE
fixed dropdown in safari

### DIFF
--- a/apps/web/pages/v2/event-types/index.tsx
+++ b/apps/web/pages/v2/event-types/index.tsx
@@ -1,5 +1,4 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { UserPlan } from "@prisma/client";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/apps/web/pages/v2/event-types/index.tsx
+++ b/apps/web/pages/v2/event-types/index.tsx
@@ -293,8 +293,9 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
                               <DropdownMenuItem>
                                 <DropdownItem
                                   type="button"
-                                  href={"/event-types/" + type.id}
-                                  StartIcon={Icon.FiEdit2}>
+                                  data-testid={"event-type-edit-" + type.id}
+                                  StartIcon={Icon.FiEdit2}
+                                  onClick={() => router.push("/event-types/" + type.id)}>
                                   {t("edit") as string}
                                 </DropdownItem>
                               </DropdownMenuItem>
@@ -397,9 +398,9 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
                         <DropdownMenuItem className="outline-none">
                           <Button
                             type="button"
-                            href={"/event-types/" + type.id}
+                            onClick={() => router.push("/event-types/" + type.id)}
                             color="minimal"
-                            className="w-full"
+                            className="w-full rounded-none"
                             StartIcon={Icon.FiEdit}>
                             {t("edit") as string}
                           </Button>

--- a/packages/ui/v2/core/Dropdown.tsx
+++ b/packages/ui/v2/core/Dropdown.tsx
@@ -115,7 +115,11 @@ export function ButtonOrLink({ href, ...props }: ButtonOrLinkProps) {
   const content = <ButtonOrLink {...props} />;
 
   if (isLink) {
-    return <Link href={href}>{content}</Link>;
+    return (
+      <Link href={href}>
+        <a>{content}</a>
+      </Link>
+    );
   }
 
   return content;


### PR DESCRIPTION
TIL: turns out safari doesnt like the `<a>` styling. it's now a button with router.push

before
<img width="169" alt="CleanShot 2022-10-04 at 16 26 14@2x" src="https://user-images.githubusercontent.com/8019099/193860853-2f759012-0698-4474-b41e-4ad71877eda5.png">

after

<img width="345" alt="CleanShot 2022-10-04 at 16 26 32@2x" src="https://user-images.githubusercontent.com/8019099/193860921-8cc9cc91-3c43-4411-a392-30bbca422c40.png">
