### PR TITLE
fix: overflow + zindex of cal icon

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -117,7 +117,7 @@ const BookerComponent = ({
     <>
       <div
         className={classNames(
-          "text-default flex min-h-full w-full flex-col items-center overflow-clip",
+          "text-default flex min-h-full w-full flex-col items-center",
           layout === BookerLayouts.MONTH_VIEW ? "overflow-visible" : "overflow-clip"
         )}>
         <div

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -115,7 +115,11 @@ const BookerComponent = ({
 
   return (
     <>
-      <div className="text-default flex min-h-full w-full flex-col items-center overflow-clip">
+      <div
+        className={classNames(
+          "text-default flex min-h-full w-full flex-col items-center overflow-clip",
+          layout === BookerLayouts.MONTH_VIEW ? "overflow-visible" : "overflow-clip"
+        )}>
         <div
           ref={animationScope}
           className={classNames(
@@ -218,7 +222,7 @@ const BookerComponent = ({
         <m.span
           key="logo"
           className={classNames(
-            "mt-auto mb-6 pt-6 [&_img]:h-[15px]",
+            "relative -z-50 mt-auto mb-6 pt-6 [&_img]:h-[15px]",
             layout === BookerLayouts.MONTH_VIEW ? "block" : "hidden"
           )}>
           {!hideBranding ? <PoweredBy logoOnly /> : null}


### PR DESCRIPTION
PR fixes larger select items content being clipped 
Fixes Cal.com logo being visible over the dropdown 

Before:
![chrome-capture-2023-5-22](https://github.com/calcom/cal.com/assets/55134778/17475c8c-99f7-48aa-afcb-4adcc83341f9)

After:
<img width="1027" alt="CleanShot 2023-06-22 at 09 05 07@2x" src="https://github.com/calcom/cal.com/assets/55134778/5e50319f-6d8d-4e5d-a2bc-c96595abdfd4">
