### PR TITLE
Fix: utcOffset for getWorkingHours

### DIFF
--- a/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
@@ -55,7 +55,14 @@ export const getHandler = async ({ ctx, input }: GetOptions) => {
     id: schedule.id,
     name: schedule.name,
     isManaged: schedule.userId !== user.id,
-    workingHours: getWorkingHours({ timeZone: schedule.timeZone || undefined }, schedule.availability || []),
+    workingHours: getWorkingHours(
+      {
+        utcOffset: schedule.timeZone
+          ? dayjs().tz(schedule.timeZone).utcOffset() - dayjs().tz(user.timeZone).utcOffset()
+          : 0,
+      },
+      schedule.availability || []
+    ),
     schedule: schedule.availability,
     availability: convertScheduleToAvailability(schedule).map((a) =>
       a.map((startAndEnd) => ({


### PR DESCRIPTION
## What does this PR do?

workingHours utcOffset is set to show user timezone time, in the Calendar override in the schedule.

Fixes #8833

/attempt #8833


**Environment**: Staging(main branch)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)