### PR TITLE
Hotfix/account provider should be lowercase

### DIFF
--- a/apps/web/pages/auth/logout.tsx
+++ b/apps/web/pages/auth/logout.tsx
@@ -43,7 +43,7 @@ export default function Logout(props: Props) {
           </div>
         </div>
       </div>
-      <Button href="/auth/login" passHref className="flex w-full justify-center">
+      <Button href="/auth/login" className="flex w-full justify-center">
         {t("go_back_login")}
       </Button>
     </AuthContainer>


### PR DESCRIPTION
## What does this PR do?

* `Account.provider` is 'google' whereas iDP was 'GOOGLE', - `account.provider` has the right lowercase value.
* Updates the identityProviderId to the account.providerAccountId instead of the userId
* Create a userland solution for fixing this retroactively.