### PR TITLE
fix: make cal video default value

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -34,6 +34,16 @@ const getLocationFromType = (
   }
 };
 
+const getDefaultLocationValue = (options: EventTypeSetupProps["locationOptions"], type: string) => {
+  for (const locationType of options) {
+    for (const location of locationType.options) {
+      if (location.value === type && location.disabled === false) {
+        return location;
+      }
+    }
+  }
+};
+
 export const EventSetupTab = (
   props: Pick<EventTypeSetupProps, "eventType" | "locationOptions" | "team" | "teamMembers">
 ) => {
@@ -138,9 +148,7 @@ export const EventSetupTab = (
       return true;
     });
 
-    const defaultValue = locationOptions
-      .find((item) => item.label === "video")
-      ?.options.find((option) => option.value === "integrations:daily");
+    const defaultValue = getDefaultLocationValue(locationOptions, "integrations:daily");
 
     return (
       <div className="w-full">

--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -138,7 +138,10 @@ export const EventSetupTab = (
       return true;
     });
 
-    const defaultValue = locationOptions.find((item) => item.label === "video")?.options;
+    const defaultValue = locationOptions
+      .find((item) => item.label === "video")
+      ?.options.find((option) => option.value === "integrations:daily");
+
     return (
       <div className="w-full">
         {validLocations.length === 0 && (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
previously all the other video apps didn't show up in the location select dropdown list. after this PR #6712 everything is working as expected. this PR aims to improve the filter logic of cal video.

before:
![Screenshot 2023-01-26 at 10-39-14 30min Event Type Cal com](https://user-images.githubusercontent.com/84864519/214762936-21703d2d-03af-48b2-abe1-56acbcf19fcd.png)


after:
![Screenshot 2023-01-26 at 10-38-33 30min Event Type Cal com](https://user-images.githubusercontent.com/84864519/214762954-5ae95e30-c3b1-45b2-b67e-fcb62496b1f5.png)



<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


