### PR TITLE
fix: In certain conditions, don't add a booking to busyTimes

### DIFF
--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -15,7 +15,7 @@ import {
 test.describe.configure({ mode: "parallel" });
 test.afterEach(async ({ users }) => users.deleteAll());
 
-testBothBookers.describe("free user", (bookerVariant) => {
+test.describe("free user", () => {
   test.beforeEach(async ({ page, users }) => {
     const free = await users.create();
     await page.goto(`/${free.username}`);
@@ -26,17 +26,6 @@ testBothBookers.describe("free user", (bookerVariant) => {
     await page.click('[data-testid="event-type-link"]');
 
     await selectFirstAvailableTimeSlotNextMonth(page);
-
-    // Kept in if statement here, since it's only temporary
-    // until the old booker isn't used anymore, and I wanted
-    // to change the test as little as possible.
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (bookerVariant !== "new-booker") {
-      // Navigate to book page
-      await page.waitForURL((url) => {
-        return url.pathname.endsWith("/book");
-      });
-    }
 
     // save booking url
     const bookingUrl: string = page.url();

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -114,10 +114,8 @@ export async function getBusyTimes(params: {
     (aggregate: EventBusyDetails[], { id, startTime, endTime, eventType, title, seatsReferences }) => {
       // Seat references on the current event are non-blocking until the event is fully booked.
       if (
-        // when this is a seated event and there are booked seats.
-        seatsReferences &&
-        // and there are still seats available.
-        seatsReferences.length < (eventType?.seatsPerTimeSlot || 1) &&
+        // if this is a seated event and there are still seats available.
+        seatsReferences.length < (eventType?.seatsPerTimeSlot || 0) &&
         // and this is the seated event, other event types should be blocked.
         eventTypeId === eventType?.id
       ) {

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -114,6 +114,8 @@ export async function getBusyTimes(params: {
     (aggregate: EventBusyDetails[], { id, startTime, endTime, eventType, title, seatsReferences }) => {
       // Seat references on the current event are non-blocking until the event is fully booked.
       if (
+        // this is purely for jest; prisma responses are []
+        seatsReferences &&
         // if this is a seated event and there are still seats available.
         seatsReferences.length < (eventType?.seatsPerTimeSlot || 0) &&
         // and this is the seated event, other event types should be blocked.


### PR DESCRIPTION
## What does this PR do?

Seated events should not block themselves until fully booked.