### PR TITLE
Generate getSchedule response using the invitee timeZone

### DIFF
--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -367,25 +367,25 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   const computedAvailableSlots = availableTimeSlots.reduce(
     (
       r: Record<string, { time: string; users: string[]; attendees?: number; bookingUid?: string }[]>,
-      { time: time, ...passThroughProps }
+      { time: _time, ...passThroughProps }
     ) => {
-      const timeTZ = time.tz(input.timeZone);
-      r[timeTZ.format("YYYY-MM-DD")] = r[timeTZ.format("YYYY-MM-DD")] || [];
-      r[timeTZ.format("YYYY-MM-DD")].push({
+      const time = _time.tz(input.timeZone);
+      r[time.format("YYYY-MM-DD")] = r[time.format("YYYY-MM-DD")] || [];
+      r[time.format("YYYY-MM-DD")].push({
         ...passThroughProps,
-        time: timeTZ.toISOString(),
+        time: time.toISOString(),
         users: (eventType.hosts ? eventType.hosts.map((host) => host.user) : eventType.users).map(
           (user) => user.username || ""
         ),
         // Conditionally add the attendees and booking id to slots object if there is already a booking during that time
-        ...(currentSeats?.some((booking) => booking.startTime.toISOString() === timeTZ.toISOString()) && {
+        ...(currentSeats?.some((booking) => booking.startTime.toISOString() === time.toISOString()) && {
           attendees:
             currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === timeTZ.toISOString())
+              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
             ]._count.attendees,
           bookingUid:
             currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === timeTZ.toISOString())
+              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
             ].uid,
         }),
       });

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -369,22 +369,23 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       r: Record<string, { time: string; users: string[]; attendees?: number; bookingUid?: string }[]>,
       { time: time, ...passThroughProps }
     ) => {
-      r[time.format("YYYY-MM-DD")] = r[time.format("YYYY-MM-DD")] || [];
-      r[time.format("YYYY-MM-DD")].push({
+      const timeTZ = time.tz(input.timeZone);
+      r[timeTZ.format("YYYY-MM-DD")] = r[timeTZ.format("YYYY-MM-DD")] || [];
+      r[timeTZ.format("YYYY-MM-DD")].push({
         ...passThroughProps,
-        time: time.toISOString(),
+        time: timeTZ.toISOString(),
         users: (eventType.hosts ? eventType.hosts.map((host) => host.user) : eventType.users).map(
           (user) => user.username || ""
         ),
         // Conditionally add the attendees and booking id to slots object if there is already a booking during that time
-        ...(currentSeats?.some((booking) => booking.startTime.toISOString() === time.toISOString()) && {
+        ...(currentSeats?.some((booking) => booking.startTime.toISOString() === timeTZ.toISOString()) && {
           attendees:
             currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
+              currentSeats.findIndex((booking) => booking.startTime.toISOString() === timeTZ.toISOString())
             ]._count.attendees,
           bookingUid:
             currentSeats[
-              currentSeats.findIndex((booking) => booking.startTime.toISOString() === time.toISOString())
+              currentSeats.findIndex((booking) => booking.startTime.toISOString() === timeTZ.toISOString())
             ].uid,
         }),
       });

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -369,6 +369,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       r: Record<string, { time: string; users: string[]; attendees?: number; bookingUid?: string }[]>,
       { time: _time, ...passThroughProps }
     ) => {
+      // TODO: Adds unit tests to prevent regressions in getSchedule (try multiple timezones)
       const time = _time.tz(input.timeZone);
       r[time.format("YYYY-MM-DD")] = r[time.format("YYYY-MM-DD")] || [];
       r[time.format("YYYY-MM-DD")].push({


### PR DESCRIPTION
## What does this PR do?

fixed a bug when the organizer is in utc- and the guest is in utc+, the response of the getSchedule endpoint was not being 
formed correctly, when grouping by day the slots were being put in the wrong day/group. 


**This fix should correct many issues related to the differences with the connected calendars.**

Example of the current response:

![imagen](https://user-images.githubusercontent.com/525369/223601039-95f9ae35-324d-43e5-aedb-42241e96044b.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Create an event with utc-1 time zone e.g. America/Los_Angeles and on the booking page select an utc+ time zone e.g. Europe/Amsterdam. check that the times are displayed correctly.

