### PR TITLE
Revalidate booking pages on updateProfile

### DIFF
--- a/packages/trpc/server/routers/viewer.tsx
+++ b/packages/trpc/server/routers/viewer.tsx
@@ -2,6 +2,7 @@ import type { DestinationCalendar, Prisma } from "@prisma/client";
 import { AppCategories, BookingStatus, IdentityProvider } from "@prisma/client";
 import { cityMapping } from "city-timezones";
 import { reverse } from "lodash";
+import type { NextApiResponse } from "next";
 import { authenticator } from "otplib";
 import z from "zod";
 
@@ -707,6 +708,25 @@ const loggedInViewerRouter = router({
             userId: updatedUser.id,
           },
         });
+      }
+      // Revalidate booking pages
+      const res = ctx.res as NextApiResponse;
+      if (typeof res?.revalidate !== "undefined") {
+        const eventTypes = await prisma.eventType.findMany({
+          where: {
+            userId: user.id,
+            team: null,
+            hidden: false,
+          },
+          select: {
+            id: true,
+            slug: true,
+          },
+        });
+        // waiting for this isn't needed
+        Promise.all(eventTypes.map((eventType) => res?.revalidate(`/${ctx.user.username}/${eventType.slug}`)))
+          .then(() => console.info("Booking pages revalidated"))
+          .catch((e) => console.error(e));
       }
     }),
   eventTypeOrder: authedProcedure


### PR DESCRIPTION
## What does this PR do?

Revalidate booking page cache when the user change personal or general settings

Fixes #7892 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Change your name on profile settings
- [ ] Visit the booking page of an event type, it should display your new name
