### PR TITLE
fix(app): disable edit availability link while fetching

### DIFF
--- a/apps/web/components/eventtype/AvailabilityTab.tsx
+++ b/apps/web/components/eventtype/AvailabilityTab.tsx
@@ -157,6 +157,7 @@ const EventTypeScheduleDetails = () => {
         </span>
         <Button
           href={`/availability/${schedule?.schedule.id}`}
+          disabled={isLoading}
           color="minimal"
           EndIcon={FiExternalLink}
           target="_blank"


### PR DESCRIPTION
## What does this PR do?

Disables the "Edit availability" link when editing an event type until the availability has finished fetching. Handles an issue where clicking the link otherwise would cause it to link to `/availbilities/undefined`

Fixes #7124 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

[ ] Edit an event type, click on the availability tab and verify that the "Edit availability" link is not clickable while the availability is still fetching.
