### PR TITLE
fix: use items-center

### DIFF
--- a/apps/web/components/booking/BookingDescription.tsx
+++ b/apps/web/components/booking/BookingDescription.tsx
@@ -123,7 +123,8 @@ const BookingDescription: FC<Props> = (props) => {
         <div
           className={classNames(
             "flex flex-nowrap text-sm font-medium",
-            isBookingPage && "dark:text-darkgray-600 text-gray-600"
+            isBookingPage && "dark:text-darkgray-600 text-gray-600",
+            !eventType.metadata?.multipleDuration && "items-center"
           )}>
           <Icon.FiClock
             className={classNames(


### PR DESCRIPTION
Fixes:

**Before: Time not centered**

<img width="233" alt="Screenshot 2023-01-22 at 5 03 59 PM" src="https://user-images.githubusercontent.com/53316345/213913619-070b9d51-ba1b-4289-941f-27535aaf2709.png">

**After:-** 
<img width="233" alt="Screenshot 2023-01-22 at 5 04 42 PM" src="https://user-images.githubusercontent.com/53316345/213913651-d8ffe59d-1071-45dc-b090-fdf293ae19cc.png">

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
