### PR TITLE
Hotfix: ping,riverside,whereby and around not showing up in list

### DIFF
--- a/packages/app-store/around/config.json
+++ b/packages/app-store/around/config.json
@@ -12,5 +12,14 @@
   "publisher": "Cal.com",
   "email": "help@cal.com",
   "description": "Discover radically unique video calls designed to help hybrid-remote teams create, collaborate and celebrate together.",
-  "__createdUsingCli": true
+  "__createdUsingCli": true,
+  "appData": {
+    "location": {
+      "linkType": "static",
+      "type": "integrations:around_video",
+      "label": "Around Video",
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?around.co\\/[a-zA-Z0-9]*",
+      "organizerInputPlaceholder": "https://www.around.co/rick"
+    }
+  }
 }

--- a/packages/app-store/ping/config.json
+++ b/packages/app-store/ping/config.json
@@ -12,5 +12,14 @@
   "publisher": "Ping.gg",
   "email": "support@ping.gg",
   "description": "Ping.gg makes high quality video collaborations easier than ever. Think 'Zoom for streamers and creators'. Join a call in 3 clicks, manage audio and video like a pro, and copy-paste your guests straight into OBS",
-  "__createdUsingCli": true
+  "__createdUsingCli": true,
+  "appData": {
+    "location": {
+      "linkType": "static",
+      "type": "integrations:ping_video",
+      "label": "Ping.gg",
+      "organizerInputPlaceholder": "https://www.ping.gg/call/theo",
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?ping.gg\\/call\\/[a-zA-Z0-9]*"
+    }
+  }
 }

--- a/packages/app-store/riverside/config.json
+++ b/packages/app-store/riverside/config.json
@@ -11,5 +11,13 @@
   "publisher": "Cal.com",
   "email": "help@cal.com",
   "description": "Your online recording studio. The easiest way to record podcasts and videos in studio quality from anywhere. All from the browser.",
-  "__createdUsingCli": true
+  "__createdUsingCli": true,
+  "appData": {
+    "location": {
+      "label": "Riverside Video",
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?riverside.fm\\/studio\\/[a-zA-Z0-9]*",
+      "type": "integrations:riverside_video",
+      "linkType": "static"
+    }
+  }
 }

--- a/packages/app-store/whereby/config.json
+++ b/packages/app-store/whereby/config.json
@@ -12,5 +12,14 @@
   "publisher": "Cal.com",
   "email": "help@cal.com",
   "description": "Whereby makes it super simple for collaborating teams to jump on a video call.",
-  "__createdUsingCli": true
+  "__createdUsingCli": true,
+  "appData": {
+    "location": {
+      "linkType": "static",
+      "type": "integrations:whereby_video",
+      "label": "Whereby Video",
+      "organizerInputPlaceholder": "https://www.whereby.com/cal",
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?(team.)?whereby.com\\/[a-zA-Z0-9]*"
+    }
+  }
 }


### PR DESCRIPTION
Fix ping, riverside, whereby and around configs.

These configs were actually in _metadata.ts which is now not being used for most apps. Other video apps which already had it in config.json were working.