### PR TITLE
fix: Forever increasing scroll height in embed in month_view on certain screen size.

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -169,7 +169,8 @@ const BookerComponent = ({
               key="meta"
               className={classNames(
                 "relative z-10 flex [grid-area:meta]",
-                layout !== BookerLayouts.MONTH_VIEW && "sm:min-h-screen"
+                // Important: In Embed if we make min-height:100vh, it will cause the height to continuously keep on increasing
+                layout !== BookerLayouts.MONTH_VIEW && !isEmbed && "sm:min-h-screen"
               )}>
               <BookerSection
                 area="meta"


### PR DESCRIPTION
## What does this PR do?

Fixes #9819
Before Fix: https://www.loom.com/share/e72ded4ef73a42f0af89a4cc9651f138
After Fix: https://www.loom.com/share/dfcf5d8cd2e1499a9f9bc77c1facab5d
## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Set inline embed container width to 761px and open up Date/Time selection page of booker(e.g. /pro/30min)
- [x] Select a timeslot and see the scroll continuously increasing.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
