### PR TITLE
HotFix for Main Branch: Booking Page Crash if it has no attendees 

### DIFF
--- a/apps/web/lib/getBooking.tsx
+++ b/apps/web/lib/getBooking.tsx
@@ -30,8 +30,9 @@ function getResponsesFromOldBooking(
     return acc;
   }, {});
   return {
-    name: rawBooking.attendees[0].name,
-    email: rawBooking.attendees[0].email,
+    // It is possible to have no attendees in a booking when the booking is cancelled.
+    name: rawBooking.attendees[0]?.name || "Nameless",
+    email: rawBooking.attendees[0]?.email || "",
     guests: rawBooking.attendees.slice(1).map((attendee) => {
       return attendee.email;
     }),


### PR DESCRIPTION
The bug is in `main` only right now. I just stumbled upon a booking in my local DB which had no attendees.