### PR TITLE
Fix Embed Tests

### DIFF
--- a/packages/embeds/embed-core/playwright/config/playwright.config.ts
+++ b/packages/embeds/embed-core/playwright/config/playwright.config.ts
@@ -1,4 +1,5 @@
-import { PlaywrightTestConfig, Frame, devices, expect } from "@playwright/test";
+import type { PlaywrightTestConfig, Frame } from "@playwright/test";
+import { devices, expect } from "@playwright/test";
 import * as path from "path";
 
 require("dotenv").config({ path: "../../../../../.env" });

--- a/packages/embeds/embed-core/playwright/tests/action-based.test.ts
+++ b/packages/embeds/embed-core/playwright/tests/action-based.test.ts
@@ -1,6 +1,8 @@
-import { expect, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
-import { Fixtures, test } from "../fixtures/fixtures";
+import type { Fixtures } from "../fixtures/fixtures";
+import { test } from "../fixtures/fixtures";
 import {
   todo,
   getEmbedIframe,

--- a/turbo.json
+++ b/turbo.json
@@ -152,8 +152,7 @@
       "dependsOn": [
         "@calcom/prisma#db-seed",
         "@calcom/web#build",
-        "@calcom/embed-core#build",
-        "@calcom/embed-react#build",
+        "^build",
         "^embed-tests-update-snapshots:ci"
       ]
     },


### PR DESCRIPTION
Fixes embed.js being 404 in tests. I couldn't  point out the reason why it was happening, but I tried to simplify turbo pipeline and it endedup fixing the issue.