### PR TITLE
fix: use recordingId to check loading

### DIFF
--- a/apps/web/playwright/event-types.e2e.ts
+++ b/apps/web/playwright/event-types.e2e.ts
@@ -139,6 +139,8 @@ test.describe("Event Types tests", () => {
       const fillLocation = async (inputText: string) => {
         await page.locator("#location-select").click();
         await page.locator("text=In Person (Organizer Address)").click();
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(250);
         await page.locator('input[name="locationAddress"]').fill(inputText);
         await page.locator("[data-testid=display-location]").check();
         await page.locator("[data-testid=update-location]").click();

--- a/packages/features/ee/video/ViewRecordingsDialog.tsx
+++ b/packages/features/ee/video/ViewRecordingsDialog.tsx
@@ -94,12 +94,13 @@ const useRecordingDownload = () => {
       // assume it is still fetching, do nothing.
     },
     isFetching,
+    recordingId,
   };
 };
 
 const ViewRecordingsList = ({ roomName, hasPaidPlan }: { roomName: string; hasPaidPlan: boolean }) => {
   const { t } = useLocale();
-  const { setRecordingId, isFetching } = useRecordingDownload();
+  const { setRecordingId, isFetching, recordingId } = useRecordingDownload();
 
   const { data: recordings } = trpc.viewer.getCalVideoRecordings.useQuery(
     { roomName },
@@ -134,7 +135,7 @@ const ViewRecordingsList = ({ roomName, hasPaidPlan }: { roomName: string; hasPa
                   <Button
                     StartIcon={FiDownload}
                     className="ml-4 lg:ml-0"
-                    loading={isFetching}
+                    loading={isFetching && recordingId === recording.id}
                     onClick={() => handleDownloadClick(recording.id)}>
                     {t("download")}
                   </Button>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ if (IS_EMBED_TEST) {
 
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  retries: 2,
   workers: os.cpus().length,
   timeout: 60_000,
   maxFailures: headless ? 10 : undefined,


### PR DESCRIPTION
## What does this PR do?

Fixes regression from https://github.com/calcom/cal.com/pull/7495

every recording item was loading when clicked on one item 



https://user-images.githubusercontent.com/53316345/222983195-51a277fe-4810-42fe-9b59-28bd409cc1d9.mov



**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
