### PR TITLE
fix: attendee scheduled email not translated in bookers locale

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1267,12 +1267,15 @@ async function handler(
         videoCallUrl = metadata.hangoutLink || defaultLocationUrl || videoCallUrl;
       }
       if (noEmail !== true) {
-        await sendScheduledEmails({
-          ...evt,
-          additionalInformation: metadata,
-          additionalNotes,
-          customInputs,
-        });
+        await sendScheduledEmails(
+          {
+            ...evt,
+            additionalInformation: metadata,
+            additionalNotes,
+            customInputs,
+          },
+          eventNameObject
+        );
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes attendee scheduled email subject not translated in bookers locale.

before:
![Screenshot 2023-03-10 at 16-45-28 MailDev ( 6)](https://user-images.githubusercontent.com/84864519/224302451-c118c146-55ce-4e05-ae9a-86eaee39252a.png)

after:
![Screenshot 2023-03-10 at 16-45-56 MailDev ( 6)](https://user-images.githubusercontent.com/84864519/224302495-6612654c-8022-480d-850a-7b76f6cee296.png)





## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 

