### PR TITLE
fix/Add conditional if response received from graph api v1 was empty

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -153,6 +153,10 @@ const TeamsVideoApiAdapter = (credential: CredentialPayload): VideoApiAdapter =>
 
       const resultObject = JSON.parse(resultString);
 
+      if (!resultObject.id || !resultObject.joinUrl) {
+        throw new HttpError({ statusCode: 500, message: "Error creating MS Teams meeting" });
+      }
+
       return Promise.resolve({
         type: "office365_video",
         id: resultObject.id,

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -30,6 +30,7 @@ export async function handleErrorsJson<Type>(response: Response): Promise<Type> 
 
 export function handleErrorsRaw(response: Response) {
   if (response.status === 204) {
+    console.error({ response });
     return "{}";
   }
   if (!response.ok && response.status < 200 && response.status >= 300) {


### PR DESCRIPTION
## What does this PR do?

Looks like due to some unknown behaviour MSTeams createMeeting return 204 

- Add conditional to throw error if response from msteam graph api was empty and 2XX.
- console.error on handleErrorRaw to logs which services shouldn't throw 204.

Fixes #5546 


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


- I haven't added tests that prove my fix is effective or that my feature works

