### PR TITLE
Fixed regression introduced when date.format() was removed

### DIFF
--- a/apps/web/components/booking/AvailableTimes.tsx
+++ b/apps/web/components/booking/AvailableTimes.tsx
@@ -58,7 +58,7 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
             {nameOfDay(i18n.language, Number(date.format("d")), "short")}
           </span>
           <span className="text-bookinglight font-medium">
-            , {date.toDate().toLocaleString(i18n.language, { month: "long", day: "numeric" })}
+            , {date.toDate().toLocaleString(i18n.language, { month: "long" })} {date.format(" D ")}
           </span>
         </div>
         <div className="ml-auto">


### PR DESCRIPTION
Fixes #5260

toLocaleString does date transformations of the original date in accordance to browser settings, losing the timezone information embedded into dayjs, this can shift the date. 