### PR TITLE
feat: add auth property when user and pass are not empty in serverConfig.ts

### DIFF
--- a/packages/lib/serverConfig.ts
+++ b/packages/lib/serverConfig.ts
@@ -1,7 +1,7 @@
 import type SendmailTransport from "nodemailer/lib/sendmail-transport";
 import type SMTPConnection from "nodemailer/lib/smtp-connection";
 
-import { isENVDev } from "@calcom/lib/env";
+import {isENVDev} from "@calcom/lib/env";
 
 function detectTransport(): SendmailTransport.Options | SMTPConnection.Options | string {
   if (process.env.EMAIL_SERVER) {
@@ -10,18 +10,25 @@ function detectTransport(): SendmailTransport.Options | SMTPConnection.Options |
 
   if (process.env.EMAIL_SERVER_HOST) {
     const port = parseInt(process.env.EMAIL_SERVER_PORT!);
-    const transport = {
+    const user = process.env.EMAIL_SERVER_USER;
+    const pass = process.env.EMAIL_SERVER_PASSWORD;
+    let transport: SMTPConnection.Options = {
       host: process.env.EMAIL_SERVER_HOST,
       port,
-      auth: {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      },
       secure: port === 465,
       tls: {
         rejectUnauthorized: isENVDev ? false : true,
       },
     };
+
+    if (user && pass && user.length > 0) {
+      transport = {
+        ...transport, auth: {
+          user,
+          pass,
+        }
+      }
+    }
 
     return transport;
   }

--- a/packages/lib/serverConfig.ts
+++ b/packages/lib/serverConfig.ts
@@ -1,7 +1,7 @@
 import type SendmailTransport from "nodemailer/lib/sendmail-transport";
 import type SMTPConnection from "nodemailer/lib/smtp-connection";
 
-import {isENVDev} from "@calcom/lib/env";
+import { isENVDev } from "@calcom/lib/env";
 
 function detectTransport(): SendmailTransport.Options | SMTPConnection.Options | string {
   if (process.env.EMAIL_SERVER) {
@@ -29,7 +29,6 @@ function detectTransport(): SendmailTransport.Options | SMTPConnection.Options |
         }
       }
     }
-
     return transport;
   }
 


### PR DESCRIPTION
add auth property when user and pass are not emty

when using an internat smtp server, we dont need a user and password for authentification, so the object auth is empty

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
