### PR TITLE
Hotfix/ Fix failing build due to terser missing

### DIFF
--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/embed-core",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "This is the vanilla JS core script that embeds Cal Link",
   "main": "./dist/embed/embed.js",
   "types": "./dist/index.d.ts",

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@calcom/embed-react",
   "sideEffects": false,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Embed Cal Link as a React Component",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@calcom/embed-snippet",
   "sideEffects": false,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "./dist/snippet.umd.js",
   "module": "./dist/snippet.es.js",
   "description": "Vanilla JS embed snippet that is responsible to fetch @calcom/embed-core and thus show Cal Link as an embed on a page.",

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -25,7 +25,8 @@
   "types": "./dist/index.d.ts",
   "devDependencies": {
     "eslint": "^8.34.0",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "vite": "^4.1.2"
   },
   "dependencies": {
     "@calcom/embed-core": "*"

--- a/packages/embeds/embed-snippet/vite.config.js
+++ b/packages/embeds/embed-snippet/vite.config.js
@@ -11,9 +11,5 @@ module.exports = defineConfig({
       name: "snippet",
       fileName: (format) => `snippet.${format}.js`,
     },
-    minify: "terser",
-    terserOptions: {
-      compress: true,
-    },
   },
 });


### PR DESCRIPTION
Fixes #7277

It wasn't breaking earlier, a simple Vite upgrade has broken it. Here is the reason for that https://vitejs.dev/blog/announcing-vite3.html#bundle-size-reduction