### PR TITLE
Fixing add button in Installed Calendars list

### DIFF
--- a/apps/web/components/apps/AdditionalCalendarSelector.tsx
+++ b/apps/web/components/apps/AdditionalCalendarSelector.tsx
@@ -61,12 +61,10 @@ const AdditionalCalendarSelector = ({ isLoading }: AdditionalCalendarSelectorPro
           <Select
             name="additionalCalendar"
             placeholder={
-              <div className="flex justify-start text-black">
-                <Icon.FiPlus className="-ml-1 h-4 w-4 ltr:mr-2 rtl:ml-2 rtl:-mr-1" />
-                <p>{t("add")}</p>
-              </div>
+              <Button StartIcon={Icon.FiPlus} color="secondary">
+                {t("add")}
+              </Button>
             }
-            className="min-w-44"
             options={options}
             isSearchable={false}
             isLoading={isLoading}
@@ -80,11 +78,16 @@ const AdditionalCalendarSelector = ({ isLoading }: AdditionalCalendarSelectorPro
                 width: "max-content",
                 right: "0",
               }),
+              indicatorSeparator: (defaultStyles) => ({
+                ...defaultStyles,
+                display: "none",
+              }),
               control: (defaultStyles) => ({
                 ...defaultStyles,
                 padding: "0",
                 border: "0",
-                borderRadius: "inherit",
+                borderRadius: "6px",
+                minHeight: "auto",
               }),
               dropdownIndicator: (defaultStyles) => ({
                 ...defaultStyles,


### PR DESCRIPTION
## What does this PR do?

The add button for installed calendars was broken. Fixing it.

Before:
![image](https://user-images.githubusercontent.com/467258/204615713-3206cc19-61af-4069-9552-f04d7cfa2641.png)

After:
![image](https://user-images.githubusercontent.com/467258/204615653-49ab975d-de43-41be-9482-efdfd29c9fb7.png)


Fixes #5778 

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to http://app.cal.dev/apps/installed/calendar and see the "+ Add" button with correct styles.
