### PR TITLE
Remove 'userIsOwner' from isCancelled

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -272,10 +272,8 @@ export default function Success(props: SuccessProps) {
   const isCancelled =
     status === "CANCELLED" ||
     status === "REJECTED" ||
-    (isCancellationMode &&
-      (!!seatReferenceUid
-        ? !bookingInfo.seatsReferences.some((reference) => reference.referenceUid === seatReferenceUid)
-        : !userIsOwner));
+    (!!seatReferenceUid &&
+      !bookingInfo.seatsReferences.some((reference) => reference.referenceUid === seatReferenceUid));
 
   const telemetry = useTelemetry();
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes: https://github.com/calcom/cal.com/issues/7768

No need to check isCancelledMode and we can just assume the seat has been cancelled if the seatReferenceId is given and the seat reference is not seating the booking.