### PR TITLE
fix non-admin team preview button

### DIFF
--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -92,7 +92,7 @@ const ProfileView = () => {
   const isAdmin =
     team && (team.membership.role === MembershipRole.OWNER || team.membership.role === MembershipRole.ADMIN);
 
-  const permalink = `${CAL_URL?.replace(/^(https?:|)\/\//, "")}/team/${team?.slug}`;
+  const permalink = `${WEBAPP_URL}/team/${team?.slug}`;
 
   const isBioEmpty = !team || !team.bio || !team.bio.replace("<p><br></p>", "").length;
 


### PR DESCRIPTION
fix the non admin preview button taking you to an invalid URL with [id] in the URL

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Act as a user in a team, that's not an admin or owner, go to the Team -> Profile page in Settings. and click preview - the URL is wrong, then try after my PR and it's right - the copy link also uses this feature and worked before, but that still works in this.

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
