### PR TITLE
fix: title in booking submitted page

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -279,9 +279,7 @@ export default function Success(props: SuccessProps) {
     darkBrandColor: props.profile.darkBrandColor,
   });
   const title = t(
-    `booking_${needsConfirmation ? "booking_submitted" : "confirmed"}${
-      props.recurringBookings ? "_recurring" : ""
-    }`
+    `booking_${needsConfirmation ? "submitted" : "confirmed"}${props.recurringBookings ? "_recurring" : ""}`
   );
 
   const locationToDisplay = getSuccessPageLocationMessage(


### PR DESCRIPTION
## What does this PR do?

regression from one of my prs #9234. i18n key should be `booking_submitted` not `booking_booking_submitted`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

