### PR TITLE
chore: Adding team and org registration suggestion in 404 error

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -187,7 +187,7 @@
   "guests": "Guests",
   "guest": "Guest",
   "web_conferencing_details_to_follow": "Web conferencing details to follow in the confirmation email.",
-  "the_username": "The username",
+  "404_the_user": "The username",
   "username": "Username",
   "is_still_available": "is still available.",
   "documentation": "Documentation",
@@ -198,7 +198,7 @@
   "blog_description": "Read our latest news and articles",
   "join_our_community": "Join our community",
   "join_our_slack": "Join our Slack",
-  "claim_username_and_schedule_events": "Claim your username and schedule events",
+  "404_claim_entity_user": "Claim your username and schedule events",
   "popular_pages": "Popular pages",
   "register_now": "Register now",
   "register": "Register",
@@ -1902,5 +1902,9 @@
   "org_name": "Organization name",
   "org_url": "Organization URL",
   "copy_link_org": "Copy link to organization",
+  "404_the_org": "The organization",
+  "404_the_team": "The team",
+  "404_claim_entity_org": "Claim your subdomain for your organization",
+  "404_claim_entity_team": "Claim this team and start managing schedules collectively",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/ee/organizations/components/CreateANewOrganizationForm.tsx
+++ b/packages/features/ee/organizations/components/CreateANewOrganizationForm.tsx
@@ -141,13 +141,18 @@ export const CreateANewOrganizationForm = () => {
   const telemetry = useTelemetry();
   const [serverErrorMessage, setServerErrorMessage] = useState<string | null>(null);
   const [showVerifyCode, setShowVerifyCode] = useState(false);
+  const { slug } = router.query;
 
   const newOrganizationFormMethods = useForm<{
     name: string;
     slug: string;
     adminEmail: string;
     adminUsername: string;
-  }>();
+  }>({
+    defaultValues: {
+      slug: `${slug}`,
+    },
+  });
   const watchAdminEmail = newOrganizationFormMethods.watch("adminEmail");
 
   const createOrganizationMutation = trpc.viewer.organizations.create.useMutation({
@@ -216,7 +221,9 @@ export const CreateANewOrganizationForm = () => {
                     const domain = extractDomainFromEmail(e?.target.value);
                     newOrganizationFormMethods.setValue("adminEmail", e?.target.value);
                     newOrganizationFormMethods.setValue("adminUsername", e?.target.value.split("@")[0]);
-                    newOrganizationFormMethods.setValue("slug", domain);
+                    if (newOrganizationFormMethods.getValues("slug") === "") {
+                      newOrganizationFormMethods.setValue("slug", domain);
+                    }
                     newOrganizationFormMethods.setValue(
                       "name",
                       domain.charAt(0).toUpperCase() + domain.slice(1)

--- a/packages/features/ee/teams/components/CreateANewTeamForm.tsx
+++ b/packages/features/ee/teams/components/CreateANewTeamForm.tsx
@@ -15,21 +15,27 @@ import { ArrowRight } from "@calcom/ui/components/icon";
 import type { NewTeamFormValues } from "../lib/types";
 
 const querySchema = z.object({
-  returnTo: z.string(),
+  returnTo: z.string().optional(),
+  slug: z.string().optional(),
 });
 
 export const CreateANewTeamForm = () => {
   const { t } = useLocale();
   const router = useRouter();
   const telemetry = useTelemetry();
-  const returnToParsed = querySchema.safeParse(router.query);
+  const parsedQuery = querySchema.safeParse(router.query);
+  console.log({ parsedQuery });
   const [serverErrorMessage, setServerErrorMessage] = useState<string | null>(null);
 
   const returnToParam =
-    (returnToParsed.success ? getSafeRedirectUrl(returnToParsed.data.returnTo) : "/settings/teams") ||
+    (parsedQuery.success ? getSafeRedirectUrl(parsedQuery.data.returnTo) : "/settings/teams") ||
     "/settings/teams";
 
-  const newTeamFormMethods = useForm<NewTeamFormValues>();
+  const newTeamFormMethods = useForm<NewTeamFormValues>({
+    defaultValues: {
+      slug: parsedQuery.success ? parsedQuery.data.slug : "",
+    },
+  });
 
   const createTeamMutation = trpc.viewer.teams.create.useMutation({
     onSuccess: (data) => {


### PR DESCRIPTION
## What does this PR do?

 - Adding team and org registration suggestion in 404 error. 
 - A new "Enterprise" section of popular pages is added when the 404 is about an org.
 - Moved "POPULAR PAGES" to the bottom of the "register" box 

<kbd><img width="500" src="https://github.com/calcom/cal.com/assets/467258/057a7bc8-1e78-4c00-bf9c-31b1c0a05a7d" /></kbd>

<kbd><img width="500" src="https://github.com/calcom/cal.com/assets/467258/eecd2beb-2751-4abf-b319-7a831f30cdab" /></kbd>

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Type down an inexistent organization subdomain (if testing locally, be sure to have in in your hosts file) or an inexistent team URL, you will be getting the 404 with the respective registration suggestions as shown above. 

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.