### PR TITLE
fix: Preview deployements don't have NEXT_PUBLIC_WEBAPP_URL defined

### DIFF
--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -30,7 +30,9 @@ exports.teamTypeRoutePath = "/team/:slug/:type((?!book$)[^/]+)";
 exports.privateLinkRoutePath = "/d/:link/:slug((?!book$)[^/]+)";
 exports.embedUserTypeRoutePath = `/:user((?!${afterFilesRewriteExcludePages.join("/|")})[^/]*)/:type/embed`;
 exports.embedTeamTypeRoutePath = "/team/:slug/:type/embed";
-let subdomainRegExp = (exports.subdomainRegExp = getSubdomainRegExp(process.env.NEXT_PUBLIC_WEBAPP_URL));
+let subdomainRegExp = (exports.subdomainRegExp = getSubdomainRegExp(
+  process.env.NEXT_PUBLIC_WEBAPP_URL || "https://" + process.env.VERCEL_URL
+));
 exports.orgHostPath = `^(?<orgSlug>${subdomainRegExp})\\..*`;
 
 let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes);


### PR DESCRIPTION
## What does this PR do?

We fallback similarly in next.config.js - but this code is ran before that happens - so we need to fallback explicitly here. 