### PR TITLE
fix: theme in API key expiration time calender

### DIFF
--- a/packages/ui/components/form/datepicker/DatePicker.tsx
+++ b/packages/ui/components/form/datepicker/DatePicker.tsx
@@ -21,7 +21,7 @@ const DatePicker = ({ minDate, disabled, date, onDatesChange, className }: Props
         "focus:ring-primary-500 focus:border-primary-500 border-default rounded-md border p-1 pl-2 shadow-sm sm:text-sm",
         className
       )}
-      calendarClassName="rounded-md"
+      calendarClassName="rounded-md dark:text-black"
       clearIcon={null}
       calendarIcon={<Calendar className="text-subtle h-5 w-5 rounded-md" />}
       value={date}


### PR DESCRIPTION
## What does this PR do?

This Pull Request fixes text colour in API key expiration time calendar in dark theme and matches it with the theme of the app

Fixes  #9670

Before:
![screenshot-github com-2023 06 24-23_42_02](https://github.com/calcom/cal.com/assets/104218999/72bfbebc-ecce-4f2c-9451-4481aceeca78)

After:
[<!-- Please  #provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->]([](https://www.loom.com/share/55e24b047d4547b788ef3d06c8038123))

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Click on settings on bottom left
Select API keys from side bar
Try to choose expiration time from calendar in dark theme and you should be able to see the dates clearly (before fix the dates in weekdays are transparent)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
