### PR TITLE
migration/remove-payment-type-enum-use-appId-instead

### DIFF
--- a/packages/prisma/migrations/20230204002419_remove_payment_type_and_use_payment_app_id/migration.sql
+++ b/packages/prisma/migrations/20230204002419_remove_payment_type_and_use_payment_app_id/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `type` on the `Payment` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Payment" DROP COLUMN "type",
+ADD COLUMN     "appId" TEXT;
+
+-- DropEnum
+DROP TYPE "PaymentType";
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_appId_fkey" FOREIGN KEY ("appId") REFERENCES "App"("slug") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -399,24 +399,20 @@ model ReminderMail {
   createdAt      DateTime     @default(now())
 }
 
-enum PaymentType {
-  STRIPE
-}
-
 model Payment {
-  id         Int         @id @default(autoincrement())
-  uid        String      @unique
-  // TODO: Use an App relationship instead of PaymentType enum?
-  type       PaymentType
+  id         Int      @id @default(autoincrement())
+  uid        String   @unique
+  app        App?     @relation(fields: [appId], references: [slug], onDelete: Cascade)
+  appId      String?
   bookingId  Int
-  booking    Booking?    @relation(fields: [bookingId], references: [id], onDelete: Cascade)
+  booking    Booking? @relation(fields: [bookingId], references: [id], onDelete: Cascade)
   amount     Int
   fee        Int
   currency   String
   success    Boolean
   refunded   Boolean
   data       Json
-  externalId String      @unique
+  externalId String   @unique
 }
 
 enum WebhookTriggerEvents {
@@ -525,6 +521,7 @@ model App {
   createdAt   DateTime        @default(now())
   updatedAt   DateTime        @updatedAt
   credentials Credential[]
+  payments    Payment[]
   Webhook     Webhook[]
   ApiKey      ApiKey[]
   enabled     Boolean         @default(false)


### PR DESCRIPTION
## What does this PR do?
- Run migration required for for [6677](https://github.com/calcom/cal.com/pull/6677)
- Removes payment Type enum as uses app Id instead

NOTE: should be merge before 6677 and along with it

