### PR TITLE
CAL-1558: Fixed responsiveness of booker for small calendar layout

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -121,13 +121,19 @@ const BookerComponent = ({ username, eventSlug, month, rescheduleBooking }: Book
         <div
           style={resizeAnimationConfig[layout]?.[bookerState] || resizeAnimationConfig[layout].default}
           className={classNames(
+            // Size settings are abstracted on their own lines purely for readbility.
+            // General sizes:
             "[--booker-main-width:480px] [--booker-timeslots-width:240px] lg:[--booker-timeslots-width:280px]",
-            "bg-muted grid max-w-full items-start overflow-clip dark:[color-scheme:dark] md:flex-row",
+            // Sizes only applicable for small_calendar
             layout === "small_calendar" &&
-              "border-subtle mt-20 min-h-[450px] w-[calc(var(--booker-meta-width)+var(--booker-main-width))] rounded-md border [--booker-meta-width:280px]",
-            layout !== "small_calendar" &&
-              "h-auto min-h-screen w-screen [--booker-meta-width:340px] lg:[--booker-meta-width:424px]",
-            "transition-[width] duration-300"
+              "w-[calc(var(--booker-meta-width)+var(--booker-main-width))] [--booker-meta-width:240px] lg:[--booker-meta-width:280px]",
+            // Sizes for fullscreen layouts:
+            layout !== "small_calendar" && "[--booker-meta-width:340px] lg:[--booker-meta-width:424px]",
+            // Other styles
+            "bg-muted grid max-w-full items-start overflow-clip dark:[color-scheme:dark] md:flex-row",
+            layout === "small_calendar" && "border-subtle mt-20 min-h-[450px] rounded-md border",
+            layout !== "small_calendar" && "h-auto min-h-screen w-screen",
+            "transition-[width,max-width] duration-300"
           )}>
           <AnimatePresence>
             <StickyOnDesktop key="meta" className="relative z-10">

--- a/packages/features/bookings/Booker/config.ts
+++ b/packages/features/bookings/Booker/config.ts
@@ -54,18 +54,21 @@ export const resizeAnimationConfig: ResizeAnimationConfig = {
   small_calendar: {
     default: {
       width: "calc(var(--booker-meta-width) + var(--booker-main-width))",
+      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) var(--booker-main-width)",
     },
     selecting_time: {
-      width: "calc(var(--booker-meta-width) + var(--booker-main-width) + var(--booker-timeslots-width))",
+      width: "100%",
+      maxWidth: "calc(var(--booker-meta-width) + var(--booker-main-width) + var(--booker-timeslots-width))",
       gridTemplateAreas: `"meta main timeslots"`,
-      gridTemplateColumns: "var(--booker-meta-width) var(--booker-main-width) var(--booker-timeslots-width)",
+      gridTemplateColumns: "var(--booker-meta-width) 1fr var(--booker-timeslots-width)",
     },
   },
   large_calendar: {
     default: {
       width: "100%",
+      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) 1fr",
     },
@@ -73,6 +76,7 @@ export const resizeAnimationConfig: ResizeAnimationConfig = {
   large_timeslots: {
     default: {
       width: "100%",
+      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) 1fr",
     },

--- a/packages/features/bookings/Booker/config.ts
+++ b/packages/features/bookings/Booker/config.ts
@@ -54,7 +54,6 @@ export const resizeAnimationConfig: ResizeAnimationConfig = {
   small_calendar: {
     default: {
       width: "calc(var(--booker-meta-width) + var(--booker-main-width))",
-      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) var(--booker-main-width)",
     },
@@ -68,7 +67,6 @@ export const resizeAnimationConfig: ResizeAnimationConfig = {
   large_calendar: {
     default: {
       width: "100%",
-      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) 1fr",
     },
@@ -76,7 +74,6 @@ export const resizeAnimationConfig: ResizeAnimationConfig = {
   large_timeslots: {
     default: {
       width: "100%",
-      // maxWidth: "100%",
       gridTemplateAreas: `"meta main"`,
       gridTemplateColumns: "var(--booker-meta-width) 1fr",
     },


### PR DESCRIPTION
## What does this PR do?

Improves responsive behaviour for non fullscreen layouts. Issue only occurred in this view when also having the timeslots open. 

### Previous behaviour: 

![CleanShot 2023-05-04 at 11 07 39@2x](https://user-images.githubusercontent.com/2969573/236174810-c5a4c967-16fe-4eda-b3c4-688bd7c7c924.jpg)

### After this PR: 
![CleanShot 2023-05-04 at 11 08 07@2x](https://user-images.githubusercontent.com/2969573/236174911-a2533c81-5d5c-4f5a-9654-f485dde83a52.jpg)


Fixes CAL-1558

**Environment**: Staging(main branch) 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Ensure that the view now behaves correctly responsive
- [ ] View shouldn't be broken on desktop now
- [ ] Other two views should still be responsive too
- [ ] When going to mobile we always force the small calendar view
