### PR TITLE
Embed: Add missing eventTypeSelected event for team events listing

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
-import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
+import { sdkActionManager, useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import EventTypeDescription from "@calcom/features/eventtypes/components/EventTypeDescription";
 import { CAL_URL } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
@@ -67,6 +67,11 @@ function TeamPage({ team, isUnpublished }: TeamPageProps) {
           <div className="px-6 py-4 ">
             <Link
               href={`/team/${team.slug}/${type.slug}`}
+              onClick={async () => {
+                sdkActionManager?.fire("eventTypeSelected", {
+                  eventType: type,
+                });
+              }}
               data-testid="event-type-link"
               className="flex justify-between">
               <div className="flex-shrink">


### PR DESCRIPTION
## What does this PR do?

Fixes #8895

- During the initial implementation the event wasn't added to team events list and it never got reported.

See [this loom](https://www.loom.com/share/0e37b302c6924febada9d5cce52667c1) to check that `eventTypeSelected` event is fired 

**Environment**: Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Open the teams link in embed and try selecting an eventType. Notice that you would see an eventTypeSelected event now which wasn't there earlier.
## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
