### PR TITLE
Fixes error when adding booking question without input type

### DIFF
--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -255,7 +255,7 @@ export const FormBuilder = function FormBuilder({
     remove(index);
   };
 
-  const fieldType = FieldTypesMap[fieldForm.watch("type")];
+  const fieldType = FieldTypesMap[fieldForm.watch("type") || "text"];
   const isFieldEditMode = fieldDialog.fieldIndex !== -1;
   return (
     <div>
@@ -374,6 +374,7 @@ export const FormBuilder = function FormBuilder({
             <Form
               form={fieldForm}
               handleSubmit={(data) => {
+                const type = data.type || "text";
                 const isNewField = fieldDialog.fieldIndex == -1;
                 if (isNewField && fields.some((f) => f.name === data.name)) {
                   showToast(t("form_builder_field_already_exists"), "error");
@@ -384,6 +385,7 @@ export const FormBuilder = function FormBuilder({
                 } else {
                   const field: RhfFormField = {
                     ...data,
+                    type,
                     sources: [
                       {
                         label: "User",
@@ -402,7 +404,7 @@ export const FormBuilder = function FormBuilder({
                 });
               }}>
               <SelectField
-                required
+                defaultValue={FieldTypes[3]} // "text" as defaultValue
                 isDisabled={
                   fieldForm.getValues("editable") === "system" ||
                   fieldForm.getValues("editable") === "system-but-optional"
@@ -543,7 +545,7 @@ export const ComponentForField = ({
   };
   readOnly: boolean;
 } & ValueProps) => {
-  const fieldType = field.type;
+  const fieldType = field.type || "text";
   const componentConfig = Components[fieldType];
 
   const isValueOfPropsType = (val: unknown, propsType: typeof componentConfig.propsType) => {


### PR DESCRIPTION
## What does this PR do?

A booking question without an input type can be added and after adding it this error is shown: 

<img width="599" alt="Screenshot 2023-03-06 at 14 43 49" src="https://user-images.githubusercontent.com/30310907/223214434-31cc0de3-8a56-4844-801a-89604af02c2e.png">

This PR sets 'Short Text' as the default value to avoid that error. 

**Environment**: Staging(main branch) 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)