### PR TITLE
Handle double quotes situation in checkLicense function

### DIFF
--- a/packages/features/ee/common/server/checkLicense.ts
+++ b/packages/features/ee/common/server/checkLicense.ts
@@ -1,12 +1,26 @@
 import cache from "memory-cache";
+import { z } from "zod";
 
 import { CONSOLE_URL } from "@calcom/lib/constants";
 
 const CACHING_TIME = 86400000; // 24 hours in milliseconds
 
+const schemaLicenseKey = z
+  .string()
+  // .uuid() exists but I'd to fix the situation where the CALCOM_LICENSE_KEY is wrapped in quotes
+  .regex(/^\"?[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}\"?$/, {
+    message: "License key must follow UUID format: 8-4-4-4-12",
+  })
+  .transform((v) => {
+    // Remove the double quotes from the license key, as they 404 the fetch.
+    return v != null && v.length >= 2 && v.charAt(0) == '"' && v.charAt(v.length - 1) == '"'
+      ? v.substring(1, v.length - 1)
+      : v;
+  });
+
 async function checkLicense(license: string): Promise<boolean> {
   if (!!process.env.NEXT_PUBLIC_IS_E2E) return true;
-  const url = `${CONSOLE_URL}/api/license?key=${license}`;
+  const url = `${CONSOLE_URL}/api/license?key=${schemaLicenseKey.parse(license)}`;
   const cachedResponse = cache.get(url);
   if (cachedResponse) {
     return cachedResponse;


### PR DESCRIPTION
## What does this PR do?

This fixes the likely culprit to our invalid `CALCOM_LICENSE_KEY` API issues. When you create a key and save the .env file on windows there may be wrapping `""`'s. 

Another situation where this happens is in linux when you accidentally add a trailing space after the .env file.
`CALCOM_LICENSE_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"<space>`

Also adds validation for the `CALCOM_LICENSE_KEY` format.