### PR TITLE
Fixes issues with workflows that have more than one action

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowListPage.tsx
+++ b/packages/features/ee/workflows/components/WorkflowListPage.tsx
@@ -94,12 +94,14 @@ export default function WorkflowListPage({ workflows }: Props) {
                         )}>
                         {workflow.name
                           ? workflow.name
-                          : "Untitled (" +
+                          : workflow.steps[0]
+                          ? "Untitled (" +
                             `${t(`${workflow.steps[0].action.toLowerCase()}_action`)}`
                               .charAt(0)
                               .toUpperCase() +
                             `${t(`${workflow.steps[0].action.toLowerCase()}_action`)}`.slice(1) +
-                            ")"}
+                            ")"
+                          : "Untitled"}
                       </div>
                       <ul className="mt-2 flex flex-wrap space-x-1 sm:flex-nowrap ">
                         <li className="mb-1 flex items-center whitespace-nowrap rounded-sm bg-gray-100 px-1 py-px text-xs text-gray-800 dark:bg-gray-900 dark:text-white">

--- a/packages/features/ee/workflows/pages/workflow.tsx
+++ b/packages/features/ee/workflows/pages/workflow.tsx
@@ -100,7 +100,7 @@ function WorkflowPage() {
     data: workflow,
     isError,
     error,
-    isLoading,
+    dataUpdatedAt,
   } = trpc.viewer.workflows.get.useQuery(
     { id: +workflowId },
     {
@@ -111,7 +111,7 @@ function WorkflowPage() {
   const { data: verifiedNumbers } = trpc.viewer.workflows.getVerifiedNumbers.useQuery();
 
   useEffect(() => {
-    if (workflow && !isLoading) {
+    if (workflow && (workflow.steps.length === 0 || workflow.steps[0].stepNumber === 1)) {
       setSelectedEventTypes(
         workflow.activeOn.map((active) => ({
           value: String(active.eventType.id),
@@ -155,7 +155,7 @@ function WorkflowPage() {
       form.setValue("activeOn", activeOn || []);
       setIsAllDataLoaded(true);
     }
-  }, [isLoading]);
+  }, [dataUpdatedAt]);
 
   const updateMutation = trpc.viewer.workflows.update.useMutation({
     onSuccess: async ({ workflow }) => {

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -713,14 +713,14 @@ export const workflowsRouter = router({
         });
         addedSteps.forEach(async (step) => {
           if (step) {
-            const newStep = step;
+            const { senderName, ...newStep } = step;
             newStep.sender = getSender({
               action: newStep.action,
               sender: newStep.sender || null,
-              senderName: newStep.senderName,
+              senderName: senderName,
             });
             const createdStep = await ctx.prisma.workflowStep.create({
-              data: { ...step, numberVerificationPending: false },
+              data: { ...newStep, numberVerificationPending: false },
             });
             if (
               (trigger === WorkflowTriggerEvents.BEFORE_EVENT ||


### PR DESCRIPTION
## What does this PR do?

- Fixes issue that workflow with more than once action couldn't be saved
- Fixes data loading issues when an action was added. The sorting was wrong on the first load 
- Fixes error in /workflows when an untitled workflows doesn't have any steps

Fixes https://linear.app/calcom/issue/CAL-881/saving-workflow-fails-if-more-than-one-action)\
Fixes: #5940

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

First two issues: 
1. Create a workflow with several actions
2. Click save 
3. Click on the workflow, and check if all actions are there and sorted correctly

Last issue:
1. Create a new workflow without a name
2. Delete all actions 
3. Click save
4. See that there is no error in /workflows and the workflow is called 'Untitled'