### PR TITLE
fix: tight line height in email info

### DIFF
--- a/packages/emails/src/components/Info.tsx
+++ b/packages/emails/src/components/Info.tsx
@@ -19,7 +19,7 @@ export const Info = (props: {
   return (
     <>
       {props.withSpacer && <Spacer />}
-      <div style={{ lineHeight: "6px" }}>
+      <div>
         <p style={{ color: "#101010" }}>{props.label}</p>
         <p
           style={{


### PR DESCRIPTION
## What does this PR do?

before:
![Screenshot 2023-04-06 at 22-36-45 MailDev](https://user-images.githubusercontent.com/84864519/230451374-a20f4b8d-5cbe-4cb9-ba45-9608e06c8b3a.png)

after:
![Screenshot 2023-04-06 at 22-36-10 MailDev](https://user-images.githubusercontent.com/84864519/230451411-a8a05653-0dbd-45e9-b6fb-948e5c249918.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
