### PR TITLE
chore: add no-index tags for apps setup pages

### DIFF
--- a/apps/web/pages/apps/[slug]/setup.tsx
+++ b/apps/web/pages/apps/[slug]/setup.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import { AppSetupPage } from "@calcom/app-store/_pages/setup";
 import { getStaticProps } from "@calcom/app-store/_pages/setup/_getStaticProps";
+import { HeadSeo } from "@calcom/ui";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -25,7 +26,13 @@ export default function SetupInformation(props: InferGetStaticPropsType<typeof g
     });
   }
 
-  return <AppSetupPage slug={slug} {...props} />;
+  return (
+    <>
+      {/* So that the set up page does not get indexed by search engines */}
+      <HeadSeo nextSeoProps={{ noindex: true, nofollow: true }} title={`${slug} | Cal.com`} description="" />
+      <AppSetupPage slug={slug} {...props} />
+    </>
+  );
 }
 
 SetupInformation.PageWrapper = PageWrapper;


### PR DESCRIPTION
## What does this PR do?

Fixes: So that search engines don't index empty pages.

![CleanShot 2023-04-25 at 19 14 15@2x](https://user-images.githubusercontent.com/18185649/234352626-02bb7832-1723-4963-ba3b-71ec9fc3d640.png)


**Environment**: Production

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- [ ] Open a setup page, e.g. cal.com/apps/zapier/setup and inspect the browser console, the robots and googlebot meta tags should be no-index

