### PR TITLE
Update to message for invalid method

### DIFF
--- a/packages/lib/server/defaultHandler.ts
+++ b/packages/lib/server/defaultHandler.ts
@@ -4,11 +4,15 @@ type Handlers = {
   [method in "GET" | "POST" | "PATCH" | "PUT" | "DELETE"]?: Promise<{ default: NextApiHandler }>;
 };
 
-/** Allows us to split big API handlers by method and auto catch unsupported methods */
+/** Allows us to split big API handlers by method */
 const defaultHandler = (handlers: Handlers) => async (req: NextApiRequest, res: NextApiResponse) => {
   const handler = (await handlers[req.method as keyof typeof handlers])?.default;
-
-  if (!handler) return res.status(405).json({ message: "Method not allowed" });
+  // auto catch unsupported methods.
+  if (!handler) {
+    return res
+      .status(405)
+      .json({ message: `Method Not Allowed (Allow: ${Object.keys(handlers).join(",")})` });
+  }
 
   try {
     await handler(req, res);


### PR DESCRIPTION
Small but helpful message update

Before:
```json
{"message": "Method not allowed"}
```
After:
```json
{"message": "Method Not Allowed (Allow: GET,PATCH,DELETE)"}
```
Accompanied by work to the API to reach this function (removed middleware).