### PR TITLE
Fix: avatar group buggy with +0

### DIFF
--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -16,48 +16,43 @@ export type AvatarGroupProps = {
 };
 
 export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
-  const avatars = props.items.slice(0, 4);
   const LENGTH = props.items.length;
   const truncateAfter = props.truncateAfter || 4;
+  const displayedAvatars = props.items
+    .filter((avatar) => avatar.image)
+    .filter((_, idx) => idx < truncateAfter);
+  const numTruncatedAvatars = LENGTH - displayedAvatars.length;
 
   return (
     <ul className={classNames("flex items-center", props.className)}>
-      {avatars.map((item, enumerator) => {
-        if (item.image != null) {
-          if (LENGTH > truncateAfter && enumerator === truncateAfter - 1) {
-            return (
-              <li key={enumerator} className="relative -mr-[4px] inline-block ">
-                <div className="relative">
-                  <div className="h-90 relative min-w-full scale-105 transform border-gray-200 ">
-                    <Avatar className="" imageSrc={item.image} alt={item.alt || ""} size={props.size} />
-                  </div>
-                </div>
-                <div
-                  className={classNames(
-                    "absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-white",
-                    props.size === "sm" ? "text-base" : "text-2xl"
-                  )}>
-                  <span>+{LENGTH - truncateAfter - 1}</span>
-                </div>
-              </li>
-            );
-          }
-          // Always display the first Four items items
-          return (
-            <li key={enumerator} className="-mr-[4px] inline-block">
-              <Avatar
-                className="border-gray-200"
-                imageSrc={item.image}
-                title={item.title}
-                alt={item.alt || ""}
-                accepted={props.accepted}
-                size={props.size}
-                href={item.href}
-              />
-            </li>
-          );
-        }
-      })}
+      {displayedAvatars.map((item, idx) => (
+        <li key={idx} className="-mr-[4px] inline-block">
+          <Avatar
+            className="border-gray-200"
+            imageSrc={item.image}
+            title={item.title}
+            alt={item.alt || ""}
+            accepted={props.accepted}
+            size={props.size}
+            href={item.href}
+          />
+        </li>
+      ))}
+      {numTruncatedAvatars > 0 && (
+        <li
+          className={classNames(
+            "relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full bg-black",
+            props.size === "sm" ? "h-6 w-6" : "h-16 w-16"
+          )}>
+          <span
+            className={classNames(
+              "m-auto text-center text-white",
+              props.size === "sm" ? "text-[12px]" : "text-2xl"
+            )}>
+            +{numTruncatedAvatars}
+          </span>
+        </li>
+      )}
     </ul>
   );
 };

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -43,7 +43,7 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
       {numTruncatedAvatars > 0 && (
         <li
           className={classNames(
-            "relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full bg-black",
+            "relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full bg-darkgray-300",
             props.size === "sm" ? "min-w-6 h-6" : "min-w-16 h-16"
           )}>
           <span

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -18,9 +18,11 @@ export type AvatarGroupProps = {
 export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
   const LENGTH = props.items.length;
   const truncateAfter = props.truncateAfter || 4;
-  const displayedAvatars = props.items
-    .filter((avatar) => avatar.image)
-    .filter((_, idx) => idx < truncateAfter);
+  /**
+   * First, filter all the avatars with image included
+   * Then, slice it until`truncateAfter` index
+   */
+  const displayedAvatars = props.items.filter((avatar) => avatar.image).slice(0, truncateAfter);
   const numTruncatedAvatars = LENGTH - displayedAvatars.length;
 
   return (

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -42,11 +42,11 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
         <li
           className={classNames(
             "relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full bg-black",
-            props.size === "sm" ? "h-6 w-6" : "h-16 w-16"
+            props.size === "sm" ? "min-w-6 h-6" : "min-w-16 h-16"
           )}>
           <span
             className={classNames(
-              "m-auto text-center text-white",
+              "m-auto px-1 text-center text-white",
               props.size === "sm" ? "text-[12px]" : "text-2xl"
             )}>
             +{numTruncatedAvatars}

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -43,7 +43,7 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
       {numTruncatedAvatars > 0 && (
         <li
           className={classNames(
-            "relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full bg-darkgray-300",
+            "bg-darkgray-300 relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full",
             props.size === "sm" ? "min-w-6 h-6" : "min-w-16 h-16"
           )}>
           <span

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -19,8 +19,8 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
   const LENGTH = props.items.length;
   const truncateAfter = props.truncateAfter || 4;
   /**
-   * First, filter all the avatars with image included
-   * Then, slice it until`truncateAfter` index
+   * First, filter all the avatars object that have image
+   * Then, slice it until before `truncateAfter` index
    */
   const displayedAvatars = props.items.filter((avatar) => avatar.image).slice(0, truncateAfter);
   const numTruncatedAvatars = LENGTH - displayedAvatars.length;


### PR DESCRIPTION
## What does this PR do?

Fix `AvatarGroups` component to follow: https://www.figma.com/file/9MOufQNLtdkpnDucmNX10R/%E2%9D%96-Cal-DS?node-id=1573%3A77871&t=I8UQXj6AtCkQ0f0E-0

Fixes #7032
![Screenshot 2023-02-11 at 4 18 03 AM](https://user-images.githubusercontent.com/73758525/218190242-1c993a6d-dab9-4944-a364-6cee68c4912b.png)

In-case the truncated avatars are more that 1 digits
![Screenshot 2023-02-11 at 4 18 45 AM](https://user-images.githubusercontent.com/73758525/218190288-fcf3385f-49cd-4f64-aaab-3888d8647d65.png)

For this video, behind the scenes (on my IDE) I'm changing the `truncatedAfter` prop value from 3 -> 1 -> 2 -> 3 -> 4. You can see the behaviour as below:

https://user-images.githubusercontent.com/73758525/218243781-b0fd6985-0607-434b-9924-28fd389e75a5.mov

**Environment**: Staging(main branch) / Pr

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Run locally and open a dynamic collective event booking page
