### PR TITLE
fix: hide giphy in cancellation detail page

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -431,7 +431,7 @@ export default function Success(props: SuccessProps) {
                       : "",
                     isCancelled ? "h-12 w-12 rounded-full bg-red-100" : ""
                   )}>
-                  {giphyImage && !needsConfirmation && (
+                  {giphyImage && !needsConfirmation && !isCancelled && (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={giphyImage} alt="Gif from Giphy" />
                   )}


### PR DESCRIPTION
## What does this PR do?
fixes one of the issue mentioned in  #7817
before:

![Screenshot 2023-03-20 at 08-16-26 Your booking has been confirmed Cal com](https://user-images.githubusercontent.com/84864519/226235300-1877de8c-7900-4afc-9d46-befa92418987.png)


after:
![Screenshot 2023-03-20 at 08-16-46 Your booking has been confirmed Cal com](https://user-images.githubusercontent.com/84864519/226235314-0e018ef3-e432-4015-ac48-fa4d11bd7615.png)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
