### PR TITLE
fix(web): set canonical as `https://cal.com` in the `<HeadSeo/>`

### DIFF
--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -78,8 +78,10 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
 
   const image = getSeoImage("ogImage") + constructGenericImage({ title, description });
   const truncatedDescription = truncateOnWord(description, 158);
-
   const pageTitle = title + " | " + APP_NAME;
+  // build the canonical url to ensure it's always cal.com (not app.cal.com)
+  const router = useRouter()
+  canonical = Boolean(canonical) ?? (`https://cal.com` + (router.asPath === "/" ? "": router.asPath)).split("?")[0];// cut off search params
   let seoObject = buildSeoMeta({
     title: pageTitle,
     image,

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -83,7 +83,6 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   const image = getSeoImage("ogImage") + constructGenericImage({ title, description });
   const truncatedDescription = truncateOnWord(description, 158);
   const pageTitle = title + " | " + APP_NAME;
-
   let seoObject = buildSeoMeta({
     title: pageTitle,
     image,

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -76,8 +76,7 @@ const buildSeoMeta = (pageProps: {
 export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   // build the canonical url to ensure it's always cal.com (not app.cal.com)
   const router = useRouter();
-  // REVIEW: we don't need to handle asPath === '/' because it's handled by apps/website/pages/index.tsx
-  const calcomUrl = (`https://cal.com` + router.asPath).split("?")[0]; // cut off search params
+  const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
   const defaultUrl = isCalcom ? calcomUrl : getBrowserInfo()?.url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -1,5 +1,6 @@
 import merge from "lodash/merge";
 import { NextSeo, NextSeoProps } from "next-seo";
+import { useRouter } from "next/router";
 
 import {
   AppImageProps,
@@ -9,10 +10,9 @@ import {
   MeetingImageProps,
 } from "@calcom/lib/OgImages";
 import { getBrowserInfo } from "@calcom/lib/browser/browser.utils";
-import { APP_NAME } from "@calcom/lib/constants";
+import { APP_NAME, IS_SELF_HOSTED } from "@calcom/lib/constants";
 import { seoConfig, getSeoImage } from "@calcom/lib/next-seo.config";
 import { truncateOnWord } from "@calcom/lib/text";
-import { useRouter } from "next/router";
 
 export type HeadSeoProps = {
   title: string;
@@ -74,8 +74,9 @@ const buildSeoMeta = (pageProps: {
 
 export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   // build the canonical url to ensure it's always cal.com (not app.cal.com)
-  const router = useRouter()
-  const defaultUrl = (`https://cal.com` + (router.asPath === "/" ? "": router.asPath)).split("?")[0];// cut off search params
+  const router = useRouter();
+  const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
+  const defaultUrl = IS_SELF_HOSTED ? getBrowserInfo()?.url : calcomUrl;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;
 

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -10,7 +10,8 @@ import {
   MeetingImageProps,
 } from "@calcom/lib/OgImages";
 import { getBrowserInfo } from "@calcom/lib/browser/browser.utils";
-import { APP_NAME, IS_SELF_HOSTED } from "@calcom/lib/constants";
+import { APP_NAME } from "@calcom/lib/constants";
+import isCalcom from "@calcom/lib/isCalcom";
 import { seoConfig, getSeoImage } from "@calcom/lib/next-seo.config";
 import { truncateOnWord } from "@calcom/lib/text";
 
@@ -75,8 +76,9 @@ const buildSeoMeta = (pageProps: {
 export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   // build the canonical url to ensure it's always cal.com (not app.cal.com)
   const router = useRouter();
-  const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
-  const defaultUrl = IS_SELF_HOSTED ? getBrowserInfo()?.url : calcomUrl;
+  // REVIEW: we don't need to handle asPath === '/' because it's handled by apps/website/pages/index.tsx
+  const calcomUrl = (`https://cal.com` + router.asPath).split("?")[0]; // cut off search params
+  const defaultUrl = isCalcom ? calcomUrl : getBrowserInfo()?.url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;
 


### PR DESCRIPTION
## What does this PR do?

This PR handles canonicalization of the `web` app's pages that are deployed to both `app.cal.com` & `cal.com` (see [issue](https://github.com/calcom/website/issues/416)).


Fixes https://github.com/calcom/cal.com/issues/6726
note: see [#416](https://github.com/calcom/website/issues/416) for some context

![CleanShot 2023-01-25 at 11 18 28@2x](https://user-images.githubusercontent.com/18185649/214587526-db3a202c-de58-4780-8064-2ae43956c345.png)


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] `yarn test-e2e` should pass
- [ ] Inspect a couple of pages manually to re-evaluate the canonical tag

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
