### PR TITLE
fix: Configuring totp code when verifying too

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
@@ -24,6 +24,7 @@ export const verifyCodeHandler = async ({ ctx, input }: VerifyCodeOptions) => {
     .update(email + process.env.CALENDSO_ENCRYPTION_KEY)
     .digest("hex");
 
+  totp.options = { step: 900 };
   const isValidToken = totp.check(code, secret);
 
   if (!isValidToken) throw new TRPCError({ code: "BAD_REQUEST", message: "invalid_code" });


### PR DESCRIPTION
## What does this PR do?

Org admin email verification code was set up to be 15 min only when sent, now it is set up to behave the same when verifying...

<img width="300" src="https://github.com/calcom/cal.com/assets/467258/1b0517f9-da14-4c8e-8302-0e64f0eec53d" />

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Same as #9574 

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
