### PR TITLE
Consistent Behavior in Displaying Timezones on Availabilities

### DIFF
--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -51,6 +51,12 @@ export function ScheduleListItem({
               )}
             </div>
             <p className="mt-1 text-xs text-gray-500">
+              {(schedule.timeZone || displayOptions?.timeZone) && (
+                <p className="my-1 flex items-center first-letter:text-xs">
+                  <FiGlobe />
+                  &nbsp;{schedule.timeZone ?? displayOptions?.timeZone}
+                </p>
+              )}
               {schedule.availability
                 .filter((availability) => !!availability.days.length)
                 .map((availability) => (
@@ -62,12 +68,6 @@ export function ScheduleListItem({
                     <br />
                   </Fragment>
                 ))}
-              {schedule.timeZone && schedule.timeZone !== displayOptions?.timeZone && (
-                <p className="my-1 flex items-center first-letter:text-xs">
-                  <FiGlobe />
-                  &nbsp;{schedule.timeZone}
-                </p>
-              )}
             </p>
           </Link>
         </div>


### PR DESCRIPTION
## What does this PR do?

Display timezones on availabilities regardless of whether there are no days available.

Fixes #7073  

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/61478825/218605426-30bccd0d-9b2e-42a0-ba82-385d95e59d78.png">

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)