### PR TITLE
chore: Updated staleness check to start with old content

### DIFF
--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
+          ascending: true
           days-before-issue-stale: 60
           days-before-issue-close: -1
           days-before-pr-stale: 14


### PR DESCRIPTION
## What does this PR do?

Updates our staleness check to start with oldest content first. We are currently maxing out the number of operations to run and older content is not being check for staleness. The default value in this action is [ascending: false](https://github.com/calcom/cal.com/blob/main/packages/lib/availability.ts). 

Will look into increasing the operations-per-run value after seeing the results of this change.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)
