### PR TITLE
fix: #9217 | redirected unready /settings/admin to one of its tabs

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -274,6 +274,11 @@ const nextConfig = {
         destination: "/teams",
         permanent: true,
       },
+      {
+        source: "/settings/admin",
+        destination: "/settings/admin/flags",
+        permanent: true,
+      },
       /* V2 testers get redirected to the new settings */
       {
         source: "/settings/profile",


### PR DESCRIPTION
## What does this PR do?

Fixes #9217 
Redirected the unready **settings/admin** route to its **flags** tab

## Demo
![fix](https://github.com/calcom/cal.com/assets/78294692/f07c9f53-682b-4efd-b3cd-a71e0cc8e654)

## Type of change

- Bug fix