### PR TITLE
Added serverside translations to the forgot password page.

### DIFF
--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -186,7 +186,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         },
         id,
         csrfToken: await getCsrfToken({ req: context.req }),
-        ...(await serverSideTranslations(context.locale || "en", ["common", "home"])),
+        ...(await serverSideTranslations(context.locale || "en", ["common"])),
       },
     };
   } catch (reason) {

--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -2,6 +2,7 @@ import type { ResetPasswordRequest } from "@prisma/client";
 import debounce from "lodash/debounce";
 import type { GetServerSidePropsContext } from "next";
 import { getCsrfToken } from "next-auth/react";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import React, { useMemo } from "react";
 
@@ -185,6 +186,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         },
         id,
         csrfToken: await getCsrfToken({ req: context.req }),
+        ...(await serverSideTranslations(context.locale || "en", ["common", "home"])),
       },
     };
   } catch (reason) {

--- a/apps/web/pages/auth/forgot-password/index.tsx
+++ b/apps/web/pages/auth/forgot-password/index.tsx
@@ -1,6 +1,7 @@
 import debounce from "lodash/debounce";
 import type { GetServerSidePropsContext } from "next";
 import { getCsrfToken } from "next-auth/react";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { SyntheticEvent } from "react";
@@ -144,5 +145,6 @@ ForgotPassword.getInitialProps = async (context: GetServerSidePropsContext) => {
 
   return {
     csrfToken: await getCsrfToken(context),
+    ...(await serverSideTranslations(context.locale || "en", ["common", "home"])),
   };
 };

--- a/apps/web/pages/auth/forgot-password/index.tsx
+++ b/apps/web/pages/auth/forgot-password/index.tsx
@@ -145,6 +145,6 @@ ForgotPassword.getInitialProps = async (context: GetServerSidePropsContext) => {
 
   return {
     csrfToken: await getCsrfToken(context),
-    ...(await serverSideTranslations(context.locale || "en", ["common", "home"])),
+    ...(await serverSideTranslations(context.locale || "en", ["common"])),
   };
 };


### PR DESCRIPTION
## What does this PR do?

Adds server side translations to the forgot password page. Looks better in google and generates proper titles in OG image 😁

**Environment**: Staging(main branch)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Visit the forgot password page and check that you don't see a flash in the page title where the translation key is shown
- [ ] Check the page's OG image and ensure that it now has the right text instead of translation keys. 
