### PR TITLE
fix: Routing form accepts blank as its name Fix: #9871

### DIFF
--- a/packages/app-store/routing-forms/components/FormActions.tsx
+++ b/packages/app-store/routing-forms/components/FormActions.tsx
@@ -77,6 +77,10 @@ function NewFormDialog({ appUrl }: { appUrl: string }) {
     },
   });
 
+  const isNotEmpty = (value: string) => {
+    return /\S/.test(value); // Check if value contains a non-whitespace character
+  };
+
   const hookForm = useForm<{
     name: string;
     description: string;
@@ -116,11 +120,16 @@ function NewFormDialog({ appUrl }: { appUrl: string }) {
             });
           }}>
           <div className="mt-3 space-y-5">
-            <TextField label={t("title")} required placeholder={t("a_routing_form")} {...register("name")} />
+            <TextField
+              label={t("title")}
+              required
+              placeholder={t("a_routing_form")}
+              {...register("name", { required: true, validate: isNotEmpty })}
+            />
             <div className="mb-5">
               <TextAreaField
                 id="description"
-                label={t("description")}
+                label={t("description", { required: true, validate: isNotEmpty })}
                 {...register("description")}
                 data-testid="description"
                 placeholder={t("form_description_placeholder")}


### PR DESCRIPTION
fix #9871


/claim #9871
Summary:
This pull request addresses the issue where the routing form accepts a blank name as a valid value. The expected behavior is to validate that there is no valid value and display an error message.

Changes Made:

- Added validation to ensure that the name field is not blank
- Implemented a custom validation function to check for non-empty values
- Updated the routing form component to display an error message when the name field is blank

Testing Done:

- Replicated the steps provided in the issue description
- Verified that the routing form now correctly validates blank names and displays an error message
