### PR TITLE
Fix: EventType Ordering listing

### DIFF
--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -299,6 +299,8 @@ const loggedInViewerRouter = createProtectedRouter()
     async resolve({ ctx }) {
       const { prisma } = ctx;
       const eventTypeSelect = Prisma.validator<Prisma.EventTypeSelect>()({
+        // Position is required by lodash to sort on it. Don't remove it, TS won't complain but it would silently break reordering
+        position: true,
         hashedLink: true,
         destinationCalendar: true,
         team: {


### PR DESCRIPTION
Bug Introduced here [#4727 (files)](https://github.com/calcom/cal.com/pull/4727/files#diff-a1bfce47255580cef674136f50179f345fca5dd6e15bb01007a83eb4c2a8dd1dL277)

Fixes #5255

I had expected TS to complain while doing the cleanup but it didn't because orderBy is not completely TS safe