### PR TITLE
fix: sidebar skeleton layout shift on isLocaleReady

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -646,12 +646,12 @@ const NavigationItem: React.FC<{
           href={item.href}
           aria-label={t(item.name)}
           className={classNames(
-            "hover:bg-emphasis [&[aria-current='page']]:bg-emphasis hover:text-emphasis text-default group flex items-center rounded-md py-2 px-3 text-sm font-medium",
+            `[&[aria-current='page']]:bg-emphasis text-default group flex items-center rounded-md py-2 px-3 text-sm font-medium`,
             isChild
-              ? `[&[aria-current='page']]:text-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 [&[aria-current='page']]:bg-transparent ${
+              ? `[&[aria-current='page']]:text-emphasis hover:text-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 [&[aria-current='page']]:bg-transparent ${
                   props.index === 0 ? "mt-0" : "mt-px"
                 }`
-              : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm"
+              :`${isLocaleReady?"hover:bg-emphasis hover:text-emphasis":"my-[0.395rem]"} [&[aria-current='page']]:text-emphasis mt-0.5 text-sm`
           )}
           aria-current={current ? "page" : undefined}>
           {item.icon && (
@@ -667,7 +667,7 @@ const NavigationItem: React.FC<{
               {item.badge && item.badge}
             </span>
           ) : (
-            <SkeletonText className="h-3 w-32" />
+            <SkeletonText className="ml-2 h-3 w-32" />
           )}
         </Link>
       </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Fixes the following issues:
- layout shift (different heights)
- skeleton has no padding left to the icon
- hover should be disabled while loading

Fixes #9309 

Demo:
![fix](https://github.com/calcom/cal.com/assets/78294692/6f31e1b1-8948-4b70-beda-3d91da88542d)

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Note for maintainer:
I tried to give the skeleton different widths according to the length of the item name, however, it only works for 1-2 items. It seems to be an issue with Tailwind's JIT compiler. 

Attempt: At [this](https://github.com/calcom/cal.com/blob/main/packages/features/shell/Shell.tsx#LL670C25-L670C25) line ```<SkeletonText className={`ml-2 h-3 w-[${item.name.length*10}px]`} />```

/claim #9309 