### PR TITLE
Removed 'as any' in jackson.ts

### DIFF
--- a/packages/features/ee/sso/lib/jackson.ts
+++ b/packages/features/ee/sso/lib/jackson.ts
@@ -1,9 +1,10 @@
-import jackson, {
+import type {
   IConnectionAPIController,
   IOAuthController,
   JacksonOption,
   ISPSAMLConfig,
 } from "@boxyhq/saml-jackson";
+import jackson from "@boxyhq/saml-jackson";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 
@@ -27,10 +28,16 @@ let connectionController: IConnectionAPIController;
 let oauthController: IOAuthController;
 let samlSPConfig: ISPSAMLConfig;
 
-const g = global as any;
+const g = global;
+
+declare global {
+  var connectionController: IConnectionAPIController | undefined;
+  var oauthController: IOAuthController | undefined;
+  var samlSPConfig: ISPSAMLConfig | undefined;
+}
 
 export default async function init() {
-  if (!g.connectionController || !g.oauthController) {
+  if (!g.connectionController || !g.oauthController || !g.samlSPConfig) {
     const ret = await jackson(opts);
 
     connectionController = ret.connectionAPIController;


### PR DESCRIPTION
## What does this PR do?

Removes an 'as any' in `jackson.ts`.

Makes the `init` function also check if `g.samlSPConfig` is defined before returning it.

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Complete