### PR TITLE
Removed an invalidate onDelete + updated test

### DIFF
--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -9,14 +9,11 @@ test.describe("Teams", () => {
     await users.deleteAll();
   });
 
-  test("Can create teams via Wizard", async ({ page, users, prisma }) => {
+  test("Can create teams via Wizard", async ({ page, users }) => {
     const user = await users.create();
     const inviteeEmail = `${user.username}+invitee@example.com`;
     await user.login();
     await page.goto("/teams");
-
-    // Expect teams to be empty
-    await expect(page.locator('[data-testid="empty-screen"]')).toBeVisible();
 
     await test.step("Can create team", async () => {
       // Click text=Create Team
@@ -58,7 +55,9 @@ test.describe("Teams", () => {
       await page.locator("text=Delete Team").click();
       await page.locator("text=Yes, disband team").click();
       await page.waitForURL("/teams");
-      await expect(page.locator('[data-testid="empty-screen"]')).toBeVisible();
+      await expect(await page.locator(`text=${user.username}'s Team`).count()).toEqual(0);
+      // FLAKY: If other tests are running async this may mean there are >0 teams, empty screen will not be shown.
+      // await expect(page.locator('[data-testid="empty-screen"]')).toBeVisible();
     });
   });
 });

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -71,7 +71,6 @@ const ProfileView = () => {
 
   const deleteTeamMutation = trpc.viewer.teams.delete.useMutation({
     async onSuccess() {
-      await utils.viewer.teams.get.invalidate();
       await utils.viewer.teams.list.invalidate();
       showToast(t("your_team_disbanded_successfully"), "success");
       router.push(`${WEBAPP_URL}/teams`);


### PR DESCRIPTION
## What does this PR do?

* Fixes invalidate `await utils.viewer.teams.get.invalidate();` holding up the delete. It tried 3 times to invalidate all resulting in 404's as the resource was gone at that point. 
* Test would break occasionally if any other test for any reason created a team, so did a minor update to fix that potential flakiness.