### PR TITLE
fix: hide 2fa tab when using google as identity provider

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -10,6 +10,7 @@ import { classNames } from "@calcom/lib";
 import { HOSTED_CAL_FEATURES, WEBAPP_URL } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import { MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import useAvatarQuery from "@calcom/trpc/react/hooks/useAvatarQuery";
@@ -51,8 +52,8 @@ const tabs: VerticalTabItemProps[] = [
     icon: Key,
     children: [
       { name: "password", href: "/settings/security/password" },
-      { name: "2fa_auth", href: "/settings/security/two-factor-auth" },
       { name: "impersonation", href: "/settings/security/impersonation" },
+      { name: "2fa_auth", href: "/settings/security/two-factor-auth" },
     ],
   },
   {
@@ -116,6 +117,10 @@ const useTabs = () => {
       tab.name = user?.name || "my_account";
       tab.icon = undefined;
       tab.avatar = avatar?.avatar || WEBAPP_URL + "/" + session?.data?.user?.username + "/avatar.png";
+    } else if (tab.href === "/settings/security" && user?.identityProvider === IdentityProvider.GOOGLE) {
+      tab.children = tab?.children?.filter(
+        (childTab) => childTab.href !== "/settings/security/two-factor-auth"
+      );
     }
     return tab;
   });


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/9332

<img width="1440" alt="Screenshot 2023-06-05 at 5 05 31 PM" src="https://github.com/calcom/cal.com/assets/53316345/810eef40-6389-4cfb-ace5-9a77ee89e762">


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1) Login with google 
2) Got to /settings
3) Check if you are able to see two factor auth under security  section in the sidebar
