### PR TITLE
Fix MS Teams missing refresh token

### DIFF
--- a/packages/app-store/office365video/api/add.ts
+++ b/packages/app-store/office365video/api/add.ts
@@ -6,7 +6,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { encodeOAuthState } from "../../_utils/encodeOAuthState";
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 
-const scopes = ["OnlineMeetings.ReadWrite"];
+const scopes = ["OnlineMeetings.ReadWrite", "offline_access"];
 
 let client_id = "";
 

--- a/packages/app-store/office365video/api/callback.ts
+++ b/packages/app-store/office365video/api/callback.ts
@@ -8,7 +8,7 @@ import { decodeOAuthState } from "../../_utils/decodeOAuthState";
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 
-const scopes = ["OnlineMeetings.ReadWrite"];
+const scopes = ["OnlineMeetings.ReadWrite", "offline_access"];
 
 let client_id = "";
 let client_secret = "";

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -49,7 +49,6 @@ const o365Auth = async (credential: Credential) => {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
-        scope: "User.Read OnlineMeetings.ReadWrite",
         client_id,
         refresh_token: refreshToken,
         grant_type: "refresh_token",
@@ -57,6 +56,10 @@ const o365Auth = async (credential: Credential) => {
       }),
     });
     const responseBody = await handleErrorsJson(response);
+    if (responseBody.error) {
+      console.error(responseBody);
+      throw new HttpError({ statusCode: 500, message: "Error contacting MS Teams" });
+    }
     // set expiry date as offset from current time.
     responseBody.expiry_date = Math.round(Date.now() + responseBody.expires_in * 1000);
     delete responseBody.expires_in;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds the "offline_access" scope when connecting to MS Teams. Having this scope gives us the refresh token that was missing from our credentials.

Fixes #3854 #2818 #2946

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Connect to MS Teams
    - Ensure that the refresh token is included in the responseBody
- In the DB change the expiration date to the past
- Create a booking with MS Teams as the location. The tokens should have refreshed. 

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
