### PR TITLE
iCalendar timezone fix in CalDAV

### DIFF
--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -47,6 +47,17 @@ const getDuration = (start: string, end: string): DurationObject => ({
   minutes: dayjs(end).diff(dayjs(start), "minute"),
 });
 
+const buildUtcOffset = (minutes: number): string => {
+  const h =
+    minutes > 0
+      ? "+" + (Math.floor(minutes / 60) < 10 ? "0" + Math.floor(minutes / 60) : Math.floor(minutes / 60))
+      : "-" +
+        (Math.ceil(minutes / 60) > -10 ? "0" + Math.ceil(minutes / 60) * -1 : Math.ceil(minutes / 60) * -1);
+  const m = minutes > 0 ? minutes % 60 : (minutes % 60) * -1;
+  const offset = `${h}:${m}`;
+  return offset;
+};
+
 const getAttendees = (attendees: Person[]): Attendee[] =>
   attendees.map(({ email, name }) => ({ name, email, partstat: "NEEDS-ACTION" }));
 
@@ -274,6 +285,24 @@ export default abstract class BaseCalendarService implements Calendar {
       if (vevent?.getFirstPropertyValue("transp") === "TRANSPARENT") return;
 
       const event = new ICAL.Event(vevent);
+
+      const tzid: string | undefined = vevent?.getFirstPropertyValue("tzid");
+      // In case of icalendar, when only tzid is available without vtimezone, we need to add vtimezone explicitly to take care of timezone diff
+      if (!vcalendar.getFirstSubcomponent("vtimezone") && tzid) {
+        const timezoneComp = new ICAL.Component("vtimezone");
+        timezoneComp.addPropertyWithValue("tzid", tzid);
+        const standard = new ICAL.Component("standard");
+        // get timezone offset
+        const tzoffsetfrom = buildUtcOffset(dayjs(event.startDate.toJSDate()).tz(tzid, true).utcOffset());
+        const tzoffsetto = buildUtcOffset(dayjs(event.endDate.toJSDate()).tz(tzid, true).utcOffset());
+        // set timezone offset
+        standard.addPropertyWithValue("tzoffsetfrom", tzoffsetfrom);
+        standard.addPropertyWithValue("tzoffsetto", tzoffsetto);
+        // provide a standard dtstart
+        standard.addPropertyWithValue("dtstart", "1601-01-01T00:00:00");
+        timezoneComp.addSubcomponent(standard);
+        vcalendar.addSubcomponent(timezoneComp);
+      }
       const vtimezone = vcalendar.getFirstSubcomponent("vtimezone");
 
       if (event.isRecurring()) {

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -53,7 +53,7 @@ const buildUtcOffset = (minutes: number): string => {
       ? "+" + (Math.floor(minutes / 60) < 10 ? "0" + Math.floor(minutes / 60) : Math.floor(minutes / 60))
       : "-" +
         (Math.ceil(minutes / 60) > -10 ? "0" + Math.ceil(minutes / 60) * -1 : Math.ceil(minutes / 60) * -1);
-  const m = minutes > 0 ? minutes % 60 : (minutes % 60) * -1;
+  const m = Math.abs(minutes % 60);
   const offset = `${h}:${m}`;
   return offset;
 };


### PR DESCRIPTION
## What does this PR do?

Adds support for timezone change when vTimezone is not provided in the calendar object, but tzid is provided. This is the case with iCalendar, along with a few other service providers.

Fixes #2139 

[Loom](https://www.loom.com/share/8aee64f227884d9f84ac9f25d1d86455)

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] connect apple calendar and mark something busy there
- [x] Test for the timeslot in Cal to ensure timezone shift for the slots is accurate

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
