### PR TITLE
fix: Pass event duration to schedule api call

### DIFF
--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -37,8 +37,8 @@ export const useEvent = () => {
 export const useScheduleForEvent = ({ prefetchNextMonth }: { prefetchNextMonth?: boolean } = {}) => {
   const { timezone } = useTimePreferences();
   const event = useEvent();
-  const [username, eventSlug, month] = useBookerStore(
-    (state) => [state.username, state.eventSlug, state.month],
+  const [username, eventSlug, month, duration] = useBookerStore(
+    (state) => [state.username, state.eventSlug, state.month, state.selectedDuration],
     shallow
   );
 
@@ -49,5 +49,6 @@ export const useScheduleForEvent = ({ prefetchNextMonth }: { prefetchNextMonth?:
     month,
     timezone,
     prefetchNextMonth,
+    duration,
   });
 };

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -8,6 +8,7 @@ type UseScheduleWithCacheArgs = {
   month?: string | null;
   timezone?: string | null;
   prefetchNextMonth?: boolean;
+  duration?: number | null;
 };
 
 export const useSchedule = ({
@@ -17,6 +18,7 @@ export const useSchedule = ({
   eventSlug,
   eventId,
   prefetchNextMonth,
+  duration,
 }: UseScheduleWithCacheArgs) => {
   const monthDayjs = month ? dayjs(month) : dayjs();
   const nextMonthDayjs = monthDayjs.add(1, "month");
@@ -35,6 +37,7 @@ export const useSchedule = ({
       endTime: (prefetchNextMonth ? nextMonthDayjs : monthDayjs).endOf("month").toISOString(),
       timeZone: timezone!,
       eventTypeId: eventId!,
+      duration: duration ? `${duration}` : undefined,
     },
     {
       refetchOnWindowFocus: false,


### PR DESCRIPTION
## What does this PR do?

Ensures we fetch new timeslots when changing duration in new booker.

Fixes CAL-1940 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Choose a multi duration event, change duration, and notice the slots update. 
- [ ] Events with only a single duration should also still show the correct timeslots. 
