### PR TITLE
Stabilize Tests

### DIFF
--- a/apps/web/playwright/app-store.e2e.ts
+++ b/apps/web/playwright/app-store.e2e.ts
@@ -12,6 +12,7 @@ test.describe("App Store - Authed", () => {
     await pro.login();
     await page.goto("/apps/categories/calendar");
     await page.click('[data-testid="app-store-app-card-apple-calendar"]');
+    await page.waitForURL("/apps/apple-calendar");
     await page.click('[data-testid="install-app-button"]');
     await expect(page.locator(`text=Connect to Apple Server`)).toBeVisible();
   });

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -94,7 +94,12 @@ testBothBookers.describe("pro user", () => {
     });
   });
 
-  test("Can cancel the recently created booking and rebook the same timeslot", async ({ page, users }) => {
+  test("Can cancel the recently created booking and rebook the same timeslot", async ({
+    page,
+    users,
+  }, testInfo) => {
+    // Because it tests the entire booking flow + the cancellation + rebooking
+    test.setTimeout(testInfo.timeout * 3);
     await bookFirstEvent(page);
 
     const [pro] = users.get();
@@ -103,7 +108,7 @@ testBothBookers.describe("pro user", () => {
     await page.goto("/bookings/upcoming");
     await page.locator('[data-testid="cancel"]').first().click();
     await page.waitForURL((url) => {
-      return url.pathname.startsWith("/booking");
+      return url.pathname.startsWith("/booking/");
     });
     await page.locator('[data-testid="cancel"]').click();
 

--- a/packages/embeds/embed-core/playwright/lib/testUtils.ts
+++ b/packages/embeds/embed-core/playwright/lib/testUtils.ts
@@ -91,10 +91,11 @@ async function selectFirstAvailableTimeSlotNextMonth(frame: Frame, page: Page) {
 }
 
 export async function bookFirstEvent(username: string, frame: Frame, page: Page) {
-  // Click first event type
+  // Click first event type on Profile Page
   await frame.click('[data-testid="event-type-link"]');
   await frame.waitForURL((url) => {
-    return !!url.pathname.match(new RegExp(`/${username}/.*$`));
+    // Wait for reaching the event page
+    return !!url.pathname.match(new RegExp(`/${username}/.+$`));
   });
 
   // Let current month dates fully render.


### PR DESCRIPTION
Earlier waitForNavigation was behaving in a very flaky manner and it was replaced by waitForURL everywhere. But waitForURL has a difference that it can consider the same page in assertion without actually waiting for navigation(vs waitForNavigation which would require an actual navigation to even match the current page URL)

There are fixes in this PR for the above scenario.