### PR TITLE
feat: get country code from ip geolocation

### DIFF
--- a/apps/web/pages/api/countrycode.ts
+++ b/apps/web/pages/api/countrycode.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from "next/server";
+
+export const config = {
+  runtime: "experimental-edge",
+};
+
+export default async function handler(req: NextRequest) {
+  const countryCode = req.headers.get("x-vercel-ip-city") ?? "";
+  return new Response(
+    JSON.stringify({
+      countryCode,
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    }
+  );
+}

--- a/apps/web/pages/api/countrycode.ts
+++ b/apps/web/pages/api/countrycode.ts
@@ -5,7 +5,7 @@ export const config = {
 };
 
 export default async function handler(req: NextRequest) {
-  const countryCode = req.headers.get("x-vercel-ip-city") ?? "";
+  const countryCode = req.headers.get("x-vercel-ip-country") ?? "";
   return new Response(
     JSON.stringify({
       countryCode,

--- a/packages/ui/form/PhoneInput.tsx
+++ b/packages/ui/form/PhoneInput.tsx
@@ -21,17 +21,7 @@ function PhoneInput<FormValues>({
   onChange,
   ...rest
 }: PhoneInputProps<FormValues>) {
-  const [defaultCountry, setDefaultCountry] = useState("US");
-  useEffect(() => {
-    fetch("/api/countrycode")
-      .then((res) => res.json())
-      .then((res) => {
-        if (isSupportedCountry(res.countryCode)) setDefaultCountry(res.countryCode);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, []);
+  const defaultCountry = useDefaultCountry();
   return (
     <BasePhoneInput
       {...rest}
@@ -48,5 +38,21 @@ function PhoneInput<FormValues>({
     />
   );
 }
+
+const useDefaultCountry = () => {
+  const [defaultCountry, setDefaultCountry] = useState("US");
+  useEffect(() => {
+    fetch("/api/countrycode")
+      .then((res) => res.json())
+      .then((res) => {
+        if (isSupportedCountry(res.countryCode)) setDefaultCountry(res.countryCode);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+
+  return defaultCountry;
+};
 
 export default PhoneInput;

--- a/packages/ui/form/PhoneInput.tsx
+++ b/packages/ui/form/PhoneInput.tsx
@@ -23,10 +23,10 @@ function PhoneInput<FormValues>({
 }: PhoneInputProps<FormValues>) {
   const [defaultCountry, setDefaultCountry] = useState("US");
   useEffect(() => {
-    fetch("https://ipapi.co/json/")
+    fetch("/api/countrycode")
       .then((res) => res.json())
-      .then((data) => {
-        if (isSupportedCountry(data.country_code)) setDefaultCountry(data.country_code);
+      .then((res) => {
+        if (isSupportedCountry(res.countryCode)) setDefaultCountry(res.countryCode);
       })
       .catch((err) => {
         console.log(err);

--- a/packages/ui/form/PhoneInput.tsx
+++ b/packages/ui/form/PhoneInput.tsx
@@ -1,3 +1,5 @@
+import { isSupportedCountry } from "libphonenumber-js";
+import { useEffect, useState } from "react";
 import type { Props } from "react-phone-number-input/react-hook-form";
 import BasePhoneInput from "react-phone-number-input/react-hook-form";
 import "react-phone-number-input/style.css";
@@ -19,10 +21,22 @@ function PhoneInput<FormValues>({
   onChange,
   ...rest
 }: PhoneInputProps<FormValues>) {
+  const [defaultCountry, setDefaultCountry] = useState("US");
+  useEffect(() => {
+    fetch("https://ipapi.co/json/")
+      .then((res) => res.json())
+      .then((data) => {
+        if (isSupportedCountry(data.country_code)) setDefaultCountry(data.country_code);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
   return (
     <BasePhoneInput
       {...rest}
       international
+      defaultCountry={defaultCountry}
       name={name}
       control={control}
       onChange={onChange}


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/6621

- set default country code in react-phone-number input from geolocation api for better user experience

TODO
- [x] test on preview deployment

https://user-images.githubusercontent.com/53316345/216760540-18b048fb-933d-4889-be8e-92ff01b9d306.mov




**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update