### PR TITLE
Use Intl.DateTimeFormat logic to determine locale.

### DIFF
--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -31,13 +31,8 @@ export const isBrowserLocale24h = () => {
   } else if (localStorageTimeFormat === false) {
     return false;
   }
-
-  let locale = "en-US";
-  if (typeof window !== "undefined" && navigator) {
-    locale = window.navigator?.language;
-  }
-
-  if (!!new Intl.DateTimeFormat(locale, { hour: "numeric" }).format(0).match(/M/i)) {
+  // Intl.DateTimeFormat with value=undefined uses local browser settings.
+  if (!!new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(0).match(/M/i)) {
     setIs24hClockInLocalStorage(false);
     return false;
   } else {


### PR DESCRIPTION
I believe in ChromeHeadless `window.navigator.language` === "": this is throwing errors.

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/1046695/201715205-c1b0b18b-e1d1-4cea-a1dc-a1a58681c4f9.png">

(Shared IP in screenshot is AWS, not PII)