### PR TITLE
feat(UI): improvements booker

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -103,7 +103,7 @@ const BookerComponent = ({
         since that's not a valid option, so it would set the layout to null.
       */}
       {!isMobile && (
-        <div className="[&>div]:bg-muted fixed top-2 right-3 z-10">
+        <div className="[&>div]:bg-default fixed top-2 right-3 z-10">
           <ToggleGroup
             onValueChange={onLayoutToggle}
             defaultValue={layout}
@@ -133,7 +133,7 @@ const BookerComponent = ({
           className={classNames(
             // Sets booker size css variables for the size of all the columns.
             ...getBookerSizeClassNames(layout, bookerState),
-            "bg-muted grid max-w-full auto-rows-fr items-start overflow-clip dark:[color-scheme:dark] sm:transition-[width] sm:duration-300 sm:motion-reduce:transition-none md:flex-row",
+            "bg-default grid max-w-full auto-rows-fr items-start overflow-clip dark:[color-scheme:dark] sm:transition-[width] sm:duration-300 sm:motion-reduce:transition-none md:flex-row",
             layout === "small_calendar" && "border-subtle rounded-md border"
           )}>
           <AnimatePresence>

--- a/packages/features/bookings/Booker/components/EventMeta.tsx
+++ b/packages/features/bookings/Booker/components/EventMeta.tsx
@@ -35,7 +35,12 @@ export const EventMeta = () => {
       {!isLoading && !!event && (
         <m.div {...fadeInUp} layout transition={{ ...fadeInUp.transition, delay: 0.3 }}>
           <EventMembers schedulingType={event.schedulingType} users={event.users} profile={event.profile} />
-          <EventTitle className="mt-2 mb-8">{event?.title}</EventTitle>
+          <EventTitle className="my-2">{event?.title}</EventTitle>
+          {event.description && (
+            <EventMetaBlock contentClassName="mb-8 break-words max-w-full max-h-[180px] scroll-bar pr-4">
+              <div dangerouslySetInnerHTML={{ __html: event.description }} />
+            </EventMetaBlock>
+          )}
           <div className="space-y-4 font-medium">
             {rescheduleBooking && (
               <EventMetaBlock icon={Calendar}>

--- a/packages/features/bookings/Booker/components/LargeCalendar.tsx
+++ b/packages/features/bookings/Booker/components/LargeCalendar.tsx
@@ -11,7 +11,7 @@ export const LargeCalendar = () => {
   );
 
   return (
-    <div className="bg-muted flex h-full w-full flex-col items-center justify-center">
+    <div className="bg-default flex h-full w-full flex-col items-center justify-center">
       Something big is coming...
       <br />
       <button

--- a/packages/features/bookings/Booker/components/Unavailable.tsx
+++ b/packages/features/bookings/Booker/components/Unavailable.tsx
@@ -2,7 +2,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 const UnAvailableMessage = ({ children, title }: { children: React.ReactNode; title: string }) => (
   <div className="mx-auto w-full max-w-2xl">
-    <div className="bg-muted border-subtle overflow-hidden rounded-lg border p-10">
+    <div className="border-subtle bg-default overflow-hidden rounded-lg border p-10">
       <h2 className="font-cal mb-4 text-3xl">{title}</h2>
       {children}
     </div>

--- a/packages/features/bookings/components/AvailableTimes.tsx
+++ b/packages/features/bookings/components/AvailableTimes.tsx
@@ -110,9 +110,9 @@ export const AvailableTimes = ({
 };
 
 export const AvailableTimesSkeleton = () => (
-  <div className="mt-8 flex h-full w-[20%] flex-col only:w-full">
-    {/* Random number of elements between 1 and 10. */}
-    {Array.from({ length: Math.floor(Math.random() * 10) + 1 }).map((_, i) => (
+  <div className="mt-8 flex w-[20%] flex-col only:w-full">
+    {/* Random number of elements between 1 and 6. */}
+    {Array.from({ length: Math.floor(Math.random() * 6) + 1 }).map((_, i) => (
       <SkeletonText className="mb-4 h-6 w-full" key={i} />
     ))}
   </div>

--- a/packages/features/bookings/components/event-meta/Details.tsx
+++ b/packages/features/bookings/components/event-meta/Details.tsx
@@ -44,7 +44,6 @@ interface EventMetaProps {
  * Default order in which the event details will be rendered.
  */
 const defaultEventDetailsBlocks = [
-  EventDetailBlocks.DESCRIPTION,
   EventDetailBlocks.REQUIRES_CONFIRMATION,
   EventDetailBlocks.DURATION,
   EventDetailBlocks.OCCURENCES,
@@ -112,16 +111,6 @@ export const EventDetails = ({ event, blocks = defaultEventDetailsBlocks }: Even
         }
 
         switch (block) {
-          case EventDetailBlocks.DESCRIPTION:
-            if (!event.description) return null;
-            return (
-              <EventMetaBlock
-                key={block}
-                contentClassName="break-words max-w-full max-h-[180px] scroll-bar pr-4">
-                <div dangerouslySetInnerHTML={{ __html: event.description }} />
-              </EventMetaBlock>
-            );
-
           case EventDetailBlocks.DURATION:
             return (
               <EventMetaBlock key={block} icon={Clock}>

--- a/packages/features/bookings/types.ts
+++ b/packages/features/bookings/types.ts
@@ -8,7 +8,6 @@ export type PublicEvent = NonNullable<RouterOutputs["viewer"]["public"]["event"]
 export type ValidationErrors<T extends object> = { key: FieldPath<T>; error: ErrorOption }[];
 
 export enum EventDetailBlocks {
-  DESCRIPTION,
   // Includes duration select when event has multiple durations.
   DURATION,
   LOCATION,

--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -146,7 +146,7 @@ const Days = ({
             <div key={`e-${idx}`} />
           ) : props.isLoading ? (
             <button
-              className=" bg-muted text-muted opcaity-50 absolute top-0 left-0 right-0 bottom-0 mx-auto flex w-full items-center justify-center rounded-sm border-transparent text-center font-medium"
+              className="bg-muted text-muted absolute top-0 left-0 right-0 bottom-0 mx-auto flex w-full items-center justify-center rounded-sm border-transparent text-center font-medium opacity-50"
               key={`e-${idx}`}
               disabled>
               <SkeletonText className="h-4 w-5" />

--- a/packages/ui/components/skeleton/index.tsx
+++ b/packages/ui/components/skeleton/index.tsx
@@ -52,7 +52,7 @@ const Skeleton = <T extends keyof JSX.IntrinsicElements | React.FC>({
     <Component
       className={classNames(
         loading
-          ? classNames("font-size-0 bg-subtle animate-pulse rounded-md text-transparent", loadingClassName)
+          ? classNames("font-size-0 bg-emphasis animate-pulse rounded-md text-transparent", loadingClassName)
           : "",
         className
       )}
@@ -69,7 +69,7 @@ const SkeletonText: React.FC<SkeletonBaseProps & { invisible?: boolean }> = ({
   return (
     <span
       className={classNames(
-        `font-size-0 bg-subtle inline-block animate-pulse rounded-md empty:before:inline-block empty:before:content-['']`,
+        `font-size-0 bg-emphasis inline-block animate-pulse rounded-md empty:before:inline-block empty:before:content-['']`,
         className,
         invisible ? "invisible" : ""
       )}


### PR DESCRIPTION
## What does this PR do?

Small UI tweaks for booker: 

* Skeletons are made a liiiittle bit darker. Note: This impacts the whole app @Jaibles 
* Moved event meta description to top of meta, because description doesn't have an icon, and this way it looks better.
* Changed booker background color from muted to white
* Prevent scrollbar in loading state timeslots (CAL-1820)

**Environment**: Staging(main branch)

## Type of change
- New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Verify skeletons look great in all pages, and in booker too. 
- [ ] There shouldn't be scrollbar on timeslots when loading (see CAL-1820)
- [ ] Verify that description in booker looks good. 
- [ ] Verify that in light mode the background of the booker now is white. 


