### PR TITLE
Don't schedule cancelled workflow reminders

### DIFF
--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -101,6 +101,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     where: {
       method: WorkflowMethods.EMAIL,
       scheduled: false,
+      cancelled: false,
       scheduledDate: {
         lte: dayjs().add(72, "hour").toISOString(),
       },


### PR DESCRIPTION
## What does this PR do?

Make sure not to schedule canceled reminders again. 

- Bug fix (non-breaking change which fixes an issue)