### PR TITLE
Fixing issues around workflows

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -204,6 +204,11 @@ export const deleteScheduledEmailReminder = async (referenceId: string) => {
         status: "cancel",
       },
     });
+
+    await client.request({
+      url: `/v3/user/scheduled_sends/${referenceId}`,
+      method: "DELETE",
+    });
   } catch (error) {
     console.log(`Error canceling reminder with error ${error}`);
   }

--- a/packages/features/ee/workflows/pages/workflow.tsx
+++ b/packages/features/ee/workflows/pages/workflow.tsx
@@ -100,7 +100,7 @@ function WorkflowPage() {
     data: workflow,
     isError,
     error,
-    dataUpdatedAt,
+    isLoading,
   } = trpc.viewer.workflows.get.useQuery(
     { id: +workflowId },
     {
@@ -111,7 +111,7 @@ function WorkflowPage() {
   const { data: verifiedNumbers } = trpc.viewer.workflows.getVerifiedNumbers.useQuery();
 
   useEffect(() => {
-    if (workflow && (workflow.steps.length === 0 || workflow.steps[0].stepNumber === 1)) {
+    if (workflow && !isLoading) {
       setSelectedEventTypes(
         workflow.activeOn.map((active) => ({
           value: String(active.eventType.id),
@@ -155,7 +155,7 @@ function WorkflowPage() {
       form.setValue("activeOn", activeOn || []);
       setIsAllDataLoaded(true);
     }
-  }, [dataUpdatedAt]);
+  }, [isLoading]);
 
   const updateMutation = trpc.viewer.workflows.update.useMutation({
     onSuccess: async ({ workflow }) => {

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -856,7 +856,11 @@ export const workflowsRouter = router({
               eventType: true,
             },
           },
-          steps: true,
+          steps: {
+            orderBy: {
+              stepNumber: "asc",
+            },
+          },
         },
       });
 


### PR DESCRIPTION
## What does this PR do?

Fixes issue that workflow email reminders of canceled bookings were still sent. 
Fixes issue that bookings that requested rescheduling still sent SMS and email reminders. 
Also, fixes the issue that when editing a workflow the data gets lost when clicking outside of the workflow. 

Fixes #6973
Fixes #6905
Fixes #6956

**Environment**: Staging(main branch) / Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)