### PR TITLE
Fixes timezone of {EVENT_DATE}

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -1,5 +1,6 @@
 import { guessEventLocationType } from "@calcom/app-store/locations";
 import type { Dayjs } from "@calcom/dayjs";
+import dayjs from "@calcom/dayjs";
 import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
 import type { CalEventResponses } from "@calcom/types/Calendar";
 
@@ -30,7 +31,7 @@ const customTemplate = (
     month: "long",
     day: "numeric",
     year: "numeric",
-  }).format(variables.eventDate?.toDate());
+  }).format(variables.eventDate?.add(dayjs().tz(variables.timeZone).utcOffset(), "minute").toDate());
 
   let locationString = variables.location || "";
 


### PR DESCRIPTION
## What does this PR do?

Fixes timezone of {EVENT_DATE} variable. It was shown in UTC and not the attendee/organizer timezone. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Organizer should be in Los Angeles time zone
- Create workflow to send email/sms to organizer when new event is booked with the {EVENT_DATE} variable 
- Set an event type active and make a test booking on this event type 
   - Book any time that would be the next day already in UTC (so for example 6pm)
   - Check the workflow notification and see that it shows the correct day (before it showed the day next day)