### PR TITLE
fix: Copy private link to clipboard and 404 public link when 'Generate private link' is enabled

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -145,6 +145,19 @@ async function getUserPageProps(context: GetStaticPropsContext) {
 
   if (!eventType) return { notFound: true };
 
+  // If Private Link is generated, we will not let users book events through normal slug
+  const hashedLink = await prisma.hashedLink.findUnique({
+    where: {
+      eventTypeId: eventType.id,
+    },
+    select: {
+      link: true,
+    },
+  });
+  if (hashedLink?.link) {
+    return { notFound: true };
+  }
+
   //TODO: Use zodSchema to verify it instead of using Type Assertion
   const locations = eventType.locations ? (eventType.locations as LocationObject[]) : [];
   const eventTypeObject = Object.assign({}, eventType, {

--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -360,7 +360,11 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
       <ul ref={parent} className="divide-subtle !static w-full divide-y" data-testid="event-types">
         {types.map((type, index) => {
           const embedLink = `${group.profile.slug}/${type.slug}`;
-          const calLink = `${CAL_URL}/${embedLink}`;
+          let calLink = `${CAL_URL}/${embedLink}`;
+          // If Private link is generated, use this link
+          if (type?.hashedLink?.link) {
+            calLink = `${CAL_URL}/d/${type.hashedLink.link}/${type.slug}`;
+          }
           const isManagedEventType = type.schedulingType === SchedulingType.MANAGED;
           const isChildrenManagedEventType =
             type.metadata?.managedEventConfig !== undefined && type.schedulingType !== SchedulingType.MANAGED;


### PR DESCRIPTION
## What does this PR do?

Copy private link to clipboard and 404 public link when 'Generate private link' is enabled

Fixes #5583 

https://www.loom.com/share/b237953c521c4df68b52222b1bb0aa20

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create a new event type
2. Enable `Generate private link`
3. Now copy the event link from `Copy link to event` and verify the private link is copied

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
