### PR TITLE
fix: Make public event endpoint take less data

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -63,7 +63,13 @@ const publicEventSelect = Prisma.validator<Prisma.EventTypeSelect>()({
       },
     },
   },
-  owner: true,
+  owner: {
+    select: {
+      weekStart: true,
+      username: true,
+      name: true,
+    },
+  },
   hidden: true,
 });
 


### PR DESCRIPTION
## What does this PR do?

Only take owner data we need in public event api, instead of everything. Saves bandwidth.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

