### PR TITLE
Show all locations and team members on /book page

### DIFF
--- a/apps/web/components/booking/BookingDescription.tsx
+++ b/apps/web/components/booking/BookingDescription.tsx
@@ -85,11 +85,9 @@ const BookingDescription: FC<Props> = (props) => {
             {t("requires_confirmation")}
           </div>
         )}
-        {!isBookingPage && !props.rescheduleUid ? (
-          <AvailableEventLocations
-            locations={eventType.locations as AvailabilityPageProps["eventType"]["locations"]}
-          />
-        ) : null}
+        <AvailableEventLocations
+          locations={eventType.locations as AvailabilityPageProps["eventType"]["locations"]}
+        />
         <p
           className={classNames(
             "text-sm font-medium",


### PR DESCRIPTION
What does this PR do?
Meeting location and team members are now shown on the /book page.

Fixes https://github.com/calcom/cal.com/issues/3734

Environment: Staging(main branch) / Production

Type of change
- [x] Bug fix (non-breaking change which fixes an issue)