### PR TITLE
Fix for Apple Calendar failing entire availability check because of Shared Calendars

### DIFF
--- a/packages/lib/sanitizeCalendarObject.ts
+++ b/packages/lib/sanitizeCalendarObject.ts
@@ -4,7 +4,6 @@ export const sanitizeCalendarObject = (obj: DAVObject) => {
   return obj.data
     .replaceAll("\r\n", "\r")
     .replaceAll("\r", "\r\n")
-    .replaceAll(/(: \r\n|:\r\n|\r\n:|\r\n :)/gm, ":")
     .replaceAll(/(; \r\n|;\r\n|\r\n;|\r\n ;)/gm, ";")
     .replaceAll(/(= \r\n|=\r\n|\r\n=|\r\n =)/gm, "=");
 };


### PR DESCRIPTION
## What does this PR do?

Removes bad Broad Spectrum ReplaceAll call from the ICal body sanitizer function that resulted in poor EOL replacement in very specific situations on a shared Apple Calendar (and I imagine a few other calendars).

The Sanitizer function requires a nice proper testing and potentially  revamp, but this should do as a hotfix for now without any major issues.

Fixes: #7201 

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

