### PR TITLE
Invalidate hasTeamPlan when the last team is removed

### DIFF
--- a/packages/features/ee/teams/components/TeamList.tsx
+++ b/packages/features/ee/teams/components/TeamList.tsx
@@ -29,6 +29,7 @@ export default function TeamList(props: Props) {
   const deleteTeamMutation = trpc.viewer.teams.delete.useMutation({
     async onSuccess() {
       await utils.viewer.teams.list.invalidate();
+      await utils.viewer.teams.hasTeamPlan.invalidate();
     },
     async onError(err) {
       showToast(err.message, "error");


### PR DESCRIPTION
## What does this PR do?

Missing piece to get the EmptyScreen to appear in the UpgradeTip @PeerRich 