### PR TITLE
fix: removed switch hover bug in dark mode

### DIFF
--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -371,7 +371,7 @@ export const FormBuilder = function FormBuilder({
                         onCheckedChange={(checked) => {
                           update(index, { ...field, hidden: !checked });
                         }}
-                        classNames={{ container: "p-2 hover:bg-gray-100 dark:hover:bg-transparent rounded" }}
+                        classNames={{ container: "p-2 rounded" }}
                         tooltip={t("show_on_booking_page")}
                       />
                     )}

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -371,7 +371,7 @@ export const FormBuilder = function FormBuilder({
                         onCheckedChange={(checked) => {
                           update(index, { ...field, hidden: !checked });
                         }}
-                        classNames={{ container: "p-2 hover:bg-gray-100 rounded" }}
+                        classNames={{ container: "p-2 hover:bg-gray-100 dark:hover:bg-transparent rounded" }}
                         tooltip={t("show_on_booking_page")}
                       />
                     )}

--- a/packages/ui/components/form/switch/Switch.tsx
+++ b/packages/ui/components/form/switch/Switch.tsx
@@ -33,7 +33,7 @@ const Switch = (
     <Wrapper tooltip={props.tooltip}>
       <div
         className={cx(
-          "flex h-auto w-auto flex-row items-center",
+          "flex h-auto w-auto flex-row items-center !bg-transparent",
           fitToHeight && "h-fit",
           labelOnLeading && "flex-row-reverse",
           classNames?.container


### PR DESCRIPTION
## What does this PR do?

Removed a hover effect from switch on https://app.cal.com/event-types/[type] in dark mode.

Fixes [#8995](https://github.com/calcom/cal.com/issues/8995)

Before:
<img width="347" alt="image" src="https://github.com/calcom/cal.com/assets/16950308/a39e8205-0b42-4e93-910f-51baf966879a">

After:
<img width="317" alt="image" src="https://github.com/calcom/cal.com/assets/16950308/83473cd7-ca67-434b-aa26-fc6c45044467">


**Environment**: Staging(main branch) 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
