### PR TITLE
CAL-1624: Timezone select layout improvements when typing

### DIFF
--- a/packages/features/bookings/Booker/components/EventMeta.tsx
+++ b/packages/features/bookings/Booker/components/EventMeta.tsx
@@ -66,18 +66,20 @@ export const EventMeta = () => {
             <EventDetails event={event} />
             <EventMetaBlock
               className="cursor-pointer [&_.current-timezone:before]:focus-within:opacity-100 [&_.current-timezone:before]:hover:opacity-100"
-              contentClassName="relative"
+              contentClassName="relative max-w-[90%]"
               icon={Globe}>
               {bookerState === "booking" ? (
                 <>{timezone}</>
               ) : (
-                <span className="current-timezone before:bg-subtle -mt-[2px] flex h-6 items-center justify-center before:absolute before:inset-0 before:left-[-30px] before:top-[-3px] before:bottom-[-3px] before:w-[calc(100%_+_35px)] before:rounded-md before:py-3 before:opacity-0 before:transition-opacity">
+                <span className="min-w-32 current-timezone before:bg-subtle -mt-[2px] flex h-6 max-w-full items-center justify-start before:absolute before:inset-0 before:left-[-30px] before:top-[-3px] before:bottom-[-3px] before:w-[calc(100%_+_35px)] before:rounded-md before:py-3 before:opacity-0 before:transition-opacity">
                   <TimezoneSelect
                     menuPosition="fixed"
                     classNames={{
-                      control: () => "!min-h-0 p-0 border-0 bg-transparent focus-within:ring-0",
+                      control: () => "!min-h-0 p-0 w-full border-0 bg-transparent focus-within:ring-0",
                       menu: () => "!w-64 max-w-[90vw]",
                       singleValue: () => "text-text py-1",
+                      indicatorsContainer: () => "ml-auto",
+                      container: () => "max-w-full",
                     }}
                     value={timezone}
                     onChange={(tz) => setTimezone(tz.value)}

--- a/packages/ui/components/form/timezone-select/TimezoneSelect.tsx
+++ b/packages/ui/components/form/timezone-select/TimezoneSelect.tsx
@@ -52,7 +52,7 @@ export function TimezoneSelect({
       classNames={{
         ...timezoneClassNames,
         input: (state) =>
-          classNames("text-emphasis", timezoneClassNames?.input && timezoneClassNames.input(state)),
+          classNames("text-emphasis h-6", timezoneClassNames?.input && timezoneClassNames.input(state)),
         option: (state) =>
           classNames(
             "bg-default flex cursor-pointer justify-between py-2.5 px-3 rounded-none text-default ",
@@ -106,6 +106,7 @@ export function TimezoneSelect({
             timezoneClassNames?.indicatorsContainer && timezoneClassNames.indicatorsContainer(state)
           ),
         multiValueRemove: () => "text-default py-auto ml-2",
+        noOptionsMessage: () => "h-12 py-2 flex items-center justify-center",
       }}
     />
   );


### PR DESCRIPTION
## What does this PR do?

* Removes the layout shift when starting to type in the timezone select
* Gives timezone select a minimum width to have even less movement (I don't really like to min width, see video below)
* Gave no results option some more breathing room, it was a very narrow row before. 

Fixes CAL-1624

https://github.com/calcom/cal.com/assets/2969573/64a5e1c1-8fe4-4a5c-884b-f19d46da6131

@PeerRich  The min-width is the only thing I have doubts about. I tried this before and wasn't really happy with the results. See the video. 
I could also make it full width always, but that also looks a bit awkward. Now I gave it a reasonable min width that still grows if needed. Mainly the arrow is bothering me, that this moves along. But when I move this to the right, it's always on the right side, also if you have selected an option. Not sure if that's better, see the second video below. **note:** This full width layout is NOT included in this PR. I could easily add it if we like it more. 

cc @Jaibles  

https://github.com/calcom/cal.com/assets/2969573/cfbbdb06-ef7b-4cef-8ef4-eb2444fde9d4

**Environment**: Staging(main branch)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test layout of the timezone select
