### PR TITLE
fix: for recurring events in new booker

### DIFF
--- a/packages/features/bookings/components/event-meta/Details.tsx
+++ b/packages/features/bookings/components/event-meta/Details.tsx
@@ -136,7 +136,7 @@ export const EventDetails = ({ event, blocks = defaultEventDetailsBlocks }: Even
             );
 
           case EventDetailBlocks.OCCURENCES:
-            if (!event.requiresConfirmation || !event.recurringEvent) return null;
+            if (!event.recurringEvent) return null;
 
             return (
               <EventMetaBlock key={block} icon={RefreshCcw}>


### PR DESCRIPTION
## What does this PR do?

Recurring event doesn't neccessarily mean an event that requires confirmation. We need to show the recurring option nevertheless. Before recurring events option wasn't shown when event did NOT require confirmation. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
