### PR TITLE
Adds windows compatibility for copywebpackplugin

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -97,7 +97,7 @@ const nextConfig = {
       new CopyWebpackPlugin({
         patterns: [
           {
-            from: "../../packages/app-store/*/static/**",
+            from: "../../packages/app-store/**/static/**",
             to({ context, absoluteFilename }) {
               // Adds compatibility for windows path
               const absoluteFilenameWin = absoluteFilename.replaceAll("\\", "/");

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -97,10 +97,16 @@ const nextConfig = {
       new CopyWebpackPlugin({
         patterns: [
           {
-            from: "../../packages/app-store/**/static/**",
+            from: "../../packages/app-store/*/static/**",
             to({ context, absoluteFilename }) {
-              const appName = /app-store\/(.*)\/static/.exec(absoluteFilename);
-              return Promise.resolve(`${context}/public/app-store/${appName[1]}/[name][ext]`);
+              // Adds compatibility for windows path
+              const absoluteFilenameWin = absoluteFilename.replaceAll("\\", "/");
+              // Adds compatibility for windows path
+              const normalizedContext = context.replaceAll("\\", "/");
+              const appName =
+                /app-store\/(.*)\/static/.exec(absoluteFilename) ||
+                /app-store\/(.*)\/static/.exec(absoluteFilenameWin);
+              return Promise.resolve(`${normalizedContext}/public/app-store/${appName[1]}/[name][ext]`);
             },
           },
         ],


### PR DESCRIPTION
## What does this PR do?

- Attempts to add windows compatibility for CopyWebpackPlugin without destroying Mac compatibility

Fixes #4053 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Running `yarn dev` on Windows should not cause error mentioned in #4053 and all the images/assets should be available in the app (all app store images, for example)
