### PR TITLE
fix: Ability to add pending members to event-types

### DIFF
--- a/apps/web/components/eventtype/EventTeamTab.tsx
+++ b/apps/web/components/eventtype/EventTeamTab.tsx
@@ -43,7 +43,7 @@ export const mapMemberToChildrenOption = (
       eventTypeSlugs: member.eventTypes ?? [],
     },
     value: `${member.id ?? ""}`,
-    label: member.name ?? "",
+    label: member.name || member.email || "",
   };
 };
 

--- a/apps/web/components/eventtype/EventTeamTab.tsx
+++ b/apps/web/components/eventtype/EventTeamTab.tsx
@@ -21,7 +21,7 @@ interface IUserToValue {
 
 const mapUserToValue = ({ id, name, username, email }: IUserToValue) => ({
   value: `${id || ""}`,
-  label: `${name || ""}`,
+  label: `${name || email || ""}`,
   avatar: `${WEBAPP_URL}/${username}/avatar.png`,
   email,
 });
@@ -291,6 +291,7 @@ export const EventTeamTab = ({
       // description: t("round_robin_description"),
     },
   ];
+  console.log(teamMembers);
   const teamMembersOptions = teamMembers.map(mapUserToValue);
   const childrenEventTypeOptions = teamMembers.map((member) => {
     return mapMemberToChildrenOption(member, eventType.slug);

--- a/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
+++ b/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
@@ -62,13 +62,13 @@ export const ChildrenEventTypeSelect = ({
                 size="mdLg"
                 className="overflow-visible"
                 imageSrc={`${CAL_URL}/${children.owner.username}/avatar.png`}
-                alt={children.owner.name || ""}
+                alt={children.owner.name || children.owner.email || ""}
               />
               <div className="flex w-full flex-row justify-between">
                 <div className="flex flex-col">
                   <span className="text text-sm font-semibold leading-none">
-                    {children.owner.name}
-                    <div className="flex flex-row gap-1">
+                    {children.owner.name || children.owner.email}
+                    <div className="mt-1 flex flex-row gap-1">
                       {children.owner.membership === MembershipRole.OWNER ? (
                         <Badge variant="gray">{t("owner")}</Badge>
                       ) : (
@@ -77,9 +77,11 @@ export const ChildrenEventTypeSelect = ({
                       {children.hidden && <Badge variant="gray">{t("hidden")}</Badge>}
                     </div>
                   </span>
-                  <small className="text-subtle font-normal leading-normal">
-                    {`/${children.owner.username}/${children.slug}`}
-                  </small>
+                  {children.owner.username && (
+                    <small className="text-subtle font-normal leading-normal">
+                      {`/${children.owner.username}/${children.slug}`}
+                    </small>
+                  )}
                 </div>
                 <div className="flex flex-row items-center gap-2">
                   <Tooltip content={t("show_eventtype_on_profile")}>
@@ -97,7 +99,7 @@ export const ChildrenEventTypeSelect = ({
                     </div>
                   </Tooltip>
                   <ButtonGroup combined>
-                    {children.created && (
+                    {children.created && children.owner.username && (
                       <Tooltip content={t("preview")}>
                         <Button
                           color="secondary"

--- a/packages/lib/getEventTypeById.ts
+++ b/packages/lib/getEventTypeById.ts
@@ -114,9 +114,6 @@ export default async function getEventTypeById({
           id: true,
           slug: true,
           members: {
-            where: {
-              accepted: true,
-            },
             select: {
               role: true,
               user: {

--- a/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
@@ -176,22 +176,6 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   }
 
   if (teamId && hosts) {
-    // check if all hosts can be assigned (memberships that have accepted invite)
-    const memberships =
-      (await ctx.prisma.membership.findMany({
-        where: {
-          teamId,
-          accepted: true,
-        },
-      })) || [];
-    const teamMemberIds = memberships.map((membership) => membership.userId);
-    // guard against missing IDs, this may mean a member has just been removed
-    // or this request was forged.
-    if (!hosts.every((host) => teamMemberIds.includes(host.userId))) {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-      });
-    }
     data.hosts = {
       deleteMany: {},
       create: hosts.map((host) => ({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This Pull Request add the ability to invite pending member to round robin, collective or managed event types

Fixes [#9745](https://github.com/calcom/cal.com/issues/9745)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->
- Chore (refactoring code, technical debt, workflow improvements)

## After PR
<img width="1512" alt="Screenshot 2023-06-25 at 4 04 12 PM" src="https://github.com/calcom/cal.com/assets/14893769/a3267792-e31d-4529-96a1-ecf2f3ea1ea0">

I removed the user url under Role and Preview link because user don't have a slug yet
<img width="1509" alt="Screenshot 2023-06-25 at 4 04 48 PM" src="https://github.com/calcom/cal.com/assets/14893769/89b061b8-069d-4db4-8992-89bc468ed7b9">

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
