### PR TITLE
Fix/event location when fallback video

### DIFF
--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -98,9 +98,11 @@ export default class EventManager {
     // If and only if event type is a dedicated meeting, create a dedicated video meeting.
     if (isDedicated) {
       const result = await this.createVideoEvent(evt);
+
       if (result.createdEvent) {
         evt.videoCallData = result.createdEvent;
         evt.location = result.originalEvent.location;
+        result.type = result.createdEvent.type;
       }
 
       results.push(result);
@@ -114,6 +116,7 @@ export default class EventManager {
       if (typeof result?.createdEvent === "string") {
         createdEventObj = createdEventSchema.parse(JSON.parse(result.createdEvent));
       }
+
       return {
         type: result.type,
         uid: createdEventObj ? createdEventObj.id : result.createdEvent?.id?.toString() ?? "",

--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -100,6 +100,7 @@ export default class EventManager {
       const result = await this.createVideoEvent(evt);
       if (result.createdEvent) {
         evt.videoCallData = result.createdEvent;
+        evt.location = result.originalEvent.location;
       }
 
       results.push(result);


### PR DESCRIPTION
## What does this PR do?

Fix reference type when fallback to calVideo. This created a row in BookingReferences with cal video credentials but zoom_video as type. This was because it wasn't even considering that when fallback to cal video we should update references to create.

Fixes # (issue)

https://www.loom.com/share/df667a4e21fd4d8f9d016596874bbacd

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Force an exception while doing a booking with zoom video
- [ ] Open email with cal.video link and it should be working now.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
