### PR TITLE
fix: whitelist legacy custom event name variables 

### DIFF
--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -85,6 +85,12 @@ export const validateCustomEventName = (
     "{Organiser}",
     "{Scheduler}",
     "{Location}",
+    //allowed for fallback reasons
+    "{LOCATION}",
+    "{HOST/ATTENDEE}",
+    "{HOST}",
+    "{ATTENDEE}",
+    "{USER}",
   ]);
   const matches = value.match(/\{([^}]+)\}/g);
   if (matches?.length) {


### PR DESCRIPTION
## What does this PR do?

Fixes #8094

after:

[Screencast 2023-04-05 13:33:23.webm](https://user-images.githubusercontent.com/84864519/230021064-6b7970c3-795e-4beb-815d-c1c284595344.webm)



## Type of change

- Bug fix (non-breaking change which fixes an issue)

