### PR TITLE
Don't initialize KBar when unauthed

### DIFF
--- a/packages/ui/v2/core/Kbar.tsx
+++ b/packages/ui/v2/core/Kbar.tsx
@@ -273,7 +273,7 @@ export const KBarContent = () => {
 
 export const KBarTrigger = () => {
   const { query } = useKBar();
-  return (
+  return query ? (
     <>
       <Tooltip side="right" content={isMac ? "⌘ + K" : "CTRL + K"}>
         <button
@@ -284,7 +284,7 @@ export const KBarTrigger = () => {
         </button>
       </Tooltip>
     </>
-  );
+  ) : null;
 };
 
 const DisplayShortcuts = (item: shortcutArrayType) => {

--- a/packages/ui/v2/core/Shell.tsx
+++ b/packages/ui/v2/core/Shell.tsx
@@ -195,8 +195,13 @@ export default function Shell(props: LayoutProps) {
   useRedirectToLoginIfUnauthenticated(props.isPublic);
   useRedirectToOnboardingIfNeeded();
   useTheme("light");
-
-  return (
+  // don't load KBar when unauthed
+  return props.isPublic ? (
+    <>
+      <CustomBrandingContainer />
+      <Layout {...props} />
+    </>
+  ) : (
     <KBarRoot>
       <CustomBrandingContainer />
       <Layout {...props} />


### PR DESCRIPTION
## What does this PR do?

Rather than making sure KBar work in an unauthed env, I don't see a reason we should load it at all - this PR removes it from the tree on unauthed pages (like /apps/...)