### PR TITLE
Fixing sessionTimeout conversion

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -342,7 +342,7 @@ export default NextAuth({
         if (user) {
           const metadata = userMetadata.parse(user.metadata);
           if (metadata?.sessionTimeout) {
-            maxAge = metadata.sessionTimeout / 60;
+            maxAge = metadata.sessionTimeout * 60;
           }
         }
       }


### PR DESCRIPTION
## What does this PR do?

After the last refactor the conversion to get the number stored in the DB representing minutes to set maxAge of session got bugged. This corrects it, number is DB is 10, then multiplied by 60 seconds get its representation in seconds as the session maxAge parameter needs.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Set up a session timeout in Settings > Password and see it respecting the defined number of minutes.
