### PR TITLE
Bugfix/allow impersonation non cal id p

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -167,8 +167,9 @@ const providers: Provider[] = [
       // authentication success- but does it meet the minimum password requirements?
       if (
         user.role === "ADMIN" &&
-        user.identityProvider === IdentityProvider.CAL &&
-        !isPasswordValid(credentials.password, false, true)
+        ((user.identityProvider === IdentityProvider.CAL &&
+          !isPasswordValid(credentials.password, false, true)) ||
+          !user.twoFactorEnabled)
       ) {
         return {
           id: user.id,

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -165,7 +165,11 @@ const providers: Provider[] = [
         }).length > 0;
 
       // authentication success- but does it meet the minimum password requirements?
-      if (user.role === "ADMIN" && !isPasswordValid(credentials.password, false, true)) {
+      if (
+        user.role === "ADMIN" &&
+        user.identityProvider === IdentityProvider.CAL &&
+        !isPasswordValid(credentials.password, false, true)
+      ) {
         return {
           id: user.id,
           username: user.username,


### PR DESCRIPTION
## What does this PR do?

* Require twoFactorEnabled (this was previously enforced by policy)
* Only require a valid password when the IdP is CAL, otherwise ignore.