### PR TITLE
fix: Booking Page crash with prefilling guests

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -19,7 +19,9 @@ import {
   mapRecurringBookingToMutationInput,
 } from "@calcom/features/bookings/lib";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
-import getBookingResponsesSchema from "@calcom/features/bookings/lib/getBookingResponsesSchema";
+import getBookingResponsesSchema, {
+  getBookingResponsesPartialSchema,
+} from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { HttpError } from "@calcom/lib/http-error";
 import { Form, Button, Alert, EmptyScreen } from "@calcom/ui";
@@ -27,7 +29,6 @@ import { Calendar } from "@calcom/ui/components/icon";
 
 import { useBookerStore } from "../../store";
 import { useEvent } from "../../utils/event";
-import { getQueryParam } from "../../utils/query-param";
 import { BookingFields } from "./BookingFields";
 import { FormSkeleton } from "./Skeleton";
 
@@ -82,10 +83,23 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
     if (!eventType?.bookingFields) {
       return {};
     }
+    const querySchema = getBookingResponsesPartialSchema({
+      eventType: {
+        bookingFields: eventType.bookingFields,
+      },
+      view: rescheduleUid ? "reschedule" : "booking",
+    });
+
+    const parsedQuery = querySchema.parse({
+      ...router.query,
+      // `guest` because we need to support legacy URL with `guest` query param support
+      // `guests` because the `name` of the corresponding bookingField is `guests`
+      guests: router.query.guests || router.query.guest,
+    });
 
     const defaultUserValues = {
-      email: rescheduleUid ? rescheduleBooking?.attendees[0].email : getQueryParam("email") || "",
-      name: rescheduleUid ? rescheduleBooking?.attendees[0].name : getQueryParam("name") || "",
+      email: rescheduleUid ? rescheduleBooking?.attendees[0].email : parsedQuery["email"] || "",
+      name: rescheduleUid ? rescheduleBooking?.attendees[0].name : parsedQuery["name"] || "",
     };
 
     if (!isRescheduling) {
@@ -96,9 +110,10 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
       const responses = eventType.bookingFields.reduce((responses, field) => {
         return {
           ...responses,
-          [field.name]: getQueryParam(field.name) || undefined,
+          [field.name]: parsedQuery[field.name] || undefined,
         };
       }, {});
+
       defaults.responses = {
         ...responses,
         name: defaultUserValues.name,
@@ -162,6 +177,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
   const createBookingMutation = useMutation(createBooking, {
     onSuccess: async (responseData) => {
       const { uid, paymentUid } = responseData;
+
       if (paymentUid) {
         return await router.push(
           createPaymentLink({

--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -177,7 +177,6 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
   const createBookingMutation = useMutation(createBooking, {
     onSuccess: async (responseData) => {
       const { uid, paymentUid } = responseData;
-
       if (paymentUid) {
         return await router.push(
           createPaymentLink({


### PR DESCRIPTION
## What does this PR do?
Fixes new booker crash when guests are prefilled.

This PR borrows the code from https://github.com/calcom/cal.com/pull/8671/files?diff=unified#r1185081708(a low priority PR which had this fix)

Before:
https://www.loom.com/share/6a223160687c4f52a2c16a1a6e5342af

After:
https://www.loom.com/share/0e362bac6d044b5ba74653975155ce95?from_recorder=1&focus_title=1

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Simply go to booking page with guests query param .e.g http://localhost:3000/free/30min?duration=30&guests=abc%40example.com&guests=def%40example.com&date=2023-06-20&slot=2023-06-20T08%3A30%3A00.000Z. Notice that the page is crashed

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
