### PR TITLE
fix/collective-event-handle-multiple-calendars-credentials

### DIFF
--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -314,6 +314,7 @@ export default class EventManager {
       if (
         event.schedulingType === "COLLECTIVE" &&
         event.team &&
+        event.team.destinationCalendar &&
         event.team.destinationCalendar.length > 0 &&
         event.team.members.length > 0
       ) {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -769,10 +769,6 @@ async function handler(
   const attendeesList = [...invitee, ...guests];
 
   if (isTeamEventType && eventType.schedulingType === "COLLECTIVE") {
-    // remove the organizer from the team members
-    const organizerIndex = teamMembers.findIndex((member) => member.email === organizerUser.email);
-    teamMembers.splice(organizerIndex, 1);
-
     attendeesList.push(...teamMembers);
   }
 

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -746,14 +746,16 @@ async function handler(
   const customInputs = getCustomInputsResponses(reqBody, eventType.customInputs);
 
   const teamDestinationCalendar: DestinationCalendar[] = [];
-  const teamMemberPromises = users.map(async function (user) {
+
+  // Organizer or user owner of this event type it's not listed as a team member.
+  const teamMemberPromises = users.slice(1).map(async (user) => {
     // push to teamDestinationCalendar if it's a team event but collective only
     if (isTeamEventType && eventType.schedulingType === "COLLECTIVE" && user.destinationCalendar) {
       teamDestinationCalendar.push(user.destinationCalendar);
     }
     return {
-      email: user.email || "",
-      name: user.name || "",
+      email: user.email ?? "",
+      name: user.name ?? "",
       timeZone: user.timeZone,
       language: {
         translate: await getTranslation(user.locale ?? "en", "common"),
@@ -761,6 +763,7 @@ async function handler(
       },
     };
   });
+
   const teamMembers = await Promise.all(teamMemberPromises);
 
   const attendeesList = [...invitee, ...guests];

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -1,4 +1,10 @@
-import type { Prisma, DestinationCalendar, SelectedCalendar, BookingSeat } from "@prisma/client";
+import type {
+  Prisma,
+  DestinationCalendar,
+  SelectedCalendar,
+  BookingSeat,
+  SchedulingType,
+} from "@prisma/client";
 import type { Dayjs } from "dayjs";
 import type { calendar_v3 } from "googleapis";
 import type { Time } from "ical.js";
@@ -149,6 +155,7 @@ export interface CalendarEvent {
   team?: {
     name: string;
     members: TeamMember[];
+    destinationCalendar: DestinationCalendar[];
   };
   location?: string | null;
   conferenceData?: ConferenceData;
@@ -168,7 +175,7 @@ export interface CalendarEvent {
   seatsShowAttendees?: boolean | null;
   attendeeSeatId?: string;
   seatsPerTimeSlot?: number | null;
-
+  schedulingType?: SchedulingType | null;
   // It has responses to all the fields(system + user)
   responses?: Record<
     string,

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -155,7 +155,7 @@ export interface CalendarEvent {
   team?: {
     name: string;
     members: TeamMember[];
-    destinationCalendar: DestinationCalendar[];
+    destinationCalendar?: DestinationCalendar[];
   };
   location?: string | null;
   conferenceData?: ConferenceData;


### PR DESCRIPTION
## What does this PR do?

When collective event is created, EventManager.createCalendars just uses organiser calendar credentials for creating the event. With these changes we can use team destination calendars and create each calendars for each team member with right list of attendees.

Fixes #7754

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Create a Collective Team Event
- [ ] Add Teampro and Team free as hosters
- [ ] Add to each user a different google calendar
- [ ] Book using a random user
- [ ] Finally you should be able to see calendar in google with right attendees and for each user host calendar.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
