### PR TITLE
fix: no translation into other language issue in identifier label in  form 

### DIFF
--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -67,6 +67,8 @@ const AppearanceView = () => {
 
   const {
     formState: { isSubmitting, isDirty },
+    reset,
+    
   } = formMethods;
 
   const mutation = trpc.viewer.updateProfile.useMutation({
@@ -96,6 +98,7 @@ const AppearanceView = () => {
           // back to null here.
           theme: values.theme || null,
         });
+        reset(values);
       }}>
       <Meta title={t("appearance")} description={t("appearance_description")} />
       <div className="mb-6 flex items-center text-sm">
@@ -127,7 +130,6 @@ const AppearanceView = () => {
           register={formMethods.register}
         />
       </div>
-
       <hr className="border-subtle my-8 border" />
       <div className="mb-6 flex items-center text-sm">
         <div>
@@ -135,7 +137,6 @@ const AppearanceView = () => {
           <p className="text-default mt-0.5 leading-5">{t("customize_your_brand_colors")}</p>
         </div>
       </div>
-
       <div className="block justify-between sm:flex">
         <Controller
           name="brandColor"
@@ -199,9 +200,10 @@ const AppearanceView = () => {
         </div>
       ) : null}
       {/* TODO future PR to preview brandColors */}
+
       {/* <Button
         color="secondary"
-        EndIcon={ExternalLink}
+        EndIcon={}
         className="mt-6"
         onClick={() => window.open(`${WEBAPP_URL}/${user.username}/${user.eventTypes[0].title}`, "_blank")}>
         Preview

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -203,7 +203,7 @@ const AppearanceView = () => {
 
       {/* <Button
         color="secondary"
-        EndIcon={}
+        EndIcon={ExternalLink}
         className="mt-6"
         onClick={() => window.open(`${WEBAPP_URL}/${user.username}/${user.eventTypes[0].title}`, "_blank")}>
         Preview

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -203,7 +203,7 @@ const AppearanceView = () => {
 
       {/* <Button
         color="secondary"
-        EndIcon={ExternalLink}
+        EndIcon={}
         className="mt-6"
         onClick={() => window.open(`${WEBAPP_URL}/${user.username}/${user.eventTypes[0].title}`, "_blank")}>
         Preview

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -483,7 +483,7 @@ export const FormBuilder = function FormBuilder({
                   fieldForm.getValues("editable") === "system" ||
                   fieldForm.getValues("editable") === "system-but-optional"
                 }
-                label="Identifier"
+                label={t("Identifier")}
               />
               <InputField
                 {...fieldForm.register("label")}


### PR DESCRIPTION

The label prop of InputField component was being supplied a plain string instead of translated string translated using useLocale hook . This pull request addresses all the necessary changes

Fixes #9164

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)



