### PR TITLE
Bug: Change color variable for dark mode

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -84,8 +84,8 @@
   /* Brand shenanigans
       -> These will be computed for the users theme at runtime.
     */
-  --cal-brand: #111827;
-  --cal-brand-emphasis: #101010;
+  --cal-brand: white;
+  --cal-brand-emphasis: #e1e1e1;
   --cal-brand-text: black;
 }
 


### PR DESCRIPTION
## What does this PR do?

Updated the dark mode variables for `--cal-brand` and `--cal-brand-emphasis` in `globals.css`. This fixes the colour of the  'Save' button for App installation setup in dark mode.

Fixes #8756 

Before:
<img width="902" alt="Screenshot 2023-05-08 at 8 43 06 PM" src="https://user-images.githubusercontent.com/35249409/236875639-1bcb194a-ed78-44d2-af0d-a5e4b3a32327.png">

After:
<img width="902" alt="Screenshot 2023-05-08 at 9 36 33 PM" src="https://user-images.githubusercontent.com/35249409/236875697-37634e0c-900b-4add-98fe-9259857d55b5.png">

Light Mode (No changes required):
<img width="902" alt="Screenshot 2023-05-08 at 8 43 46 PM" src="https://user-images.githubusercontent.com/35249409/236875747-f4817e10-768f-4de6-9442-cb16f990bc12.png">

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
