### PR TITLE
feat: added duplicate button to the event-type page

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -45,6 +45,7 @@ import {
   Users,
   ExternalLink,
   Code,
+  Copy,
   Trash,
   MoreHorizontal,
   Loader,
@@ -306,6 +307,15 @@ function EventTypeSingleLayout({
                   tooltip={t("embed")}
                 />
               </>
+            )}
+            {!isManagedEventType && !isChildrenManagedEventType && (
+              <Button
+                color="secondary"
+                variant="icon"
+                StartIcon={Copy}
+                tooltip={t("duplicate")}
+                onClick={() => router.push(`/event-types?dialog=duplicate&title=${eventType.title}&description=${eventType.description}&slug=${eventType.slug}&id=${eventType.id}&length=${eventType.length}&pageSlug=${team ? `team/${team.slug}` : eventType.users[0].username}`)}
+              />
             )}
             {!isChildrenManagedEventType && (
               <Button


### PR DESCRIPTION
## What does this PR do?
Added the duplicate button on the event-type page.

Fixes #9223

## Demo:
![fix2](https://github.com/calcom/cal.com/assets/78294692/f28f58d1-f946-4c7f-94d4-ead35734522d)

## Type of change

- Bug fix
- New feature

## Note for maintainers:
- pushing the user to the link was easier than reusing code in `pages/event-types/index.tsx`