### PR TITLE
CAL-1557: Improve timeformat selector alignment in new booker

### DIFF
--- a/packages/features/bookings/components/AvailableTimes.tsx
+++ b/packages/features/bookings/components/AvailableTimes.tsx
@@ -39,7 +39,7 @@ export const AvailableTimes = ({
 
   return (
     <div className={classNames("text-default", className)}>
-      <header className="bg-muted before:bg-muted mb-5 flex w-full flex-row items-center font-medium md:flex-col md:items-start lg:flex-row lg:items-center">
+      <header className="bg-muted before:bg-muted mb-5 flex w-full flex-row items-center font-medium">
         <span className={classNames(isLargeTimeslots && "w-full text-center")}>
           <span className="text-emphasis font-semibold">
             {nameOfDay(i18n.language, Number(date.format("d")), "short")}
@@ -54,7 +54,7 @@ export const AvailableTimes = ({
         </span>
 
         {showTimeformatToggle && (
-          <div className="ml-auto md:ml-0 lg:ml-auto">
+          <div className="ml-auto">
             <TimeFormatToggle />
           </div>
         )}


### PR DESCRIPTION
## What does this PR do?

Improves alignment for timeformat select in new booker. See:

https://github.com/calcom/cal.com/assets/2969573/bcbc76fb-079c-4ff3-850c-d2dfa859bab3

Fixes CAL-1557

**Environment**: Staging(main branch)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Ensure timeformat now always fits on same line with day