### PR TITLE
Hotfix: Prevent looping b/w dark and light

### DIFF
--- a/packages/lib/hooks/useTheme.tsx
+++ b/packages/lib/hooks/useTheme.tsx
@@ -15,16 +15,17 @@ export default function useTheme(themeToSet?: Maybe<string>) {
 
   useEffect(() => {
     // If themeToSet is not provided the purpose is to just return the current the current values
-    if (themeToSet === undefined) return;
+    if (!themeToSet) return;
 
     // Embed theme takes precedence over theme configured in app. This allows embeds to be themed differently
-    const finalThemeToSet = embedTheme || themeToSet || "system";
+    const finalThemeToSet = embedTheme || themeToSet;
 
     if (!finalThemeToSet || finalThemeToSet === activeTheme) return;
 
     setTheme(finalThemeToSet);
-  }, [themeToSet, setTheme, embedTheme, activeTheme]);
-
+    // We must not add `activeTheme` to the dependency list as it can cause an infinite loop b/w dark and theme switches
+    // because there might be another booking page with conflicting theme.
+  }, [themeToSet, setTheme, embedTheme]);
   return {
     resolvedTheme,
     setTheme,


### PR DESCRIPTION
Found the root cause of the theme flickering issue.

`booking-theme` is the storage key for Booking Page-1 and Booking Page-2. Infact it's same for all booking pages.
Scenario:
Booking Page-1 decides that it needs dark theme and tries to update `booking-theme` in localStorage to dark. 
If Booking Page-2 decides that it needs light theme, it would try to update `booking-theme` in localStorage to light.

There is `storage` event listener that can detect on Booking-Page-1 that someone outside(here Booking Page-2) has changed the `booking-theme` in localStorage and it updates it's theme to that. But, our logic in useTheme doesn't agree with it and tries to revert it.