### PR TITLE
chore: Fix settings layout + org headings

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -100,14 +100,6 @@ const tabs: VerticalTabItemProps[] = [
         name: "billing",
         href: "/settings/organizations/billing",
       },
-      {
-        name: "saml_config",
-        href: "/settings/organizations/sso",
-      },
-      {
-        name: "developer",
-        href: "/settings/organizations/developer",
-      },
     ],
   },
   {
@@ -302,7 +294,7 @@ const SettingsSidebarContainer = ({
                               }),
                             ])
                           }>
-                          <CollapsibleTrigger>
+                          <CollapsibleTrigger asChild>
                             <div
                               className="hover:bg-subtle [&[aria-current='page']]:bg-emphasis [&[aria-current='page']]:text-emphasis text-default flex h-9 w-full flex-row items-center rounded-md px-3 py-[10px]  text-left text-sm font-medium leading-none"
                               onClick={() =>


### PR DESCRIPTION
Fixes: CAL-2019

Makes team collapsable `asChild` and makes it full width
<img width="242" alt="CleanShot 2023-06-22 at 10 40 20@2x" src="https://github.com/calcom/cal.com/assets/55134778/e842b4bd-90e4-450a-8981-ce2e77db1fba">

Removes redundant nav items
<img width="227" alt="CleanShot 2023-06-22 at 10 40 27@2x" src="https://github.com/calcom/cal.com/assets/55134778/b2f4d996-a591-4221-b356-5d1962325a9f">
