### PR TITLE
Bugfix/reinstate tab name with fixed test

### DIFF
--- a/apps/web/pages/v2/event-types/index.tsx
+++ b/apps/web/pages/v2/event-types/index.tsx
@@ -52,7 +52,7 @@ const Item = ({ type, group, readOnly }: { type: EventType; group: EventTypeGrou
   const { t } = useLocale();
 
   return (
-    <Link href={`/event-types/${type.id}`}>
+    <Link href={`/event-types/${type.id}?tabName=setup`}>
       <a
         className="flex-grow truncate text-sm"
         title={`${type.title} ${type.description ? `– ${type.description}` : ""}`}>

--- a/apps/web/playwright/event-types.e2e.ts
+++ b/apps/web/playwright/event-types.e2e.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { WEBAPP_URL } from "@calcom/lib/constants";
+
 import { randomString } from "../lib/random";
 import { test } from "./lib/fixtures";
 
@@ -87,7 +89,7 @@ test.describe("Event Types tests", () => {
       );
       const href = await firstElement.getAttribute("href");
       if (!href) throw new Error("No href found for event type");
-      const [eventTypeId] = href.split("/").reverse();
+      const [eventTypeId] = new URL(WEBAPP_URL + href).pathname.split("/").reverse();
       const firstTitle = await page.locator(`[data-testid=event-type-title-${eventTypeId}]`).innerText();
       const firstFullSlug = await page.locator(`[data-testid=event-type-slug-${eventTypeId}]`).innerText();
       const firstSlug = firstFullSlug.split("/")[2];


### PR DESCRIPTION
## What does this PR do?

Brings back ?tabName= setup without breaking e2e, un-reverts revert in https://github.com/calcom/cal.com/pull/4834/commits/6a6ee21865cd2c2efa59c3a8dbdd2f19d8fcfb55