### PR TITLE
Fixes locked workflow toggle in event type settings

### DIFF
--- a/packages/features/ee/workflows/components/EventWorkflowsTab.tsx
+++ b/packages/features/ee/workflows/components/EventWorkflowsTab.tsx
@@ -197,7 +197,7 @@ function EventWorkflowsTab(props: Props) {
         const dataWf = data.workflows.find((wf) => wf.id === workflowOnEventType.id);
         return {
           ...workflowOnEventType,
-          readOnly: isChildrenManagedEventType && dataWf?.teamId ? true : dataWf?.readOnly ?? true,
+          readOnly: isChildrenManagedEventType && dataWf?.teamId ? true : dataWf?.readOnly ?? false,
         } as WorkflowType;
       });
       const disabledWorkflows = data.workflows.filter(


### PR DESCRIPTION
## What does this PR do?

Fixes that the toggle to disable a workflow on a user event type is locked

This was the bug: 
<img width="959" alt="Screenshot 2023-05-16 at 11 50 09" src="https://github.com/calcom/cal.com/assets/30310907/9d5dbc29-4bb0-46e6-a6f8-4cb4d59d92e9">

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a user workflow
- Set it active on a normal user event type 
- Got to the settings of that event type and click the workflows tab 
- See that the toggle of the workflow is not locked and workflow can be disabled