### PR TITLE
Fix: Send responses in confirm booking flow

### DIFF
--- a/apps/web/pages/[user]/book.tsx
+++ b/apps/web/pages/[user]/book.tsx
@@ -237,11 +237,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   let booking: GetBookingType | null = null;
   if (rescheduleUid || query.bookingUid || bookingUidWithSeats) {
-    booking = await getBooking(
-      prisma,
-      rescheduleUid || query.bookingUid || bookingUidWithSeats || "",
-      eventTypeObject.bookingFields
-    );
+    booking = await getBooking(prisma, rescheduleUid || query.bookingUid || bookingUidWithSeats || "");
   }
 
   if (rescheduleEventTypeHasSeats && booking?.attendees && booking?.attendees.length > 0) {

--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -1087,8 +1087,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     };
   }
 
-  const bookingInfo = getBookingWithResponses(bookingInfoRaw, eventTypeRaw);
-
+  const bookingInfo = getBookingWithResponses(bookingInfoRaw);
   // @NOTE: had to do this because Server side cant return [Object objects]
   // probably fixable with json.stringify -> json.parse
   bookingInfo["startTime"] = (bookingInfo?.startTime as Date)?.toISOString() as unknown as Date;

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -2,7 +2,6 @@ import type { GetServerSidePropsContext } from "next";
 
 import type { LocationObject } from "@calcom/core/location";
 import { privacyFilteredLocations } from "@calcom/core/location";
-import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
 import { parseRecurringEvent } from "@calcom/lib";
 import { getWorkingHours } from "@calcom/lib/availability";
 import prisma from "@calcom/prisma";
@@ -177,7 +176,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   let booking: GetBookingType | null = null;
   if (rescheduleUid) {
-    booking = await getBooking(prisma, rescheduleUid, getBookingFieldsWithSystemFields(eventTypeObject));
+    booking = await getBooking(prisma, rescheduleUid);
   }
 
   const weekStart = eventType.team?.members?.[0]?.user?.weekStart;

--- a/apps/web/pages/team/[slug]/book.tsx
+++ b/apps/web/pages/team/[slug]/book.tsx
@@ -127,7 +127,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   let booking: GetBookingType | null = null;
   const { rescheduleUid, bookingUid } = querySchema.parse(context.query);
   if (rescheduleUid || bookingUid) {
-    booking = await getBooking(prisma, rescheduleUid || bookingUid || "", eventTypeObject.bookingFields);
+    booking = await getBooking(prisma, rescheduleUid || bookingUid || "");
   }
 
   // Checking if number of recurring event ocurrances is valid against event type configuration

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -9,6 +9,20 @@ type EventType = Parameters<typeof preprocess>[0]["eventType"];
 // eslint-disable-next-line @typescript-eslint/ban-types
 type View = ALL_VIEWS | (string & {});
 
+export const bookingResponse = z.union([
+  z.string(),
+  z.boolean(),
+  z.string().array(),
+  z.object({
+    optionValue: z.string(),
+    value: z.string(),
+  }),
+]);
+
+export const bookingResponsesDbSchema = z.record(bookingResponse);
+
+const catchAllSchema = bookingResponsesDbSchema;
+
 export const getBookingResponsesPartialSchema = ({
   eventType,
   view,
@@ -16,7 +30,7 @@ export const getBookingResponsesPartialSchema = ({
   eventType: EventType;
   view: View;
 }) => {
-  const schema = bookingResponses.unwrap().partial().and(z.record(z.any()));
+  const schema = bookingResponses.unwrap().partial().and(catchAllSchema);
 
   return preprocess({ schema, eventType, isPartialSchema: true, view });
 };
@@ -38,6 +52,9 @@ function preprocess<T extends z.ZodType>({
   view: currentView,
 }: {
   schema: T;
+  // It is useful when we want to prefill the responses with the partial values. Partial can be in 2 ways
+  // - Not all required fields are need to be provided for prefill.
+  // - Even a field response itself can be partial so the content isn't validated e.g. a field with type="phone" can be given a partial phone number(e.g. Specifying the country code like +91)
   isPartialSchema: boolean;
   eventType: {
     bookingFields: (z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">) | null;
@@ -48,6 +65,7 @@ function preprocess<T extends z.ZodType>({
     (responses) => {
       const parsedResponses = z.record(z.any()).nullable().parse(responses) || {};
       const newResponses = {} as typeof parsedResponses;
+      // if eventType has been deleted, we won't have bookingFields and thus we can't preprocess or validate them.
       if (!eventType.bookingFields) return parsedResponses;
       eventType.bookingFields.forEach((field) => {
         const value = parsedResponses[field.name];
@@ -88,6 +106,7 @@ function preprocess<T extends z.ZodType>({
     },
     schema.superRefine((responses, ctx) => {
       if (!eventType.bookingFields) {
+        // if eventType has been deleted, we won't have bookingFields and thus we can't validate the responses.
         return;
       }
       eventType.bookingFields.forEach((bookingField) => {

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -1,0 +1,59 @@
+import type z from "zod";
+
+import { SystemField } from "@calcom/features/bookings/lib/getBookingFields";
+import type getBookingResponsesSchema from "@calcom/features/bookings/lib/getBookingResponsesSchema";
+import type { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+
+export const getCalEventResponses = ({
+  bookingFields,
+  responses,
+}: {
+  // If the eventType has been deleted and a booking is Accepted later on, then bookingFields will be null and we can't know the label of fields. So, we should store the label as well in the DB
+  // Also, it is no longer straightforward to identify if a field is system field or not
+  bookingFields: z.infer<typeof eventTypeBookingFields> | null;
+  responses: z.infer<ReturnType<typeof getBookingResponsesSchema>>;
+}) => {
+  const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
+  const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;
+
+  if (bookingFields) {
+    bookingFields.forEach((field) => {
+      const label = field.label || field.defaultLabel;
+      if (!label) {
+        throw new Error('Missing label for booking field "' + field.name + '"');
+      }
+      if (field.editable === "user" || field.editable === "user-readonly") {
+        calEventUserFieldsResponses[field.name] = {
+          label,
+          value: responses[field.name],
+        };
+      }
+      calEventResponses[field.name] = {
+        label,
+        value: responses[field.name],
+      };
+    });
+  } else {
+    // Alternative way to generate for a booking of whose eventType has been deleted
+    for (const [name, value] of Object.entries(responses)) {
+      const isSystemField = SystemField.safeParse(name);
+
+      // Use name for Label because we don't have access to the label.
+      const label = name;
+
+      if (!isSystemField.success) {
+        calEventUserFieldsResponses[name] = {
+          label,
+          value,
+        };
+      }
+
+      calEventResponses[name] = {
+        label,
+        value,
+      };
+    }
+  }
+  return { calEventUserFieldsResponses, calEventResponses };
+};

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -1,7 +1,7 @@
 import type z from "zod";
 
 import { SystemField } from "@calcom/features/bookings/lib/getBookingFields";
-import type getBookingResponsesSchema from "@calcom/features/bookings/lib/getBookingResponsesSchema";
+import type { getBookingResponsesPartialSchema } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import type { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
@@ -12,7 +12,7 @@ export const getCalEventResponses = ({
   // If the eventType has been deleted and a booking is Accepted later on, then bookingFields will be null and we can't know the label of fields. So, we should store the label as well in the DB
   // Also, it is no longer straightforward to identify if a field is system field or not
   bookingFields: z.infer<typeof eventTypeBookingFields> | null;
-  responses: z.infer<ReturnType<typeof getBookingResponsesSchema>>;
+  responses: z.infer<ReturnType<typeof getBookingResponsesPartialSchema>>;
 }) => {
   const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
   const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -1,7 +1,7 @@
 import type z from "zod";
 
 import { SystemField } from "@calcom/features/bookings/lib/getBookingFields";
-import type { getBookingResponsesPartialSchema } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
+import type { bookingResponsesDbSchema } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import type { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
@@ -12,7 +12,7 @@ export const getCalEventResponses = ({
   // If the eventType has been deleted and a booking is Accepted later on, then bookingFields will be null and we can't know the label of fields. So, we should store the label as well in the DB
   // Also, it is no longer straightforward to identify if a field is system field or not
   bookingFields: z.infer<typeof eventTypeBookingFields> | null;
-  responses: z.infer<ReturnType<typeof getBookingResponsesPartialSchema>>;
+  responses: z.infer<typeof bookingResponsesDbSchema>;
 }) => {
   const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
   const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;
@@ -39,7 +39,7 @@ export const getCalEventResponses = ({
     for (const [name, value] of Object.entries(responses)) {
       const isSystemField = SystemField.safeParse(name);
 
-      // Use name for Label because we don't have access to the label.
+      // Use name for Label because we don't have access to the label. This will not be needed once we start storing the label along with the response
       const label = name;
 
       if (!isSystemField.success) {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -32,6 +32,7 @@ import {
   sendScheduledSeatsEmails,
 } from "@calcom/emails";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
+import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { deleteScheduledEmailReminder } from "@calcom/features/ee/workflows/lib/reminders/emailReminderManager";
 import { scheduleWorkflowReminders } from "@calcom/features/ee/workflows/lib/reminders/reminderScheduler";
 import { deleteScheduledSMSReminder } from "@calcom/features/ee/workflows/lib/reminders/smsReminderManager";
@@ -386,23 +387,9 @@ function getBookingData({
   const reqBody = bookingDataSchema.parse(req.body);
   if ("responses" in reqBody) {
     const responses = reqBody.responses;
-    const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;
-    const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
-    eventType.bookingFields.forEach((field) => {
-      const label = field.label || field.defaultLabel;
-      if (!label) {
-        throw new Error('Missing label for booking field "' + field.name + '"');
-      }
-      if (field.editable === "user" || field.editable === "user-readonly") {
-        calEventUserFieldsResponses[field.name] = {
-          label,
-          value: responses[field.name],
-        };
-      }
-      calEventResponses[field.name] = {
-        label,
-        value: responses[field.name],
-      };
+    const { calEventUserFieldsResponses, calEventResponses } = getCalEventResponses({
+      bookingFields: eventType.bookingFields,
+      responses,
     });
     return {
       ...reqBody,

--- a/packages/lib/getLabelValueMapFromResponses.ts
+++ b/packages/lib/getLabelValueMapFromResponses.ts
@@ -1,11 +1,17 @@
+import type z from "zod";
+
+import type { bookingResponse } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
 export default function getLabelValueMapFromResponses(calEvent: CalendarEvent) {
   const { customInputs, userFieldsResponses } = calEvent;
 
-  let labelValueMap: Record<string, string | string[]> = {};
+  let labelValueMap: Record<string, z.infer<typeof bookingResponse>> = {};
   if (userFieldsResponses) {
     for (const [, value] of Object.entries(userFieldsResponses)) {
+      if (!value.label) {
+        continue;
+      }
       labelValueMap[value.label] = value.value;
     }
   } else {

--- a/packages/trpc/server/routers/viewer/bookings.tsx
+++ b/packages/trpc/server/routers/viewer/bookings.tsx
@@ -16,6 +16,7 @@ import { deleteScheduledEmailReminder } from "@calcom/ee/workflows/lib/reminders
 import { deleteScheduledSMSReminder } from "@calcom/ee/workflows/lib/reminders/smsReminderManager";
 import { sendDeclinedEmails, sendLocationChangeEmails, sendRequestRescheduleEmail } from "@calcom/emails";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
+import { getBookingResponsesPartialSchema } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { handleConfirmation } from "@calcom/features/bookings/lib/handleConfirmation";
 import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
@@ -772,12 +773,22 @@ export const bookingsRouter = router({
         scheduledJobs: true,
       },
     });
+    const bookingFields = bookingRaw.eventType
+      ? getBookingFieldsWithSystemFields(bookingRaw.eventType)
+      : null;
     const booking = {
       ...bookingRaw,
+      responses: getBookingResponsesPartialSchema({
+        eventType: {
+          bookingFields,
+        },
+        // An existing booking can have data from any number of views, so the schema should consider ALL_VIEWS
+        view: "ALL_VIEWS",
+      }),
       eventType: bookingRaw.eventType
         ? {
             ...bookingRaw.eventType,
-            bookingFields: getBookingFieldsWithSystemFields(bookingRaw.eventType),
+            bookingFields,
           }
         : null,
     };

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -3,7 +3,9 @@ import type { Dayjs } from "dayjs";
 import type { calendar_v3 } from "googleapis";
 import type { Time } from "ical.js";
 import type { TFunction } from "next-i18next";
+import type z from "zod";
 
+import type { bookingResponse } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import type { Calendar } from "@calcom/features/calendars/weeklyview";
 import type { TimeFormat } from "@calcom/lib/timeFormat";
 import type { Frequency } from "@calcom/prisma/zod-utils";
@@ -129,6 +131,14 @@ export type AppsStatus = {
   warnings?: string[];
 };
 
+type CalEventResponses = Record<
+  string,
+  {
+    label: string;
+    value: z.infer<typeof bookingResponse>;
+  }
+>;
+
 // If modifying this interface, probably should update builders/calendarEvent files
 export interface CalendarEvent {
   type: string;
@@ -164,22 +174,10 @@ export interface CalendarEvent {
   seatsPerTimeSlot?: number | null;
 
   // It has responses to all the fields(system + user)
-  responses?: Record<
-    string,
-    {
-      value: string | string[];
-      label: string;
-    }
-  > | null;
+  responses?: CalEventResponses | null;
 
   // It just has responses to only the user fields. It allows to easily iterate over to show only user fields
-  userFieldsResponses?: Record<
-    string,
-    {
-      value: string | string[];
-      label: string;
-    }
-  > | null;
+  userFieldsResponses?: CalEventResponses | null;
 }
 
 export interface EntryPoint {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7810

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Make a booking for an Event Type which requires confirmation. Accept the booking and notice that webhook payload has the `responses` and `userFieldsResponses` props.
- [x] Make a booking like the earlier test and before accepting the booking, delete the Event Type. Notice that `responses` and `userFieldsResponses` props are still there.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
