### PR TITLE
Bugfix/format without time zone

### DIFF
--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -253,7 +253,6 @@ export default class Office365CalendarService implements Calendar {
   };
 
   private translateEvent = (event: CalendarEvent) => {
-    const utcOffset = dayjs(event.startTime).tz(event.organizer.timeZone).utcOffset() / 60;
     return {
       subject: event.title,
       body: {
@@ -261,11 +260,11 @@ export default class Office365CalendarService implements Calendar {
         content: getRichDescription(event),
       },
       start: {
-        dateTime: dayjs(event.startTime).utcOffset(utcOffset).format(),
+        dateTime: dayjs(event.startTime).tz(event.organizer.timeZone).format("YYYY-MM-DDTHH:mm:ss"),
         timeZone: event.organizer.timeZone,
       },
       end: {
-        dateTime: dayjs(event.endTime).utcOffset(utcOffset).format(),
+        dateTime: dayjs(event.endTime).tz(event.organizer.timeZone).format("YYYY-MM-DDTHH:mm:ss"),
         timeZone: event.organizer.timeZone,
       },
       attendees: event.attendees.map((attendee) => ({

--- a/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
@@ -196,12 +196,11 @@ const ZoomVideoApiAdapter = (credential: CredentialPayload): VideoApiAdapter => 
     };
 
     const recurrence = getRecurrence(event);
-    const utcOffset = dayjs(event.startTime).tz(event.organizer.timeZone).utcOffset() / 60;
     // Documentation at: https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate
     return {
       topic: event.title,
       type: 2, // Means that this is a scheduled meeting
-      start_time: dayjs(event.startTime).utcOffset(utcOffset).format(),
+      start_time: dayjs(event.startTime).utc().format(),
       duration: (new Date(event.endTime).getTime() - new Date(event.startTime).getTime()) / 60000,
       //schedule_for: "string",   TODO: Used when scheduling the meeting for someone else (needed?)
       timezone: event.organizer.timeZone,


### PR DESCRIPTION
## What does this PR do?

* Removes the UTC suffix from the formatted timeZone in Office 365
* Ensures that Zoom start_time is given in UTC

## Zoom
The start time should be provided in ISO 8601 format with the "Z" character at the end to indicate that it is in UTC format. For example, the start time for a meeting on March 24th, 2023 at 4:00 PM Pacific Time (which is 7:00 PM Eastern Time) would be:

```json
"start_time": "2023-03-25T00:00:00Z"
```

Note that in this example, the start time is actually midnight UTC on March 25th, because that is the equivalent of 4:00 PM Pacific Time on March 24th.

If you need to specify a different time zone for the meeting, you can include the "timezone" parameter in the request payload to indicate the desired time zone. The Zoom API will then convert the date-time values to the specified time zone.
