### PR TITLE
fix: fixed embed where floating button was hovering over modal on mobile

### DIFF
--- a/packages/embeds/embed-core/src/FloatingButton/FloatingButtonHtml.ts
+++ b/packages/embeds/embed-core/src/FloatingButton/FloatingButtonHtml.ts
@@ -11,7 +11,7 @@ const getHtml = ({
 }) => {
   // IT IS A REQUIREMENT THAT ALL POSSIBLE CLASSES ARE HERE OTHERWISE TAILWIND WONT GENERATE THE CSS FOR CONDITIONAL CLASSES
   // To not let all these classes apply and visible, keep it hidden initially
-  return `<button class="z-[10000000000] hidden fixed md:bottom-6 bottom-4 md:right-10 right-4 md:left-10 left-4 ${buttonClasses.join(
+  return `<button class="z-[1000000] hidden fixed md:bottom-6 bottom-4 md:right-10 right-4 md:left-10 left-4 ${buttonClasses.join(
     " "
   )} flex h-16 origin-center bg-red-50 transform cursor-pointer items-center
 rounded-full py-4 px-6 text-base outline-none drop-shadow-md transition focus:outline-none fo


### PR DESCRIPTION
## What does this PR do?

Keeps the embedded floating under the modal while the modal is open.

Fixes #8851 

https://www.loom.com/share/c3960f30740a4ff8babcb6ef3dce8215

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
