### PR TITLE
fix: toLowerCase/slugify of booking page params

### DIFF
--- a/apps/web/pages/new-booker/[user]/[type].tsx
+++ b/apps/web/pages/new-booker/[user]/[type].tsx
@@ -8,6 +8,7 @@ import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { classNames } from "@calcom/lib";
 import { getUsernameList } from "@calcom/lib/defaultEvents";
+import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -93,12 +94,10 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
 }
 
 async function getUserPageProps(context: GetServerSidePropsContext) {
-  const { user: uname, type: slug } = paramsSchema.parse(context.params);
+  const { user: usernames, type: slug } = paramsSchema.parse(context.params);
+  const username = usernames[0];
   const { rescheduleUid } = context.query;
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req.headers.host ?? "");
-
-  /** TODO: We should standarize this */
-  const username = uname.toLowerCase().replace(/( |%20)/g, "+");
 
   const { ssrInit } = await import("@server/lib/ssr");
   const ssr = await ssrInit(context);
@@ -151,13 +150,16 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   };
 }
 
-const paramsSchema = z.object({ type: z.string(), user: z.string() });
+const paramsSchema = z.object({
+  type: z.string().transform((s) => slugify(s)),
+  user: z.string().transform((s) => getUsernameList(s)),
+});
 
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const { user } = paramsSchema.parse(context.params);
-  const isDynamicGroup = getUsernameList(user).length > 1;
+  const isDynamicGroup = user.length > 1;
 
   return isDynamicGroup ? await getDynamicGroupPageProps(context) : await getUserPageProps(context);
 };

--- a/apps/web/pages/new-booker/d/[link]/[slug].tsx
+++ b/apps/web/pages/new-booker/d/[link]/[slug].tsx
@@ -6,6 +6,7 @@ import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 import { getBookingByUidOrRescheduleUid } from "@calcom/features/bookings/lib/get-booking";
 import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
+import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -129,7 +130,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   };
 }
 
-const paramsSchema = z.object({ link: z.string(), slug: z.string() });
+const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
 
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.

--- a/apps/web/pages/new-booker/team/[slug]/[type].tsx
+++ b/apps/web/pages/new-booker/team/[slug]/[type].tsx
@@ -6,6 +6,7 @@ import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 import { getBookingByUidOrRescheduleUid } from "@calcom/features/bookings/lib/get-booking";
 import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { classNames } from "@calcom/lib";
+import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -39,7 +40,10 @@ export default function Type({ slug, user, booking, away, isBrandingHidden }: Pa
 
 Type.PageWrapper = PageWrapper;
 
-const paramsSchema = z.object({ type: z.string(), slug: z.string() });
+const paramsSchema = z.object({
+  type: z.string().transform((s) => slugify(s)),
+  slug: z.string().transform((s) => slugify(s)),
+});
 
 // Booker page fetches a tiny bit of data server side:
 // 1. Check if team exists, to show 404

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -2,6 +2,7 @@ import type { Prisma, Credential } from "@prisma/client";
 
 import { DailyLocationType } from "@calcom/app-store/locations";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
+import slugify from "@calcom/lib/slugify";
 import { PeriodType, SchedulingType } from "@calcom/prisma/enums";
 import type { userSelect } from "@calcom/prisma/selects";
 import type { CustomInputSchema } from "@calcom/prisma/zod-utils";
@@ -177,14 +178,8 @@ export const getUsernameList = (users: string | string[] | undefined): string[] 
   // So, even though this code handles even if individual user is dynamic link, that isn't a possibility right now.
   users = arrayCast(users);
 
-  const allUsers = users.map((user) =>
-    user
-      .toLowerCase()
-      .replace(/( |%20|%2b)/g, "+")
-      .split("+")
-  );
-
-  return Array.prototype.concat(...allUsers);
+  const allUsers = users.map((user) => user.split("+")).flat();
+  return Array.prototype.concat(...allUsers.map((userSlug) => slugify(userSlug)));
 };
 
 export default defaultEvents;


### PR DESCRIPTION
## What does this PR do?

Use slugify as a standarized way of handling event slugs/ usernames - this logic is used similarly whilst writing into the frontend and should be consistent.

We should future proof this with function parameters to prevent these from being incompatible on write/read. Ideally we'd use the slugify library to achieve this - we shouldn't have rolled our own here.

We need test coverage for this too; so we can move to a more robust system in the future or just decide never to change our slugify methods.