### PR TITLE
fix: changed assign to field as typeable input

### DIFF
--- a/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
+++ b/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
@@ -47,7 +47,6 @@ export const ChildrenEventTypeSelect = ({
         }}
         name={props.name}
         placeholder={t("select")}
-        isSearchable={false}
         options={options}
         value={value}
         isMulti


### PR DESCRIPTION
## What does this PR do?

Fixes #8412

Changed assign_to field as typable input.

**After**

https://user-images.githubusercontent.com/69904519/235213736-0a41db5c-041f-4670-bb00-da89a54ef5b3.mp4

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works