### PR TITLE
Outlook save new refresh token

### DIFF
--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -217,8 +217,13 @@ export default class Office365CalendarService implements Calendar {
           client_secret,
         }),
       });
-      const responseBody = await handleErrorsJson<{ access_token: string; expires_in: number }>(response);
+      const responseBody = await handleErrorsJson<{
+        access_token: string;
+        expires_in: number;
+        refresh_token: string;
+      }>(response);
       o365AuthCredentials.access_token = responseBody.access_token;
+      o365AuthCredentials.refresh_token = responseBody.refresh_token;
       o365AuthCredentials.expiry_date = Math.round(+new Date() / 1000 + responseBody.expires_in);
       await prisma.credential.update({
         where: {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR for Outlook saves the new refresh token every time we get a new access token. This follows Microsoft's suggestion: https://learn.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#token-types

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Connect an Outlook calendar
- In the DB change the expiry date of the token to trigger getting a new access token
    - Write down the current refresh token
- Make a call to Outlook (you can refresh the installed calendars page)
- In the DB the new refresh token should be saved along with the new access token

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
