### PR TITLE
fix: available time slot picker

### DIFF
--- a/apps/web/components/booking/AvailableTimes.tsx
+++ b/apps/web/components/booking/AvailableTimes.tsx
@@ -53,6 +53,9 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
   const { rescheduleUid } = router.query;
 
   const [brand, setBrand] = useState("#292929");
+  const [isSlotReservationPending, setIsSlotReservationPending] = useState(false);
+
+  const didSlotReservationFail = reserveSlotMutation.isError;
 
   useEffect(() => {
     setBrand(getComputedStyle(document.documentElement).getPropertyValue("--brand-color").trim());
@@ -67,13 +70,22 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
     [isMobile]
   );
 
+  useEffect(() => {
+    if (didSlotReservationFail) {
+      setIsSlotReservationPending(false);
+    }
+  }, [didSlotReservationFail]);
+
   const reserveSlot = (slot: Slot) => {
-    reserveSlotMutation.mutate({
-      slotUtcStartDate: slot.time,
-      eventTypeId,
-      slotUtcEndDate: dayjs(slot.time).utc().add(duration, "minutes").format(),
-      bookingAttendees: bookingAttendees || undefined,
-    });
+    if (!isSlotReservationPending) {
+      setIsSlotReservationPending(true);
+      reserveSlotMutation.mutate({
+        slotUtcStartDate: slot.time,
+        eventTypeId,
+        slotUtcEndDate: dayjs(slot.time).utc().add(duration, "minutes").format(),
+        bookingAttendees: bookingAttendees || undefined,
+      });
+    }
   };
 
   return (
@@ -161,7 +173,8 @@ const AvailableTimes: FC<AvailableTimesProps> = ({
                         prefetch={false}
                         className={classNames(
                           " bg-default dark:bg-muted border-default hover:bg-subtle hover:border-brand-default text-emphasis mb-2 block rounded-md border py-2 text-sm font-medium",
-                          brand === "#fff" || brand === "#ffffff" ? "" : ""
+                          brand === "#fff" || brand === "#ffffff" ? "" : "",
+                          isSlotReservationPending ? "pointer-events-none opacity-50" : ""
                         )}
                         onClick={() => reserveSlot(slot)}
                         data-testid="time">


### PR DESCRIPTION
## What does this PR do?

Fixes #8403 

A little explaination of my changes:
I used a local state instead of the state from reservationSlotMutation because there is still some delay between the mutation completes and the links takes the user to the next page and during that delay, they can still select a different time slot by mistake.

 Loom Video: https://www.loom.com/share/2075383e6995474aab7310717c99ada5

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Try booking an event

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
