### PR TITLE
fix: use destination calendar email

### DIFF
--- a/packages/features/calendars/DestinationCalendarSelector.tsx
+++ b/packages/features/calendars/DestinationCalendarSelector.tsx
@@ -119,7 +119,7 @@ const DestinationCalendarSelector = ({
 
   // Get primary calendar, which is shown in the placeholder since this is the calendar that will
   // be used when no destination calendar is selected.
-  const primaryCalendar = query.data.connectedCalendars.filter((cal) => Boolean(cal.primary))[0];
+  const primaryCalendar = query.data.destinationCalendarEmail;
 
   return (
     <div className="relative" title={`${t("select_destination_calendar")}: ${selectedOption?.label || ""}`}>
@@ -130,8 +130,7 @@ const DestinationCalendarSelector = ({
             `${t("select_destination_calendar")}`
           ) : (
             <span>
-              {t("default_calendar_selected")}{" "}
-              {primaryCalendar?.primary?.externalId && `(${primaryCalendar?.primary?.externalId})`}
+              {t("default_calendar_selected")} {primaryCalendar && `(${primaryCalendar})`}
             </span>
           )
         }

--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -320,6 +320,9 @@ const loggedInViewerRouter = router({
     // get all the connected integrations' calendars (from third party)
     const connectedCalendars = await getConnectedCalendars(calendarCredentials, user.selectedCalendars);
 
+    // store email of the destination calendar to display
+    let destinationCalendarEmail = null;
+
     if (connectedCalendars.length === 0) {
       /* As there are no connected calendars, delete the destination calendar if it exists */
       if (user.destinationCalendar) {
@@ -342,6 +345,7 @@ const loggedInViewerRouter = router({
           credentialId,
         },
       });
+      destinationCalendarEmail = user.destinationCalendar?.externalId;
     } else {
       /* There are connected calendars and a destination calendar */
 
@@ -352,6 +356,7 @@ const loggedInViewerRouter = router({
           cal.externalId === user.destinationCalendar?.externalId &&
           cal.integration === user.destinationCalendar?.integration
       );
+
       if (!destinationCal) {
         // If destinationCalendar is out of date, update it with the first primary connected calendar
         const { integration = "", externalId = "" } = connectedCalendars[0].primary ?? {};
@@ -363,11 +368,18 @@ const loggedInViewerRouter = router({
           },
         });
       }
+      destinationCalendarEmail = user.destinationCalendar?.externalId;
+
+      // in case of office_365 external id is not email
+      if (user.destinationCalendar?.integration === "office365_calendar") {
+        destinationCalendarEmail = destinationCal?.email;
+      }
     }
 
     return {
       connectedCalendars,
       destinationCalendar: user.destinationCalendar,
+      destinationCalendarEmail,
     };
   }),
   setDestinationCalendar: authedProcedure

--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -336,7 +336,7 @@ const loggedInViewerRouter = router({
         There are connected calendars, but no destination calendar
         So create a default destination calendar with the first primary connected calendar
         */
-      const { integration = "", externalId = "", credentialId } = connectedCalendars[0].primary ?? {};
+      const { integration = "", externalId = "", credentialId, email } = connectedCalendars[0].primary ?? {};
       user.destinationCalendar = await ctx.prisma.destinationCalendar.create({
         data: {
           userId: user.id,
@@ -345,7 +345,7 @@ const loggedInViewerRouter = router({
           credentialId,
         },
       });
-      destinationCalendarEmail = user.destinationCalendar?.externalId;
+      destinationCalendarEmail = email ?? user.destinationCalendar?.externalId;
     } else {
       /* There are connected calendars and a destination calendar */
 
@@ -368,12 +368,7 @@ const loggedInViewerRouter = router({
           },
         });
       }
-      destinationCalendarEmail = user.destinationCalendar?.externalId;
-
-      // in case of office_365 external id is not email
-      if (user.destinationCalendar?.integration === "office365_calendar") {
-        destinationCalendarEmail = destinationCal?.email;
-      }
+      destinationCalendarEmail = destinationCal?.email ?? user.destinationCalendar?.externalId;
     }
 
     return {


### PR DESCRIPTION
to display correct primary email

## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/6789

1) connect calendar
2) go to /event-types/3?tabName=advanced to see default calendar 

todo test all email providers

- [x] Google
- [x] Office 365
- [x] Apple
- [ ] CalDav ( how to set this up ?)
- [ ] Amie ( don't have access)



**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update