### PR TITLE
Fix/conflicts of custom input Name, with system field

### DIFF
--- a/packages/features/bookings/lib/getBookingFields.ts
+++ b/packages/features/bookings/lib/getBookingFields.ts
@@ -55,16 +55,6 @@ export const SystemField = z.enum([
   "smsReminderNumber",
 ]);
 
-export const SystemFieldsEditability: Record<z.infer<typeof SystemField>, Fields[number]["editable"]> = {
-  name: "system",
-  email: "system",
-  location: "system",
-  notes: "system-but-optional",
-  guests: "system-but-optional",
-  rescheduleReason: "system-but-optional",
-  smsReminderNumber: "system",
-};
-
 /**
  * This fn is the key to ensure on the fly mapping of customInputs to bookingFields and ensuring that all the systems fields are present and correctly ordered in bookingFields
  */
@@ -165,6 +155,7 @@ export const ensureBookingInputsHaveSystemFields = ({
       defaultLabel: "your_name",
       type: "name",
       name: "name",
+      editable: "system",
       required: true,
       sources: [
         {
@@ -179,6 +170,7 @@ export const ensureBookingInputsHaveSystemFields = ({
       type: "email",
       name: "email",
       required: true,
+      editable: "system",
       sources: [
         {
           label: "Default",
@@ -191,6 +183,7 @@ export const ensureBookingInputsHaveSystemFields = ({
       defaultLabel: "location",
       type: "radioInput",
       name: "location",
+      editable: "system",
       required: false,
       // Populated on the fly from locations. I don't want to duplicate storing locations and instead would like to be able to refer to locations in eventType.
       // options: `eventType.locations`
@@ -222,6 +215,7 @@ export const ensureBookingInputsHaveSystemFields = ({
       defaultLabel: "additional_notes",
       type: "textarea",
       name: "notes",
+      editable: "system-but-optional",
       required: additionalNotesRequired,
       defaultPlaceholder: "share_additional_notes",
       sources: [
@@ -235,6 +229,7 @@ export const ensureBookingInputsHaveSystemFields = ({
     {
       defaultLabel: "additional_guests",
       type: "multiemail",
+      editable: "system-but-optional",
       name: "guests",
       required: false,
       hidden: disableGuests,
@@ -249,6 +244,7 @@ export const ensureBookingInputsHaveSystemFields = ({
     {
       defaultLabel: "reschedule_reason",
       type: "textarea",
+      editable: "system-but-optional",
       name: "rescheduleReason",
       defaultPlaceholder: "reschedule_placeholder",
       required: false,
@@ -304,7 +300,7 @@ export const ensureBookingInputsHaveSystemFields = ({
         label: input.label,
         editable: "user",
         // Custom Input's slugified label was being used as query param for prefilling. So, make that the name of the field
-        name: `custom-${slugify(input.label)}`,
+        name: slugify(input.label),
         placeholder: input.placeholder,
         type: CustomInputTypeToFieldType[input.type],
         required: input.required,
@@ -337,18 +333,6 @@ export const ensureBookingInputsHaveSystemFields = ({
   }
 
   bookingFields = bookingFields.concat(missingSystemAfterFields);
-
-  bookingFields = bookingFields.map((field) => {
-    const foundEditableMap = SystemFieldsEditability[field.name as keyof typeof SystemFieldsEditability];
-    if (!foundEditableMap) {
-      return field;
-    }
-    // Ensure that system fields editability, even if modified to something else in DB(accidentally), get's reset to what's in the code.
-    return {
-      ...field,
-      editable: foundEditableMap,
-    };
-  });
 
   return eventTypeBookingFields.brand<"HAS_SYSTEM_FIELDS">().parse(bookingFields);
 };

--- a/packages/features/bookings/lib/getBookingFields.ts
+++ b/packages/features/bookings/lib/getBookingFields.ts
@@ -304,7 +304,7 @@ export const ensureBookingInputsHaveSystemFields = ({
         label: input.label,
         editable: "user",
         // Custom Input's slugified label was being used as query param for prefilling. So, make that the name of the field
-        name: slugify(input.label),
+        name: `custom-${slugify(input.label)}`,
         placeholder: input.placeholder,
         type: CustomInputTypeToFieldType[input.type],
         required: input.required,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7737

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Create a new EventType and change eventType.`customInputs` in DB torefer to customInputs table rows like this
<img width="1781" alt="Screenshot 2023-03-21 at 3 18 42 PM" src="https://user-images.githubusercontent.com/1780212/226570396-5c58fbc1-0fc2-49e5-9337-62890e9561fa.png">
Go to Advanced section and try saving the EventType. You won't be able to save it. If you would try to edit the custom field name, you won't be able to. With this branch, you would be able to change custom fields' names even if they are same as system fields' names
- [x] Check that the fields with same name as system fields are deletable but system fields are not deletable.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
