### PR TITLE
fix: corrected discord link pattern

### DIFF
--- a/packages/app-store/discord/config.json
+++ b/packages/app-store/discord/config.json
@@ -15,7 +15,7 @@
       "label": "{TITLE}",
       "linkType": "static",
       "organizerInputPlaceholder": "https://discord.gg/420gg69",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?(discord.gg|discord.com)\\/[a-zA-Z0-9]*"
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?(discord\\.gg|discord\\.com)\\/[a-zA-Z0-9]+"
     }
   },
   "description": "Copy your server invite link and start scheduling calls in Discord! Discord is a VoIP and instant messaging social platform. Users have the ability to communicate with voice calls, video calls, text messaging, media and files in private chats or as part of communities.",

--- a/packages/app-store/discord/config.json
+++ b/packages/app-store/discord/config.json
@@ -15,7 +15,7 @@
       "label": "{TITLE}",
       "linkType": "static",
       "organizerInputPlaceholder": "https://discord.gg/420gg69",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?(discord\\.gg|discord\\.com)\\/[a-zA-Z0-9]+"
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?discord\\.(gg|com)\\/[a-zA-Z0-9]+"
     }
   },
   "description": "Copy your server invite link and start scheduling calls in Discord! Discord is a VoIP and instant messaging social platform. Users have the ability to communicate with voice calls, video calls, text messaging, media and files in private chats or as part of communities.",


### PR DESCRIPTION
## What does this PR do?

Discord link such as `https://www.discordggg/` is also getting validated correctly with current pattern.
Problem:

1. dot(.) is not escaped.
2. url without any character after last slash (/) is also getting accepted.

So I corrected the escape pattern and also replaced `*` with `+` at the end, which mandates the character after end slash. 

Fixes and improves: https://github.com/calcom/cal.com/issues/8182

https://user-images.githubusercontent.com/32206192/235523656-b125b21d-8cf3-49ce-8630-5a78878651ed.mov

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manually building app on local 
