### PR TITLE
fix: Adding more time to org admin email verif step

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -113,7 +113,7 @@ export const createHandler = async ({ input }: CreateOptions) => {
       .update(adminEmail + process.env.CALENDSO_ENCRYPTION_KEY)
       .digest("hex");
 
-    totp.options = { step: 90 };
+    totp.options = { step: 900 };
     const code = totp.generate(secret);
 
     await sendOrganizationEmailVerification({


### PR DESCRIPTION
## What does this PR do?

Making the organization admin email verification code sent valid for 15 minutes. It was 90 seconds, not enough for people to get the email and use the code successfully.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

When creating an org, the step to verify your email will send you an email with a code. That code should be valid for 15 minutes.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
