### PR TITLE
fix: update should be based on email only

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -616,10 +616,7 @@ export const AUTH_OPTIONS: AuthOptions = {
           ) {
             await prisma.user.update({
               where: {
-                email_username: {
-                  email: existingUserWithEmail.email,
-                  username: existingUserWithEmail.username!,
-                },
+                email: existingUserWithEmail.email,
               },
               data: {
                 // update the email to the IdP email


### PR DESCRIPTION
## What does this PR do?

Fixes regression introduced in https://github.com/calcom/cal.com/pull/8993 - username will always be null but a Prisma limitation is that a compound unique key is not nullable. This causes a hard crash for invited users.