### PR TITLE
fix: background colour for disabled select option

### DIFF
--- a/apps/web/components/ui/form/CheckedSelect.tsx
+++ b/apps/web/components/ui/form/CheckedSelect.tsx
@@ -26,12 +26,6 @@ export const CheckedSelect = ({
   return (
     <>
       <Select
-        styles={{
-          option: (styles, { isDisabled }) => ({
-            ...styles,
-            backgroundColor: isDisabled ? "#F5F5F5" : "inherit",
-          }),
-        }}
         name={props.name}
         placeholder={props.placeholder || t("select")}
         isSearchable={false}

--- a/packages/features/eventtypes/components/CheckedTeamSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedTeamSelect.tsx
@@ -28,12 +28,6 @@ export const CheckedTeamSelect = ({
   return (
     <>
       <Select
-        styles={{
-          option: (styles, { isDisabled }) => ({
-            ...styles,
-            backgroundColor: isDisabled ? "#F5F5F5" : "inherit",
-          }),
-        }}
         name={props.name}
         placeholder={props.placeholder || t("select")}
         isSearchable={true}

--- a/packages/features/eventtypes/components/CheckedUserSelect.tsx
+++ b/packages/features/eventtypes/components/CheckedUserSelect.tsx
@@ -27,12 +27,6 @@ export const CheckedUserSelect = ({
   return (
     <>
       <Select
-        styles={{
-          option: (styles, { isDisabled }) => ({
-            ...styles,
-            backgroundColor: isDisabled ? "#F5F5F5" : "inherit",
-          }),
-        }}
         name={props.name}
         placeholder={props.placeholder || t("select")}
         isSearchable={false}

--- a/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
+++ b/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
@@ -40,12 +40,6 @@ export const ChildrenEventTypeSelect = ({
   return (
     <>
       <Select
-        styles={{
-          option: (styles, { isDisabled }) => ({
-            ...styles,
-            backgroundColor: isDisabled ? "#F5F5F5" : "inherit",
-          }),
-        }}
         name={props.name}
         placeholder={t("select")}
         options={options}

--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -44,6 +44,7 @@ export const Select = <
           cx(
             "bg-default flex cursor-pointer justify-between py-2.5 px-3 rounded-none text-default ",
             state.isFocused && "bg-subtle",
+            state.isDisabled && "bg-muted",
             state.isSelected && "bg-emphasis text-default",
             props.classNames?.option
           ),


### PR DESCRIPTION
## What does this PR do?
This PR fixes the background colour of disabled select option. The PR is specifically for issue #9313. While fixing the issue I noticed that the same issue might get replicated on other Select components which have the logic written in the same way.  Any feedback is appreciated if my understanding was wrong.

Fixes #9313 | [CAL-1861]

**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a new team. 
- Create new event type for this team
- Select assignment as round robin
- Select a value under the round robin hosts select dropdown.
- Try to select a host under fixed hosts section. The disabled value will have proper colour according to the theme. Attaching video for reference.


https://github.com/calcom/cal.com/assets/20976813/fac20c1d-1378-45de-b59c-23514c1e415d




