### PR TITLE
booking page: only scroll to bottom on mobile

### DIFF
--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -5,6 +5,7 @@ import { useEmbedStyles } from "@calcom/embed-core/embed-iframe";
 import classNames from "@calcom/lib/classNames";
 import { daysInMonth, yyyymmdd } from "@calcom/lib/date-fns";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import { weekdayNames } from "@calcom/lib/weekday";
 import { Button, Icon, SkeletonText } from "@calcom/ui";
 
@@ -135,6 +136,9 @@ const Days = ({
     const date = browsingDate.set("date", day);
     days.push(date);
   }
+
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
   return (
     <>
       {days.map((day, idx) => (
@@ -153,12 +157,13 @@ const Days = ({
               date={day}
               onClick={() => {
                 props.onChange(day);
-                setTimeout(() => {
-                  window.scrollTo({
-                    top: 360,
-                    behavior: "smooth",
-                  });
-                }, 500);
+                isMobile &&
+                  setTimeout(() => {
+                    window.scrollTo({
+                      top: 360,
+                      behavior: "smooth",
+                    });
+                  }, 500);
               }}
               disabled={
                 (includedDates && !includedDates.includes(yyyymmdd(day))) ||

--- a/packages/lib/hooks/useMediaQuery.ts
+++ b/packages/lib/hooks/useMediaQuery.ts
@@ -1,4 +1,3 @@
-// lets refactor and move this into packages/lib/hooks/
 import { useState, useEffect } from "react";
 
 const useMediaQuery = (query: string) => {

--- a/packages/ui/components/logo/Logo.tsx
+++ b/packages/ui/components/logo/Logo.tsx
@@ -2,12 +2,14 @@ import { LOGO_ICON, LOGO } from "@calcom/lib/constants";
 
 export default function Logo({ small, icon }: { small?: boolean; icon?: boolean }) {
   return (
-    <strong>
-      {icon ? (
-        <img className="mx-auto w-9" alt="Cal" title="Cal" src={LOGO_ICON} />
-      ) : (
-        <img className={small ? "h-4 w-auto" : "h-5 w-auto"} alt="Cal" title="Cal" src={LOGO} />
-      )}
-    </strong>
+    <h1 className="logo inline">
+      <strong>
+        {icon ? (
+          <img className="mx-auto w-9" alt="Cal" title="Cal" src={LOGO_ICON} />
+        ) : (
+          <img className={small ? "h-4 w-auto" : "h-5 w-auto"} alt="Cal" title="Cal" src={LOGO} />
+        )}
+      </strong>
+    </h1>
   );
 }

--- a/packages/ui/components/logo/Logo.tsx
+++ b/packages/ui/components/logo/Logo.tsx
@@ -2,14 +2,12 @@ import { LOGO_ICON, LOGO } from "@calcom/lib/constants";
 
 export default function Logo({ small, icon }: { small?: boolean; icon?: boolean }) {
   return (
-    <h1 className="logo inline">
-      <strong>
-        {icon ? (
-          <img className="mx-auto w-9" alt="Cal" title="Cal" src={LOGO_ICON} />
-        ) : (
-          <img className={small ? "h-4 w-auto" : "h-5 w-auto"} alt="Cal" title="Cal" src={LOGO} />
-        )}
-      </strong>
-    </h1>
+    <strong>
+      {icon ? (
+        <img className="mx-auto w-9" alt="Cal" title="Cal" src={LOGO_ICON} />
+      ) : (
+        <img className={small ? "h-4 w-auto" : "h-5 w-auto"} alt="Cal" title="Cal" src={LOGO} />
+      )}
+    </strong>
   );
 }


### PR DESCRIPTION
fixes #6452 

previously we scrolled at any view point which causes issues on tablet if the outside container is too big when embedded.

todo:
- [ ] refactor and move useMediaQuery from /web/lib/hooks this into packages/lib/hooks/ and fix imports