### PR TITLE
[URGENT] Hotfix: re-adds the password and username set check in signup

### DIFF
--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -36,8 +36,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // There is actually an existingUser if username matches
-  // OR if email matches and both username and password are set
+  // There is an existingUser if the username matches
+  // OR if the email matches AND either the email is verified
+  // or both username and password are set
   const existingUser = await prisma.user.findFirst({
     where: {
       OR: [

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -43,7 +43,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       OR: [
         { username },
         {
-          AND: [{ email: userEmail }, { password: { not: null } }, { username: { not: null } }],
+          AND: [
+            { email: userEmail },
+            {
+              OR: [
+                { verified: true },
+                {
+                  AND: [{ password: { not: null } }, { username: { not: null } }],
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -43,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       OR: [
         { username },
         {
-          AND: [{ email: userEmail }],
+          AND: [{ email: userEmail }, { password: { not: null } }, { username: { not: null } }],
         },
       ],
     },

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -47,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             { email: userEmail },
             {
               OR: [
-                { verified: true },
+                { emailVerified: { not: null } },
                 {
                   AND: [{ password: { not: null } }, { username: { not: null } }],
                 },


### PR DESCRIPTION
## What does this PR do?

Check for existing password and username to ensure it isn't an invite. 
If we send a team invite, the email is added to the DB and the existing check would render their sign-up process to fail as their email is in the DB.
~Reverting this to a previous state (prior to commit-1ee3783db30fe62dcf7fe1eef746759275525ecc) to check for a set password and a set username which ensures that the user is already registered and it isn't just an invite.~
Added a check to allow the previous state (if a password and username is also set), along with a check based on the fact that email is verified, which is true for SAML/SSO.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

