### PR TITLE
fix: [Hotfix]No phone number is valid

### DIFF
--- a/packages/ui/form/PhoneInput.tsx
+++ b/packages/ui/form/PhoneInput.tsx
@@ -65,7 +65,7 @@ const useDefaultCountry = () => {
     retry: false,
     onSuccess: (data) => {
       if (isSupportedCountry(data?.countryCode)) {
-        setDefaultCountry(data.countryCode);
+        setDefaultCountry(data.countryCode.toLowerCase());
       }
     },
   });

--- a/packages/ui/form/PhoneInput.tsx
+++ b/packages/ui/form/PhoneInput.tsx
@@ -30,7 +30,9 @@ function BasePhoneInput({ name, className = "", onChange, ...rest }: PhoneInputP
         required: rest.required,
         placeholder: rest.placeholder,
       }}
-      onChange={(value) => onChange(value)}
+      onChange={(value) => {
+        onChange("+" + value);
+      }}
       containerClass={classNames(
         "hover:border-emphasis dark:focus:border-emphasis border-default !bg-default rounded-md border focus-within:outline-none focus-within:ring-2 focus-within:ring-brand-default disabled:cursor-not-allowed",
         className


### PR DESCRIPTION
We recently moved to react-phone-input-2 and after that all phone numbers are considered invalid by `isValidPhoneNumber`. 
 https://github.com/calcom/cal.com/pull/8705/files
 
 Tests:
- Verified workflow SMS sending to specific number.
- Booking Form Phone Number Submission

 Demo https://www.loom.com/share/2593647cf1ea442e8ba3b7873c5fa127