### PR TITLE
Bugfix/dst available hour mismatch

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -42,6 +42,8 @@ const splitAvailableTime = (
 const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, eventLength }: GetSlots) => {
   // current date in invitee tz
   const startDate = dayjs().add(minimumBookingNotice, "minute");
+  // This code is ran client side, startOf() does some conversions based on the
+  // local tz of the client. Sometimes this shifts the day incorrectly.
   const startOfDayUTC = dayjs.utc().set("hour", 0).set("minute", 0).set("second", 0);
   const startOfInviteeDay = inviteeDate.startOf("day");
   // checks if the start date is in the past
@@ -62,6 +64,9 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
     endTime: /* Why? */ startOfDayUTC.add(schedule.endTime, "minute"),
   }));
 
+  // Dayjs does not expose the timeZone value publicly through .get("timeZone")
+  // instead, we as devs are required to somewhat hack our way to get the ...
+  // tz value as string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const timeZone: string = (inviteeDate as any)["$x"]["$timezone"];
 

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -67,6 +67,7 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
 
   const localWorkingHours = getWorkingHours(
     {
+      // initialize current day with timeZone without conversion, just parse.
       utcOffset: -dayjs.tz(dayjs(), timeZone).utcOffset(),
     },
     workingHoursUTC

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -42,7 +42,7 @@ const splitAvailableTime = (
 const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, eventLength }: GetSlots) => {
   // current date in invitee tz
   const startDate = dayjs().add(minimumBookingNotice, "minute");
-  const startOfDayUTC = dayjs.utc().startOf("day");
+  const startOfDayUTC = dayjs.utc().set("hour", 0).set("minute", 0).set("second", 0);
   const startOfInviteeDay = inviteeDate.startOf("day");
   // checks if the start date is in the past
 
@@ -62,9 +62,15 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
     endTime: /* Why? */ startOfDayUTC.add(schedule.endTime, "minute"),
   }));
 
-  const localWorkingHours = getWorkingHours({ utcOffset: -dayjs().utcOffset() }, workingHoursUTC).filter(
-    (hours) => hours.days.includes(inviteeDate.day())
-  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const timeZone: string = (inviteeDate as any)["$x"]["$timezone"];
+
+  const localWorkingHours = getWorkingHours(
+    {
+      utcOffset: -dayjs.tz(dayjs(), timeZone).utcOffset(),
+    },
+    workingHoursUTC
+  ).filter((hours) => hours.days.includes(inviteeDate.day()));
 
   const slots: Dayjs[] = [];
 

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -61,7 +61,8 @@ const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, 
     startTime: /* Why? */ startOfDayUTC.add(schedule.startTime, "minute"),
     endTime: /* Why? */ startOfDayUTC.add(schedule.endTime, "minute"),
   }));
-  const localWorkingHours = getWorkingHours({ utcOffset: -inviteeDate.utcOffset() }, workingHoursUTC).filter(
+
+  const localWorkingHours = getWorkingHours({ utcOffset: -dayjs().utcOffset() }, workingHoursUTC).filter(
     (hours) => hours.days.includes(inviteeDate.day())
   );
 


### PR DESCRIPTION
## What does this PR do?

Aims to fix the hour discrepancy going into DST - tries to use the selected invitee date (with tz) and use the current day tz offset to properly display the booking slots.