### PR TITLE
Stripe App not showing in Event Type apps

### DIFF
--- a/packages/app-store/_components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/_components/EventTypeAppCardInterface.tsx
@@ -16,7 +16,11 @@ export const EventTypeAppCard = (props: {
   return (
     <ErrorBoundary message={`There is some problem with ${app.name} App`}>
       <EventTypeAppContext.Provider value={[getAppData, setAppData]}>
-        <DynamicComponent slug={app.slug} componentMap={EventTypeAddonMap} {...props} />
+        <DynamicComponent
+          slug={app.slug === "stripe" ? "stripepayment" : app.slug}
+          componentMap={EventTypeAddonMap}
+          {...props}
+        />
       </EventTypeAppContext.Provider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## What does this PR do?

Due to having two different slugs for the same app, Stripe was not showing up in Event Type Apps as installed, even though it was installed. Now it shows up:

<kbd><img width="1486" alt="image" src="https://user-images.githubusercontent.com/467258/213930023-3407059a-8470-47fc-8e1b-f2984f98716c.png"></kbd>

This comes as a temporary fix, we should probably standardise using a single slug for it or perhaps using `dirName` to be sure we refer to the app internally where it is located. cc: @hariombalhara 

Fixes #6615 

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to an Event Type with payment enabled and see that Stripe is present in the Installed apps list for the event type settings.