### PR TITLE
Make dates in header of fullscreen booker layouts work again

### DIFF
--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -101,7 +101,7 @@ export const useBookerStore = create<BookerStore>((set, get) => ({
   setLayout: (layout: BookerLayout) => {
     // If we switch to a large layout and don't have a date selected yet,
     // we selected it here, so week title is rendered properly.
-    if (["large_calendar", "large_timeslots"].includes(get().layout) && !get().selectedDate) {
+    if (["large_calendar", "large_timeslots"].includes(layout) && !get().selectedDate) {
       set({ selectedDate: dayjs().format("YYYY-MM-DD") });
     }
     return set({ layout });


### PR DESCRIPTION
## What does this PR do?

Set selecteddate to today when switching layout. Before we were getting the current layout from the store, which would actually be the OLD layout you were switching from 😅

Before: 
![CleanShot 2023-05-05 at 17 19 41@2x](https://user-images.githubusercontent.com/2969573/236512819-3ee0c065-fbff-4e13-8652-58a7b3bfdc20.jpg)

After: 
![CleanShot 2023-05-05 at 17 20 00@2x](https://user-images.githubusercontent.com/2969573/236512871-39b85eac-645b-4780-8c49-3535c98bf146.jpg)

**Environment**: Staging(main branch)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
