### PR TITLE
Adding border to tabs

### DIFF
--- a/packages/ui/v2/core/navigation/tabs/HorizontalTabItem.tsx
+++ b/packages/ui/v2/core/navigation/tabs/HorizontalTabItem.tsx
@@ -27,7 +27,7 @@ const HorizontalTabItem = function ({ name, href, linkProps, ...props }: Horizon
       <a
         className={classNames(
           isCurrent ? "bg-gray-200 text-gray-900" : "  text-gray-600 hover:bg-gray-100 hover:text-gray-900 ",
-          "inline-flex items-center justify-center whitespace-nowrap rounded-md py-[10px] px-4 text-sm font-medium leading-4 md:mb-0",
+          "inline-flex items-center justify-center whitespace-nowrap rounded-[4px] py-[10px] px-4 text-sm font-medium leading-4 md:mb-0",
           props.disabled && "pointer-events-none !opacity-30",
           props.className
         )}

--- a/packages/ui/v2/core/navigation/tabs/HorizontalTabItem.tsx
+++ b/packages/ui/v2/core/navigation/tabs/HorizontalTabItem.tsx
@@ -27,7 +27,7 @@ const HorizontalTabItem = function ({ name, href, linkProps, ...props }: Horizon
       <a
         className={classNames(
           isCurrent ? "bg-gray-200 text-gray-900" : "  text-gray-600 hover:bg-gray-100 hover:text-gray-900 ",
-          "mb-2 inline-flex items-center justify-center whitespace-nowrap rounded-md py-[10px] px-4 text-sm font-medium leading-4 md:mb-0",
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md py-[10px] px-4 text-sm font-medium leading-4 md:mb-0",
           props.disabled && "pointer-events-none !opacity-30",
           props.className
         )}

--- a/packages/ui/v2/core/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/v2/core/navigation/tabs/HorizontalTabs.tsx
@@ -10,7 +10,7 @@ export interface NavTabProps {
 
 const HorizontalTabs = function ({ tabs, linkProps, actions, ...props }: NavTabProps) {
   return (
-    <div className="mb-2 max-w-[calc(100%+40px)]">
+    <div className="mb-2 max-w-[calc(100%+40px)] lg:mb-5">
       <nav className="no-scrollbar flex overflow-scroll rounded-md border p-1" aria-label="Tabs" {...props}>
         {tabs.map((tab, idx) => (
           <HorizontalTabItem {...tab} key={idx} {...linkProps} />

--- a/packages/ui/v2/core/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/v2/core/navigation/tabs/HorizontalTabs.tsx
@@ -10,8 +10,8 @@ export interface NavTabProps {
 
 const HorizontalTabs = function ({ tabs, linkProps, actions, ...props }: NavTabProps) {
   return (
-    <div className="-mx-6 mb-2 w-[calc(100%+40px)]">
-      <nav className="no-scrollbar flex space-x-1 overflow-scroll px-6" aria-label="Tabs" {...props}>
+    <div className="mb-2 max-w-[calc(100%+40px)]">
+      <nav className="no-scrollbar flex overflow-scroll rounded-md border p-1" aria-label="Tabs" {...props}>
         {tabs.map((tab, idx) => (
           <HorizontalTabItem {...tab} key={idx} {...linkProps} />
         ))}


### PR DESCRIPTION
Adds border to tab to match the design system: 
https://www.figma.com/file/ZJNAFHCAq6rnuGRgUFxjzQ/Cal.com-Teams?node-id=439%3A55821&t=gW0CNjRpXs3AVbrN-4

Mobile:
<img width="344" alt="CleanShot 2023-01-05 at 12 21 01@2x" src="https://user-images.githubusercontent.com/55134778/210779047-45079da3-2041-45e6-a2ae-74f5f23195ba.png">

Desktop
<img width="1511" alt="CleanShot 2023-01-05 at 12 21 39@2x" src="https://user-images.githubusercontent.com/55134778/210779147-e6fa9d1d-c6af-43dd-a80b-309a9067ac85.png">

