### PR TITLE
On duplicating an event type, spacing between arrows and label is wide (Length field)

### DIFF
--- a/packages/features/eventtypes/components/DuplicateDialog.tsx
+++ b/packages/features/eventtypes/components/DuplicateDialog.tsx
@@ -117,7 +117,6 @@ const DuplicateDialog = () => {
                 min="10"
                 placeholder="15"
                 label={t("length")}
-                className="pr-20"
                 {...register("length", { valueAsNumber: true })}
                 addOnSuffix={t("minutes")}
               />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #5624

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
## Demo
https://www.loom.com/share/3acf6bd61e57489d9a43233b1eb5af17

**Environment**: Staging(main branch) / Production

