### PR TITLE
fix: error when updating event type availability

### DIFF
--- a/apps/web/pages/event-types/[type]/index.tsx
+++ b/apps/web/pages/event-types/[type]/index.tsx
@@ -372,8 +372,9 @@ const EventTypePage = (props: EventTypeSetupProps) => {
       throw new Error(t("seats_and_no_show_fee_error"));
     }
 
+    const { availability, ...rest } = input;
     updateMutation.mutate({
-      ...input,
+      ...rest,
       locations,
       recurringEvent,
       periodStartDate: periodDates.startDate,
@@ -453,9 +454,9 @@ const EventTypePage = (props: EventTypeSetupProps) => {
                 }
               }
             }
-
+            const { availability, ...rest } = input;
             updateMutation.mutate({
-              ...input,
+              ...rest,
               locations,
               recurringEvent,
               periodStartDate: periodDates.startDate,


### PR DESCRIPTION
## What does this PR do?

Fixes error when updating the availability in the event type settings

Error message:
<img width="418" alt="Screenshot 2023-06-09 at 09 03 36" src="https://github.com/calcom/cal.com/assets/30310907/a605b21b-48c5-4785-84b7-3b446eca16aa">

<img width="448" alt="Screenshot 2023-06-09 at 09 04 19" src="https://github.com/calcom/cal.com/assets/30310907/8ce77f6f-634f-492b-9d04-1542dd8b0ec1">

Fixes #9418

## Type of change

- Bug fix (non-breaking change which fixes an issue)