### PR TITLE
Add max h to booking filters

### DIFF
--- a/packages/ui/components/popover/AnimatedPopover.tsx
+++ b/packages/ui/components/popover/AnimatedPopover.tsx
@@ -62,7 +62,7 @@ export const AnimatedPopover = ({
       <Popover.Content side="bottom" align={align} asChild>
         <div
           className={classNames(
-            "absolute z-50 mt-2 w-56  rounded-md bg-white  py-[2px] shadow-sm ring-1 ring-black ring-opacity-5 focus-within:outline-none",
+            "absolute z-50 mt-2 max-h-64 w-56 overflow-y-scroll rounded-md bg-white py-[2px] shadow-sm ring-1 ring-black ring-opacity-5 focus-within:outline-none",
             align === "end" && "-translate-x-[228px]"
           )}>
           {children}


### PR DESCRIPTION
Adds a max-h to any animated popovers making them scrollable when they go over this.

Used in booking filters 