### PR TITLE
Hotfix: Adds missing team members to gCal event

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -75,6 +75,13 @@ export default class GoogleCalendarService implements Calendar {
       ...rest,
       responseStatus: "accepted",
     }));
+    // TODO: Check every other CalendarService for team members
+    const teamMembers =
+      calEventRaw.team?.members.map((m) => ({
+        email: m.email,
+        displayName: m.name,
+        responseStatus: "accepted",
+      })) || [];
     return new Promise(async (resolve, reject) => {
       const myGoogleAuth = await this.auth.getToken();
       const payload: calendar_v3.Schema$Event = {
@@ -99,6 +106,7 @@ export default class GoogleCalendarService implements Calendar {
               : calEventRaw.organizer.email,
           },
           ...eventAttendees,
+          ...teamMembers,
         ],
         reminders: {
           useDefault: true,


### PR DESCRIPTION
## What does this PR do?

- Re-adds team members to calendar invite that were removed in #7207

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Create a team collective event and add team members to it
- [ ] Connect a google calendar
- [ ] Create an event, all team members should appear as part of the calendar event invitees

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works (Will do in a follow up)
