### PR TITLE
fix: add calendar button width for longer languages and alignment

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -447,7 +447,7 @@ function ShellHeader() {
             <div className="mb-1 h-6 w-32 animate-pulse rounded-md bg-gray-200" />
           )}
         </div>
-        <div className="ml-auto">{meta.CTA}</div>
+        <div className="flex-shrink-0 ltr:ml-auto rtl:mr-auto">{meta.CTA}</div>
       </div>
     </header>
   );


### PR DESCRIPTION
## What does this PR do?

Fixes the width of add calendar button on "/settings/my-account/calendars" page for longer languages and also fixes its alignment in rtl languages

Fixes #7800 

<img width="523" alt="Screenshot 2023-03-18 at 11 15 47 AM" src="https://user-images.githubusercontent.com/82832085/226087648-117070cd-ec13-4c46-bba8-e880df3608ba.png">
<img width="897" alt="Screenshot 2023-03-18 at 11 16 05 AM" src="https://user-images.githubusercontent.com/82832085/226087655-aa02470c-14d9-481a-9992-57311c63ac20.png">


**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

