### PR TITLE
Placing prisma dependency in root only

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "jest-watch-typeahead": "^2.0.0",
     "lint-staged": "^12.5.0",
     "prettier": "^2.7.1",
-    "ts-jest": "^28.0.8"
+    "ts-jest": "^28.0.8",
+    "@prisma/client": "^4.2.1",
+    "prisma": "^4.2.1"
   },
   "dependencies": {
     "turbo": "^1.4.3"

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -24,11 +24,13 @@
   },
   "dependencies": {
     "@calcom/lib": "*",
-    "@prisma/client": "^4.2.1",
-    "prisma": "^4.2.1",
     "ts-node": "^10.9.1",
     "zod": "^3.19.1",
     "zod-prisma": "^0.5.4"
+  },
+  "peerDependencies": {
+    "@prisma/client": "*",
+    "prisma": "*"
   },
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
## What does this PR do?

Making sure we only have Prisma dependencies in the root, to avoid any mismatch version used anywhere else.

Related Console PR to tackle this: 

Fixes #2653

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)