### PR TITLE
fix: Even after closing modal, pointer-events: none was applied on body.

### DIFF
--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -177,7 +177,7 @@ export default function MemberListItem(props: Props) {
                 />
               </Tooltip>
               {editMode && (
-                <Dropdown>
+                <Dropdown modal={false}>
                   <DropdownMenuTrigger asChild>
                     <Button
                       className="radix-state-open:rounded-r-md"
@@ -222,7 +222,7 @@ export default function MemberListItem(props: Props) {
               )}
             </ButtonGroup>
             <div className="flex md:hidden">
-              <Dropdown>
+              <Dropdown modal={false}>
                 <DropdownMenuTrigger asChild>
                   <Button type="button" variant="icon" color="minimal" StartIcon={MoreHorizontal} />
                 </DropdownMenuTrigger>


### PR DESCRIPTION
## What does this PR do?
After closing modal pointer-events: none property was still applied on body, which resulted in user was not able to click anywhere on UI.

Fixes #10004 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Open Members section of Team.
- Try to open modal by edit member or remove option.
- After closing Modal as well UI works fine.

