### PR TITLE
fix: page rendering comments initially

### DIFF
--- a/apps/web/pages/getting-started/[[...step]].tsx
+++ b/apps/web/pages/getting-started/[[...step]].tsx
@@ -117,9 +117,7 @@ const OnboardingPage = (props: IOnboardingPageProps) => {
       }
       key={router.asPath}>
       <Head>
-        <title>
-          {APP_NAME} - {t("getting_started")}
-        </title>
+        <title>{`${APP_NAME} - ${t("getting_started")}`}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 


### PR DESCRIPTION
## What does this PR do?

The issue seems to be due to multiple nodes created by React. 


Fixes #9267

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Previously:
https://github.com/calcom/cal.com/assets/49358949/f0cecad7-08a4-4ec6-bfda-8a74afa4272e


Now:
https://github.com/calcom/cal.com/assets/49358949/e83071f5-ef4e-44b3-b689-8ecf314c7f39


**Environment**: Staging(main branch

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

 Go to signup. 
Create an account.
You will be redirected to `/getting-started` page. When initially loading the page, you can no longer see the comment.


- [x] Fixes comment shown during first load.

