### PR TITLE
Update package.json in packages/emails

### DIFF
--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dx": "docker compose up -d"
+    "dx": "docker-compose up -d"
   },
   "dependencies": {
     "@calcom/dayjs": "*",


### PR DESCRIPTION
In discussion #3303, fixed the typo form "docker compose up -d" to "docker-compose up -d"

## What does this PR do?

When trying to set up this project locally, yarn dx was throwing this error <b>command (/home/pratyush/projects/cal.com/packages/emails) yarn run dx exited (125)</b>. 
This is just a typo fix in packages/emails/package.json

Fixes # (issue)
In the 'package.json' file in 'emails' directory, the script associated with the dx command was wrong. 
<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


