### PR TITLE
fix: app crash issue on setting a greater recurring count than the ma…

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -204,7 +204,13 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
                               isFullWidth={false}
                               className="me-2 inline w-16"
                               onChange={(event) => {
-                                setRecurringEventCount(parseInt(event?.target.value));
+                                const count =
+                                  eventType?.recurringEvent?.count &&
+                                  parseInt(event?.target.value) > eventType?.recurringEvent?.count
+                                    ? eventType.recurringEvent.count
+                                    : parseInt(event?.target.value);
+
+                                setRecurringEventCount(count);
                               }}
                             />
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes the app crash issue that happens when a user enters a recurring count greater than the one specified by the author. Have changed the behaviour to default to the author's max count on submit if the provided count is greater than that.

Fixes #9606

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://github.com/calcom/cal.com/assets/47187878/e52aabe3-4c42-4b39-835c-1eb622907cd7



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a recurring event and specify a recurring count
- On another go to the link of the event
- In the recurring count manually enter a number greater than the author-specified count
- On submitting the count defaults to the author's specified maximum count

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
