### PR TITLE
fix: 7040 fix - team profile description

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -56,12 +56,12 @@ function TeamPage({ team, isUnpublished }: TeamPageProps) {
   }
 
   const EventTypes = () => (
-    <ul className="border-subtle border-subtle rounded-md border">
+    <ul className="border-subtle rounded-md border">
       {team.eventTypes.map((type, index) => (
         <li
           key={index}
           className={classNames(
-            "dark:bg-darkgray-100 border-subtle bg-default hover:bg-muted border-subtle group relative border-b first:rounded-t-md last:rounded-b-md last:border-b-0",
+            "dark:bg-darkgray-100 bg-default hover:bg-muted border-subtle group relative border-b first:rounded-t-md last:rounded-b-md last:border-b-0",
             !isEmbed && "bg-default"
           )}>
           <div className="px-6 py-4 ">
@@ -126,7 +126,7 @@ function TeamPage({ team, isUnpublished }: TeamPageProps) {
               <div>
                 <div className="relative mt-12">
                   <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                    <div className="border-subtle border-subtle w-full border-t" />
+                    <div className="border-subtle w-full border-t" />
                   </div>
                   <div className="relative flex justify-center">
                     <span className="dark:bg-darkgray-50 bg-subtle text-subtle dark:text-inverted px-2 text-sm">

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -105,7 +105,7 @@ function TeamPage({ team, isUnpublished }: TeamPageProps) {
         }}
       />
       <main className="dark:bg-darkgray-50 bg-subtle mx-auto max-w-3xl rounded-md px-4 pt-12 pb-12">
-        <div className="max-w-96 mx-auto mb-8 text-center">
+        <div className="mx-auto mb-8 max-w-3xl text-center">
           <Avatar alt={teamName} imageSrc={getPlaceholderAvatar(team.logo, team.name)} size="lg" />
           <p className="font-cal  text-emphasis mb-2 text-2xl tracking-wider">{teamName}</p>
           {!isBioEmpty && (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7040

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

You will see that the user profile page and team profile page description width does not match. This is the current styling:

<img width="1440" alt="Screenshot 2023-04-23 at 09 10 34" src="https://user-images.githubusercontent.com/22655069/233828335-0cfafbcb-4b37-4faf-b397-1297b553c9db.png">

Changed to:

<img width="1440" alt="Screenshot 2023-04-23 at 09 13 24" src="https://user-images.githubusercontent.com/22655069/233828349-939a763a-c02e-4598-8c8f-3c2048ce2d95.png">

 I noticed that both the user and team profile page styling does not match e.g. top margin, image size etc, Do these need to be changed as well so both styling on the pages are the same? If so I get get these changed as well if needed?

Also some duplicate tailwind classes have been removed. 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
