### PR TITLE
Fix booking filters not working for admin

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings.tsx
+++ b/packages/trpc/server/routers/viewer/bookings.tsx
@@ -241,7 +241,9 @@ export const bookingsRouter = router({
                   members: {
                     some: {
                       userId: user.id,
-                      role: "OWNER",
+                      role: {
+                        in: ["ADMIN", "OWNER"],
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
Fixes booking filter not working for admins 

Hide team filter if not admin or owner TODO: #6575 