### PR TITLE
fix: Push mini calendar down in week / column view

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -144,7 +144,7 @@ const BookerComponent = ({
               )}>
               <BookerSection
                 area="meta"
-                className="max-w-screen flex h-full w-full flex-col md:w-[var(--booker-meta-width)]">
+                className="max-w-screen flex w-full flex-col md:w-[var(--booker-meta-width)]">
                 <EventMeta />
                 {layout !== BookerLayouts.MONTH_VIEW &&
                   !(layout === "mobile" && bookerState === "booking") && (


### PR DESCRIPTION
## What does this PR do?

Removed full height which incorrectly limited height in booker sidebar. Tested in Chrome, FF and Safari.

### Before

![image](https://github.com/calcom/cal.com/assets/2969573/2a7efaa0-de28-41cb-9c5c-c3e029f6ed4e)

### After

![CleanShot 2023-06-19 at 14 55 14@2x](https://github.com/calcom/cal.com/assets/2969573/31920054-20b9-4b42-9840-091ab675190c)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Ensure mini calendar in weekview / column view is pushed down. 
- [ ] Ensure calendar looks okay on mobile too
