### PR TITLE
Fix duplicating even types with active workflows

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes.tsx
+++ b/packages/trpc/server/routers/viewer/eventTypes.tsx
@@ -770,20 +770,12 @@ export const eventTypesRouter = router({
       }
 
       if (workflows.length > 0) {
-        const workflowIds = workflows.map((workflow) => {
-          return { id: workflow.workflowId };
+        const relationCreateData = workflows.map((workflow) => {
+          return { eventTypeId: newEventType.id, workflowId: workflow.workflowId };
         });
 
-        const eventUpdateData: Prisma.EventTypeUpdateInput = {
-          workflows: {
-            connect: workflowIds,
-          },
-        };
-        await ctx.prisma.eventType.update({
-          where: {
-            id: newEventType.id,
-          },
-          data: eventUpdateData,
+        await ctx.prisma.workflowsOnEventTypes.createMany({
+          data: relationCreateData,
         });
       }
 


### PR DESCRIPTION
## What does this PR do?

Fixes duplicating event types that have active workflows. 

Fixes #6722

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a workflow and set it active for an event type
- Duplicate this event type
- Go to the event type settings (of the duplicated event type) and check in the workflow tab if the workflow is active
