### PR TITLE
Fix: Sylaps app shown uninstalled after installation

### DIFF
--- a/packages/app-store/sylapsvideo/api/add.ts
+++ b/packages/app-store/sylapsvideo/api/add.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@calcom/prisma";
 
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import config from "../config.json";
 
 /**
  * This is an example endpoint for an app, these will run under `/api/integrations/[...args]`
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!req.session?.user?.id) {
     return res.status(401).json({ message: "You must be logged in to do this" });
   }
-  const appType = "sylaps_video";
+  const appType = config.type;
   try {
     const alreadyInstalled = await prisma.credential.findFirst({
       where: {
@@ -29,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         type: appType,
         key: {},
         userId: req.session.user.id,
-        appId: "sylaps",
+        appId: config.slug,
       },
     });
     if (!installation) {
@@ -41,5 +42,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     return res.status(500);
   }
-  return res.status(200).json({ url: getInstalledAppPath({ variant: "conferencing", slug: "sylaps" }) });
+  return res.status(200).json({ url: getInstalledAppPath({ variant: "conferencing", slug: config.slug }) });
 }

--- a/packages/prisma/seed-app-store.ts
+++ b/packages/prisma/seed-app-store.ts
@@ -232,7 +232,7 @@ export default async function main() {
     });
   }
   await createApp("jitsi", "jitsivideo", ["video"], "jitsi_video");
-  await createApp("sylaps", "sylapsvideo", ["video"], "sylaps_video");
+  await createApp("sylapsvideo", "sylapsvideo", ["video"], "sylaps_video");
   // Other apps
   if (process.env.HUBSPOT_CLIENT_ID && process.env.HUBSPOT_CLIENT_SECRET) {
     await createApp("hubspot", "hubspot", ["other"], "hubspot_other_calendar", {


### PR DESCRIPTION
As reported here https://github.com/calcom/cal.com/pull/6728#issuecomment-1507771582

The reason for the issue was changing slug from `sylaps` to `sylapsvideo`. A few places were left.
I have removed hardcoded value and instead using the value from config directly.

A Follow-up would be to create a template for dynamic video link apps, so that all new apps being created won't make the same mistakes.