### PR TITLE
added ?tabName=setup to event-type detail link to give it active status

### DIFF
--- a/apps/web/pages/v2/event-types/index.tsx
+++ b/apps/web/pages/v2/event-types/index.tsx
@@ -53,7 +53,7 @@ const Item = ({ type, group, readOnly }: { type: EventType; group: EventTypeGrou
   const { t } = useLocale();
 
   return (
-    <Link href={`/event-types/${type.id}`}>
+    <Link href={`/event-types/${type.id}?tabName=setup`}>
       <a
         className="flex-grow truncate text-sm"
         title={`${type.title} ${type.description ? `– ${type.description}` : ""}`}>


### PR DESCRIPTION
we use the query to assign active state to the nav, which means there is no initial active state, hence we added the query to the detail page link


before
<img width="563" alt="CleanShot 2022-10-04 at 16 33 45@2x" src="https://user-images.githubusercontent.com/8019099/193862538-9e41ddd3-1985-4e9c-bd34-607fa0b8df76.png">


after
<img width="551" alt="CleanShot 2022-10-04 at 16 33 31@2x" src="https://user-images.githubusercontent.com/8019099/193862484-7ad7ab32-ccd8-4de5-9c84-8a39058ddfb4.png">
