### PR TITLE
export `AppCategories` from `@calcom/prisma`

### DIFF
--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -2,6 +2,9 @@ import { Prisma, PrismaClient } from "@prisma/client";
 
 import { bookingReferenceMiddleware, eventTypeDescriptionParseAndSanitizeMiddleware } from "./middleware";
 
+// REVIEW: This enum is needed in apps/website to generate the sitemap paths
+export { AppCategories } from "@prisma/client";
+
 declare global {
   // eslint-disable-next-line no-var
   var prisma: PrismaClient | undefined;


### PR DESCRIPTION
## What does this PR do?

Exports a prisma enum needed to generate the sitemap in apps/website.

Fixes [[CAL-933]](https://github.com/calcom/cal.com/issues/6726)

Usage: 
```ts
// somewhere in apps/website/pages...
import { prisma, AppCategories } from "@calcom/prisma";
```
**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [ ] Everything should work as before on apps/web.
- [ ] On apps/website, the cal.com/sitemap.xml does not break at runtime.

## Checklist