### PR TITLE
fix: Improve booker header for large views

### DIFF
--- a/packages/features/bookings/Booker/components/Header.tsx
+++ b/packages/features/bookings/Booker/components/Header.tsx
@@ -32,7 +32,7 @@ export function Header({
     [setLayout]
   );
 
-  if (isMobile || !enabledLayouts || enabledLayouts.length <= 1) return null;
+  if (isMobile || !enabledLayouts) return null;
 
   // Only reason we create this component, is because it is used 3 times in this component,
   // and this way we can't forget to update one of the props in all places :)
@@ -42,6 +42,7 @@ export function Header({
 
   // In month view we only show the layout toggle.
   if (isMonthView) {
+    if (enabledLayouts.length <= 1) return null;
     return (
       <div className="fixed top-3 right-3 z-10">
         <LayoutToggleWithData />
@@ -73,22 +74,24 @@ export function Header({
           />
         </ButtonGroup>
       </div>
-      <div className="ml-auto flex gap-3">
-        <TimeFormatToggle />
-        <div className="fixed top-4 right-4">
-          <LayoutToggleWithData />
-        </div>
-        {/*
+      {enabledLayouts.length > 1 && (
+        <div className="ml-auto flex gap-3">
+          <TimeFormatToggle />
+          <div className="fixed top-4 right-4">
+            <LayoutToggleWithData />
+          </div>
+          {/*
           This second layout toggle is hidden, but needed to reserve the correct spot in the DIV
           for the fixed toggle above to fit into. If we wouldn't make it fixed in this view, the transition
           would be really weird, because the element is positioned fixed in the month view, and then
           when switching layouts wouldn't anymmore, causing it to animate from the center to the top right,
           while it actuall already was on place. That's why we have this element twice.
         */}
-        <div className="pointer-events-none opacity-0" aria-hidden>
-          <LayoutToggleWithData />
+          <div className="pointer-events-none opacity-0" aria-hidden>
+            <LayoutToggleWithData />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Show header layout in large views even if theres only one layout enable. Don't show toggle though.

![CleanShot 2023-06-07 at 18 57 51@2x](https://github.com/calcom/cal.com/assets/2969573/49bc9686-fd98-4708-bd03-ef21bbaf0eb3)

Fixes CAL-1890

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Enable only column view, header bar with date and prev/next toggle should be visible. There should be no additional space at the top though. Layout toggle should not be visible. 
- [ ] Enable only month view, this layout has no top bar, so that should not be visible. Layout toggle also should not be visible
- [ ] Enable both or all 3 layouts – layout toggle should be visible and in column view the header bar should be visible as well (with date range that's visible).
