### PR TITLE
Adds cron endpoint to keep team subscriptions in sync

### DIFF
--- a/.github/workflows/cron-downgradeUsers.yml
+++ b/.github/workflows/cron-downgradeUsers.yml
@@ -5,8 +5,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “Everyday at midnight” (see https://crontab.guru)
-    - cron: "0 0 * * *"
+    # Runs “Every month at 1st (see https://crontab.guru)
+    - cron: "0 0 1 * *"
 jobs:
   cron-downgradeUsers:
     env:

--- a/.github/workflows/cron-downgradeUsers.yml
+++ b/.github/workflows/cron-downgradeUsers.yml
@@ -1,11 +1,12 @@
 name: Cron - downgradeUsers
 
 on:
+  workflow_dispatch:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At minute 0, 15, 30, and 45.” (see https://crontab.guru)
-    - cron: "0,15,30,45 * * * *"
+    # Runs “Everyday at midnight” (see https://crontab.guru)
+    - cron: "0 0 * * *"
 jobs:
   cron-downgradeUsers:
     env:

--- a/apps/web/pages/api/cron/downgradeUsers.ts
+++ b/apps/web/pages/api/cron/downgradeUsers.ts
@@ -1,5 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { updateQuantitySubscriptionFromStripe } from "@calcom/features/ee/teams/lib/payments";
+import prisma from "@calcom/prisma";
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const apiKey = req.headers.authorization || req.query.apiKey;
   if (process.env.CRON_API_KEY !== apiKey) {
@@ -11,10 +14,35 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  /**
-   * TODO:
-   * Remove this endpoint
-   */
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  const pageSize = 10; // Adjust this value based on the total number of teams and the available processing time
+  let pageNumber = 0;
+
+  while (true) {
+    const teams = await prisma.team.findMany({
+      where: {
+        slug: {
+          not: null,
+        },
+      },
+      select: {
+        id: true,
+      },
+      skip: pageNumber * pageSize,
+      take: pageSize,
+    });
+
+    if (teams.length === 0) {
+      break;
+    }
+
+    for (const team of teams) {
+      await updateQuantitySubscriptionFromStripe(team.id);
+      await delay(500); // Adjust the delay as needed to avoid rate limiting
+    }
+
+    pageNumber++;
+  }
 
   res.json({ ok: true });
 }

--- a/apps/web/pages/api/cron/downgradeUsers.ts
+++ b/apps/web/pages/api/cron/downgradeUsers.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-  const pageSize = 10; // Adjust this value based on the total number of teams and the available processing time
+  const pageSize = 90; // Adjust this value based on the total number of teams and the available processing time
   let pageNumber = 0;
 
   while (true) {
@@ -38,7 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     for (const team of teams) {
       await updateQuantitySubscriptionFromStripe(team.id);
-      await delay(500); // Adjust the delay as needed to avoid rate limiting
+      await delay(100); // Adjust the delay as needed to avoid rate limiting
     }
 
     pageNumber++;

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -23,7 +23,7 @@ export const checkIfTeamPaymentRequired = async ({ teamId = -1 }) => {
   if (!metadata?.paymentId) return { url: null };
   const checkoutSession = await stripe.checkout.sessions.retrieve(metadata.paymentId);
   /** If there's a pending session but it isn't paid, we need to pay this team */
-  if (checkoutSession.payment_status === "paid") return { url: null };
+  if (checkoutSession.payment_status !== "paid") return { url: null };
   /** If the session is already paid we return the upgrade URL so team is updated. */
   return { url: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id=${metadata.paymentId}` };
 };

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -98,6 +98,9 @@ export const updateQuantitySubscriptionFromStripe = async (teamId: number) => {
     await stripe.subscriptions.update(subscriptionId, {
       items: [{ quantity: team.members.length, id: subscriptionItemId }],
     });
+    console.info(
+      `Updated subscription ${subscriptionId} for team ${teamId} to ${team.members.length} seats.`
+    );
   } catch (error) {
     let message = "Unknown error on updateQuantitySubscriptionFromStripe";
     if (error instanceof Error) message = error.message;


### PR DESCRIPTION
## What does this PR do?

- Repurposed the downgrade cron endpoint (which wasn't being used anymore) to keep team subscriptions in sync with Stripe
- Updated the interval to run once a day at midnight
- Added possibility to trigger the endpoint manually as well

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Trigger from Github Actions
- [ ] Check logs

