### PR TITLE
Fix switch label hover

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -238,7 +238,7 @@ function EventTypeSingleLayout({
         <div className="flex items-center justify-end">
           {!eventType.metadata.managedEventConfig && (
             <>
-              <div className="sm:hover:bg-subtle hidden items-center rounded-md px-2 lg:flex">
+              <div className="sm:hover:bg-muted hidden items-center rounded-md px-2 lg:flex">
                 <Skeleton
                   as={Label}
                   htmlFor="hiddenSwitch"

--- a/apps/web/pages/availability/[schedule].tsx
+++ b/apps/web/pages/availability/[schedule].tsx
@@ -188,7 +188,7 @@ export default function Availability() {
       }
       CTA={
         <div className="flex items-center justify-end">
-          <div className="hidden items-center rounded-md px-2 sm:flex sm:hover:bg-gray-100">
+          <div className="sm:hover:bg-muted hidden items-center rounded-md px-2 sm:flex">
             <Skeleton as={Label} htmlFor="hiddenSwitch" className="mt-2 cursor-pointer self-center pr-2 ">
               {t("set_to_default")}
             </Skeleton>


### PR DESCRIPTION
Fixes hover being unreadable on darkmode 

Makes it impossible to tell if the switch was actually there when the state was off

Before:
<img width="201" alt="CleanShot 2023-05-05 at 12 11 53@2x" src="https://user-images.githubusercontent.com/55134778/236443099-b0f2b2b1-7f09-4336-a917-a1c95bd8f695.png">


After:
<img width="207" alt="CleanShot 2023-05-05 at 12 06 35@2x" src="https://user-images.githubusercontent.com/55134778/236442461-c047250a-6221-4856-a546-42cdb3083f16.png">
<img width="235" alt="CleanShot 2023-05-05 at 12 06 45@2x" src="https://user-images.githubusercontent.com/55134778/236442463-fa2bea34-5b4e-4b07-b85e-ca1358a59378.png">
