### PR TITLE
fix: consistency on menu hover border bug :wrench:

### DIFF
--- a/packages/ui/v2/core/Shell.tsx
+++ b/packages/ui/v2/core/Shell.tsx
@@ -313,7 +313,7 @@ function UserDropdown({ small }: { small?: boolean }) {
                     mutation.mutate({ away: !user?.away });
                     utils.viewer.me.invalidate();
                   }}
-                  className="flex w-full min-w-max cursor-pointer items-center px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900">
+                  className="flex w-full min-w-max cursor-pointer items-center px-4 py-2 text-sm">
                   <Icon.FiMoon
                     className={classNames(
                       user.away
@@ -362,7 +362,7 @@ function UserDropdown({ small }: { small?: boolean }) {
                   href={JOIN_SLACK}
                   target="_blank"
                   rel="noreferrer"
-                  className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900">
+                  className="flex items-center px-4 py-2 text-sm text-gray-700">
                   <Icon.FiSlack strokeWidth={1.5} className="h-4 w-4 text-gray-500 ltr:mr-2 rtl:ml-3" />{" "}
                   {t("join_our_slack")}
                 </a>
@@ -379,7 +379,7 @@ function UserDropdown({ small }: { small?: boolean }) {
               <DropdownMenuItem>
                 <button
                   onClick={() => setHelpOpen(true)}
-                  className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900">
+                  className="flex w-full items-center px-4 py-2 text-sm text-gray-700">
                   <Icon.FiHelpCircle
                     className={classNames(
                       "text-gray-500 group-hover:text-neutral-500",


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <Siddhantkhare2694@gmail.com>

## What does this PR do?

This PR proposes to fix the bug on menu items. The bug was related to an inconsistent hover border

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6185

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


https://user-images.githubusercontent.com/55068936/210036134-4ca151a6-65c8-4c30-93c1-3e70a0768284.mov






**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Open this PR in [Gitpod - Cloud Dev Environment](https://gitpod.io/#https://github.com/calcom/cal.com/pull/6218) - without any cloning & tools installation/setup
- Run yarn & yarn dx
- Open Preview URL 3000:

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/55068936/210036412-d6e92e94-83a0-4aea-b5a7-bdd3fe720368.png">

- Complete Login & Signup (do take care of the URL routes or configure your preview URL in `.env` before running `yarn dx`)
- See changes 👀 in the left bottom menu bar by hovering on the menus


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I have performed a self-review of my own code and corrected any misspellings
- I haven't added tests that prove my fix is effective or that my feature works (comments: _not required in this change_)
