### PR TITLE
Allow og image api in robots.txt

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -2,3 +2,6 @@ User-agent: *
 Disallow: /sandbox
 Disallow: /api
 Disallow: /static/locales
+
+# Specifically allow access to OG Image api, otherwise eg Twitter won't render these images.
+Allow: /api/social/og/image


### PR DESCRIPTION
## What does this PR do?

Allows OG image api in robots.txt so Twitter can access it to render images. 

Before Twitter would error like so: 

![CleanShot 2022-10-31 at 08 31 58@2x](https://user-images.githubusercontent.com/2969573/198955054-42b736ae-eba6-42f3-83da-18bba7b64082.jpg)

## Results on test env: 

![CleanShot 2022-10-31 at 10 34 00@2x](https://user-images.githubusercontent.com/2969573/198977126-cdcccb7e-9c5e-4f19-af4c-d1b3e2f21c98.jpg)

![CleanShot 2022-10-31 at 10 34 42@2x](https://user-images.githubusercontent.com/2969573/198977223-5b207f49-b2ba-452d-9fca-81ce456172f8.jpg)

![CleanShot 2022-10-31 at 10 35 14@2x](https://user-images.githubusercontent.com/2969573/198977327-7b7a8cde-561b-4c52-ab65-00080703a3c9.jpg)

![CleanShot 2022-10-31 at 10 39 47@2x](https://user-images.githubusercontent.com/2969573/198978207-3c4e6d12-2bf6-4784-8c28-fd41504cd74b.jpg)

As for Twitter; It seems that the dev preview tool doesn't show previews anymore, only validates (multiple github issues etc around. Next to that, Twitter.com DOES have some aggressive caching ;) 

![CleanShot 2022-10-31 at 10 40 50@2x](https://user-images.githubusercontent.com/2969573/198978379-0a3850aa-01a6-42db-838f-cb8671804056.jpg)


**Environment**: Staging(main branch)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
