### PR TITLE
fix: hardcoded label of identifier label in form builder

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1672,6 +1672,7 @@
   "booking_questions_title": "Booking questions",
   "booking_questions_description": "Customize the questions asked on the booking page",
   "add_a_booking_question": "Add a question",
+  "identifier": "Identifier",
   "duplicate_email": "Email is duplicate",
   "booking_with_payment_cancelled": "Paying for this event is no longer possible",
   "booking_with_payment_cancelled_already_paid": "A refund for this booking payment it's on the way.",

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -493,7 +493,7 @@ export const FormBuilder = function FormBuilder({
                   fieldForm.getValues("editable") === "system" ||
                   fieldForm.getValues("editable") === "system-but-optional"
                 }
-                label="Identifier"
+                label={t("identifier")}
               />
               <InputField
                 {...fieldForm.register("label")}


### PR DESCRIPTION
## What does this PR do?
This PR is to make Identifier label fetch from translations instead of being hard coded in form builder.

Fixes #9164 

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)


