### PR TITLE
fix: text color when hover

### DIFF
--- a/packages/ui/components/apps/AllApps.tsx
+++ b/packages/ui/components/apps/AllApps.tsx
@@ -94,7 +94,7 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
           }}
           className={classNames(
             selectedCategory === null ? "bg-emphasis text-default" : "bg-muted text-emphasis",
-            "hover:bg-emphasis min-w-max rounded-md px-4 py-2.5 text-sm font-medium hover:cursor-pointer hover:text-gray-50"
+            "hover:bg-emphasis min-w-max rounded-md px-4 py-2.5 text-sm font-medium hover:cursor-pointer"
           )}>
           {t("all_apps")}
         </li>
@@ -112,7 +112,7 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
             }}
             className={classNames(
               selectedCategory === cat ? "bg-emphasis text-default" : "bg-muted text-emphasis",
-              "hover:bg-emphasis rounded-md px-4 py-2.5 text-sm font-medium hover:cursor-pointer hover:text-gray-50"
+              "hover:bg-emphasis rounded-md px-4 py-2.5 text-sm font-medium hover:cursor-pointer"
             )}>
             {cat[0].toUpperCase() + cat.slice(1)}
           </li>


### PR DESCRIPTION
## What does this PR do?

Fixes #8480

Fixed text color when hovering

**Before**

![before](https://user-images.githubusercontent.com/69904519/234055337-736aaf4c-113c-4ae2-b687-62c17de52ef1.png)

**After**

![after](https://user-images.githubusercontent.com/69904519/234055346-c422c514-d37f-4057-a2ef-167094f0bee8.png)

https://user-images.githubusercontent.com/69904519/234055390-328207e0-cef0-4e47-80a7-f83fbe149f8f.mp4

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Go to apps page and hover on apps category

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works

