### PR TITLE
fix: show recordings even to free plan users

### DIFF
--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -1132,39 +1132,8 @@ const loggedInViewerRouter = router({
     )
     .query(async ({ ctx, input }) => {
       const { roomName } = input;
-      let shouldHideRecordingsData = false;
-      // If self-hosted, he should be able to get recordings
-      if (IS_TEAM_BILLING_ENABLED) {
-        // If user is not a team member, throw error
-        const { hasTeamPlan } = await viewerTeamsRouter.createCaller(ctx).hasTeamPlan();
-        if (!hasTeamPlan) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "You are not a team plan.",
-          });
-        } else {
-          shouldHideRecordingsData = true;
-        }
-      }
-
       try {
         const res = await getRecordingsOfCalVideoByRoomName(roomName);
-
-        if (shouldHideRecordingsData) {
-          if (res && "data" in res && res.data.length > 0) {
-            res.data = res.data.map((recording) => {
-              return {
-                id: "",
-                room_name: "",
-                start_ts: recording.start_ts,
-                status: recording.status,
-                max_participants: recording.max_participants,
-                duration: recording.duration,
-                share_token: recording.share_token,
-              };
-            });
-          }
-        }
         return res;
       } catch (err) {
         throw new TRPCError({


### PR DESCRIPTION
## What does this PR do?

Fixes: for free plan users they should be able to see the recordings but with upgrade button. currently the api end point inly returns the recordings to teams plan user. 

https://files.slack.com/files-pri/T01N4FWPGPP-F04J87495RC/screenshot_2023-01-11_at_7.39.16_pm.png

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
