### PR TITLE
Block /auth/:path, nothing else.

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -185,8 +185,7 @@ const nextConfig = {
   async headers() {
     return [
       {
-        // prettier-ignore
-        source: "/:path*((?<!\/embed$)(?<!\/embed\/preview\.html$))",
+        source: "/auth/:path*",
         headers: [
           {
             key: "X-Frame-Options",

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -194,6 +194,15 @@ const nextConfig = {
         ],
       },
       {
+        source: "/signup",
+        headers: [
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+        ],
+      },
+      {
         source: "/:path*",
         headers: [
           {


### PR DESCRIPTION
## What does this PR do?

Allow iframe embeds except for on the /auth pages.

Resolves #6946