### PR TITLE
test: Hotfix/Orgs rewrite causing 404 with 3 or more dots domains

### DIFF
--- a/apps/web/getSubdomainRegExp.js
+++ b/apps/web/getSubdomainRegExp.js
@@ -1,0 +1,15 @@
+const getDefaultSubdomain = (url) => {
+  if (!url.startsWith("http:") && !url.startsWith("https:")) {
+    // Make it a valid URL. Mabe we can simply return null and opt-out from orgs support till the use a URL scheme.
+    url = `https://${url}`;
+  }
+  const _url = new URL(url);
+  const regex = new RegExp(/^([a-z]+\:\/{2})?((?<subdomain>[\w-.]+)\.[\w-]+\.\w+)$/);
+  //console.log(_url.hostname, _url.hostname.match(regex));
+  return _url.hostname.match(regex)?.groups?.subdomain || null;
+};
+exports.getSubdomainRegExp = (url) => {
+  const defaultSubdomain = getDefaultSubdomain(url);
+  const subdomain = defaultSubdomain ? `(?!${defaultSubdomain})[^.]+` : "[^.]+";
+  return subdomain;
+};

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -186,7 +186,10 @@ const nextConfig = {
     return config;
   },
   async rewrites() {
-    const subdomain = getSubdomainRegExp(process.env.NEXT_PUBLIC_WEBAPP_URL);
+    const subdomainRegExp = getSubdomainRegExp(process.env.NEXT_PUBLIC_WEBAPP_URL);
+    // Important Note: Do update the RegExp in apps/web/test/lib/next-config.test.ts when changing it.
+    const orgPagesRouteRegExp = `^(?<orgSlug>${subdomainRegExp})\\..*`;
+
     const beforeFiles = [
       ...(process.env.ORGANIZATIONS_ENABLED
         ? [
@@ -194,7 +197,7 @@ const nextConfig = {
               has: [
                 {
                   type: "host",
-                  value: `^(?<orgSlug>${subdomain})\\..*`,
+                  value: orgPagesRouteRegExp,
                 },
               ],
               source: "/",
@@ -204,7 +207,7 @@ const nextConfig = {
               has: [
                 {
                   type: "host",
-                  value: `^(?<orgSlug>${subdomain})\\..*`,
+                  value: orgPagesRouteRegExp,
                 },
               ],
               source: `/:user((?!${pages.join("|")}|_next|public)[a-zA-Z0-9\-_]+)`,
@@ -214,7 +217,7 @@ const nextConfig = {
               has: [
                 {
                   type: "host",
-                  value: `^(?<orgSlug>${subdomain}[^.]+)\\..*`,
+                  value: `^(?<orgSlug>${subdomainRegExp}[^.]+)\\..*`,
                 },
               ],
               source: `/:user((?!${pages.join("|")}|_next|public))/:path*`,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -5,6 +5,7 @@ const englishTranslation = require("./public/static/locales/en/common.json");
 const { withAxiom } = require("next-axiom");
 const { i18n } = require("./next-i18next.config");
 const { pages } = require("./pages");
+const { getSubdomainRegExp } = require("./getSubdomainRegExp");
 
 if (!process.env.NEXTAUTH_SECRET) throw new Error("Please set NEXTAUTH_SECRET");
 if (!process.env.CALENDSO_ENCRYPTION_KEY) throw new Error("Please set CALENDSO_ENCRYPTION_KEY");
@@ -70,14 +71,6 @@ const informAboutDuplicateTranslations = () => {
 };
 
 informAboutDuplicateTranslations();
-
-const getSubdomain = () => {
-  const _url = new URL(process.env.NEXT_PUBLIC_WEBAPP_URL);
-  const regex = new RegExp(/^([a-z]+\:\/{2})?((?<subdomain>[\w-]+)\.[\w-]+\.\w+)$/);
-  //console.log(_url.hostname, _url.hostname.match(regex));
-  return _url.hostname.match(regex)?.groups?.subdomain || null;
-};
-
 const plugins = [];
 if (process.env.ANALYZE === "true") {
   // only load dependency if env `ANALYZE` was set
@@ -193,9 +186,7 @@ const nextConfig = {
     return config;
   },
   async rewrites() {
-    const defaultSubdomain = getSubdomain();
-    const subdomain = defaultSubdomain ? `(?!${defaultSubdomain})[^.]+` : "[^.]+";
-
+    const subdomain = getSubdomainRegExp(process.env.NEXT_PUBLIC_WEBAPP_URL);
     const beforeFiles = [
       {
         has: [

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -188,36 +188,40 @@ const nextConfig = {
   async rewrites() {
     const subdomain = getSubdomainRegExp(process.env.NEXT_PUBLIC_WEBAPP_URL);
     const beforeFiles = [
-      {
-        has: [
-          {
-            type: "host",
-            value: `^(?<orgSlug>${subdomain})\\..*`,
-          },
-        ],
-        source: "/",
-        destination: "/team/:orgSlug",
-      },
-      {
-        has: [
-          {
-            type: "host",
-            value: `^(?<orgSlug>${subdomain})\\..*`,
-          },
-        ],
-        source: `/:user((?!${pages.join("|")}|_next|public)[a-zA-Z0-9\-_]+)`,
-        destination: "/org/:orgSlug/:user",
-      },
-      {
-        has: [
-          {
-            type: "host",
-            value: `^(?<orgSlug>${subdomain}[^.]+)\\..*`,
-          },
-        ],
-        source: `/:user((?!${pages.join("|")}|_next|public))/:path*`,
-        destination: "/:user/:path*",
-      },
+      ...(process.env.ORGANIZATIONS_ENABLED
+        ? [
+            {
+              has: [
+                {
+                  type: "host",
+                  value: `^(?<orgSlug>${subdomain})\\..*`,
+                },
+              ],
+              source: "/",
+              destination: "/team/:orgSlug",
+            },
+            {
+              has: [
+                {
+                  type: "host",
+                  value: `^(?<orgSlug>${subdomain})\\..*`,
+                },
+              ],
+              source: `/:user((?!${pages.join("|")}|_next|public)[a-zA-Z0-9\-_]+)`,
+              destination: "/org/:orgSlug/:user",
+            },
+            {
+              has: [
+                {
+                  type: "host",
+                  value: `^(?<orgSlug>${subdomain}[^.]+)\\..*`,
+                },
+              ],
+              source: `/:user((?!${pages.join("|")}|_next|public))/:path*`,
+              destination: "/:user/:path*",
+            },
+          ]
+        : []),
     ];
 
     let afterFiles = [

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -1,5 +1,6 @@
 
 import { it, expect, describe, beforeAll, afterAll } from "vitest";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { getSubdomainRegExp } = require("../../getSubdomainRegExp");
 let userTypeRouteRegExp: RegExp;
 let teamTypeRouteRegExp:RegExp;
@@ -159,8 +160,8 @@ describe('next.config.js - RegExp', ()=>{
 
 describe('next.config.js - Org Rewrite', ()=> {
   //^(?<orgSlug>${subdomainRegExp})\\..*
-  const pagesRewriteRegex = (subdomainRegExp)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
-  describe.only('SubDomain Retrieval from NEXT_PUBLIC_WEBAPP_URL', ()=>{
+  const pagesRewriteRegex = (subdomainRegExp:string)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
+  describe('SubDomain Retrieval from NEXT_PUBLIC_WEBAPP_URL', ()=>{
     it('https://app.cal.com', ()=>{
       const subdomainRegExp = getSubdomainRegExp('https://app.cal.com');
       expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -160,33 +160,33 @@ describe('next.config.js - RegExp', ()=>{
 
 describe('next.config.js - Org Rewrite', ()=> {
   // RegExp copied from next.config.js
-  const pagesRewriteRegex = (subdomainRegExp:string)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
+  const orgHostRegExp = (subdomainRegExp:string)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
   describe('SubDomain Retrieval from NEXT_PUBLIC_WEBAPP_URL', ()=>{
     it('https://app.cal.com', ()=>{
       const subdomainRegExp = getSubdomainRegExp('https://app.cal.com');
-      expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)
-      expect(pagesRewriteRegex(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
-      expect(pagesRewriteRegex(subdomainRegExp).exec('org.cal.com')?.groups?.orgSlug).toEqual('org')
+      expect(orgHostRegExp(subdomainRegExp).exec('app.cal.com')).toEqual(null)
+      expect(orgHostRegExp(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
+      expect(orgHostRegExp(subdomainRegExp).exec('org.cal.com')?.groups?.orgSlug).toEqual('org')
     })
 
     it('app.cal.com', ()=>{
       const subdomainRegExp = getSubdomainRegExp('app.cal.com');
-      expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)
-      expect(pagesRewriteRegex(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
+      expect(orgHostRegExp(subdomainRegExp).exec('app.cal.com')).toEqual(null)
+      expect(orgHostRegExp(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
     })
 
     it('https://calcom.app.company.com', ()=>{
       const subdomainRegExp = getSubdomainRegExp('https://calcom.app.company.com');
-      expect(pagesRewriteRegex(subdomainRegExp).exec('calcom.app.company.com')).toEqual(null)
-      expect(pagesRewriteRegex(subdomainRegExp).exec('acme.calcom.app.company.com')?.groups?.orgSlug).toEqual('acme')
+      expect(orgHostRegExp(subdomainRegExp).exec('calcom.app.company.com')).toEqual(null)
+      expect(orgHostRegExp(subdomainRegExp).exec('acme.calcom.app.company.com')?.groups?.orgSlug).toEqual('acme')
     })
 
     it('https://calcom.example.com', ()=>{
       const subdomainRegExp = getSubdomainRegExp('https://calcom.example.com');
-      expect(pagesRewriteRegex(subdomainRegExp).exec('calcom.example.com')).toEqual(null)
-      expect(pagesRewriteRegex(subdomainRegExp).exec('acme.calcom.example.com')?.groups?.orgSlug).toEqual('acme')
+      expect(orgHostRegExp(subdomainRegExp).exec('calcom.example.com')).toEqual(null)
+      expect(orgHostRegExp(subdomainRegExp).exec('acme.calcom.example.com')?.groups?.orgSlug).toEqual('acme')
       // The following also matches which causes anything other than the domain in NEXT_PUBLIC_WEBAPP_URL to give 404
-      expect(pagesRewriteRegex(subdomainRegExp).exec('some-other.company.com')?.groups?.orgSlug).toEqual('some-other')
+      expect(orgHostRegExp(subdomainRegExp).exec('some-other.company.com')?.groups?.orgSlug).toEqual('some-other')
     })
   })
 })

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -166,6 +166,7 @@ describe('next.config.js - Org Rewrite', ()=> {
       const subdomainRegExp = getSubdomainRegExp('https://app.cal.com');
       expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)
       expect(pagesRewriteRegex(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
+      expect(pagesRewriteRegex(subdomainRegExp).exec('org.cal.com')?.groups?.orgSlug).toEqual('org')
     })
 
     it('app.cal.com', ()=>{

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -159,7 +159,7 @@ describe('next.config.js - RegExp', ()=>{
 
 
 describe('next.config.js - Org Rewrite', ()=> {
-  //^(?<orgSlug>${subdomainRegExp})\\..*
+  // RegExp copied from next.config.js
   const pagesRewriteRegex = (subdomainRegExp:string)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
   describe('SubDomain Retrieval from NEXT_PUBLIC_WEBAPP_URL', ()=>{
     it('https://app.cal.com', ()=>{

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -1,5 +1,6 @@
 
 import { it, expect, describe, beforeAll, afterAll } from "vitest";
+const { getSubdomainRegExp } = require("../../getSubdomainRegExp");
 let userTypeRouteRegExp: RegExp;
 let teamTypeRouteRegExp:RegExp;
 let privateLinkRouteRegExp:RegExp
@@ -155,3 +156,35 @@ describe('next.config.js - RegExp', ()=>{
   })
 })
 
+
+describe('next.config.js - Org Rewrite', ()=> {
+  //^(?<orgSlug>${subdomainRegExp})\\..*
+  const pagesRewriteRegex = (subdomainRegExp)=> new RegExp(`^(?<orgSlug>${subdomainRegExp})\\..*`)
+  describe.only('SubDomain Retrieval from NEXT_PUBLIC_WEBAPP_URL', ()=>{
+    it('https://app.cal.com', ()=>{
+      const subdomainRegExp = getSubdomainRegExp('https://app.cal.com');
+      expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)
+      expect(pagesRewriteRegex(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
+    })
+
+    it('app.cal.com', ()=>{
+      const subdomainRegExp = getSubdomainRegExp('app.cal.com');
+      expect(pagesRewriteRegex(subdomainRegExp).exec('app.cal.com')).toEqual(null)
+      expect(pagesRewriteRegex(subdomainRegExp).exec('company.app.cal.com')?.groups?.orgSlug).toEqual('company')
+    })
+
+    it('https://calcom.app.company.com', ()=>{
+      const subdomainRegExp = getSubdomainRegExp('https://calcom.app.company.com');
+      expect(pagesRewriteRegex(subdomainRegExp).exec('calcom.app.company.com')).toEqual(null)
+      expect(pagesRewriteRegex(subdomainRegExp).exec('acme.calcom.app.company.com')?.groups?.orgSlug).toEqual('acme')
+    })
+
+    it('https://calcom.example.com', ()=>{
+      const subdomainRegExp = getSubdomainRegExp('https://calcom.example.com');
+      expect(pagesRewriteRegex(subdomainRegExp).exec('calcom.example.com')).toEqual(null)
+      expect(pagesRewriteRegex(subdomainRegExp).exec('acme.calcom.example.com')?.groups?.orgSlug).toEqual('acme')
+      // The following also matches which causes anything other than the domain in NEXT_PUBLIC_WEBAPP_URL to give 404
+      expect(pagesRewriteRegex(subdomainRegExp).exec('some-other.company.com')?.groups?.orgSlug).toEqual('some-other')
+    })
+  })
+})

--- a/packages/lib/default-cookies.ts
+++ b/packages/lib/default-cookies.ts
@@ -22,7 +22,8 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
   const defaultOptions: CookieOption["options"] = {
     domain: isENVDev
       ? process.env.ORGANIZATIONS_ENABLED
-        ? ".cal.local"
+        ? //FIXME: This is causing login to not work if someone uses anything other .cal.local for testing
+          ".cal.local"
         : undefined
       : NEXTAUTH_COOKIE_DOMAIN,
     // To enable cookies on widgets,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9768
Added tests as well. Helped in testing and helps in avoiding future bugs.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [x] Add a hosts entry for `calcom.app.company.com` and `acme.calcom.app.company.com` to 127.0.0.1
 - [x] Visit `calcom.app.company.com` and see a 404. With this branch that 404 is fixed. Also, test `acme.calcom.app.company.com`, it should also not be 404.
- [x] Ensure that env variables are like this
<img width="796" alt="Screenshot 2023-06-26 at 7 25 16 PM" src="https://github.com/calcom/cal.com/assets/1780212/4023dcab-2e9c-4ded-a06d-613a7eea75ce">



## Here are the tests done with app.cal.com and vwo org.
<img width="1157" alt="Screenshot 2023-06-27 at 12 36 32 PM" src="https://github.com/calcom/cal.com/assets/1780212/bacefa5a-516d-4894-b1dc-809e987d69fa">
<img width="1517" alt="Screenshot 2023-06-27 at 12 36 47 PM" src="https://github.com/calcom/cal.com/assets/1780212/31dcc11d-24de-46ff-8cb5-f491404bcbe5">
<img width="1353" alt="Screenshot 2023-06-27 at 12 37 00 PM" src="https://github.com/calcom/cal.com/assets/1780212/4a347fb0-6f5c-4202-b9de-bc9a76ac30bc">
<img width="1123" alt="Screenshot 2023-06-27 at 12 37 28 PM" src="https://github.com/calcom/cal.com/assets/1780212/19702c84-82f0-45ec-86ad-772284410e27">


## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
