### PR TITLE
fix: Update FormActions.tsx solves Routing form accepts blank as its name issue

### DIFF
--- a/packages/app-store/routing-forms/components/FormActions.tsx
+++ b/packages/app-store/routing-forms/components/FormActions.tsx
@@ -65,6 +65,8 @@ function NewFormDialog({ appUrl }: { appUrl: string }) {
   const router = useRouter();
   const utils = trpc.useContext();
 
+  const [isNameErrorVisible, setIsNameErrorVisible] = useState(false);
+  
   const mutation = trpc.viewer.appRoutingForms.formMutation.useMutation({
     onSuccess: (_data, variables) => {
       router.push(`${appUrl}/form-edit/${variables.id}`);
@@ -106,17 +108,24 @@ function NewFormDialog({ appUrl }: { appUrl: string }) {
           form={hookForm}
           handleSubmit={(values) => {
             const formId = uuidv4();
+            const formName = values.name.trim();
 
-            mutation.mutate({
-              id: formId,
-              ...values,
-              addFallback: true,
-              teamId,
-              duplicateFrom: formToDuplicate,
-            });
+            if (formName === "") {
+              setIsNameErrorVisible(true);
+            } else {
+              setIsNameErrorVisible(true);
+              mutation.mutate({
+                id: formId,
+                ...values,
+                addFallback: true,
+                teamId,
+                duplicateFrom: formToDuplicate,
+              });
+            }
           }}>
           <div className="mt-3 space-y-5">
             <TextField label={t("title")} required placeholder={t("a_routing_form")} {...register("name")} />
+            {isNameErrorVisible && <div className="text-sm text-red-600 dark:text-red-500">Please Enter Form Title</div>}
             <div className="mb-5">
               <TextAreaField
                 id="description"


### PR DESCRIPTION

Fixes #9871
/claim #9871 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

![1](https://github.com/calcom/cal.com/assets/65810349/02799d2f-61d8-4516-b721-dad382bbeaf8)
![2](https://github.com/calcom/cal.com/assets/65810349/40bc683a-9ca3-4646-9314-76c8bfa67fb7)
- [x] black input
- [x] with whitespace

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
