### PR TITLE
add try catch block in packages/email/templates/_base-email.ts getRec…

### DIFF
--- a/packages/emails/templates/_base-email.ts
+++ b/packages/emails/templates/_base-email.ts
@@ -23,9 +23,16 @@ export default class BaseEmail {
   protected getRecipientTime(time: string): Dayjs;
   protected getRecipientTime(time: string, format: string): string;
   protected getRecipientTime(time: string, format?: string) {
-    const date = dayjs(time).tz(this.getTimezone());
-    if (typeof format === "string") return date.format(format);
-    return date;
+    try {
+      const date = dayjs(time).tz(this.getTimezone());
+      if (typeof format === "string") return date.format(format);
+      return date;
+
+    } catch (error) {
+      console.error("Error in getRecipientTime:",error);
+      throw error;
+    }
+
   }
 
   protected getNodeMailerPayload(): Record<string, unknown> {


### PR DESCRIPTION
## What does this PR do?

Lack of error handling in the  /packages/email/templates/_base-email.ts -> getRecipientTime method: The dayjs library can throw errors if it is passed an invalid date string, but these errors are not being handled in the getRecipientTime method.

## Type of change
- Chore (refactoring code, technical debt, workflow improvements)


- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
