### PR TITLE
Fixes ultrawide breaking booking limits selects

### DIFF
--- a/apps/web/components/eventtype/EventLimitsTab.tsx
+++ b/apps/web/components/eventtype/EventLimitsTab.tsx
@@ -191,7 +191,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupProps, "eventTy
 
               return (
                 <>
-                  <div className="w-1/2 md:w-3/4">
+                  <div className="w-1/2 md:w-full">
                     <InputField
                       required
                       label={t("minimum_booking_notice")}


### PR DESCRIPTION
Before this page broke on ultrawides
![image](https://user-images.githubusercontent.com/55134778/211777159-dfdbce0a-cbd6-45f7-956c-e4c9e4695035.png)

After:
<img width="2060" alt="CleanShot 2023-01-11 at 10 05 00@2x" src="https://user-images.githubusercontent.com/55134778/211777265-8ca02cb7-153c-4af3-886e-cafae652dcbf.png">

