### PR TITLE
Fixes event type options for team workflows

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowDetailsPage.tsx
+++ b/packages/features/ee/workflows/components/WorkflowDetailsPage.tsx
@@ -42,8 +42,10 @@ export default function WorkflowDetailsPage(props: Props) {
   const eventTypeOptions = useMemo(
     () =>
       data?.eventTypeGroups.reduce((options, group) => {
-        /** only show event types that belong to team or user */
-        if (!(!teamId && !group.teamId) || teamId !== group.teamId) return options;
+        /** don't show team event types for user workflow */
+        if (!teamId && group.teamId) return options;
+        /** only show correct team event types for team workflows */
+        if (teamId && teamId !== group.teamId) return options;
         return [
           ...options,
           ...group.eventTypes.map((eventType) => ({


### PR DESCRIPTION
## What does this PR do?

Fixes that for team workflows no event types are shown in the  _Which event type will this apply to?_ dropdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create at least one team + event types 
- Create a user workflow => see if it only shows your user event types 
- Create a team workflow => see if it only shows the event types of the team