### PR TITLE
fix: API - typo in swagger docs for /bookings GET

### DIFF
--- a/apps/api/pages/api/bookings/_get.ts
+++ b/apps/api/pages/api/bookings/_get.ts
@@ -33,7 +33,7 @@ import { schemaQuerySingleOrMultipleUserIds } from "~/lib/validations/shared/que
  *                type: integer
  *              example: [2, 3, 4]
  *       - in: query
- *         name: attendeeEmails
+ *         name: attendeeEmail
  *         required: false
  *         schema:
  *           oneOf:


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in swagger docs for GET request on /bookings endpoint, where it used to have `attendeeEmails` instead of `attendeeEmail`

**Environment**: Staging(main branch)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

