### PR TITLE
perf: use LRU cache for getServerSession

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -82,7 +82,6 @@
     "libphonenumber-js": "^1.10.12",
     "lodash": "^4.17.21",
     "lottie-react": "^2.3.1",
-    "lru-cache": "^9.0.3",
     "markdown-it": "^13.0.1",
     "md5": "^2.3.0",
     "memory-cache": "^0.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -82,6 +82,7 @@
     "libphonenumber-js": "^1.10.12",
     "lodash": "^4.17.21",
     "lottie-react": "^2.3.1",
+    "lru-cache": "^9.0.3",
     "markdown-it": "^13.0.1",
     "md5": "^2.3.0",
     "memory-cache": "^0.2.0",

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from "lru-cache";
 import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from "next";
 import type { AuthOptions, Session } from "next-auth";
 import { getToken } from "next-auth/jwt";
@@ -9,13 +10,8 @@ import prisma from "@calcom/prisma";
 /**
  * Stores the session in memory using the stringified token as the key.
  *
- * This is fine for production as each lambda will be recycled before this
- * becomes large enough to cause issues.
- *
- * If we want to get extra spicy we could store this in edge config or similar
- * so we can TTL things and benefit from faster retrievals than prisma.
  */
-const UNSTABLE_SESSION_CACHE = new Map<string, Session>();
+const CACHE = new LRUCache({ max: 1000 });
 
 /**
  * This is a slimmed down version of the `getServerSession` function from
@@ -44,7 +40,7 @@ export async function getServerSession(options: {
     return null;
   }
 
-  const cachedSession = UNSTABLE_SESSION_CACHE.get(JSON.stringify(token));
+  const cachedSession = CACHE.get(JSON.stringify(token));
 
   if (cachedSession) {
     return cachedSession;
@@ -79,7 +75,7 @@ export async function getServerSession(options: {
     },
   };
 
-  UNSTABLE_SESSION_CACHE.set(JSON.stringify(token), session);
+  CACHE.set(JSON.stringify(token), session);
 
   return session;
 }

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -11,7 +11,7 @@ import prisma from "@calcom/prisma";
  * Stores the session in memory using the stringified token as the key.
  *
  */
-const CACHE = new LRUCache({ max: 1000 });
+const CACHE = new LRUCache<string, Session>({ max: 1000 });
 
 /**
  * This is a slimmed down version of the `getServerSession` function from

--- a/packages/features/auth/package.json
+++ b/packages/features/auth/package.json
@@ -14,6 +14,7 @@
     "bcryptjs": "^2.4.3",
     "handlebars": "^4.7.7",
     "jose": "^4.13.1",
+    "lru-cache": "^9.0.3",
     "next-auth": "^4.20.1",
     "nodemailer": "^6.7.8",
     "otplib": "^12.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4332,6 +4332,7 @@ __metadata:
     bcryptjs: ^2.4.3
     handlebars: ^4.7.7
     jose: ^4.13.1
+    lru-cache: ^9.0.3
     next-auth: ^4.20.1
     nodemailer: ^6.7.8
     otplib: ^12.0.1
@@ -27366,6 +27367,13 @@ __metadata:
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "lru-cache@npm:9.0.3"
+  checksum: 218415714d44c113bc3a8d12ceca6dedf310915aa861f9e0df13df1fe6db9833e1b5f1f656e9a117ac82677ad3e499be23bff2f670f2a7c5c186d64a92596b68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

currently the Map object is used as a in memory-store for storing session tokens which might cause memory leaks while used on a long running servers. this PR aims to fix that

## Type of change

- Bug fix (non-breaking change which fixes an issue)
