### PR TITLE
Fix Zapier sample data and payload

### DIFF
--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -33,7 +33,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         location: true,
         cancellationReason: true,
         status: true,
-        user: true,
+        user: {
+          select: {
+            username: true,
+            name: true,
+            email: true,
+            timeZone: true,
+          },
+        },
         eventType: {
           select: {
             title: true,

--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -39,6 +39,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             name: true,
             email: true,
             timeZone: true,
+            locale: true,
           },
         },
         eventType: {

--- a/packages/features/webhooks/lib/sendPayload.tsx
+++ b/packages/features/webhooks/lib/sendPayload.tsx
@@ -42,6 +42,7 @@ function getZapierPayload(data: CalendarEvent & EventTypeInfo & { status?: strin
       name: data.organizer.name,
       email: data.organizer.email,
       timeZone: data.organizer.timeZone,
+      locale: data.organizer.locale,
     },
     eventType: {
       title: data.eventTitle,

--- a/packages/features/webhooks/lib/sendPayload.tsx
+++ b/packages/features/webhooks/lib/sendPayload.tsx
@@ -36,6 +36,13 @@ function getZapierPayload(data: CalendarEvent & EventTypeInfo & { status?: strin
     endTime: data.endTime,
     location: location,
     status: data.status,
+    cancellationReason: data.cancellationReason,
+    user: {
+      username: data.organizer.username,
+      name: data.organizer.name,
+      email: data.organizer.email,
+      timeZone: data.organizer.timeZone,
+    },
     eventType: {
       title: data.eventTitle,
       description: data.eventDescription,


### PR DESCRIPTION
## What does this PR do?

The sample data (`/listBookings` endpoint) shown to the user when testing a Zapier trigger should show the same data as the `sendPayload` function sends once a zap triggers. 

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
