### PR TITLE
User email as impersonation if username is null

### DIFF
--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -5,7 +5,8 @@ import { useState } from "react";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { RouterOutputs, trpc } from "@calcom/trpc/react";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import {
   Avatar,
@@ -251,7 +252,7 @@ export default function MemberListItem(props: Props) {
               onSubmit={async (e) => {
                 e.preventDefault();
                 await signIn("impersonation-auth", {
-                  username: props.member.username,
+                  username: props.member.username || props.member.email,
                   teamId: props.team.id,
                 });
                 setShowImpersonateModal(false);


### PR DESCRIPTION
Fixes : https://github.com/calcom/cal.com/issues/7239

Enables you to impersonate a user via email. 

On teams side if the user has no username we fall back to their email instead 