### PR TITLE
Fix: Full name is not refreshing on user update

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -105,14 +105,15 @@ const adminRequiredKeys = ["admin"];
 
 const useTabs = () => {
   const session = useSession();
+  const { data: user } = trpc.viewer.me.useQuery();
 
   const isAdmin = session.data?.user.role === UserPermissionRole.ADMIN;
 
   tabs.map((tab) => {
-    if (tab.name === "my_account") {
-      tab.name = session.data?.user?.name || "my_account";
+    if (tab.href === "/settings/my-account") {
+      tab.name = user?.name || "my_account";
       tab.icon = undefined;
-      tab.avatar = WEBAPP_URL + "/" + session.data?.user?.username + "/avatar.png";
+      tab.avatar = WEBAPP_URL + "/" + user?.username + "/avatar.png";
     }
     return tab;
   });


### PR DESCRIPTION
## What does this PR do?

Fixes #8567 

## Type of change
The session may retain previous user information even after it has been updated. Therefore, to ensure that we are using the most up-to-date user information, we are retrieving the user details directly from the `user` table rather than relying solely on the session details.