### PR TITLE
Update dialog min-width

### DIFF
--- a/packages/ui/components/dialog/Dialog.tsx
+++ b/packages/ui/components/dialog/Dialog.tsx
@@ -77,7 +77,7 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
         <DialogPrimitive.Content
           {...props}
           className={classNames(
-            "fadeIn fixed left-1/2 top-1/2 z-50 min-w-[360px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
+            "fadeIn fixed left-1/2 top-1/2 z-50 min-w-[270px] -translate-x-1/2 -translate-y-1/2 rounded bg-white text-left shadow-xl focus-visible:outline-none sm:w-full sm:align-middle",
             props.size == "xl"
               ? "p-8 sm:max-w-[90rem]"
               : props.size == "lg"


### PR DESCRIPTION
## What does this PR do?

 The `<Dialog></Dialog>` component, specifically the `<DialogPrimitive.Content></DialogPrimitive.Content>` had a property with `min-w-[360px]`. In the past few years, many 'thin' smartphones have come to the market, among them, are the 'folding' phones. they are usually thinner, as thin as 280px, and might be smaller. so I updated the min-width to 270px, so it looks nicer and doesn't overflow on smaller-width screen devices.

You can see[ here](https://nadav2.imgbb.com/), where I took screenshots of before and after the simple min-width change would look like using Galaxy Fold, for example.

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

I, unfortunately, don't have the time right now to go deeper and run specific tests to check each component that is using the Dialog component. you can feel free to do so if you choose. Other things that should be considered are buttons and other action items. they could be affected as well. This is probably not a permanent solution, it is more to raise the issue, and make cal a better app for thinner devices.
if you deem this to be a worthy cause and would like me to, perhaps next week I can spend more time on this and come up with a better solution.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
