### PR TITLE
No delete of booking on seated events, fix id->uid

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -86,7 +86,7 @@ export default function CancelBooking(props: Props) {
 
                   const res = await fetch("/api/cancel", {
                     body: JSON.stringify({
-                      id: booking?.id,
+                      uid: booking?.uid,
                       cancellationReason: cancellationReason,
                       allRemainingBookings,
                       // @NOTE: very important this shouldn't cancel with number ID use uid instead

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -1,4 +1,4 @@
-import type { WebhookTriggerEvents, WorkflowReminder } from "@prisma/client";
+import type { WebhookTriggerEvents, WorkflowReminder, Prisma } from "@prisma/client";
 import { BookingStatus, MembershipRole, WorkflowMethods } from "@prisma/client";
 import type { NextApiRequest } from "next";
 
@@ -391,10 +391,11 @@ async function handler(req: CustomRequest) {
         },
       });
     }
+
+    const where: Prisma.BookingWhereUniqueInput = uid ? { uid } : { id };
+
     const updatedBooking = await prisma.booking.update({
-      where: {
-        uid,
-      },
+      where,
       data: {
         status: BookingStatus.CANCELLED,
         cancellationReason: cancellationReason,

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -266,9 +266,12 @@ async function handler(req: CustomRequest) {
 
     await Promise.all(integrationsToDelete).then(async () => {
       if (lastAttendee) {
-        await prisma.booking.delete({
+        await prisma.booking.update({
           where: {
             id: bookingToDelete.id,
+          },
+          data: {
+            status: BookingStatus.CANCELLED,
           },
         });
       }
@@ -390,7 +393,6 @@ async function handler(req: CustomRequest) {
     }
     const updatedBooking = await prisma.booking.update({
       where: {
-        id,
         uid,
       },
       data: {


### PR DESCRIPTION
## What does this PR do?

* Fixes orphaned cancelled events in the /bookings list.

@leog If you still remember, could you provide the reasoning behind the uid -> id change? I miss that context. https://github.com/calcom/cal.com/pull/5105/files#diff-b56ec7c13bd93d1e15d6398bf474cc86185a6178f6043f6d99071e8189c8f738

@alannnc Fixup to seated events to not delete the original event (just cancel)