### PR TITLE
Amend logic to figure out if selected slot is in available working hours

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -111,7 +111,6 @@ function buildSlots({
 
     return startOfInviteeDay.tz(inviteeTimeZone).add(minutes, "minutes");
   };
-
   for (const item of Object.values(slotsTimeFrameAvailable)) {
     /*
      * @calcom/web:dev: 2022-11-06T00:00:00-04:00
@@ -121,15 +120,10 @@ function buildSlots({
      * @calcom/web:dev: 2022-11-06T03:00:00-04:00
      * ...
      */
-    const slot = {
+    slots.push({
       userIds: item.userIds,
       time: getTime(item.startTime),
-    };
-    // If the startOfInviteeDay has a different UTC offset than the slot, a DST change has occurred.
-    // As the time has now fallen backwards, or forwards; this difference -
-    // needs to be manually added as this is not done for us. Usually 0.
-    slot.time = slot.time.add(startOfInviteeDay.utcOffset() - slot.time.utcOffset(), "minutes");
-    slots.push(slot);
+    });
   }
   return slots;
 }


### PR DESCRIPTION
## What does this PR do?

- Small DST fix
- avoid "no available users found" error when the invitee is in utc+ (e.g. Europe/London) in DST and the host is in utc- (e.g. America/Detroit)

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Select the time zones that meet the following criteria to test booking at the beginning and end of the day
- [ ] Organizer in utc- invitee utc+
   - [ ] Organizer and invitee out of DST
   - [ ] Organizer in DST invitee don`t
   - [ ] Organizer and invitee in DST
   - [ ] Invitee in DST organizer don`t
- [ ] Organizer in utc+ invitee utc-
   - [ ] Organizer and invitee out of DST
   - [ ] Organizer in DST invitee don`t
   - [ ] Organizer and invitee in DST
   - [ ] Invitee in DST organizer don`t

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
