### PR TITLE
feat: Cloudflare captcha integrated

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useReducer, useState } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
-import { Turnstile } from '@marsidev/react-turnstile'
+import { Turnstile } from "@marsidev/react-turnstile";
 
 import BookingPageTagManager from "@calcom/app-store/BookingPageTagManager";
 import type { EventLocationType } from "@calcom/app-store/locations";
@@ -211,7 +211,7 @@ const BookingPage = ({
   hashedLink,
   ...restProps
 }: BookingPageProps) => {
-  const [status, setStatus] = useState("")
+  const [status, setStatus] = useState("");
   const removeSelectedSlotMarkMutation = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation();
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation();
   const { t, i18n } = useLocale();
@@ -661,17 +661,19 @@ const BookingPage = ({
                       ? "-mt-4"
                       : ""
                   )}>
-                    <Turnstile className="fixed bottom-4 right-4" 
-                     onError={() => setStatus('error')}
-                     onExpire={() => setStatus('expired')}
-                     onSuccess={() => setStatus('solved')}
-                     siteKey='0x4AAAAAAAFM2dMLqlOd35hp'/>
+                <Turnstile
+                    className="fixed bottom-4 right-4"
+                    onError={() => setStatus("error")}
+                    onExpire={() => setStatus("expired")}
+                    onSuccess={() => setStatus("solved")}
+                    siteKey="0x4AAAAAAAFM2dMLqlOd35hp"
+                  />
                   <Button color="minimal" type="button" onClick={() => router.back()}>
                     {t("cancel")}
                   </Button>
                   <Button
                     type="submit"
-                    disabled = {status === "solved" ? (false) : (true)}
+                    disabled={status === "solved" ? false : true}
                     data-testid={rescheduleUid ? "confirm-reschedule-button" : "confirm-book-button"}
                     loading={mutation.isLoading || recurringMutation.isLoading}>
                     {rescheduleUid ? t("reschedule") : t("confirm")}

--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useReducer, useState } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
+import { Turnstile } from '@marsidev/react-turnstile'
 
 import BookingPageTagManager from "@calcom/app-store/BookingPageTagManager";
 import type { EventLocationType } from "@calcom/app-store/locations";
@@ -210,6 +211,7 @@ const BookingPage = ({
   hashedLink,
   ...restProps
 }: BookingPageProps) => {
+  const [status, setStatus] = useState("")
   const removeSelectedSlotMarkMutation = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation();
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation();
   const { t, i18n } = useLocale();
@@ -659,11 +661,17 @@ const BookingPage = ({
                       ? "-mt-4"
                       : ""
                   )}>
+                    <Turnstile className="fixed bottom-4 right-4" 
+                     onError={() => setStatus('error')}
+                     onExpire={() => setStatus('expired')}
+                     onSuccess={() => setStatus('solved')}
+                     siteKey='0x4AAAAAAAFM2dMLqlOd35hp'/>
                   <Button color="minimal" type="button" onClick={() => router.back()}>
                     {t("cancel")}
                   </Button>
                   <Button
                     type="submit"
+                    disabled = {status === "solved" ? (false) : (true)}
                     data-testid={rescheduleUid ? "confirm-reschedule-button" : "confirm-book-button"}
                     loading={mutation.isLoading || recurringMutation.isLoading}>
                     {rescheduleUid ? t("reschedule") : t("confirm")}


### PR DESCRIPTION
## What does this PR do?
 I have integrated cloudflare turnstile in  the booking page, which will block bots from booking someone.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/calcom/cal.com/issues/9044
<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
 It disables confirm button until the cloudflare turnstile test is passed
![image](https://github.com/calcom/cal.com/assets/88783020/aba8fc17-cc00-4850-ba3e-3d3b74027f77)

Then after getting test getting solved the confirm button is enabled 
![image](https://github.com/calcom/cal.com/assets/88783020/f47a29f9-1ff5-4701-9d4f-6cb3408eb1b3)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- New feature (non-breaking change which adds functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1.Click on three dots beside profile
2.Click on view public profile
3.Book a slot



## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->


**special note** : After running yarn test-e2e some test regarding booking are failed , which I think because of adding captcha as these test are conducted by bots (I think so).