### PR TITLE
Send only warn, error and fatal logs

### DIFF
--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -3,6 +3,7 @@ import { Logger } from "tslog";
 import { IS_PRODUCTION } from "./constants";
 
 const logger = new Logger({
+  minLevel: "warn",
   dateTimePattern: "hour:minute:second.millisecond timeZoneName",
   displayFunctionName: false,
   displayFilePath: "hidden",


### PR DESCRIPTION
Reduce default logging to warn and above and thus reduce logs in Axiom