### PR TITLE
Techdebt/improve sentry config

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -80,6 +80,7 @@ plugins.push(withAxiom);
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   i18n,
+  productionBrowserSourceMaps: true,
   /* We already do type check on GH actions */
   typescript: {
     ignoreBuildErrors: !!process.env.CI,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -88,10 +88,8 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: !!process.env.CI,
   },
-  experimental: {
-    images: {
-      unoptimized: true,
-    },
+  images: {
+    unoptimized: true,
   },
   webpack: (config) => {
     config.plugins.push(
@@ -230,11 +228,6 @@ const nextConfig = {
 
     return redirects;
   },
-  sentry: {
-    hideSourceMaps: true,
-    // Prevents Sentry from running on this Edge function, where Sentry doesn't work yet (build whould crash the api route).
-    excludeServerRoutes: [/\/api\/social\/og\/image\/?/],
-  },
 };
 
 const sentryWebpackPluginOptions = {
@@ -242,6 +235,14 @@ const sentryWebpackPluginOptions = {
 };
 
 const moduleExports = () => plugins.reduce((acc, next) => next(acc), nextConfig);
+
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  nextConfig.sentry = {
+    hideSourceMaps: true,
+    // Prevents Sentry from running on this Edge function, where Sentry doesn't work yet (build whould crash the api route).
+    excludeServerRoutes: [/\/api\/social\/og\/image\/?/],
+  };
+}
 
 // Sentry should be the last thing to export to catch everything right
 module.exports = process.env.NEXT_PUBLIC_SENTRY_DSN


### PR DESCRIPTION
## What does this PR do?

* Moves unoptimised images out of experimental
* enables `productionBrowserSourceMaps` with the intention to make Sentry more readable.
* Only add sentry config if it is used, prevents 

> The root value has an unexpected property, sentry, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).