### PR TITLE
fix: API: Only include accepted users, ignore all pending, unregistered or not

### DIFF
--- a/apps/api/pages/api/availability/_get.ts
+++ b/apps/api/pages/api/availability/_get.ts
@@ -133,7 +133,12 @@ async function handler(req: NextApiRequest) {
   });
   if (!team) throw new HttpError({ statusCode: 404, message: "teamId not found" });
   if (!team.members) throw new HttpError({ statusCode: 404, message: "team has no members" });
-  const allMemberIds = team.members.map((membership) => membership.userId);
+  const allMemberIds = team.members.reduce((allMemberIds: number[], member) => {
+    if (member.accepted) {
+      allMemberIds.push(member.userId);
+    }
+    return allMemberIds;
+  }, []);
   const members = await prisma.user.findMany({
     where: { id: { in: allMemberIds } },
     select: availabilityUserSelect,


### PR DESCRIPTION
## What does this PR do?

An unregistered user does not have availability yet which causes the crash, but also pending users shouldn't be returned yet as part of the availability call - as they have not yet accepted the invite.

Fixes #9246

