### PR TITLE
feat: Made booker layout settings more user friendly

### DIFF
--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -99,7 +99,7 @@ const AppearanceView = () => {
     <Form
       form={formMethods}
       handleSubmit={(values) => {
-        const layoutError = validateBookerLayouts(values.defaultBookerLayouts || null);
+        const layoutError = validateBookerLayouts(values?.metadata?.defaultBookerLayouts || null);
         if (layoutError) throw new Error(t(layoutError));
 
         mutation.mutate({

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import type { z } from "zod";
 
 import { BookerLayoutSelector } from "@calcom/features/settings/BookerLayoutSelector";
 import ThemeLabel from "@calcom/features/settings/ThemeLabel";
@@ -9,6 +10,7 @@ import { checkWCAGContrastColor } from "@calcom/lib/getBrandColours";
 import { useHasPaidPlan } from "@calcom/lib/hooks/useHasPaidPlan";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
+import type { userMetadata } from "@calcom/prisma/zod-utils";
 import { trpc } from "@calcom/trpc/react";
 import {
   Alert,
@@ -64,7 +66,7 @@ const AppearanceView = () => {
       brandColor: user?.brandColor || "#292929",
       darkBrandColor: user?.darkBrandColor || "#fafafa",
       hideBranding: user?.hideBranding,
-      defaultBookerLayouts: user?.defaultBookerLayouts,
+      metadata: user?.metadata as z.infer<typeof userMetadata>,
     },
   });
 

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -5,9 +5,8 @@ import StickyBox from "react-sticky-box";
 import { shallow } from "zustand/shallow";
 
 import classNames from "@calcom/lib/classNames";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
-import { BookerLayouts, bookerLayoutOptions } from "@calcom/prisma/zod-utils";
+import { BookerLayouts, defaultBookerLayoutSettings } from "@calcom/prisma/zod-utils";
 
 import { AvailableTimeSlots } from "./components/AvailableTimeSlots";
 import { BookEventForm } from "./components/BookEventForm";
@@ -35,7 +34,6 @@ const BookerComponent = ({
   rescheduleBooking,
   hideBranding = false,
 }: BookerProps) => {
-  const { t } = useLocale();
   const isMobile = useMediaQuery("(max-width: 768px)");
   const isTablet = useMediaQuery("(max-width: 1024px)");
   const timeslotsRef = useRef<HTMLDivElement>(null);
@@ -51,10 +49,7 @@ const BookerComponent = ({
     shallow
   );
   const extraDays = layout === BookerLayouts.COLUMN_VIEW ? (isTablet ? 2 : 4) : 0;
-  const bookerLayouts = event.data?.profile?.bookerLayouts || {
-    defaultLayout: BookerLayouts.MONTH_VIEW,
-    enabledLayouts: bookerLayoutOptions,
-  };
+  const bookerLayouts = event.data?.profile?.bookerLayouts || defaultBookerLayoutSettings;
 
   const animationScope = useBookerResizeAnimation(layout, bookerState);
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -55,6 +55,12 @@ export const bookerLayouts = z
   })
   .nullable();
 
+export const defaultBookerLayoutSettings = {
+  defaultLayout: BookerLayouts.MONTH_VIEW,
+  // if the user has no explicit layouts set (not in user profile and not in event settings), we only show the month view.
+  enabledLayouts: [BookerLayouts.MONTH_VIEW],
+};
+
 export type BookerLayoutSettings = z.infer<typeof bookerLayouts>;
 
 export const RequiresConfirmationThresholdUnits: z.ZodType<UnitTypeLongPlural> = z.enum(["hours", "minutes"]);

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -57,8 +57,8 @@ export const bookerLayouts = z
 
 export const defaultBookerLayoutSettings = {
   defaultLayout: BookerLayouts.MONTH_VIEW,
-  // if the user has no explicit layouts set (not in user profile and not in event settings), we only show the month view.
-  enabledLayouts: [BookerLayouts.MONTH_VIEW],
+  // if the user has no explicit layouts set (not in user profile and not in event settings), all layouts are enabled.
+  enabledLayouts: bookerLayoutOptions,
 };
 
 export type BookerLayoutSettings = z.infer<typeof bookerLayouts>;


### PR DESCRIPTION
## What does this PR do?

Makes booker layout settings a bit more user friendly. These things have changed:

1. When you disable a layout as one of the enabled options, the button to mark it as default layout disables too.
2. If it was chosen as a default before you disabled that layout, it takes the next enabled layout and makes that default now. 
3. If you only enable one layout, the settings for the default layout aren't shown at all


Fixes CAL-1889 CAL-1893 CAL-1894 CAL-1895


https://github.com/calcom/cal.com/assets/2969573/2fdfbc65-c2fa-42a1-88ea-b3b4997646f4

## Type of change

- New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Enable and disable layouts, and ensure that the behaviour is clear. 
- [ ] Test that the enabled layouts are also still shown correctly on the booker page
- [ ] Test with a user that doesn't have any settings set yet, and note that by default it now only shows the month view.
