### PR TITLE
fix: modal width while removing installed apps

### DIFF
--- a/packages/features/apps/components/DisconnectIntegrationModal.tsx
+++ b/packages/features/apps/components/DisconnectIntegrationModal.tsx
@@ -1,7 +1,6 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { Dialog, DialogContent, showToast, DialogFooter, DialogClose } from "@calcom/ui";
-import { AlertCircle } from "@calcom/ui/components/icon";
+import { Dialog, showToast, ConfirmationDialogContent } from "@calcom/ui";
 
 interface DisconnectIntegrationModalProps {
   credentialId: number | null;
@@ -32,25 +31,17 @@ export default function DisconnectIntegrationModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleModelClose}>
-      <DialogContent
-        title={t("remove_app")}
-        size="sm"
-        description={t("are_you_sure_you_want_to_remove_this_app")}
-        type="confirmation"
-        Icon={AlertCircle}>
-        <DialogFooter>
-          <DialogClose onClick={handleModelClose} />
-          <DialogClose
-            color="primary"
-            onClick={() => {
-              if (credentialId) {
-                mutation.mutate({ id: credentialId });
-              }
-            }}>
-            {t("yes_remove_app")}
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
+       <ConfirmationDialogContent
+          variety="danger"
+          title={t("remove_app")}
+          confirmBtnText={t("yes_remove_app")}
+          onConfirm={() => {
+            if (credentialId) {
+              mutation.mutate({ id: credentialId });
+            }
+          }}>
+          <p className="mt-5">{t("are_you_sure_you_want_to_remove_this_app")}</p>
+        </ConfirmationDialogContent>
     </Dialog>
   );
 }

--- a/packages/features/apps/components/DisconnectIntegrationModal.tsx
+++ b/packages/features/apps/components/DisconnectIntegrationModal.tsx
@@ -34,6 +34,7 @@ export default function DisconnectIntegrationModal({
     <Dialog open={isOpen} onOpenChange={handleModelClose}>
       <DialogContent
         title={t("remove_app")}
+        size="sm"
         description={t("are_you_sure_you_want_to_remove_this_app")}
         type="confirmation"
         Icon={AlertCircle}>

--- a/packages/ui/components/dialog/Dialog.tsx
+++ b/packages/ui/components/dialog/Dialog.tsx
@@ -58,7 +58,7 @@ export function Dialog(props: DialogProps) {
   return <DialogPrimitive.Root {...dialogProps}>{children}</DialogPrimitive.Root>;
 }
 type DialogContentProps = React.ComponentProps<(typeof DialogPrimitive)["Content"]> & {
-  size?: "xl" | "lg" | "md" | "sm";
+  size?: "xl" | "lg" | "md";
   type?: "creation" | "confirmation";
   title?: string;
   description?: string | JSX.Element | null;
@@ -84,8 +84,6 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
               ? "p-8 sm:max-w-[70rem]"
               : props.size == "md"
               ? "p-8 sm:max-w-[48rem]"
-              : props.size == "sm"
-              ? "p-8 sm:max-w-[25rem]"
               : "p-8 sm:max-w-[35rem]",
             "max-h-[95vh]",
             enableOverflow ? "overflow-auto" : "overflow-visible",

--- a/packages/ui/components/dialog/Dialog.tsx
+++ b/packages/ui/components/dialog/Dialog.tsx
@@ -58,7 +58,7 @@ export function Dialog(props: DialogProps) {
   return <DialogPrimitive.Root {...dialogProps}>{children}</DialogPrimitive.Root>;
 }
 type DialogContentProps = React.ComponentProps<(typeof DialogPrimitive)["Content"]> & {
-  size?: "xl" | "lg" | "md";
+  size?: "xl" | "lg" | "md" | "sm";
   type?: "creation" | "confirmation";
   title?: string;
   description?: string | JSX.Element | null;
@@ -84,6 +84,8 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
               ? "p-8 sm:max-w-[70rem]"
               : props.size == "md"
               ? "p-8 sm:max-w-[48rem]"
+              : props.size == "sm"
+              ? "p-8 sm:max-w-[25rem]"
               : "p-8 sm:max-w-[35rem]",
             "max-h-[95vh]",
             enableOverflow ? "overflow-auto" : "overflow-visible",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the modal width while removing installed apps.
![Screenshot 2023-06-30 231534](https://github.com/calcom/cal.com/assets/20976813/80f05c87-5d6b-4e1b-a4f3-09fdad3360ff)


Fixes #9846

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try to remove an already installed apps. Dialog should be rendered with proper width.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
