### PR TITLE
Incorrect tab selected issue fix

### DIFF
--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -142,7 +142,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
           <ToggleGroup
             isFullWidth={true}
             onValueChange={(val) => setModalInputMode(val as ModalMode)}
-            defaultValue="INDIVIDUAL"
+            defaultValue={modalImportMode}
             options={[
               {
                 value: "INDIVIDUAL",


### PR DESCRIPTION
## What does this PR do?

fixes the incorrect tab has been selected for the second time when user try to add team members.

Fixes #9490

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


https://github.com/calcom/cal.com/assets/123581387/da36da9c-119a-4570-a0c5-3cb95a6797ec

