### PR TITLE
modified the reduce() function to update the keys object directly,

### DIFF
--- a/packages/trpc/server/routers/viewer/apps/listLocal.handler.ts
+++ b/packages/trpc/server/routers/viewer/apps/listLocal.handler.ts
@@ -68,9 +68,11 @@ export const listLocalHandler = async ({ ctx, input }: ListLocalOptions) => {
     // it is important to avoid string to string comparisons as much as we can
     if (keysSchema !== undefined) {
       // TODO: Why don't we parse with schema here? Not doing it makes default() not work in schema.
-      Object.values(keysSchema.keyof()._def.values).reduce((keysObject, key) => {
+      Object.values(keysSchema.keyof()._def.values).forEach(key => {
         keys[key as string] = "";
-        return keysObject;
+      });
+    }
+        return keysSchema;
       }, {} as Record<string, string>);
     }
 


### PR DESCRIPTION


## What does this PR do?

uses the forEach() function to iterate over the schema's keys and set each key in the keys object to an empty string. Note that this assumes that the schema's keys are all strings, so we need to cast them to string using the as operator.


Fixes # (issue) 

#8825 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change 

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

