### PR TITLE
fix: copy icon for dark mode

### DIFF
--- a/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -74,7 +74,7 @@ export default function ApiKeyDialogForm({
                   }}
                   type="button"
                   className="rounded-l-none py-[19px] text-base ">
-                  <Clipboard className="h-5 w-5 text-gray-100 ltr:mr-2 rtl:ml-2" />
+                  <Clipboard className="h-5 w-5 ltr:mr-2 rtl:ml-2" />
                   {t("copy")}
                 </Button>
               </Tooltip>

--- a/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -73,8 +73,8 @@ export default function ApiKeyDialogForm({
                     showToast(t("api_key_copied"), "success");
                   }}
                   type="button"
-                  className="rounded-l-none py-[19px] text-base ">
-                  <Clipboard className="h-5 w-5 ltr:mr-2 rtl:ml-2" />
+                  className="rounded-l-none text-base"
+                  StartIcon={Clipboard}>
                   {t("copy")}
                 </Button>
               </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Fixes the visibility of copy icon in dark mode

Fixes #9458

<img width="1260" alt="Screenshot 2023-06-12 at 12 02 55 AM" src="https://github.com/calcom/cal.com/assets/96714915/526b5c91-f644-4823-85b5-09cc24435438">

