### PR TITLE
fix: vertical-scrollbar-issue-when-organization-table-contains-no-records

### DIFF
--- a/packages/ui/components/table/Table.tsx
+++ b/packages/ui/components/table/Table.tsx
@@ -42,7 +42,7 @@ const Cell = ({ children, widthClassNames }: TableProps & DynamicWidth) => (
 );
 
 export const Table = ({ children }: TableProps) => (
-  <div className="bg-default border-subtle overflow-x-auto rounded-md border">
+  <div className="bg-default border-subtle overflow-x-auto overflow-y-hidden rounded-md border">
     <table className="divide-subtle w-full divide-y rounded-md">{children}</table>
   </div>
 );


### PR DESCRIPTION
## What does this PR do?

When there are no records in organizations table, it should not show a vertical scrollbar.

Fixes #10003 

![Screenshot 2023-07-08 123709](https://github.com/calcom/cal.com/assets/20976813/044a87ba-9807-4b96-b0f1-0a93e670c1b1)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to organizations tab from settings as an admin user.
- Should not see vertical scrollbar when table contains no records.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
