### PR TITLE
Make sure that a hidden field/question is never required

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -76,7 +76,8 @@ function preprocess<T extends z.ZodType>({
           : z.string().refine((val) => isValidPhoneNumber(val));
         // Tag the message with the input name so that the message can be shown at appropriate place
         const m = (message: string) => `{${bookingField.name}}${message}`;
-        const isRequired = bookingField.required;
+        // If the field is hidden, then it can never be required
+        const isRequired = bookingField.hidden ? false : bookingField.required;
         if ((isPartialSchema || !isRequired) && value === undefined) {
           return;
         }

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -307,9 +307,9 @@ export const FormBuilder = function FormBuilder({
                     <div className="flex items-center space-x-2">
                       {field.hidden ? (
                         // Hidden field can't be required, so we don't need to show the Optional badge
-                        <Badge variant="gray">Hidden</Badge>
+                        <Badge variant="gray">{t("hidden")}</Badge>
                       ) : (
-                        <Badge variant="gray">{isRequired ? "Required" : "Optional"}</Badge>
+                        <Badge variant="gray">{isRequired ? t("required") : t("optional")}</Badge>
                       )}
                       {Object.entries(groupedBySourceLabel).map(([sourceLabel, sources], key) => (
                         // We don't know how to pluralize `sourceLabel` because it can be anything
@@ -477,7 +477,7 @@ export const FormBuilder = function FormBuilder({
                       onValueChange={(val) => {
                         onChange(val);
                       }}
-                      label="Required"
+                      label={t("required")}
                     />
                   );
                 }}

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -447,13 +447,13 @@ export const FormBuilder = function FormBuilder({
                 required={!["system", "system-but-optional"].includes(fieldForm.getValues("editable") || "")}
                 placeholder={t(fieldForm.getValues("defaultLabel") || "")}
                 containerClassName="mt-6"
-                label="Label"
+                label={t("label")}
               />
               {fieldType?.isTextType ? (
                 <InputField
                   {...fieldForm.register("placeholder")}
                   containerClassName="mt-6"
-                  label="Placeholder"
+                  label={t("placeholder")}
                   placeholder={t(fieldForm.getValues("defaultPlaceholder") || "")}
                 />
               ) : null}

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -266,8 +266,7 @@ export const FormBuilder = function FormBuilder({
           {fields.map((field, index) => {
             const fieldType = FieldTypesMap[field.type];
 
-            // Hidden fields can't be required
-            const isRequired = field.required && !field.hidden;
+            const isRequired = field.required;
 
             if (!fieldType) {
               throw new Error(`Invalid field type - ${field.type}`);
@@ -306,8 +305,12 @@ export const FormBuilder = function FormBuilder({
                       {field.label || t(field.defaultLabel || "")}
                     </div>
                     <div className="flex items-center space-x-2">
-                      <Badge variant="gray">{isRequired ? "Required" : "Optional"}</Badge>
-                      {field.hidden ? <Badge variant="gray">Hidden</Badge> : null}
+                      {field.hidden ? (
+                        // Hidden field can't be required, so we don't need to show the Optional badge
+                        <Badge variant="gray">Hidden</Badge>
+                      ) : (
+                        <Badge variant="gray">{isRequired ? "Required" : "Optional"}</Badge>
+                      )}
                       {Object.entries(groupedBySourceLabel).map(([sourceLabel, sources], key) => (
                         // We don't know how to pluralize `sourceLabel` because it can be anything
                         <Badge key={key} variant="blue">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7653

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Create a field. By default, it would be required. Now toggle it to hidden. Note that you would just see **Hidden** badge now. If you would go and edit the field you would still see that it's marked required, but it won't actually be required during booking. Go and make a booking without prefilling the hidden field value.
## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
