### PR TITLE
Check for session in addition for isPublic prop

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -172,23 +172,38 @@ const CustomBrandingContainer = () => {
   return <CustomBranding lightVal={user?.brandColor} darkVal={user?.darkBrandColor} />;
 };
 
-export default function Shell(props: LayoutProps) {
-  useRedirectToLoginIfUnauthenticated(props.isPublic);
-  useRedirectToOnboardingIfNeeded();
-  useTheme("light");
-  // don't load KBar when unauthed
-  return props.isPublic ? (
-    <>
-      <CustomBrandingContainer />
-      <Layout {...props} />
-    </>
-  ) : (
+const PublicShell = (props: LayoutProps) => {
+  const { status } = useSession();
+  return status === "authenticated" ? (
     <KBarRoot>
       <CustomBrandingContainer />
       <Layout {...props} />
       <KBarContent />
     </KBarRoot>
+  ) : (
+    <>
+      <CustomBrandingContainer />
+      <Layout {...props} />
+    </>
   );
+};
+
+export default function Shell(props: LayoutProps) {
+  // if a page is unauthed and isPublic is true, the redirect does not happen.
+  useRedirectToLoginIfUnauthenticated(props.isPublic);
+  useRedirectToOnboardingIfNeeded();
+  useTheme("light");
+  // if not a public page, we can assume a session.
+  if (!props.isPublic) {
+    return (
+      <KBarRoot>
+        <CustomBrandingContainer />
+        <Layout {...props} />
+        <KBarContent />
+      </KBarRoot>
+    );
+  }
+  return <PublicShell {...props} />;
 }
 
 function UserDropdown({ small }: { small?: boolean }) {

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -172,19 +172,23 @@ const CustomBrandingContainer = () => {
   return <CustomBranding lightVal={user?.brandColor} darkVal={user?.darkBrandColor} />;
 };
 
-const PublicShell = (props: LayoutProps) => {
-  const { status } = useSession();
-  return status === "authenticated" ? (
+const KBarWrapper = ({ children, withKBar = false }: { withKBar: boolean; children: React.ReactNode }) =>
+  withKBar ? (
     <KBarRoot>
-      <CustomBrandingContainer />
-      <Layout {...props} />
+      {children}
       <KBarContent />
     </KBarRoot>
   ) : (
-    <>
+    <>{children}</>
+  );
+
+const PublicShell = (props: LayoutProps) => {
+  const { status } = useSession();
+  return (
+    <KBarWrapper withKBar={status === "authenticated"}>
       <CustomBrandingContainer />
       <Layout {...props} />
-    </>
+    </KBarWrapper>
   );
 };
 
@@ -194,16 +198,15 @@ export default function Shell(props: LayoutProps) {
   useRedirectToOnboardingIfNeeded();
   useTheme("light");
   // if not a public page, we can assume a session.
-  if (!props.isPublic) {
-    return (
-      <KBarRoot>
-        <CustomBrandingContainer />
-        <Layout {...props} />
-        <KBarContent />
-      </KBarRoot>
-    );
+  if (props.isPublic) {
+    return <PublicShell {...props} />;
   }
-  return <PublicShell {...props} />;
+  return (
+    <KBarWrapper withKBar>
+      <CustomBrandingContainer />
+      <Layout {...props} />
+    </KBarWrapper>
+  );
 }
 
 function UserDropdown({ small }: { small?: boolean }) {

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -26,18 +26,18 @@ import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { SVGComponent } from "@calcom/types/SVGComponent";
 import {
   Button,
+  Credits,
   Dropdown,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  showToast,
-  Logo,
   ErrorBoundary,
-  Credits,
   HeadSeo,
   Icon,
+  Logo,
+  showToast,
   SkeletonText,
 } from "@calcom/ui";
 
@@ -182,27 +182,15 @@ const KBarWrapper = ({ children, withKBar = false }: { withKBar: boolean; childr
     <>{children}</>
   );
 
-const PublicShell = (props: LayoutProps) => {
-  const { status } = useSession();
-  return (
-    <KBarWrapper withKBar={status === "authenticated"}>
-      <CustomBrandingContainer />
-      <Layout {...props} />
-    </KBarWrapper>
-  );
-};
-
 export default function Shell(props: LayoutProps) {
+  const { status } = useSession();
   // if a page is unauthed and isPublic is true, the redirect does not happen.
   useRedirectToLoginIfUnauthenticated(props.isPublic);
   useRedirectToOnboardingIfNeeded();
   useTheme("light");
-  // if not a public page, we can assume a session.
-  if (props.isPublic) {
-    return <PublicShell {...props} />;
-  }
+
   return (
-    <KBarWrapper withKBar>
+    <KBarWrapper withKBar={status === "authenticated"}>
       <CustomBrandingContainer />
       <Layout {...props} />
     </KBarWrapper>


### PR DESCRIPTION
## What does this PR do?

Fixes woopsy that excluded the KBar on /apps entirely; Fixes by checking for "authenticated" instead of isPublic, returning early when isPublic is false.