### PR TITLE
fix: Remove cache-db from without database build

### DIFF
--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -13,5 +13,4 @@ jobs:
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/env-read-file
-      - uses: ./.github/actions/cache-db
       - uses: ./.github/actions/cache-build


### PR DESCRIPTION
Remove cache-db from without database build which was causing the step to fail.
