### PR TITLE
fix: remove local slot caching

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -75,16 +75,9 @@ const useSlots = ({
       enabled: !!startTime && !!endTime,
     }
   );
-  const [cachedSlots, setCachedSlots] = useState<NonNullable<typeof data>["slots"]>({});
-
-  useEffect(() => {
-    if (data?.slots) {
-      setCachedSlots((c) => ({ ...c, ...data?.slots }));
-    }
-  }, [data]);
 
   // The very first time isPaused is set if auto-fetch is disabled, so isPaused should also be considered a loading state.
-  return { slots: cachedSlots, isLoading: isLoading || isPaused };
+  return { slots: data?.slots, isLoading: isLoading || isPaused };
 };
 
 const SlotPicker = ({


### PR DESCRIPTION
## What does this PR do?

Fixes #6932
Partially fix: #6622

Revert caching of slots that was introduced from: [PR 3118](https://github.com/calcom/cal.com/pull/3118)

This caching behavior causes unexpected issues client side. Aside from the issues mentioned earlier, this also prevent real-time revalidation of slots based on limits as they are reached (I'm working on another feat requests to add total booking time limits, this gave me a lot of headache tbh).

**Why remove this?**
- This cache does not provide any perf improvement whether for rendering or reducing requests send to the server.
- This was designed to persist slots when switching months based on PR 3118.
   - However, moving between months fetches new data everytime, so that "cached" slots gets discarded anyway (cached contents does not have a reliable invalidation logic, causing bugs).

This feature was added by @zomars, would be interested if there's other reasons why this was added and if we should refrain from removing this.

> ~~Not sure if this would be eligible for the full bounty, but hey /claim~~

**Environment**: Production

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Test for #6932: Changing timezone must not include slots from previous timezone (also affects dynamic time)
  - Open a booking page where the user has limited availability (e.g. Monday - Friday).
  - Change timezone that would cause the slots to extend to weekends.
  - Go back to the previous timezone.
  - Unlike before, the slots for the weekends aren't retained.
- [x] Test for #6622: Users can still click select time slots even if fully booked.
  - Create an event with a limit of 1 booking per day.
  - Open the booking page for this event in two tabs.
  - Book a meeting to the event using Tab A.
  - **Old Behavior:** User can still book for the same day. Slot won't show as full unless page is refreshed.
  - **New Behavior:** Switch to Tab B. Slot should now show as fully booked.


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
