### PR TITLE
Fixes password recovery email displays unparsed username

### DIFF
--- a/apps/web/public/static/locales/es/common.json
+++ b/apps/web/public/static/locales/es/common.json
@@ -76,7 +76,7 @@
   "rescheduled_event_type_subject": "Solicitud de reprogramación enviada: {{eventType}} con {{name}} el {{date}}",
   "requested_to_reschedule_subject_attendee": "Reprogramar acción requerida: reserva una nueva hora para {{eventType}} con {{name}}",
   "reschedule_reason": "Motivo de la reprogramación",
-  "hi_user_name": "Hola {{userName}}",
+  "hi_user_name": "Hola {{name}}",
   "ics_event_title": "{{eventType}} con {{name}}",
   "new_event_subject": "Nuevo Evento: {{attendeeName}} - {{date}} - {{eventType}}",
   "join_by_entrypoint": "Únase por {{entryPoint}}",

--- a/apps/web/public/static/locales/ro/common.json
+++ b/apps/web/public/static/locales/ro/common.json
@@ -76,7 +76,7 @@
   "rescheduled_event_type_subject": "Cerere de reprogramare trimisă: {{eventType}} cu {{name}} în {{date}}",
   "requested_to_reschedule_subject_attendee": "Acțiunea necesită reprogramare: rezervați o nouă dată pentru {{eventType}} cu {{name}}",
   "reschedule_reason": "Motivul reprogramării",
-  "hi_user_name": "Salut {{userName}}",
+  "hi_user_name": "Salut {{name}}",
   "ics_event_title": "{{eventType}} cu {{name}}",
   "new_event_subject": "Eveniment nou: {{attendeeName}} - {{date}} - {{eventType}}",
   "join_by_entrypoint": "Alăturați-vă de {{entryPoint}}",


### PR DESCRIPTION
## What does this PR do?

Fixes that password recovery email displays unparsed username in 2 languages

Fixes #7285