### PR TITLE
Fixes formatting issues with lists in event type description and bio

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -1,7 +1,6 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isValidPhoneNumber } from "libphonenumber-js";
-import MarkdownIt from "markdown-it";
 import { Trans } from "next-i18next";
 import Link from "next/link";
 import type { EventTypeSetupProps, FormValues } from "pages/event-types/[type]";
@@ -19,11 +18,11 @@ import turndown from "@calcom/lib/turndownService";
 import { Button, Editor, Label, Select, SettingsToggle, Skeleton, TextField } from "@calcom/ui";
 import { FiEdit2, FiCheck, FiX, FiPlus } from "@calcom/ui/components/icon";
 
+import { md } from "@lib/markdownIt";
+
 import { EditLocationDialog } from "@components/dialog/EditLocationDialog";
 import type { SingleValueLocationOption, LocationOption } from "@components/ui/form/LocationSelect";
 import LocationSelect from "@components/ui/form/LocationSelect";
-
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
 
 const getLocationFromType = (
   type: EventLocationType["type"],

--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -13,12 +13,11 @@ import type { EventLocationType } from "@calcom/app-store/locations";
 import { getEventLocationType, MeetLocationType, LocationType } from "@calcom/app-store/locations";
 import { CAL_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
 import { slugify } from "@calcom/lib/slugify";
 import turndown from "@calcom/lib/turndownService";
 import { Button, Editor, Label, Select, SettingsToggle, Skeleton, TextField } from "@calcom/ui";
 import { FiEdit2, FiCheck, FiX, FiPlus } from "@calcom/ui/components/icon";
-
-import { md } from "@lib/markdownIt";
 
 import { EditLocationDialog } from "@components/dialog/EditLocationDialog";
 import type { SingleValueLocationOption, LocationOption } from "@components/ui/form/LocationSelect";

--- a/apps/web/components/getting-started/steps-views/UserProfile.tsx
+++ b/apps/web/components/getting-started/steps-views/UserProfile.tsx
@@ -1,5 +1,4 @@
 import { ArrowRightIcon } from "@heroicons/react/solid";
-import MarkdownIt from "markdown-it";
 import { useRouter } from "next/router";
 import type { FormEvent } from "react";
 import { useRef, useState } from "react";
@@ -12,9 +11,9 @@ import { trpc } from "@calcom/trpc/react";
 import { Button, Editor, ImageUploader, Label, showToast } from "@calcom/ui";
 import { Avatar } from "@calcom/ui";
 
-import type { IOnboardingPageProps } from "../../../pages/getting-started/[[...step]]";
+import { md } from "@lib/markdownIt";
 
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+import type { IOnboardingPageProps } from "../../../pages/getting-started/[[...step]]";
 
 type FormData = {
   bio: string;

--- a/apps/web/components/getting-started/steps-views/UserProfile.tsx
+++ b/apps/web/components/getting-started/steps-views/UserProfile.tsx
@@ -5,13 +5,12 @@ import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
 import { telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import turndown from "@calcom/lib/turndownService";
 import { trpc } from "@calcom/trpc/react";
 import { Button, Editor, ImageUploader, Label, showToast } from "@calcom/ui";
 import { Avatar } from "@calcom/ui";
-
-import { md } from "@lib/markdownIt";
 
 import type { IOnboardingPageProps } from "../../../pages/getting-started/[[...step]]";
 

--- a/apps/web/components/team/screens/Team.tsx
+++ b/apps/web/components/team/screens/Team.tsx
@@ -3,9 +3,8 @@ import type { TeamPageProps } from "pages/team/[slug]";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
 import { Avatar } from "@calcom/ui";
-
-import { md } from "@lib/markdownIt";
 
 type TeamType = TeamPageProps["team"];
 type MembersType = TeamType["members"];

--- a/apps/web/components/team/screens/Team.tsx
+++ b/apps/web/components/team/screens/Team.tsx
@@ -1,4 +1,3 @@
-import MarkdownIt from "markdown-it";
 import Link from "next/link";
 import type { TeamPageProps } from "pages/team/[slug]";
 
@@ -6,7 +5,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Avatar } from "@calcom/ui";
 
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+import { md } from "@lib/markdownIt";
 
 type TeamType = TeamPageProps["team"];
 type MembersType = TeamType["members"];
@@ -19,7 +18,7 @@ const Member = ({ member, teamName }: { member: MemberType; teamName: string | n
 
   return (
     <Link key={member.id} href={`/${member.username}`}>
-      <div className="sm:min-w-80 sm:max-w-80 dark:bg-darkgray-200 dark:hover:bg-darkgray-300 group flex min-h-full flex-col space-y-2 rounded-md bg-white p-4  hover:cursor-pointer hover:bg-gray-50 ">
+      <div className="sm:min-w-80 sm:max-w-80 dark:bg-darkgray-200 dark:hover:bg-darkgray-300 group flex min-h-full flex-col space-y-2 rounded-md bg-white p-4 hover:cursor-pointer hover:bg-gray-50 ">
         <Avatar
           size="md"
           alt={member.name || ""}

--- a/apps/web/lib/markdownIt.ts
+++ b/apps/web/lib/markdownIt.ts
@@ -1,0 +1,9 @@
+import MarkdownIt from "markdown-it";
+
+export const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+
+export function addListFormatting(html: string) {
+  return html
+    .replaceAll("<ul>", "<ul style='list-style-type: disc; list-style-position: inside'>")
+    .replaceAll("<ol>", "<ol style='list-style-type: decimal; list-style-position: inside'>");
+}

--- a/apps/web/lib/markdownIt.ts
+++ b/apps/web/lib/markdownIt.ts
@@ -1,9 +1,0 @@
-import MarkdownIt from "markdown-it";
-
-export const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
-
-export function addListFormatting(html: string) {
-  return html
-    .replaceAll("<ul>", "<ul style='list-style-type: disc; list-style-position: inside'>")
-    .replaceAll("<ol>", "<ol style='list-style-type: decimal; list-style-position: inside'>");
-}

--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -1,6 +1,5 @@
 import { BadgeCheckIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
-import MarkdownIt from "markdown-it";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -31,12 +30,11 @@ import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import { Avatar, AvatarGroup, HeadSeo } from "@calcom/ui";
 import { FiArrowRight } from "@calcom/ui/components/icon";
 
+import { md } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 import type { EmbedProps } from "@lib/withEmbedSsr";
 
 import { ssrInit } from "@server/lib/ssr";
-
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
 
 export default function User(props: inferSSRProps<typeof getServerSideProps> & EmbedProps) {
   const { users, profile, eventTypes, isDynamicGroup, dynamicNames, dynamicUsernames, isSingleUser } = props;
@@ -147,7 +145,7 @@ export default function User(props: inferSSRProps<typeof getServerSideProps> & E
               {!isBioEmpty && (
                 <>
                   <div
-                    className="dark:text-darkgray-600 text-sm text-gray-500 [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
+                    className=" dark:text-darkgray-600 text-sm text-gray-500 [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
                     dangerouslySetInnerHTML={{ __html: md.render(user.bio || "") }}
                   />
                 </>

--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -23,6 +23,7 @@ import defaultEvents, {
 } from "@calcom/lib/defaultEvents";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
+import { md } from "@calcom/lib/markdownIt";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import prisma from "@calcom/prisma";
 import { baseEventTypeSelect } from "@calcom/prisma/selects";
@@ -30,7 +31,6 @@ import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import { Avatar, AvatarGroup, HeadSeo } from "@calcom/ui";
 import { FiArrowRight } from "@calcom/ui/components/icon";
 
-import { md } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 import type { EmbedProps } from "@lib/withEmbedSsr";
 

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -8,6 +8,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { User } from "@calcom/prisma/client";
 
 import { isBrandingHidden } from "@lib/isBrandingHidden";
+import { addListFormatting } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 import type { EmbedProps } from "@lib/withEmbedSsr";
 
@@ -152,7 +153,7 @@ async function getUserPageProps(context: GetStaticPropsContext) {
     metadata: EventTypeMetaDataSchema.parse(eventType.metadata || {}),
     recurringEvent: parseRecurringEvent(eventType.recurringEvent),
     locations: privacyFilteredLocations(locations),
-    descriptionAsSafeHTML: eventType.description ? md.render(eventType.description) : null,
+    descriptionAsSafeHTML: eventType.description ? addListFormatting(md.render(eventType.description)) : null,
   });
   // Check if the user you are logging into has any active teams or premium user name
   const hasActiveTeam =

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -5,10 +5,10 @@ import type { LocationObject } from "@calcom/app-store/locations";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import hasKeyInMetadata from "@calcom/lib/hasKeyInMetadata";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { addListFormatting } from "@calcom/lib/markdownIt";
 import type { User } from "@calcom/prisma/client";
 
 import { isBrandingHidden } from "@lib/isBrandingHidden";
-import { addListFormatting } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 import type { EmbedProps } from "@lib/withEmbedSsr";
 

--- a/apps/web/pages/settings/my-account/profile.tsx
+++ b/apps/web/pages/settings/my-account/profile.tsx
@@ -1,6 +1,5 @@
 import { IdentityProvider } from "@prisma/client";
 import crypto from "crypto";
-import MarkdownIt from "markdown-it";
 import { signOut } from "next-auth/react";
 import type { BaseSyntheticEvent } from "react";
 import { useRef, useState } from "react";
@@ -38,10 +37,10 @@ import {
 } from "@calcom/ui";
 import { FiAlertTriangle, FiTrash2 } from "@calcom/ui/components/icon";
 
+import { md } from "@lib/markdownIt";
+
 import TwoFactor from "@components/auth/TwoFactor";
 import { UsernameAvailabilityField } from "@components/ui/UsernameAvailability";
-
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
 
 const SkeletonLoader = ({ title, description }: { title: string; description: string }) => {
   return (
@@ -371,6 +370,7 @@ const ProfileForm = ({
             formMethods.setValue("bio", turndown(value), { shouldDirty: true });
           }}
           excludedToolbarItems={["blockType"]}
+          disableLists
         />
       </div>
       <Button disabled={isDisabled} color="primary" className="mt-8" type="submit">

--- a/apps/web/pages/settings/my-account/profile.tsx
+++ b/apps/web/pages/settings/my-account/profile.tsx
@@ -9,6 +9,7 @@ import { getLayout } from "@calcom/features/settings/layouts/SettingsLayout";
 import { ErrorCode } from "@calcom/lib/auth";
 import { APP_NAME } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
 import turndown from "@calcom/lib/turndownService";
 import type { TRPCClientErrorLike } from "@calcom/trpc/client";
 import { trpc } from "@calcom/trpc/react";
@@ -36,8 +37,6 @@ import {
   Editor,
 } from "@calcom/ui";
 import { FiAlertTriangle, FiTrash2 } from "@calcom/ui/components/icon";
-
-import { md } from "@lib/markdownIt";
 
 import TwoFactor from "@components/auth/TwoFactor";
 import { UsernameAvailabilityField } from "@components/ui/UsernameAvailability";

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -10,13 +10,13 @@ import { CAL_URL } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/getPlaceholderAvatar";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
+import { md } from "@calcom/lib/markdownIt";
 import { getTeamWithMembers } from "@calcom/lib/server/queries/teams";
 import { collectPageParameters, telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import { Avatar, Button, HeadSeo, AvatarGroup } from "@calcom/ui";
 import { FiArrowRight } from "@calcom/ui/components/icon";
 
 import { useToggleQuery } from "@lib/hooks/useToggleQuery";
-import { md } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 
 import Team from "@components/team/screens/Team";

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import MarkdownIt from "markdown-it";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -17,13 +16,12 @@ import { Avatar, Button, HeadSeo, AvatarGroup } from "@calcom/ui";
 import { FiArrowRight } from "@calcom/ui/components/icon";
 
 import { useToggleQuery } from "@lib/hooks/useToggleQuery";
+import { md } from "@lib/markdownIt";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 
 import Team from "@components/team/screens/Team";
 
 import { ssrInit } from "@server/lib/ssr";
-
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
 
 export type TeamPageProps = inferSSRProps<typeof getServerSideProps>;
 function TeamPage({ team }: TeamPageProps) {

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -223,6 +223,7 @@ const ProfileView = () => {
                   getText={() => md.render(form.getValues("bio") || "")}
                   setText={(value: string) => form.setValue("bio", turndown(value))}
                   excludedToolbarItems={["blockType"]}
+                  disableLists
                 />
               </div>
               <p className="mt-2 text-sm text-gray-600">{t("team_description")}</p>

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Prisma } from "@prisma/client";
 import { MembershipRole } from "@prisma/client";
-import MarkdownIt from "markdown-it";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -31,9 +30,9 @@ import {
 } from "@calcom/ui";
 import { FiExternalLink, FiLink, FiTrash2, FiLogOut } from "@calcom/ui/components/icon";
 
-import { getLayout } from "../../../settings/layouts/SettingsLayout";
+import { md } from "@lib/markdownIt";
 
-const md = new MarkdownIt("default", { html: true, breaks: true });
+import { getLayout } from "../../../settings/layouts/SettingsLayout";
 
 const regex = new RegExp("^[a-zA-Z0-9-]*$");
 

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/getPlaceholderAvatar";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { md } from "@calcom/lib/markdownIt";
 import objectKeys from "@calcom/lib/objectKeys";
 import turndown from "@calcom/lib/turndownService";
 import { trpc } from "@calcom/trpc/react";
@@ -29,8 +30,6 @@ import {
   Editor,
 } from "@calcom/ui";
 import { FiExternalLink, FiLink, FiTrash2, FiLogOut } from "@calcom/ui/components/icon";
-
-import { md } from "@lib/markdownIt";
 
 import { getLayout } from "../../../settings/layouts/SettingsLayout";
 

--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SchedulingType } from "@prisma/client";
 import { isValidPhoneNumber } from "libphonenumber-js";
-import MarkdownIt from "markdown-it";
 import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -9,6 +8,7 @@ import { z } from "zod";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useTypedQuery } from "@calcom/lib/hooks/useTypedQuery";
 import { HttpError } from "@calcom/lib/http-error";
+import { md } from "@calcom/lib/markdownIt";
 import slugify from "@calcom/lib/slugify";
 import turndown from "@calcom/lib/turndownService";
 import { createEventTypeInput } from "@calcom/prisma/zod/custom/eventtype";
@@ -25,8 +25,6 @@ import {
   TextField,
   Editor,
 } from "@calcom/ui";
-
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
 
 // this describes the uniform data needed to create a new event type on Profile or Team
 export interface EventTypeParent {
@@ -203,26 +201,26 @@ export default function CreateEventTypeDialog() {
                     message={form.formState.errors.schedulingType.message}
                   />
                 )}
-                <RadioArea.Group className="flex mt-1 space-x-4">
+                <RadioArea.Group className="mt-1 flex space-x-4">
                   <RadioArea.Item
                     {...register("schedulingType")}
                     value={SchedulingType.COLLECTIVE}
                     className="w-1/2 text-sm">
-                    <strong className="block mb-1">{t("collective")}</strong>
+                    <strong className="mb-1 block">{t("collective")}</strong>
                     <p>{t("collective_description")}</p>
                   </RadioArea.Item>
                   <RadioArea.Item
                     {...register("schedulingType")}
                     value={SchedulingType.ROUND_ROBIN}
                     className="w-1/2 text-sm">
-                    <strong className="block mb-1">{t("round_robin")}</strong>
+                    <strong className="mb-1 block">{t("round_robin")}</strong>
                     <p>{t("round_robin_description")}</p>
                   </RadioArea.Item>
                 </RadioArea.Group>
               </div>
             )}
           </div>
-          <div className="flex flex-row-reverse mt-8 gap-x-2">
+          <div className="mt-8 flex flex-row-reverse gap-x-2">
             <Button type="submit" loading={createMutation.isLoading}>
               {t("continue")}
             </Button>

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -1,14 +1,14 @@
-import { Prisma, SchedulingType } from "@prisma/client";
-import MarkdownIt from "markdown-it";
+import type { Prisma } from "@prisma/client";
+import { SchedulingType } from "@prisma/client";
 import { useMemo } from "react";
 import { FormattedNumber, IntlProvider } from "react-intl";
-import { z } from "zod";
+import type { z } from "zod";
 
 import { classNames, parseRecurringEvent } from "@calcom/lib";
 import getPaymentAppData from "@calcom/lib/getPaymentAppData";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { baseEventTypeSelect } from "@calcom/prisma";
-import { EventTypeModel } from "@calcom/prisma/zod";
+import type { baseEventTypeSelect } from "@calcom/prisma";
+import type { EventTypeModel } from "@calcom/prisma/zod";
 import { Badge } from "@calcom/ui";
 import {
   FiClock,
@@ -19,6 +19,8 @@ import {
   FiPlus,
   FiUser,
 } from "@calcom/ui/components/icon";
+
+import { md } from "@lib/markdownIt";
 
 export type EventTypeDescriptionProps = {
   eventType: Pick<
@@ -31,8 +33,6 @@ export type EventTypeDescriptionProps = {
   className?: string;
   shortenDescription?: true;
 };
-
-const md = new MarkdownIt("default", { html: true, breaks: false, linkify: true });
 
 export const EventTypeDescription = ({
   eventType,

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -30,7 +30,7 @@ export type EventTypeDescriptionProps = {
     seatsPerTimeSlot?: number;
   };
   className?: string;
-  shortenDescription?: true;
+  shortenDescription?: boolean;
 };
 
 export const EventTypeDescription = ({
@@ -57,9 +57,7 @@ export const EventTypeDescription = ({
               shortenDescription ? "line-clamp-4" : ""
             )}
             dangerouslySetInnerHTML={{
-              __html: shortenDescription
-                ? addListFormatting(md.render(eventType.description?.replace(/<p><br><\/p>|\n/g, " ")))
-                : addListFormatting(md.render(eventType.description)),
+              __html: addListFormatting(md.render(eventType.description)),
             }}
           />
         )}

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -7,6 +7,7 @@ import type { z } from "zod";
 import { classNames, parseRecurringEvent } from "@calcom/lib";
 import getPaymentAppData from "@calcom/lib/getPaymentAppData";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { addListFormatting, md } from "@calcom/lib/markdownIt";
 import type { baseEventTypeSelect } from "@calcom/prisma";
 import type { EventTypeModel } from "@calcom/prisma/zod";
 import { Badge } from "@calcom/ui";
@@ -19,8 +20,6 @@ import {
   FiPlus,
   FiUser,
 } from "@calcom/ui/components/icon";
-
-import { md } from "@lib/markdownIt";
 
 export type EventTypeDescriptionProps = {
   eventType: Pick<
@@ -59,8 +58,8 @@ export const EventTypeDescription = ({
             )}
             dangerouslySetInnerHTML={{
               __html: shortenDescription
-                ? md.render(eventType.description?.replace(/<p><br><\/p>|\n/g, " "))
-                : md.render(eventType.description),
+                ? addListFormatting(md.render(eventType.description?.replace(/<p><br><\/p>|\n/g, " ")))
+                : addListFormatting(md.render(eventType.description)),
             }}
           />
         )}

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -1,0 +1,12 @@
+import MarkdownIt from "markdown-it";
+
+export const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+
+export function addListFormatting(html: string) {
+  return html
+    .replaceAll("<ul>", "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px'>")
+    .replaceAll(
+      "<ol>",
+      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px'>"
+    );
+}

--- a/packages/prisma/middleware/eventTypeDescriptionParseAndSanitize.ts
+++ b/packages/prisma/middleware/eventTypeDescriptionParseAndSanitize.ts
@@ -1,7 +1,6 @@
 import type { PrismaClient, EventType } from "@prisma/client";
-import MarkdownIt from "markdown-it";
 
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+import { md } from "@lib/markdownIt";
 
 function parseAndSanitize(description: string) {
   const parsedMarkdown = md.render(description);

--- a/packages/prisma/middleware/eventTypeDescriptionParseAndSanitize.ts
+++ b/packages/prisma/middleware/eventTypeDescriptionParseAndSanitize.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, EventType } from "@prisma/client";
 
-import { md } from "@lib/markdownIt";
+import { md } from "@calcom/lib/markdownIt";
 
 function parseAndSanitize(description: string) {
   const parsedMarkdown = md.render(description);

--- a/packages/ui/components/editor/Editor.tsx
+++ b/packages/ui/components/editor/Editor.tsx
@@ -31,6 +31,7 @@ export type TextEditorProps = {
   variables?: string[];
   height?: string;
   placeholder?: string;
+  disableLists?: boolean;
 };
 
 const editorConfig = {
@@ -74,7 +75,15 @@ export const Editor = (props: TextEditorProps) => {
             <ListPlugin />
             <LinkPlugin />
             <AutoLinkPlugin />
-            <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+            <MarkdownShortcutPlugin
+              transformers={
+                props.disableLists
+                  ? TRANSFORMERS.filter((value, index) => {
+                      if (index !== 3 && index !== 4) return value;
+                    })
+                  : TRANSFORMERS
+              }
+            />
           </div>
         </div>
       </LexicalComposer>

--- a/packages/ui/components/editor/stylesEditor.css
+++ b/packages/ui/components/editor/stylesEditor.css
@@ -26,7 +26,7 @@
   text-align: left;
   border-color: #D1D5DB;
   border-width: 1px;
-  padding: 1px
+  padding: 1px;
 }
 
 .editor-inner {
@@ -37,6 +37,7 @@
   overflow: scroll;
   resize: vertical;
   height: auto;
+  min-height: 40px;
 }
 
 .editor-input {


### PR DESCRIPTION
## What does this PR do?

Lists were disabled in the editor for the bio as we don't have a good way to display it, because we have the text centered like that: 
<img width="328" alt="Screenshot 2023-03-03 at 17 33 51" src="https://user-images.githubusercontent.com/30310907/222844381-c8c6021b-3b34-4b6b-9ae6-396cabcc5d46.png">


Ordered and underordered list now for event type description: 
<img width="365" alt="Screenshot 2023-03-03 at 17 35 19" src="https://user-images.githubusercontent.com/30310907/222844574-c5ff5c4b-f871-4ed7-99e1-0d92bc469f7e.png">

<img width="784" alt="Screenshot 2023-03-03 at 17 36 43" src="https://user-images.githubusercontent.com/30310907/222844710-c35ca0dc-a717-4e41-a8b4-f5f5db43dced.png">

<img width="443" alt="Screenshot 2023-03-03 at 17 36 59" src="https://user-images.githubusercontent.com/30310907/222844736-ef36a4de-5e13-45e4-a229-9e026898e7a7.png">

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)