### PR TITLE
fix: emailLanguage

### DIFF
--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -27,7 +27,7 @@ export default class AttendeeScheduledEmail extends BaseEmail {
     }
     this.name = "SEND_BOOKING_CONFIRMATION";
     this.attendee = attendee;
-    this.t = attendee.language.translate;
+    this.t = this.calEvent.organizer.language.translate;
   }
 
   protected getiCalEventAsString(): string | undefined {


### PR DESCRIPTION
## What does this PR do?
The email the guest recieves is in the same language the organizer prefers.

Fixes #8436 







