### PR TITLE
fix: adds triggerEvent attribute to meeting ended webhook

### DIFF
--- a/packages/app-store/zapier/lib/nodeScheduler.ts
+++ b/packages/app-store/zapier/lib/nodeScheduler.ts
@@ -1,6 +1,7 @@
 import schedule from "node-schedule";
 
 import prisma from "@calcom/prisma";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 export async function scheduleTrigger(
   booking: { id: number; endTime: Date; scheduledJobs: string[] },
@@ -13,7 +14,7 @@ export async function scheduleTrigger(
       `${subscriber.appId}_${subscriber.id}`,
       booking.endTime,
       async function () {
-        const body = JSON.stringify(booking);
+        const body = JSON.stringify({ triggerEvent: WebhookTriggerEvents.MEETING_ENDED, ...booking });
         await fetch(subscriberUrl, {
           method: "POST",
           body,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9766

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Enter a webhook URL in the developer settings
- subscribe to the meeting_ended event
- book any event type and wait for it to end
- check the webhook response as it includes the triggerEvent attribute

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
