### PR TITLE
Add app-store installed page navigationt ests

### DIFF
--- a/apps/web/components/apps/CalendarListContainer.tsx
+++ b/apps/web/components/apps/CalendarListContainer.tsx
@@ -330,7 +330,10 @@ export function CalendarListContainer(props: { heading?: boolean; fromOnboarding
                 })}
                 description={t(`no_category_apps_description_calendar`)}
                 buttonRaw={
-                  <Button color="secondary" href="/apps/categories/calendar">
+                  <Button
+                    color="secondary"
+                    data-testid="connect-calendar-apps"
+                    href="/apps/categories/calendar">
                     {t(`connect_calendar_apps`)}
                   </Button>
                 }

--- a/apps/web/pages/apps/installed/[category].tsx
+++ b/apps/web/pages/apps/installed/[category].tsx
@@ -183,6 +183,7 @@ const IntegrationsContainer = ({ variant, exclude }: IntegrationsContainerProps)
                 buttonRaw={
                   <Button
                     color="secondary"
+                    data-testid={`connect-${variant || "other"}-apps`}
                     href={variant ? `/apps/categories/${variant}` : "/apps/categories/other"}>
                     {t(`connect_${variant || "other"}_apps`)}
                   </Button>

--- a/apps/web/playwright/app-store.e2e.ts
+++ b/apps/web/playwright/app-store.e2e.ts
@@ -14,6 +14,17 @@ test.describe("App Store - Authed", () => {
     await expect(page.locator(`text=Connect to Apple Server`)).toBeVisible();
     await pro.delete();
   });
+
+  test("Installed Apps - Navigation", async ({ page, users }) => {
+    const user = await users.create();
+    await user.login();
+    await page.goto("/apps/installed");
+    await page.waitForSelector('[data-testid="connect-calendar-apps"]');
+    await page.click('[data-testid="vertical-tab-payment"]');
+    await page.waitForSelector('[data-testid="connect-payment-apps"]');
+    await page.click('[data-testid="vertical-tab-automation"]');
+    await page.waitForSelector('[data-testid="connect-automation-apps"]');
+  });
 });
 
 test.describe("App Store - Unauthed", () => {


### PR DESCRIPTION
Adds app-store installed page navigation tests.

Adding these tests because that page's navigation has broken multiple times in the past and it's a critical page for us. Recently I have broken it, so adding the tests.