### PR TITLE
Fixed wrong calculation of duration type on event type page.

### DIFF
--- a/apps/web/components/eventtype/EventLimitsTab.tsx
+++ b/apps/web/components/eventtype/EventLimitsTab.tsx
@@ -173,7 +173,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupInfered, "event
         </div>
       </div>
       <div className="flex flex-col space-y-4 pt-4 lg:flex-row lg:space-y-0 lg:space-x-4">
-        <div className="flex w-full items-end">
+        <div className="flex w-full items-end justify-end">
           <Controller
             name="minimumBookingNotice"
             control={formMethods.control}
@@ -201,7 +201,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupInfered, "event
                       label={t("minimum_booking_notice")}
                       type="number"
                       placeholder="120"
-                      className="mr-2 rounded-[4px]"
+                      className="mr-2 mb-0 h-[38px] rounded-[4px]"
                       {...formMethods.register("minimumBookingNoticeInDurationType", {
                         onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
                           onMinimumNoticeChange(event.target.value),
@@ -211,7 +211,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupInfered, "event
                   </div>
                   <Select
                     isSearchable={false}
-                    className="mb-2 ml-2 w-full capitalize md:min-w-[150px] md:max-w-[200px]"
+                    className="mb-0 ml-2 h-[38px] w-full capitalize md:min-w-[150px] md:max-w-[200px]"
                     defaultValue={durationTypeOptions.find(
                       (option) => option.value === minimumBookingNoticeType.current
                     )}

--- a/packages/lib/convertToNewDurationType.ts
+++ b/packages/lib/convertToNewDurationType.ts
@@ -12,13 +12,13 @@ export default function convertToNewDurationType(
   /** Convert `prevValue` from `prevType` to `newType` */
   const newDurationTypeMap = {
     minutes_minutes: () => prevValue,
-    minutes_hours: () => prevValue * MINUTES_IN_HOUR,
-    minutes_days: () => prevValue * MINUTES_IN_DAY,
-    hours_minutes: () => prevValue / MINUTES_IN_HOUR,
+    minutes_hours: () => prevValue / MINUTES_IN_HOUR,
+    minutes_days: () => prevValue / MINUTES_IN_DAY,
+    hours_minutes: () => prevValue * MINUTES_IN_HOUR,
     hours_hours: () => prevValue,
     hours_days: () => prevValue * HOURS_IN_DAY,
-    days_minutes: () => prevValue / MINUTES_IN_DAY,
-    days_hours: () => prevValue / HOURS_IN_DAY,
+    days_minutes: () => prevValue * MINUTES_IN_DAY,
+    days_hours: () => prevValue * HOURS_IN_DAY,
     days_days: () => prevValue,
   };
   const getNewValue = newDurationTypeMap[`${prevType}_${newType}`];


### PR DESCRIPTION
## What does this PR do?

Calculation of the event type duration was not correct, eg 90 mins was converted into a very big number of hours. 

**Environment**: Staging(main branch)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to an event type page, go to the advanced tab, fill in a number of minutes (eg 300). Save it, and see that after a refresh we've converted into the correct amount of hours or days. It will only show it as hours / days when it rounds to a full amount of hours / days. No decimals. If it does not round, we still show minutes. 
