### PR TITLE
TZ Fix for event created on icloud app

### DIFF
--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -311,9 +311,9 @@ export default abstract class BaseCalendarService implements Calendar {
       if (vevent?.getFirstPropertyValue("transp") === "TRANSPARENT") return;
 
       const event = new ICAL.Event(vevent);
-
-      const tzid: string | undefined =
-        vevent?.getFirstPropertyValue("tzid") || vevent?.getFirstPropertyValue("dtstart")["timezone"];
+      const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
+      const timezone = dtstart ? dtstart["timezone"] : undefined;
+      const tzid: string | undefined = vevent?.getFirstPropertyValue("tzid") || timezone;
       // In case of icalendar, when only tzid is available without vtimezone, we need to add vtimezone explicitly to take care of timezone diff
       if (!vcalendar.getFirstSubcomponent("vtimezone") && tzid) {
         const timezoneComp = new ICAL.Component("vtimezone");

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -312,7 +312,8 @@ export default abstract class BaseCalendarService implements Calendar {
 
       const event = new ICAL.Event(vevent);
 
-      const tzid: string | undefined = vevent?.getFirstPropertyValue("tzid");
+      const tzid: string | undefined =
+        vevent?.getFirstPropertyValue("tzid") || vevent?.getFirstPropertyValue("dtstart")["timezone"];
       // In case of icalendar, when only tzid is available without vtimezone, we need to add vtimezone explicitly to take care of timezone diff
       if (!vcalendar.getFirstSubcomponent("vtimezone") && tzid) {
         const timezoneComp = new ICAL.Component("vtimezone");


### PR DESCRIPTION
## What does this PR do?

So, Apple being Apple decided to provide Timezone information in different places when an event is created on browser vs on the icloud native app. This PR adds the compatibility for adjusting TZ when the event is created on the app.

Fixes #5309 


**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

