### PR TITLE
fix langauge in booking submitted email for attendee

### DIFF
--- a/packages/emails/src/templates/AttendeeRequestEmail.tsx
+++ b/packages/emails/src/templates/AttendeeRequestEmail.tsx
@@ -2,12 +2,12 @@ import { AttendeeScheduledEmail } from "./AttendeeScheduledEmail";
 
 export const AttendeeRequestEmail = (props: React.ComponentProps<typeof AttendeeScheduledEmail>) => (
   <AttendeeScheduledEmail
-    title={props.calEvent.organizer.language.translate(
+    title={props.calEvent.attendees[0].language.translate(
       props.calEvent.recurringEvent?.count ? "booking_submitted_recurring" : "booking_submitted"
     )}
     subtitle={
       <>
-        {props.calEvent.organizer.language.translate(
+        {props.calEvent.attendees[0].language.translate(
           props.calEvent.recurringEvent?.count
             ? "user_needs_to_confirm_or_reject_booking_recurring"
             : "user_needs_to_confirm_or_reject_booking",
@@ -16,7 +16,7 @@ export const AttendeeRequestEmail = (props: React.ComponentProps<typeof Attendee
       </>
     }
     headerType="calendarCircle"
-    subject="booking_submitted_subject"
+    subject={props.calEvent.attendees[0].language.translate("booking_submitted_subject")}
     {...props}
   />
 );

--- a/packages/emails/templates/attendee-request-email.ts
+++ b/packages/emails/templates/attendee-request-email.ts
@@ -16,7 +16,7 @@ export default class AttendeeRequestEmail extends AttendeeScheduledEmail {
     return {
       from: `Cal.com <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      subject: `${this.calEvent.organizer.language.translate("booking_submitted_subject", {
+      subject: `${this.calEvent.attendees[0].language.translate("booking_submitted_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.team?.name || this.calEvent.organizer.name,
         date: this.getFormattedDate(),


### PR DESCRIPTION
## What does this PR do?

When booking an event that requires a confirmation and the organizer and attendee have different languages, the 'booking submitted' email was sent in the organizer's language to the attendee. 

Fixes #5490

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)