### PR TITLE
Fixes that some locations weren't shown in workflow notifications

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -20,7 +20,7 @@ const customTemplate = async (text: string, variables: VariablesType, locale: st
   let locationString = variables.location || "";
 
   if (text.includes("{LOCATION}")) {
-    locationString = guessEventLocationType(locationString)?.label || "";
+    locationString = guessEventLocationType(locationString)?.label || locationString;
   }
 
   let dynamicText = text


### PR DESCRIPTION
## What does this PR do?

Fixes that some locations like attendee's phone number and the address of in-person meetings weren't shown. 

Fixes [Linear CAL-288](https://linear.app/calcom/issue/CAL-288/location-variable-in-workflows-doesnt-get-pulled-if-location-is)

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)