### PR TITLE
Prepare schema before the Split Full Booking Change.

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -17,6 +17,8 @@ export const bookingResponse = z.union([
     optionValue: z.string(),
     value: z.string(),
   }),
+  // For variantsConfig case
+  z.record(z.string()),
 ]);
 
 export const bookingResponsesDbSchema = z.record(bookingResponse);


### PR DESCRIPTION
It's a preparation PR for https://github.com/calcom/cal.com/pull/8671.

This change allows bookings with Split full name to still load in case the PR needs to be reverted.  The same change is also there in #8671 