### PR TITLE
fix padding of length input on add event modal

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeButton.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeButton.tsx
@@ -202,7 +202,7 @@ const CreateEventTypeDialog = () => {
                 min="10"
                 placeholder="15"
                 label={t("length")}
-                className="pr-20"
+                className="pr-4"
                 {...register("length", { valueAsNumber: true })}
                 addOnSuffix={t("minutes")}
               />


### PR DESCRIPTION
## What does this PR do?

This PR fixes the UI of length input on the `add new event` modal

Didn't create an issue, let me know if I should

## Before
<img width="777" alt="Screenshot 2023-01-28 at 3 23 25 PM" src="https://user-images.githubusercontent.com/43727167/215260417-886f57fe-f593-4d08-99c1-c16acca60bd6.png">

## After
<img width="743" alt="Screenshot 2023-01-28 at 3 35 15 PM" src="https://user-images.githubusercontent.com/43727167/215260425-8c04a44a-37d5-410a-9bdc-a21548e31dad.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



