### PR TITLE
fix: CalDAV, Cannot read properties of undefined (reading 'data')

### DIFF
--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -337,7 +337,7 @@ export default abstract class BaseCalendarService implements Calendar {
     const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
     const events: { start: string; end: string }[] = [];
     objects.forEach((object) => {
-      if (object.data == null || JSON.stringify(object.data) == "{}") return;
+      if (!object || object.data == null || JSON.stringify(object.data) == "{}") return;
       let vcalendar: ICAL.Component;
       try {
         const jcalData = ICAL.parse(sanitizeCalendarObject(object));


### PR DESCRIPTION
## What does this PR do?

Handles the object.data check better to first confirm if object itself is not undefined

Fixes #8684 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] When the calendar returns undefined object, it should simply ignore it instead of throwing the error `Cannot read properties of undefined (reading 'data')` in the console.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

