### PR TITLE
fix/success-page-seats-description-5338

### DIFF
--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -788,7 +788,7 @@ const schema = z.object({
 
 const handleSeatsEventTypeOnBooking = (
   eventType: {
-    seatsPerTimeSlot: boolean | null;
+    seatsPerTimeSlot?: boolean | null;
     seatsShowAttendees: boolean | null;
     [x: string | number | symbol]: unknown;
   },
@@ -797,7 +797,7 @@ const handleSeatsEventTypeOnBooking = (
   >,
   email: string
 ) => {
-  if (eventType.seatsPerTimeSlot !== null) {
+  if (eventType?.seatsPerTimeSlot !== null) {
     // @TODO: right now bookings with seats doesn't save every description that its entered by every user
     delete booking.description;
   }

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -369,23 +369,12 @@ export default function Success(props: SuccessProps) {
                                 <p className="text-bookinglight">{bookingInfo.user.email}</p>
                               </div>
                             )}
-                            {!eventType.seatsShowAttendees
-                              ? bookingInfo?.attendees
-                                  .filter((attendee) => attendee.email === email)
-                                  .map((attendee) => (
-                                    <div key={attendee.name} className="mb-3">
-                                      <p>{attendee.name}</p>
-                                      <p className="text-bookinglight">{attendee.email}</p>
-                                    </div>
-                                  ))
-                              : bookingInfo?.attendees.map((attendee, index) => (
-                                  <div
-                                    key={attendee.name}
-                                    className={index === bookingInfo.attendees.length - 1 ? "" : "mb-3"}>
-                                    <p>{attendee.name}</p>
-                                    <p className="text-bookinglight">{attendee.email}</p>
-                                  </div>
-                                ))}
+                            {bookingInfo?.attendees.map((attendee, index) => (
+                              <div key={attendee.name} className="mb-3 last:mb-0">
+                                <p>{attendee.name}</p>
+                                <p className="text-bookinglight">{attendee.email}</p>
+                              </div>
+                            ))}
                           </>
                         </div>
                       </>

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -788,6 +788,7 @@ const schema = z.object({
 
 const handleSeatsEventTypeOnBooking = (
   eventType: {
+    seatsPerTimeSlot: boolean | null;
     seatsShowAttendees: boolean | null;
     [x: string | number | symbol]: unknown;
   },
@@ -796,7 +797,7 @@ const handleSeatsEventTypeOnBooking = (
   >,
   email: string
 ) => {
-  if (eventType.seatsShowAttendees !== null) {
+  if (eventType.seatsPerTimeSlot !== null) {
     // @TODO: right now bookings with seats doesn't save every description that its entered by every user
     delete booking.description;
   }


### PR DESCRIPTION


## What does this PR do?

- Removed description from bookingInfo if eventType has seats. This is due we don't save every description input on the DB for every user with a seat.
- Added server side validation that if booking has seats we don't leak any user's info to the client if seatsShowAttendees is false;

Fixes #5338 


**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- [ ] Add seats to booking and turn off/on Show attendees list
- [ ] While booking success make sure any description is shown and proper user list should be displayed if showAttendees its true|false.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
