### PR TITLE
Fixing multiple duration default issues (#6114)

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -262,12 +262,14 @@ export const EventSetupTab = (
                   if (!newOptions.find((opt) => opt.value === defaultDuration?.value)) {
                     if (newOptions.length > 0) {
                       setDefaultDuration(newOptions[0]);
+                      formMethods.setValue("length", newOptions[0].value);
                     } else {
                       setDefaultDuration(null);
                     }
                   }
                   if (newOptions.length === 1 && defaultDuration === null) {
                     setDefaultDuration(newOptions[0]);
+                    formMethods.setValue("length", newOptions[0].value);
                   }
                   formMethods.setValue("metadata.multipleDuration", values);
                 }}

--- a/apps/web/pages/event-types/[type]/index.tsx
+++ b/apps/web/pages/event-types/[type]/index.tsx
@@ -283,7 +283,7 @@ const EventTypePage = (props: inferSSRProps<typeof getServerSideProps>) => {
             if (metadata?.multipleDuration.length < 1) {
               throw new Error(t("event_setup_multiple_duration_error"));
             } else {
-              if (input.length && !metadata?.multipleDuration?.includes(input.length)) {
+              if (!input.length && !metadata?.multipleDuration?.includes(input.length)) {
                 throw new Error(t("event_setup_multiple_duration_default_error"));
               }
             }

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -13,6 +13,8 @@ export type GetSlots = {
 };
 export type TimeFrame = { startTime: number; endTime: number };
 
+const minimumOfOne = (input: number) => (input < 1 ? 1 : input);
+
 /**
  * TODO: What does this function do?
  * Why is it needed?
@@ -26,16 +28,24 @@ const splitAvailableTime = (
   let initialTime = startTimeMinutes;
   const finalizationTime = endTimeMinutes;
   const result = [] as TimeFrame[];
+
+  // Ensure that both the frequency and event length are at least 1 minute, if they
+  // would be zero, we would have an infinite loop in this while!
+  const frequencyMinimumOne = minimumOfOne(frequency);
+  const eventLengthMinimumOne = minimumOfOne(eventLength);
+
   while (initialTime < finalizationTime) {
-    const periodTime = initialTime + frequency;
-    const slotEndTime = initialTime + eventLength;
+    const periodTime = initialTime + frequencyMinimumOne;
+    const slotEndTime = initialTime + eventLengthMinimumOne;
     /*
     check if the slot end time surpasses availability end time of the user
     1 minute is added to round up the hour mark so that end of the slot is considered in the check instead of x9
     eg: if finalization time is 11:59, slotEndTime is 12:00, we ideally want the slot to be available
     */
     if (slotEndTime <= finalizationTime + 1) result.push({ startTime: initialTime, endTime: periodTime });
-    initialTime += frequency;
+    // Ensure that both the frequency and event length are at least 1 minute, if they
+    // would be zero, we would have an infinite loop in this while!
+    initialTime += frequencyMinimumOne;
   }
   return result;
 };


### PR DESCRIPTION
* Fixing multiple duration default issues

* Ensure that when calculation time slots we use 1 as a minimum interval, since 0 min meetings would result in an infinite loop.

PROD PR for #6114 