### PR TITLE
FIX: [CAL-1824] 404: wrong slack icon color #9210

### DIFF
--- a/apps/web/pages/404.tsx
+++ b/apps/web/pages/404.tsx
@@ -291,7 +291,7 @@ export default function Custom404() {
                       className="relative flex items-start space-x-4 py-6 rtl:space-x-reverse">
                       <div className="flex-shrink-0">
                         <span className="bg-muted flex h-12 w-12 items-center justify-center rounded-lg">
-                          <Slack strokeWidth="1.5" fill="currentColor" className="h-6 w-6" />
+                          <Slack strokeWidth="1.5" fill="currentColor" className="h-6 w-6 dark:text-white" />
                         </span>
                       </div>
                       <div className="min-w-0 flex-1">


### PR DESCRIPTION
This PR Fixes the slack icon color in dark mode

Resolves #9210 
/claim #9210

![image](https://github.com/calcom/cal.com/assets/85151171/a218d3d5-c51d-4d06-ba14-943eaae0b06c)
