### PR TITLE
chore: Cache node_modules

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -53,6 +53,7 @@ runs:
       run: |
         yarn install --inline-builds
         yarn prisma generate
+      if: steps.yarn-install-state-cache.outputs.cache-hit != 'true'
       env:
         # CI optimizations. Overrides yarnrc.yml options (or their defaults) in the CI action.
         YARN_ENABLE_IMMUTABLE_INSTALLS: "false" # So it doesn't try to remove our private submodule deps

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -29,31 +29,30 @@ runs:
       run: |
         echo "CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-    # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
-    # Yarn cache is also reusable between arch and os.
-    - name: Restore yarn cache
-      uses: buildjet/cache@v3
-      id: yarn-download-cache
-      with:
-        path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
-        key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-download-cache-
+    # # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
+    # # Yarn cache is also reusable between arch and os.
+    # - name: Restore yarn cache
+    #   uses: buildjet/setup-node@v3
+    #   id: yarn-download-cache
+    #   with:
+    #     path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
+    #     key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
+    #     restore-keys: |
+    #       yarn-download-cache-
 
-    # Invalidated on yarn.lock changes
-    - name: Restore yarn install state
-      id: yarn-install-state-cache
-      uses: buildjet/cache@v3
-      with:
-        path: .yarn/ci-cache/
-        key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+    # # Invalidated on yarn.lock changes
+    # - name: Restore yarn install state
+    #   id: yarn-install-state-cache
+    #   uses: buildjet/cache@v3
+    #   with:
+    #     path: .yarn/ci-cache/
+    #     key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
       shell: bash
       run: |
         yarn install --inline-builds
         yarn prisma generate
-      if: steps.yarn-install-state-cache.outputs.cache-hit != 'true'
       env:
         # CI optimizations. Overrides yarnrc.yml options (or their defaults) in the CI action.
         YARN_ENABLE_IMMUTABLE_INSTALLS: "false" # So it doesn't try to remove our private submodule deps

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -32,7 +32,7 @@ runs:
     # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
     # Yarn cache is also reusable between arch and os.
     - name: Restore yarn cache
-      uses: buildjet/setup-node@v3
+      uses: buildjet/cache@v3
       id: yarn-download-cache
       with:
         path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -29,24 +29,24 @@ runs:
       run: |
         echo "CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-    # # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
-    # # Yarn cache is also reusable between arch and os.
-    # - name: Restore yarn cache
-    #   uses: buildjet/setup-node@v3
-    #   id: yarn-download-cache
-    #   with:
-    #     path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
-    #     key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
-    #     restore-keys: |
-    #       yarn-download-cache-
+    # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
+    # Yarn cache is also reusable between arch and os.
+    - name: Restore yarn cache
+      uses: buildjet/setup-node@v3
+      id: yarn-download-cache
+      with:
+        path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
+        key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-download-cache-
 
-    # # Invalidated on yarn.lock changes
-    # - name: Restore yarn install state
-    #   id: yarn-install-state-cache
-    #   uses: buildjet/cache@v3
-    #   with:
-    #     path: .yarn/ci-cache/
-    #     key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+    # Invalidated on yarn.lock changes
+    - name: Restore yarn install state
+      id: yarn-install-state-cache
+      uses: buildjet/cache@v3
+      with:
+        path: .yarn/ci-cache/
+        key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -40,6 +40,7 @@ runs:
         restore-keys: |
           yarn-download-cache-
 
+    # Invalidated on yarn.lock changes
     - name: Restore node_modules
       id: yarn-nm-cache
       uses: buildjet/cache@v3

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -40,6 +40,13 @@ runs:
         restore-keys: |
           yarn-download-cache-
 
+    - name: Restore node_modules
+      id: yarn-nm-cache
+      uses: buildjet/cache@v3
+      with:
+        path: "**/node_modules/"
+        key: ${{ runner.os }}-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+
     # Invalidated on yarn.lock changes
     - name: Restore yarn install state
       id: yarn-install-state-cache
@@ -53,10 +60,12 @@ runs:
       run: |
         yarn install --inline-builds
         yarn prisma generate
+      if: steps.yarn-install-state-cache.outputs.cache-hit != 'true'
       env:
         # CI optimizations. Overrides yarnrc.yml options (or their defaults) in the CI action.
         YARN_ENABLE_IMMUTABLE_INSTALLS: "false" # So it doesn't try to remove our private submodule deps
         YARN_ENABLE_GLOBAL_CACHE: "false" # Use local cache folder to keep downloaded archives
         YARN_INSTALL_STATE_PATH: .yarn/ci-cache/install-state.gz # Very small speedup when lock does not change
+        YARN_NM_MODE: "hardlinks-local" # Reduce node_modules size
         # Other environment variables
         HUSKY: "0" # By default do not run HUSKY install

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -60,7 +60,6 @@ runs:
       run: |
         yarn install --inline-builds
         yarn prisma generate
-      if: steps.yarn-install-state-cache.outputs.cache-hit != 'true'
       env:
         # CI optimizations. Overrides yarnrc.yml options (or their defaults) in the CI action.
         YARN_ENABLE_IMMUTABLE_INSTALLS: "false" # So it doesn't try to remove our private submodule deps

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - name: Save Code Linting Reports
+      - name: Run Linting with Reports
         run: yarn lint:report
         continue-on-error: true
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   changes:
-    name: "Detect changes"
+    name: Detect changes
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       pull-requests: read
@@ -41,36 +41,23 @@ jobs:
               - 'apps/web/**'
               - 'packages/embeds/**'
 
-  install:
-    name: Install
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=6144"' >> $GITHUB_ENV
-      - uses: ./.github/actions/yarn-install
-
   env:
     name: Create env file
-    needs: install
     uses: ./.github/workflows/env-create-file.yml
     secrets: inherit
 
   type-check:
     name: Type check
-    needs: install
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
-    needs: install
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
   lint:
     name: Linters
-    needs: install
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,23 +40,35 @@ jobs:
               - 'apps/web/**'
               - 'packages/embeds/**'
 
+  install:
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/dangerous-git-checkout
+      - run: echo 'NODE_OPTIONS="--max_old_space_size=6144"' >> $GITHUB_ENV
+      - uses: ./.github/actions/yarn-install
+
   env:
     name: Create env file
+    needs: install
     uses: ./.github/workflows/env-create-file.yml
     secrets: inherit
 
   type-check:
     name: Type check
+    needs: install
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
+    needs: install
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
   lint:
     name: Linters
+    needs: install
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   changes:
+    name: "Detect changes"
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       pull-requests: read
@@ -41,6 +42,7 @@ jobs:
               - 'packages/embeds/**'
 
   install:
+    name: Install
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

This caches our node_modules so we save 40+ seconds on every yarn install link step across the build pipeline. The cache restore step takes about 10 seconds so overall savings for the yarn install command will be ~30 seconds.

In total, this will shave off about 1-1.5 minutes from every PR workflow.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)
