### PR TITLE
added history plugin to support undo and redo

### DIFF
--- a/packages/ui/components/editor/Editor.tsx
+++ b/packages/ui/components/editor/Editor.tsx
@@ -4,6 +4,7 @@ import { ListItemNode, ListNode } from "@lexical/list";
 import { TRANSFORMERS } from "@lexical/markdown";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
@@ -87,6 +88,7 @@ export const Editor = (props: TextEditorProps) => {
             <ListPlugin />
             <LinkPlugin />
             <AutoLinkPlugin />
+            <HistoryPlugin />
             <MarkdownShortcutPlugin
               transformers={
                 props.disableLists


### PR DESCRIPTION
## What does this PR do?
In the editor component which is used for writing the description or agenda for a new meeting `undo`(ctrl+z) and `redo`(ctrl+shift+z) don't work. Which is now fixed with the help of HistoryPlugin.<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #8602

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->


- New feature (non-breaking change which adds functionality)


## How should this be tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Check the description section when you create a new meeting and enter some text and the pres `ctrl+z`. It works




