### PR TITLE
Remove External Calendar Id

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -304,8 +304,7 @@ export const createEvent = async (
 export const updateEvent = async (
   credential: CredentialWithAppName,
   calEvent: CalendarEvent,
-  bookingRefUid: string | null,
-  externalCalendarId: string | null
+  bookingRefUid: string | null
 ): Promise<EventResult<NewCalendarEventType>> => {
   const uid = getUid(calEvent);
   const calendar = await getCalendar(credential);
@@ -319,7 +318,7 @@ export const updateEvent = async (
   const updatedResult =
     calendar && bookingRefUid
       ? await calendar
-          .updateEvent(bookingRefUid, calEvent, externalCalendarId)
+          .updateEvent(bookingRefUid, calEvent)
           .then((event) => {
             success = true;
             return event;

--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -454,24 +454,20 @@ export default class EventManager {
       if (!calendarReference) {
         return [];
       }
-      const { uid: bookingRefUid, externalCalendarId: bookingExternalCalendarId } = calendarReference;
-
-      if (!bookingExternalCalendarId) {
-        throw new Error("externalCalendarId");
-      }
+      const { uid: bookingRefUid } = calendarReference;
 
       let result = [];
       if (calendarReference.credentialId) {
         credential = this.calendarCredentials.filter(
           (credential) => credential.id === calendarReference?.credentialId
         )[0];
-        result.push(updateEvent(credential, event, bookingRefUid, bookingExternalCalendarId));
+        result.push(updateEvent(credential, event, bookingRefUid));
       } else {
         const credentials = this.calendarCredentials.filter(
           (credential) => credential.type === calendarReference?.type
         );
         for (const credential of credentials) {
-          result.push(updateEvent(credential, event, bookingRefUid, bookingExternalCalendarId));
+          result.push(updateEvent(credential, event, bookingRefUid));
         }
       }
 
@@ -506,9 +502,8 @@ export default class EventManager {
                   originalEvent: event,
                 };
               }
-            const { externalCalendarId: bookingExternalCalendarId, meetingId: bookingRefUid } =
-              calendarReference;
-            return await updateEvent(cred, event, bookingRefUid ?? null, bookingExternalCalendarId ?? null);
+            const { meetingId: bookingRefUid } = calendarReference;
+            return await updateEvent(cred, event, bookingRefUid ?? null);
           })
       );
 

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -216,11 +216,7 @@ export interface IntegrationCalendar extends Ensure<Partial<SelectedCalendar>, "
 export interface Calendar {
   createEvent(event: CalendarEvent): Promise<NewCalendarEventType>;
 
-  updateEvent(
-    uid: string,
-    event: CalendarEvent,
-    externalCalendarId?: string | null
-  ): Promise<NewCalendarEventType | NewCalendarEventType[]>;
+  updateEvent(uid: string, event: CalendarEvent): Promise<NewCalendarEventType | NewCalendarEventType[]>;
 
   deleteEvent(uid: string, event: CalendarEvent, externalCalendarId?: string | null): Promise<unknown>;
 


### PR DESCRIPTION
## What does this PR do?

Removed the External Calendar Id from the UpdateAllCalendar Event , externalCalendarId is not being used in the update event of Calendar Service but declared in the CalendarManager.


```CalendarManager.tsx```

![image](https://github.com/calcom/cal.com/assets/53969232/cc3c0ab2-e42e-45b0-ae97-26bca3ac5c07)


```CalendarService.tsx```

![image](https://github.com/calcom/cal.com/assets/53969232/4eb574ec-0c27-41ff-a6b2-30f341f48045)

Fixes #8601

-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
