### PR TITLE
fixes required custom radio element on firefox

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -800,6 +800,7 @@ const BookingPage = ({
                       {input.options && input.type === EventTypeCustomInputType.RADIO && (
                         <div className="flex">
                           <Group
+                            name={`customInputs.${input.id}`}
                             required={input.required}
                             onValueChange={(e) => {
                               bookingForm.setValue(`customInputs.${input.id}`, e);


### PR DESCRIPTION
## What does this PR do?

Firefox users were unable to submit bookings with custom radios element because the name was not set on the elements.

Fixes #6160 

**Environment**: Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

* Open Firefox
* Create required custom radio
* Try to make booking
* See that form completes with required fields completed

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
