### PR TITLE
Adds deployment settings to DB

### DIFF
--- a/packages/prisma/extensions/index.ts
+++ b/packages/prisma/extensions/index.ts
@@ -1,0 +1,67 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export function addPrismaExtensions(prisma: PrismaClient) {
+  const xprisma = prisma.$extends({
+    model: {
+      /**
+       * We extend deployment model since it's supposed to be a single record table.
+       * New settings should be added as Columns as needed.F
+       * */
+      deployment: {
+        /**
+         * This is the preferred method for accessing deployment settings,
+         * it can be called without any arguments:
+         * @example
+         * ```
+         * const deployment = await prisma.deployment.get();
+         * ```
+         */
+        async get(args?: Omit<Prisma.DeploymentFindUniqueArgs, "where">) {
+          return prisma.deployment.findUnique({ where: { id: 1 }, ...args });
+        },
+        async findFirst(args: Omit<Prisma.DeploymentFindFirstArgs, "where">) {
+          return prisma.deployment.findFirst({ where: { id: 1 }, ...args });
+        },
+        async findFirstOrThrow(args: Omit<Prisma.DeploymentFindFirstOrThrowArgs, "where">) {
+          return prisma.deployment.findFirstOrThrow({ where: { id: 1 }, ...args });
+        },
+        async findUnique(args: Omit<Prisma.DeploymentFindUniqueArgs, "where">) {
+          return prisma.deployment.findUnique({ where: { id: 1 }, ...args });
+        },
+        async findUniqueOrThrow(args: Omit<Prisma.DeploymentFindUniqueOrThrowArgs, "where">) {
+          return prisma.deployment.findUniqueOrThrow({ where: { id: 1 }, ...args });
+        },
+        async upsert(args: Omit<Prisma.DeploymentUpsertArgs, "where">) {
+          return prisma.deployment.upsert({ where: { id: 1 }, ...args });
+        },
+        async update(args: Omit<Prisma.DeploymentUpdateArgs, "where">) {
+          return prisma.deployment.update({ where: { id: 1 }, ...args });
+        },
+        async findMany() {
+          throw new Error("Use prisma.deployment.get method");
+        },
+        async updateMany() {
+          throw new Error("Use prisma.deployment.update method");
+        },
+        async create() {
+          throw new Error("Use prisma.deployment.upsert method");
+        },
+        async createMany() {
+          throw new Error("Use prisma.deployment.upsert method");
+        },
+        async delete() {
+          throw new Error("Deployment shouldn't be deleted");
+        },
+        async deleteMany() {
+          throw new Error("Deployment shouldn't be deleted");
+        },
+      },
+      user: {
+        async signUp(email: string) {
+          await prisma.user.create({ data: { email } });
+        },
+      },
+    },
+  });
+  return xprisma;
+}

--- a/packages/prisma/extensions/index.ts
+++ b/packages/prisma/extensions/index.ts
@@ -5,7 +5,7 @@ export function addPrismaExtensions(prisma: PrismaClient) {
     model: {
       /**
        * We extend deployment model since it's supposed to be a single record table.
-       * New settings should be added as Columns as needed.F
+       * New settings should be added as Columns as needed.
        * */
       deployment: {
         /**
@@ -54,11 +54,6 @@ export function addPrismaExtensions(prisma: PrismaClient) {
         },
         async deleteMany() {
           throw new Error("Deployment shouldn't be deleted");
-        },
-      },
-      user: {
-        async signUp(email: string) {
-          await prisma.user.create({ data: { email } });
         },
       },
     },

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -1,27 +1,34 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 
+import { addPrismaExtensions } from "./extensions";
 import { bookingReferenceMiddleware, eventTypeDescriptionParseAndSanitizeMiddleware } from "./middleware";
 
 declare global {
   // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined;
+  var prisma: ReturnType<typeof createPrismaClient> | undefined;
 }
 
 const prismaOptions: Prisma.PrismaClientOptions = {};
 
 if (!!process.env.NEXT_PUBLIC_DEBUG) prismaOptions.log = ["query", "error", "warn"];
 
-export const prisma = globalThis.prisma || new PrismaClient(prismaOptions);
+function createPrismaClient(options: Prisma.PrismaClientOptions) {
+  const newPrisma = new PrismaClient(options);
+  bookingReferenceMiddleware(newPrisma);
+  eventTypeDescriptionParseAndSanitizeMiddleware(newPrisma);
+  const xprisma = addPrismaExtensions(newPrisma);
+  return xprisma;
+}
+
+export const prisma = globalThis.prisma || createPrismaClient(prismaOptions);
 
 export const customPrisma = (options: Prisma.PrismaClientOptions) =>
-  new PrismaClient({ ...prismaOptions, ...options });
+  createPrismaClient({ ...prismaOptions, ...options });
 
 if (process.env.NODE_ENV !== "production") {
   globalThis.prisma = prisma;
 }
 // If any changed on middleware server restart is required
-bookingReferenceMiddleware(prisma);
-eventTypeDescriptionParseAndSanitizeMiddleware(prisma);
 
 export default prisma;
 

--- a/packages/prisma/migrations/20230125182832_add_deployment/migration.sql
+++ b/packages/prisma/migrations/20230125182832_add_deployment/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "Deployment" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "logo" TEXT,
+    "theme" JSONB,
+    "licenseKey" TEXT,
+    "agreedLicenseAt" TIMESTAMP(3),
+
+    CONSTRAINT "Deployment_pkey" PRIMARY KEY ("id")
+);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["interactiveTransactions"]
+  previewFeatures = ["clientExtensions"]
 }
 
 generator zod {

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -615,6 +615,16 @@ model WorkflowsOnEventTypes {
   eventTypeId Int
 }
 
+model Deployment {
+  /// This is a single row table, so we use a fixed id
+  id              Int       @id @default(1)
+  logo            String?
+  /// @zod.custom(imports.DeploymentTheme)
+  theme           Json?
+  licenseKey      String?
+  agreedLicenseAt DateTime?
+}
+
 enum TimeUnit {
   DAY    @map("day")
   HOUR   @map("hour")

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -293,6 +293,24 @@ export const RoutingFormSettings = z
   })
   .nullable();
 
+export const DeploymentTheme = z
+  .object({
+    brand: z.string().default("#292929"),
+    textBrand: z.string().default("#ffffff"),
+    darkBrand: z.string().default("#fafafa"),
+    textDarkBrand: z.string().default("#292929"),
+    bookingHighlight: z.string().default("#10B981"),
+    bookingLightest: z.string().default("#E1E1E1"),
+    bookingLighter: z.string().default("#ACACAC"),
+    bookingLight: z.string().default("#888888"),
+    bookingMedian: z.string().default("#494949"),
+    bookingDark: z.string().default("#313131"),
+    bookingDarker: z.string().default("#292929"),
+    fontName: z.string().default("Cal Sans"),
+    fontSrc: z.string().default("https://cal.com/cal.ttf"),
+  })
+  .optional();
+
 export type ZodDenullish<T extends ZodTypeAny> = T extends ZodNullable<infer U> | ZodOptional<infer U>
   ? ZodDenullish<U>
   : T;


### PR DESCRIPTION
## What does this PR do?

Prep-work for #6574 

- Uses prisma extensions to limit which models can be user for deployments

This will allow us to save instance-specific data like:
- License key
- Theme data
- Global settings
- App name
- Etc...

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] yarn prisma migrate deploy

