### PR TITLE
fix: embed booking 404

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -186,7 +186,7 @@ const nextConfig = {
     // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
     // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages
     // It would also not match /free/30min/embed because we are ensuring just two slashes
-    const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type((?!book))`;
+    const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type`;
 
     let rewrites = [
       {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -186,6 +186,7 @@ const nextConfig = {
     // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
     // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages
     // It would also not match /free/30min/embed because we are ensuring just two slashes
+    // const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type((?!book))`;
     const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type`;
 
     let rewrites = [

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -186,7 +186,7 @@ const nextConfig = {
     // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
     // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages
     // It would also not match /free/30min/embed because we are ensuring just two slashes
-    const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type`;
+    const userTypeRouteRegExp = `/:user((?!${pages.join("|")})[^/]*)/:type((?!book))`;
 
     let rewrites = [
       {


### PR DESCRIPTION
## What does this PR do?

As reported on Threads. Fixes the last booking page error that was happening on embeds that don't use the new booker yet.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Locally: `http://localhost:3000/pro/book?embed=&embedType=inline&type=3&duration=30&date=2023-06-23T01%3A00%3A00-07%3A00&slug=30min&timeFormat=HH%3Amm&count=`
- [ ] Locally it should return 404 without this PR fix
- [ ] It should display the book page normally after the fix applied.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
