### PR TITLE
Left / Right buttons now bottom-aligned and slightly shorter

### DIFF
--- a/packages/ui/components/apps/AllApps.tsx
+++ b/packages/ui/components/apps/AllApps.tsx
@@ -76,11 +76,11 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
             })}
       </h2>
       {leftVisible && (
-        <button onClick={handleLeft} className="absolute top-9 flex md:left-1/2 md:-top-1">
-          <div className="flex h-12 w-5 items-center justify-end bg-white">
+        <button onClick={handleLeft} className="absolute bottom-0 flex md:left-1/2 md:-top-1">
+          <div className="flex h-10 w-5 items-center justify-end bg-white">
             <FiChevronLeft className="h-4 w-4 text-gray-500" />
           </div>
-          <div className="flex h-12 w-5 bg-gradient-to-l from-transparent to-white" />
+          <div className="flex h-10 w-5 bg-gradient-to-l from-transparent to-white" />
         </button>
       )}
       <ul
@@ -118,9 +118,9 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
         ))}
       </ul>
       {rightVisible && (
-        <button onClick={handleRight} className="absolute top-9 right-0 flex md:-top-1">
-          <div className="flex h-12 w-5 bg-gradient-to-r from-transparent to-white" />
-          <div className="flex h-12 w-5 items-center justify-end bg-white">
+        <button onClick={handleRight} className="absolute bottom-0 right-0 flex md:-top-1">
+          <div className="flex h-10 w-5 bg-gradient-to-r from-transparent to-white" />
+          <div className="flex h-10 w-5 items-center justify-end bg-white">
             <FiChevronRight className="h-4 w-4 text-gray-500" />
           </div>
         </button>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6589 

Previously the left / right arrows within the Category slider was misaligned. This PR does the following:
- Bottom-aligns the arrow buttons. This is necessary because the height of the surrounding `div` changes depending on browser width. Aligning the buttons to the bottom creates a consistent reference regardless of browser width.
- Makes the buttons slightly shorter. Previously `h-12` was resulting of the arrows not being _quite_ center. Lowering this value to `h-10` aligns them perfectly.

Below gif is what's currently seen in Production:

![arrow-misaligned](https://user-images.githubusercontent.com/155617/216424822-93ae38b4-72b8-4f5d-8133-86939c30c9f0.gif)


Below is their new alignment:

![client-files-upload](https://user-images.githubusercontent.com/155617/216422115-ce9cfe45-1c5c-49df-8f89-7a4fa6eba006.gif)


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Open the Production `/apps` page on a mobile device or narrow browser, notice the left / right arrows are misaligned
- [ ] Open this PR's `/apps` page on a mobile device or narrow browser, notice the left / right arrows are centered with the list of categories 👌 