### PR TITLE
fix: change max width for mobile

### DIFF
--- a/packages/ui/v2/modules/event-types/EventTypeDescription.tsx
+++ b/packages/ui/v2/modules/event-types/EventTypeDescription.tsx
@@ -35,7 +35,7 @@ export const EventTypeDescription = ({ eventType, className }: EventTypeDescript
     <>
       <div className={classNames("dark:text-darkgray-800 text-neutral-500", className)}>
         {eventType.description && (
-          <h2 className="dark:text-darkgray-800 max-w-[280px] overflow-hidden text-ellipsis py-2 text-sm text-gray-600 opacity-60 sm:max-w-[500px]">
+          <h2 className="dark:text-darkgray-800 max-w-[200px] overflow-hidden text-ellipsis py-2 text-sm text-gray-600 opacity-60 sm:max-w-[500px]">
             {eventType.description.substring(0, 100)}
             {eventType.description.length > 100 && "..."}
           </h2>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/53316345/201470028-3d9f2200-3628-4936-85d4-4a893a35615f.png)


after

<img width="320" alt="Screenshot 2022-11-12 at 4 00 06 PM" src="https://user-images.githubusercontent.com/53316345/201470053-c557eb8f-4101-4bab-bd47-47a1a6325662.png">
