### PR TITLE
Fixes weird background color on selects

### DIFF
--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -84,16 +84,6 @@ export const Select = <
       {...reactSelectProps}
       {...props}
       styles={{
-        option: (defaultStyles, state) => ({
-          ...defaultStyles,
-          backgroundColor: state.isSelected
-            ? state.isFocused
-              ? "var(--brand-color)"
-              : "var(--brand-color)"
-            : state.isFocused
-            ? "var(--brand-color-dark-mode)"
-            : "var(--brand-text-color)",
-        }),
         ...styles,
       }}
     />


### PR DESCRIPTION
I have no clue why we did this. All it seems to do is break stuff

Before

<img width="724" alt="CleanShot 2023-03-12 at 23 30 46@2x" src="https://user-images.githubusercontent.com/55134778/224555158-6a15394e-5b3f-49c6-948d-858bc59b2f40.png">


After:
<img width="709" alt="CleanShot 2023-03-12 at 23 30 30@2x" src="https://user-images.githubusercontent.com/55134778/224555114-8f347894-2443-4433-a617-90d1a53d379d.png">
