### PR TITLE
Make radio field id unique by adding custom input id to their identifier

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -809,9 +809,9 @@ const BookingPage = ({
                               {input.options.map((option, i) => (
                                 <RadioField
                                   label={option.label}
-                                  key={`option.${i}.radio`}
+                                  key={`option.${input.id}.${i}.radio`}
                                   value={option.label}
-                                  id={`option.${i}.radio`}
+                                  id={`option.${input.id}.${i}.radio`}
                                 />
                               ))}
                             </>


### PR DESCRIPTION
## What does this PR do?

When adding multiple radio fields to an event type, the HTML input field id was generate only by the progressive order of the radio item in the current field. In case of multiple radio fields in the same form, the input id was repeated through the different form fields.

Fixes # (issue)

The input field id is now generate using also the customfield id, so that it is unique across the form.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

In order to verify the issue, you need to create an event type with 2 radio inputs. Clicking on an option in the second field changes the value of the first one and no values in the second field is ever selected.

With the fixed version, you get the right selection upon clicking the items.

I went through the whole process and verified the correct answers are displayed in the confirmation page and in the email.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
