### PR TITLE
adds devcontainer/codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker
+{
+  "name": "Docker outside of Docker",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+  "features": {
+    "ghcr.io/devcontainers/features/docker-from-docker:1": {
+      "version": "latest",
+      "enableNonRootDocker": "true",
+      "moby": "true"
+    },
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-contrib/features/npm-package:1": {},
+    "ghcr.io/devcontainers-contrib/features/jest:2": {},
+    "ghcr.io/devcontainers-contrib/features/prisma:2": {},
+    "ghcr.io/guiyomh/features/vim:0": {}
+  },
+
+  // Use this environment variable if you need to bind mount your local source code into a new container.
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+  },
+
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb"
+  },
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "./deploy/install.sh"
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/first-run-notice.txt
+++ b/.devcontainer/first-run-notice.txt
@@ -1,0 +1,1 @@
+🚀 Welcome to Cal.com! Try typing 'yarn dx' to get a quick dev envionment.

--- a/deploy/codespaces/install.sh
+++ b/deploy/codespaces/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -xeuf -o pipefail
+
+# exit this file if we are not in Codespaces
+if [ -z "${CODESPACES}" ]; then
+  exit 0
+fi
+
+echo "echo \"🚀 Welcome to Cal.com! Try typing 'yarn dx' to get a quick dev envionment.\"" >> ~/.bashrc

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeuf -o pipefail
+
+cp .env.example .env
+
+sed -i 's|NEXTAUTH_SECRET=.*|NEXTAUTH_SECRET='"$(openssl rand -base64 32)"'|g' .env
+sed -i 's|CALENDSO_ENCRYPTION_KEY=.*|CALENDSO_ENCRYPTION_KEY='"$(openssl rand -base64 32)"'|g' .env
+yarn
+
+./deploy/codespaces/install.sh


### PR DESCRIPTION
## What does this PR do?

Adds setup-free development environments in VSCode/docker and also VSCode/GitHub Codespaces

**Environment**: Staging(main branch)

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/26844/210409520-7365dae1-6a25-43fb-9aa6-ee98e4750479.png">

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- [ ] Navigate to this PR
- [ ] Click "Code", "+", tooltip should say "create a codespace on devcontainer"
- [ ] Open Codespaces in the browser, however, you can also connect to these Codespaces from desktop VSCode 
- [ ] Should setup .env and yarn

Also, you should be able to run this locally without Codespaces

- [ ] Clone cal.com
- [ ] Change branch to `devcontainer`
- [ ] Open VSCode, it should ask to open the project in a devcontainer
- [ ] Should setup .env and yarn

## Checklist