### PR TITLE
Ability to write placeholder in routing forms

### DIFF
--- a/packages/app-store/ee/routing-forms/components/FormInputFields.tsx
+++ b/packages/app-store/ee/routing-forms/components/FormInputFields.tsx
@@ -50,6 +50,7 @@ export default function FormInputFields(props: Props) {
             <div className="flex rounded-sm">
               <Component
                 value={response[field.id]?.value}
+                placeholder={field.placeholder ?? ""}
                 // required property isn't accepted by query-builder types
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 /* @ts-ignore */

--- a/packages/app-store/ee/routing-forms/pages/form-edit/[...appPages].tsx
+++ b/packages/app-store/ee/routing-forms/pages/form-edit/[...appPages].tsx
@@ -139,6 +139,15 @@ function Field({
               onChange={(e) => setUserChangedIdentifier(e.target.value)}
             />
           </div>
+          <div className="mb-6 w-full">
+            <TextField
+              disabled={!!router}
+              label="Placeholder"
+              placeholder="This will be the placeholder"
+              defaultValue={routerField?.placeholder}
+              {...hookForm.register(`${hookFieldNamespace}.placeholder`)}
+            />
+          </div>
           <div className="mb-6 w-full ">
             <Controller
               name={`${hookFieldNamespace}.type`}

--- a/packages/app-store/ee/routing-forms/zod.ts
+++ b/packages/app-store/ee/routing-forms/zod.ts
@@ -4,6 +4,7 @@ export const zodNonRouterField = z.object({
   id: z.string(),
   label: z.string(),
   identifier: z.string().optional(),
+  placeholder: z.string().optional(),
   type: z.string(),
   selectText: z.string().optional(),
   required: z.boolean().optional(),


### PR DESCRIPTION
## What does this PR do?

Adds an input field to write a placeholder text in routing form edits and shows this text as placeholder in forms.

Fixes #7035 

![image](https://user-images.githubusercontent.com/82832085/218268505-52ef9fbe-07f6-48f8-8f83-31e45b1f8865.png)

![image](https://user-images.githubusercontent.com/82832085/218268622-f2fac4d2-1e8f-411e-a6b5-d2cb4673e4d1.png)

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
