### PR TITLE
chore: remove enable_new_call_ui prop

### DIFF
--- a/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
@@ -30,7 +30,6 @@ const dailyReturnTypeSchema = z.object({
     enable_chat: z.boolean(),
     enable_knocking: z.boolean(),
     enable_prejoin_ui: z.boolean(),
-    enable_new_call_ui: z.boolean(),
   }),
 });
 
@@ -123,7 +122,6 @@ const DailyVideoApiAdapter = (): VideoApiAdapter => {
       return {
         privacy: "public",
         properties: {
-          enable_new_call_ui: true,
           enable_prejoin_ui: true,
           enable_knocking: true,
           enable_screenshare: true,
@@ -136,7 +134,6 @@ const DailyVideoApiAdapter = (): VideoApiAdapter => {
     return {
       privacy: "public",
       properties: {
-        enable_new_call_ui: true,
         enable_prejoin_ui: true,
         enable_knocking: true,
         enable_screenshare: true,


### PR DESCRIPTION
## What does this PR do?


Fixes # (issue)
- enable_new_call_ui is not required to be passed now
More info:- https://calcominc.slack.com/archives/C02EQ5KP630/p1685464804851579

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)
