### PR TITLE
Possible fix for iOS redirection

### DIFF
--- a/packages/lib/bookingSuccessRedirect.ts
+++ b/packages/lib/bookingSuccessRedirect.ts
@@ -24,6 +24,7 @@ export const bookingSuccessRedirect = async ({
 
     // Using parent ensures, Embed iframe would redirect outside of the iframe.
     window.parent.location.href = url.toString();
+    return;
   }
   return router.push({
     pathname: `/booking/${bookingUid}`,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #8452
On iOS it seems like location.href is ignored if it is followed by router.push which is probably doing a soft navigation.
When I put a breakpoint to debug it works. So, this is a potential fix for the issue.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**:  Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] When you book a meeting with "Redirect on booking" enabled on iOS the redirect doesn't happen.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
