### PR TITLE
fix: availability header margin bottom

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -778,7 +778,7 @@ export function ShellMain(props: LayoutProps) {
 
   return (
     <>
-      <div className={classNames("flex sm:mt-0 md:mb-6", props.smallHeading ? "lg:mb-7" : "lg:mb-8")}>
+      <div className={classNames("mb-4 flex sm:mt-0 md:mb-6", props.smallHeading ? "lg:mb-7" : "lg:mb-8")}>
         {!!props.backPath && (
           <Button
             variant="icon"


### PR DESCRIPTION
## What does this PR do?

Fixes #6966

Fixed margin bottom of the availability page header. added `mb-4`

**After**
![image](https://user-images.githubusercontent.com/69904519/218101451-cb0eede6-23f9-43ba-a4a0-9f150b63c17d.png)


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

