### PR TITLE
fix: add UAE to list of non alphanumeric sender id support

### DIFF
--- a/packages/features/ee/workflows/lib/alphanumericSenderIdSupport.ts
+++ b/packages/features/ee/workflows/lib/alphanumericSenderIdSupport.ts
@@ -85,4 +85,5 @@ const noAlphanumericSenderIdSupport = [
   "+84",
   "+260",
   "+61",
+  "+971",
 ];


### PR DESCRIPTION
## What does this PR do?

UAE does not support non-registered alphanumeric senders ids anymore. It is added to `noAlphanumericSenderIdSupport`

Twilio email: 
<img width="669" alt="Screenshot 2023-06-23 at 10 32 10" src="https://github.com/calcom/cal.com/assets/30310907/d9ca96d5-3cfc-442f-a13b-8f0f4f403cf1">

Created an issue to automate these updates: https://github.com/calcom/cal.com/issues/9751