### PR TITLE
Fix: AppStore CLI Create command not working after upgrading to yarn 3

### DIFF
--- a/packages/app-store-cli/src/core.ts
+++ b/packages/app-store-cli/src/core.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import seedAppStoreConfig from "@calcom/prisma/seed-app-store.config.json";
+import type seedAppStoreConfig from "@calcom/prisma/seed-app-store.config.json";
 
 import { APP_STORE_PATH, TEMPLATES_PATH } from "./constants";
 import execSync from "./utils/execSync";
@@ -127,6 +127,8 @@ export const BaseAppFork = {
         .replace(/_DESCRIPTION_/g, description)
         .replace(/_APP_DIR_/g, slug)
     );
+    // New monorepo package has been added, so we need to run yarn again
+    await execSync("yarn");
   },
 
   delete: async function ({ slug, isTemplate }: { slug: string; isTemplate: boolean }) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes
- Failing `yarn create-app` command. Reported [here](https://calendso.slack.com/archives/C04MXT89BNF/p1679917991428659) ![image](https://user-images.githubusercontent.com/1780212/228203270-c203afc1-401c-456b-9377-c86fe74d52cc.png)
- Also removes stale README.md from template


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Run `yarn create-app` and notice that it was failing earlier and now it passes.

