### PR TITLE
fix: cancel button not working on payment page

### DIFF
--- a/packages/features/ee/payments/components/Payment.tsx
+++ b/packages/features/ee/payments/components/Payment.tsx
@@ -115,7 +115,9 @@ const PaymentForm = (props: Props) => {
         <Button
           color="minimal"
           disabled={!holdAcknowledged || ["processing", "error"].includes(state.status)}
-          id="cancel">
+          id="cancel"
+          onClick={() => router.back()}
+          >
           <span id="button-text">{t("cancel")}</span>
         </Button>
         <Button


### PR DESCRIPTION
## What does this PR do?

Fixes #9986

This PR fixes the issue "meetings with payment: cancel button doesnt work".
I added `router.back()` in the Cancel Button's onClick 


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Open a meeting link with payment and click "Cancel" button.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
