### PR TITLE
fix: use the correct step in team creation wizard

### DIFF
--- a/apps/web/pages/settings/teams/[id]/onboard-members.tsx
+++ b/apps/web/pages/settings/teams/[id]/onboard-members.tsx
@@ -19,7 +19,7 @@ const OnboardTeamMembersPage = () => {
 };
 
 OnboardTeamMembersPage.getLayout = (page: React.ReactElement) => (
-  <WizardLayout currentStep={1} maxSteps={2}>
+  <WizardLayout currentStep={2} maxSteps={2}>
     {page}
   </WizardLayout>
 );

--- a/apps/web/pages/settings/teams/new/index.tsx
+++ b/apps/web/pages/settings/teams/new/index.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import { CreateANewTeamForm } from "@calcom/features/ee/teams/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import { getLayout } from "@components/layouts/WizardLayout";
+import WizardLayout from "@components/layouts/WizardLayout";
 
 const CreateNewTeamPage = () => {
   const { t } = useLocale();
@@ -17,7 +17,14 @@ const CreateNewTeamPage = () => {
     </>
   );
 };
+const LayoutWrapper = (page: React.ReactElement) => {
+  return (
+    <WizardLayout currentStep={1} maxSteps={2}>
+      {page}
+    </WizardLayout>
+  );
+};
 
-CreateNewTeamPage.getLayout = getLayout;
+CreateNewTeamPage.getLayout = LayoutWrapper;
 
 export default CreateNewTeamPage;


### PR DESCRIPTION
## What does this PR do?

before:

![Screenshot 2023-03-31 at 14-04-24 Create a new team](https://user-images.githubusercontent.com/84864519/229070626-0bca0165-3353-4806-823a-c242d988c86e.png)

![Screenshot 2023-03-31 at 14-04-36 Add team members](https://user-images.githubusercontent.com/84864519/229070639-268a8f0e-7d85-44a9-8f22-9e48a505d1a1.png)

after:

![Screenshot 2023-03-31 at 14-03-49 Create a new team](https://user-images.githubusercontent.com/84864519/229070794-7790f142-6328-4121-a7a7-b8d594e5392a.png)

![Screenshot 2023-03-31 at 14-04-09 Add team members](https://user-images.githubusercontent.com/84864519/229070830-e91b5e29-4261-4441-9d33-b05358c6d670.png)




## Type of change

- Bug fix (non-breaking change which fixes an issue)

