### PR TITLE
feat: remove member from hosts on removal

### DIFF
--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -27,7 +27,7 @@ import {
   showToast,
   Tooltip,
 } from "@calcom/ui";
-import { ExternalLink, MoreHorizontal, Edit2, Lock, Trash } from "@calcom/ui/components/icon";
+import { ExternalLink, MoreHorizontal, Edit2, Lock, UserX } from "@calcom/ui/components/icon";
 
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamAvailabilityModal from "./TeamAvailabilityModal";
@@ -212,8 +212,8 @@ export default function MemberListItem(props: Props) {
                         type="button"
                         onClick={() => setShowDeleteModal(true)}
                         color="destructive"
-                        StartIcon={Trash}>
-                        {t("delete")}
+                        StartIcon={UserX}>
+                        {t("remove")}
                       </DropdownItem>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
@@ -246,8 +246,8 @@ export default function MemberListItem(props: Props) {
                           type="button"
                           color="destructive"
                           onClick={() => setShowDeleteModal(true)}
-                          StartIcon={Trash}>
-                          {t("delete")}
+                          StartIcon={UserX}>
+                          {t("remove")}
                         </DropdownItem>
                       </DropdownMenuItem>
                     </>

--- a/packages/prisma/migrations/20230622164946_remove_host_remnants_from_old_team_members/migration.sql
+++ b/packages/prisma/migrations/20230622164946_remove_host_remnants_from_old_team_members/migration.sql
@@ -1,0 +1,16 @@
+
+DELETE FROM "Host" 
+WHERE "Host"."userId" IN ( 
+    SELECT "Host"."userId" FROM "Host" 
+    LEFT JOIN "Membership" ON "Membership"."userId" = "Host"."userId" 
+    INNER JOIN "EventType" ON "EventType"."id" = "Host"."eventTypeId" 
+    WHERE "EventType"."teamId" IS NOT NULL 
+    AND "Membership"."userId" IS NULL
+)
+AND "Host"."eventTypeId" IN ( 
+    SELECT "Host"."eventTypeId" FROM "Host" 
+    LEFT JOIN "Membership" ON "Membership"."userId" = "Host"."userId" 
+    INNER JOIN "EventType" ON "EventType"."id" = "Host"."eventTypeId" 
+    WHERE "EventType"."teamId" IS NOT NULL 
+    AND "Membership"."userId" IS NULL
+);


### PR DESCRIPTION
## What does this PR do?

* Fixes #9720
* UI tweak, different dropdown item icon/text for removing a team member

### How to test this:
#### Reproduction
Before checking out this PR, use the seeded-team and add a host to "Collective".

- [ ] Then go in the seeded-team, and remove the member you just assigned as a host from the event
- [ ] Go back to the event "Collective" and attempt to edit, you should see a "FORBIDDEN" toast

Now checkout this PR

- [ ] You should still see "FORBIDDEN" on the "Collective" event type. Old events are still affected.
- [ ] If you now add a host to "Round Robin"
- [ ] Do the same as before and remove the member you just assigned from the team.
- [ ] Go back to the event "Round Robin" and attempt to edit - this should work

Apply the migration

```bash
cd packages/prisma && yarn prisma migrate dev && ../..
```
- [ ] After applying - Go back to the event "Collective" and attempt to edit, this should now also work.