### PR TITLE
Fixes localisation of {EVENT_DATE} in workflows

### DIFF
--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -95,6 +95,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           ? reminder.booking?.attendees[0].timeZone
           : reminder.booking?.user?.timeZone;
 
+      const locale =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.attendees[0].locale
+          : reminder.booking?.user?.locale;
+
       let emailContent = {
         emailSubject: reminder.workflowStep.emailSubject || "",
         emailBody: {
@@ -131,13 +137,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           const emailSubject = await customTemplate(
             reminder.workflowStep.emailSubject || "",
             variables,
-            reminder.booking?.user?.locale || ""
+            locale || ""
           );
           emailContent.emailSubject = emailSubject.text;
           emailContent.emailBody = await customTemplate(
             reminder.workflowStep.reminderBody || "",
             variables,
-            reminder.booking?.user?.locale || ""
+            locale || ""
           );
           break;
       }

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -76,6 +76,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
       const senderID = getSenderId(sendTo, reminder.workflowStep.sender);
 
+      const locale =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.attendees[0].locale
+          : reminder.booking?.user?.locale;
+
       let message: string | null = reminder.workflowStep.reminderBody;
       switch (reminder.workflowStep.template) {
         case WorkflowTemplates.REMINDER:
@@ -104,7 +110,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           const customMessage = await customTemplate(
             reminder.workflowStep.reminderBody || "",
             variables,
-            reminder.booking?.user?.locale || ""
+            locale || ""
           );
           message = customMessage.text;
           break;

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -108,13 +108,14 @@ export const scheduleEmailReminder = async (
         meetingUrl: bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl,
       };
 
-      const emailSubjectTemplate = await customTemplate(
-        emailSubject,
-        variables,
-        evt.organizer.language.locale
-      );
+      const locale =
+        action === WorkflowActions.EMAIL_ATTENDEE || action === WorkflowActions.SMS_ATTENDEE
+          ? evt.attendees[0].language?.locale
+          : evt.organizer.language.locale;
+
+      const emailSubjectTemplate = await customTemplate(emailSubject, variables, locale);
       emailContent.emailSubject = emailSubjectTemplate.text;
-      emailContent.emailBody = await customTemplate(emailBody, variables, evt.organizer.language.locale);
+      emailContent.emailBody = await customTemplate(emailBody, variables, locale);
       break;
   }
 

--- a/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
@@ -25,8 +25,13 @@ export enum timeUnitLowerCase {
 
 export type BookingInfo = {
   uid?: string | null;
-  attendees: Person[];
-  organizer: Person;
+  attendees: { name: string; email: string; timeZone: string; language: { locale: string } }[];
+  organizer: {
+    language: { locale: string };
+    name: string;
+    email: string;
+    timeZone: string;
+  };
   startTime: string;
   endTime: string;
   title: string;

--- a/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
@@ -10,6 +10,7 @@ import dayjs from "@calcom/dayjs";
 import prisma from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
+import { Person } from "@calcom/types/Calendar";
 
 import { getSenderId } from "../alphanumericSenderIdSupport";
 import * as twilio from "./smsProviders/twilioProvider";
@@ -24,13 +25,8 @@ export enum timeUnitLowerCase {
 
 export type BookingInfo = {
   uid?: string | null;
-  attendees: { name: string; email: string; timeZone: string }[];
-  organizer: {
-    language: { locale: string };
-    name: string;
-    email: string;
-    timeZone: string;
-  };
+  attendees: Person[];
+  organizer: Person;
   startTime: string;
   endTime: string;
   title: string;
@@ -87,6 +83,11 @@ export const scheduleSMSReminder = async (
   const timeZone =
     action === WorkflowActions.SMS_ATTENDEE ? evt.attendees[0].timeZone : evt.organizer.timeZone;
 
+  const locale =
+    action === WorkflowActions.EMAIL_ATTENDEE || action === WorkflowActions.SMS_ATTENDEE
+      ? evt.attendees[0].language?.locale
+      : evt.organizer.language.locale;
+
   switch (template) {
     case WorkflowTemplates.REMINDER:
       message = smsReminderTemplate(evt.startTime, evt.title, timeZone, attendeeName, name) || message;
@@ -105,7 +106,7 @@ export const scheduleSMSReminder = async (
         customInputs: evt.customInputs,
         meetingUrl: bookingMetadataSchema.parse(evt.metadata || {})?.videoCallUrl,
       };
-      const customMessage = await customTemplate(message, variables, evt.organizer.language.locale);
+      const customMessage = await customTemplate(message, variables, locale);
       message = customMessage.text;
       break;
   }

--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -1,5 +1,6 @@
 import { guessEventLocationType } from "@calcom/app-store/locations";
-import { Dayjs } from "@calcom/dayjs";
+import dayjs, { Dayjs } from "@calcom/dayjs";
+import { getTranslation } from "@calcom/lib/server";
 import { Prisma } from "@calcom/prisma/client";
 
 export type VariablesType = {
@@ -17,7 +18,12 @@ export type VariablesType = {
 };
 
 const customTemplate = async (text: string, variables: VariablesType, locale: string) => {
-  const timeWithTimeZone = `${variables.eventTime?.locale(locale).format("HH:mm")} (${variables.timeZone})`;
+  const translate = await getTranslation(locale ?? "en", "common");
+  const day = translate(dayjs(variables.eventDate).format("dddd").toLowerCase());
+  const month = translate(dayjs(variables.eventDate).format("MMMM").toLowerCase());
+  const dayYear = dayjs(variables.eventDate).format("D, YYYY");
+
+  const timeWithTimeZone = `${variables.eventTime?.format("HH:mm")} (${variables.timeZone})`;
   let locationString = variables.location || "";
 
   if (text.includes("{LOCATION}")) {
@@ -30,7 +36,7 @@ const customTemplate = async (text: string, variables: VariablesType, locale: st
     .replaceAll("{ATTENDEE}", variables.attendeeName || "")
     .replaceAll("{ORGANIZER_NAME}", variables.organizerName || "") //old variable names
     .replaceAll("{ATTENDEE_NAME}", variables.attendeeName || "") //old variable names
-    .replaceAll("{EVENT_DATE}", variables.eventDate?.locale(locale).format("dddd, MMMM D, YYYY") || "")
+    .replaceAll("{EVENT_DATE}", `${day}, ${month} ${dayYear}`)
     .replaceAll("{EVENT_TIME}", timeWithTimeZone)
     .replaceAll("{LOCATION}", locationString)
     .replaceAll("{ADDITIONAL_NOTES}", variables.additionalNotes || "")

--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -1,6 +1,5 @@
 import { guessEventLocationType } from "@calcom/app-store/locations";
-import dayjs, { Dayjs } from "@calcom/dayjs";
-import { getTranslation } from "@calcom/lib/server";
+import { Dayjs } from "@calcom/dayjs";
 import { Prisma } from "@calcom/prisma/client";
 
 export type VariablesType = {
@@ -18,10 +17,12 @@ export type VariablesType = {
 };
 
 const customTemplate = async (text: string, variables: VariablesType, locale: string) => {
-  const translate = await getTranslation(locale ?? "en", "common");
-  const day = translate(dayjs(variables.eventDate).format("dddd").toLowerCase());
-  const month = translate(dayjs(variables.eventDate).format("MMMM").toLowerCase());
-  const dayYear = dayjs(variables.eventDate).format("D, YYYY");
+  const translatedDate = new Intl.DateTimeFormat(locale, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(variables.eventDate?.toDate());
 
   const timeWithTimeZone = `${variables.eventTime?.format("HH:mm")} (${variables.timeZone})`;
   let locationString = variables.location || "";
@@ -36,7 +37,7 @@ const customTemplate = async (text: string, variables: VariablesType, locale: st
     .replaceAll("{ATTENDEE}", variables.attendeeName || "")
     .replaceAll("{ORGANIZER_NAME}", variables.organizerName || "") //old variable names
     .replaceAll("{ATTENDEE_NAME}", variables.attendeeName || "") //old variable names
-    .replaceAll("{EVENT_DATE}", `${day}, ${month} ${dayYear}`)
+    .replaceAll("{EVENT_DATE}", translatedDate)
     .replaceAll("{EVENT_TIME}", timeWithTimeZone)
     .replaceAll("{LOCATION}", locationString)
     .replaceAll("{ADDITIONAL_NOTES}", variables.additionalNotes || "")

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -918,72 +918,72 @@ export const workflowsRouter = router({
     }
 
     if (isSMSAction(step.action) /*|| step.action === WorkflowActions.EMAIL_ADDRESS*/ /*) {
-const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
-if (!hasTeamPlan) {
-  throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
-}
-}
+    const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
+    if (!hasTeamPlan) {
+      throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
+    }
+  }
 
-const booking = await ctx.prisma.booking.findFirst({
-orderBy: {
-  createdAt: "desc",
-},
-where: {
-  userId: ctx.user.id,
-},
-include: {
-  attendees: true,
-  user: true,
-},
-});
-
-let evt: BookingInfo;
-if (booking) {
-evt = {
-  uid: booking?.uid,
-  attendees:
-    booking?.attendees.map((attendee) => {
-      return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
-    }) || [],
-  organizer: {
-    language: {
-      locale: booking?.user?.locale || "",
+  const booking = await ctx.prisma.booking.findFirst({
+    orderBy: {
+      createdAt: "desc",
     },
-    name: booking?.user?.name || "",
-    email: booking?.user?.email || "",
-    timeZone: booking?.user?.timeZone || "",
-  },
-  startTime: booking?.startTime.toISOString() || "",
-  endTime: booking?.endTime.toISOString() || "",
-  title: booking?.title || "",
-  location: booking?.location || null,
-  additionalNotes: booking?.description || null,
-  customInputs: booking?.customInputs,
-};
-} else {
-//if no booking exists create an example booking
-evt = {
-  attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
-  organizer: {
-    language: {
-      locale: ctx.user.locale,
+    where: {
+      userId: ctx.user.id,
     },
-    name: ctx.user.name || "",
-    email: ctx.user.email,
-    timeZone: ctx.user.timeZone,
-  },
-  startTime: dayjs().add(10, "hour").toISOString(),
-  endTime: dayjs().add(11, "hour").toISOString(),
-  title: "Example Booking",
-  location: "Office",
-  additionalNotes: "These are additional notes",
-};
-}
+    include: {
+      attendees: true,
+      user: true,
+    },
+  });
 
-if (
-action === WorkflowActions.EMAIL_ATTENDEE ||
-action === WorkflowActions.EMAIL_HOST /*||
-action === WorkflowActions.EMAIL_ADDRESS*/
+  let evt: BookingInfo;
+  if (booking) {
+    evt = {
+      uid: booking?.uid,
+      attendees:
+        booking?.attendees.map((attendee) => {
+          return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+        }) || [],
+      organizer: {
+        language: {
+          locale: booking?.user?.locale || "",
+        },
+        name: booking?.user?.name || "",
+        email: booking?.user?.email || "",
+        timeZone: booking?.user?.timeZone || "",
+      },
+      startTime: booking?.startTime.toISOString() || "",
+      endTime: booking?.endTime.toISOString() || "",
+      title: booking?.title || "",
+      location: booking?.location || null,
+      additionalNotes: booking?.description || null,
+      customInputs: booking?.customInputs,
+    };
+  } else {
+    //if no booking exists create an example booking
+    evt = {
+      attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
+      organizer: {
+        language: {
+          locale: ctx.user.locale,
+        },
+        name: ctx.user.name || "",
+        email: ctx.user.email,
+        timeZone: ctx.user.timeZone,
+      },
+      startTime: dayjs().add(10, "hour").toISOString(),
+      endTime: dayjs().add(11, "hour").toISOString(),
+      title: "Example Booking",
+      location: "Office",
+      additionalNotes: "These are additional notes",
+    };
+  }
+
+  if (
+    action === WorkflowActions.EMAIL_ATTENDEE ||
+    action === WorkflowActions.EMAIL_HOST /*||
+    action === WorkflowActions.EMAIL_ADDRESS*/
   /*) {
       scheduleEmailReminder(
         evt,

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -437,7 +437,7 @@ export const workflowsRouter = router({
                       name: attendee.name,
                       email: attendee.email,
                       timeZone: attendee.timeZone,
-                      language: { locale: attendee.locale },
+                      language: { locale: attendee.locale || "" },
                     };
                   }),
                   organizer: booking.user
@@ -630,7 +630,12 @@ export const workflowsRouter = router({
               const bookingInfo = {
                 uid: booking.uid,
                 attendees: booking.attendees.map((attendee) => {
-                  return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+                  return {
+                    name: attendee.name,
+                    email: attendee.email,
+                    timeZone: attendee.timeZone,
+                    language: { locale: attendee.locale || "" },
+                  };
                 }),
                 organizer: booking.user
                   ? {
@@ -751,7 +756,12 @@ export const workflowsRouter = router({
                 const bookingInfo = {
                   uid: booking.uid,
                   attendees: booking.attendees.map((attendee) => {
-                    return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+                    return {
+                      name: attendee.name,
+                      email: attendee.email,
+                      timeZone: attendee.timeZone,
+                      language: { locale: attendee.locale || "" },
+                    };
                   }),
                   organizer: booking.user
                     ? {
@@ -908,72 +918,72 @@ export const workflowsRouter = router({
     }
 
     if (isSMSAction(step.action) /*|| step.action === WorkflowActions.EMAIL_ADDRESS*/ /*) {
-    const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
-    if (!hasTeamPlan) {
-      throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
-    }
-  }
+const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
+if (!hasTeamPlan) {
+  throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
+}
+}
 
-  const booking = await ctx.prisma.booking.findFirst({
-    orderBy: {
-      createdAt: "desc",
-    },
-    where: {
-      userId: ctx.user.id,
-    },
-    include: {
-      attendees: true,
-      user: true,
-    },
-  });
+const booking = await ctx.prisma.booking.findFirst({
+orderBy: {
+  createdAt: "desc",
+},
+where: {
+  userId: ctx.user.id,
+},
+include: {
+  attendees: true,
+  user: true,
+},
+});
 
-  let evt: BookingInfo;
-  if (booking) {
-    evt = {
-      uid: booking?.uid,
-      attendees:
-        booking?.attendees.map((attendee) => {
-          return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
-        }) || [],
-      organizer: {
-        language: {
-          locale: booking?.user?.locale || "",
-        },
-        name: booking?.user?.name || "",
-        email: booking?.user?.email || "",
-        timeZone: booking?.user?.timeZone || "",
-      },
-      startTime: booking?.startTime.toISOString() || "",
-      endTime: booking?.endTime.toISOString() || "",
-      title: booking?.title || "",
-      location: booking?.location || null,
-      additionalNotes: booking?.description || null,
-      customInputs: booking?.customInputs,
-    };
-  } else {
-    //if no booking exists create an example booking
-    evt = {
-      attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
-      organizer: {
-        language: {
-          locale: ctx.user.locale,
-        },
-        name: ctx.user.name || "",
-        email: ctx.user.email,
-        timeZone: ctx.user.timeZone,
-      },
-      startTime: dayjs().add(10, "hour").toISOString(),
-      endTime: dayjs().add(11, "hour").toISOString(),
-      title: "Example Booking",
-      location: "Office",
-      additionalNotes: "These are additional notes",
-    };
-  }
+let evt: BookingInfo;
+if (booking) {
+evt = {
+  uid: booking?.uid,
+  attendees:
+    booking?.attendees.map((attendee) => {
+      return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+    }) || [],
+  organizer: {
+    language: {
+      locale: booking?.user?.locale || "",
+    },
+    name: booking?.user?.name || "",
+    email: booking?.user?.email || "",
+    timeZone: booking?.user?.timeZone || "",
+  },
+  startTime: booking?.startTime.toISOString() || "",
+  endTime: booking?.endTime.toISOString() || "",
+  title: booking?.title || "",
+  location: booking?.location || null,
+  additionalNotes: booking?.description || null,
+  customInputs: booking?.customInputs,
+};
+} else {
+//if no booking exists create an example booking
+evt = {
+  attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
+  organizer: {
+    language: {
+      locale: ctx.user.locale,
+    },
+    name: ctx.user.name || "",
+    email: ctx.user.email,
+    timeZone: ctx.user.timeZone,
+  },
+  startTime: dayjs().add(10, "hour").toISOString(),
+  endTime: dayjs().add(11, "hour").toISOString(),
+  title: "Example Booking",
+  location: "Office",
+  additionalNotes: "These are additional notes",
+};
+}
 
-  if (
-    action === WorkflowActions.EMAIL_ATTENDEE ||
-    action === WorkflowActions.EMAIL_HOST /*||
-    action === WorkflowActions.EMAIL_ADDRESS*/
+if (
+action === WorkflowActions.EMAIL_ATTENDEE ||
+action === WorkflowActions.EMAIL_HOST /*||
+action === WorkflowActions.EMAIL_ADDRESS*/
   /*) {
       scheduleEmailReminder(
         evt,

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -918,72 +918,72 @@ export const workflowsRouter = router({
     }
 
     if (isSMSAction(step.action) /*|| step.action === WorkflowActions.EMAIL_ADDRESS*/ /*) {
-    const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
-    if (!hasTeamPlan) {
-      throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
-    }
-  }
+const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
+if (!hasTeamPlan) {
+  throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
+}
+}
 
-  const booking = await ctx.prisma.booking.findFirst({
-    orderBy: {
-      createdAt: "desc",
-    },
-    where: {
-      userId: ctx.user.id,
-    },
-    include: {
-      attendees: true,
-      user: true,
-    },
-  });
+const booking = await ctx.prisma.booking.findFirst({
+orderBy: {
+  createdAt: "desc",
+},
+where: {
+  userId: ctx.user.id,
+},
+include: {
+  attendees: true,
+  user: true,
+},
+});
 
-  let evt: BookingInfo;
-  if (booking) {
-    evt = {
-      uid: booking?.uid,
-      attendees:
-        booking?.attendees.map((attendee) => {
-          return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
-        }) || [],
-      organizer: {
-        language: {
-          locale: booking?.user?.locale || "",
-        },
-        name: booking?.user?.name || "",
-        email: booking?.user?.email || "",
-        timeZone: booking?.user?.timeZone || "",
-      },
-      startTime: booking?.startTime.toISOString() || "",
-      endTime: booking?.endTime.toISOString() || "",
-      title: booking?.title || "",
-      location: booking?.location || null,
-      additionalNotes: booking?.description || null,
-      customInputs: booking?.customInputs,
-    };
-  } else {
-    //if no booking exists create an example booking
-    evt = {
-      attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
-      organizer: {
-        language: {
-          locale: ctx.user.locale,
-        },
-        name: ctx.user.name || "",
-        email: ctx.user.email,
-        timeZone: ctx.user.timeZone,
-      },
-      startTime: dayjs().add(10, "hour").toISOString(),
-      endTime: dayjs().add(11, "hour").toISOString(),
-      title: "Example Booking",
-      location: "Office",
-      additionalNotes: "These are additional notes",
-    };
-  }
+let evt: BookingInfo;
+if (booking) {
+evt = {
+  uid: booking?.uid,
+  attendees:
+    booking?.attendees.map((attendee) => {
+      return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+    }) || [],
+  organizer: {
+    language: {
+      locale: booking?.user?.locale || "",
+    },
+    name: booking?.user?.name || "",
+    email: booking?.user?.email || "",
+    timeZone: booking?.user?.timeZone || "",
+  },
+  startTime: booking?.startTime.toISOString() || "",
+  endTime: booking?.endTime.toISOString() || "",
+  title: booking?.title || "",
+  location: booking?.location || null,
+  additionalNotes: booking?.description || null,
+  customInputs: booking?.customInputs,
+};
+} else {
+//if no booking exists create an example booking
+evt = {
+  attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
+  organizer: {
+    language: {
+      locale: ctx.user.locale,
+    },
+    name: ctx.user.name || "",
+    email: ctx.user.email,
+    timeZone: ctx.user.timeZone,
+  },
+  startTime: dayjs().add(10, "hour").toISOString(),
+  endTime: dayjs().add(11, "hour").toISOString(),
+  title: "Example Booking",
+  location: "Office",
+  additionalNotes: "These are additional notes",
+};
+}
 
-  if (
-    action === WorkflowActions.EMAIL_ATTENDEE ||
-    action === WorkflowActions.EMAIL_HOST /*||
-    action === WorkflowActions.EMAIL_ADDRESS*/
+if (
+action === WorkflowActions.EMAIL_ATTENDEE ||
+action === WorkflowActions.EMAIL_HOST /*||
+action === WorkflowActions.EMAIL_ADDRESS*/
   /*) {
       scheduleEmailReminder(
         evt,

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -433,7 +433,12 @@ export const workflowsRouter = router({
                 const bookingInfo = {
                   uid: booking.uid,
                   attendees: booking.attendees.map((attendee) => {
-                    return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+                    return {
+                      name: attendee.name,
+                      email: attendee.email,
+                      timeZone: attendee.timeZone,
+                      language: { locale: attendee.locale },
+                    };
                   }),
                   organizer: booking.user
                     ? {
@@ -903,72 +908,72 @@ export const workflowsRouter = router({
     }
 
     if (isSMSAction(step.action) /*|| step.action === WorkflowActions.EMAIL_ADDRESS*/ /*) {
-      const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
-      if (!hasTeamPlan) {
-        throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
-      }
+    const hasTeamPlan = (await ctx.prisma.membership.count({ where: { userId: user.id } })) > 0;
+    if (!hasTeamPlan) {
+      throw new TRPCError({ code: "UNAUTHORIZED", message: "Team plan needed" });
     }
+  }
 
-    const booking = await ctx.prisma.booking.findFirst({
-      orderBy: {
-        createdAt: "desc",
-      },
-      where: {
-        userId: ctx.user.id,
-      },
-      include: {
-        attendees: true,
-        user: true,
-      },
-    });
+  const booking = await ctx.prisma.booking.findFirst({
+    orderBy: {
+      createdAt: "desc",
+    },
+    where: {
+      userId: ctx.user.id,
+    },
+    include: {
+      attendees: true,
+      user: true,
+    },
+  });
 
-    let evt: BookingInfo;
-    if (booking) {
-      evt = {
-        uid: booking?.uid,
-        attendees:
-          booking?.attendees.map((attendee) => {
-            return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
-          }) || [],
-        organizer: {
-          language: {
-            locale: booking?.user?.locale || "",
-          },
-          name: booking?.user?.name || "",
-          email: booking?.user?.email || "",
-          timeZone: booking?.user?.timeZone || "",
+  let evt: BookingInfo;
+  if (booking) {
+    evt = {
+      uid: booking?.uid,
+      attendees:
+        booking?.attendees.map((attendee) => {
+          return { name: attendee.name, email: attendee.email, timeZone: attendee.timeZone };
+        }) || [],
+      organizer: {
+        language: {
+          locale: booking?.user?.locale || "",
         },
-        startTime: booking?.startTime.toISOString() || "",
-        endTime: booking?.endTime.toISOString() || "",
-        title: booking?.title || "",
-        location: booking?.location || null,
-        additionalNotes: booking?.description || null,
-        customInputs: booking?.customInputs,
-      };
-    } else {
-      //if no booking exists create an example booking
-      evt = {
-        attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
-        organizer: {
-          language: {
-            locale: ctx.user.locale,
-          },
-          name: ctx.user.name || "",
-          email: ctx.user.email,
-          timeZone: ctx.user.timeZone,
+        name: booking?.user?.name || "",
+        email: booking?.user?.email || "",
+        timeZone: booking?.user?.timeZone || "",
+      },
+      startTime: booking?.startTime.toISOString() || "",
+      endTime: booking?.endTime.toISOString() || "",
+      title: booking?.title || "",
+      location: booking?.location || null,
+      additionalNotes: booking?.description || null,
+      customInputs: booking?.customInputs,
+    };
+  } else {
+    //if no booking exists create an example booking
+    evt = {
+      attendees: [{ name: "John Doe", email: "john.doe@example.com", timeZone: "Europe/London" }],
+      organizer: {
+        language: {
+          locale: ctx.user.locale,
         },
-        startTime: dayjs().add(10, "hour").toISOString(),
-        endTime: dayjs().add(11, "hour").toISOString(),
-        title: "Example Booking",
-        location: "Office",
-        additionalNotes: "These are additional notes",
-      };
-    }
+        name: ctx.user.name || "",
+        email: ctx.user.email,
+        timeZone: ctx.user.timeZone,
+      },
+      startTime: dayjs().add(10, "hour").toISOString(),
+      endTime: dayjs().add(11, "hour").toISOString(),
+      title: "Example Booking",
+      location: "Office",
+      additionalNotes: "These are additional notes",
+    };
+  }
 
-    if (
-      action === WorkflowActions.EMAIL_ATTENDEE ||
-      action === WorkflowActions.EMAIL_HOST /*||
-      action === WorkflowActions.EMAIL_ADDRESS*/
+  if (
+    action === WorkflowActions.EMAIL_ATTENDEE ||
+    action === WorkflowActions.EMAIL_HOST /*||
+    action === WorkflowActions.EMAIL_ADDRESS*/
   /*) {
       scheduleEmailReminder(
         evt,


### PR DESCRIPTION
## What does this PR do?

Adds correct translations of the dynamic text variable {EVENT_DATE} for custom workflow templates. The workflow actions 'send SMS to attendee' and 'send Email to attendee' are now using the attendee's language to translate the event date. 

Fixes #6733

German: 
![Screenshot 2023-02-06 at 13 54 21](https://user-images.githubusercontent.com/30310907/217062408-7502e759-2a58-491a-895a-5b7592a1f79f.png)

English:
![Screenshot 2023-02-06 at 13 55 59](https://user-images.githubusercontent.com/30310907/217062416-e2d66fbd-dd5a-4a33-8667-32bbab3962ef.png)


**Environment**: Staging(main branch) / Production