### PR TITLE
Fixing Admin Wizard step 1 blocking step 2

### DIFF
--- a/apps/web/pages/auth/setup/index.tsx
+++ b/apps/web/pages/auth/setup/index.tsx
@@ -32,7 +32,7 @@ export default function Setup(props: inferSSRProps<typeof getServerSideProps>) {
   return (
     <>
       <main className="flex items-center bg-gray-100 print:h-full">
-        <WizardForm href="/auth/setup" steps={steps} disableNavigation={shouldDisable} />
+        <WizardForm href="/auth/setup" steps={steps} />
       </main>
     </>
   );

--- a/apps/web/pages/auth/setup/steps/StepDone.tsx
+++ b/apps/web/pages/auth/setup/steps/StepDone.tsx
@@ -1,18 +1,30 @@
+import { useRouter } from "next/router";
+
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Icon } from "@calcom/ui";
 
 const StepDone = () => {
+  const router = useRouter();
   const { t } = useLocale();
 
   return (
-    <div className="min-h-36 my-6 flex flex-col items-center justify-center">
-      <div className="flex h-[72px] w-[72px] items-center justify-center rounded-full bg-gray-600 dark:bg-white">
-        <Icon.FiCheck className="inline-block h-10 w-10 text-white dark:bg-white dark:text-gray-600" />
+    <form
+      id="wizard-step-1"
+      name="wizard-step-1"
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        router.replace(`/auth/setup?step=2&category=calendar`);
+      }}>
+      <div className="min-h-36 my-6 flex flex-col items-center justify-center">
+        <div className="flex h-[72px] w-[72px] items-center justify-center rounded-full bg-gray-600 dark:bg-white">
+          <Icon.FiCheck className="inline-block h-10 w-10 text-white dark:bg-white dark:text-gray-600" />
+        </div>
+        <div className="max-w-[420px] text-center">
+          <h2 className="mt-6 mb-1 text-lg font-medium dark:text-gray-300">{t("all_done")}</h2>
+        </div>
       </div>
-      <div className="max-w-[420px] text-center">
-        <h2 className="mt-6 mb-1 text-lg font-medium dark:text-gray-300">{t("all_done")}</h2>
-      </div>
-    </div>
+    </form>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

Old code blocking navigation was in effect when step 1 was done, neglecting step 2 existence.

| Before      | After |
| ----------- | ----------- |
| <kbd><img src="https://user-images.githubusercontent.com/467258/208139756-da069c6a-5d97-4058-a699-f278baaa46ae.png" /></kbd>  | <img alt="image" src="https://user-images.githubusercontent.com/467258/208139931-385791c2-b8b4-45f4-945d-5073b8de08d9.png">     |

Fixes #6062 

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Login as admin user
2. Go to `/auth/setup` to see step 1
3. You should be able to go to next step now
