### PR TITLE
Improved API key error message for SendGrid setup page

### DIFF
--- a/packages/app-store/sendgrid/api/_postAdd.ts
+++ b/packages/app-store/sendgrid/api/_postAdd.ts
@@ -15,7 +15,13 @@ export async function getHandler(req: NextApiRequest) {
   const { api_key } = req.body;
   if (!api_key) throw new HttpError({ statusCode: 400, message: "No Api Key provided to check" });
 
-  const encrypted = symmetricEncrypt(JSON.stringify({ api_key }), process.env.CALENDSO_ENCRYPTION_KEY || "");
+  let encrypted;
+  try {
+    encrypted = symmetricEncrypt(JSON.stringify({ api_key }), process.env.CALENDSO_ENCRYPTION_KEY || "");
+  } catch (reason) {
+    logger.error("Could not add Sendgrid app", reason);
+    throw new HttpError({ statusCode: 500, message: "Invalid length - CALENDSO_ENCRYPTION_KEY" });
+  }
 
   const data = {
     type: "sendgrid_other_calendar",

--- a/packages/app-store/sendgrid/pages/setup/index.tsx
+++ b/packages/app-store/sendgrid/pages/setup/index.tsx
@@ -84,7 +84,7 @@ export default function SendgridSetup() {
                         onBlur={onBlur}
                         disabled={testPassed === true}
                         name="api_key"
-                        placeholder="api_xyz..."
+                        placeholder="SG.xxxxxx..."
                         onChange={async (e) => {
                           onChange(e.target.value);
                           form.setValue("api_key", e.target.value);


### PR DESCRIPTION
## What does this PR do?

Initially, I could not figure out why my 'SendGrid API Key' could not be saved. (Although the 'Test API key' test is passed)

The 'Invalid key length' error message was misleading. I thought SendGrid API key length is invalid. Also, the default key format shown in the text box was not correct.

See the before-fix video:

https://github.com/calcom/cal.com/assets/87233758/1393a364-41d6-4edf-bc6b-52681bc4d451

See the after-fix video:

https://github.com/calcom/cal.com/assets/87233758/366d5ad7-909c-4226-bd76-7117827c4ecf

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Try to add a SendGrid API key with an invalid length CALENDSO_ENCRYPTION_KEY.


