### PR TITLE
Fix Zod errors in Outlook auth function

### DIFF
--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -219,7 +219,7 @@ export default class Office365CalendarService implements Calendar {
     };
     const o365AuthCredentials = credential.key as O365AuthCredentials;
 
-    const refreshAccessToken = async (refreshToken: string) => {
+    const refreshAccessToken = async (o365AuthCredentials: O365AuthCredentials) => {
       const { client_id, client_secret } = await getOfficeAppKeys();
       const response = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {
         method: "POST",
@@ -227,12 +227,17 @@ export default class Office365CalendarService implements Calendar {
         body: new URLSearchParams({
           scope: "User.Read Calendars.Read Calendars.ReadWrite",
           client_id,
-          refresh_token: refreshToken,
+          refresh_token: o365AuthCredentials.refresh_token,
           grant_type: "refresh_token",
           client_secret,
         }),
       });
-      const o365AuthCredentials = refreshTokenResponseSchema.parse(await handleErrorsJson(response));
+      const responseJson = await handleErrorsJson(response);
+      const tokenResponse = refreshTokenResponseSchema.safeParse(responseJson);
+      o365AuthCredentials = { ...o365AuthCredentials, ...(tokenResponse.success && tokenResponse.data) };
+      if (!tokenResponse.success) {
+        console.error("zodError:", tokenResponse.error, "MS response:", responseJson);
+      }
       await prisma.credential.update({
         where: {
           id: credential.id,
@@ -246,9 +251,10 @@ export default class Office365CalendarService implements Calendar {
 
     return {
       getToken: () =>
+        refreshTokenResponseSchema.safeParse(o365AuthCredentials).success ||
         !isExpired(o365AuthCredentials.expires_in)
           ? Promise.resolve(o365AuthCredentials.access_token)
-          : refreshAccessToken(o365AuthCredentials.refresh_token),
+          : refreshAccessToken(o365AuthCredentials),
     };
   };
 

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -232,8 +232,7 @@ export default class Office365CalendarService implements Calendar {
           client_secret,
         }),
       });
-      // const responseJson = await handleErrorsJson(response);
-      const responseJson = { error: "This is an error" };
+      const responseJson = await handleErrorsJson(response);
       const tokenResponse = refreshTokenResponseSchema.safeParse(responseJson);
       o365AuthCredentials = { ...o365AuthCredentials, ...(tokenResponse.success && tokenResponse.data) };
       if (!tokenResponse.success) {

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -232,11 +232,17 @@ export default class Office365CalendarService implements Calendar {
           client_secret,
         }),
       });
-      const responseJson = await handleErrorsJson(response);
+      // const responseJson = await handleErrorsJson(response);
+      const responseJson = { error: "This is an error" };
       const tokenResponse = refreshTokenResponseSchema.safeParse(responseJson);
       o365AuthCredentials = { ...o365AuthCredentials, ...(tokenResponse.success && tokenResponse.data) };
       if (!tokenResponse.success) {
-        console.error("zodError:", tokenResponse.error, "MS response:", responseJson);
+        console.error(
+          "Outlook error grabbing new tokens ~ zodError:",
+          tokenResponse.error,
+          "MS response:",
+          responseJson
+        );
       }
       await prisma.credential.update({
         where: {
@@ -251,7 +257,7 @@ export default class Office365CalendarService implements Calendar {
 
     return {
       getToken: () =>
-        refreshTokenResponseSchema.safeParse(o365AuthCredentials).success ||
+        refreshTokenResponseSchema.safeParse(o365AuthCredentials).success &&
         !isExpired(o365AuthCredentials.expires_in)
           ? Promise.resolve(o365AuthCredentials.access_token)
           : refreshAccessToken(o365AuthCredentials),


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes Zod parsing errors in the Outlook auth function. By using safeParse we will not throw an error when the response from MS is not as expected. We also added increased logging of MS error responses to better handle future errors.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://www.loom.com/share/3ca4e240e5864151854c50ed88431cc3

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Connect an Outlook account
- In the DB change the expiry date to force a refresh
- Refresh the listed calendars page
    - There should be a new token
- In the DB remove a property so that the zod parse will fail
- Refresh the listed calendars page
    - There should be a new token
- Create a fake response in the Outlook auth function. The error log should contain the zod error & the response

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
