### PR TITLE
Disable reserve slot on seated events

### DIFF
--- a/apps/web/components/booking/AvailableTimes.tsx
+++ b/apps/web/components/booking/AvailableTimes.tsx
@@ -72,6 +72,7 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
       slotUtcStartDate: slot.time,
       eventTypeId,
       slotUtcEndDate: dayjs(slot.time).utc().add(duration, "minutes").format(),
+      bookingAttendees: bookingAttendees || undefined,
     });
   };
 

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -230,7 +230,19 @@ const BookingPage = ({
     }),
     {}
   );
+
   const reserveSlot = () => {
+    // If it is a seats event and it is not the last attendee then do not reserve
+    if (eventType.seatsPerTimeSlot) {
+      // Check to see if this is the last attendee
+      if (booking) {
+        const seatsLeft = eventType.seatsPerTimeSlot - booking.attendees.length;
+        if (seatsLeft < 1) return null;
+      } else {
+        // If there is no booking yet then don't reserve the slot
+        return null;
+      }
+    }
     if (queryDuration) {
       reserveSlotMutation.mutate({
         eventTypeId: eventType.id,

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -237,7 +237,7 @@ const BookingPage = ({
         eventTypeId: eventType.id,
         slotUtcStartDate: dayjs(queryDate).utc().format(),
         slotUtcEndDate: dayjs(queryDate).utc().add(parseInt(queryDuration), "minutes").format(),
-        bookingAttendees: currentSlotBooking.attendees.length,
+        bookingAttendees: currentSlotBooking ? currentSlotBooking.attendees.length : undefined,
       });
     }
   };

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -237,6 +237,7 @@ const BookingPage = ({
         eventTypeId: eventType.id,
         slotUtcStartDate: dayjs(queryDate).utc().format(),
         slotUtcEndDate: dayjs(queryDate).utc().add(parseInt(queryDuration), "minutes").format(),
+        bookingAttendees: currentSlotBooking.attendees.length,
       });
     }
   };

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -232,17 +232,6 @@ const BookingPage = ({
   );
 
   const reserveSlot = () => {
-    // If it is a seats event and it is not the last attendee then do not reserve
-    if (eventType.seatsPerTimeSlot) {
-      // Check to see if this is the last attendee
-      if (booking) {
-        const seatsLeft = eventType.seatsPerTimeSlot - booking.attendees.length;
-        if (seatsLeft < 1) return null;
-      } else {
-        // If there is no booking yet then don't reserve the slot
-        return null;
-      }
-    }
     if (queryDuration) {
       reserveSlotMutation.mutate({
         eventTypeId: eventType.id,

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -52,7 +52,6 @@ export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => 
 
   if (eventType && shouldReserveSlot) {
     try {
-      console.log("This triggers");
       await Promise.all(
         eventType.users.map((user) =>
           prisma.selectedSlots.upsert({

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -19,42 +19,68 @@ interface ReserveSlotOptions {
   input: TReserveSlotInputSchema;
 }
 export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => {
+  console.log("🚀 ~ file: reserveSlot.handler.ts:22 ~ reserveSlotHandler ~ input:", input);
   const { prisma, req, res } = ctx;
   const uid = req?.cookies?.uid || uuid();
-  const { slotUtcStartDate, slotUtcEndDate, eventTypeId } = input;
+  const { slotUtcStartDate, slotUtcEndDate, eventTypeId, bookingAttendees } = input;
   const releaseAt = dayjs.utc().add(parseInt(MINUTES_TO_BOOK), "minutes").format();
   const eventType = await prisma.eventType.findUnique({
     where: { id: eventTypeId },
     select: { users: { select: { id: true } }, seatsPerTimeSlot: true },
   });
-  if (eventType) {
-    await Promise.all(
-      eventType.users.map((user) =>
-        prisma.selectedSlots.upsert({
-          where: { selectedSlotUnique: { userId: user.id, slotUtcStartDate, slotUtcEndDate, uid } },
-          update: {
-            slotUtcStartDate,
-            slotUtcEndDate,
-            releaseAt,
-            eventTypeId,
-          },
-          create: {
-            userId: user.id,
-            eventTypeId,
-            slotUtcStartDate,
-            slotUtcEndDate,
-            uid,
-            releaseAt,
-            isSeat: eventType.seatsPerTimeSlot !== null,
-          },
-        })
-      )
-    );
-  } else {
+
+  if (!eventType) {
     throw new TRPCError({
       message: "Event type not found",
       code: "NOT_FOUND",
     });
+  }
+
+  let shouldReserveSlot = true;
+
+  // If this is a seated event then don't reserve a slot
+  if (eventType.seatsPerTimeSlot) {
+    // Check to see if this is the last attendee
+    if (bookingAttendees) {
+      const seatsLeft = eventType.seatsPerTimeSlot - bookingAttendees;
+      if (seatsLeft < 1) shouldReserveSlot = false;
+    } else {
+      // If there is no booking yet then don't reserve the slot
+      shouldReserveSlot = false;
+    }
+  }
+
+  if (eventType && shouldReserveSlot) {
+    try {
+      console.log("This triggers");
+      await Promise.all(
+        eventType.users.map((user) =>
+          prisma.selectedSlots.upsert({
+            where: { selectedSlotUnique: { userId: user.id, slotUtcStartDate, slotUtcEndDate, uid } },
+            update: {
+              slotUtcStartDate,
+              slotUtcEndDate,
+              releaseAt,
+              eventTypeId,
+            },
+            create: {
+              userId: user.id,
+              eventTypeId,
+              slotUtcStartDate,
+              slotUtcEndDate,
+              uid,
+              releaseAt,
+              isSeat: eventType.seatsPerTimeSlot !== null,
+            },
+          })
+        )
+      );
+    } catch {
+      throw new TRPCError({
+        message: "Event type not found",
+        code: "NOT_FOUND",
+      });
+    }
   }
   res?.setHeader("Set-Cookie", serialize("uid", uid, { path: "/", sameSite: "lax" }));
   return;

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -19,7 +19,6 @@ interface ReserveSlotOptions {
   input: TReserveSlotInputSchema;
 }
 export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => {
-  console.log("🚀 ~ file: reserveSlot.handler.ts:22 ~ reserveSlotHandler ~ input:", input);
   const { prisma, req, res } = ctx;
   const uid = req?.cookies?.uid || uuid();
   const { slotUtcStartDate, slotUtcEndDate, eventTypeId, bookingAttendees } = input;

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -33,6 +33,7 @@ export const reserveSlotSchema = z
     slotUtcStartDate: z.string(),
     // endTime ISOString
     slotUtcEndDate: z.string(),
+    bookingAttendees: z.number().optional(),
   })
   .refine(
     (data) => !!data.eventTypeId || !!data.slotUtcStartDate || !!data.slotUtcEndDate,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes a bug where the reserve slots function was blocking some users booking on seated events. The reserve slots logic should only run on the last seat available.

https://www.loom.com/share/ec793dff3da8434fabf783bac6158706

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a seated event
- In one window, choose a time slot
- In a second window, choose the same timeslot
    - You should notice that the same slot doesn't say it has any seats taken
    - Book that time slot, it should succeed
- Now book seats on that time slot until there is one seat left
- When choosing to book that slot, on another window it should say the booking is full

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
