### PR TITLE
fix #6376 : Location dropdown is overflowing 

### DIFF
--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -7,6 +7,7 @@ import ReactSelect, {
   SingleValue,
   MultiValue,
   SelectComponentsConfig,
+  MenuPlacement,
 } from "react-select";
 
 import classNames from "@calcom/lib/classNames";
@@ -37,10 +38,13 @@ export const getReactSelectProps = <
 >({
   className,
   components,
+  menuPlacement = "auto",
 }: {
   className?: string;
   components: SelectComponentsConfig<Option, IsMulti, Group>;
+  menuPlacement?: MenuPlacement;
 }) => ({
+  menuPlacement,
   className: classNames("block h-[36px] w-full min-w-0 flex-1 rounded-md", className),
   classNamePrefix: "cal-react-select",
   components: {
@@ -69,7 +73,10 @@ export const Select = <
   ...props
 }: SelectProps<Option, IsMulti, Group>) => {
   const reactSelectProps = React.useMemo(() => {
-    return getReactSelectProps<Option, IsMulti, Group>({ className, components: components || {} });
+    return getReactSelectProps<Option, IsMulti, Group>({
+      className,
+      components: components || {},
+    });
   }, [className, components]);
 
   return (


### PR DESCRIPTION


## What does this PR do?
Fix https://github.com/calcom/cal.com/issues/6376 by adding  `menuPlacement` react-select's props to `getReactSelectProps` to avoid dropdown overflow on small screen. By default, set to "auto".

Fixes #6376 


https://www.loom.com/share/a3b81d8f57894225bc2fddd2d2778fd9

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- open `/event-types/[id]`
- when interacting with `Location` select, dropdown should be placed well according to you screen (try with a small windows to check if the dropdown goes up when screen is small)


## Checklist

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
