### PR TITLE
Fixes text color of webhook response

### DIFF
--- a/packages/features/webhooks/components/WebhookTestDisclosure.tsx
+++ b/packages/features/webhooks/components/WebhookTestDisclosure.tsx
@@ -31,7 +31,7 @@ export default function WebhookTestDisclosure() {
           {t("ping_test")}
         </Button>
       </div>
-      <div className="space-y-0 rounded-md  border border-neutral-200 sm:mx-0">
+      <div className="space-y-0 rounded-md border border-neutral-200 sm:mx-0">
         <div className="flex justify-between border-b p-4">
           <div className="flex items-center space-x-1">
             <h3 className="self-center text-sm font-semibold leading-4">{t("webhook_response")}</h3>
@@ -45,7 +45,7 @@ export default function WebhookTestDisclosure() {
         <div className="rounded-b-md bg-black p-4 font-mono text-[13px] leading-4 text-white">
           {!mutation.data && <p>{t("no_data_yet")}</p>}
           {mutation.status === "success" && (
-            <div className="overflow-x-auto  text-gray-900">{JSON.stringify(mutation.data, null, 4)}</div>
+            <div className="overflow-x-auto text-white">{JSON.stringify(mutation.data, null, 4)}</div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Fixes text color of webhook response. Text color was black (on black background)

**Before**
![Screenshot 2023-02-11 at 20 10 37](https://user-images.githubusercontent.com/30310907/218288051-9c83be6c-21ba-44d7-8f51-adfab1f4205e.jpg)

**After**
![Screenshot 2023-02-11 at 20 09 42](https://user-images.githubusercontent.com/30310907/218288063-f6368d4d-edd2-4e3c-aeeb-0c6abe469fb5.jpg)
