### PR TITLE
fix: Get brand colors from DB for owner, so it's reflected in booker

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -71,6 +71,8 @@ const publicEventSelect = Prisma.validator<Prisma.EventTypeSelect>()({
       name: true,
       theme: true,
       metadata: true,
+      brandColor: true,
+      darkBrandColor: true,
     },
   },
   hidden: true,


### PR DESCRIPTION
## What does this PR do?

Brand colors weren't pulled from DB for owner, so it wasn't reflected in booker. This PR fixes that. 

![CleanShot 2023-06-21 at 10 02 39@2x](https://github.com/calcom/cal.com/assets/2969573/01165ef4-e01b-4ff9-8bb4-87a4198204ba)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Change the brand color in the appearance settings and note it being reflected in the booker.
