### PR TITLE
Change button text to 'Browse App Store'

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -782,7 +782,7 @@
   "analytics": "Analytics",
   "empty_installed_apps_headline": "No apps installed",
   "empty_installed_apps_description": "Apps enable you to enhance your workflow and improve your scheduling life significantly.",
-  "empty_installed_apps_button": "Explore the App Store or Install from below apps",
+  "empty_installed_apps_button": "Browse App Store",
   "manage_your_connected_apps": "Manage your installed apps or change settings",
   "browse_apps": "Browse Apps",
   "features": "Features",


### PR DESCRIPTION
## What does this PR do?

Fix text for button to browse app store if there are no apps installed. Text was too long and all the button does it to redirect the user to app store to browse the app store.

Before:
![Screenshot 2022-11-10 at 09 33 37](https://user-images.githubusercontent.com/30310907/201040837-34b567af-8926-4fc7-aee7-3714a8fbe62a.png)

After: 
![Screenshot 2022-11-10 at 09 33 58](https://user-images.githubusercontent.com/30310907/201040891-16d017bf-868a-474f-8709-7811c5242012.png)

**Environment**: Staging(main branch) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)