### PR TITLE
feat: Ports getSchedule to public API

### DIFF
--- a/apps/api/pages/api/slots/_get.ts
+++ b/apps/api/pages/api/slots/_get.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { HttpError } from "@calcom/lib/http-error";
+import { defaultResponder } from "@calcom/lib/server";
+import { createContext } from "@calcom/trpc/server/createContext";
+import { viewerRouter } from "@calcom/trpc/server/routers/viewer/_router";
+
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  /** @see https://trpc.io/docs/server-side-calls */
+  const ctx = await createContext({ req, res });
+  const caller = viewerRouter.createCaller(ctx);
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await caller.slots.getSchedule(req.query as any /* Let tRPC handle this */);
+  } catch (cause) {
+    if (cause instanceof TRPCError) {
+      const statusCode = getHTTPStatusCodeFromError(cause);
+      throw new HttpError({ statusCode, message: cause.message });
+    }
+    throw cause;
+  }
+}
+
+export default defaultResponder(handler);

--- a/apps/api/pages/api/slots/index.ts
+++ b/apps/api/pages/api/slots/index.ts
@@ -1,0 +1,9 @@
+import { defaultHandler } from "@calcom/lib/server";
+
+import { withMiddleware } from "~/lib/helpers/withMiddleware";
+
+export default withMiddleware()(
+  defaultHandler({
+    GET: import("./_get"),
+  })
+);

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -7,13 +7,13 @@ export const getScheduleSchema = z
     // endTime ISOString
     endTime: z.string(),
     // Event type ID
-    eventTypeId: z.number().int().optional(),
+    eventTypeId: z.coerce.number().int().optional(),
     // Event type slug
-    eventTypeSlug: z.string(),
+    eventTypeSlug: z.string().optional(),
     // invitee timezone
     timeZone: z.string().optional(),
     // or list of users (for dynamic events)
-    usernameList: z.array(z.string()).optional(),
+    usernameList: z.union([z.string(), z.array(z.string())]).optional(),
     debug: z.boolean().optional(),
     // to handle event types with multiple duration options
     duration: z
@@ -21,9 +21,16 @@ export const getScheduleSchema = z
       .optional()
       .transform((val) => val && parseInt(val)),
   })
+  .transform((val) => {
+    // Need this so we can pass a single username in the query string form public API
+    if (val.usernameList) {
+      val.usernameList = Array.isArray(val.usernameList) ? val.usernameList : [val.usernameList];
+    }
+    return val;
+  })
   .refine(
-    (data) => !!data.eventTypeId || !!data.usernameList,
-    "Either usernameList or eventTypeId should be filled in."
+    (data) => !!data.eventTypeId || (!!data.usernameList && !!data.eventTypeSlug),
+    "You need to either pass an eventTypeId OR an usernameList/eventTypeSlug combination"
   );
 
 export const reserveSlotSchema = z

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -11,8 +11,7 @@ import isTimeOutOfBounds from "@calcom/lib/isOutOfBounds";
 import logger from "@calcom/lib/logger";
 import { performance } from "@calcom/lib/server/perfObserver";
 import getTimeSlots from "@calcom/lib/slots";
-import { availabilityUserSelect } from "@calcom/prisma";
-import prisma from "@calcom/prisma";
+import prisma, { availabilityUserSelect } from "@calcom/prisma";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import type { EventBusyDate } from "@calcom/types/Calendar";
@@ -140,6 +139,12 @@ export async function getEventType(input: TGetScheduleInputSchema) {
 
 export async function getDynamicEventType(input: TGetScheduleInputSchema) {
   // For dynamic booking, we need to get and update user credentials, schedule and availability in the eventTypeObject as they're required in the new availability logic
+  if (!input.eventTypeSlug) {
+    throw new TRPCError({
+      message: "eventTypeSlug is required for dynamic booking",
+      code: "BAD_REQUEST",
+    });
+  }
   const dynamicEventType = getDefaultEvent(input.eventTypeSlug);
   const users = await prisma.user.findMany({
     where: {


### PR DESCRIPTION
## What does this PR do?

fixes #9251 

Allows getting user available slots from API

## Type of change

<!-- Please delete bullets that are not relevant. -->

- New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Postman: [Get User Available Slots](https://www.postman.com/calcom/workspace/cal-com-workspace/request/20666831-28754839-f8d9-41b2-8aa8-59e84721e7a0?ctx=documentation)
- [x] Postman: [Get Team Available Slots](https://www.postman.com/calcom/workspace/cal-com-workspace/request/20666831-566e042a-86b2-4d81-b20d-1dced580716b?ctx=documentation)
