### PR TITLE
update isCalcom for canonicals to handle https://cal.com

### DIFF
--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -77,7 +77,7 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   const router = useRouter();
   // compose the url with only the router's path (e.g. /apps/zapier) such that on app.cal.com the canonical is still cal.com
   const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
-  const url = getBrowserInfo()?.url;
+  const url = getBrowserInfo()?.url ?? "";
   // avoid setting cal.com canonicals on self-hosted apps. Note: isCalcom or IS_SELF_HOSTED from @calcom/lib do not handle https:cal.com
   const isCalcom = new URL(url).hostname.endsWith("cal.com");
   const defaultUrl = isCalcom ? calcomUrl : url;

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -77,6 +77,7 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
 
   // Get the current URL from the window object
   const url = getBrowserInfo()?.url;
+  console.log("[HeadSeo] - url: ", url);
   // Check if the URL is from cal.com
   const isCalcom = url && new URL(url).hostname.endsWith("cal.com");
   // Get the router's path

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -77,9 +77,9 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   const router = useRouter();
   // compose the url with only the router's path (e.g. /apps/zapier) such that on app.cal.com the canonical is still cal.com
   const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
-  const url = getBrowserInfo()?.url
+  const url = getBrowserInfo()?.url;
   // avoid setting cal.com canonicals on self-hosted apps. Note: isCalcom or IS_SELF_HOSTED from @calcom/lib do not handle https:cal.com
-  const isCalcom = new URL(url).hostname.endsWith("cal.com")
+  const isCalcom = new URL(url).hostname.endsWith("cal.com");
   const defaultUrl = isCalcom ? calcomUrl : url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -77,7 +77,6 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
 
   // Get the current URL from the window object
   const url = getBrowserInfo()?.url;
-  console.log("[HeadSeo] - url: ", url);
   // Check if the URL is from cal.com
   const isCalcom = url && new URL(url).hostname.endsWith("cal.com");
   // Get the router's path

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -11,7 +11,6 @@ import {
 } from "@calcom/lib/OgImages";
 import { getBrowserInfo } from "@calcom/lib/browser/browser.utils";
 import { APP_NAME } from "@calcom/lib/constants";
-import isCalcom from "@calcom/lib/isCalcom";
 import { seoConfig, getSeoImage } from "@calcom/lib/next-seo.config";
 import { truncateOnWord } from "@calcom/lib/text";
 
@@ -76,7 +75,10 @@ const buildSeoMeta = (pageProps: {
 export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   // build the canonical url to ensure it's always cal.com (not app.cal.com)
   const router = useRouter();
+  // compose the url with only the router's path (e.g. /apps/zapier) such that on app.cal.com the canonical is still cal.com
   const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
+  // avoid setting cal.com canonicals on self-hosted apps. Note: isCalcom or IS_SELF_HOSTED from @calcom/lib do not handle https:cal.com
+  const isCalcom = new URL(process.env.WEBAPP_URL).hostname.endsWith("cal.com")
   const defaultUrl = isCalcom ? calcomUrl : getBrowserInfo()?.url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -73,14 +73,18 @@ const buildSeoMeta = (pageProps: {
 };
 
 export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
-  // build the canonical url to ensure it's always cal.com (not app.cal.com)
-  const router = useRouter();
-  // compose the url with only the router's path (e.g. /apps/zapier) such that on app.cal.com the canonical is still cal.com
-  const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
-  const url = getBrowserInfo()?.url ?? "";
-  // avoid setting cal.com canonicals on self-hosted apps. Note: isCalcom or IS_SELF_HOSTED from @calcom/lib do not handle https:cal.com
-  const isCalcom = new URL(url).hostname.endsWith("cal.com");
-  const defaultUrl = isCalcom ? calcomUrl : url;
+  // The below code sets the defaultUrl for our canonical tags
+
+  // Get the current URL from the window object
+  const url = getBrowserInfo()?.url;
+  // Check if the URL is from cal.com
+  const isCalcom = url && new URL(url).hostname.endsWith("cal.com");
+  // Get the router's path
+  const path = useRouter().asPath;
+  // Build the canonical URL using the router's path, without query parameters. Note: on homepage it omits the trailing slash
+  const calcomCanonical = `https://cal.com${path === "/" ? "" : path}`.split("?")[0];
+  // Set the default URL to either the current URL (if self-hosted) or https://cal.com canonical URL
+  const defaultUrl = isCalcom ? calcomCanonical : url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;
 

--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -77,9 +77,10 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   const router = useRouter();
   // compose the url with only the router's path (e.g. /apps/zapier) such that on app.cal.com the canonical is still cal.com
   const calcomUrl = (`https://cal.com` + (router.asPath === "/" ? "" : router.asPath)).split("?")[0]; // cut off search params
+  const url = getBrowserInfo()?.url
   // avoid setting cal.com canonicals on self-hosted apps. Note: isCalcom or IS_SELF_HOSTED from @calcom/lib do not handle https:cal.com
-  const isCalcom = new URL(process.env.WEBAPP_URL).hostname.endsWith("cal.com")
-  const defaultUrl = isCalcom ? calcomUrl : getBrowserInfo()?.url;
+  const isCalcom = new URL(url).hostname.endsWith("cal.com")
+  const defaultUrl = isCalcom ? calcomUrl : url;
 
   const { title, description, siteName, canonical = defaultUrl, nextSeoProps = {}, app, meeting } = props;
 


### PR DESCRIPTION
## What does this PR do?

A follow up to https://github.com/calcom/cal.com/pull/6693

It should set the canonical on to point to `https://cal.com` on calcom owned hosts (dev.cal.com, app.cal.com, cal.com) but not on self hosted versions.

Fixes https://github.com/calcom/cal.com/issues/6726

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- [ ] Check if the canonical link on https://app.cal.com/apps/zapier points to `https://cal.com/apps/zapier` in production
