### PR TITLE
Stop long urls from overflowing on booking page.

### DIFF
--- a/apps/web/components/booking/BookingDescription.tsx
+++ b/apps/web/components/booking/BookingDescription.tsx
@@ -70,7 +70,9 @@ const BookingDescription: FC<Props> = (props) => {
                 )}
               />
             </div>
-            <EventTypeDescriptionSafeHTML eventType={eventType} />
+            <div className="max-w-[calc(100%_-_2rem)] flex-shrink break-words">
+              <EventTypeDescriptionSafeHTML eventType={eventType} />
+            </div>
           </div>
         )}
         {eventType?.requiresConfirmation && (


### PR DESCRIPTION
## What does this PR do?

Prevents long urls (or other very long texts for that matter) from overflowing on the public booking page. It will only break long words if they're longer than one sentence.  

It's not the most beautiful thing, but for edge cases this works and is way better than the overflowing. Probably down the line we can add the HTML editor @CarinaWolli is working on here as well, and give people to option to add real anchors? 

### Before

![CleanShot 2022-10-27 at 09 49 34@2x](https://user-images.githubusercontent.com/2969573/198223057-75f5f37c-7eff-4166-8992-b7b37108bfd6.jpg)


### After 

![CleanShot 2022-10-27 at 09 49 04@2x](https://user-images.githubusercontent.com/2969573/198222972-d1ba92c9-464c-4cf4-b34f-c37de2715d75.jpg)

**Environment**: Staging(main branch)

## Type of change

-  Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Create an event with a long discription with either a very long word or url in there (without dashes, . etc, since it will break there too), and notice that it now breaks it over multiple lines.

