### PR TITLE
Follow-up team webhooks

### DIFF
--- a/apps/web/components/eventtype/EventWebhooksTab.tsx
+++ b/apps/web/components/eventtype/EventWebhooksTab.tsx
@@ -160,6 +160,7 @@ export const EventWebhooksTab = ({ eventType }: Pick<EventTypeSetupProps, "event
               title={t("create_webhook")}
               description={t("create_webhook_team_event_type")}>
               <WebhookForm
+                noRoutingFormTriggers={true}
                 onSubmit={onCreateWebhook}
                 onCancel={() => setCreateModalOpen(false)}
                 apps={installedApps?.items.map((app) => app.slug)}
@@ -170,6 +171,7 @@ export const EventWebhooksTab = ({ eventType }: Pick<EventTypeSetupProps, "event
           <Dialog open={editModalOpen} onOpenChange={(isOpen) => !isOpen && setEditModalOpen(false)}>
             <DialogContent enableOverflow title={t("edit_webhook")}>
               <WebhookForm
+                noRoutingFormTriggers={true}
                 webhook={webhookToEdit}
                 apps={installedApps?.items.map((app) => app.slug)}
                 onCancel={() => setEditModalOpen(false)}

--- a/apps/web/components/eventtype/EventWebhooksTab.tsx
+++ b/apps/web/components/eventtype/EventWebhooksTab.tsx
@@ -177,7 +177,7 @@ export const EventWebhooksTab = ({ eventType }: Pick<EventTypeSetupProps, "event
                   if (
                     subscriberUrlReserved({
                       subscriberUrl: values.subscriberUrl,
-                      id: values.id,
+                      id: webhookToEdit?.id,
                       webhooks,
                       eventTypeId: eventType.id,
                     })

--- a/packages/features/webhooks/components/WebhookForm.tsx
+++ b/packages/features/webhooks/components/WebhookForm.tsx
@@ -44,6 +44,7 @@ const WebhookForm = (props: {
   apps?: (keyof typeof WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2)[];
   onSubmit: (event: WebhookFormSubmitData) => void;
   onCancel?: () => void;
+  noRoutingFormTriggers: boolean;
 }) => {
   const { apps = [] } = props;
   const { t } = useLocale();
@@ -51,6 +52,7 @@ const WebhookForm = (props: {
   const triggerOptions = [...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2["core"]];
   if (apps) {
     for (const app of apps) {
+      if (app === "routing-forms" && props.noRoutingFormTriggers) continue;
       if (WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]) {
         triggerOptions.push(...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]);
       }

--- a/packages/features/webhooks/pages/webhook-edit-view.tsx
+++ b/packages/features/webhooks/pages/webhook-edit-view.tsx
@@ -59,6 +59,7 @@ const EditWebhook = () => {
         />
         <WebhookForm
           webhook={webhook}
+          noRoutingFormTriggers={!!webhook.teamId}
           onSubmit={(values: WebhookFormSubmitData) => {
             if (
               subscriberUrlReserved({

--- a/packages/features/webhooks/pages/webhook-new-view.tsx
+++ b/packages/features/webhooks/pages/webhook-new-view.tsx
@@ -79,8 +79,11 @@ const NewWebhookView = () => {
         description={t("add_webhook_description", { appName: APP_NAME })}
         backButton
       />
-
-      <WebhookForm onSubmit={onCreateWebhook} apps={installedApps?.items.map((app) => app.slug)} />
+      <WebhookForm
+        onSubmit={onCreateWebhook}
+        apps={installedApps?.items.map((app) => app.slug)}
+        noRoutingFormTriggers={!!teamId}
+      />
     </>
   );
 };


### PR DESCRIPTION
## What does this PR do?

Follow-up for https://github.com/calcom/cal.com/pull/8917

- Fixes 'Webhook subscriber url is already defined' error when editing event type webhook. 
- Removes the 'Form Submitted' trigger from team webhooks and from event type webhooks

## Type of change

- Bug fix (non-breaking change which fixes an issue)