### PR TITLE
fix: show button on empty string

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -220,7 +220,8 @@ function BookingListItem(booking: BookingItemProps) {
       },
     });
   };
-  const showRecordingsButtons = booking.location === "integrations:daily" && isPast && isConfirmed;
+  const showRecordingsButtons =
+    (booking.location === "integrations:daily" || booking?.location?.trim() === "") && isPast && isConfirmed;
   return (
     <>
       <RescheduleDialog

--- a/packages/features/ee/video/ViewRecordingsDialog.tsx
+++ b/packages/features/ee/video/ViewRecordingsDialog.tsx
@@ -109,7 +109,7 @@ export const ViewRecordingsDialog = (props: IViewRecordingsDialog) => {
         <DialogHeader title={t("recordings_title")} subtitle={subtitle} />
         <LicenseRequired>
           <>
-            {isLoading && isLoadingHasTeamPlan && <RecordingListSkeleton />}
+            {(isLoading || isLoadingHasTeamPlan) && <RecordingListSkeleton />}
             {recordings && "data" in recordings && recordings?.data?.length > 0 && (
               <div className="flex flex-col gap-3">
                 {recordings.data.map((recording: RecordingItemSchema, index: number) => {


### PR DESCRIPTION
## What does this PR do?

Fixes:  some bookings location were stored as empty string in the DB when cal video was selected as location. so a temporary fix until we fix those records in the prod database.

https://threads.com/34443186565?s=69kPSFxFfX1eAvwThYve8v

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
