### PR TITLE
add "reset to default" color option for ColorPicker

### DIFF
--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -146,6 +146,7 @@ const AppearanceView = () => {
               <p className="text-default mb-2 block text-sm font-medium">{t("light_brand_color")}</p>
               <ColorPicker
                 defaultValue={user.brandColor}
+                resetDefaultValue="#292929"
                 onChange={(value) => {
                   if (!checkWCAGContrastColor("#ffffff", value)) {
                     setLightModeError(true);
@@ -167,6 +168,7 @@ const AppearanceView = () => {
               <p className="text-default mb-2 block text-sm font-medium">{t("dark_brand_color")}</p>
               <ColorPicker
                 defaultValue={user.darkBrandColor}
+                resetDefaultValue="#fafafa"
                 onChange={(value) => {
                   if (!checkWCAGContrastColor("#101010", value)) {
                     setDarkModeError(true);

--- a/packages/features/ee/teams/pages/team-appearance-view.tsx
+++ b/packages/features/ee/teams/pages/team-appearance-view.tsx
@@ -151,6 +151,7 @@ const ProfileView = () => {
                   <p className="text-emphasis mb-2 block text-sm font-medium">{t("light_brand_color")}</p>
                   <ColorPicker
                     defaultValue={team.brandColor}
+                    resetDefaultValue="#292929"
                     onChange={(value) => form.setValue("brandColor", value, { shouldDirty: true })}
                   />
                 </div>
@@ -165,6 +166,7 @@ const ProfileView = () => {
                   <p className="text-emphasis mb-2 block text-sm font-medium">{t("dark_brand_color")}</p>
                   <ColorPicker
                     defaultValue={team.darkBrandColor}
+                    resetDefaultValue="#fafafa"
                     onChange={(value) => form.setValue("darkBrandColor", value, { shouldDirty: true })}
                   />
                 </div>

--- a/packages/ui/components/form/color-picker/colorpicker.tsx
+++ b/packages/ui/components/form/color-picker/colorpicker.tsx
@@ -65,7 +65,7 @@ const ColorPicker = (props: ColorPickerProps) => {
         }}
         type="text"
       />
-      {resetDefaultValue && (
+      {resetDefaultValue && color != resetDefaultValue && (
         <div className="px-1">
           <Button
             color={resetDefaultValue == "#292929" ? "primary" : "secondary"}

--- a/packages/ui/components/form/color-picker/colorpicker.tsx
+++ b/packages/ui/components/form/color-picker/colorpicker.tsx
@@ -2,7 +2,6 @@ import * as Popover from "@radix-ui/react-popover";
 import { useState } from "react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
 
-import { classNames } from "@calcom/lib";
 import cx from "@calcom/lib/classNames";
 import { fallBackHex, isValidHexCode } from "@calcom/lib/getBrandColours";
 import { Button } from "@calcom/ui";
@@ -62,21 +61,23 @@ const ColorPicker = (props: ColorPickerProps) => {
         }}
         type="text"
       />
-      <div className={classNames("px-1", resetDefaultValue == null && "invisible")}>
-        <Button
-          color={resetDefaultValue == "#292929" ? "primary" : "secondary"}
-          data-testid="preview-button"
-          target="_blank"
-          variant="icon"
-          rel="noreferrer"
-          StartIcon={RotateCcw}
-          tooltip="Reset to default"
-          onClick={() => {
-            setColor(fallBackHex(resetDefaultValue, false));
-            props.onChange(resetDefaultValue);
-          }}
-        />
-      </div>
+      {resetDefaultValue && (
+        <div className="px-1">
+          <Button
+            color={resetDefaultValue == "#292929" ? "primary" : "secondary"}
+            data-testid="preview-button"
+            target="_blank"
+            variant="icon"
+            rel="noreferrer"
+            StartIcon={RotateCcw}
+            tooltip="Reset to default"
+            onClick={() => {
+              setColor(fallBackHex(resetDefaultValue, false));
+              props.onChange(resetDefaultValue);
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/ui/components/form/color-picker/colorpicker.tsx
+++ b/packages/ui/components/form/color-picker/colorpicker.tsx
@@ -20,7 +20,11 @@ const ColorPicker = (props: ColorPickerProps) => {
   const init = !isValidHexCode(props.defaultValue)
     ? fallBackHex(props.defaultValue, false)
     : props.defaultValue;
-  const resetDefaultValue = props.resetDefaultValue;
+  const resetDefaultValue =
+    props.resetDefaultValue &&
+    (!isValidHexCode(props.resetDefaultValue)
+      ? fallBackHex(props.resetDefaultValue, false)
+      : props.resetDefaultValue);
   const [color, setColor] = useState(init);
 
   return (

--- a/packages/ui/components/form/color-picker/colorpicker.tsx
+++ b/packages/ui/components/form/color-picker/colorpicker.tsx
@@ -69,7 +69,6 @@ const ColorPicker = (props: ColorPickerProps) => {
         <div className="px-1">
           <Button
             color={resetDefaultValue == "#292929" ? "primary" : "secondary"}
-            data-testid="preview-button"
             target="_blank"
             variant="icon"
             rel="noreferrer"

--- a/packages/ui/components/form/color-picker/colorpicker.tsx
+++ b/packages/ui/components/form/color-picker/colorpicker.tsx
@@ -2,8 +2,11 @@ import * as Popover from "@radix-ui/react-popover";
 import { useState } from "react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
 
+import { classNames } from "@calcom/lib";
 import cx from "@calcom/lib/classNames";
 import { fallBackHex, isValidHexCode } from "@calcom/lib/getBrandColours";
+import { Button } from "@calcom/ui";
+import { RotateCcw } from "@calcom/ui/components/icon";
 
 export type ColorPickerProps = {
   defaultValue: string;
@@ -11,12 +14,14 @@ export type ColorPickerProps = {
   container?: HTMLElement;
   popoverAlign?: React.ComponentProps<typeof Popover.Content>["align"];
   className?: string;
+  resetDefaultValue?: string;
 };
 
 const ColorPicker = (props: ColorPickerProps) => {
   const init = !isValidHexCode(props.defaultValue)
     ? fallBackHex(props.defaultValue, false)
     : props.defaultValue;
+  const resetDefaultValue = props.resetDefaultValue;
   const [color, setColor] = useState(init);
 
   return (
@@ -57,6 +62,21 @@ const ColorPicker = (props: ColorPickerProps) => {
         }}
         type="text"
       />
+      <div className={classNames("px-1", resetDefaultValue == null && "invisible")}>
+        <Button
+          color={resetDefaultValue == "#292929" ? "primary" : "secondary"}
+          data-testid="preview-button"
+          target="_blank"
+          variant="icon"
+          rel="noreferrer"
+          StartIcon={RotateCcw}
+          tooltip="Reset to default"
+          onClick={() => {
+            setColor(fallBackHex(resetDefaultValue, false));
+            props.onChange(resetDefaultValue);
+          }}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #8642
Adds the option to reset to the default color.
<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://user-images.githubusercontent.com/47350983/235989553-07d3de0b-e109-4f40-bd9e-0d9d1132893f.mp4

Description of the code changes:

ColorPicker
- Add a non-required prop to the props passed on the the component called "resetDefaultValue".
- Add a button which has the RotateCcw icon. This icon is invisible by default. Only if the resetDefaultValue is passed on by the part component, this icon will be visible.
- Upon clicking this icon, the color is set to the "resetDefaultValue"

The color picker component is used in 3 places: 
1. Appearance section for a user: https://app.cal.com/settings/my-account/appearance - 2 instances.
   Default resetDefaultValue of #292929 and #fafafa added for light and dark themes .
2. Appearance section for a Team - 2 instances.
   Default resetDefaultValue of #292929 and #fafafa added for light and dark themes .
3. The Embed option for a meeting - 1 instance.
  resetDefaultValue has not been set meaning the reset icon will not appear.


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->


- New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Set the color to a different value and then use the reset option.
- [x] Click on Update at the bottom without using the reset option and refresh page to ensure that the color is saved.
- [x] Click on Update at the bottom after using the reset option and refresh page to ensure that the color is saved. 
