### PR TITLE
Fixed padding issue with username

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -308,10 +308,10 @@ function UserDropdown({ small }: { small?: boolean }) {
             {!small && (
               <span className="flex flex-grow items-center truncate">
                 <span className="flex-grow truncate text-sm">
-                  <span className="text-emphasis mb-1 block truncate font-medium leading-none">
+                  <span className="text-emphasis block truncate font-medium leading-none">
                     {user.name || "Nameless User"}
                   </span>
-                  <span className="text-default block truncate font-normal leading-none">
+                  <span className="text-default py-1 block truncate font-normal leading-none">
                     {user.username
                       ? process.env.NEXT_PUBLIC_WEBSITE_URL === "https://cal.com"
                         ? `cal.com/${user.username}`


### PR DESCRIPTION
## What does this PR do?

Fixed padding issue with the username, earlier bottom part of the username was cutting off due to the wrong padding

Fixes #8563 

**Environment**:  Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Check the user profile section in the bottom left corner, earlier bottom part of the username was cutting off due to the wrong padding, now it's fixed.
- **Before**
![before](https://user-images.githubusercontent.com/47536121/235340456-2a89af46-07d7-4340-80a7-cc7cb23c418f.png)
- **After**
![after](https://user-images.githubusercontent.com/47536121/235340470-983c2a81-2076-4c05-aaed-41c6df4f41a7.png)

