### PR TITLE
fix: add team slug to team event link

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
@@ -226,7 +226,7 @@ export const getByViewerHandler = async ({ ctx }: GetByViewerOptions) => {
             image: `${CAL_URL}/team/${membership.team.slug}/avatar.png`,
             slug: membership.team.slug
               ? !membership.team.parentId
-                ? `team`
+                ? `team/${membership.team.slug}`
                 : "" + membership.team.slug
               : null,
           },


### PR DESCRIPTION
## What does this PR do?

Fixes that the preview button of a team event redirected to 404.

before: 
![Screenshot 2023-06-16 at 10 51 22](https://github.com/calcom/cal.com/assets/30310907/858a20f4-d8e7-42c3-974d-558d57163b2e)


after: 
![Screenshot 2023-06-16 at 10 51 54](https://github.com/calcom/cal.com/assets/30310907/95ecdc5d-e987-4d10-832b-741e5e7538d6)


