### PR TITLE
fix: remove @tailwindcss/line-clamp from plugins

### DIFF
--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -149,7 +149,6 @@ module.exports = {
   plugins: [
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
-    require("@tailwindcss/line-clamp"),
     require("tailwind-scrollbar"),
     require("tailwindcss-radix")(),
     plugin(({ addVariant }) => {


### PR DESCRIPTION
## What does this PR do?

Fixes #8307

Fixes tailwind warning (@tailwindcss/line-clamp)

And this is just one of two warnings out there. The other warning (@variants) will be fixed in this PR #8171

**Before**

![image](https://user-images.githubusercontent.com/69904519/232310049-71183e36-fef7-420c-ad19-a47b28ae6cb7.png)


**After**

![image](https://user-images.githubusercontent.com/69904519/232310168-3b43a748-dfd9-46e3-ba3d-a714339bf9e7.png)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

