### PR TITLE
fix: Default tab selected issue

### DIFF
--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -59,6 +59,8 @@ export const AddNewTeamMembersForm = ({
 
   const { data: team, isLoading } = trpc.viewer.teams.get.useQuery({ teamId });
 
+  let resetChildFunc: Function;
+
   const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation({
     async onSuccess(data) {
       await utils.viewer.teams.get.invalidate();
@@ -71,6 +73,7 @@ export const AddNewTeamMembersForm = ({
             }),
             "success"
           );
+          if(resetChildFunc instanceof Function) resetChildFunc();
         } else {
           showToast(
             t("email_invite_team", {
@@ -121,7 +124,8 @@ export const AddNewTeamMembersForm = ({
             teamId={teamId}
             token={team?.inviteToken?.token}
             onExit={() => setMemberInviteModal(false)}
-            onSubmit={(values) => {
+            onSubmit={(values,resetFields) => {
+              resetChildFunc = resetFields;
               inviteMemberMutation.mutate({
                 teamId,
                 language: i18n.language,

--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -59,8 +59,6 @@ export const AddNewTeamMembersForm = ({
 
   const { data: team, isLoading } = trpc.viewer.teams.get.useQuery({ teamId });
 
-  let resetChildFunc: Function;
-
   const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation({
     async onSuccess(data) {
       await utils.viewer.teams.get.invalidate();
@@ -73,7 +71,6 @@ export const AddNewTeamMembersForm = ({
             }),
             "success"
           );
-          if(resetChildFunc instanceof Function) resetChildFunc();
         } else {
           showToast(
             t("email_invite_team", {
@@ -124,15 +121,15 @@ export const AddNewTeamMembersForm = ({
             teamId={teamId}
             token={team?.inviteToken?.token}
             onExit={() => setMemberInviteModal(false)}
-            onSubmit={(values,resetFields) => {
-              resetChildFunc = resetFields;
-              inviteMemberMutation.mutate({
+            onSubmit={async (values, resetFields) => {
+              await inviteMemberMutation.mutate({
                 teamId,
                 language: i18n.language,
                 role: values.role,
                 usernameOrEmail: values.emailOrUsername,
                 sendEmailInvitation: values.sendInviteEmail,
               });
+              resetFields();
             }}
             onSettingsOpen={() => {
               setMemberInviteModal(false);

--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -59,32 +59,7 @@ export const AddNewTeamMembersForm = ({
 
   const { data: team, isLoading } = trpc.viewer.teams.get.useQuery({ teamId });
 
-  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation({
-    async onSuccess(data) {
-      await utils.viewer.teams.get.invalidate();
-      setMemberInviteModal(false);
-      if (data.sendEmailInvitation) {
-        if (Array.isArray(data.usernameOrEmail)) {
-          showToast(
-            t("email_invite_team_bulk", {
-              userCount: data.usernameOrEmail.length,
-            }),
-            "success"
-          );
-        } else {
-          showToast(
-            t("email_invite_team", {
-              email: data.usernameOrEmail,
-            }),
-            "success"
-          );
-        }
-      }
-    },
-    onError: (error) => {
-      showToast(error.message, "error");
-    },
-  });
+  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation();
 
   const publishTeamMutation = trpc.viewer.teams.publish.useMutation({
     onSuccess(data) {
@@ -131,8 +106,30 @@ export const AddNewTeamMembersForm = ({
                   sendEmailInvitation: values.sendInviteEmail,
                 },
                 {
-                  onSuccess: () => {
-                    resetFields();
+                  onSuccess: async (data) => {
+                    await utils.viewer.teams.get.invalidate();
+                    setMemberInviteModal(false);
+                    if (data.sendEmailInvitation) {
+                      if (Array.isArray(data.usernameOrEmail)) {
+                        showToast(
+                          t("email_invite_team_bulk", {
+                            userCount: data.usernameOrEmail.length,
+                          }),
+                          "success"
+                        );
+                        resetFields();
+                      } else {
+                        showToast(
+                          t("email_invite_team", {
+                            email: data.usernameOrEmail,
+                          }),
+                          "success"
+                        );
+                      }
+                    }
+                  },
+                  onError: (error) => {
+                    showToast(error.message, "error");
                   },
                 }
               );

--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -121,15 +121,21 @@ export const AddNewTeamMembersForm = ({
             teamId={teamId}
             token={team?.inviteToken?.token}
             onExit={() => setMemberInviteModal(false)}
-            onSubmit={async (values, resetFields) => {
-              await inviteMemberMutation.mutate({
-                teamId,
-                language: i18n.language,
-                role: values.role,
-                usernameOrEmail: values.emailOrUsername,
-                sendEmailInvitation: values.sendInviteEmail,
-              });
-              resetFields();
+            onSubmit={(values, resetFields) => {
+              inviteMemberMutation.mutate(
+                {
+                  teamId,
+                  language: i18n.language,
+                  role: values.role,
+                  usernameOrEmail: values.emailOrUsername,
+                  sendEmailInvitation: values.sendInviteEmail,
+                },
+                {
+                  onSuccess: () => {
+                    resetFields();
+                  },
+                }
+              );
             }}
             onSettingsOpen={() => {
               setMemberInviteModal(false);

--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -31,7 +31,7 @@ import { GoogleWorkspaceInviteButton } from "./GoogleWorkspaceInviteButton";
 type MemberInvitationModalProps = {
   isOpen: boolean;
   onExit: () => void;
-  onSubmit: (values: NewMemberForm, resetFields: Function) => void;
+  onSubmit: (values: NewMemberForm, resetFields: () => void) => void;
   onSettingsOpen: () => void;
   teamId: number;
   members: PendingMember[];

--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -32,7 +32,7 @@ type MemberInvitationModalProps = {
   isOpen: boolean;
   onExit: () => void;
   onSubmit: (values: NewMemberForm, resetFields: () => void) => void;
-  onSettingsOpen: () => void;
+  onSettingsOpen?: () => void;
   teamId: number;
   members: PendingMember[];
   token?: string;

--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -31,8 +31,8 @@ import { GoogleWorkspaceInviteButton } from "./GoogleWorkspaceInviteButton";
 type MemberInvitationModalProps = {
   isOpen: boolean;
   onExit: () => void;
-  onSubmit: (values: NewMemberForm) => void;
-  onSettingsOpen?: () => void;
+  onSubmit: (values: NewMemberForm, resetFields: Function) => void;
+  onSettingsOpen: () => void;
   teamId: number;
   members: PendingMember[];
   token?: string;
@@ -114,6 +114,12 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
     }
   };
 
+  const resetFields = () => {
+    newMemberFormMethods.reset();
+    newMemberFormMethods.setValue("emailOrUsername", "");
+    setModalInputMode("INDIVIDUAL");
+  };
+
   return (
     <Dialog
       name="inviteModal"
@@ -154,7 +160,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
           />
         </div>
 
-        <Form form={newMemberFormMethods} handleSubmit={(values) => props.onSubmit(values)}>
+        <Form form={newMemberFormMethods} handleSubmit={(values) => props.onSubmit(values, resetFields)}>
           <div className="mt-6 mb-10 space-y-6">
             {/* Indivdual Invite */}
             {modalImportMode === "INDIVIDUAL" && (
@@ -308,7 +314,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
               color="minimal"
               onClick={() => {
                 props.onExit();
-                newMemberFormMethods.reset();
+                resetFields();
               }}>
               {t("cancel")}
             </Button>

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -64,32 +64,7 @@ export default function TeamListItem(props: Props) {
   const [openInviteLinkSettingsModal, setOpenInviteLinkSettingsModal] = useState(false);
 
   const teamQuery = trpc.viewer.teams.get.useQuery({ teamId: team?.id });
-  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation({
-    async onSuccess(data) {
-      await utils.viewer.teams.get.invalidate();
-      setOpenMemberInvitationModal(false);
-      if (data.sendEmailInvitation) {
-        if (Array.isArray(data.usernameOrEmail)) {
-          showToast(
-            t("email_invite_team_bulk", {
-              userCount: data.usernameOrEmail.length,
-            }),
-            "success"
-          );
-        } else {
-          showToast(
-            t("email_invite_team", {
-              email: data.usernameOrEmail,
-            }),
-            "success"
-          );
-        }
-      }
-    },
-    onError: (error) => {
-      showToast(error.message, "error");
-    },
-  });
+  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation();
 
   const acceptOrLeaveMutation = trpc.viewer.teams.acceptOrLeave.useMutation({
     onSuccess: () => {
@@ -156,8 +131,30 @@ export default function TeamListItem(props: Props) {
               sendEmailInvitation: values.sendInviteEmail,
             },
             {
-              onSuccess: () => {
-                resetFields();
+              onSuccess: async (data) => {
+                await utils.viewer.teams.get.invalidate();
+                setOpenMemberInvitationModal(false);
+                if (data.sendEmailInvitation) {
+                  if (Array.isArray(data.usernameOrEmail)) {
+                    showToast(
+                      t("email_invite_team_bulk", {
+                        userCount: data.usernameOrEmail.length,
+                      }),
+                      "success"
+                    );
+                    resetFields();
+                  } else {
+                    showToast(
+                      t("email_invite_team", {
+                        email: data.usernameOrEmail,
+                      }),
+                      "success"
+                    );
+                  }
+                }
+              },
+              onError: (error) => {
+                showToast(error.message, "error");
               },
             }
           );

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -146,14 +146,21 @@ export default function TeamListItem(props: Props) {
         onExit={() => {
           setOpenMemberInvitationModal(false);
         }}
-        onSubmit={(values) => {
-          inviteMemberMutation.mutate({
-            teamId: team.id,
-            language: i18n.language,
-            role: values.role,
-            usernameOrEmail: values.emailOrUsername,
-            sendEmailInvitation: values.sendInviteEmail,
-          });
+        onSubmit={(values, resetFields) => {
+          inviteMemberMutation.mutate(
+            {
+              teamId: team.id,
+              language: i18n.language,
+              role: values.role,
+              usernameOrEmail: values.emailOrUsername,
+              sendEmailInvitation: values.sendInviteEmail,
+            },
+            {
+              onSuccess: () => {
+                resetFields();
+              },
+            }
+          );
         }}
         onSettingsOpen={() => {
           setOpenMemberInvitationModal(false);

--- a/packages/features/ee/teams/pages/team-members-view.tsx
+++ b/packages/features/ee/teams/pages/team-members-view.tsx
@@ -83,32 +83,7 @@ const MembersView = () => {
     }
   );
 
-  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation({
-    async onSuccess(data) {
-      await utils.viewer.teams.get.invalidate();
-      setShowMemberInvitationModal(false);
-      if (data.sendEmailInvitation) {
-        if (Array.isArray(data.usernameOrEmail)) {
-          showToast(
-            t("email_invite_team_bulk", {
-              userCount: data.usernameOrEmail.length,
-            }),
-            "success"
-          );
-        } else {
-          showToast(
-            t("email_invite_team", {
-              email: data.usernameOrEmail,
-            }),
-            "success"
-          );
-        }
-      }
-    },
-    onError: (error) => {
-      showToast(error.message, "error");
-    },
-  });
+  const inviteMemberMutation = trpc.viewer.teams.inviteMember.useMutation();
 
   const isInviteOpen = !team?.membership.accepted;
 
@@ -186,8 +161,30 @@ const MembersView = () => {
                     sendEmailInvitation: values.sendInviteEmail,
                   },
                   {
-                    onSuccess: () => {
-                      resetFields();
+                    onSuccess: async (data) => {
+                      await utils.viewer.teams.get.invalidate();
+                      setShowMemberInvitationModal(false);
+                      if (data.sendEmailInvitation) {
+                        if (Array.isArray(data.usernameOrEmail)) {
+                          showToast(
+                            t("email_invite_team_bulk", {
+                              userCount: data.usernameOrEmail.length,
+                            }),
+                            "success"
+                          );
+                          resetFields();
+                        } else {
+                          showToast(
+                            t("email_invite_team", {
+                              email: data.usernameOrEmail,
+                            }),
+                            "success"
+                          );
+                        }
+                      }
+                    },
+                    onError: (error) => {
+                      showToast(error.message, "error");
                     },
                   }
                 );

--- a/packages/features/ee/teams/pages/team-members-view.tsx
+++ b/packages/features/ee/teams/pages/team-members-view.tsx
@@ -67,7 +67,6 @@ const MembersView = () => {
 
   const router = useRouter();
   const session = useSession();
-
   const utils = trpc.useContext();
   const teamId = Number(router.query.id);
 
@@ -177,14 +176,21 @@ const MembersView = () => {
               teamId={team.id}
               token={team.inviteToken?.token}
               onExit={() => setShowMemberInvitationModal(false)}
-              onSubmit={(values) => {
-                inviteMemberMutation.mutate({
-                  teamId,
-                  language: i18n.language,
-                  role: values.role,
-                  usernameOrEmail: values.emailOrUsername,
-                  sendEmailInvitation: values.sendInviteEmail,
-                });
+              onSubmit={(values, resetFields) => {
+                inviteMemberMutation.mutate(
+                  {
+                    teamId,
+                    language: i18n.language,
+                    role: values.role,
+                    usernameOrEmail: values.emailOrUsername,
+                    sendEmailInvitation: values.sendInviteEmail,
+                  },
+                  {
+                    onSuccess: () => {
+                      resetFields();
+                    },
+                  }
+                );
               }}
               onSettingsOpen={() => {
                 setShowMemberInvitationModal(false);


### PR DESCRIPTION
## What does this PR do?

Fixes the **bulk import** components rendering but **individual invite** tab has been selected issue.

Fixes #9490


https://github.com/calcom/cal.com/assets/123581387/08415c0f-0890-4841-b726-badd2fcae171



## Type of change

- Create a function that reset the values.
- Called that function onSuccess function

Note : The reason to get a function from child to parent and called it in onSuccess function is to avoid clearing the inputs before the service is getting called. That prevents the data if services are down.