### PR TITLE
fix: Added custom error with more details to debug the ciaran event issue

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -192,7 +192,20 @@ function getProfileFromEvent(event: Event) {
   if (!profile) throw new Error("Event has no owner");
 
   const username = "username" in profile ? profile.username : team?.slug;
-  if (!username) throw new Error("Event has no username/team slug");
+  if (!username) {
+    if (event.slug === "test") {
+      // @TODO: This is a temporary debug statement that should be removed asap.
+      throw new Error(
+        "Ciaran event error" +
+          JSON.stringify(team) +
+          " -- " +
+          JSON.stringify(hosts) +
+          " -- " +
+          JSON.stringify(owner)
+      );
+    }
+    throw new Error("Event has no username/team slug");
+  }
   const weekStart = hosts?.[0]?.user?.weekStart || owner?.weekStart || "Monday";
   const basePath = team ? `/team/${username}` : `/${username}`;
   const eventMetaData = EventTypeMetaDataSchema.parse(event.metadata || {});


### PR DESCRIPTION
## What does this PR do?

Adds more detail to error in order to debug. Added small additional if to only run on specific events, plus this only runs on new booker, so it shouldn't run for anyone else. And even IF it did, the error would already be thrown, so no risk in my opinion to add this temporarily. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
