### PR TITLE
Fix date override delete removing wrong date override

### DIFF
--- a/packages/features/schedules/components/DateOverrideList.tsx
+++ b/packages/features/schedules/components/DateOverrideList.tsx
@@ -1,14 +1,13 @@
-import type { UseFieldArrayRemove } from "react-hook-form";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
-import type { TimeRange, WorkingHours } from "@calcom/types/schedule";
-import { Button, DialogTrigger, Tooltip } from "@calcom/ui";
+import type { TimeRange } from "@calcom/types/schedule";
+import { Button, Tooltip } from "@calcom/ui";
 import { FiEdit2, FiTrash2 } from "@calcom/ui/components/icon";
 
-import DateOverrideInputDialog from "./DateOverrideInputDialog";
+import type { DateOverrideDialogProps } from "./DateOverrideDialog";
+import DateOverrideDialog from "./DateOverrideDialog";
 
-const sortByDate = (a: { ranges: TimeRange[]; id: string }, b: { ranges: TimeRange[]; id: string }) => {
+const sortByDate = (a: { ranges: TimeRange[] }, b: { ranges: TimeRange[] }) => {
   return a.ranges[0].start > b.ranges[0].start ? 1 : -1;
 };
 
@@ -20,94 +19,110 @@ const useSettings = () => {
   };
 };
 
-const DateOverrideList = ({
-  items,
-  remove,
-  update,
-  workingHours,
-  excludedDates = [],
-}: {
-  remove: UseFieldArrayRemove;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  update: any;
-  items: { ranges: TimeRange[]; id: string }[];
-  workingHours: WorkingHours[];
-  excludedDates?: string[];
-}) => {
-  const { t, i18n } = useLocale();
+const TimeRangeFormatted = ({ start, end }: TimeRange) => {
   const { hour12 } = useSettings();
-  if (!items.length) {
-    return <></>;
-  }
-
-  const timeSpan = ({ start, end }: TimeRange) => {
-    return (
-      new Intl.DateTimeFormat(i18n.language, { hour: "numeric", minute: "numeric", hour12 }).format(
+  const { i18n } = useLocale();
+  return (
+    <>
+      {new Intl.DateTimeFormat(i18n.language, { hour: "numeric", minute: "numeric", hour12 }).format(
         new Date(start.toISOString().slice(0, -1))
       ) +
-      " - " +
-      new Intl.DateTimeFormat(i18n.language, { hour: "numeric", minute: "numeric", hour12 }).format(
-        new Date(end.toISOString().slice(0, -1))
-      )
-    );
-  };
+        " - " +
+        new Intl.DateTimeFormat(i18n.language, { hour: "numeric", minute: "numeric", hour12 }).format(
+          new Date(end.toISOString().slice(0, -1))
+        )}
+    </>
+  );
+};
+
+const DateOverrideListItem = ({
+  actions,
+  ...item
+}: {
+  id: string;
+  ranges: TimeRange[];
+  actions: React.ReactNode;
+}) => {
+  const { t } = useLocale();
+  return (
+    <li key={item.id} className="flex justify-between border-b px-5 py-4 last:border-b-0">
+      <div>
+        <h3 className="text-sm text-gray-900">
+          {new Intl.DateTimeFormat("en-GB", {
+            weekday: "short",
+            month: "long",
+            day: "numeric",
+          }).format(item.ranges[0].start)}
+        </h3>
+        {item.ranges[0].start.valueOf() - item.ranges[0].end.valueOf() === 0 ? (
+          <p className="text-xs text-gray-500">{t("unavailable")}</p>
+        ) : (
+          item.ranges.map((range, i) => (
+            <p key={i} className="text-xs text-gray-500">
+              <TimeRangeFormatted start={range.start} end={range.end} />
+            </p>
+          ))
+        )}
+      </div>
+      {actions}
+    </li>
+  );
+};
+
+const DateOverrideList = ({
+  items,
+  onDelete,
+  updateDialogProps,
+}: {
+  items: { id: string; ranges: TimeRange[] }[];
+  onDelete: (index: string) => void;
+  updateDialogProps: Omit<DateOverrideDialogProps, "Trigger">;
+}) => {
+  const { t } = useLocale();
+  // no display needed
+  if (!items.length) {
+    return null;
+  }
 
   return (
     <ul className="rounded border border-gray-200" data-testid="date-overrides-list">
-      {items.sort(sortByDate).map((item, index) => (
-        <li key={item.id} className="flex justify-between border-b px-5 py-4 last:border-b-0">
-          <div>
-            <h3 className="text-sm text-gray-900">
-              {new Intl.DateTimeFormat("en-GB", {
-                weekday: "short",
-                month: "long",
-                day: "numeric",
-              }).format(item.ranges[0].start)}
-            </h3>
-            {item.ranges[0].start.valueOf() - item.ranges[0].end.valueOf() === 0 ? (
-              <p className="text-xs text-gray-500">{t("unavailable")}</p>
-            ) : (
-              item.ranges.map((range, i) => (
-                <p key={i} className="text-xs text-gray-500">
-                  {timeSpan(range)}
-                </p>
-              ))
-            )}
-          </div>
-          <div className="flex flex-row-reverse gap-5 space-x-2 rtl:space-x-reverse">
-            <DateOverrideInputDialog
-              excludedDates={excludedDates}
-              workingHours={workingHours}
-              value={item.ranges}
-              onChange={(ranges) => {
-                update(index, {
-                  ranges,
-                });
-              }}
-              Trigger={
-                <DialogTrigger asChild>
+      {items.sort(sortByDate).map((item) => {
+        return (
+          <DateOverrideListItem
+            key={item.id}
+            {...item}
+            actions={
+              <div className="flex flex-row-reverse gap-5 space-x-2 rtl:space-x-reverse">
+                <DateOverrideDialog
+                  {...updateDialogProps}
+                  index={item.id}
+                  value={item.ranges}
+                  Trigger={
+                    <Button
+                      tooltip={t("edit")}
+                      className="text-gray-700"
+                      color="minimal"
+                      variant="icon"
+                      StartIcon={FiEdit2}
+                    />
+                  }
+                />
+                <Tooltip content="Delete">
                   <Button
-                    tooltip={t("edit")}
                     className="text-gray-700"
-                    color="minimal"
+                    color="destructive"
                     variant="icon"
-                    StartIcon={FiEdit2}
+                    StartIcon={FiTrash2}
+                    onClick={() => {
+                      onDelete(item.id);
+                    }}
                   />
-                </DialogTrigger>
-              }
-            />
-            <Tooltip content="Delete">
-              <Button
-                className="text-gray-700"
-                color="destructive"
-                variant="icon"
-                StartIcon={FiTrash2}
-                onClick={() => remove(index)}
-              />
-            </Tooltip>
-          </div>
-        </li>
-      ))}
+                </Tooltip>
+              </div>
+            }
+          />
+        );
+      })}
     </ul>
   );
 };

--- a/packages/features/schedules/components/DateOverrideView.tsx
+++ b/packages/features/schedules/components/DateOverrideView.tsx
@@ -20,7 +20,7 @@ export const DateOverrideView = ({
         {...createDialogProps}
         Trigger={
           <Button color="secondary" StartIcon={FiPlus} data-testid="add-override">
-            {t("add_override_btn_text")}
+            {t("date_overrides_add_btn")}
           </Button>
         }
       />

--- a/packages/features/schedules/components/DateOverrideView.tsx
+++ b/packages/features/schedules/components/DateOverrideView.tsx
@@ -1,0 +1,31 @@
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui";
+import { FiPlus } from "@calcom/ui/components/icon";
+
+import type { DateOverrideDialogProps } from "./DateOverrideDialog";
+import DateOverrideDialog from "./DateOverrideDialog";
+
+export const DateOverrideView = ({
+  createDialogProps,
+  list,
+}: {
+  list: React.ReactNode;
+  createDialogProps: Omit<DateOverrideDialogProps, "Trigger">;
+}) => {
+  const { t } = useLocale();
+  return (
+    <>
+      {list}
+      <DateOverrideDialog
+        {...createDialogProps}
+        Trigger={
+          <Button color="secondary" StartIcon={FiPlus} data-testid="add-override">
+            {t("add_override_btn_text")}
+          </Button>
+        }
+      />
+    </>
+  );
+};
+
+export default DateOverrideView;

--- a/packages/features/schedules/components/index.ts
+++ b/packages/features/schedules/components/index.ts
@@ -1,5 +1,6 @@
 export { NewScheduleButton } from "./NewScheduleButton";
 export { ScheduleListItem } from "./ScheduleListItem";
-export { default as DateOverrideInputDialog } from "./DateOverrideInputDialog";
+export { default as DateOverrideInputDialog } from "./DateOverrideDialog";
 export { default as Schedule } from "./Schedule";
 export { default as DateOverrideList } from "./DateOverrideList";
+export { default as DateOverrideView } from "./DateOverrideView";


### PR DESCRIPTION
## What does this PR do?

Fixes #8055

- [x] Removes the right date override on delete.
- [x] Better "no date selected" state during date override before selecting a date.
- [x] Adds missing translation to "Add Override" button.


TODO before merge:
- [ ] Figure out why adding a new date override does not auto-close the dialog.