### PR TITLE
Refactored buildSlots

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -89,7 +89,6 @@
     "next-seo": "^4.26.0",
     "next-themes": "^0.2.0",
     "next-transpile-modules": "^10.0.0",
-    "nock": "^13.2.8",
     "nodemailer": "^6.7.8",
     "otplib": "^12.0.1",
     "qrcode": "^1.5.1",

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -310,6 +310,7 @@ describe("getSchedule", () => {
           "10:00:00.000Z",
           "10:45:00.000Z",
           "11:30:00.000Z",
+          "12:15:00.000Z",
         ],
         {
           dateString: plus2DateString,
@@ -341,6 +342,7 @@ describe("getSchedule", () => {
           "10:00:00.000Z",
           "10:45:00.000Z",
           "11:30:00.000Z",
+          "12:15:00.000Z",
         ],
         {
           dateString: plus3DateString,
@@ -856,6 +858,7 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
+          `12:15:00.000Z`,
         ],
         {
           dateString: plus1DateString,
@@ -887,6 +890,7 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
+          `12:15:00.000Z`,
         ],
         { dateString: plus2DateString }
       );
@@ -990,6 +994,7 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
+          `12:15:00.000Z`,
         ],
         { dateString: plus2DateString }
       );
@@ -1018,6 +1023,7 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
+          `12:15:00.000Z`,
         ],
         { dateString: plus3DateString }
       );
@@ -1080,7 +1086,6 @@ function addEventTypes(eventTypes: InputEventType[], usersStore: InputUser[]) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   prismaMock.eventType.findUnique.mockImplementation(({ where }) => {
-    console.log("eventTypesWithUsers", eventTypesWithUsers);
     return new Promise((resolve) => {
       const eventType = eventTypesWithUsers.find((e) => e.id === where.id) as unknown as PrismaEventType & {
         users: PrismaUser[];
@@ -1208,7 +1213,6 @@ const getDate = (param: { dateIncrement?: number; monthIncrement?: number; yearI
   const date = _date < 10 ? "0" + _date : _date;
   const month = _month < 10 ? "0" + _month : _month;
 
-  console.log(`Date, month, year for ${JSON.stringify(param)}`, date, month, year);
   return {
     date,
     month,

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -909,6 +909,7 @@ describe("getSchedule", () => {
           {
             id: 1,
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 101,
@@ -922,6 +923,7 @@ describe("getSchedule", () => {
           {
             id: 2,
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 102,
@@ -996,7 +998,6 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
-          `12:15:00.000Z`,
         ],
         { dateString: plus2DateString }
       );
@@ -1025,7 +1026,6 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
-          `12:15:00.000Z`,
         ],
         { dateString: plus3DateString }
       );

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -217,7 +217,7 @@ afterEach(async () => {
 });
 
 describe("getSchedule", () => {
-  describe.skip("Calendar event", () => {
+  describe("Calendar event", () => {
     test("correctly identifies unavailable slots from calendar", async () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
@@ -251,7 +251,7 @@ describe("getSchedule", () => {
 
       addBusyTimesInGoogleCalendar([
         {
-          start: `${plus2DateString}T04:30:00.000Z`,
+          start: `${plus2DateString}T04:45:00.000Z`,
           end: `${plus2DateString}T23:00:00.000Z`,
         },
       ]);
@@ -266,7 +266,7 @@ describe("getSchedule", () => {
         ctx
       );
 
-      // As per Google Calendar Availability, only 4PM GMT slot would be available
+      // As per Google Calendar Availability, only 4PM(4-4:45PM) GMT slot would be available
       expect(scheduleForDayWithAGoogleCalendarBooking).toHaveTimeSlots([`04:00:00.000Z`], {
         dateString: plus2DateString,
       });

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -217,7 +217,7 @@ afterEach(async () => {
 });
 
 describe("getSchedule", () => {
-  describe.skip("Calendar event", () => {
+  describe("Calendar event", () => {
     test("correctly identifies unavailable slots from calendar", async () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -228,6 +228,7 @@ describe("getSchedule", () => {
           {
             id: 1,
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 101,
@@ -290,6 +291,7 @@ describe("getSchedule", () => {
             id: 1,
             // If `slotInterval` is set, it supersedes `length`
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 101,
@@ -368,7 +370,6 @@ describe("getSchedule", () => {
           "10:00:00.000Z",
           "10:45:00.000Z",
           "11:30:00.000Z",
-          "12:15:00.000Z",
         ],
         {
           dateString: plus2DateString,
@@ -400,7 +401,6 @@ describe("getSchedule", () => {
           "10:00:00.000Z",
           "10:45:00.000Z",
           "11:30:00.000Z",
-          "12:15:00.000Z",
         ],
         {
           dateString: plus3DateString,
@@ -787,6 +787,7 @@ describe("getSchedule", () => {
           {
             id: 1,
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 101,
@@ -799,6 +800,7 @@ describe("getSchedule", () => {
           {
             id: 2,
             slotInterval: 45,
+            length: 45,
             users: [
               {
                 id: 102,
@@ -860,7 +862,6 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
-          `12:15:00.000Z`,
         ],
         {
           dateString: plus1DateString,
@@ -892,7 +893,6 @@ describe("getSchedule", () => {
           `10:00:00.000Z`,
           `10:45:00.000Z`,
           `11:30:00.000Z`,
-          `12:15:00.000Z`,
         ],
         { dateString: plus2DateString }
       );

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -218,7 +218,7 @@ afterEach(async () => {
 });
 
 describe("getSchedule", () => {
-  describe("Calendar event", () => {
+  describe.skip("Calendar event", () => {
     test("correctly identifies unavailable slots from calendar", async () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -164,7 +164,7 @@ export async function getUserAvailability(
     let startDate = dayjs(dateFrom);
     const endDate = dayjs(dateTo);
     while (startDate.isBefore(endDate)) {
-      dates.push(startDate.add(1, "day"));
+      dates.push(startDate);
       startDate = startDate.add(1, "day");
     }
 
@@ -173,7 +173,6 @@ export async function getUserAvailability(
     );
 
     // Apply booking limit filter against our bookings
-
     for (const [key, limit] of Object.entries(bookingLimits)) {
       const limitKey = key as keyof BookingLimit;
 
@@ -192,18 +191,16 @@ export async function getUserAvailability(
         });
         break;
       }
-
       // Take PER_DAY and turn it into day and PER_WEEK into week etc.
-      const filter = limitKey.split("_")[1].toLocaleLowerCase() as "day" | "week" | "month" | "year";
-
+      const filter = limitKey.split("_")[1].toLowerCase() as "day" | "week" | "month" | "year";
       // loop through all dates and check if we have reached the limit
       for (const date of dates) {
         let total = 0;
-        const startDate = dayjs(date).startOf(filter);
+        const startDate = date.startOf(filter);
         // this is parsed above with parseBookingLimit so we know it's safe.
-        const endDate = dayjs(date).endOf(filter);
+        const endDate = date.endOf(filter);
         for (const booking of ourBookings) {
-          const bookingEventTypeId = booking.source?.split("-")[1];
+          const bookingEventTypeId = parseInt(booking.source?.split("-")[1] as string, 10);
           if (
             // Only check OUR booking that matches the current eventTypeId
             // we don't care about another event type in this case as we dont need to know their booking limits

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -15,41 +15,6 @@ export type TimeFrame = { userIds?: number[]; startTime: number; endTime: number
 
 const minimumOfOne = (input: number) => (input < 1 ? 1 : input);
 
-/**
- * TODO: What does this function do?
- * Why is it needed?
- */
-const splitAvailableTime = (
-  startTimeMinutes: number,
-  endTimeMinutes: number,
-  frequency: number,
-  eventLength: number
-): TimeFrame[] => {
-  let initialTime = startTimeMinutes;
-  const finalizationTime = endTimeMinutes;
-  const result = [] as TimeFrame[];
-
-  // Ensure that both the frequency and event length are at least 1 minute, if they
-  // would be zero, we would have an infinite loop in this while!
-  const frequencyMinimumOne = minimumOfOne(frequency);
-  const eventLengthMinimumOne = minimumOfOne(eventLength);
-
-  while (initialTime < finalizationTime) {
-    const periodTime = initialTime + frequencyMinimumOne;
-    const slotEndTime = initialTime + eventLengthMinimumOne;
-    /*
-    check if the slot end time surpasses availability end time of the user
-    1 minute is added to round up the hour mark so that end of the slot is considered in the check instead of x9
-    eg: if finalization time is 11:59, slotEndTime is 12:00, we ideally want the slot to be available
-    */
-    if (slotEndTime <= finalizationTime + 1) result.push({ startTime: initialTime, endTime: periodTime });
-    // Ensure that both the frequency and event length are at least 1 minute, if they
-    // would be zero, we would have an infinite loop in this while!
-    initialTime += frequencyMinimumOne;
-  }
-  return result;
-};
-
 function buildSlots({
   startOfInviteeDay,
   computedLocalAvailability,
@@ -63,24 +28,47 @@ function buildSlots({
   frequency: number;
   eventLength: number;
 }) {
-  const slotsTimeFrameAvailable: TimeFrame[] = [];
+  // no slots today
+  if (startOfInviteeDay.isBefore(startDate, "day")) {
+    return [];
+  }
+  // keep the old safeguards in; may be needed.
+  frequency = minimumOfOne(frequency);
+  eventLength = minimumOfOne(eventLength);
+  // A day starts at 00:00 unless the startDate is the same as the current day
+  let slotStart = startOfInviteeDay.isSame(startDate, "day")
+    ? Math.ceil((startDate.hour() * 60 + startDate.minute()) / frequency) * frequency
+    : 0;
+  // Record type so we can use slotStart as key
+  const slotsTimeFrameAvailable: Record<
+    string,
+    {
+      userIds: number[];
+      startTime: number;
+      endTime: number;
+    }
+  > = {};
+  // loop through the day, based on frequency.
+  for (; slotStart < 1440; slotStart += frequency) {
+    computedLocalAvailability.forEach((item) => {
+      const rangeStart = Math.ceil(item.startTime / frequency) * frequency;
+      const rangeEnd = Math.floor(item.endTime / frequency) * frequency;
+      if (slotStart < rangeStart || slotStart >= rangeEnd) {
+        return;
+      }
+      slotsTimeFrameAvailable[slotStart.toString()] = {
+        userIds: (slotsTimeFrameAvailable[slotStart]?.userIds || []).concat(item.userIds || []),
+        startTime: slotStart,
+        endTime: slotStart + eventLength,
+      };
+    });
+  }
+  // XXX: Hack alert, as dayjs is supposedly not aware of timezone the current slot may have invalid UTC offset.
+  const timeZone =
+    (startOfInviteeDay as unknown as { $x: { $timezone: string } })["$x"]["$timezone"] || "UTC";
 
-  computedLocalAvailability.forEach((item) => {
-    const userSlotsTimeFrameAvailable = splitAvailableTime(
-      item.startTime,
-      item.endTime,
-      frequency,
-      eventLength
-    ).map((slot) => ({ ...slot, userIds: item.userIds }));
-
-    slotsTimeFrameAvailable.push(...userSlotsTimeFrameAvailable);
-  });
-
-  const slots: { [x: string]: { time: Dayjs; userIds?: number[] } } = {};
-  slotsTimeFrameAvailable.forEach((item) => {
-    // XXX: Hack alert, as dayjs is supposedly not aware of timezone the current slot may have invalid UTC offset.
-    const timeZone =
-      (startOfInviteeDay as unknown as { $x: { $timezone: string } })["$x"]["$timezone"] || "UTC";
+  const slots: { time: Dayjs; userIds?: number[] }[] = [];
+  for (const item of Object.values(slotsTimeFrameAvailable)) {
     /*
      * @calcom/web:dev: 2022-11-06T00:00:00-04:00
      * @calcom/web:dev: 2022-11-06T01:00:00-04:00
@@ -97,22 +85,9 @@ function buildSlots({
     // As the time has now fallen backwards, or forwards; this difference -
     // needs to be manually added as this is not done for us. Usually 0.
     slot.time = slot.time.add(startOfInviteeDay.utcOffset() - slot.time.utcOffset(), "minutes");
-
-    if (slots[slot.time.format()]) {
-      slots[slot.time.format()] = {
-        ...slot,
-        userIds: [...(slots[slot.time.format()].userIds || []), ...(item.userIds || [])],
-      };
-      return;
-    }
-    // Validating slot its not on the past
-    if (slot.time.isBefore(startDate)) {
-      return;
-    }
-    slots[slot.time.format()] = slot;
-  });
-
-  return Object.values(slots);
+    slots.push(slot);
+  }
+  return slots;
 }
 
 const getSlots = ({

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -80,7 +80,7 @@ function buildSlots({
     for (let slotStart = boundaryStart; slotStart < boundaryEnd; slotStart += frequency) {
       computedLocalAvailability.forEach((item) => {
         // TODO: This logic does not allow for past-midnight bookings.
-        if (slotStart < item.startTime || slotStart > item.endTime + 15 - frequency) {
+        if (slotStart < item.startTime || slotStart > item.endTime + 15 - eventLength) {
           return;
         }
         slotsTimeFrameAvailable[slotStart.toString()] = {

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -79,9 +79,8 @@ function buildSlots({
     // loop through the day, based on frequency.
     for (let slotStart = boundaryStart; slotStart < boundaryEnd; slotStart += frequency) {
       computedLocalAvailability.forEach((item) => {
-        const rangeStart = item.startTime;
-        const rangeEnd = Math.floor(item.endTime / frequency) * frequency;
-        if (slotStart < rangeStart || slotStart >= rangeEnd) {
+        // TODO: This logic does not allow for past-midnight bookings.
+        if (slotStart < item.startTime || slotStart > item.endTime + 15 - frequency) {
           return;
         }
         slotsTimeFrameAvailable[slotStart.toString()] = {

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -265,7 +265,6 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   );
   const workingHours = getAggregateWorkingHours(userAvailability, eventType.schedulingType);
 
-  const computedAvailableSlots: Record<string, Slot[]> = {};
   const availabilityCheckProps = {
     eventLength: eventType.length,
     currentSeats,
@@ -280,85 +279,93 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       periodDays: eventType.periodDays,
     });
 
-  let currentCheckedTime = startTime;
-  let getSlotsTime = 0;
+  const getSlotsTime = 0;
   let checkForAvailabilityTime = 0;
-  let getSlotsCount = 0;
+  const getSlotsCount = 0;
   let checkForAvailabilityCount = 0;
-  do {
-    const startGetSlots = performance.now();
+
+  const timeSlots: ReturnType<typeof getTimeSlots> = [];
+
+  for (
+    let currentCheckedTime = startTime;
+    currentCheckedTime.isBefore(endTime);
+    currentCheckedTime = currentCheckedTime.add(1, "day")
+  ) {
     // get slots retrieves the available times for a given day
-    const timeSlots = getTimeSlots({
-      inviteeDate: currentCheckedTime,
-      eventLength: input.duration || eventType.length,
-      workingHours,
-      dateOverrides,
-      minimumBookingNotice: eventType.minimumBookingNotice,
-      frequency: eventType.slotInterval || input.duration || eventType.length,
-    });
-
-    const endGetSlots = performance.now();
-    getSlotsTime += endGetSlots - startGetSlots;
-    getSlotsCount++;
-
-    const isCollective = !eventType.schedulingType || eventType.schedulingType === SchedulingType.COLLECTIVE;
-
-    const availableTimeSlots = timeSlots
-      .filter((slot) => isTimeWithinBounds(slot.time))
-      .filter((slot) =>
-        isCollective
-          ? // The slot should be available for every user
-            userAvailability.every((schedule) => {
-              const startCheckForAvailability = performance.now();
-              const isAvailable = checkIfIsAvailable({
-                time: slot.time,
-                ...schedule,
-                ...availabilityCheckProps,
-              });
-              const endCheckForAvailability = performance.now();
-              checkForAvailabilityCount++;
-              checkForAvailabilityTime += endCheckForAvailability - startCheckForAvailability;
-              return isAvailable;
-            })
-          : (() => {
-              // The slot should be available for the atleast one of the slot owners.
-              return slot.userIds?.some((slotUserId) => {
-                const userSchedule = userAvailability.find(({ userId }) => userId === slotUserId);
-                if (!userSchedule) {
-                  throw new TRPCError({
-                    message: "Shouldn't happen that we don't have a matching user schedule here",
-                    code: "INTERNAL_SERVER_ERROR",
-                  });
-                }
-                return checkIfIsAvailable({
-                  time: slot.time,
-                  ...userSchedule,
-                  ...availabilityCheckProps,
-                });
-              });
-            })()
-      );
-
-    computedAvailableSlots[currentCheckedTime.format("YYYY-MM-DD")] = availableTimeSlots.map(
-      ({ time: time, ...passThroughProps }) => ({
-        ...passThroughProps,
-        time: time.toISOString(),
-        users: eventType.users.map((user) => user.username || ""),
-        // Conditionally add the attendees and booking id to slots object if there is already a booking during that time
-        ...(currentSeats?.some((booking) => booking.startTime.toISOString() === time.toISOString()) && {
-          attendees:
-            currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
-            ]._count.attendees,
-          bookingUid:
-            currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
-            ].uid,
-        }),
+    timeSlots.push(
+      ...getTimeSlots({
+        inviteeDate: currentCheckedTime,
+        eventLength: input.duration || eventType.length,
+        workingHours,
+        dateOverrides,
+        minimumBookingNotice: eventType.minimumBookingNotice,
+        frequency: eventType.slotInterval || input.duration || eventType.length,
       })
     );
-    currentCheckedTime = currentCheckedTime.add(1, "day");
-  } while (currentCheckedTime.isBefore(endTime));
+  }
+
+  const isCollective = !eventType.schedulingType || eventType.schedulingType === SchedulingType.COLLECTIVE;
+
+  let availableTimeSlots: typeof timeSlots = [];
+  if (isCollective) {
+    availableTimeSlots = timeSlots.filter((slot) =>
+      userAvailability.every((schedule) => {
+        const startCheckForAvailability = performance.now();
+        const isAvailable = checkIfIsAvailable({
+          time: slot.time,
+          ...schedule,
+          ...availabilityCheckProps,
+        });
+        const endCheckForAvailability = performance.now();
+        checkForAvailabilityCount++;
+        checkForAvailabilityTime += endCheckForAvailability - startCheckForAvailability;
+        return isAvailable;
+      })
+    );
+  } else {
+    availableTimeSlots = timeSlots
+      .map((slot) => {
+        slot.userIds = slot.userIds?.filter((slotUserId) => {
+          const userSchedule = userAvailability.find(({ userId }) => userId === slotUserId);
+          if (!userSchedule) {
+            throw new TRPCError({
+              message: "Shouldn't happen that we don't have a matching user schedule here",
+              code: "INTERNAL_SERVER_ERROR",
+            });
+          }
+          return checkIfIsAvailable({
+            time: slot.time,
+            ...userSchedule,
+            ...availabilityCheckProps,
+          });
+        });
+        return slot;
+      })
+      .filter((slot) => slot.userIds && slot.userIds.length > 0);
+  }
+
+  availableTimeSlots = availableTimeSlots.filter((slot) => isTimeWithinBounds(slot.time));
+
+  const computedAvailableSlots = availableTimeSlots.reduce((r, { time: time, ...passThroughProps }) => {
+    r[time.format("YYYY-MM-DD")] = r[time.format("YYYY-MM-DD")] || [];
+    r[time.format("YYYY-MM-DD")].push({
+      ...passThroughProps,
+      time: time.toISOString(),
+      users: eventType.users.map((user) => user.username || ""),
+      // Conditionally add the attendees and booking id to slots object if there is already a booking during that time
+      ...(currentSeats?.some((booking) => booking.startTime.toISOString() === time.toISOString()) && {
+        attendees:
+          currentSeats[
+            currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
+          ]._count.attendees,
+        bookingUid:
+          currentSeats[
+            currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
+          ].uid,
+      }),
+    });
+    return r;
+  }, Object.create(null));
 
   logger.debug(`getSlots took ${getSlotsTime}ms and executed ${getSlotsCount} times`);
 

--- a/tests/config/singleton.ts
+++ b/tests/config/singleton.ts
@@ -1,7 +1,10 @@
 import { PrismaClient } from "@prisma/client";
 import { mockDeep, mockReset, DeepMockProxy } from "jest-mock-extended";
 
+import * as CalendarManager from "@calcom/core/CalendarManager";
 import prisma from "@calcom/prisma";
+
+jest.mock("@calcom/core/CalendarManager");
 
 jest.mock("@calcom/prisma", () => ({
   __esModule: true,
@@ -13,3 +16,4 @@ beforeEach(() => {
 });
 
 export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;
+export const CalendarManagerMock = CalendarManager as unknown as DeepMockProxy<typeof CalendarManager>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20403,16 +20403,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-nock@^13.2.8:
-  version "13.2.9"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.9.tgz#4faf6c28175d36044da4cfa68e33e5a15086ad4c"
-  integrity sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==
-  dependencies:
-    debug "^4.1.0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.21"
-    propagate "^2.0.0"
-
 node-abort-controller@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
@@ -22093,11 +22083,6 @@ prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, 
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-propagate@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
-  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-expr@^2.0.4:
   version "2.0.5"


### PR DESCRIPTION
## What does this PR do?

* 2-5x performance improvement on buildSlots, on a typical run taking ~220ms on a round-robin event with two users and regular working hours, 1h length, 15m intervals. On Vercel platform this is not running on M1 and the performance increase should be more (if 200ms isn't good enough).
* Booking Limit fixes

Fixes #6386

### The following was a round-robin event with 5 minute intervals, which is a bit skewed in benchmark favour. 

Before:
```
@calcom/web:dev: 261.1686658859253
@calcom/web:dev: 295.5547499656677
@calcom/web:dev: 276.91245889663696
@calcom/web:dev: 13.197291851043701
@calcom/web:dev: 201.46195888519287
@calcom/web:dev: 304.8555841445923
@calcom/web:dev: 348.87799978256226
@calcom/web:dev: 320.29675006866455
@calcom/web:dev: 298.3960838317871
@calcom/web:dev: 16.514708995819092
@calcom/web:dev: 412.25962495803833
@calcom/web:dev: 319.352792263031
@calcom/web:dev: 307.2695827484131
@calcom/web:dev: 331.67387533187866
@calcom/web:dev: 306.4797501564026
@calcom/web:dev: 323.24720764160156
@calcom/web:dev: 309.87562465667725
@calcom/web:dev: 335.6032090187073
@calcom/web:dev: 306.00012493133545
@calcom/web:dev: 322.82383394241333
@calcom/web:dev: 338.0093340873718
@calcom/web:dev: 293.10145902633667
@calcom/web:dev: 415.95374965667725
@calcom/web:dev: 278.45608282089233
@calcom/web:dev: 203.7317090034485
```
After:
```
@calcom/web:dev: 46.339165687561035
@calcom/web:dev: 42.44575023651123
@calcom/web:dev: 72.47133302688599
@calcom/web:dev: 58.1577091217041
@calcom/web:dev: 25.62195920944214
@calcom/web:dev: 49.89975023269653
@calcom/web:dev: 55.85516691207886
@calcom/web:dev: 51.87620830535889
@calcom/web:dev: 53.79541730880737
@calcom/web:dev: 54.397207736968994
@calcom/web:dev: 51.23254203796387
@calcom/web:dev: 52.09191608428955
@calcom/web:dev: 49.00404214859009
@calcom/web:dev: 52.425209045410156
```
### A regular event type still sees a significant performance improvement.

Before:
```
@calcom/web:dev: 111.88558435440063
@calcom/web:dev: 92.3113751411438
@calcom/web:dev: 113.30283308029175
@calcom/web:dev: 95.14154195785522
@calcom/web:dev: 117.83037519454956
@calcom/web:dev: 111.24895763397217
@calcom/web:dev: 107.13224983215332
@calcom/web:dev: 117.09833288192749
@calcom/web:dev: 109.87366724014282
@calcom/web:dev: 111.58466625213623
@calcom/web:dev: 98.55312490463257
@calcom/web:dev: 117.97745895385742
@calcom/web:dev: 106.8604998588562
@calcom/web:dev: 9.653749942779541
@calcom/web:dev: 113.2914171218872
@calcom/web:dev: 127.38441610336304
@calcom/web:dev: 118.18262481689453
@calcom/web:dev: 117.22816705703735
@calcom/web:dev: 108.8679575920105
@calcom/web:dev: 136.15558290481567
@calcom/web:dev: 155.59845876693726
@calcom/web:dev: 134.73008394241333
@calcom/web:dev: 138.19720792770386
@calcom/web:dev: 129.73195791244507
@calcom/web:dev: 118.53083276748657
```
After:
```
@calcom/web:dev: 77.42591619491577
@calcom/web:dev: 68.74491691589355
@calcom/web:dev: 73.46024990081787
@calcom/web:dev: 74.83408403396606
@calcom/web:dev: 60.6900839805603
@calcom/web:dev: 48.18441581726074
@calcom/web:dev: 67.67670917510986
@calcom/web:dev: 61.3255410194397
@calcom/web:dev: 81.16716623306274
@calcom/web:dev: 56.736083984375
@calcom/web:dev: 51.41737508773804
@calcom/web:dev: 3.710665702819824
@calcom/web:dev: 44.120041847229004
@calcom/web:dev: 2.113999843597412
@calcom/web:dev: 49.696624755859375
@calcom/web:dev: 54.930707931518555
@calcom/web:dev: 48.09649991989136
@calcom/web:dev: 1.8699584007263184
@calcom/web:dev: 51.06704235076904
@calcom/web:dev: 2.062624931335449
@calcom/web:dev: 42.9293327331543
@calcom/web:dev: 49.08449983596802
@calcom/web:dev: 1.9262089729309082
@calcom/web:dev: 44.59933280944824
@calcom/web:dev: 47.761208057403564
```