### PR TITLE
refactor: translated request_password_reset in dutch

### DIFF
--- a/apps/web/public/static/locales/nl/common.json
+++ b/apps/web/public/static/locales/nl/common.json
@@ -222,7 +222,7 @@
   "sign_in": "Log in",
   "go_back_login": "Ga terug naar de inlogpagina",
   "error_during_login": "Er is een fout opgetreden tijdens het inloggen. Ga terug naar de inlogpagina en probeer het opnieuw.",
-  "request_password_reset": "E-mail voor opnieuw instellen van wachtwoord versturen",
+  "request_password_reset": "Verstuur wachtwoord herstel e-mail",
   "send_invite": "Uitnodiging versturen",
   "forgot_password": "Wachtwoord vergeten?",
   "forgot": "Vergeten?",


### PR DESCRIPTION
## What does this PR do?

Changed translation of dutch "Forgotten password" button text

Before:
![image](https://github.com/calcom/cal.com/assets/63718527/d828cab6-79dc-470a-b499-b856733da7ae)
After:
<img width="520" alt="Screenshot 2023-06-17 at 23 31 06" src="https://github.com/calcom/cal.com/assets/63718527/dd13af1c-5592-4d2b-9c04-4a48f96939d6">

Fixes #9547 

## Type of change
- Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.