### PR TITLE
fix: Possible conditional hook usage issue in SetupAvailability.tsx

### DIFF
--- a/apps/web/components/getting-started/steps-views/SetupAvailability.tsx
+++ b/apps/web/components/getting-started/steps-views/SetupAvailability.tsx
@@ -22,21 +22,20 @@ const SetupAvailability = (props: ISetupAvailabilityProps) => {
   const { nextStep } = props;
 
   const router = useRouter();
-  let queryAvailability;
-  if (defaultScheduleId) {
-    queryAvailability = trpc.viewer.availability.schedule.get.useQuery(
-      { scheduleId: defaultScheduleId },
-      {
-        enabled: router.isReady,
-      }
-    );
+  
+  queryAvailability = trpc.viewer.availability.schedule.get.useQuery(
+  { scheduleId: defaultScheduleId },
+  {
+    enabled: router.isReady,
   }
-
+  );
+  
   const availabilityForm = useForm({
-    defaultValues: {
-      schedule: queryAvailability?.data?.availability || DEFAULT_SCHEDULE,
-    },
+  defaultValues: {
+    schedule: queryAvailability?.data?.availability || DEFAULT_SCHEDULE,
+  },
   });
+
 
   const mutationOptions = {
     onError: (error: TRPCClientErrorLike<AppRouter>) => {


### PR DESCRIPTION
## What does this PR do?

Error while testing the user onboarding locally. Can be replicated by creating a new user.
Removed the conditional assignment, the queryAvailability hook will always be used, ensuring that the availability data is consistently fetched and assigned to the availabilityForm.

Fixes #9539
Befor :
![image](https://github.com/calcom/cal.com/assets/93502358/2e502a93-0e11-4f82-b5bd-12302e3e295c)

After:
![image](https://github.com/calcom/cal.com/assets/93502358/5bdd243a-1fc3-4f73-ba05-e3f2f703f6ee)

Fixes # 9539
## Type of change


- Bug fix 

## How should this be tested?
Error while testing the user onboarding locally. Can be replicated by creating a new user. Removed the conditional assignment, the queryAvailability hook will always be used, ensuring that the availability data is consistently fetched and assigned to the availabilityForm.

