### PR TITLE
Booking page now displays localized dates, times, and timezones

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -28,7 +28,11 @@ import {
 import { parseRecurringEvent } from "@calcom/lib";
 import CustomBranding from "@calcom/lib/CustomBranding";
 import { APP_NAME } from "@calcom/lib/constants";
-import { formatTime } from "@calcom/lib/date-fns";
+import {
+  formatToLocalizedDate,
+  formatToLocalizedTime,
+  formatToLocalizedTimezone,
+} from "@calcom/lib/date-fns";
 import { getDefaultEvent } from "@calcom/lib/defaultEvents";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
@@ -820,7 +824,10 @@ export function RecurringBookings({
   isCancelled,
 }: RecurringBookingsProps) {
   const [moreEventsVisible, setMoreEventsVisible] = useState(false);
-  const { t } = useLocale();
+  const {
+    t,
+    i18n: { language },
+  } = useLocale();
 
   const recurringBookingsSorted = recurringBookings
     ? recurringBookings.sort((a: ConfigType, b: ConfigType) => (dayjs(a).isAfter(dayjs(b)) ? 1 : -1))
@@ -843,11 +850,13 @@ export function RecurringBookings({
         {eventType.recurringEvent?.count &&
           recurringBookingsSorted.slice(0, 4).map((dateStr: string, idx: number) => (
             <div key={idx} className={classNames("mb-2", isCancelled ? "line-through" : "")}>
-              {dayjs.tz(dateStr, timeZone()).format("dddd, DD MMMM YYYY")}
+              {formatToLocalizedDate(dayjs.tz(dateStr, timeZone()), language, "full")}
               <br />
-              {formatTime(dateStr, is24h ? 24 : 12, timeZone().toLowerCase())} -{" "}
-              {formatTime(dayjs(dateStr).add(duration, "m"), is24h ? 24 : 12, timeZone().toLowerCase())}{" "}
-              <span className="text-bookinglight">({timeZone()})</span>
+              {formatToLocalizedTime(dayjs(dateStr), language, undefined, !is24h)} -{" "}
+              {formatToLocalizedTime(dayjs(dateStr).add(duration, "m"), language, undefined, !is24h)}{" "}
+              <span className="text-bookinglight">
+                ({formatToLocalizedTimezone(dayjs(dateStr), language)})
+              </span>
             </div>
           ))}
         {recurringBookingsSorted.length > 4 && (
@@ -861,11 +870,13 @@ export function RecurringBookings({
               {eventType.recurringEvent?.count &&
                 recurringBookingsSorted.slice(4).map((dateStr: string, idx: number) => (
                   <div key={idx} className={classNames("mb-2", isCancelled ? "line-through" : "")}>
-                    {dayjs.tz(dateStr, timeZone()).format("dddd, DD MMMM YYYY")}
+                    {formatToLocalizedDate(dayjs.tz(date, timeZone()), language, "full")}
                     <br />
-                    {formatTime(dateStr, is24h ? 24 : 12, timeZone().toLowerCase())} -{" "}
-                    {formatTime(dayjs(dateStr).add(duration, "m"), is24h ? 24 : 12, timeZone().toLowerCase())}{" "}
-                    <span className="text-bookinglight">({timeZone()})</span>
+                    {formatToLocalizedTime(date, language, undefined, !is24h)} -{" "}
+                    {formatToLocalizedTime(dayjs(date).add(duration, "m"), language, undefined, !is24h)}{" "}
+                    <span className="text-bookinglight">
+                      ({formatToLocalizedTimezone(dayjs(dateStr), language)})
+                    </span>
                   </div>
                 ))}
             </CollapsibleContent>
@@ -877,11 +888,11 @@ export function RecurringBookings({
 
   return (
     <div className={classNames(isCancelled ? "line-through" : "")}>
-      {dayjs.tz(date, timeZone()).format("dddd, DD MMMM YYYY")}
+      {formatToLocalizedDate(dayjs.tz(date, timeZone()), language, "full")}
       <br />
-      {formatTime(date, is24h ? 24 : 12, timeZone().toLowerCase())} -{" "}
-      {formatTime(dayjs(date).add(duration, "m"), is24h ? 24 : 12, timeZone().toLowerCase())}{" "}
-      <span className="text-bookinglight">({timeZone()})</span>
+      {formatToLocalizedTime(date, language, undefined, !is24h)} -{" "}
+      {formatToLocalizedTime(dayjs(date).add(duration, "m"), language, undefined, !is24h)}{" "}
+      <span className="text-bookinglight">({formatToLocalizedTimezone(date, language)})</span>
     </div>
   );
 }

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -30,6 +30,61 @@ export const formatTime = (
 };
 
 /**
+ * Returns a localized and translated date or time, based on the native
+ * Intl.DateTimeFormat available to JS. Undefined values mean the browser's
+ * locale will be used.
+ */
+export const formatLocalizedDateTime = (
+  date: Date | Dayjs,
+  options: Intl.DateTimeFormatOptions = {},
+  locale: string | undefined = undefined
+) => {
+  const theDate = date instanceof dayjs ? (date as Dayjs).toDate() : (date as Date);
+  return Intl.DateTimeFormat(locale, options).format(theDate);
+};
+
+/**
+ * Returns a localized and translated calendar day based on the
+ * given Date object and locale. Undefined values mean the defaults
+ * associated with the browser's current locale will be used.
+ */
+export const formatToLocalizedDate = (
+  date: Date | Dayjs,
+  locale: string | undefined = undefined,
+  dateStyle: Intl.DateTimeFormatOptions["dateStyle"] = "long"
+) => formatLocalizedDateTime(date, { dateStyle }, locale);
+
+/**
+ * Returns a localized and translated time of day based on the
+ * given Date object and locale. Undefined values mean the defaults
+ * associated with the browser's current locale will be used.
+ */
+export const formatToLocalizedTime = (
+  date: Date | Dayjs,
+  locale: string | undefined = undefined,
+  timeStyle: Intl.DateTimeFormatOptions["timeStyle"] = "short",
+  hour12: Intl.DateTimeFormatOptions["hour12"] = undefined
+) => formatLocalizedDateTime(date, { timeStyle, hour12 }, locale);
+
+/**
+ * Returns a translated timezone based on the given Date object and
+ * locale. Undefined values mean the browser's current locale
+ * will be used.
+ */
+export const formatToLocalizedTimezone = (
+  date: Date | Dayjs,
+  locale: string | undefined = undefined,
+  timeZoneName: Intl.DateTimeFormatOptions["timeZoneName"] = "long"
+) => {
+  // Intl.DateTimeFormat doesn't format into a timezone only, so we must
+  //  formatToParts() and return the piece we want
+  const theDate = date instanceof dayjs ? (date as Dayjs).toDate() : (date as Date);
+  return Intl.DateTimeFormat(locale, { timeZoneName })
+    .formatToParts(theDate)
+    .find((d) => d.type == "timeZoneName")?.value;
+};
+
+/**
  * Sorts two timezones by their offset from GMT.
  */
 export const sortByTimezone = (timezoneA: string, timezoneB: string) => {


### PR DESCRIPTION
⚠️ This is unfortunately a recreation of PR #6988 due to my own dumbness 🤦 

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6951 

Previously, the Booking page is fully translated **except** for the dates, times, and timezone. Below are relevant screenshots

| Production (English) | Production (German) |
| ----- | ----- |
| <img width="612" alt="Screenshot 2023-02-09 at 1 15 44 PM" src="https://user-images.githubusercontent.com/155617/217940905-32b8dd75-6f92-4345-8df4-3dc27db8d0e7.png"> | <img width="598" alt="Screenshot 2023-02-09 at 1 16 37 PM" src="https://user-images.githubusercontent.com/155617/217941077-ee3b2dc3-2b8a-44f4-95c2-73e2a396daaa.png">  |

 This PR does the following:
- Created new functions in the `@calcom/lib/date-fns` package which allow for simple localization / translation of any date within the codebase
- Updated the Booking page to use these new functions to achieve translation

| This Branch (English) | This Branch (German) |
| ----- | ----- |
| <img width="609" alt="Screenshot 2023-02-09 at 1 19 52 PM" src="https://user-images.githubusercontent.com/155617/217941637-cdf43da4-aeba-439c-9be4-b5c226e5bec9.png"> | <img width="603" alt="Screenshot 2023-02-09 at 1 18 59 PM" src="https://user-images.githubusercontent.com/155617/217941478-70e666a7-7257-4567-bb68-32939dc1ab20.png"> |

### Approach

This codebase makes heavy use of DayJS, which does have i18n functionality ([source](https://day.js.org/docs/en/i18n/loading-into-browser)). However this feature requires an additional import of the given locale's data. That means there would be an additional file loaded each time the user changes pages / changed languages.

This approach is likely overkill, because the DayJS locale data is likely [CLDR data](https://cldr.unicode.org/), which is available to use natively within Javascript through `Intl.DateTimeFormat` which is supported by [all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility). Additionally, relying on native Javascript means we are almost guaranteed to be using data from Unicode, which isn't necessarily the case with a third party library.

Therefore, this code adds very simple wrappers around the native `Intl.DateTimeFormat` function. The use of wrappers are recommended because in the future there will likely be a scenario in which we want to override the default. Putting this code within a few wrappers now will vastly simplify things for our future selves.

### FAQ

- **Who did the translations?** The translations are part of Common Locale Data Repository (CLDR), which is maintained by the Unicode Consortium ([view some of this data here](https://github.com/unicode-org/cldr-json)). CLDR is the source used by all major Operating Systems, Browsers, and everything in between. Under the hood, `Intl.DateTimeFormat` is referencing this data not only to get the translated value for "December" but also to know in which order the `de` locale expects a given date or time to be generated
- **Why did the English output change?** Since the correct date localization varies so widely by any combination of language + region, proper localization means giving up a bit of control to Unicode's CLDR. The difference output is a result of the Unicode Consortium determining that value is likely the least-bad output for the given lang + region. It's an imperfect approach, which is why I've embedded this code into a simple wrapper so the Cal.com team can overwrite the Unicode defaults should the need arise.
- **How does this code determine which language to show?** The localization will target any authenticated user's preferred language, otherwise it falls back to the locale set by the browser.

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Book a meeting for any given event, in any given language
2. Observe the Date, Time, and Timezone output of the confirmation page
3. If authenticated, change your preferred language and observe the Date, Time, and Timezone are now translated into the desired language
4. If unauthenticated, change your browser's preferred language then observe the Date, Time, and Timezone are now translated into the desired language

## Checklist

- No tests fail as a result of this change