### PR TITLE
Fixing admin wizard translations

### DIFF
--- a/packages/ui/v2/core/Stepper.tsx
+++ b/packages/ui/v2/core/Stepper.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
 type DefaultStep = {
   title: string;
 };
@@ -10,13 +12,14 @@ function Stepper<T extends DefaultStep>(props: {
   steps: T[];
   disableSteps?: boolean;
 }) {
+  const { t } = useLocale();
   const { href, steps } = props;
   return (
     <>
       {steps.length > 1 && (
         <nav className="flex items-center justify-center" aria-label="Progress">
           <p className="text-sm font-medium">
-            Step {props.step} of {steps.length}
+            {t("current_step_of_total", { currentStep: props.step, maxSteps: steps.length })}
           </p>
           <ol role="list" className="ml-8 flex items-center space-x-5">
             {steps.map((mapStep, index) => (

--- a/packages/ui/v2/core/WizardForm.tsx
+++ b/packages/ui/v2/core/WizardForm.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 
 import classNames from "@calcom/lib/classNames";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 import { Button, Stepper } from "../..";
 
@@ -19,6 +20,7 @@ function WizardForm<T extends DefaultStep>(props: {
   containerClassname?: string;
 }) {
   const { href, steps } = props;
+  const { t } = useLocale();
   const router = useRouter();
   const step = parseInt((router.query.step as string) || "1");
   const currentStep = steps[step - 1];
@@ -51,7 +53,7 @@ function WizardForm<T extends DefaultStep>(props: {
                     onClick={() => {
                       setStep(step - 1);
                     }}>
-                    Back
+                    {t("prev_step")}
                   </Button>
                 )}
 
@@ -65,7 +67,7 @@ function WizardForm<T extends DefaultStep>(props: {
                   onClick={() => {
                     setStep(step + 1);
                   }}>
-                  {step < steps.length ? "Next" : "Finish"}
+                  {step < steps.length ? t("next_step_text") : t("finish")}
                 </Button>
               </div>
             )}


### PR DESCRIPTION
## What does this PR do?

Wizard was not correctly translated in order to be shown with the correct locale for the admin onboarding wizard using browsers' language

| Before      | After |
| ----------- | ----------- |
| <img alt="image" src="https://user-images.githubusercontent.com/467258/207874707-a4270789-fef1-46a7-9b45-027ab0074a76.png">       | <img alt="image" src="https://user-images.githubusercontent.com/467258/207875308-8248388f-3567-4fb1-9f0a-ec7761c57395.png">       |

Fixes #2579

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to the app deleting all users to trigger the admin onboarding. Switch language from browser and see its content language adapt accordingly.