### PR TITLE
Fix for missing module due to path.join in browser export on Windows

### DIFF
--- a/packages/app-store-cli/src/build.ts
+++ b/packages/app-store-cli/src/build.ts
@@ -294,7 +294,7 @@ function generateFiles() {
   browserOutput.push(
     ...getExportedObject("EventTypeAddonMap", {
       importConfig: {
-        fileToBeImported: path.join("components", "EventTypeAppCardInterface.tsx"),
+        fileToBeImported: "components/EventTypeAppCardInterface.tsx",
       },
       lazyImport: true,
     })


### PR DESCRIPTION
## What does this PR do?

Fixes the path by replacing path.join function with '/' between the path being joined which is analogous to the other similar exports.

Fixes # (issue)

**Environment**: Staging(main branch) 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

