### PR TITLE
Fixes issues with negative number shown for unconfirmed bookings badge

### DIFF
--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -1458,6 +1458,7 @@ const loggedInViewerRouter = createProtectedRouter()
           recurringEventId: { not: { equals: null } },
           status: { equals: "PENDING" },
           userId: user.id,
+          endTime: { gt: new Date() },
         },
       });
       return recurringGrouping.reduce((prev, current) => {


### PR DESCRIPTION
## What does this PR do?

Unconfirmed recurring bookings from the past were subtracted from the count. Now only upcoming ones are substracted. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

