### PR TITLE
Booking Limits checking ALL events not the event the limit is applied too

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -911,7 +911,7 @@ function ErrorMessage({ error }: { error: unknown }) {
         <div className="ltr:ml-3 rtl:mr-3">
           <p className="text-sm text-yellow-700">
             {rescheduleUid ? t("reschedule_fail") : t("booking_fail")}{" "}
-            {error instanceof HttpError || error instanceof Error ? error.message : "Unknown error"}
+            {error instanceof HttpError || error instanceof Error ? t(error.message) : "Unknown error"}
           </p>
         </div>
       </div>

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1372,5 +1372,6 @@
   "test_preview": "Test Preview",
   "route_to": "Route to",
   "test_preview_description": "Test your routing form without submitting any data",
-  "test_routing": "Test Routing"
+  "test_routing": "Test Routing",
+  "booking_limit_reached":"Booking Limit for this event type has been reached"
 }

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -52,6 +52,7 @@ export async function getBusyTimes(params: {
         title: true,
         eventType: {
           select: {
+            id: true,
             afterEventBuffer: true,
             beforeEventBuffer: true,
           },
@@ -67,7 +68,7 @@ export async function getBusyTimes(params: {
           .add((eventType?.afterEventBuffer || 0) + (beforeEventBuffer || 0), "minute")
           .toDate(),
         title,
-        source: `eventType-${eventTypeId}-booking-${id}`,
+        source: `eventType-${eventType?.id}-booking-${id}`,
       }))
     );
   logger.silly(`Busy Time from Cal Bookings ${JSON.stringify(busyTimes)}`);

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -202,10 +202,12 @@ export async function getUserAvailability(
         const startDate = dayjs(booking.start).startOf(filter);
         // this is parsed above with parseBookingLimit so we know it's safe.
         const endDate = dayjs(startDate).endOf(filter);
-
+        const bookingEventTypeId = booking.source?.split("-")[1];
+        console.log({ bookingEventTypeId, eventTypeId, booking });
         if (dayjs(booking.start).isBetween(startDate, endDate)) total++;
-        if (total >= limit)
+        if (total >= limit && bookingEventTypeId === eventType?.id?.toString()) {
           bufferedBusyTimes.push({ start: startDate.toISOString(), end: endDate.toISOString() });
+        }
       });
     }
   }

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -203,7 +203,6 @@ export async function getUserAvailability(
         // this is parsed above with parseBookingLimit so we know it's safe.
         const endDate = dayjs(startDate).endOf(filter);
         const bookingEventTypeId = booking.source?.split("-")[1];
-        console.log({ bookingEventTypeId, eventTypeId, booking });
         if (dayjs(booking.start).isBetween(startDate, endDate)) total++;
         if (total >= limit && bookingEventTypeId === eventType?.id?.toString()) {
           bufferedBusyTimes.push({ start: startDate.toISOString(), end: endDate.toISOString() });

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -204,6 +204,8 @@ export async function getUserAvailability(
         const endDate = dayjs(startDate).endOf(filter);
         const bookingEventTypeId = booking.source?.split("-")[1];
         if (dayjs(booking.start).isBetween(startDate, endDate)) total++;
+        // Only check OUR booking that matches the current eventTypeId
+        // we don't care about another event type in this case as we dont need to know their booking limits
         if (total >= limit && bookingEventTypeId === eventType?.id?.toString()) {
           bufferedBusyTimes.push({ start: startDate.toISOString(), end: endDate.toISOString() });
         }

--- a/packages/lib/server/checkBookingLimits.ts
+++ b/packages/lib/server/checkBookingLimits.ts
@@ -86,7 +86,7 @@ export async function checkLimit({
       }
 
       throw new HttpError({
-        message: `Booking limit of ${limitingNumber}/${filter} reached for this eventType`,
+        message: `Booking limit of ${limitingNumber}/${filter} reached for this Event Type`,
         statusCode: 403,
       });
     }

--- a/packages/lib/server/checkBookingLimits.ts
+++ b/packages/lib/server/checkBookingLimits.ts
@@ -86,7 +86,7 @@ export async function checkLimit({
       }
 
       throw new HttpError({
-        message: `Booking limit of ${limitingNumber}/${filter} reached for this Event Type`,
+        message: `booking_limit_reached`,
         statusCode: 403,
       });
     }


### PR DESCRIPTION
This PR ensure we only check the event type the user is booking and not all bookings of OUR bookings in the users calendar.

**_Should_** fix the issue where we were getting an inconsistent result between availability being hidden on the calendar and the booking error message 


Translate error string on booking page if any. If there is no translation found we will just display the English error as per the normal usage of `useLocale`

<img width="492" alt="CleanShot 2022-11-21 at 11 42 49@2x" src="https://user-images.githubusercontent.com/55134778/203042953-203909a6-5b42-404d-9d16-581e124d277f.png">
