### PR TITLE
Fixes cron job to schedule all workflow emails

### DIFF
--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -102,10 +102,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     where: {
       method: WorkflowMethods.EMAIL,
       scheduled: false,
-      cancelled: false,
       scheduledDate: {
         lte: dayjs().add(72, "hour").toISOString(),
       },
+      OR: [{ cancelled: false }, { cancelled: null }],
     },
     include: {
       workflowStep: true,


### PR DESCRIPTION
## What does this PR do?

Fixes that the Cron job `scheduleEmailReminders` didn't schedule workflow emails correctly. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)