### PR TITLE
Added validation for duration field in the event types

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -466,6 +466,7 @@ export const EventSetupTab = (
             defaultValue={eventType.length ?? 15}
             {...formMethods.register("length")}
             addOnSuffix={<>{t("minutes")}</>}
+            min={1}
           />
         )}
         {!lengthLockedProps.disabled && (


### PR DESCRIPTION
## What does this PR do?
- Prevented negative value to be entered in the **duration** field in the event types

Fixes #8648 
![validation-for-duration-field](https://user-images.githubusercontent.com/47536121/236042967-7dece239-bddc-43bf-a4f3-e979d90a761b.gif)


**Environment**: Staging(main branch) / Production

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Go to Event Types
- Edit any Event Type
- Try to put -ve value in the **Duration** field