### PR TITLE
fix teams text content to use from common

### DIFF
--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -66,8 +66,8 @@ export function TeamsListing() {
       {!!errorMessage && <Alert severity="error" title={errorMessage} />}
 
       <UpgradeTip
-        title="calcom_is_better_with_team"
-        description="add_your_team_members"
+        title={t("calcom_is_better_with_team")}
+        description={t("add_your_team_members")}
         features={features}
         background="/team-banner-background.jpg"
         buttons={


### PR DESCRIPTION
## What does this PR do?

Teams text for users without a team, shows the placeholder and not the actual text.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Used to show calcom_is_better_with_team and add_your_team_members - now it shows the actual content
## Checklist

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
