### PR TITLE
fix: Prevents undefined features flags on first render

### DIFF
--- a/apps/web/server/lib/ssr.ts
+++ b/apps/web/server/lib/ssr.ts
@@ -26,6 +26,8 @@ export async function ssrInit(context: GetServerSidePropsContext) {
 
   // always preload "viewer.public.i18n"
   await ssr.viewer.public.i18n.fetch();
+  // So feature flags are available on first render
+  await ssr.viewer.features.map.prefetch();
 
   return ssr;
 }


### PR DESCRIPTION
## What does this PR do?

This allows feature flags to be prefetched on most pages. You still need to use `getServerSideProps` and `ssrInit` helper in order to benefit from this.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] On any page with `ssrInit` try using `const featureFlags = useFlagMap();`
- [x] It should never return an empty object.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
