### PR TITLE
Fixing rescheduled booking email date

### DIFF
--- a/packages/emails/src/components/WhenInfo.tsx
+++ b/packages/emails/src/components/WhenInfo.tsx
@@ -37,7 +37,9 @@ export function WhenInfo(props: { calEvent: CalendarEvent; timeZone: string; t: 
     <div>
       <Info
         label={`${t("when")} ${getRecurringWhen(props)}`}
-        lineThrough={!!props.calEvent.cancellationReason}
+        lineThrough={
+          !!props.calEvent.cancellationReason && !props.calEvent.cancellationReason.includes("$RCH$")
+        }
         description={
           <>
             {recurringEvent?.count ? `${t("starting")} ` : ""}

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -56,7 +56,13 @@ export const BaseScheduledEmail = (
           : props.callToAction || <ManageLink attendee={props.attendee} calEvent={props.calEvent} />
       }
       subtitle={props.subtitle || <>{t("emailed_you_and_any_other_attendees")}</>}>
-      <Info label={t("cancellation_reason")} description={props.calEvent.cancellationReason} withSpacer />
+      <Info
+        label={t("cancellation_reason")}
+        description={
+          props.calEvent.cancellationReason && props.calEvent.cancellationReason.replace("$RCH$", "")
+        } // Removing flag to distinguish reschedule from cancellation
+        withSpacer
+      />
       <Info label={t("rejection_reason")} description={props.calEvent.rejectionReason} withSpacer />
       <Info label={t("what")} description={props.calEvent.type} withSpacer />
       <WhenInfo calEvent={props.calEvent} t={t} timeZone={timeZone} />

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -752,7 +752,7 @@ async function handler(req: NextApiRequest & { userId?: number }) {
           ...evt,
           additionalInformation: metadata,
           additionalNotes, // Resets back to the additionalNote input and not the override value
-          cancellationReason: reqBody.rescheduleReason,
+          cancellationReason: "$RCH$" + reqBody.rescheduleReason, // Removable code prefix to differentiate cancellation from rescheduling for email
         });
       }
     }


### PR DESCRIPTION
## What does this PR do?

The base email template assumes that if there is a "cancellationReason" text, it is a cancellation email striking out the date from the email. The thing is we also rely on that same variable to hold a rescheduling reason, which ends up sending a rescheduled booking email with a striked out date when it doesn't apply. This is intended to fix that for every email destinatary.

Before:
<kbd><img width="500" src="https://user-images.githubusercontent.com/467258/196043261-9bcc126d-f4fe-4e16-8011-36c363e20579.png" /></kbd>

After:
<kbd><img width="500" src="https://user-images.githubusercontent.com/467258/196043274-63372e32-dcbd-4150-9592-ee70585e2057.png" /></kbd>


Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try rescheduling a booking and receive an email as an attendee and organizer. The date should not be stricken out, whether you include a rescheduling reason or not.
