### PR TITLE
Fixes SMS workflow actions for premium users

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -388,12 +388,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
 
       //step was edited
     } else if (JSON.stringify(oldStep) !== JSON.stringify(newStep)) {
-      if (
-        !userWorkflow.teamId &&
-        !hasPaidPlan &&
-        !isSMSAction(oldStep.action) &&
-        isSMSAction(newStep.action)
-      ) {
+      if (!hasPaidPlan && !isSMSAction(oldStep.action) && isSMSAction(newStep.action)) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
       await ctx.prisma.workflowStep.update({


### PR DESCRIPTION
## What does this PR do?

Fixes that workflows with SMS actions could not be saved when user was not on Teams plan but had premium username. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- User should not be part of a team and should have premium user name (`metadata: {"isPremium":true}`)
- Create a workflow 
- Add a SMS action 
- Save workflow
- See that no error is thrown
- Go back to the workflow and see that the SMS action is saved