### PR TITLE
perf: fix multiple versions of `emotion/react` loaded warning

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -105,6 +105,7 @@ const nextConfig = {
     "@calcom/trpc",
     "@calcom/ui",
     "lucide-react",
+    "react-timezone-select",
   ],
   modularizeImports: {
     "@calcom/ui/components/icon": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -113,7 +113,7 @@
     "react-phone-number-input": "^3.2.7",
     "react-schemaorg": "^2.0.0",
     "react-select": "^5.7.0",
-    "react-timezone-select": "^1.4.0",
+    "react-timezone-select": "^1.5.1",
     "react-use-intercom": "1.5.1",
     "remark": "^14.0.2",
     "rrule": "^2.7.1",


### PR DESCRIPTION
## What does this PR do?

upgrades `react-timezone-select` to prevent loading multiple versions of `@emotion/react`. ref: https://github.com/ndom91/react-timezone-select/issues/60#issuecomment-1484759792


initial warning:

![Screenshot 2023-04-27 21:36:40](https://user-images.githubusercontent.com/84864519/234921406-0f2071bf-a788-4cd1-9263-698924c03db1.png)

## Type of change


- Bug fix (non-breaking change which fixes an issue)

