### PR TITLE
chore: increase operations-per-run for stale issues job

### DIFF
--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -10,16 +10,17 @@ on:
   schedule:
     # Runs every day (see https://crontab.guru)
     - cron: "0 0 * * *"
+  workflow_dispatch:
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v7
         with:
-          ascending: true
           days-before-issue-stale: 60
           days-before-issue-close: -1
           days-before-pr-stale: 14
           days-before-pr-close: 7
           stale-pr-message: "This PR is being marked as stale due to inactivity."
           close-pr-message: "This PR is being closed due to inactivity. Please reopen if work is intended to be continued."
+          operations-per-run: 100


### PR DESCRIPTION
## What does this PR do?

Increases the number of operations per run so that all of our issues and PRs are actually checked. Right now, it's stopping early and skipping items. Also added a way for us to manually trigger this workflow for testing.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)
