### PR TITLE
Dont default empty to cal video

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -152,14 +152,11 @@ export const EventSetupTab = (
       return true;
     });
 
-    const defaultValue = getDefaultLocationValue(locationOptions, "integrations:daily");
-
     return (
       <div className="w-full">
         {validLocations.length === 0 && (
           <div className="flex">
             <LocationSelect
-              defaultValue={defaultValue}
               placeholder={t("select")}
               options={locationOptions}
               isSearchable={false}


### PR DESCRIPTION
https://www.loom.com/share/8af16d3dfec549769151ebac59d06461 

Fixes the issue where the user crosses the only location and gets stuck with cal video as default and on way to add new locations.

In short what is happening is we set the default value of the select but since the select isnt tied in with RHF this doesnt get picked up (Only the onchange events fire RHF manually).

(We hit this false here which we shouldnt ever hit) 
<img width="728" alt="CleanShot 2023-02-19 at 20 07 31@2x" src="https://user-images.githubusercontent.com/55134778/219972545-d4da80c6-875b-4c79-909d-276f29a7397f.png">

Thus the default value doesnt get set to the form and your end up with a broken state that the UI doesnt cover.

Removing cal video from default form state here prevents this (We set default on event creation so this isnt an issue)  