### PR TITLE
Fixing count and redundant checks for recurring

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -9,7 +9,6 @@ import {
 import async from "async";
 import { cloneDeep } from "lodash";
 import type { NextApiRequest } from "next";
-import { RRule } from "rrule";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 import z from "zod";
@@ -212,7 +211,11 @@ async function ensureAvailableUsers(
   eventType: Awaited<ReturnType<typeof getEventTypesFromDB>> & {
     users: User[];
   },
-  input: { dateFrom: string; dateTo: string }
+  input: { dateFrom: string; dateTo: string },
+  recurringDatesInfo?: {
+    allRecurringDates: string[] | undefined;
+    currentRecurringIndex: number | undefined;
+  }
 ) {
   const availableUsers: typeof eventType.users = [];
   /** Let's start checking for availability */
@@ -243,9 +246,12 @@ async function ensureAvailableUsers(
 
     let foundConflict = false;
     try {
-      if (eventType.recurringEvent) {
-        const recurringEvent = parseRecurringEvent(eventType.recurringEvent);
-        const allBookingDates = new RRule({ dtstart: new Date(input.dateFrom), ...recurringEvent }).all();
+      if (
+        eventType.recurringEvent &&
+        recurringDatesInfo?.currentRecurringIndex === 0 &&
+        recurringDatesInfo.allRecurringDates
+      ) {
+        const allBookingDates = recurringDatesInfo.allRecurringDates.map((strDate) => new Date(strDate));
         // Go through each date for the recurring event and check if each one's availability
         // DONE: Decreased computational complexity from O(2^n) to O(n) by refactoring this loop to stop
         // running at the first unavailable time.
@@ -277,6 +283,8 @@ async function handler(req: NextApiRequest & { userId?: number | undefined }) {
 
   const {
     recurringCount,
+    allRecurringDates,
+    currentRecurringIndex,
     noEmail,
     eventTypeSlug,
     eventTypeId,
@@ -376,10 +384,20 @@ async function handler(req: NextApiRequest & { userId?: number | undefined }) {
       {
         ...eventType,
         users,
+        ...(eventType.recurringEvent && {
+          recurringEvent: {
+            ...eventType.recurringEvent,
+            count: recurringCount || eventType.recurringEvent.count,
+          },
+        }),
       },
       {
         dateFrom: reqBody.start,
         dateTo: reqBody.end,
+      },
+      {
+        allRecurringDates,
+        currentRecurringIndex,
       }
     );
 

--- a/packages/lib/CloseCom.ts
+++ b/packages/lib/CloseCom.ts
@@ -513,7 +513,6 @@ export default class CloseCom {
       description: "Generic Lead for Contacts created by Cal.com",
     }
   ): Promise<string> {
-    debugger;
     const closeComLeadNames = await this.lead.list({ query: { _fields: ["name", "id"] } });
     const searchLeadFromCalCom = closeComLeadNames.data.filter((lead) => lead.name === leadInfo.companyName);
     if (searchLeadFromCalCom.length === 0) {

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -150,6 +150,8 @@ export const extendedBookingCreateBody = bookingCreateBodySchema.merge(
   z.object({
     noEmail: z.boolean().optional(),
     recurringCount: z.number().optional(),
+    allRecurringDates: z.string().array().optional(),
+    currentRecurringIndex: z.number().optional(),
     rescheduleReason: z.string().optional(),
     smsReminderNumber: z.string().optional(),
     appsStatus: z


### PR DESCRIPTION
## What does this PR do?

When creating a recurring event, the user selects the number of occurrences, which was not taken into consideration when ensuring availability for the organizer, the number of occurrences used was the one initially configured by the organizer as the maximum number of occurrences. Also, for each recurring booking, the user availability check was run redundantly for unneeded dates. 

For example, given a recurring event with a maximum of 12 occurrences setup by the organizer, a user wants to book 5 occurrences, the checks were checking 12 occurrences either way, and for each of those 12 occurrences, 12 more occurences in the future.

This fixes both issues, also improving the performance avoiding the hard calculation using the heavy-weight RRule.js dependency for it.

My other finding regarding the blocking issue preventing booking a recurring event was fixed in [this commit](https://github.com/calcom/cal.com/commit/69100a0fe8ba756b7b2f0c4022473ea8a35093fc), thanks @emrysal for taking care of changing it as a super hotfix 😁

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try to book a recurring event, being able to successfully book it, probably cutting some time of delay.
