### PR TITLE
Remove redirection after app uninstalltion

### DIFF
--- a/apps/web/components/apps/App.tsx
+++ b/apps/web/components/apps/App.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { useRouter } from "next/router";
 import type { IframeHTMLAttributes } from "react";
 import React, { useState } from "react";
 
@@ -43,7 +42,6 @@ const Component = ({
 }: Parameters<typeof App>[0]) => {
   const { t, i18n } = useLocale();
   const hasDescriptionItems = descriptionItems && descriptionItems.length > 0;
-  const router = useRouter();
 
   const mutation = useAddAppMutation(null, {
     onSuccess: (data) => {
@@ -186,7 +184,7 @@ const Component = ({
               label={t("disconnect")}
               credentialId={existingCredentials[0]}
               onSuccess={() => {
-                router.replace("/apps/installed");
+               appCredentials.refetch();
               }}
             />
           ) : (

--- a/apps/web/components/apps/App.tsx
+++ b/apps/web/components/apps/App.tsx
@@ -184,7 +184,7 @@ const Component = ({
               label={t("disconnect")}
               credentialId={existingCredentials[0]}
               onSuccess={() => {
-               appCredentials.refetch();
+                appCredentials.refetch();
               }}
             />
           ) : (


### PR DESCRIPTION
## What does this PR do?

So When an app was uninstalled it used to redirect to apps/installed This PR makes sure that if it's uninstalled from route app/[appName] it does not redirect and stays as it is. 
Still need feedback if this behavior needs to be implemented on an app install as well.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


Fixes #8554

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
Loom Video : 
https://www.loom.com/share/98a370e17ee54a87a0e33f8c8bac3d32

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

 Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
