### PR TITLE
Remove unsupported operators by JSOnLogic

### DIFF
--- a/packages/app-store/ee/routing-forms/components/react-awesome-query-builder/config/config.tsx
+++ b/packages/app-store/ee/routing-forms/components/react-awesome-query-builder/config/config.tsx
@@ -123,6 +123,13 @@ operators.between.label = "Between";
 delete operators.proximity;
 delete operators.is_null;
 delete operators.is_not_null;
+
+/**
+ * Not supported with JSONLogic. Implement them and add these back -> https://github.com/jwadhams/json-logic-js/issues/81
+ */
+delete operators.starts_with;
+delete operators.ends_with;
+
 const config = {
   conjunctions: BasicConfig.conjunctions,
   operators,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
**Fixes Bug:** Remove unsupported operators(startsWith and endsWith) by JSONLogic. react-query-awesome-builder supports them but not JSONLogic that we use for rule evaluation.
_Found this bug while building reporting for all operators_

- These would be the operators that would remain. `Contains` is still supported and should be enough for now.
 <img width="390" alt="Screenshot 2022-11-06 at 11 40 06 AM" src="https://user-images.githubusercontent.com/1780212/200156965-4a70776a-e3d8-44d6-9e75-dab7b665b9d1.png">

- Rules that might be using it already (just in case) actually always evaluate to true, so removing these operators shouldn't have an effect on them.


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- They should stop showing up in select as an operator

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
