### PR TITLE
fixes : keyboard-navigation-8887

### DIFF
--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import type {
   ArrayPath,
   Control,
@@ -382,6 +382,38 @@ const CopyTimes = ({
 }) => {
   const [selected, setSelected] = useState<number[]>([]);
   const { i18n, t } = useLocale();
+  const itteratablesByKeyRef = useRef<(HTMLInputElement | HTMLButtonElement)[]>([]);
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const itteratables = itteratablesByKeyRef.current;
+    const isActionRequired =
+      event.key === "Tab" || event.key === "ArrowUp" || event.key === "ArrowDown" || event.key === "Enter";
+    if (!isActionRequired || !itteratables.length) return;
+    event.preventDefault();
+    const currentFocused = document.activeElement as HTMLInputElement | HTMLButtonElement;
+    let currentIndex = itteratables.findIndex((checkbox) => checkbox === currentFocused);
+    if (event.key === "Enter") {
+      if (currentIndex === -1) return;
+      currentFocused.click();
+      return;
+    }
+    if (currentIndex === -1) {
+      itteratables[0].focus();
+    } else {
+      // Move focus based on the arrow key pressed
+      if (event.key === "ArrowUp") {
+        currentIndex = (currentIndex - 1 + itteratables.length) % itteratables.length;
+      } else if (event.key === "ArrowDown" || event.key === "Tab") {
+        currentIndex = (currentIndex + 1) % itteratables.length;
+      }
+      itteratables[currentIndex].focus();
+    }
+  };
 
   return (
     <div className="space-y-2 py-2">
@@ -400,6 +432,11 @@ const CopyTimes = ({
                     setSelected([0, 1, 2, 3, 4, 5, 6]);
                   } else if (!e.target.checked) {
                     setSelected([]);
+                  }
+                }}
+                ref={(ref) => {
+                  if (ref) {
+                    itteratablesByKeyRef.current.push(ref as HTMLInputElement);
                   }
                 }}
               />
@@ -423,6 +460,12 @@ const CopyTimes = ({
                         setSelected(selected.filter((item) => item !== weekdayIndex));
                       }
                     }}
+                    ref={(ref) => {
+                      if (ref && disabled !== weekdayIndex) {
+                        //we don't need to iterate over disabled elements
+                        itteratablesByKeyRef.current.push(ref as HTMLInputElement);
+                      }
+                    }}
                   />
                 </label>
               </li>
@@ -432,10 +475,24 @@ const CopyTimes = ({
       </div>
       <hr className="border-subtle" />
       <div className="space-x-2 px-2 rtl:space-x-reverse">
-        <Button color="minimal" onClick={() => onCancel()}>
+        <Button
+          color="minimal"
+          onClick={() => onCancel()}
+          ref={(ref) => {
+            if (ref) {
+              itteratablesByKeyRef.current.push(ref as HTMLButtonElement);
+            }
+          }}>
           {t("cancel")}
         </Button>
-        <Button color="primary" onClick={() => onClick(selected)}>
+        <Button
+          color="primary"
+          onClick={() => onClick(selected)}
+          ref={(ref) => {
+            if (ref) {
+              itteratablesByKeyRef.current.push(ref as HTMLButtonElement);
+            }
+          }}>
           {t("apply")}
         </Button>
       </div>


### PR DESCRIPTION
## What does this PR do?

It adds the feature to allow user to iterate through out the weekday checkbox in the availability section
The navigation can be enabled either by **clicking Tab key or UP and Down Arrow key**
The user can use enter key to toggle the focused checkbox as well as to click on the buttons

Fixes https://github.com/calcom/cal.com/issues/8887


 Loom Video: https://www.loom.com/share/c88a7cebf4d3441684d020e4df51bc2a

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- New feature (non-breaking change which adds functionality)

