### PR TITLE
fix: wrong i18n  placeholder in many locales

### DIFF
--- a/apps/web/public/static/locales/cs/common.json
+++ b/apps/web/public/static/locales/cs/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Událost stále čeká na schválení",
   "booking_submitted_subject": "Rezervace odeslána: {{eventType}} s {{name}} během {{date}}",
   "your_meeting_has_been_booked": "Vaše schůzka byla rezervována",
-  "event_type_has_been_rescheduled_on_time_date": "Váš {{eventType}} s {{name}} byl přesunut na {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Váš {{title}} byl přeplánován na {{date}}.",
   "event_has_been_rescheduled": "Změna - Vaše událost byla přesunuta na jindy",
   "request_reschedule_title_attendee": "Žádost o přeplánování rezervace",
   "request_reschedule_subtitle": "Organizátor {{organizer}} zrušil rezervaci a požádal vás, abyste si vybrali jiný čas.",

--- a/apps/web/public/static/locales/es/common.json
+++ b/apps/web/public/static/locales/es/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Un evento aún está esperando su aprobación",
   "booking_submitted_subject": "Reserva enviada: {{eventType}} con {{name}} el {{date}}",
   "your_meeting_has_been_booked": "Su reunión ha sido reservada",
-  "event_type_has_been_rescheduled_on_time_date": "Tu {{eventType}} con {{name}} se reprogramó para el {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Tu {{title}} ha sido reprogramado para {{date}}.",
   "event_has_been_rescheduled": "Tu evento ha sido reprogramado.",
   "request_reschedule_title_attendee": "Solicitud para reprogramar su reserva",
   "request_reschedule_subtitle": "{{organizer}} ha cancelado la reserva y le ha solicitado que elija otra hora.",

--- a/apps/web/public/static/locales/it/common.json
+++ b/apps/web/public/static/locales/it/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Un evento è ancora in attesa della tua approvazione",
   "booking_submitted_subject": "Prenotazione inviata: {{eventType}} con {{name}} il {{date}}",
   "your_meeting_has_been_booked": "Il tuo meeting è stata prenotato",
-  "event_type_has_been_rescheduled_on_time_date": "Il tuo {{eventType}} con {{name}} è stato riprogrammato il {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Il tuo {{title}} è stato riprogrammato per il {{date}}.",
   "event_has_been_rescheduled": "Aggiornato: il tuo evento è stato riprogrammato",
   "request_reschedule_title_attendee": "Richiesta di riprogrammare la prenotazione",
   "request_reschedule_subtitle": "{{organizer}} ha annullato la prenotazione e ti ha chiesto di scegliere un altro orario.",

--- a/apps/web/public/static/locales/ja/common.json
+++ b/apps/web/public/static/locales/ja/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "イベントはまだあなたの承認待ちです",
   "booking_submitted_subject": "予約を送信しました: {{date}} の {{name}} との {{eventType}}",
   "your_meeting_has_been_booked": "ミーティングが予約されました",
-  "event_type_has_been_rescheduled_on_time_date": "{{name}} との {{eventType}} は {{date}} にスケジュールが変更されました。",
+  "event_type_has_been_rescheduled_on_time_date": "あなたの {{title}} は {{date}} に再スケジュールされました。",
   "event_has_been_rescheduled": "更新 - イベントのスケジュールが変更されました",
   "request_reschedule_title_attendee": "予約のスケジュール変更をリクエスト",
   "request_reschedule_subtitle": "{{organizer}} が予約をキャンセルしました。別の時間を選択することをあなたにリクエストしています。",

--- a/apps/web/public/static/locales/ko/common.json
+++ b/apps/web/public/static/locales/ko/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "이벤트가 아직 승인을 기다리고 있습니다.",
   "booking_submitted_subject": "예약 제출됨: {{date}}에 {{name}}에 의한 {{eventType}}",
   "your_meeting_has_been_booked": "회의가 예약되었습니다.",
-  "event_type_has_been_rescheduled_on_time_date": "{{name}}의 {{eventType}} 일정이 {{date}}(으)로 변경되었습니다.",
+  "event_type_has_been_rescheduled_on_time_date": "귀하의 {{title}} 일정이 {{date}}로 변경되었습니다.",
   "event_has_been_rescheduled": "업데이트 - 이벤트 일정이 변경되었습니다.",
   "request_reschedule_title_attendee": "예약 일정 변경 요청",
   "request_reschedule_subtitle": "{{organizer}}에서 예약을 취소했고 다른 시간을 선택할 것을 요청했습니다.",

--- a/apps/web/public/static/locales/nl/common.json
+++ b/apps/web/public/static/locales/nl/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Een gebeurtenis wacht nog op uw goedkeuring",
   "booking_submitted_subject": "Boeking verzonden: {{eventType}} met {{name}} om {{date}}",
   "your_meeting_has_been_booked": "Uw afspraak is geboekt",
-  "event_type_has_been_rescheduled_on_time_date": "Uw {{eventType}} met {{name}} is verplaatst naar {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Uw {{title}} is verplaatst naar {{date}}.",
   "event_has_been_rescheduled": "Bijgewerkt - Uw gebeurtenis is verplaatst",
   "request_reschedule_title_attendee": "Vezoek om uw boeking te verplaatsen",
   "request_reschedule_subtitle": "{{organizer}} heeft de boeking geannuleerd en u verzocht een andere tijd te kiezen.",

--- a/apps/web/public/static/locales/no/common.json
+++ b/apps/web/public/static/locales/no/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "En hendelse venter fortsatt på din godkjenning",
   "booking_submitted_subject": "Booking sendt inn: {{eventType}} med {{name}} kl. {{date}}",
   "your_meeting_has_been_booked": "Møtet ditt er booket",
-  "event_type_has_been_rescheduled_on_time_date": "Din {{eventType}} med {{name}} har blitt flyttet til {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Din {{title}} har blitt flyttet til {{date}}.",
   "event_has_been_rescheduled": "Oppdatert – Hendelsen din har blitt endret",
   "request_reschedule_title_attendee": "Be om å få endre tidspunkt for bookingen din",
   "request_reschedule_subtitle": "{{organizer}} har kansellert bookingen og bedt deg om å velge et annet tidspunkt.",

--- a/apps/web/public/static/locales/pl/common.json
+++ b/apps/web/public/static/locales/pl/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Wydarzenie nadal oczekuje na Twoje zatwierdzenie",
   "booking_submitted_subject": "Rezerwacja potwierdzona: {{eventType}} z {{name}} w {{date}}",
   "your_meeting_has_been_booked": "Twoje spotkanie zostało zarezerwowane",
-  "event_type_has_been_rescheduled_on_time_date": "Wydarzenie {{eventType}} z {{name}} przełożono na {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Twój {{title}} został przełożony na {{date}}.",
   "event_has_been_rescheduled": "Zaktualizowano - Twoje wydarzenie zostało przełożone",
   "request_reschedule_title_attendee": "Poproś o przełożenie rezerwacji",
   "request_reschedule_subtitle": "{{organizer}} anulował(a) rezerwację i prosi Cię o wybranie innego terminu.",

--- a/apps/web/public/static/locales/pt-BR/common.json
+++ b/apps/web/public/static/locales/pt-BR/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Um evento está aguardando a sua aprovação",
   "booking_submitted_subject": "Reserva enviada: {{eventType}} com {{name}} em {{date}}",
   "your_meeting_has_been_booked": "A sua reunião foi agendada",
-  "event_type_has_been_rescheduled_on_time_date": "O evento {{eventType}} com {{name}} foi reagendado para as {{time}} ({{timeZone}}) de {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Seu {{title}} foi remarcado para {{date}}.",
   "event_has_been_rescheduled": "Atualização - O seu evento foi reagendado",
   "request_reschedule_title_attendee": "Solicitar reagendamento da reserva",
   "request_reschedule_subtitle": "{{organizer}} cancelou a reserva e solicitou que você escolhesse outro horário.",

--- a/apps/web/public/static/locales/pt/common.json
+++ b/apps/web/public/static/locales/pt/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Um evento ainda aguarda a sua aprovação",
   "booking_submitted_subject": "Reserva submetida: {{eventType}} com {{name}} em {{date}}",
   "your_meeting_has_been_booked": "A sua reunião foi reservada",
-  "event_type_has_been_rescheduled_on_time_date": "O evento {{eventType}} com {{name}} foi reagendado para as {{time}} ({{timeZone}}) de {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Seu {{title}} foi remarcado para {{date}}.",
   "event_has_been_rescheduled": "O seu evento foi reagendado.",
   "request_reschedule_title_attendee": "Solicitar o reagendamento da sua reserva",
   "request_reschedule_subtitle": "{{organizer}} cancelou a reserva e pediu para que escolhesse outro horário.",

--- a/apps/web/public/static/locales/ro/common.json
+++ b/apps/web/public/static/locales/ro/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Un eveniment încă așteaptă aprobarea dvs.",
   "booking_submitted_subject": "Rezervare transmisă: {{eventType}} cu {{name}} în {{date}}",
   "your_meeting_has_been_booked": "Întâlnirea dvs. a fost programată",
-  "event_type_has_been_rescheduled_on_time_date": "{{eventType}} cu {{name}} a fost reprogramat/ă pe {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "{{title}} dvs. a fost reprogramat la {{date}}.",
   "event_has_been_rescheduled": "Evenimentul dvs. a fost reprogramat.",
   "request_reschedule_title_attendee": "Solicitați reprogramarea rezervării",
   "request_reschedule_subtitle": "{{organizer}} a anulat rezervarea și v-a cerut să alegeți o altă dată.",

--- a/apps/web/public/static/locales/ru/common.json
+++ b/apps/web/public/static/locales/ru/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Событие все еще ждет вашего подтверждения",
   "booking_submitted_subject": "Бронирование отправлено: {{eventType}} с {{name}}, {{date}}",
   "your_meeting_has_been_booked": "Ваша встреча была забронирована",
-  "event_type_has_been_rescheduled_on_time_date": "Перенесено: {{eventType}} с {{name}} на {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Ваше {{title}} было перенесено на {{date}}.",
   "event_has_been_rescheduled": "Ваше событие было перенесено.",
   "request_reschedule_title_attendee": "Запросить перенос бронирования",
   "request_reschedule_subtitle": "{{organizer}} отменил(-а) бронирование и попросил(-а) вас выбрать другое время.",

--- a/apps/web/public/static/locales/sr/common.json
+++ b/apps/web/public/static/locales/sr/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Događaj još čeka na vaše odobrenje",
   "booking_submitted_subject": "Rezervacija podneta: {{eventType}} sa {{name}} datuma {{date}}",
   "your_meeting_has_been_booked": "Sastanak je zakazan",
-  "event_type_has_been_rescheduled_on_time_date": "Vaš {{eventType}} sa {{name}} je odložen za {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Ваш {{титле}} је померен за {{дате}}.",
   "event_has_been_rescheduled": "Ažurirano - Vaš dogadjaj je odložen",
   "request_reschedule_title_attendee": "Zahtev za promenu vremena rezervacije",
   "request_reschedule_subtitle": "{{organizer}} je otkazao/la rezervaciju i tražio/la je da odaberete drugo vreme.",

--- a/apps/web/public/static/locales/sv/common.json
+++ b/apps/web/public/static/locales/sv/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "En bokning väntar fortfarande på ditt godkännande",
   "booking_submitted_subject": "Bokning skickad: {{eventType}} med {{name}} {{date}}",
   "your_meeting_has_been_booked": "Ditt möte har bokats",
-  "event_type_has_been_rescheduled_on_time_date": "Din {{eventType}} med {{name}} har bokats om till {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Din {{title}} har ändrats till {{date}}.",
   "event_has_been_rescheduled": "Uppdatering - Din bokning har blivit omplanerad",
   "request_reschedule_title_attendee": "Begäran om att boka om din bokning",
   "request_reschedule_subtitle": "{{organizer}} har avbokat bokningen och bett dig att välja en annan tid.",

--- a/apps/web/public/static/locales/tr/common.json
+++ b/apps/web/public/static/locales/tr/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Bir etkinlik hâlâ onayınızı bekliyor",
   "booking_submitted_subject": "Rezervasyon Gönderildi: {{date}} tarihinde {{name}} ile {{eventType}}",
   "your_meeting_has_been_booked": "Toplantı rezervasyonunuz yapıldı",
-  "event_type_has_been_rescheduled_on_time_date": "{{name}} ile yapacağınız {{eventType}} etkinliğiniz {{date}} olarak yeniden planlandı.",
+  "event_type_has_been_rescheduled_on_time_date": "{{title}}, {{date}} olarak yeniden planlandı.",
   "event_has_been_rescheduled": "Güncellendi - Etkinliğiniz yeniden planlandı",
   "request_reschedule_title_attendee": "Rezervasyonunuz için yeniden planlama isteğinde bulunun",
   "request_reschedule_subtitle": "{{organizer}} rezervasyonu iptal etti ve sizden başka bir saat seçmenizi istiyor.",

--- a/apps/web/public/static/locales/uk/common.json
+++ b/apps/web/public/static/locales/uk/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Захід досі чекає на ваше схвалення",
   "booking_submitted_subject": "Бронювання надіслано: {{eventType}} «{{name}}», {{date}}",
   "your_meeting_has_been_booked": "Вашу нараду заброньовано",
-  "event_type_has_been_rescheduled_on_time_date": "{{eventType}} «{{name}}» перенесено. Новий час: {{time}} ({{timeZone}}), {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "Ваш {{title}} перенесено на {{date}}.",
   "event_has_been_rescheduled": "Оновлено – ваш захід перенесено",
   "request_reschedule_title_attendee": "Надіслати запит на перенесення бронювання",
   "request_reschedule_subtitle": "{{organizer}} скасував(-ла) бронювання та попросив(-ла) вас вибрати інший час.",

--- a/apps/web/public/static/locales/vi/common.json
+++ b/apps/web/public/static/locales/vi/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "Một sự kiện vẫn đang chờ bạn phê duyệt",
   "booking_submitted_subject": "Đặt chỗ đã được gửi: {{eventType}} với {{name}} lúc {{date}}",
   "your_meeting_has_been_booked": "Cuộc họp của bạn đã được đặt",
-  "event_type_has_been_rescheduled_on_time_date": "{{eventType}} của bạn với {{name}} đã được chuyển sang ngày {{date}}.",
+  "event_type_has_been_rescheduled_on_time_date": "{{title}} của bạn đã được lên lịch lại vào {{date}}.",
   "event_has_been_rescheduled": "Đã cập nhật - Sự kiện của bạn đã được đổi",
   "request_reschedule_title_attendee": "Yêu cầu xếp lại lịch đặt chỗ của bạn",
   "request_reschedule_subtitle": "{{organizer}} đã huỷ đặt chỗ đó và yêu cầu bạn chọn thời gian khác.",

--- a/apps/web/public/static/locales/zh-CN/common.json
+++ b/apps/web/public/static/locales/zh-CN/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "有活动仍在等待您的批准",
   "booking_submitted_subject": "预约已提交: 名称为 {{name}} 的 {{eventType}}，日期为 {{date}}",
   "your_meeting_has_been_booked": "您的会议已预定",
-  "event_type_has_been_rescheduled_on_time_date": "您与 {{name}} 的 {{eventType}} 已被重新安排到 {{date}} {{time}} ({{timeZone}})。",
+  "event_type_has_been_rescheduled_on_time_date": "您的 {{title}} 已改期至 {{date}}。",
   "event_has_been_rescheduled": "已更新 - 您的活动已被重新安排",
   "request_reschedule_title_attendee": "请求重新安排您的预约",
   "request_reschedule_subtitle": "{{organizer}} 取消了预约并要求您选择其他时间。",

--- a/apps/web/public/static/locales/zh-TW/common.json
+++ b/apps/web/public/static/locales/zh-TW/common.json
@@ -68,7 +68,7 @@
   "event_still_awaiting_approval": "活動還在等待核准",
   "booking_submitted_subject": "已提出預約：{{date}} 與 {{name}} 的 {{eventType}}",
   "your_meeting_has_been_booked": "會議已經預定",
-  "event_type_has_been_rescheduled_on_time_date": "您和 {{name}} 的 {{eventType}} 的預定時間已改為 {{date}}。",
+  "event_type_has_been_rescheduled_on_time_date": "您的 {{title}} 已改期至 {{date}}。",
   "event_has_been_rescheduled": "已更新 - 已經重新預定活動時間",
   "request_reschedule_title_attendee": "要求重新安排您的預約",
   "request_reschedule_subtitle": "{{organizer}} 已取消預約，並要求您選擇其他時間。",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

this PR fixes i18n placeholder doesn't get translated while sending a reschedule email. related to #6480. used google translate for translation.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
