### PR TITLE
/settings -> /settings/.. redirect in next.config.js is server only

### DIFF
--- a/packages/ui/v2/core/Shell.tsx
+++ b/packages/ui/v2/core/Shell.tsx
@@ -517,7 +517,7 @@ const navigation: NavigationItemType[] = [
   },
   {
     name: "settings",
-    href: "/settings",
+    href: "/settings/my-account/profile",
     icon: Icon.FiSettings,
   },
 ];


### PR DESCRIPTION
## What does this PR do?

Sets the full path as the nextjs router does not trigger the redirects in next.config.js on navigation.

Fixes #5382