### PR TITLE
Implement `UpgradeTip` in App installation flow for apps that need teams plan

### DIFF
--- a/apps/web/components/apps/App.tsx
+++ b/apps/web/components/apps/App.tsx
@@ -36,6 +36,7 @@ const Component = ({
   tos,
   privacy,
   isProOnly,
+  teamsPlanRequired,
   descriptionItems,
   isTemplate,
   dependencies,
@@ -152,6 +153,7 @@ const Component = ({
                   type={type}
                   isProOnly={isProOnly}
                   disableInstall={disableInstall}
+                  teamsPlanRequired={teamsPlanRequired}
                   render={({ useDefaultComponent, ...props }) => {
                     if (useDefaultComponent) {
                       props = {
@@ -192,6 +194,7 @@ const Component = ({
               type={type}
               isProOnly={isProOnly}
               disableInstall={disableInstall}
+              teamsPlanRequired={teamsPlanRequired}
               render={({ useDefaultComponent, ...props }) => {
                 if (useDefaultComponent) {
                   props = {
@@ -241,7 +244,9 @@ const Component = ({
         </div>
         <h4 className="text-emphasis mt-8 font-semibold ">{t("pricing")}</h4>
         <span className="text-default">
-          {price === 0 ? (
+          {teamsPlanRequired ? (
+            t("teams_plan_required")
+          ) : price === 0 ? (
             t("free_to_use_apps")
           ) : (
             <>
@@ -358,6 +363,7 @@ export default function App(props: {
   privacy?: string;
   licenseRequired: AppType["licenseRequired"];
   isProOnly: AppType["isProOnly"];
+  teamsPlanRequired: AppType["teamsPlanRequired"];
   descriptionItems?: Array<string | { iframe: IframeHTMLAttributes<HTMLIFrameElement> }>;
   isTemplate?: boolean;
   disableInstall?: boolean;

--- a/apps/web/pages/apps/[slug]/index.tsx
+++ b/apps/web/pages/apps/[slug]/index.tsx
@@ -72,6 +72,7 @@ function SingleAppPage(props: inferSSRProps<typeof getStaticProps>) {
       website={data.url}
       email={data.email}
       licenseRequired={data.licenseRequired}
+      teamsPlanRequired={data.teamsPlanRequired}
       isProOnly={data.isProOnly}
       descriptionItems={source.data?.items as string[] | undefined}
       isTemplate={data.isTemplate}

--- a/packages/app-store/_components/OmniInstallAppButton.tsx
+++ b/packages/app-store/_components/OmniInstallAppButton.tsx
@@ -47,6 +47,7 @@ export default function OmniInstallAppButton({
     <InstallAppButton
       type={app.type}
       isProOnly={app.isProOnly}
+      teamsPlanRequired={app.teamsPlanRequired}
       wrapperClassName={classNames("[@media(max-width:260px)]:w-full", className)}
       render={({ useDefaultComponent, ...props }) => {
         if (useDefaultComponent) {

--- a/packages/app-store/routing-forms/config.json
+++ b/packages/app-store/routing-forms/config.json
@@ -11,6 +11,9 @@
   "publisher": "Cal.com",
   "email": "help@cal.com",
   "licenseRequired": true,
+  "teamsPlanRequired": {
+    "upgradeUrl": "/apps/routing-forms/forms"
+  }, 
   "description": "It would allow a booker to connect with the right person or choose the right event, faster. It would work by taking inputs from the booker and using that data to route to the correct booker/event as configured by Cal user",
   "__createdUsingCli": true
 }

--- a/packages/types/App.d.ts
+++ b/packages/types/App.d.ts
@@ -126,6 +126,9 @@ export interface App {
   /** only required for "usage-based" billing. % of commission for paid bookings */
   commission?: number;
   licenseRequired?: boolean;
+  teamsPlanRequired?: {
+    upgradeUrl: string;
+  };
   isProOnly?: boolean;
   appData?: AppData;
   /**

--- a/packages/ui/components/apps/AppCard.tsx
+++ b/packages/ui/components/apps/AppCard.tsx
@@ -97,6 +97,7 @@ export function AppCard({ app, credentials, searchText }: AppCardProps) {
               <InstallAppButton
                 type={app.type}
                 isProOnly={app.isProOnly}
+                teamsPlanRequired={app.teamsPlanRequired}
                 disableInstall={!!app.dependencies && !app.dependencyData?.some((data) => !data.installed)}
                 wrapperClassName="[@media(max-width:260px)]:w-full"
                 render={({ useDefaultComponent, ...props }) => {
@@ -127,6 +128,7 @@ export function AppCard({ app, credentials, searchText }: AppCardProps) {
                 isProOnly={app.isProOnly}
                 wrapperClassName="[@media(max-width:260px)]:w-full"
                 disableInstall={!!app.dependencies && app.dependencyData?.some((data) => !data.installed)}
+                teamsPlanRequired={app.teamsPlanRequired}
                 render={({ useDefaultComponent, ...props }) => {
                   if (useDefaultComponent) {
                     props = {


### PR DESCRIPTION
## What does this PR do?


Fixes #7973

## Demo
https://www.loom.com/share/eae39ce07e824e1385be4e39ee82b5d7

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [x] Try installing Routing Forms App when for an account that doesn't have teams plan and you would notice that you are shown Upgrade Tip.
- [x] Try the same for an account that has teams plan and it won't show Upgrade Tip.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
