### PR TITLE
Adds missing spaces in email (reschedule or cancel)

### DIFF
--- a/apps/web/public/static/locales/fr/common.json
+++ b/apps/web/public/static/locales/fr/common.json
@@ -82,7 +82,7 @@
   "join_by_entrypoint": "Rejoindre par {{entryPoint}}",
   "notes": "Notes",
   "manage_my_bookings": "Gérer mes réservations",
-  "need_to_make_a_change": "Besoin de faire un changement ?",
+  "need_to_make_a_change": "Besoin de faire un changement?",
   "new_event_scheduled": "Un nouvel événement a été programmé.",
   "new_event_scheduled_recurring": "Un nouvel événement récurrent a été programmé.",
   "invitee_email": "E-mail de l'invité",

--- a/packages/emails/src/components/ManageLink.tsx
+++ b/packages/emails/src/components/ManageLink.tsx
@@ -28,16 +28,18 @@ export function ManageLink(props: { calEvent: CalendarEvent; attendee: Person })
             width: "100%",
             gap: "8px",
           }}>
-          <>{t("need_to_make_a_change")}</>{" "}
+          <>{t("need_to_make_a_change")}</>
           {!props.calEvent.recurringEvent && (
             <>
-              <a href={getRescheduleLink(props.calEvent)} style={{ color: "#3e3e3e" }}>
-                <>{t("reschedule")}</>{" "}
+              <a
+                href={getRescheduleLink(props.calEvent)}
+                style={{ color: "#3e3e3e", marginLeft: "5px", marginRight: "5px" }}>
+                <>{t("reschedule")}</>
               </a>
-              <>{t("or_lowercase")}</>{" "}
+              <>{t("or_lowercase")}</>
             </>
           )}
-          <a href={getCancelLink(props.calEvent)} style={{ color: "#3e3e3e" }}>
+          <a href={getCancelLink(props.calEvent)} style={{ color: "#3e3e3e", marginLeft: "5px" }}>
             <>{t("cancel")}</>
           </a>
         </p>


### PR DESCRIPTION
## What does this PR do?

Adds missing spaces to reschedule and cancel link in email. 

Before: 
![Screenshot 2022-12-12 at 15 20 34](https://user-images.githubusercontent.com/30310907/207069539-341478a3-f886-458e-bc0e-f9afa10a2c8c.png)

After: 
![Screenshot 2022-12-12 at 15 20 44](https://user-images.githubusercontent.com/30310907/207069554-294abc3c-ef88-4d34-873a-8af399390a58.png)

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)