### PR TITLE
test: Add E2E test to verify theme change

### DIFF
--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -263,7 +263,8 @@ const AppearanceView = () => {
         type="submit"
         loading={mutation.isLoading}
         color="primary"
-        className="mt-8">
+        className="mt-8"
+        data-testid="update-theme-btn">
         {t("update")}
       </Button>
     </Form>

--- a/apps/web/playwright/change-theme.e2e.ts
+++ b/apps/web/playwright/change-theme.e2e.ts
@@ -5,17 +5,15 @@ import { test } from "./lib/fixtures";
 test.describe("Change Theme Test", () => {
   test("change theme to dark", async ({ page, users }) => {
     const pro = await users.create();
-    await pro.login();
+    await pro.apiLogin();
 
     await page.goto("/settings/my-account/appearance");
 
     await page.waitForLoadState("networkidle");
-    //Find the theme button which has label "Dark"
-    const $themeButton = page.getByText("Dark", { exact: true });
-    await $themeButton.click();
-    //Find the update button
-    const $updateButton = page.locator("text=Update");
-    await $updateButton.click();
+    //Click the "Dark" theme label
+    await page.click('[data-testid="theme-dark"]');
+    //Click the update button
+    await page.click('[data-testid="update-theme-btn"]');
     //Wait for the toast to appear
     const toast = await page.waitForSelector("div[class*='data-testid-toast-success']");
     expect(toast).toBeTruthy();
@@ -27,17 +25,15 @@ test.describe("Change Theme Test", () => {
 
   test("change theme to light", async ({ page, users }) => {
     const pro = await users.create();
-    await pro.login();
+    await pro.apiLogin();
 
     await page.goto("/settings/my-account/appearance");
 
     await page.waitForLoadState("networkidle");
-    //Find the theme button which has label "Light"
-    const $themeButton = page.getByText("Light", { exact: true });
-    await $themeButton.click();
-    //Find the update button
-    const $updateButton = page.locator("text=Update");
-    await $updateButton.click();
+    //Click the "Light" theme label
+    await page.click('[data-testid="theme-light"]');
+    //Click the update theme button
+    await page.click('[data-testid="update-theme-btn"]');
     //Wait for the toast to appear
     const toast = await page.waitForSelector("div[class*='data-testid-toast-success']");
     expect(toast).toBeTruthy();

--- a/apps/web/playwright/change-theme.e2e.ts
+++ b/apps/web/playwright/change-theme.e2e.ts
@@ -1,0 +1,49 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+
+test.describe("Change Theme Test", () => {
+  test("change theme to dark", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.login();
+
+    await page.goto("/settings/my-account/appearance");
+
+    await page.waitForLoadState("networkidle");
+    //Find the theme button which has label "Dark"
+    const $themeButton = page.getByText("Dark", { exact: true });
+    await $themeButton.click();
+    //Find the update button
+    const $updateButton = page.locator("text=Update");
+    await $updateButton.click();
+    //Wait for the toast to appear
+    const toast = await page.waitForSelector("div[class*='data-testid-toast-success']");
+    expect(toast).toBeTruthy();
+    //Go to the profile page and check if the theme is dark
+    await page.goto(`/${pro.username}`);
+    const darkModeClass = await page.getAttribute("html", "class");
+    expect(darkModeClass).toContain("dark");
+  });
+
+  test("change theme to light", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.login();
+
+    await page.goto("/settings/my-account/appearance");
+
+    await page.waitForLoadState("networkidle");
+    //Find the theme button which has label "Light"
+    const $themeButton = page.getByText("Light", { exact: true });
+    await $themeButton.click();
+    //Find the update button
+    const $updateButton = page.locator("text=Update");
+    await $updateButton.click();
+    //Wait for the toast to appear
+    const toast = await page.waitForSelector("div[class*='data-testid-toast-success']");
+    expect(toast).toBeTruthy();
+    //Go to the profile page and check if the theme is light
+    await page.goto(`/${pro.username}`);
+    const darkModeClass = await page.getAttribute("html", "class");
+    expect(darkModeClass).toContain("light");
+  });
+});

--- a/packages/features/settings/ThemeLabel.tsx
+++ b/packages/features/settings/ThemeLabel.tsx
@@ -18,6 +18,7 @@ export default function ThemeLabel(props: ThemeLabelProps) {
         type="radio"
         value={value}
         id={`theme-${variant}`}
+        data-testid={`theme-${variant}`}
         defaultChecked={defaultChecked}
         {...register("theme")}
       />

--- a/packages/features/settings/ThemeLabel.tsx
+++ b/packages/features/settings/ThemeLabel.tsx
@@ -12,13 +12,13 @@ export default function ThemeLabel(props: ThemeLabelProps) {
   return (
     <label
       className="relative mb-4 flex-1 cursor-pointer text-center last:mb-0 last:mr-0 sm:mr-4 sm:mb-0"
-      htmlFor={`theme-${variant}`}>
+      htmlFor={`theme-${variant}`}
+      data-testid={`theme-${variant}`}>
       <input
         className="peer absolute top-8 left-8"
         type="radio"
         value={value}
         id={`theme-${variant}`}
-        data-testid={`theme-${variant}`}
         defaultChecked={defaultChecked}
         {...register("theme")}
       />


### PR DESCRIPTION
## What does this PR do?

This PR adds end-to-end tests to verify if the theme has been applied successfully to public booking pages.
- change-theme.e2e.ts
  - Verify if the theme change has been applied to the respective public booking page successfully
- ThemeLabel.tsx
  - Added data-testid to the theme label

Fixes #5977
/claim #5977

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- [x] Run automated e2e tests

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

(all complete)
