### PR TITLE
fix: Allows team owners and team admins to query team availability

### DIFF
--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -138,10 +138,10 @@ async function handler(req: NextApiRequest) {
     where: { id: { in: allMemberIds } },
     select: availabilityUserSelect,
   });
-  const memberRoles: MemberRoles = team.members.reduce((acc, membership) => {
+  const memberRoles: MemberRoles = team.members.reduce((acc: MemberRoles, membership) => {
     acc[membership.userId] = membership.role;
     return acc;
-  }, {});
+  }, {} as MemberRoles);
   // check if the user is a team Admin or Owner, if it is a team request, or a system Admin
   const isUserAdminOrOwner =
     memberRoles[userId] === MembershipRole.Admin || memberRoles[userId] === MembershipRole.Owner || isAdmin;

--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -98,6 +98,9 @@ import { stringOrNumber } from "@calcom/prisma/zod-utils";
  *       404:
  *         description: User not found | Team not found | Team has no members
  */
+interface MemberRoles {
+  [userId: string]: MembershipRole;
+}
 
 const availabilitySchema = z
   .object({
@@ -135,7 +138,7 @@ async function handler(req: NextApiRequest) {
     where: { id: { in: allMemberIds } },
     select: availabilityUserSelect,
   });
-  const memberRoles = team.members.reduce((acc, membership) => {
+  const memberRoles: MemberRoles = team.members.reduce((acc, membership) => {
     acc[membership.userId] = membership.role;
     return acc;
   }, {});

--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -99,7 +99,7 @@ import { stringOrNumber } from "@calcom/prisma/zod-utils";
  *         description: User not found | Team not found | Team has no members
  */
 interface MemberRoles {
-  [userId: string]: MembershipRole;
+  [userId: number]: MembershipRole;
 }
 
 const availabilitySchema = z
@@ -138,13 +138,16 @@ async function handler(req: NextApiRequest) {
     where: { id: { in: allMemberIds } },
     select: availabilityUserSelect,
   });
+  const numUserId = Number(userId);
   const memberRoles: MemberRoles = team.members.reduce((acc: MemberRoles, membership) => {
-    acc[membership.userId] = membership.role;
+    acc[membership.numUserId] = membership.role;
     return acc;
   }, {} as MemberRoles);
   // check if the user is a team Admin or Owner, if it is a team request, or a system Admin
   const isUserAdminOrOwner =
-    memberRoles[userId] === MembershipRole.Admin || memberRoles[userId] === MembershipRole.Owner || isAdmin;
+    memberRoles[numUserId] === MembershipRole.Admin ||
+    memberRoles[numUserId] === MembershipRole.Owner ||
+    isAdmin;
   if (!isUserAdminOrOwner) throw new HttpError({ statusCode: 403, message: "Forbidden" });
   const availabilities = members.map(async (user) => {
     return {

--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -99,7 +99,7 @@ import { stringOrNumber } from "@calcom/prisma/zod-utils";
  *         description: User not found | Team not found | Team has no members
  */
 interface MemberRoles {
-  [userId: number]: MembershipRole;
+  [userId: number | string]: MembershipRole;
 }
 
 const availabilitySchema = z

--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -139,10 +139,10 @@ async function handler(req: NextApiRequest) {
     acc[membership.userId] = membership.role;
     return acc;
   }, {});
-  // check if the user is a team Admin or Owner, if it is a team request
+  // check if the user is a team Admin or Owner, if it is a team request, or a system Admin
   const isUserAdminOrOwner =
-    memberRoles[userId] === MembershipRole.Admin || memberRoles[userId] === MembershipRole.Owner;
-  if (!isAdmin && !isUserAdminOrOwner) throw new HttpError({ statusCode: 403, message: "Forbidden" });
+    memberRoles[userId] === MembershipRole.Admin || memberRoles[userId] === MembershipRole.Owner || isAdmin;
+  if (!isUserAdminOrOwner) throw new HttpError({ statusCode: 403, message: "Forbidden" });
   const availabilities = members.map(async (user) => {
     return {
       userId: user.id,


### PR DESCRIPTION
## What does this PR do?

The modification was to remove the restriction if the user is an 'Admin' or 'Owner' of the team being queried. If the user's role within the team is either 'Admin' or 'Owner', they are allowed to retrieve the availability of each member, regardless of their Admin status as a user in the instance.

Fixes #9243 

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] If you send an API request to the teams/{teamId}/availability endpoint with a team owner or a team admin, who isn't a system admin, now the call should go through fine. Earlier, it was returning 403 if it was made by anyone who isn't a system admin

## Checklist
