### PR TITLE
enable search in select and adding border bottom color

### DIFF
--- a/packages/features/eventtypes/components/CheckedTeamSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedTeamSelect.tsx
@@ -36,7 +36,7 @@ export const CheckedTeamSelect = ({
         }}
         name={props.name}
         placeholder={props.placeholder || t("select")}
-        isSearchable={false}
+        isSearchable={true}
         options={options}
         value={value}
         isMulti

--- a/packages/features/eventtypes/components/CheckedTeamSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedTeamSelect.tsx
@@ -48,7 +48,7 @@ export const CheckedTeamSelect = ({
         className={classNames("mt-3 rounded-md", value.length >= 1 && "border-subtle border")}
         ref={animationRef}>
         {value.map((option, index) => (
-          <li key={option.value} className={`flex py-2 px-3 ${index === value.length - 1 ? "" : "border-b"}`}>
+          <li key={option.value} className={`flex py-2 px-3 ${index === value.length - 1 ? "" : "border-b border-subtle"}`}>
             <Avatar size="sm" imageSrc={option.avatar} alt={option.label} />
             <p className="text-emphasis ms-3 my-auto text-sm">{option.label}</p>
             <X


### PR DESCRIPTION
## What does this PR do?

Enabling search functionality in select input and border-bottom-color added to the divider.

Fixes #8984 

**Environment**: Staging(main branch)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Create a collective event for a team
![image](https://github.com/calcom/cal.com/assets/60579654/0d70e871-5607-46e5-bfe3-7348ab119517)
- [ ] Goto assignment
![image](https://github.com/calcom/cal.com/assets/60579654/c54a97b0-77fc-43cb-9932-a6c11495243d)
- [ ] The team selects input that should be searchable
![Screenshot (1)](https://github.com/calcom/cal.com/assets/60579654/130b5564-f2f2-4103-87fc-d7b528167645)
