### PR TITLE
Add embed versions

### DIFF
--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -50,7 +50,7 @@
     "vite": "^4.1.2"
   },
   "dependencies": {
-    "@calcom/embed-core": "*",
-    "@calcom/embed-snippet": "*"
+    "@calcom/embed-core": "^1.1.2",
+    "@calcom/embed-snippet": "^1.0.4"
   }
 }

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -28,6 +28,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@calcom/embed-core": "*"
+    "@calcom/embed-core": "^1.1.2"
   }
 }


### PR DESCRIPTION
It is important to add embed versions so that packages are very clear on what their dependency's version is.

**embed-react** may not be compatible with all previous versions of **embed-core**

The dependency version was changed to '*' in [this PR](https://github.com/calcom/cal.com/pull/3139), so I hope if build is passing it should be okay to merge.