### PR TITLE
CAL-1556: Alignment of current day dot in datepicker.

### DIFF
--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -44,6 +44,7 @@ export const Day = ({
   active: boolean;
   date: Dayjs;
 }) => {
+  const { t } = useLocale();
   const enabledDateButtonEmbedStyles = useEmbedStyles("enabledDateButton");
   const disabledDateButtonEmbedStyles = useEmbedStyles("disabledDateButton");
   return (
@@ -64,7 +65,9 @@ export const Day = ({
       {...props}>
       {date.date()}
       {date.isToday() && (
-        <span className="absolute left-0 right-0 bottom-0 h-2/5 align-middle text-4xl leading-[0rem]">.</span>
+        <span className="absolute left-1/2 top-1/2 flex h-[5px] w-[5px] translate-y-[8px] -translate-x-1/2 items-center justify-center rounded-full bg-white align-middle sm:translate-y-[12px]">
+          <span className="sr-only">{t("today")}</span>
+        </span>
       )}
     </button>
   );


### PR DESCRIPTION
## What does this PR do?

Improves alignment of current day "dot" in datepicker, on small layouts (when calendar is very small, so could also be on desktop). It's not perfect yet, but at least it's aligned properly. I think eventually we need to improve our datepicker even more.

Before: 
![CleanShot 2023-05-04 at 11 23 57@2x](https://user-images.githubusercontent.com/2969573/236178214-5de6e759-ea97-4d19-bc47-870aebe7ea9a.jpg)

After: 
![CleanShot 2023-05-04 at 11 24 36@2x](https://user-images.githubusercontent.com/2969573/236178262-dd56f30b-0331-4c1b-9a6e-4a1633f333ee.jpg)

Fixes CAL-1556

**Environment**: Staging(main branch)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
## How should this be tested?

- [ ] Ensure datepicker "today dot" is aligned properly on both smaller and bigger breakpoints. Best page to test is /pro/30min.
