### PR TITLE
fixes START_TIME variable in sms reminder

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -49,6 +49,7 @@ const customTemplate = (
     .replaceAll("{ATTENDEE_NAME}", variables.attendeeName || "") //old variable names
     .replaceAll("{EVENT_DATE}", translatedDate)
     .replaceAll("{EVENT_TIME}", variables.eventDate?.format("H:mmA") || "")
+    .replaceAll("{START_TIME}", variables.eventDate?.format("H:mmA") || "")
     .replaceAll("{EVENT_END_TIME}", variables.eventEndTime?.format("H:mmA") || "")
     .replaceAll("{LOCATION}", locationString)
     .replaceAll("{ADDITIONAL_NOTES}", variables.additionalNotes || "")
@@ -64,7 +65,11 @@ const customTemplate = (
 
   // event date/time with formatting
   customInputvariables?.forEach((variable) => {
-    if (variable.startsWith("EVENT_DATE_") || variable.startsWith("EVENT_TIME_")) {
+    if (
+      variable.startsWith("EVENT_DATE_") ||
+      variable.startsWith("EVENT_TIME_") ||
+      variable.startsWith("START_TIME_")
+    ) {
       const dateFormat = variable.substring(11, text.length);
       const formattedDate = variables.eventDate?.format(dateFormat);
       dynamicText = dynamicText.replace(`{${variable}}`, formattedDate || "");

--- a/packages/features/ee/workflows/lib/reminders/templates/smsReminderTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/smsReminderTemplate.ts
@@ -14,7 +14,7 @@ const smsReminderTemplate = (
   if (isEditingMode) {
     eventName = "{EVENT_NAME}";
     timeZone = "{TIMEZONE}";
-    startTime = "{START_TIME_h:mmA}";
+    startTime = "{EVENT_TIME_h:mmA}";
 
     eventDate = "{EVENT_DATE_YYYY MMM D}";
     attendee = action === WorkflowActions.SMS_ATTENDEE ? "{ORGANIZER}" : "{ATTENDEE}";

--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -9,7 +9,7 @@ import {
   deleteScheduledSMSReminder,
   scheduleSMSReminder,
 } from "@calcom/features/ee/workflows/lib/reminders/smsReminderManager";
-import { SENDER_ID, SENDER_NAME } from "@calcom/lib/constants";
+import { IS_SELF_HOSTED, SENDER_ID, SENDER_NAME } from "@calcom/lib/constants";
 import type { PrismaClient } from "@calcom/prisma/client";
 import { BookingStatus, WorkflowActions, WorkflowMethods, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
@@ -333,7 +333,8 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         !userWorkflow.teamId &&
         !userWorkflow.user?.teams.length &&
         !isSMSAction(oldStep.action) &&
-        isSMSAction(newStep.action)
+        isSMSAction(newStep.action) &&
+        !IS_SELF_HOSTED
       ) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
@@ -487,7 +488,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   //added steps
   const addedSteps = steps.map((s) => {
     if (s.id <= 0) {
-      if (!userWorkflow.user?.teams.length && isSMSAction(s.action)) {
+      if (!userWorkflow.user?.teams.length && isSMSAction(s.action) && !IS_SELF_HOSTED) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
       const { id: _stepId, ...stepToAdd } = s;


### PR DESCRIPTION
## What does this PR do?

Fixes: 
<img width="267" alt="Screenshot 2023-05-09 at 09 25 39" src="https://user-images.githubusercontent.com/30310907/237024763-fbcbd18b-370c-49ce-830c-f6846be82e33.png">

We now correctly use EVENT_TIME instead of START_TIME for the SMS reminder template and also make sure that already created workflows with the START_TIME variable work. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)