### PR TITLE
Button loading spinner not showing clearly for dark and light modes

### DIFF
--- a/packages/ui/components/button/Button.tsx
+++ b/packages/ui/components/button/Button.tsx
@@ -221,7 +221,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
       {loading && (
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform">
           <svg
-            className="mx-4 h-5 w-5 animate-spin text-black dark:text-white"
+            className="mx-4 h-5 w-5 animate-spin text-white dark:text-black"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24">


### PR DESCRIPTION
## What does this PR do?
Fixes the button loading spinner styles for both light and dark themed buttons.

Fixes # (issue)
https://www.loom.com/share/a2fe28b17e364a4aa92edc5728100a26

**Environment**: Staging(main branch) / Production

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
It's a TailwindCSS change and doesn't have dedicated tests but I have provided a video to show the visual change that has been made below;
https://www.loom.com/share/3030223f285e448a8796849c8d1f8124

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
