### PR TITLE
Fixes that sometimes last shown slot was unavailable

### DIFF
--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -112,4 +112,25 @@ describe("Tests the slot logic", () => {
       })
     ).toHaveLength(11);
   });
+
+  it("shows correct time slots for 20 minutes long events with working hours that do not end at a full hour ", async () => {
+    // 72 20-minutes events in a 24h day
+    expect(
+      getSlots({
+        inviteeDate: dayjs.utc().add(1, "day"),
+        frequency: 20,
+        minimumBookingNotice: 0,
+        workingHours: [
+          {
+            userId: 1,
+            days: Array.from(Array(7).keys()),
+            startTime: MINUTES_DAY_START,
+            endTime: MINUTES_DAY_END - 14, // 23:45
+          },
+        ],
+        eventLength: 20,
+        organizerTimeZone: "America/Toronto",
+      })
+    ).toHaveLength(71);
+  });
 });

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -86,8 +86,8 @@ function buildSlots({
     // loop through the day, based on frequency.
     for (let slotStart = boundaryStart; slotStart < boundaryEnd; slotStart += frequency) {
       computedLocalAvailability.forEach((item) => {
-        // TODO: This logic does not allow for past-midnight bookings.
-        if (slotStart < item.startTime || slotStart > item.endTime + 15 - eventLength) {
+        // TODO: This logic does not allow for past-midnight bookings
+        if (slotStart < item.startTime || slotStart > item.endTime + 1 - eventLength) {
           return;
         }
         slotsTimeFrameAvailable[slotStart.toString()] = {

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -86,7 +86,7 @@ function buildSlots({
     // loop through the day, based on frequency.
     for (let slotStart = boundaryStart; slotStart < boundaryEnd; slotStart += frequency) {
       computedLocalAvailability.forEach((item) => {
-        // TODO: This logic does not allow for past-midnight bookings
+        // TODO: This logic does not allow for past-midnight bookings.
         if (slotStart < item.startTime || slotStart > item.endTime + 1 - eventLength) {
           return;
         }


### PR DESCRIPTION
## What does this PR do?

Fixes that sometimes the last time slot shown is not within working hours. This is the case for 20 minute long events that have working hours that don't end in a full hour. 

Also adds a test that fails before and succeeds with the new changes

Fixes #7659

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create event type with event length 20 minutes
- Set your availability to 9:00 - 16:45 (or anything else that does not end in a full hour)
- See that the 16:40 time slot is not shown anymore
