### PR TITLE
test: Remove mockdate and replate with vitest system time

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -162,7 +162,6 @@
     "copy-webpack-plugin": "^11.0.0",
     "detect-port": "^1.3.0",
     "env-cmd": "^10.1.0",
-    "mockdate": "^3.0.5",
     "module-alias": "^2.2.2",
     "msw": "^0.42.3",
     "postcss": "^8.4.18",

--- a/apps/web/test/lib/getAggregateWorkingHours.test.ts
+++ b/apps/web/test/lib/getAggregateWorkingHours.test.ts
@@ -1,9 +1,11 @@
-import MockDate from "mockdate";
-import { expect, it } from "vitest";
+import { expect, it ,beforeAll,vi} from "vitest";
 
 import { getAggregateWorkingHours } from "@calcom/core/getAggregateWorkingHours";
 
-MockDate.set("2021-06-20T11:59:59Z");
+
+beforeAll(()=>{
+  vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
+})
 
 const HAWAII_AND_NEWYORK_TEAM = [
   {

--- a/apps/web/test/lib/getAggregateWorkingHours.test.ts
+++ b/apps/web/test/lib/getAggregateWorkingHours.test.ts
@@ -1,9 +1,9 @@
-import { expect, it ,beforeAll,vi} from "vitest";
+import { expect, it, beforeAll, vi } from "vitest";
 
 import { getAggregateWorkingHours } from "@calcom/core/getAggregateWorkingHours";
 
 
-beforeAll(()=>{
+beforeAll(() => {
   vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
 })
 

--- a/apps/web/test/lib/getAvailabilityFromSchedule.test.ts
+++ b/apps/web/test/lib/getAvailabilityFromSchedule.test.ts
@@ -1,11 +1,13 @@
 import type { Availability } from "@prisma/client";
-import MockDate from "mockdate";
-import { expect, it } from "vitest";
+import { expect, it,beforeAll,vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { getAvailabilityFromSchedule } from "@calcom/lib/availability";
 
-MockDate.set("2021-06-20T11:59:59Z");
+
+beforeAll(()=>{
+  vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
+})
 
 //parse "hh:mm-hh:mm" into <Availability> object
 const parseWorkingHours = (workingHours: string) => {

--- a/apps/web/test/lib/getAvailabilityFromSchedule.test.ts
+++ b/apps/web/test/lib/getAvailabilityFromSchedule.test.ts
@@ -1,11 +1,11 @@
 import type { Availability } from "@prisma/client";
-import { expect, it,beforeAll,vi } from "vitest";
+import { expect, it, beforeAll, vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { getAvailabilityFromSchedule } from "@calcom/lib/availability";
 
 
-beforeAll(()=>{
+beforeAll(() => {
   vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
 })
 

--- a/apps/web/test/lib/getWorkingHours.test.ts
+++ b/apps/web/test/lib/getWorkingHours.test.ts
@@ -1,9 +1,9 @@
-import { expect, it,vi,beforeAll } from "vitest";
+import { expect, it, vi, beforeAll } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { getWorkingHours } from "@calcom/lib/availability";
 
-beforeAll(()=>{
+beforeAll(() => {
   vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
 })
 

--- a/apps/web/test/lib/getWorkingHours.test.ts
+++ b/apps/web/test/lib/getWorkingHours.test.ts
@@ -1,10 +1,11 @@
-import MockDate from "mockdate";
-import { expect, it } from "vitest";
+import { expect, it,vi,beforeAll } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { getWorkingHours } from "@calcom/lib/availability";
 
-MockDate.set("2021-06-20T11:59:59Z");
+beforeAll(()=>{
+  vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
+})
 
 it("correctly translates Availability (UTC+0) to UTC workingHours", async () => {
   expect(

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it,beforeAll,vi } from "vitest";
+import { describe, expect, it, beforeAll, vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { MINUTES_DAY_END, MINUTES_DAY_START } from "@calcom/lib/availability";
 import getSlots from "@calcom/lib/slots";
 
 
-beforeAll(()=>{
+beforeAll(() => {
   vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
 })
 

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -1,11 +1,13 @@
-import MockDate from "mockdate";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it,beforeAll,vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { MINUTES_DAY_END, MINUTES_DAY_START } from "@calcom/lib/availability";
 import getSlots from "@calcom/lib/slots";
 
-MockDate.set("2021-06-20T11:59:59Z");
+
+beforeAll(()=>{
+  vi.setSystemTime(new Date("2021-06-20T11:59:59Z"));
+})
 
 describe("Tests the slot logic", () => {
   it("can fit 24 hourly slots for an empty day", async () => {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -20,7 +20,6 @@
     "zustand": "^4.3.2"
   },
   "devDependencies": {
-    "@testing-library/react-hooks": "^8.0.1",
-    "mockdate": "^3.0.5"
+    "@testing-library/react-hooks": "^8.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,7 +4186,6 @@ __metadata:
     dompurify: ^2.4.1
     framer-motion: ^10.12.8
     lexical: ^0.9.0
-    mockdate: ^3.0.5
     react-select: ^5.7.0
     react-sticky-box: ^2.0.4
     zustand: ^4.3.2
@@ -4788,7 +4787,6 @@ __metadata:
     memory-cache: ^0.2.0
     micro: ^10.0.1
     mime-types: ^2.1.35
-    mockdate: ^3.0.5
     module-alias: ^2.2.2
     msw: ^0.42.3
     next: ^13.4.6
@@ -26474,13 +26472,6 @@ __metadata:
   version: 4.14.0
   resolution: "mock-fs@npm:4.14.0"
   checksum: dccd976a8d753e19d3c7602ea422d1f7137def3c1128c177e1f5500fe8c50ec15fe0937cfc3a15c4577fe7adb9a37628b92da9294d13d90f08be4b669b0fca76
-  languageName: node
-  linkType: hard
-
-"mockdate@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "mockdate@npm:3.0.5"
-  checksum: 72b66786d9e072379693f80bf9fb82eb5153c9741030a4294184e3ccaf952d0713fae8966f77780580cf902f8ec7ccc95577b0ad47980d255e2ffb71fc7ca49c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removing mockdate as it seemed like a pretty useless dependancy 

Implements vitests version of mocking system time https://vitest.dev/api/vi.html#vi-setsystemtime

