### PR TITLE
fix: New booker selected date issues

### DIFF
--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -167,9 +167,8 @@ export const useBookerStore = create<BookerStore>((set, get) => ({
       layout: layout || BookerLayouts.MONTH_VIEW,
       // Preselect today's date in week / column view, since they use this to show the week title.
       selectedDate:
-        selectedDateInStore || ["week_view", "column_view"].includes(layout)
-          ? dayjs().format("YYYY-MM-DD")
-          : null,
+        selectedDateInStore ||
+        (["week_view", "column_view"].includes(layout) ? dayjs().format("YYYY-MM-DD") : null),
     });
 
     // Unset selected timeslot if user is rescheduling. This could happen

--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -109,7 +109,7 @@ const Days = ({
   nextMonthButton: () => void;
 }) => {
   // Create placeholder elements for empty days in first week
-  const weekdayOfFirst = browsingDate.day();
+  const weekdayOfFirst = browsingDate.date(1).day();
   const currentDate = minDate.utcOffset(browsingDate.utcOffset());
   const availableDates = (includedDates: string[] | undefined) => {
     const dates = [];

--- a/packages/features/calendars/weeklyview/state/store.ts
+++ b/packages/features/calendars/weeklyview/state/store.ts
@@ -1,8 +1,8 @@
-import create from "zustand";
+import { create } from "zustand";
 
 import dayjs from "@calcom/dayjs";
 
-import {
+import type {
   CalendarComponentProps,
   CalendarPublicActions,
   CalendarState,

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -16,7 +16,7 @@ import {
   EventTypeMetaDataSchema,
   customInputSchema,
   userMetadata as userMetadataSchema,
-  bookerLayouts,
+  bookerLayouts as bookerLayoutsSchema,
   BookerLayouts,
 } from "@calcom/prisma/zod-utils";
 
@@ -69,6 +69,7 @@ const publicEventSelect = Prisma.validator<Prisma.EventTypeSelect>()({
       username: true,
       name: true,
       theme: true,
+      metadata: true,
     },
   },
   hidden: true,
@@ -132,7 +133,7 @@ export const getPublicEvent = async (username: string, eventSlug: string, prisma
         brandColor: users[0].brandColor,
         darkBrandColor: users[0].darkBrandColor,
         theme: null,
-        bookerLayouts: bookerLayouts.parse(
+        bookerLayouts: bookerLayoutsSchema.parse(
           firstUsersMetadata?.defaultBookerLayouts || defaultEventBookerLayouts
         ),
       },
@@ -167,7 +168,7 @@ export const getPublicEvent = async (username: string, eventSlug: string, prisma
 
   return {
     ...event,
-    bookerLayouts: bookerLayouts.parse(eventMetaData?.bookerLayouts || null),
+    bookerLayouts: bookerLayoutsSchema.parse(eventMetaData?.bookerLayouts || null),
     description: markdownToSafeHTML(event.description),
     metadata: eventMetaData,
     customInputs: customInputSchema.array().parse(event.customInputs || []),
@@ -220,7 +221,7 @@ function getProfileFromEvent(event: Event) {
     brandColor: profile.brandColor,
     darkBrandColor: profile.darkBrandColor,
     theme: profile.theme,
-    bookerLayouts: bookerLayouts.parse(
+    bookerLayouts: bookerLayoutsSchema.parse(
       eventMetaData?.bookerLayouts ||
         (userMetaData && "defaultBookerLayouts" in userMetaData ? userMetaData.defaultBookerLayouts : null)
     ),

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -129,13 +129,13 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
     });
   }
   // Revalidate booking pages
-  const res = ctx.res as NextApiResponse;
+  // Disabled because the booking pages are currently not using getStaticProps
+  /*const res = ctx.res as NextApiResponse;
   if (typeof res?.revalidate !== "undefined") {
     const eventTypes = await prisma.eventType.findMany({
       where: {
         userId: user.id,
         team: null,
-        hidden: false,
       },
       select: {
         id: true,
@@ -143,9 +143,11 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
       },
     });
     // waiting for this isn't needed
-    Promise.all(eventTypes.map((eventType) => res?.revalidate(`/${ctx.user.username}/${eventType.slug}`)))
+    Promise.all(
+      eventTypes.map((eventType) => res?.revalidate(`/new-booker/${ctx.user.username}/${eventType.slug}`))
+    )
       .then(() => console.info("Booking pages revalidated"))
       .catch((e) => console.error(e));
-  }
+  }*/
   return input;
 };


### PR DESCRIPTION
## What does this PR do?

* Fixes zustand deprecation warning
* Fixes setting selected date to current regardless of ?date param being passed.
* Fixes the selected bookingLayout not being applied from user profile settings.
* Disables revalidate call as the booker page is currently using getServerSideProps
* Fixes incorrect start day - which was based on the browsingDate rather than the start of the month. startOf("month") has some translation happening so I used date(1) to fix.
