### PR TITLE
Fix cancelScheduledJobs on reschedule

### DIFF
--- a/packages/app-store/zapier/lib/nodeScheduler.ts
+++ b/packages/app-store/zapier/lib/nodeScheduler.ts
@@ -49,7 +49,8 @@ export async function scheduleTrigger(
 
 export async function cancelScheduledJobs(
   booking: { uid: string; scheduledJobs?: string[] },
-  appId?: string | null
+  appId?: string | null,
+  isReschedule?: boolean
 ) {
   let scheduledJobs = booking.scheduledJobs || [];
 
@@ -70,14 +71,16 @@ export async function cancelScheduledJobs(
         scheduledJobs = [];
       }
 
-      await prisma.booking.update({
-        where: {
-          uid: booking.uid,
-        },
-        data: {
-          scheduledJobs: scheduledJobs,
-        },
-      });
+      if (!isReschedule) {
+        await prisma.booking.update({
+          where: {
+            uid: booking.uid,
+          },
+          data: {
+            scheduledJobs: scheduledJobs,
+          },
+        });
+      }
     });
   }
 }

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -887,7 +887,7 @@ async function handler(req: NextApiRequest & { userId?: number | undefined }) {
 
     subscribersMeetingEnded.forEach((subscriber) => {
       if (rescheduleUid && originalRescheduledBooking) {
-        cancelScheduledJobs(originalRescheduledBooking);
+        cancelScheduledJobs(originalRescheduledBooking, undefined, true);
       }
       if (booking && booking.status === BookingStatus.ACCEPTED) {
         scheduleTrigger(booking, subscriber.subscriberUrl, subscriber);


### PR DESCRIPTION
## What does this PR do?

Don't update booking in cancelScheduledJobs when called while rescheduling an event (booking does not exist anymore at that time). 

Fixes #5183

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)