### PR TITLE
Removes EMAIL_ADDRESS action

### DIFF
--- a/packages/features/ee/workflows/lib/constants.ts
+++ b/packages/features/ee/workflows/lib/constants.ts
@@ -11,7 +11,7 @@ export const WORKFLOW_TRIGGER_EVENTS = [
 export const WORKFLOW_ACTIONS = [
   WorkflowActions.EMAIL_HOST,
   WorkflowActions.EMAIL_ATTENDEE,
-  //WorkflowActions.EMAIL_ADDRESS, Disabling for now due to abuse episode
+  WorkflowActions.EMAIL_ADDRESS,
   WorkflowActions.SMS_ATTENDEE,
   WorkflowActions.SMS_NUMBER,
 ] as const;

--- a/packages/features/ee/workflows/lib/constants.ts
+++ b/packages/features/ee/workflows/lib/constants.ts
@@ -11,7 +11,7 @@ export const WORKFLOW_TRIGGER_EVENTS = [
 export const WORKFLOW_ACTIONS = [
   WorkflowActions.EMAIL_HOST,
   WorkflowActions.EMAIL_ATTENDEE,
-  WorkflowActions.EMAIL_ADDRESS,
+  //WorkflowActions.EMAIL_ADDRESS, Disabling for now due to abuse episode
   WorkflowActions.SMS_ATTENDEE,
   WorkflowActions.SMS_NUMBER,
 ] as const;

--- a/packages/features/ee/workflows/lib/getOptions.ts
+++ b/packages/features/ee/workflows/lib/getOptions.ts
@@ -4,17 +4,18 @@ import { TFunction } from "next-i18next";
 import { TIME_UNIT, WORKFLOW_ACTIONS, WORKFLOW_TEMPLATES, WORKFLOW_TRIGGER_EVENTS } from "./constants";
 
 export function getWorkflowActionOptions(t: TFunction, isTeamsPlan?: boolean) {
-  return WORKFLOW_ACTIONS.map((action) => {
-    const actionString = t(`${action.toLowerCase()}_action`);
+  return WORKFLOW_ACTIONS.filter((action) => action !== WorkflowActions.EMAIL_ADDRESS) //removing EMAIL_ADDRESS for now due to abuse episode
+    .map((action) => {
+      const actionString = t(`${action.toLowerCase()}_action`);
 
-    const isSMSAction = action === WorkflowActions.SMS_ATTENDEE || action === WorkflowActions.SMS_NUMBER;
+      const isSMSAction = action === WorkflowActions.SMS_ATTENDEE || action === WorkflowActions.SMS_NUMBER;
 
-    return {
-      label: actionString.charAt(0).toUpperCase() + actionString.slice(1),
-      value: action,
-      disabled: isSMSAction && !isTeamsPlan,
-    };
-  });
+      return {
+        label: actionString.charAt(0).toUpperCase() + actionString.slice(1),
+        value: action,
+        disabled: isSMSAction && !isTeamsPlan,
+      };
+    });
 }
 
 export function getWorkflowTriggerOptions(t: TFunction) {


### PR DESCRIPTION
## What does this PR do?

Removes 'email to a specific email address' workflow action. 
Was originally implemented in #6075 but got reverted by #6085