### PR TITLE
Add a minute in endTime working hours when 11:59 is selected

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -131,7 +131,9 @@ const isWithinAvailableHours = (
 
   for (const workingHour of workingHours) {
     const startTime = getTime(timeSlotStart, workingHour.startTime);
-    const endTime = getTime(timeSlotEnd, workingHour.endTime);
+    // workingHours function logic set 1439 minutes when user select the end of the day (11:59) in his schedule
+    // so, we need to add a minute, to avoid, "No available user" error when the last available slot is selected.
+    const endTime = getTime(timeSlotEnd, workingHour.endTime === 1439 ? 1440 : workingHour.endTime);
     if (
       workingHour.days.includes(timeSlotStart.day()) &&
       // UTC mode, should be performant.


### PR DESCRIPTION
## What does this PR do?

When users create an schedule using 11:59pm, is getting "No user avaliable" error, because the last time slot event ends at 00:00

![imagen](https://user-images.githubusercontent.com/525369/226534807-4c17ed8e-dcdf-4683-adcf-a7baffa70fbb.png)


Fixes #

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Create an schedule that ends at 11:59pm
- [ ] Try to reserve the last space of a 30-minute event.
- [ ] you must be able to book successfully
