### PR TITLE
#4851: Always take timeformat on booking page from profile for loggedin users

### DIFF
--- a/apps/web/components/booking/TimeOptions.tsx
+++ b/apps/web/components/booking/TimeOptions.tsx
@@ -10,9 +10,10 @@ type Props = {
   onSelectTimeZone: (selectedTimeZone: string) => void;
   onToggle24hClock: (is24hClock: boolean) => void;
   timeFormat: string;
+  hideTimeFormatToggle?: boolean;
 };
 
-const TimeOptions: FC<Props> = ({ onToggle24hClock, onSelectTimeZone, timeFormat }) => {
+const TimeOptions: FC<Props> = ({ onToggle24hClock, onSelectTimeZone, timeFormat, hideTimeFormatToggle }) => {
   const [selectedTimeZone, setSelectedTimeZone] = useState("");
   const [is24hClock, setIs24hClock] = useState(timeFormat === "HH:mm" && true);
   const { t } = useLocale();
@@ -36,17 +37,19 @@ const TimeOptions: FC<Props> = ({ onToggle24hClock, onSelectTimeZone, timeFormat
     <div className="dark:border-darkgray-300 dark:bg-darkgray-200 rounded-sm border border-gray-200 bg-white px-4 pt-4 pb-3 shadow-sm">
       <div className="mb-4 flex">
         <div className="text-sm font-medium text-gray-600 dark:text-white">{t("time_options")}</div>
-        <div className="ml-auto flex items-center">
-          <label className="ltl:mr-3 mr-2 align-text-top text-sm font-medium text-neutral-700 ltr:ml-3 rtl:mr-3 dark:text-white">
-            {t("am_pm")}
-          </label>
-          <Switch
-            name="24hClock"
-            label={t("24_h")}
-            defaultChecked={is24hClock}
-            onCheckedChange={handle24hClockToggle}
-          />
-        </div>
+        {!hideTimeFormatToggle && (
+          <div className="ml-auto flex items-center">
+            <label className="ltl:mr-3 mr-2 align-text-top text-sm font-medium text-neutral-700 ltr:ml-3 rtl:mr-3 dark:text-white">
+              {t("am_pm")}
+            </label>
+            <Switch
+              name="24hClock"
+              label={t("24_h")}
+              defaultChecked={is24hClock}
+              onCheckedChange={handle24hClockToggle}
+            />
+          </div>
+        )}
       </div>
       <TimezoneSelect
         id="timeZone"


### PR DESCRIPTION
## What does this PR do?

Always take timeformat on booking page from profile if user is… logged in. Also hides timeformat toggle on booking page for logged in users. For non loggedin users we still infer by looking at browser timezone, after that we set a localstorage which we will look at, and which will get updated when the user updates the toggle in the timezone dropdown.

Fixes #4851

https://www.loom.com/share/3e9e3a17f0e0430f88dfe742d4f398d5

**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Ensure that when you're logged in, on the booking page we we take the timeformat (am/pm vs 24h) from your profile
- [ ] Ensure that when you're logged in there's no am/pm / 24h toggle in the timezone dropdown anymore
- [ ] Ensure that when you're logged in and change your timeformat in the profile, the booking page updates after a refresh.
- [ ] Ensure that when you're NOT logged in, the timeformat on the booking page is inferred based on your browser location (guess)
- [ ] Ensure that when you're NOT logged in, the toggle to change am/pm / 24h is visible in the timezone dropdown
- [ ] Ensure that when you update the am/pm / 24h toggle in the dropdown, the timeformat on the booking page updates. Also this should remain remain visible after a refresh (it's stored in localstorage)
