### PR TITLE
fix: Missing Video Apps

### DIFF
--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -13,6 +13,7 @@ import {
   getHumanReadableLocationValue,
   getMessageForOrganizer,
   LocationType,
+  OrganizerDefaultConferencingAppType,
 } from "@calcom/app-store/locations";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
@@ -311,8 +312,15 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                 query={locationsQuery}
                 success={({ data }) => {
                   if (!data.length) return null;
-                  const locationOptions = [...data].filter((option) => {
-                    return !isTeamEvent ? option.label !== "Conferencing" : true;
+                  const locationOptions = [...data].map((option) => {
+                    if (isTeamEvent) {
+                      // Let host's Default conferencing App option show for Team Event
+                      return option;
+                    }
+                    return {
+                      ...option,
+                      options: option.options.filter((o) => o.value !== OrganizerDefaultConferencingAppType),
+                    };
                   });
                   if (booking) {
                     locationOptions.map((location) =>


### PR DESCRIPTION
## What does this PR do?

Fixes missing video apps. Happened because "conferencing" was a reserved group name already by 'Host's Default conferencing app'(which is shown only for Team Events) and all existing apps got recategorized to the same 'Conferencing' name. 

- Bug fix (non-breaking change which fixes an issue)

Team Event
![image](https://github.com/calcom/cal.com/assets/1780212/ddb27def-e646-4424-9cf5-3608e55d32d0)

User Event
<img width="692" alt="Screenshot 2023-07-05 at 12 30 31 AM" src="https://github.com/calcom/cal.com/assets/1780212/fdaf6183-b30a-4541-b148-977ab99d4edf">
![image](https://github.com/calcom/cal.com/assets/1780212/f58fe302-5cfe-45d1-aa71-bb5d346cf323)


