### PR TITLE
logic for determining months between dates improved

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -208,7 +208,12 @@ export const getBusyCalendarTimes = async (
   } else {
     // if dateFrom and dateTo is from different months get cache by each month
     const months: string[] = [dayjs(dateFrom).format("YYYY-MM")];
-    for (let i = 1; dayjs(dateFrom).add(i, "month").isBefore(dateTo); i++) {
+    for (
+      let i = 1;
+      dayjs(dateFrom).add(i, "month").isBefore(dateTo) ||
+      dayjs(dateFrom).add(i, "month").isSame(dateTo, "month");
+      i++
+    ) {
       months.push(dayjs(dateFrom).add(i, "month").format("YYYY-MM"));
     }
     const data: EventBusyDate[][][] = await Promise.all(months.map((month) => getNextCache(username, month)));


### PR DESCRIPTION
## What does this PR do?

When a user in utc+ requests a month ahead it sends the following dates to getSchedule endpoint:

`{ startTime: 2023-03-31T23:00:00.000Z, endTime: 2023-04-30T22:59:59.999Z, ...}`

This causes only the March cache to be obtained, leaving out April.

So, I changed the logic a little bit to not leave out the last month of the dates sent.


Fixes #7602