### PR TITLE
fix: remove box shadow none

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -148,8 +148,6 @@ select:focus {
   --tw-ring-color: var(--brand-color);
   border-color: var(--brand-color);
 }
-/*  https://stackoverflow.com/a/69308190 */
-input[type='text']:focus { box-shadow: none; }
 
 
 @layer components {


### PR DESCRIPTION
## What does this PR do?

Fixes this bug https://www.loom.com/share/247906747b714aba99b70dc5b4c2cf08

Earlier there was a bug in which you would see blue border  in the edit location dialog like this https://stackoverflow.com/questions/69307885/unexpected-blue-border-while-typing-text-react-select/69308190#69308190. 

<img width="659" alt="Screenshot 2023-04-04 at 1 09 45 PM" src="https://user-images.githubusercontent.com/53316345/229722094-8caaa8ea-8115-4428-ae2d-7e5a849bafa2.png">


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)