### PR TITLE
fix: add missing translation for organizer_name_info

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1306,6 +1306,7 @@
   "location_info": "The location of the event",
   "additional_notes_info": "The additional notes of booking",
   "attendee_name_info": "The person booking's name",
+  "organizer_name_info": "Organizer’s name",
   "to": "To",
   "workflow_turned_on_successfully": "{{workflowName}} workflow turned {{offOn}} successfully",
   "download_responses": "Download responses",


### PR DESCRIPTION
## What does this PR do?

The translation was missing for organizer_name_info

Before: 
<img width="530" alt="Screenshot 2023-06-30 at 16 15 22" src="https://github.com/calcom/cal.com/assets/30310907/9a91d385-15e5-4144-9972-3c6f12d17dd1">


After:
<img width="534" alt="Screenshot 2023-06-30 at 16 13 02" src="https://github.com/calcom/cal.com/assets/30310907/bd3b38f1-74df-4960-bdbd-535cbe27cfa4">
