### PR TITLE
fix: Custom Input Migration - Make sure that label is also set

### DIFF
--- a/packages/features/bookings/lib/getBookingFields.ts
+++ b/packages/features/bookings/lib/getBookingFields.ts
@@ -11,6 +11,13 @@ import {
 
 export const SMS_REMINDER_NUMBER_FIELD = "smsReminderNumber";
 
+/**
+ * PHONE -> Phone
+ */
+function upperCaseToCamelCase(upperCaseString: string) {
+  return upperCaseString[0].toUpperCase() + upperCaseString.slice(1).toLowerCase();
+}
+
 export const getSmsReminderNumberField = () =>
   ({
     name: SMS_REMINDER_NUMBER_FIELD,
@@ -296,8 +303,9 @@ export const ensureBookingInputsHaveSystemFields = ({
   // Backward Compatibility: If we are migrating from old system, we need to map `customInputs` to `bookingFields`
   if (handleMigration) {
     customInputs.forEach((input, index) => {
+      const label = input.label || `${upperCaseToCamelCase(input.type)}`;
       bookingFields.push({
-        label: input.label,
+        label: label,
         editable: "user",
         // Custom Input's slugified label was being used as query param for prefilling. So, make that the name of the field
         // Also Custom Input's label could have been empty string as well. But it's not possible to have empty name. So generate a name automatically.


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Follow-up of #7871. Even though zod allows empty label, we don't allow empty label(see https://github.com/calcom/cal.com/blob/351b4228d4d23dac052f3ccf79c4af4e7e3a5063/packages/features/bookings/lib/handleNewBooking.ts#L396) during booking because label is shown in email. So, generate a proper label as well/

**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

