### PR TITLE
fix: set canonical to https://cal.com on .dev as well

### DIFF
--- a/packages/ui/components/head-seo/HeadSeo.tsx
+++ b/packages/ui/components/head-seo/HeadSeo.tsx
@@ -75,7 +75,8 @@ export const HeadSeo = (props: HeadSeoProps): JSX.Element => {
   // Get the current URL from the window object
   const url = getBrowserInfo()?.url;
   // Check if the URL is from cal.com
-  const isCalcom = url && new URL(url).hostname.endsWith("cal.com");
+  const isCalcom =
+    url && (new URL(url).hostname.endsWith("cal.com") || new URL(url).hostname.endsWith("cal.dev"));
   // Get the router's path
   const path = useRouter().asPath;
   // Build the canonical URL using the router's path, without query parameters. Note: on homepage it omits the trailing slash


### PR DESCRIPTION
## What does this PR do?

updates the canonical logic to set it for cal.dev as well

Fixes # (issue)

- when on cal.dev, we're currently setting the canonical to cal.dev -- this PR fixes this
**Environment**: Staging(main branch) / Production

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- [ ] After deployment, visit cal.dev/apps and inspect the browser console for the `<link rel="canonical">` element. It should display the cal.com/apps link
