### PR TITLE
Fix/prevent duplicate avatars

### DIFF
--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -1,4 +1,4 @@
-import { CAL_URL } from "@calcom/lib/constants";
+import { CAL_URL, WEBAPP_URL } from "@calcom/lib/constants";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { AvatarGroup } from "@calcom/ui";
 
@@ -21,19 +21,12 @@ export const EventMembers = ({ schedulingType, users, profile }: EventMembersPro
   const avatars = shownUsers
     .map((user) => ({
       title: `${user.name}`,
-      image: "image" in user ? `${user.image}` : `${CAL_URL}/${user.username}/avatar.png`,
+      image: "image" in user ? `${user.image}` : `${WEBAPP_URL}/${user.username}/avatar.png`,
       alt: user.name || undefined,
       href: user.username ? `${CAL_URL}/${user.username}` : undefined,
     }))
     .filter((item) => !!item.image)
-    .filter((item, index, self) => {
-      // Filter out duplicates by checking both the image and the href,
-      // sometimes we tend to get the same avatar prefixed with app.cal.com and cal.com,
-      // so only the image match wouldn't work here.
-      const imageIsUnique = self.findIndex((t) => t.image === item.image) === index;
-      const hrefIsUnique = self.findIndex((t) => t.href === item.href) === index;
-      return imageIsUnique && (!item.href || hrefIsUnique);
-    });
+    .filter((item, index, self) => self.findIndex((t) => t.image === item.image) === index);
 
   return (
     <>

--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -32,7 +32,7 @@ export const EventMembers = ({ schedulingType, users, profile }: EventMembersPro
       // so only the image match wouldn't work here.
       const imageIsUnique = self.findIndex((t) => t.image === item.image) === index;
       const hrefIsUnique = self.findIndex((t) => t.href === item.href) === index;
-      return imageIsUnique && hrefIsUnique;
+      return imageIsUnique && (!item.href || hrefIsUnique);
     });
 
   return (

--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -26,7 +26,14 @@ export const EventMembers = ({ schedulingType, users, profile }: EventMembersPro
       href: user.username ? `${CAL_URL}/${user.username}` : undefined,
     }))
     .filter((item) => !!item.image)
-    .filter((item, index, self) => self.findIndex((t) => t.image === item.image) === index);
+    .filter((item, index, self) => {
+      // Filter out duplicates by checking both the image and the href,
+      // sometimes we tend to get the same avatar prefixed with app.cal.com and cal.com,
+      // so only the image match wouldn't work here.
+      const imageIsUnique = self.findIndex((t) => t.image === item.image) === index;
+      const hrefIsUnique = self.findIndex((t) => t.href === item.href) === index;
+      return imageIsUnique && hrefIsUnique;
+    });
 
   return (
     <>


### PR DESCRIPTION
## What does this PR do?

Changes avatars url to use webapp url, because that's also what is used in other places, so that way the unique filter on image url works, and we won't see any duplicate profiles for users. 

**Environment**: Staging(main branch)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to any profile (eg pro/30min) and ensure you don't see twice the same avatar – actually one 1 avatar at all for this user.