### PR TITLE
Hotfix: Can't use settings/admin/apps

### DIFF
--- a/apps/web/pages/api/trpc/appsRouter/[trpc].ts
+++ b/apps/web/pages/api/trpc/appsRouter/[trpc].ts
@@ -1,0 +1,4 @@
+import { createNextApiHandler } from "@calcom/trpc/server/createNextApiHandler";
+import { appsRouter } from "@calcom/trpc/server/routers/viewer/apps/_router";
+
+export default createNextApiHandler(appsRouter);

--- a/packages/trpc/react/trpc.ts
+++ b/packages/trpc/react/trpc.ts
@@ -37,6 +37,7 @@ const ENDPOINTS = [
   "viewer",
   "webhook",
   "workflows",
+  "appsRouter",
 ] as const;
 export type Endpoint = (typeof ENDPOINTS)[number];
 
@@ -51,15 +52,14 @@ const resolveEndpoint = (links: any) => {
   return (ctx: any) => {
     const parts = ctx.op.path.split(".");
     let endpoint;
-    let path = '';
+    let path = "";
     if (parts.length == 2) {
       endpoint = parts[0] as keyof typeof links;
       path = parts[1];
     } else {
       endpoint = parts[1] as keyof typeof links;
-      path = parts.splice(2, parts.length - 2).join('.');
+      path = parts.splice(2, parts.length - 2).join(".");
     }
-
     return links[endpoint]({ ...ctx, op: { ...ctx.op, path } });
   };
 };


### PR DESCRIPTION
Fixes unconnected appsRouter due to new per lambda routes related change

Bug can be seen in this screenshot. There is error fetching apps list due to which the apps list is empty.
<img width="1762" alt="Screenshot 2023-05-06 at 11 40 53 AM" src="https://user-images.githubusercontent.com/1780212/236604803-22435f52-1428-4615-9e0b-04a099a10ccf.png">


Also, I think with the new changes, TypeScript safety isn't there with routes as this route was defined as per the TypeScript but it wasn't actually working.
