### PR TITLE
Show admin password top banner

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -138,7 +138,7 @@ const providers: Provider[] = [
           username: user.username,
           email: user.email,
           name: user.name,
-          role: "USER",
+          role: "INACTIVE_ADMIN",
           belongsToActiveTeam: hasActiveTeams,
         };
       }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1481,5 +1481,7 @@
   "send_code" : "Send code",
   "number_verified": "Number Verified",
   "create_your_first_team_webhook_description": "Create your first webhook for this team event type",
-  "create_webhook_team_event_type": "Create a webhook for this team event type"
+  "create_webhook_team_event_type": "Create a webhook for this team event type",
+  "invalid_admin_password": "You are set as an admin but you do not have a password length of at least 15 characters",
+  "change_password_admin": "Change Password to gain admin access"
 }

--- a/packages/features/users/components/AdminPasswordBanner.tsx
+++ b/packages/features/users/components/AdminPasswordBanner.tsx
@@ -1,0 +1,27 @@
+import { useSession } from "next-auth/react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { TopBanner } from "@calcom/ui";
+
+function AdminPasswordBanner() {
+  const { t } = useLocale();
+  const { data } = useSession();
+
+  if (data?.user.role !== "INACTIVE_ADMIN") return null;
+
+  return (
+    <>
+      <TopBanner
+        text={t("invalid_admin_password", { user: data.user.username })}
+        variant="warning"
+        actions={
+          <a className="border-b border-b-black" href="/auth/logout">
+            {t("change_password_admin")}
+          </a>
+        }
+      />
+    </>
+  );
+}
+
+export default AdminPasswordBanner;

--- a/packages/features/users/components/AdminPasswordBanner.tsx
+++ b/packages/features/users/components/AdminPasswordBanner.tsx
@@ -1,4 +1,5 @@
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { TopBanner } from "@calcom/ui";
@@ -15,9 +16,9 @@ function AdminPasswordBanner() {
         text={t("invalid_admin_password", { user: data.user.username })}
         variant="warning"
         actions={
-          <a className="border-b border-b-black" href="/auth/logout">
-            {t("change_password_admin")}
-          </a>
+          <Link href="/settings/security/password">
+            <a className="border-b border-b-black">{t("change_password_admin")}</a>
+          </Link>
         }
       />
     </>

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -16,6 +16,6 @@ declare module "next-auth" {
     impersonatedByUID?: number;
     belongsToActiveTeam?: boolean;
     username?: PrismaUser["username"];
-    role?: PrismaUser["role"];
+    role?: PrismaUser["role"] | "INACTIVE_ADMIN";
   }
 }

--- a/packages/ui/v2/core/Shell.tsx
+++ b/packages/ui/v2/core/Shell.tsx
@@ -13,6 +13,7 @@ import ImpersonatingBanner from "@calcom/features/ee/impersonation/components/Im
 import HelpMenuItem from "@calcom/features/ee/support/components/HelpMenuItem";
 import { TeamsUpgradeBanner } from "@calcom/features/ee/teams/components";
 import { Tips } from "@calcom/features/tips";
+import AdminPasswordBanner from "@calcom/features/users/components/AdminPasswordBanner";
 import CustomBranding from "@calcom/lib/CustomBranding";
 import classNames from "@calcom/lib/classNames";
 import {
@@ -157,6 +158,7 @@ const Layout = (props: LayoutProps) => {
         <div className="divide-y divide-black">
           <TeamsUpgradeBanner />
           <ImpersonatingBanner />
+          <AdminPasswordBanner />
         </div>
         <div className="flex flex-1" data-testid="dashboard-shell">
           {props.SidebarContainer || <SideBarContainer />}


### PR DESCRIPTION
Adds top banner error if you are admin but do not have the right password length 

Admin with correct password length:
<img width="1511" alt="CleanShot 2022-12-31 at 12 57 16@2x" src="https://user-images.githubusercontent.com/55134778/210137536-ca5aac98-d5e2-42fc-9c0d-31a4b1693d1b.png">

ADMIN without valid password:
<img width="1505" alt="CleanShot 2022-12-31 at 13 01 48@2x" src="https://user-images.githubusercontent.com/55134778/210137634-9816676e-233c-484f-a660-8416c41e96d9.png">

Normal User:
<img width="1512" alt="CleanShot 2022-12-31 at 13 02 26@2x" src="https://user-images.githubusercontent.com/55134778/210137653-861dcfd7-c14f-4ca6-89e6-f4380a300e31.png">

