### PR TITLE
Allow account linking for Google and SAML providers

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -164,6 +164,7 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
     GoogleProvider({
       clientId: GOOGLE_CLIENT_ID,
       clientSecret: GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: !hostedCal,
     })
   );
 }
@@ -202,6 +203,7 @@ if (isSAMLLoginEnabled) {
       clientId: "dummy",
       clientSecret: "dummy",
     },
+    allowDangerousEmailAccountLinking: !hostedCal,
   });
 }
 

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -164,7 +164,7 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
     GoogleProvider({
       clientId: GOOGLE_CLIENT_ID,
       clientSecret: GOOGLE_CLIENT_SECRET,
-      allowDangerousEmailAccountLinking: !hostedCal,
+      allowDangerousEmailAccountLinking: true,
     })
   );
 }
@@ -203,7 +203,7 @@ if (isSAMLLoginEnabled) {
       clientId: "dummy",
       clientSecret: "dummy",
     },
-    allowDangerousEmailAccountLinking: !hostedCal,
+    allowDangerousEmailAccountLinking: true,
   });
 }
 
@@ -499,7 +499,13 @@ export default NextAuth({
             return true;
           }
 
-          if (existingUserWithEmail.identityProvider === IdentityProvider.CAL) {
+          // User signs up with email/password and then tries to login with Google/SAML using the same email
+          if (
+            existingUserWithEmail.identityProvider === IdentityProvider.CAL &&
+            (idP === IdentityProvider.GOOGLE || idP === IdentityProvider.SAML)
+          ) {
+            return true;
+          } else if (existingUserWithEmail.identityProvider === IdentityProvider.CAL) {
             return "/auth/error?error=use-password-login";
           }
 

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -43,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       OR: [
         { username },
         {
-          AND: [{ email: userEmail }, { password: { not: null } }, { username: { not: null } }],
+          AND: [{ email: userEmail }],
         },
       ],
     },


### PR DESCRIPTION
## What does this PR do?

It is safe to allow account linking for Google and SAML providers since the email is verified in both cases. This functionality for self-hosted instance seems to have stopped working with a recent next-auth upgrade. This PR fixes this issue as well.

**Environment**: Staging(main branch)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [x] Ensure a local instance with NEXT_PUBLIC_HOSTED_CAL_FEATURES not set so that it is treated as a self-hosted instance. Sign up with username/pass for a gmail address you have. Now sign back in using Google login, you should be allowed to login to the account you created earlier.
- [x] Repeat above with SAML instead of Google.
- [x] Repeat above with NEXT_PUBLIC_HOSTED_CAL_FEATURES=1

## Checklist
