### PR TITLE
Fix rescheduling error with attendee phone number as location

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -622,7 +622,7 @@ const BookingPage = ({
                   )}
                 </>
                 {/* TODO: Change name and id ="phone" to something generic */}
-                {AttendeeInput && (
+                {AttendeeInput && !disableInput && (
                   <div className="mb-4">
                     <label
                       htmlFor={
@@ -659,7 +659,6 @@ const BookingPage = ({
                             : ""
                         }
                         required
-                        disabled={disableInput}
                       />
                     </div>
                     {bookingForm.formState.errors.phone && (

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -299,10 +299,9 @@ export default function Success(props: SuccessProps) {
   const locationToDisplay = getSuccessPageLocationMessage(location, t);
 
   const hasSMSAttendeeAction =
-    eventType.workflows.filter(
-      (workflowEventType) =>
-        workflowEventType.workflow.steps.filter((step) => step.action === WorkflowActions.SMS_ATTENDEE).length
-    ).length > 0;
+    eventType.workflows.find((workflowEventType) =>
+      workflowEventType.workflow.steps.find((step) => step.action === WorkflowActions.SMS_ATTENDEE)
+    ) !== undefined;
 
   return (
     <div className={isEmbed ? "" : "h-screen"} data-testid="success-page">

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -1,4 +1,4 @@
-import { BookingStatus } from "@prisma/client";
+import { BookingStatus, WorkflowActions } from "@prisma/client";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import classNames from "classnames";
 import { createEvent } from "ics";
@@ -298,6 +298,12 @@ export default function Success(props: SuccessProps) {
 
   const locationToDisplay = getSuccessPageLocationMessage(location, t);
 
+  const hasSMSAttendeeAction =
+    eventType.workflows.filter(
+      (workflowEventType) =>
+        workflowEventType.workflow.steps.filter((step) => step.action === WorkflowActions.SMS_ATTENDEE).length
+    ).length > 0;
+
   return (
     <div className={isEmbed ? "" : "h-screen"} data-testid="success-page">
       {userIsOwner && !isEmbed && (
@@ -452,7 +458,7 @@ export default function Success(props: SuccessProps) {
                           </>
                         );
                       })}
-                    {bookingInfo?.smsReminderNumber && (
+                    {bookingInfo?.smsReminderNumber && hasSMSAttendeeAction && (
                       <>
                         <div className="mt-9 font-medium">{t("number_sms_notifications")}</div>
                         <div className="col-span-2 mb-2 mt-9">
@@ -775,6 +781,15 @@ const getEventTypesFromDB = async (id: number) => {
           slug: true,
           name: true,
           hideBranding: true,
+        },
+      },
+      workflows: {
+        select: {
+          workflow: {
+            select: {
+              steps: true,
+            },
+          },
         },
       },
       metadata: true,

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -153,7 +153,7 @@ export const extendedBookingCreateBody = bookingCreateBodySchema.merge(
     allRecurringDates: z.string().array().optional(),
     currentRecurringIndex: z.number().optional(),
     rescheduleReason: z.string().optional(),
-    smsReminderNumber: z.string().optional(),
+    smsReminderNumber: z.string().optional().nullable(),
     appsStatus: z
       .array(
         z.object({


### PR DESCRIPTION
## What does this PR do?

Fixes rescheduling error for bookings that have the attendee's phone number as their location. 

Also fixes that SMS reminder phone number was always shown on success page when the location was attendee's phone number. 

Fixes #5652

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Book an event with attendee's phone number as location
- Reschedule the event 