### PR TITLE
Fixes disable branding for teams and users

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -1,6 +1,7 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { EventType } from "@prisma/client";
 import * as Popover from "@radix-ui/react-popover";
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useReducer, useEffect, useMemo, useState } from "react";
 import { Toaster } from "react-hot-toast";
@@ -251,6 +252,7 @@ export type Props = AvailabilityTeamPageProps | AvailabilityPageProps | DynamicA
 const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
   const router = useRouter();
   const isEmbed = useIsEmbed(restProps.isEmbed);
+  const session = useSession();
   const query = dateQuerySchema.parse(router.query);
   const { rescheduleUid } = query;
   useTheme(profile.theme);
@@ -315,6 +317,18 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
       ? ("rainbow" as Gate)
       : undefined,
   ];
+
+  const showBranding = () => {
+    if (restProps.isBrandingHidden.type == "TEAM") {
+      return !restProps.isBrandingHidden.value;
+    } else if (restProps.isBrandingHidden.type == "USER") {
+      return !isBrandingHidden(
+        restProps.isBrandingHidden.value,
+        session.data?.user.belongsToActiveTeam || false
+      );
+    }
+    return true;
+  };
 
   return (
     <Gates gates={gates} appData={rainbowAppData} dispatch={gateDispatcher}>
@@ -442,7 +456,7 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
                 />
               </div>
             </div>
-            {(!eventType.users[0] || !isBrandingHidden(eventType.users[0])) && !isEmbed && <PoweredByCal />}
+            {(showBranding() || isEmbed) && <PoweredByCal />}
           </div>
         </main>
       </div>

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -1,7 +1,6 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { EventType } from "@prisma/client";
 import * as Popover from "@radix-ui/react-popover";
-import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useReducer, useEffect, useMemo, useState } from "react";
 import { Toaster } from "react-hot-toast";

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -318,18 +318,6 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
       : undefined,
   ];
 
-  const showBranding = () => {
-    if (restProps.isBrandingHidden.type == "TEAM") {
-      return !restProps.isBrandingHidden.value;
-    } else if (restProps.isBrandingHidden.type == "USER") {
-      return !isBrandingHidden(
-        restProps.isBrandingHidden.value,
-        session.data?.user.belongsToActiveTeam || false
-      );
-    }
-    return true;
-  };
-
   return (
     <Gates gates={gates} appData={rainbowAppData} dispatch={gateDispatcher}>
       <HeadSeo
@@ -456,7 +444,7 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
                 />
               </div>
             </div>
-            {(showBranding() || isEmbed) && <PoweredByCal />}
+            {(!restProps.isBrandingHidden || isEmbed) && <PoweredByCal />}
           </div>
         </main>
       </div>

--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -251,7 +251,6 @@ export type Props = AvailabilityTeamPageProps | AvailabilityPageProps | DynamicA
 const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
   const router = useRouter();
   const isEmbed = useIsEmbed(restProps.isEmbed);
-  const session = useSession();
   const query = dateQuerySchema.parse(router.query);
   const { rescheduleUid } = query;
   useTheme(profile.theme);

--- a/apps/web/lib/isBrandingHidden.tsx
+++ b/apps/web/lib/isBrandingHidden.tsx
@@ -1,5 +1,3 @@
-import { User } from "@prisma/client";
-
-export function isBrandingHidden<TUser extends Pick<User, "hideBranding" | "plan">>(user: TUser) {
-  return user.hideBranding && user.plan !== "FREE";
+export function isBrandingHidden(hideBrandingSetting: boolean, belongsToActiveTeam: boolean) {
+  return belongsToActiveTeam && hideBrandingSetting;
 }

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -156,6 +156,7 @@ async function getUserPageProps(context: GetStaticPropsContext) {
     locations: privacyFilteredLocations(locations),
     descriptionAsSafeHTML: eventType.description ? md.render(eventType.description) : null,
   });
+  // Check if the user you are logging into has any active teams
   const hasActiveTeam =
     user.teams.filter((m) => {
       const metadata = teamMetadataSchema.safeParse(m.team.metadata);

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -167,6 +167,10 @@ async function getUserPageProps(context: GetStaticPropsContext) {
       away: user?.away,
       isDynamic: false,
       trpcState: ssg.dehydrate(),
+      isBrandingHidden: {
+        type: "USER",
+        value: user.hideBranding,
+      },
     },
     revalidate: 10, // seconds
   };
@@ -262,6 +266,10 @@ async function getDynamicGroupPageProps(context: GetStaticPropsContext) {
       isDynamic: true,
       away: false,
       trpcState: ssg.dehydrate(),
+      isBrandingHidden: {
+        type: "DYNAMIC",
+        value: users[0].hideBranding,
+      },
     },
     revalidate: 10, // seconds
   };

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -122,7 +122,7 @@ const providers: Provider[] = [
         intervalInMs: 60 * 1000, // 1 minute
       });
       await limiter.check(10, user.email); // 10 requests per minute
-
+// Check if the user you are logging into has any active teams
       const hasActiveTeams =
         user.teams.filter((m) => {
           const metadata = teamMetadataSchema.safeParse(m.team.metadata);

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -14,12 +14,13 @@ import checkLicense from "@calcom/features/ee/common/server/checkLicense";
 import ImpersonationProvider from "@calcom/features/ee/impersonation/lib/ImpersonationProvider";
 import { hostedCal, isSAMLLoginEnabled } from "@calcom/features/ee/sso/lib/saml";
 import { ErrorCode, isPasswordValid, verifyPassword } from "@calcom/lib/auth";
-import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
+import { APP_NAME, IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
 import { defaultCookies } from "@calcom/lib/default-cookies";
 import rateLimit from "@calcom/lib/rateLimit";
 import { serverConfig } from "@calcom/lib/serverConfig";
 import prisma from "@calcom/prisma";
+import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
 import CalComAdapter from "@lib/auth/next-auth-custom-adapter";
 import { randomString } from "@lib/random";
@@ -63,6 +64,11 @@ const providers: Provider[] = [
           password: true,
           twoFactorEnabled: true,
           twoFactorSecret: true,
+          teams: {
+            include: {
+              team: true,
+            },
+          },
         },
       });
 
@@ -117,6 +123,13 @@ const providers: Provider[] = [
       });
       await limiter.check(10, user.email); // 10 requests per minute
 
+      const hasActiveTeams =
+        user.teams.filter((m) => {
+          const metadata = teamMetadataSchema.safeParse(m.team.metadata);
+          if (metadata.success && metadata.data?.subscriptionId) return false;
+          return true;
+        }).length > 0;
+
       // authentication success- but does it meet the minimum password requirements?
       if (user.role === "ADMIN" && !isPasswordValid(credentials.password, false, true)) {
         return {
@@ -125,6 +138,7 @@ const providers: Provider[] = [
           email: user.email,
           name: user.name,
           role: "USER",
+          belongsToActiveTeam: hasActiveTeams,
         };
       }
 
@@ -134,6 +148,7 @@ const providers: Provider[] = [
         email: user.email,
         name: user.name,
         role: user.role,
+        belongsToActiveTeam: hasActiveTeams,
       };
     },
   }),
@@ -272,6 +287,7 @@ export default NextAuth({
           email: user.email,
           role: user.role,
           impersonatedByUID: user?.impersonatedByUID,
+          belongsToActiveTeam: user?.belongsToActiveTeam,
         };
       }
 
@@ -307,6 +323,7 @@ export default NextAuth({
           email: existingUser.email,
           role: existingUser.role,
           impersonatedByUID: token.impersonatedByUID as number,
+          belongsToActiveTeam: token?.belongsToActiveTeam as boolean,
         };
       }
 
@@ -324,6 +341,7 @@ export default NextAuth({
           username: token.username as string,
           role: token.role as UserPermissionRole,
           impersonatedByUID: token.impersonatedByUID as number,
+          belongsToActiveTeam: token?.belongsToActiveTeam as boolean,
         },
       };
       return calendsoSession;

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -122,7 +122,7 @@ const providers: Provider[] = [
         intervalInMs: 60 * 1000, // 1 minute
       });
       await limiter.check(10, user.email); // 10 requests per minute
-// Check if the user you are logging into has any active teams
+      // Check if the user you are logging into has any active teams
       const hasActiveTeams =
         user.teams.filter((m) => {
           const metadata = teamMetadataSchema.safeParse(m.team.metadata);

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -14,7 +14,7 @@ import checkLicense from "@calcom/features/ee/common/server/checkLicense";
 import ImpersonationProvider from "@calcom/features/ee/impersonation/lib/ImpersonationProvider";
 import { hostedCal, isSAMLLoginEnabled } from "@calcom/features/ee/sso/lib/saml";
 import { ErrorCode, isPasswordValid, verifyPassword } from "@calcom/lib/auth";
-import { APP_NAME, IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
+import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
 import { defaultCookies } from "@calcom/lib/default-cookies";
 import rateLimit from "@calcom/lib/rateLimit";

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -166,10 +166,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       previousPage: context.req.headers.referer ?? null,
       booking,
       users: [user.username],
-      isBrandingHidden: {
-        type: "DYNAMIC",
-        value: user.hideBranding,
-      },
+      isBrandingHidden: user.hideBranding,
     },
   };
 };

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -166,6 +166,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       previousPage: context.req.headers.referer ?? null,
       booking,
       users: [user.username],
+      isBrandingHidden: {
+        type: "DYNAMIC",
+        value: user.hideBranding,
+      },
     },
   };
 };

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -1,3 +1,4 @@
+import { useSession } from "next-auth/react";
 import { Controller, useForm } from "react-hook-form";
 
 import { APP_NAME } from "@calcom/lib/constants";
@@ -41,7 +42,8 @@ const SkeletonLoader = () => {
 
 const AppearanceView = () => {
   const { t } = useLocale();
-
+  const session = useSession();
+  console.log({ session });
   const utils = trpc.useContext();
   const { data: user, isLoading } = trpc.viewer.me.useQuery();
 

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -43,7 +43,6 @@ const SkeletonLoader = () => {
 const AppearanceView = () => {
   const { t } = useLocale();
   const session = useSession();
-  console.log({ session });
   const utils = trpc.useContext();
   const { data: user, isLoading } = trpc.viewer.me.useQuery();
 
@@ -182,6 +181,7 @@ const AppearanceView = () => {
               <div className="flex-none">
                 <Switch
                   id="hideBranding"
+                  disabled={!session.data?.user.belongsToActiveTeam}
                   onCheckedChange={(checked) =>
                     formMethods.setValue("hideBranding", checked, { shouldDirty: true })
                   }

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -161,10 +161,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       previousPage: context.req.headers.referer ?? null,
       booking,
       trpcState: ssg.dehydrate(),
-      isBrandingHidden: {
-        type: "TEAM",
-        value: team.hideBranding,
-      },
+      isBrandingHidden: team.hideBranding,
     },
   };
 };

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -43,6 +43,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       name: true,
       slug: true,
       logo: true,
+      hideBranding: true,
       eventTypes: {
         where: {
           slug: typeParam,
@@ -160,6 +161,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       previousPage: context.req.headers.referer ?? null,
       booking,
       trpcState: ssg.dehydrate(),
+      isBrandingHidden: {
+        type: "TEAM",
+        value: team.hideBranding,
+      },
     },
   };
 };

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -14,6 +14,7 @@ declare module "next-auth" {
     emailVerified?: PrismaUser["emailVerified"];
     email_verified?: boolean;
     impersonatedByUID?: number;
+    belongsToActiveTeam?: boolean;
     username?: PrismaUser["username"];
     role?: PrismaUser["role"];
   }


### PR DESCRIPTION
## What does this PR do?
This PR moves branding to only be togglable by people with an active team subscription (Paying customer) 

This just requires the user to be in a active team to get the ability to toggle the option on their own personal events. 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/share/9d241407d66c4e07a1e83f5200145dbe
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] To test this login to teampro
- [ ] Toggle you appearance on for personal event types and team event types.
- [ ] Ensure that this reflects the expected settings on your public event type and also the event type that is attached to your team. 
- [ ] Switch to a account that doesnt have any teams and ensure that it gets blocked

