### PR TITLE
Delay workflow email cancellation in sendgrid for all case

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1145,7 +1145,7 @@ async function handler(
       // cancel workflow reminders from previous rescheduled booking
       originalRescheduledBooking.workflowReminders.forEach((reminder) => {
         if (reminder.method === WorkflowMethods.EMAIL) {
-          deleteScheduledEmailReminder(reminder.id, reminder.referenceId, true);
+          deleteScheduledEmailReminder(reminder.id, reminder.referenceId);
         } else if (reminder.method === WorkflowMethods.SMS) {
           deleteScheduledSMSReminder(reminder.id, reminder.referenceId);
         }

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -104,125 +104,126 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   for (const reminder of unscheduledReminders) {
-    if (reminder.workflowStep && reminder.booking) {
-      try {
-        let sendTo;
+    if (!reminder.workflowStep || !reminder.booking) {
+      continue;
+    }
+    try {
+      let sendTo;
 
-        switch (reminder.workflowStep.action) {
-          case WorkflowActions.EMAIL_HOST:
-            sendTo = reminder.booking.user?.email;
-            break;
-          case WorkflowActions.EMAIL_ATTENDEE:
-            sendTo = reminder.booking.attendees[0].email;
-            break;
-          case WorkflowActions.EMAIL_ADDRESS:
-            sendTo = reminder.workflowStep.sendTo;
-        }
-
-        const name =
-          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-            ? reminder.booking.attendees[0].name
-            : reminder.booking.user?.name;
-
-        const attendeeName =
-          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-            ? reminder.booking.user?.name
-            : reminder.booking.attendees[0].name;
-
-        const timeZone =
-          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-            ? reminder.booking.attendees[0].timeZone
-            : reminder.booking.user?.timeZone;
-
-        const locale =
-          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
-          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-            ? reminder.booking.attendees[0].locale
-            : reminder.booking.user?.locale;
-
-        let emailContent = {
-          emailSubject: reminder.workflowStep.emailSubject || "",
-          emailBody: {
-            text: reminder.workflowStep.reminderBody || "",
-            html: `<body style="white-space: pre-wrap;">${reminder.workflowStep.reminderBody || ""}</body>`,
-          },
-        };
-
-        switch (reminder.workflowStep.template) {
-          case WorkflowTemplates.REMINDER:
-            emailContent = emailReminderTemplate(
-              reminder.booking.startTime.toISOString() || "",
-              reminder.booking.endTime.toISOString() || "",
-              reminder.booking.eventType?.title || "",
-              timeZone || "",
-              attendeeName || "",
-              name || ""
-            );
-            break;
-          case WorkflowTemplates.CUSTOM:
-            const variables: VariablesType = {
-              eventName: reminder.booking?.eventType?.title || "",
-              organizerName: reminder.booking.user?.name || "",
-              attendeeName: reminder.booking.attendees[0].name,
-              attendeeEmail: reminder.booking.attendees[0].email,
-              eventDate: dayjs(reminder.booking.startTime).tz(timeZone),
-              eventTime: dayjs(reminder.booking.startTime).tz(timeZone),
-              timeZone: timeZone,
-              location: reminder.booking.location || "",
-              additionalNotes: reminder.booking.description,
-              customInputs: reminder.booking.customInputs,
-              meetingUrl: bookingMetadataSchema.parse(reminder.booking.metadata || {})?.videoCallUrl,
-            };
-            const emailSubject = await customTemplate(
-              reminder.workflowStep.emailSubject || "",
-              variables,
-              locale || ""
-            );
-            emailContent.emailSubject = emailSubject.text;
-            emailContent.emailBody = await customTemplate(
-              reminder.workflowStep.reminderBody || "",
-              variables,
-              locale || ""
-            );
-            break;
-        }
-        if (emailContent.emailSubject.length > 0 && emailContent.emailBody.text.length > 0 && sendTo) {
-          const batchIdResponse = await client.request({
-            url: "/v3/mail/batch",
-            method: "POST",
-          });
-
-          const batchId = batchIdResponse[1].batch_id;
-
-          if (reminder.workflowStep.action !== WorkflowActions.EMAIL_ADDRESS) {
-            await sgMail.send({
-              to: sendTo,
-              from: {
-                email: senderEmail,
-                name: reminder.workflowStep.sender || "Cal.com",
-              },
-              subject: emailContent.emailSubject,
-              text: emailContent.emailBody.text,
-              html: emailContent.emailBody.html,
-              batchId: batchId,
-              sendAt: dayjs(reminder.scheduledDate).unix(),
-              replyTo: reminder.booking.user?.email || senderEmail,
-            });
-          }
-
-          await prisma.workflowReminder.update({
-            where: {
-              id: reminder.id,
-            },
-            data: {
-              scheduled: true,
-              referenceId: batchId,
-            },
-          });
-        }
-      } catch (error) {
-        console.log(`Error scheduling Email with error ${error}`);
+      switch (reminder.workflowStep.action) {
+        case WorkflowActions.EMAIL_HOST:
+          sendTo = reminder.booking.user?.email;
+          break;
+        case WorkflowActions.EMAIL_ATTENDEE:
+          sendTo = reminder.booking.attendees[0].email;
+          break;
+        case WorkflowActions.EMAIL_ADDRESS:
+          sendTo = reminder.workflowStep.sendTo;
       }
+
+      const name =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+          ? reminder.booking.attendees[0].name
+          : reminder.booking.user?.name;
+
+      const attendeeName =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+          ? reminder.booking.user?.name
+          : reminder.booking.attendees[0].name;
+
+      const timeZone =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+          ? reminder.booking.attendees[0].timeZone
+          : reminder.booking.user?.timeZone;
+
+      const locale =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking.attendees[0].locale
+          : reminder.booking.user?.locale;
+
+      let emailContent = {
+        emailSubject: reminder.workflowStep.emailSubject || "",
+        emailBody: {
+          text: reminder.workflowStep.reminderBody || "",
+          html: `<body style="white-space: pre-wrap;">${reminder.workflowStep.reminderBody || ""}</body>`,
+        },
+      };
+
+      switch (reminder.workflowStep.template) {
+        case WorkflowTemplates.REMINDER:
+          emailContent = emailReminderTemplate(
+            reminder.booking.startTime.toISOString() || "",
+            reminder.booking.endTime.toISOString() || "",
+            reminder.booking.eventType?.title || "",
+            timeZone || "",
+            attendeeName || "",
+            name || ""
+          );
+          break;
+        case WorkflowTemplates.CUSTOM:
+          const variables: VariablesType = {
+            eventName: reminder.booking?.eventType?.title || "",
+            organizerName: reminder.booking.user?.name || "",
+            attendeeName: reminder.booking.attendees[0].name,
+            attendeeEmail: reminder.booking.attendees[0].email,
+            eventDate: dayjs(reminder.booking.startTime).tz(timeZone),
+            eventTime: dayjs(reminder.booking.startTime).tz(timeZone),
+            timeZone: timeZone,
+            location: reminder.booking.location || "",
+            additionalNotes: reminder.booking.description,
+            customInputs: reminder.booking.customInputs,
+            meetingUrl: bookingMetadataSchema.parse(reminder.booking.metadata || {})?.videoCallUrl,
+          };
+          const emailSubject = await customTemplate(
+            reminder.workflowStep.emailSubject || "",
+            variables,
+            locale || ""
+          );
+          emailContent.emailSubject = emailSubject.text;
+          emailContent.emailBody = await customTemplate(
+            reminder.workflowStep.reminderBody || "",
+            variables,
+            locale || ""
+          );
+          break;
+      }
+      if (emailContent.emailSubject.length > 0 && emailContent.emailBody.text.length > 0 && sendTo) {
+        const batchIdResponse = await client.request({
+          url: "/v3/mail/batch",
+          method: "POST",
+        });
+
+        const batchId = batchIdResponse[1].batch_id;
+
+        if (reminder.workflowStep.action !== WorkflowActions.EMAIL_ADDRESS) {
+          await sgMail.send({
+            to: sendTo,
+            from: {
+              email: senderEmail,
+              name: reminder.workflowStep.sender || "Cal.com",
+            },
+            subject: emailContent.emailSubject,
+            text: emailContent.emailBody.text,
+            html: emailContent.emailBody.html,
+            batchId: batchId,
+            sendAt: dayjs(reminder.scheduledDate).unix(),
+            replyTo: reminder.booking.user?.email || senderEmail,
+          });
+        }
+
+        await prisma.workflowReminder.update({
+          where: {
+            id: reminder.id,
+          },
+          data: {
+            scheduled: true,
+            referenceId: batchId,
+          },
+        });
+      }
+    } catch (error) {
+      console.log(`Error scheduling Email with error ${error}`);
     }
   }
   res.status(200).json({ message: "Emails scheduled" });

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -7,10 +7,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import dayjs from "@calcom/dayjs";
 import { defaultHandler } from "@calcom/lib/server";
 import prisma from "@calcom/prisma";
-import { Prisma, WorkflowReminder } from "@calcom/prisma/client";
+import type { Prisma, WorkflowReminder } from "@calcom/prisma/client";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 
-import customTemplate, { VariablesType } from "../lib/reminders/templates/customTemplate";
+import type { VariablesType } from "../lib/reminders/templates/customTemplate";
+import customTemplate from "../lib/reminders/templates/customTemplate";
 import emailReminderTemplate from "../lib/reminders/templates/emailReminderTemplate";
 
 const sendgridAPIKey = process.env.SENDGRID_API_KEY as string;
@@ -103,123 +104,125 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   for (const reminder of unscheduledReminders) {
-    try {
-      let sendTo;
+    if (reminder.workflowStep && reminder.booking) {
+      try {
+        let sendTo;
 
-      switch (reminder.workflowStep.action) {
-        case WorkflowActions.EMAIL_HOST:
-          sendTo = reminder.booking?.user?.email;
-          break;
-        case WorkflowActions.EMAIL_ATTENDEE:
-          sendTo = reminder.booking?.attendees[0].email;
-          break;
-        case WorkflowActions.EMAIL_ADDRESS:
-          sendTo = reminder.workflowStep.sendTo;
-      }
-
-      const name =
-        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-          ? reminder.booking?.attendees[0].name
-          : reminder.booking?.user?.name;
-
-      const attendeeName =
-        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-          ? reminder.booking?.user?.name
-          : reminder.booking?.attendees[0].name;
-
-      const timeZone =
-        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
-          ? reminder.booking?.attendees[0].timeZone
-          : reminder.booking?.user?.timeZone;
-
-      const locale =
-        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
-        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-          ? reminder.booking?.attendees[0].locale
-          : reminder.booking?.user?.locale;
-
-      let emailContent = {
-        emailSubject: reminder.workflowStep.emailSubject || "",
-        emailBody: {
-          text: reminder.workflowStep.reminderBody || "",
-          html: `<body style="white-space: pre-wrap;">${reminder.workflowStep.reminderBody || ""}</body>`,
-        },
-      };
-
-      switch (reminder.workflowStep.template) {
-        case WorkflowTemplates.REMINDER:
-          emailContent = emailReminderTemplate(
-            reminder.booking?.startTime.toISOString() || "",
-            reminder.booking?.endTime.toISOString() || "",
-            reminder.booking?.eventType?.title || "",
-            timeZone || "",
-            attendeeName || "",
-            name || ""
-          );
-          break;
-        case WorkflowTemplates.CUSTOM:
-          const variables: VariablesType = {
-            eventName: reminder.booking?.eventType?.title || "",
-            organizerName: reminder.booking?.user?.name || "",
-            attendeeName: reminder.booking?.attendees[0].name,
-            attendeeEmail: reminder.booking?.attendees[0].email,
-            eventDate: dayjs(reminder.booking?.startTime).tz(timeZone),
-            eventTime: dayjs(reminder.booking?.startTime).tz(timeZone),
-            timeZone: timeZone,
-            location: reminder.booking?.location || "",
-            additionalNotes: reminder.booking?.description,
-            customInputs: reminder.booking?.customInputs,
-            meetingUrl: bookingMetadataSchema.parse(reminder.booking?.metadata || {})?.videoCallUrl,
-          };
-          const emailSubject = await customTemplate(
-            reminder.workflowStep.emailSubject || "",
-            variables,
-            locale || ""
-          );
-          emailContent.emailSubject = emailSubject.text;
-          emailContent.emailBody = await customTemplate(
-            reminder.workflowStep.reminderBody || "",
-            variables,
-            locale || ""
-          );
-          break;
-      }
-      if (emailContent.emailSubject.length > 0 && emailContent.emailBody.text.length > 0 && sendTo) {
-        const batchIdResponse = await client.request({
-          url: "/v3/mail/batch",
-          method: "POST",
-        });
-
-        const batchId = batchIdResponse[1].batch_id;
-
-        if (reminder.workflowStep.action !== WorkflowActions.EMAIL_ADDRESS) {
-          await sgMail.send({
-            to: sendTo,
-            from: {
-              email: senderEmail,
-              name: reminder.workflowStep.sender || "Cal.com",
-            },
-            subject: emailContent.emailSubject,
-            text: emailContent.emailBody.text,
-            html: emailContent.emailBody.html,
-            batchId: batchId,
-            sendAt: dayjs(reminder.scheduledDate).unix(),
-            replyTo: reminder.booking?.user?.email || senderEmail,
-          });
+        switch (reminder.workflowStep.action) {
+          case WorkflowActions.EMAIL_HOST:
+            sendTo = reminder.booking.user?.email;
+            break;
+          case WorkflowActions.EMAIL_ATTENDEE:
+            sendTo = reminder.booking.attendees[0].email;
+            break;
+          case WorkflowActions.EMAIL_ADDRESS:
+            sendTo = reminder.workflowStep.sendTo;
         }
 
-        await prisma.workflowReminder.update({
-          where: {
-            id: reminder.id,
+        const name =
+          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+            ? reminder.booking.attendees[0].name
+            : reminder.booking.user?.name;
+
+        const attendeeName =
+          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+            ? reminder.booking.user?.name
+            : reminder.booking.attendees[0].name;
+
+        const timeZone =
+          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE
+            ? reminder.booking.attendees[0].timeZone
+            : reminder.booking.user?.timeZone;
+
+        const locale =
+          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+            ? reminder.booking.attendees[0].locale
+            : reminder.booking.user?.locale;
+
+        let emailContent = {
+          emailSubject: reminder.workflowStep.emailSubject || "",
+          emailBody: {
+            text: reminder.workflowStep.reminderBody || "",
+            html: `<body style="white-space: pre-wrap;">${reminder.workflowStep.reminderBody || ""}</body>`,
           },
-          data: {
-            scheduled: true,
-            referenceId: batchId,
-          },
-        });
+        };
+
+        switch (reminder.workflowStep.template) {
+          case WorkflowTemplates.REMINDER:
+            emailContent = emailReminderTemplate(
+              reminder.booking.startTime.toISOString() || "",
+              reminder.booking.endTime.toISOString() || "",
+              reminder.booking.eventType?.title || "",
+              timeZone || "",
+              attendeeName || "",
+              name || ""
+            );
+            break;
+          case WorkflowTemplates.CUSTOM:
+            const variables: VariablesType = {
+              eventName: reminder.booking?.eventType?.title || "",
+              organizerName: reminder.booking.user?.name || "",
+              attendeeName: reminder.booking.attendees[0].name,
+              attendeeEmail: reminder.booking.attendees[0].email,
+              eventDate: dayjs(reminder.booking.startTime).tz(timeZone),
+              eventTime: dayjs(reminder.booking.startTime).tz(timeZone),
+              timeZone: timeZone,
+              location: reminder.booking.location || "",
+              additionalNotes: reminder.booking.description,
+              customInputs: reminder.booking.customInputs,
+              meetingUrl: bookingMetadataSchema.parse(reminder.booking.metadata || {})?.videoCallUrl,
+            };
+            const emailSubject = await customTemplate(
+              reminder.workflowStep.emailSubject || "",
+              variables,
+              locale || ""
+            );
+            emailContent.emailSubject = emailSubject.text;
+            emailContent.emailBody = await customTemplate(
+              reminder.workflowStep.reminderBody || "",
+              variables,
+              locale || ""
+            );
+            break;
+        }
+        if (emailContent.emailSubject.length > 0 && emailContent.emailBody.text.length > 0 && sendTo) {
+          const batchIdResponse = await client.request({
+            url: "/v3/mail/batch",
+            method: "POST",
+          });
+
+          const batchId = batchIdResponse[1].batch_id;
+
+          if (reminder.workflowStep.action !== WorkflowActions.EMAIL_ADDRESS) {
+            await sgMail.send({
+              to: sendTo,
+              from: {
+                email: senderEmail,
+                name: reminder.workflowStep.sender || "Cal.com",
+              },
+              subject: emailContent.emailSubject,
+              text: emailContent.emailBody.text,
+              html: emailContent.emailBody.html,
+              batchId: batchId,
+              sendAt: dayjs(reminder.scheduledDate).unix(),
+              replyTo: reminder.booking.user?.email || senderEmail,
+            });
+          }
+
+          await prisma.workflowReminder.update({
+            where: {
+              id: reminder.id,
+            },
+            data: {
+              scheduled: true,
+              referenceId: batchId,
+            },
+          });
+        }
+      } catch (error) {
+        console.log(`Error scheduling Email with error ${error}`);
       }
-    } catch (error) {
-      console.log(`Error scheduling Email with error ${error}`);
     }
   }
   res.status(200).json({ message: "Emails scheduled" });

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -9,7 +9,8 @@ import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 
 import { getSenderId } from "../lib/alphanumericSenderIdSupport";
 import * as twilio from "../lib/reminders/smsProviders/twilioProvider";
-import customTemplate, { VariablesType } from "../lib/reminders/templates/customTemplate";
+import type { VariablesType } from "../lib/reminders/templates/customTemplate";
+import customTemplate from "../lib/reminders/templates/customTemplate";
 import smsReminderTemplate from "../lib/reminders/templates/smsReminderTemplate";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -53,83 +54,85 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!unscheduledReminders.length) res.json({ ok: true });
 
   for (const reminder of unscheduledReminders) {
-    try {
-      const sendTo =
-        reminder.workflowStep.action === WorkflowActions.SMS_NUMBER
-          ? reminder.workflowStep.sendTo
-          : reminder.booking?.smsReminderNumber;
+    if (reminder.workflowStep && reminder.booking) {
+      try {
+        const sendTo =
+          reminder.workflowStep.action === WorkflowActions.SMS_NUMBER
+            ? reminder.workflowStep.sendTo
+            : reminder.booking?.smsReminderNumber;
 
-      const userName =
-        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-          ? reminder.booking?.attendees[0].name
-          : "";
+        const userName =
+          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+            ? reminder.booking?.attendees[0].name
+            : "";
 
-      const attendeeName =
-        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-          ? reminder.booking?.user?.name
-          : reminder.booking?.attendees[0].name;
+        const attendeeName =
+          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+            ? reminder.booking?.user?.name
+            : reminder.booking?.attendees[0].name;
 
-      const timeZone =
-        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-          ? reminder.booking?.attendees[0].timeZone
-          : reminder.booking?.user?.timeZone;
+        const timeZone =
+          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+            ? reminder.booking?.attendees[0].timeZone
+            : reminder.booking?.user?.timeZone;
 
-      const senderID = getSenderId(sendTo, reminder.workflowStep.sender);
+        const senderID = getSenderId(sendTo, reminder.workflowStep.sender);
 
-      const locale =
-        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
-        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-          ? reminder.booking?.attendees[0].locale
-          : reminder.booking?.user?.locale;
+        const locale =
+          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+            ? reminder.booking?.attendees[0].locale
+            : reminder.booking?.user?.locale;
 
-      let message: string | null = reminder.workflowStep.reminderBody;
-      switch (reminder.workflowStep.template) {
-        case WorkflowTemplates.REMINDER:
-          message = smsReminderTemplate(
-            reminder.booking?.startTime.toISOString() || "",
-            reminder.booking?.eventType?.title || "",
-            timeZone || "",
-            attendeeName || "",
-            userName
-          );
-          break;
-        case WorkflowTemplates.CUSTOM:
-          const variables: VariablesType = {
-            eventName: reminder.booking?.eventType?.title,
-            organizerName: reminder.booking?.user?.name || "",
-            attendeeName: reminder.booking?.attendees[0].name,
-            attendeeEmail: reminder.booking?.attendees[0].email,
-            eventDate: dayjs(reminder.booking?.startTime).tz(timeZone),
-            eventTime: dayjs(reminder.booking?.startTime).tz(timeZone),
-            timeZone: timeZone,
-            location: reminder.booking?.location || "",
-            additionalNotes: reminder.booking?.description,
-            customInputs: reminder.booking?.customInputs,
-            meetingUrl: bookingMetadataSchema.parse(reminder.booking?.metadata || {})?.videoCallUrl,
-          };
-          const customMessage = await customTemplate(
-            reminder.workflowStep.reminderBody || "",
-            variables,
-            locale || ""
-          );
-          message = customMessage.text;
-          break;
+        let message: string | null = reminder.workflowStep.reminderBody;
+        switch (reminder.workflowStep.template) {
+          case WorkflowTemplates.REMINDER:
+            message = smsReminderTemplate(
+              reminder.booking?.startTime.toISOString() || "",
+              reminder.booking?.eventType?.title || "",
+              timeZone || "",
+              attendeeName || "",
+              userName
+            );
+            break;
+          case WorkflowTemplates.CUSTOM:
+            const variables: VariablesType = {
+              eventName: reminder.booking?.eventType?.title,
+              organizerName: reminder.booking?.user?.name || "",
+              attendeeName: reminder.booking?.attendees[0].name,
+              attendeeEmail: reminder.booking?.attendees[0].email,
+              eventDate: dayjs(reminder.booking?.startTime).tz(timeZone),
+              eventTime: dayjs(reminder.booking?.startTime).tz(timeZone),
+              timeZone: timeZone,
+              location: reminder.booking?.location || "",
+              additionalNotes: reminder.booking?.description,
+              customInputs: reminder.booking?.customInputs,
+              meetingUrl: bookingMetadataSchema.parse(reminder.booking?.metadata || {})?.videoCallUrl,
+            };
+            const customMessage = await customTemplate(
+              reminder.workflowStep.reminderBody || "",
+              variables,
+              locale || ""
+            );
+            message = customMessage.text;
+            break;
+        }
+        if (message?.length && message?.length > 0 && sendTo) {
+          const scheduledSMS = await twilio.scheduleSMS(sendTo, message, reminder.scheduledDate, senderID);
+
+          await prisma.workflowReminder.update({
+            where: {
+              id: reminder.id,
+            },
+            data: {
+              scheduled: true,
+              referenceId: scheduledSMS.sid,
+            },
+          });
+        }
+      } catch (error) {
+        console.log(`Error scheduling SMS with error ${error}`);
       }
-      if (message?.length && message?.length > 0 && sendTo) {
-        const scheduledSMS = await twilio.scheduleSMS(sendTo, message, reminder.scheduledDate, senderID);
-
-        await prisma.workflowReminder.update({
-          where: {
-            id: reminder.id,
-          },
-          data: {
-            scheduled: true,
-            referenceId: scheduledSMS.sid,
-          },
-        });
-      }
-    } catch (error) {
-      console.log(`Error scheduling SMS with error ${error}`);
     }
   }
   res.status(200).json({ message: "SMS scheduled" });

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -54,85 +54,86 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!unscheduledReminders.length) res.json({ ok: true });
 
   for (const reminder of unscheduledReminders) {
-    if (reminder.workflowStep && reminder.booking) {
-      try {
-        const sendTo =
-          reminder.workflowStep.action === WorkflowActions.SMS_NUMBER
-            ? reminder.workflowStep.sendTo
-            : reminder.booking?.smsReminderNumber;
+    if (!reminder.workflowStep || !reminder.booking) {
+      continue;
+    }
+    try {
+      const sendTo =
+        reminder.workflowStep.action === WorkflowActions.SMS_NUMBER
+          ? reminder.workflowStep.sendTo
+          : reminder.booking?.smsReminderNumber;
 
-        const userName =
-          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-            ? reminder.booking?.attendees[0].name
-            : "";
+      const userName =
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.attendees[0].name
+          : "";
 
-        const attendeeName =
-          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-            ? reminder.booking?.user?.name
-            : reminder.booking?.attendees[0].name;
+      const attendeeName =
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.user?.name
+          : reminder.booking?.attendees[0].name;
 
-        const timeZone =
-          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-            ? reminder.booking?.attendees[0].timeZone
-            : reminder.booking?.user?.timeZone;
+      const timeZone =
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.attendees[0].timeZone
+          : reminder.booking?.user?.timeZone;
 
-        const senderID = getSenderId(sendTo, reminder.workflowStep.sender);
+      const senderID = getSenderId(sendTo, reminder.workflowStep.sender);
 
-        const locale =
-          reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
-          reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
-            ? reminder.booking?.attendees[0].locale
-            : reminder.booking?.user?.locale;
+      const locale =
+        reminder.workflowStep.action === WorkflowActions.EMAIL_ATTENDEE ||
+        reminder.workflowStep.action === WorkflowActions.SMS_ATTENDEE
+          ? reminder.booking?.attendees[0].locale
+          : reminder.booking?.user?.locale;
 
-        let message: string | null = reminder.workflowStep.reminderBody;
-        switch (reminder.workflowStep.template) {
-          case WorkflowTemplates.REMINDER:
-            message = smsReminderTemplate(
-              reminder.booking?.startTime.toISOString() || "",
-              reminder.booking?.eventType?.title || "",
-              timeZone || "",
-              attendeeName || "",
-              userName
-            );
-            break;
-          case WorkflowTemplates.CUSTOM:
-            const variables: VariablesType = {
-              eventName: reminder.booking?.eventType?.title,
-              organizerName: reminder.booking?.user?.name || "",
-              attendeeName: reminder.booking?.attendees[0].name,
-              attendeeEmail: reminder.booking?.attendees[0].email,
-              eventDate: dayjs(reminder.booking?.startTime).tz(timeZone),
-              eventTime: dayjs(reminder.booking?.startTime).tz(timeZone),
-              timeZone: timeZone,
-              location: reminder.booking?.location || "",
-              additionalNotes: reminder.booking?.description,
-              customInputs: reminder.booking?.customInputs,
-              meetingUrl: bookingMetadataSchema.parse(reminder.booking?.metadata || {})?.videoCallUrl,
-            };
-            const customMessage = await customTemplate(
-              reminder.workflowStep.reminderBody || "",
-              variables,
-              locale || ""
-            );
-            message = customMessage.text;
-            break;
-        }
-        if (message?.length && message?.length > 0 && sendTo) {
-          const scheduledSMS = await twilio.scheduleSMS(sendTo, message, reminder.scheduledDate, senderID);
-
-          await prisma.workflowReminder.update({
-            where: {
-              id: reminder.id,
-            },
-            data: {
-              scheduled: true,
-              referenceId: scheduledSMS.sid,
-            },
-          });
-        }
-      } catch (error) {
-        console.log(`Error scheduling SMS with error ${error}`);
+      let message: string | null = reminder.workflowStep.reminderBody;
+      switch (reminder.workflowStep.template) {
+        case WorkflowTemplates.REMINDER:
+          message = smsReminderTemplate(
+            reminder.booking?.startTime.toISOString() || "",
+            reminder.booking?.eventType?.title || "",
+            timeZone || "",
+            attendeeName || "",
+            userName
+          );
+          break;
+        case WorkflowTemplates.CUSTOM:
+          const variables: VariablesType = {
+            eventName: reminder.booking?.eventType?.title,
+            organizerName: reminder.booking?.user?.name || "",
+            attendeeName: reminder.booking?.attendees[0].name,
+            attendeeEmail: reminder.booking?.attendees[0].email,
+            eventDate: dayjs(reminder.booking?.startTime).tz(timeZone),
+            eventTime: dayjs(reminder.booking?.startTime).tz(timeZone),
+            timeZone: timeZone,
+            location: reminder.booking?.location || "",
+            additionalNotes: reminder.booking?.description,
+            customInputs: reminder.booking?.customInputs,
+            meetingUrl: bookingMetadataSchema.parse(reminder.booking?.metadata || {})?.videoCallUrl,
+          };
+          const customMessage = await customTemplate(
+            reminder.workflowStep.reminderBody || "",
+            variables,
+            locale || ""
+          );
+          message = customMessage.text;
+          break;
       }
+      if (message?.length && message?.length > 0 && sendTo) {
+        const scheduledSMS = await twilio.scheduleSMS(sendTo, message, reminder.scheduledDate, senderID);
+
+        await prisma.workflowReminder.update({
+          where: {
+            id: reminder.id,
+          },
+          data: {
+            scheduled: true,
+            referenceId: scheduledSMS.sid,
+          },
+        });
+      }
+    } catch (error) {
+      console.log(`Error scheduling SMS with error ${error}`);
     }
   }
   res.status(200).json({ message: "SMS scheduled" });

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -1,10 +1,5 @@
-import {
-  TimeUnit,
-  WorkflowTriggerEvents,
-  WorkflowTemplates,
-  WorkflowActions,
-  WorkflowMethods,
-} from "@prisma/client";
+import type { TimeUnit } from "@prisma/client";
+import { WorkflowTriggerEvents, WorkflowTemplates, WorkflowActions, WorkflowMethods } from "@prisma/client";
 import client from "@sendgrid/client";
 import sgMail from "@sendgrid/mail";
 
@@ -12,8 +7,9 @@ import dayjs from "@calcom/dayjs";
 import prisma from "@calcom/prisma";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 
-import { BookingInfo, timeUnitLowerCase } from "./smsReminderManager";
-import customTemplate, { VariablesType } from "./templates/customTemplate";
+import type { BookingInfo, timeUnitLowerCase } from "./smsReminderManager";
+import type { VariablesType } from "./templates/customTemplate";
+import customTemplate from "./templates/customTemplate";
 import emailReminderTemplate from "./templates/emailReminderTemplate";
 
 let sendgridAPIKey, senderEmail: string;
@@ -194,11 +190,7 @@ export const scheduleEmailReminder = async (
   }
 };
 
-export const deleteScheduledEmailReminder = async (
-  reminderId: number,
-  referenceId: string | null,
-  immediateDelete?: boolean
-) => {
+export const deleteScheduledEmailReminder = async (reminderId: number, referenceId: string | null) => {
   try {
     if (!referenceId) {
       await prisma.workflowReminder.delete({
@@ -207,18 +199,6 @@ export const deleteScheduledEmailReminder = async (
         },
       });
 
-      return;
-    }
-
-    if (immediateDelete) {
-      await client.request({
-        url: "/v3/user/scheduled_sends",
-        method: "POST",
-        body: {
-          batch_id: referenceId,
-          status: "cancel",
-        },
-      });
       return;
     }
 

--- a/packages/prisma/migrations/20230309203435_make_booking_and_workflow_step_optional_for_workflow_reminder/migration.sql
+++ b/packages/prisma/migrations/20230309203435_make_booking_and_workflow_step_optional_for_workflow_reminder/migration.sql
@@ -1,0 +1,15 @@
+-- DropForeignKey
+ALTER TABLE "WorkflowReminder" DROP CONSTRAINT "WorkflowReminder_bookingUid_fkey";
+
+-- DropForeignKey
+ALTER TABLE "WorkflowReminder" DROP CONSTRAINT "WorkflowReminder_workflowStepId_fkey";
+
+-- AlterTable
+ALTER TABLE "WorkflowReminder" ALTER COLUMN "bookingUid" DROP NOT NULL,
+ALTER COLUMN "workflowStepId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "WorkflowReminder" ADD CONSTRAINT "WorkflowReminder_bookingUid_fkey" FOREIGN KEY ("bookingUid") REFERENCES "Booking"("uid") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkflowReminder" ADD CONSTRAINT "WorkflowReminder_workflowStepId_fkey" FOREIGN KEY ("workflowStepId") REFERENCES "WorkflowStep"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -642,14 +642,14 @@ enum TimeUnit {
 
 model WorkflowReminder {
   id             Int             @id @default(autoincrement())
-  bookingUid     String
-  booking        Booking?        @relation(fields: [bookingUid], references: [uid], onDelete: Cascade)
+  bookingUid     String?
+  booking        Booking?        @relation(fields: [bookingUid], references: [uid])
   method         WorkflowMethods
   scheduledDate  DateTime
   referenceId    String?         @unique
   scheduled      Boolean
-  workflowStepId Int
-  workflowStep   WorkflowStep    @relation(fields: [workflowStepId], references: [id], onDelete: Cascade)
+  workflowStepId Int?
+  workflowStep   WorkflowStep?   @relation(fields: [workflowStepId], references: [id])
   cancelled      Boolean?
 }
 

--- a/packages/trpc/server/routers/viewer/workflows.tsx
+++ b/packages/trpc/server/routers/viewer/workflows.tsx
@@ -407,7 +407,7 @@ export const workflowsRouter = router({
       //cancel workflow reminders of deleted workflow
       scheduledReminders.forEach((reminder) => {
         if (reminder.method === WorkflowMethods.EMAIL) {
-          deleteScheduledEmailReminder(reminder.id, reminder.referenceId, true);
+          deleteScheduledEmailReminder(reminder.id, reminder.referenceId);
         } else if (reminder.method === WorkflowMethods.SMS) {
           deleteScheduledSMSReminder(reminder.id, reminder.referenceId);
         }
@@ -744,7 +744,7 @@ export const workflowsRouter = router({
           if (remindersFromStep.length > 0) {
             remindersFromStep.forEach((reminder) => {
               if (reminder.method === WorkflowMethods.EMAIL) {
-                deleteScheduledEmailReminder(reminder.id, reminder.referenceId, true);
+                deleteScheduledEmailReminder(reminder.id, reminder.referenceId);
               } else if (reminder.method === WorkflowMethods.SMS) {
                 deleteScheduledSMSReminder(reminder.id, reminder.referenceId);
               }


### PR DESCRIPTION
## What does this PR do?

Sendgrid's limit for entries in` /scheduled_sends `for cancelled scheduled emails got reached again. After making some first improvements in #7232, we need to make sure to keep the number of cancelled `scheduled_sends` lower (as low as possible).

With this PR `WorkflowStep` and `Booking` will now be optional fields in `WorkflowReminder`, so we can get rid of the immediate delete that was done when workflow or workflow step was deleted and also when an event was rescheduled. 

