### PR TITLE
Self-hosted: Team Event Created without explicitly setting locations crashes on /booking page

### DIFF
--- a/apps/web/pages/team/[slug]/book.tsx
+++ b/apps/web/pages/team/[slug]/book.tsx
@@ -85,7 +85,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const eventType = {
     ...eventTypeRaw,
     //TODO: Use zodSchema to verify it instead of using Type Assertion
-    locations: privacyFilteredLocations(eventTypeRaw.locations as LocationObject[]),
+    locations: privacyFilteredLocations((eventTypeRaw.locations || []) as LocationObject[]),
     recurringEvent: parseRecurringEvent(eventTypeRaw.recurringEvent),
   };
 


### PR DESCRIPTION
In self-hosted, calvideo isn't default and thus an event can be created without locations

This error comes right now on local, while booking such an event.

<img width="1292" alt="Screenshot 2022-11-10 at 2 33 22 PM" src="https://user-images.githubusercontent.com/1780212/201047256-f16bffe6-df42-43d8-8bcb-a147cef20eee.png">
