### PR TITLE
Fix skeleton loader for /workflows

### DIFF
--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -24,6 +24,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       where: {
         userId: validKey.userId,
       },
+      orderBy: {
+        id: "desc",
+      },
       select: {
         title: true,
         description: true,

--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -24,9 +24,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       where: {
         userId: validKey.userId,
       },
-      orderBy: {
-        id: "desc",
-      },
       select: {
         title: true,
         description: true,

--- a/packages/features/ee/workflows/components/SkeletonLoaderList.tsx
+++ b/packages/features/ee/workflows/components/SkeletonLoaderList.tsx
@@ -2,7 +2,7 @@ import { Icon, SkeletonText } from "@calcom/ui";
 
 function SkeletonLoader() {
   return (
-    <ul className="mt-24 animate-pulse divide-y divide-neutral-200 rounded-md border border-gray-200 bg-white sm:overflow-hidden">
+    <ul className="animate-pulse divide-y divide-neutral-200 rounded-md border  border-gray-200 bg-white sm:overflow-hidden">
       <SkeletonItem />
       <SkeletonItem />
       <SkeletonItem />


### PR DESCRIPTION
## What does this PR do?

Fixes skeleton loader for /workflows by removing margin-top

Before: 
<img width="1243" alt="Screenshot 2022-12-23 at 12 12 38" src="https://user-images.githubusercontent.com/30310907/209326445-236b4841-2523-4cc5-8d6c-003a7ffb34ad.png">


After: 
<img width="1241" alt="Screenshot 2022-12-23 at 12 02 44" src="https://user-images.githubusercontent.com/30310907/209326387-4b09df07-1796-474d-9bdf-9fbd6c42124d.png">
