### PR TITLE
fix: Availability Name does Not Update

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -193,7 +193,7 @@ function EventTypeSingleLayout({
                   : `default_schedule_name`
               }`
             : eventType.scheduleName ?? `default_schedule_name`
-          : `default_schedule_name`,
+          : eventType.scheduleName ?? `default_schedule_name`,
     });
     // If there is a team put this navigation item within the tabs
     if (team) {

--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -178,6 +178,7 @@ function EventTypeSingleLayout({
       enabledWorkflowsNumber,
       availability,
     });
+
     navigation.splice(1, 0, {
       name: "availability",
       href: `/event-types/${eventType.id}?tabName=availability`,
@@ -185,7 +186,7 @@ function EventTypeSingleLayout({
       info:
         isManagedEventType || isChildrenManagedEventType
           ? eventType.schedule === null
-            ? "Member's default schedule"
+            ? "member_default_schedule"
             : isChildrenManagedEventType
             ? `${
                 eventType.scheduleName

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -902,6 +902,7 @@
   "availability_updated_successfully": "{{scheduleName}} schedule updated successfully",
   "schedule_deleted_successfully": "Schedule deleted successfully",
   "default_schedule_name": "Working Hours",
+  "member_default_schedule":"Member's default schedule",
   "new_schedule_heading": "Create an availability schedule",
   "new_schedule_description": "Creating availability schedules allows you to manage availability across event types. They can be applied to one or more event types.",
   "requires_ownership_of_a_token": "Requires ownership of a token belonging to the following address:",


### PR DESCRIPTION
## What does this PR do?
Earlier, the tag under event availability was only changing for the Managed events or any event with locked features in it but not for Collective events and round robin event.
Now, I have updated code which updates event availabilty tag for other event types.  

Fixes #9315 

Before
![before](https://github.com/calcom/cal.com/assets/77577810/c3574f96-1ee2-49bb-bb88-f82ea2df6ef2)

After
![after](https://github.com/calcom/cal.com/assets/77577810/36d2787c-101b-43ea-9208-9b42381d1485)

**Environment**: Staging(main branch) / Production

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Navigate to the collective even
2. Click on "Availability"
3. Toggle on "common schedule"
4. Pick a new schedule that isn't the default
5. Now, the schedule under "Availability" on the left would update, earlier it was not.

