### PR TITLE
Fix: Missing Video Call Link in reschedule

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1654,7 +1654,7 @@ async function handler(
     }
 
     // Use EventManager to conditionally use all needed integrations.
-
+    addVideoCallDataToEvt(originalRescheduledBooking.references);
     const updateManager = await eventManager.reschedule(evt, originalRescheduledBooking.uid);
     // This gets overridden when updating the event - to check if notes have been hidden or not. We just reset this back
     // to the default description when we are sending the emails.


### PR DESCRIPTION
## What does this PR do?

Fix videoLink not present in email when rescheduled
See [demo of bug and fix](https://www.loom.com/share/431e42e545674e969927b8a4f8eaab19)
**Environment**:  Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Simply do a reschedule for an EventType with Jitsi location(any other video location would work too) and see that email doesn't have video call link
## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->


- I haven't added tests that prove my fix is effective or that my feature works
