### PR TITLE
fix: Dynamic Group Links on vercel

### DIFF
--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { LocationObject } from "@calcom/app-store/locations";
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
+import { getUsernameList } from "@calcom/lib/defaultEvents";
 import hasKeyInMetadata from "@calcom/lib/hasKeyInMetadata";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
@@ -238,7 +239,6 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 
   const { type: typeParam, user: userParam } = paramsSchema.parse(context.params);
   const usernameList = getUsernameList(userParam);
-  console.log("getDynamicGroupPageProps", usernameList, userParam);
   const length = parseInt(typeParam);
   const eventType = getDefaultEvent("" + length);
 
@@ -360,9 +360,8 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { user: userParam } = paramsSchema.parse(context.params);
-  console.log("gSSP,[user]/[type]", context.params);
   // dynamic groups are not generated at build time, but otherwise are probably cached until infinity.
-  const isDynamicGroup = userParam.includes("+");
+  const isDynamicGroup = getUsernameList(userParam).length > 1;
   if (isDynamicGroup) {
     return await getDynamicGroupPageProps(context);
   } else {

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -238,6 +238,7 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 
   const { type: typeParam, user: userParam } = paramsSchema.parse(context.params);
   const usernameList = getUsernameList(userParam);
+  console.log("getDynamicGroupPageProps", usernameList, userParam);
   const length = parseInt(typeParam);
   const eventType = getDefaultEvent("" + length);
 
@@ -359,6 +360,7 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { user: userParam } = paramsSchema.parse(context.params);
+  console.log("gSSP,[user]/[type]", context.params);
   // dynamic groups are not generated at build time, but otherwise are probably cached until infinity.
   const isDynamicGroup = userParam.includes("+");
   if (isDynamicGroup) {

--- a/apps/web/pages/[user]/[type].tsx
+++ b/apps/web/pages/[user]/[type].tsx
@@ -236,7 +236,7 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 
   const { getAppFromSlug } = await import("@calcom/app-store/utils");
 
-  const { type: typeParam, user: userParam } = paramsSchema.parse(context.query);
+  const { type: typeParam, user: userParam } = paramsSchema.parse(context.params);
   const usernameList = getUsernameList(userParam);
   const length = parseInt(typeParam);
   const eventType = getDefaultEvent("" + length);
@@ -358,7 +358,7 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const { user: userParam } = paramsSchema.parse(context.query);
+  const { user: userParam } = paramsSchema.parse(context.params);
   // dynamic groups are not generated at build time, but otherwise are probably cached until infinity.
   const isDynamicGroup = userParam.includes("+");
   if (isDynamicGroup) {

--- a/apps/web/pages/new-booker/[user]/[type].tsx
+++ b/apps/web/pages/new-booker/[user]/[type].tsx
@@ -154,7 +154,7 @@ const paramsSchema = z.object({ type: z.string(), user: z.string() });
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const { user } = paramsSchema.parse(context.params);
-  const isDynamicGroup = user.includes("+");
+  const isDynamicGroup = getUsernameList(user).length > 1;
 
   return isDynamicGroup ? await getDynamicGroupPageProps(context) : await getUserPageProps(context);
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9575
Test on https://web-staging-msw9zb5uo-cal-staging.vercel.app/free+pro/30?duration=30
On local free+pro is available as 'free+pro' in gSSP but on Vercel it sometimes becomes
'free pro' because + is a very confusing thing in URL. Sometimes it's  available as 'free%20pro' and we are expecting a + always.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Go to /free+pro/30. Shouldn't be 404

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
