### PR TITLE
fix: insights-date-picker-same-time-start-end-date

### DIFF
--- a/packages/features/insights/filters/DateSelect.tsx
+++ b/packages/features/insights/filters/DateSelect.tsx
@@ -29,7 +29,7 @@ export const DateSelect = () => {
             range &&
             (range === "tdy" || range === "w" || range === "t" || range === "m" || range === "y")
           ) {
-            setDateRange([dayjs(start), dayjs(end), range]);
+            setDateRange([dayjs(start).startOf("d"), dayjs(end).endOf("d"), range]);
             return;
           } else if (start && !end) {
             // If only start time has value that means selected date should push to dateRange with last value null


### PR DESCRIPTION
## What does this PR do?

- Should handle start, end dates correctly with startOf() endOf() day.

Fixes #8173 


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to any insights page select any quick date from the DateSelect Filter
- [ ] Url should have correct startDate and endDate. 

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
