### PR TITLE
fix: Routing Form, only last option of multiselect is forwarded to Booking Form.

### DIFF
--- a/apps/web/lib/hooks/useRouterQuery.ts
+++ b/apps/web/lib/hooks/useRouterQuery.ts
@@ -5,7 +5,25 @@ export default function useRouterQuery<T extends string>(name: T) {
   const existingQueryParams = router.asPath.split("?")[1];
 
   const urlParams = new URLSearchParams(existingQueryParams);
-  const query = Object.fromEntries(urlParams);
+  const query: Record<string, string | string[]> = {};
+  // Following error is thrown by Typescript:
+  // 'Type 'URLSearchParams' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher'
+  // We should change the target to higher ES2019 atleast maybe
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  for (const [key, value] of urlParams) {
+    if (!query[key]) {
+      query[key] = value;
+    } else {
+      let queryValue = query[key];
+      if (queryValue instanceof Array) {
+        queryValue.push(value);
+      } else {
+        queryValue = query[key] = [queryValue];
+        queryValue.push(value);
+      }
+    }
+  }
 
   const setQuery = (newValue: string | number | null | undefined) => {
     router.replace({ query: { ...router.query, [name]: newValue } }, undefined, { shallow: true });

--- a/packages/app-store/routing-forms/pages/routing-link/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/routing-link/[...appPages].tsx
@@ -82,7 +82,7 @@ function RoutingForm({ form, profile, ...restProps }: Props) {
   }, [customPageMessage]);
 
   const responseMutation = trpc.viewer.appRoutingForms.public.response.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       const decidedActionWithFormResponse = decidedActionWithFormResponseRef.current;
       if (!decidedActionWithFormResponse) {
         return;
@@ -98,7 +98,7 @@ function RoutingForm({ form, profile, ...restProps }: Props) {
       if (decidedAction.type === "customPageMessage") {
         setCustomPageMessage(decidedAction.value);
       } else if (decidedAction.type === "eventTypeRedirectUrl") {
-        router.push(`/${decidedAction.value}?${allURLSearchParams}`);
+        await router.push(`/${decidedAction.value}?${allURLSearchParams}`);
       } else if (decidedAction.type === "externalRedirectUrl") {
         window.parent.location.href = `${decidedAction.value}?${allURLSearchParams}`;
       }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9329 
Fixes Cal-1865

Before Fix:
https://www.loom.com/share/fb1692f1269d47ae934300001d3a8d3f
After Fix:
https://www.loom.com/share/4f0c31c391b24eb080596b89cbfa6aff

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Bug-1: MultiSelect field has only last option in query string
- Create an Routing Form with multiple select type and choose all the options for the field.
- Notice that only last of the option is visible in  the query string.

Bug-2
- Simply submit a routing form that redirects to event-type
- Notice that submit button loader goes away and still nothing happens for a very significant amount of time


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
