### PR TITLE
fix: Allow users to login with Google if they already have an account with the same email and password

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -469,11 +469,20 @@ export default NextAuth({
             return true;
           }
 
-          if (existingUserWithEmail.identityProvider === IdentityProvider.CAL) {
-            return "/auth/error?error=use-password-login";
+          // User signup with email and password and
+          // then tries to login with Google using the same email
+          if (
+            existingUserWithEmail.identityProvider === IdentityProvider.CAL &&
+            (idP === IdentityProvider.GOOGLE || idP === IdentityProvider.SAML)
+          ) {
+            const linkAccountNewUserData = { ...account, userId: existingUserWithEmail.id };
+            await calcomAdapter.linkAccount(linkAccountNewUserData);
+
+            return true;
           }
 
-          return "/auth/error?error=use-identity-login";
+          return "/auth/error?error=use-password-login";
+          //return "/auth/error?error=use-identity-login";
         }
 
         const newUser = await prisma.user.create({

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -162,6 +162,7 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
     GoogleProvider({
       clientId: GOOGLE_CLIENT_ID,
       clientSecret: GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
     })
   );
 }
@@ -200,6 +201,7 @@ if (isSAMLLoginEnabled) {
       clientId: "dummy",
       clientSecret: "dummy",
     },
+    allowDangerousEmailAccountLinking: true,
   });
 }
 
@@ -470,19 +472,17 @@ export default NextAuth({
           }
 
           // User signup with email and password and
-          // then tries to login with Google using the same email
+          // then tries to login with Google/SAML using the same email
           if (
             existingUserWithEmail.identityProvider === IdentityProvider.CAL &&
             (idP === IdentityProvider.GOOGLE || idP === IdentityProvider.SAML)
           ) {
-            const linkAccountNewUserData = { ...account, userId: existingUserWithEmail.id };
-            await calcomAdapter.linkAccount(linkAccountNewUserData);
-
             return true;
+          } else if (existingUserWithEmail.identityProvider === IdentityProvider.CAL) {
+            return "/auth/error?error=use-password-login";
           }
 
-          return "/auth/error?error=use-password-login";
-          //return "/auth/error?error=use-identity-login";
+          return "/auth/error?error=use-identity-login";
         }
 
         const newUser = await prisma.user.create({

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -43,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       OR: [
         { username },
         {
-          AND: [{ email: userEmail }, { password: { not: null } }, { username: { not: null } }],
+          AND: [{ email: userEmail }],
         },
       ],
     },


### PR DESCRIPTION
## What does this PR do?

Allow users to login with Google if they already have an account with the same email address and password

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create an account with Email and Password, then login with Google using the same email address (should work)
- Create an account with Google, then sign up with Email and Password using the same email address (should not work)
