### PR TITLE
Fixing unconfirmed/recurring bookings

### DIFF
--- a/apps/web/pages/bookings/[status].tsx
+++ b/apps/web/pages/bookings/[status].tsx
@@ -54,17 +54,6 @@ export default function Bookings() {
 
   const isEmpty = !query.data?.pages[0]?.bookings.length;
 
-  // Get all recurring events of the series with the same recurringEventId
-  const defineRecurrentBookings = (
-    booking: BookingOutput,
-    groupedBookings: Record<string, BookingOutput[]>
-  ) => {
-    let recurringBookings = undefined;
-    if (booking.recurringEventId !== null) {
-      recurringBookings = groupedBookings[booking.recurringEventId];
-    }
-    return { recurringBookings };
-  };
   const shownBookings: Record<string, BookingOutput[]> = {};
   const filterBookings = (booking: BookingOutput) => {
     if (status === "recurring" || status === "cancelled") {
@@ -104,7 +93,7 @@ export default function Bookings() {
                               <BookingListItem
                                 key={booking.id}
                                 listingStatus={status}
-                                {...defineRecurrentBookings(booking, shownBookings)}
+                                recurringBookings={page.recurringInfo}
                                 {...booking}
                               />
                             ))}

--- a/apps/web/pages/v2/bookings/[status].tsx
+++ b/apps/web/pages/v2/bookings/[status].tsx
@@ -55,20 +55,9 @@ export default function Bookings() {
 
   const isEmpty = !query.data?.pages[0]?.bookings.length;
 
-  // Get all recurring events of the series with the same recurringEventId
-  const defineRecurrentBookings = (
-    booking: BookingOutput,
-    groupedBookings: Record<string, BookingOutput[]>
-  ) => {
-    let recurringBookings = undefined;
-    if (booking.recurringEventId !== null) {
-      recurringBookings = groupedBookings[booking.recurringEventId];
-    }
-    return { recurringBookings };
-  };
   const shownBookings: Record<string, BookingOutput[]> = {};
   const filterBookings = (booking: BookingOutput) => {
-    if (status === "recurring" || status === "cancelled") {
+    if (status === "recurring" || status == "unconfirmed" || status === "cancelled") {
       if (!booking.recurringEventId) {
         return true;
       }
@@ -111,7 +100,7 @@ export default function Bookings() {
                         <BookingListItem
                           key={booking.id}
                           listingStatus={status}
-                          {...defineRecurrentBookings(booking, shownBookings)}
+                          recurringBookings={page.recurringInfo}
                           {...booking}
                         />
                       ))}

--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -291,7 +291,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").toDate(),
             endTime: dayjs().add(1, "day").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
           {
             uid: uuid(),
@@ -299,7 +299,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").add(1, "week").toDate(),
             endTime: dayjs().add(1, "day").add(1, "week").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
           {
             uid: uuid(),
@@ -307,7 +307,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").add(2, "week").toDate(),
             endTime: dayjs().add(1, "day").add(2, "week").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
           {
             uid: uuid(),
@@ -315,7 +315,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").add(3, "week").toDate(),
             endTime: dayjs().add(1, "day").add(3, "week").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
           {
             uid: uuid(),
@@ -323,7 +323,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").add(4, "week").toDate(),
             endTime: dayjs().add(1, "day").add(4, "week").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
           {
             uid: uuid(),
@@ -331,7 +331,7 @@ async function main() {
             recurringEventId: Buffer.from("yoga-class").toString("base64"),
             startTime: dayjs().add(1, "day").add(5, "week").toDate(),
             endTime: dayjs().add(1, "day").add(5, "week").add(30, "minutes").toDate(),
-            status: BookingStatus.PENDING,
+            status: BookingStatus.ACCEPTED,
           },
         ],
       },


### PR DESCRIPTION
## What does this PR do?

When looking at "Unconfirmed" tab in Bookings, and you have recurring events to be accepted, they were not grouped correctly. Also, the number of instances in the tooltip info section for recurring events was dependant on loaded bookings, hence infinite scrolling was affecting its content, flickering the number.

See the number flickering:

https://user-images.githubusercontent.com/467258/194330940-66955dc2-d8a6-499d-ac70-8401801310c3.mov

Also as part of the fix, a new little feature is shown, the number of recurring events is adjusted to show actually dates in the future in case any instance already passed, and the tooltip shows passed instances as striked:
<kbd><img src="https://user-images.githubusercontent.com/467258/194331534-eae96aa6-7f53-4355-a0b6-fec4c093878f.jpg" /></kbd>

And the ungrouped unconfirmed recurring events:
<kbd><img src="https://user-images.githubusercontent.com/467258/194331137-f86d6d6c-73b5-46b6-a9dc-6137c7279663.jpg" /></kbd>

Fixed ungrouped unconfirmed recurring events with better tooltip content:
<kbd><img src="https://user-images.githubusercontent.com/467258/194332304-b5321da7-2a40-4196-880c-45189151fb36.jpg" /></kbd>

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Have at least 3 x12 unconfirmed recurring events and go to Unconfirmed tab or Recurring tab in Bookings page.
