### PR TITLE
Added multiple duration checks

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -115,7 +115,12 @@ const BookingPage = ({
   const stripeAppData = getStripeAppData(eventType);
   // Define duration now that we support multiple duration eventTypes
   let duration = eventType.length;
-  if (queryDuration && !isNaN(Number(queryDuration))) {
+  if (
+    queryDuration &&
+    !isNaN(Number(queryDuration)) &&
+    eventType.metadata?.multipleDuration &&
+    eventType.metadata?.multipleDuration.includes(Number(queryDuration))
+  ) {
     duration = Number(queryDuration);
   }
 


### PR DESCRIPTION
## What does this PR do?

Selecting a duration through query param could let you choose random durations in fixed duration event types. 

Fixes #6155

**Environment**: Staging(main branch) / Production

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try to add ?duration=111 to any event-type booking availability page and see it will stick to event chosen length. Same for booking page.