### PR TITLE
fix: Sets null to undefined during workflow select

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -65,7 +65,7 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
           userId: ctx.user.id,
         },
         {
-          teamId: userEventType.teamId,
+          teamId: userEventType.teamId || undefined,
         },
       ],
     },


### PR DESCRIPTION
## What does this PR do?

Prevents 'null' from making it into the query