### PR TITLE
fix: removed new button from EmptyScreen on routing-forms

### DIFF
--- a/packages/app-store/routing-forms/pages/forms/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/forms/[...appPages].tsx
@@ -124,7 +124,6 @@ export default function RoutingForms({
                   Icon={GitMerge}
                   headline={t("create_your_first_form")}
                   description={t("create_your_first_form_description")}
-                  buttonRaw={<NewFormButton />}
                 />
               ) : null}
               {forms?.length ? (


### PR DESCRIPTION
## What does this PR do?
Removes the New button ([buttonRaw](https://github.com/calcom/cal.com/blob/3ec9eb377df258d41edfde4d4e089a247df71e57/packages/ui/components/empty-screen/EmptyScreen.tsx#L28)) from the `EmptyScreen` component on Routing forms page.

Fixes #9478 

## Demo:
![demo](https://github.com/calcom/cal.com/assets/78294692/9707f76f-c7e4-4503-8d51-8d7b36f1c2bd)

**Environment**: Staging(main branch) / Production

## Type of change

- Bug fix (non-breaking change which fixes an issue)