### PR TITLE
Fix/incorrect timezone on booking success

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -790,7 +790,7 @@ export function RecurringBookings({
     t,
     i18n: { language },
   } = useLocale();
-
+  console.log(timeZone());
   const recurringBookingsSorted = recurringBookings
     ? recurringBookings.sort((a: ConfigType, b: ConfigType) => (dayjs(a).isAfter(dayjs(b)) ? 1 : -1))
     : null;
@@ -817,7 +817,7 @@ export function RecurringBookings({
               {formatToLocalizedTime(dayjs(dateStr), language, undefined, !is24h)} -{" "}
               {formatToLocalizedTime(dayjs(dateStr).add(duration, "m"), language, undefined, !is24h)}{" "}
               <span className="text-bookinglight">
-                ({formatToLocalizedTimezone(dayjs(dateStr), language)})
+                ({formatToLocalizedTimezone(dayjs(dateStr), language, timeZone())})
               </span>
             </div>
           ))}
@@ -837,7 +837,7 @@ export function RecurringBookings({
                     {formatToLocalizedTime(date, language, undefined, !is24h)} -{" "}
                     {formatToLocalizedTime(dayjs(date).add(duration, "m"), language, undefined, !is24h)}{" "}
                     <span className="text-bookinglight">
-                      ({formatToLocalizedTimezone(dayjs(dateStr), language)})
+                      ({formatToLocalizedTimezone(dayjs(dateStr), language, timeZone())})
                     </span>
                   </div>
                 ))}
@@ -854,7 +854,7 @@ export function RecurringBookings({
       <br />
       {formatToLocalizedTime(date, language, undefined, !is24h)} -{" "}
       {formatToLocalizedTime(dayjs(date).add(duration, "m"), language, undefined, !is24h)}{" "}
-      <span className="text-bookinglight">({formatToLocalizedTimezone(date, language)})</span>
+      <span className="text-bookinglight">({formatToLocalizedTimezone(date, language, timeZone())})</span>
     </div>
   );
 }

--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -790,7 +790,6 @@ export function RecurringBookings({
     t,
     i18n: { language },
   } = useLocale();
-  console.log(timeZone());
   const recurringBookingsSorted = recurringBookings
     ? recurringBookings.sort((a: ConfigType, b: ConfigType) => (dayjs(a).isAfter(dayjs(b)) ? 1 : -1))
     : null;

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -81,7 +81,6 @@ export const formatToLocalizedTimezone = (
   // Intl.DateTimeFormat doesn't format into a timezone only, so we must
   //  formatToParts() and return the piece we want
   const theDate = date instanceof dayjs ? (date as Dayjs).toDate() : (date as Date);
-  console.log(Intl.DateTimeFormat(locale, { timeZoneName, timeZone }).formatToParts(theDate));
   return Intl.DateTimeFormat(locale, { timeZoneName, timeZone })
     .formatToParts(theDate)
     .find((d) => d.type == "timeZoneName")?.value;

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -75,12 +75,14 @@ export const formatToLocalizedTime = (
 export const formatToLocalizedTimezone = (
   date: Date | Dayjs,
   locale: string | undefined = undefined,
+  timeZone: Intl.DateTimeFormatOptions["timeZone"],
   timeZoneName: Intl.DateTimeFormatOptions["timeZoneName"] = "long"
 ) => {
   // Intl.DateTimeFormat doesn't format into a timezone only, so we must
   //  formatToParts() and return the piece we want
   const theDate = date instanceof dayjs ? (date as Dayjs).toDate() : (date as Date);
-  return Intl.DateTimeFormat(locale, { timeZoneName })
+  console.log(Intl.DateTimeFormat(locale, { timeZoneName, timeZone }).formatToParts(theDate));
+  return Intl.DateTimeFormat(locale, { timeZoneName, timeZone })
     .formatToParts(theDate)
     .find((d) => d.type == "timeZoneName")?.value;
 };


### PR DESCRIPTION
## What does this PR do?

On the booking confirmation page the browser timezone is displayed and should show the timezone selected by the user.

![Captura de pantalla 2023-03-06 a la(s) 1 41 56 p m](https://user-images.githubusercontent.com/525369/223243103-b3150be2-34d4-45fe-bbd9-9668d23b8d63.png)

Result

![Captura de pantalla 2023-03-06 a la(s) 2 37 39 p m](https://user-images.githubusercontent.com/525369/223243172-7425de07-bc1a-4db2-a067-9615ac2b42a3.png)


- [x] Bug fix (non-breaking change which fixes an issue)
