### PR TITLE
Fix hidden label breaking layout [Managed Events]

### DIFF
--- a/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
+++ b/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
@@ -24,6 +24,7 @@ export type ChildrenEventType = {
   hidden: boolean;
 };
 
+// TODO: This isnt just a select... rename this component in the future took me ages to find the component i was looking for
 export const ChildrenEventTypeSelect = ({
   options = [],
   value = [],
@@ -87,7 +88,11 @@ export const ChildrenEventTypeSelect = ({
                   </small>
                 </div>
                 <div className="flex flex-row items-center gap-2">
-                  {children.hidden && <Badge variant="gray">{t("hidden")}</Badge>}
+                  {children.hidden && (
+                    <Badge variant="gray" className="hidden sm:block">
+                      {t("hidden")}
+                    </Badge>
+                  )}
                   <Tooltip content={t("show_eventtype_on_profile")}>
                     <div className="self-center rounded-md p-2">
                       <Switch


### PR DESCRIPTION
Added a todo for another time. The fact this whole component was called select confused the crap out of me 

Before
<img width="438" alt="CleanShot 2023-05-12 at 17 11 52@2x" src="https://github.com/calcom/cal.com/assets/55134778/57adde51-ee0e-4315-bd1f-e969366a1a6b">

After
<img width="511" alt="CleanShot 2023-05-12 at 17 11 28@2x" src="https://github.com/calcom/cal.com/assets/55134778/1fc390cc-3f3b-4dd9-ae54-e0627307ed85">
