### PR TITLE
Save button color fix for close.com app

### DIFF
--- a/packages/app-store/closecom/pages/setup/index.tsx
+++ b/packages/app-store/closecom/pages/setup/index.tsx
@@ -140,7 +140,7 @@ export default function CloseComSetup() {
                       testPassed !== undefined ? (testPassed ? "test_passed" : "test_failed") : "test_api_key"
                     )}
                   </Button>
-                  <Button type="submit" loading={form.formState.isSubmitting}>
+                  <Button color="secondary" type="submit" loading={form.formState.isSubmitting}>
                     {t("save")}
                   </Button>
                 </div>


### PR DESCRIPTION
## What does this PR do?

Fixes #8358  

**Environment**:  Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

Bug fix
Added CSS class to view the button in dark mode as well.

## How should this be tested?
Navigate to Close.com and install it in the App Store menu to see the change.
<img width="649" alt="Screenshot 2023-04-29 at 11 12 07 PM" src="https://user-images.githubusercontent.com/52619709/235318640-449ed395-579c-4442-87e0-eb5002001eda.png">



