### PR TITLE
An empty array is truthy, [0] potentially isn't

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -494,7 +494,7 @@ async function handler(req: CustomRequest) {
     bookingToDelete.user.credentials
       .filter((credential) => credential.type.endsWith("_video"))
       .forEach((credential) => {
-        const uidToDelete = bookingToDelete?.references?.[0].uid ?? bookingToDelete.uid;
+        const uidToDelete = bookingToDelete?.references?.[0]?.uid ?? bookingToDelete.uid;
         apiDeletes.push(deleteMeeting(credential, uidToDelete));
       });
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 Error during cancel (Only happens when the video fallback is broken, but worth fixing still) - self hosters might experience this.

```sql
prisma:query SELECT "public"."Webhook"."id", "public"."Webhook"."subscriberUrl", "public"."Webhook"."payloadTemplate", "public"."Webhook"."appId", "public"."Webhook"."secret" FROM "public"."Webhook" WHERE (("public"."Webhook"."userId" = $1 OR "public"."Webhook"."eventTypeId" = $2) AND "public"."Webhook"."eventTriggers" @> $3 AND "public"."Webhook"."active" = $4) OFFSET $5 
prisma:query BEGIN
prisma:query SELECT "public"."Booking"."id" FROM "public"."Booking" WHERE ("public"."Booking"."uid" = $1 AND 1=1) 
prisma:query UPDATE "public"."Booking" SET "status" = $1, "cancellationReason" = $2 WHERE ("public"."Booking"."id" IN ($3) AND ("public"."Booking"."uid" = $4 AND 1=1)) 
prisma:query SELECT "public"."Booking"."id", "public"."Booking"."startTime", "public"."Booking"."endTime", "public"."Booking"."uid", "public"."Booking"."scheduledJobs" FROM "public"."Booking" WHERE "public"."Booking"."id" = $1 LIMIT $2 OFFSET $3 
prisma:query SELECT "public"."BookingReference"."id", "public"."BookingReference"."uid", "public"."BookingReference"."type", "public"."BookingReference"."externalCalendarId", "public"."BookingReference"."credentialId", "public"."BookingReference"."bookingId" FROM "public"."BookingReference" WHERE "public"."BookingReference"."bookingId" IN ($1) OFFSET $2
prisma:query SELECT "public"."WorkflowReminder"."id", "public"."WorkflowReminder"."bookingUid", "public"."WorkflowReminder"."method", "public"."WorkflowReminder"."scheduledDate", "public"."WorkflowReminder"."referenceId", "public"."WorkflowReminder"."scheduled", "public"."WorkflowReminder"."workflowStepId", "public"."WorkflowReminder"."cancelled" FROM "public"."WorkflowReminder" WHERE "public"."WorkflowReminder"."bookingUid" IN ($1) OFFSET $2
prisma:query COMMIT
TypeError: Cannot read properties of undefined (reading 'uid')
    at /var/task/apps/web/.next/server/pages/api/cancel.js:1367:65
    at Array.forEach (<anonymous>)
    at handler (/var/task/apps/web/.next/server/pages/api/cancel.js:1366:99)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async handler (/var/task/apps/web/.next/server/pages/api/cancel.js:661:12)
    at async /var/task/apps/web/.next/server/chunks/7810.js:58:28
    at async /var/task/apps/web/.next/server/chunks/4358.js:717:13
    at async Object.apiResolver (/var/task/node_modules/next/dist/server/api-utils/node.js:372:9)
    at async NextNodeServer.runApi (/var/task/node_modules/next/dist/server/next-server.js:513:9)
    at async Object.fn (/var/task/node_modules/next/dist/server/next-server.js:815:35)
    at async Router.execute (/var/task/node_modules/next/dist/server/router.js:243:32)
    at async NextNodeServer.runImpl (/var/task/node_modules/next/dist/server/base-server.js:432:29)
    at async NextNodeServer.handleRequestImpl (/var/task/node_modules/next/dist/server/base-server.js:375:20)
    at async /var/task/node_modules/next/dist/server/base-server.js:157:99
    at async module.exports (/var/task/apps/web/___next_launcher.cjs:29:9)
```