### PR TITLE
fix: cal-8814 alignment issues

### DIFF
--- a/apps/web/components/eventtype/EventAvailabilityTab.tsx
+++ b/apps/web/components/eventtype/EventAvailabilityTab.tsx
@@ -119,7 +119,7 @@ const EventTypeScheduleDetails = ({
                         {format(dayRange.startTime, timeFormat === 12)}
                       </span>
                       <span className="ms-4">-</span>
-                      <div className="ml-6">{format(dayRange.endTime, timeFormat === 12)}</div>
+                      <div className="ml-6 sm:w-28">{format(dayRange.endTime, timeFormat === 12)}</div>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #8814 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

The alignment issue reported in event availability  tab has been fixed. The issue caused because the first part(staring time ) has a fixed width and second part (end time) doesn't

## Evidence

Desktop:
<img width="1350" alt="Screenshot 2023-05-10 at 11 03 31 pm" src="https://github.com/calcom/cal.com/assets/26359740/10dac656-ab89-4445-a641-3db538691042">

iPad:
<img width="795" alt="Screenshot 2023-05-10 at 11 04 25 pm" src="https://github.com/calcom/cal.com/assets/26359740/4fb34fbb-4243-4891-b3c2-a303ed1fef18">


iPhone SE
<img width="755" alt="Screenshot 2023-05-10 at 11 05 00 pm" src="https://github.com/calcom/cal.com/assets/26359740/296b9ea7-46e1-4ba7-bcdc-18fcaf730b99">

<!-- Please remove all the irrelevant bullets to your PR -->

