### PR TITLE
fix: Use correct values on append DayRange

### DIFF
--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -169,6 +169,7 @@ export const DayRanges = <TFieldValues extends FieldValues>({
   control?: Control<TFieldValues>;
 }) => {
   const { t } = useLocale();
+  const { getValues } = useFormContext();
 
   const { remove, fields, append } = useFieldArray({
     control,
@@ -191,7 +192,7 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                 StartIcon={Plus}
                 onClick={() => {
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  const nextRange: any = getNextRange(fields[fields.length - 1]);
+                  const nextRange: any = getNextRange(getValues(`${name}.${fields.length - 1}`));
                   if (nextRange) append(nextRange);
                 }}
               />


### PR DESCRIPTION
## What does this PR do?

This PR solves the issue of appending the previous value of time select if the select has changed in the availability schedule.

Fixes # (issue)

### Before
![Working Hours _Availability_Cal com_Before](https://user-images.githubusercontent.com/85764745/235440860-ce4d4565-da8e-47ca-899e-2608ca174cac.gif)

### After
![WorkingHours _Availability_ Cal com_After](https://user-images.githubusercontent.com/85764745/235440889-aface000-e3a2-4ffb-9141-05b5353033d7.gif)

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
