### PR TITLE
Enable workflows on merge_group

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR Update
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths-ignore:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,13 @@
 name: PR Update
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:
       - "**.md"
       - ".github/CODEOWNERS"
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What does this PR do?

Enables our GitHub workflows on `merge_group`. This will ensure that the same checks we have for PRs are validated against merge queues.

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

This was already tested. I created a branch called `test-merge-queues`, which acted as `main`. I then opened 2 separate PRs against that branch and put them into the merge queue.