### PR TITLE
fix: reject-button-on-unverified-organizations-listing

### DIFF
--- a/packages/features/ee/organizations/pages/settings/admin/unverifiedOrgPage.tsx
+++ b/packages/features/ee/organizations/pages/settings/admin/unverifiedOrgPage.tsx
@@ -69,6 +69,12 @@ function UnverifiedOrgTable() {
                       {
                         id: "reject",
                         label: "Reject",
+                        onClick: () => {
+                          mutation.mutate({
+                            orgId: org.id,
+                            status: "DENY",
+                          });
+                        },
                         icon: X,
                       },
                     ]}


### PR DESCRIPTION
## What does this PR do?

Reject button was not working when trying to reject from unverified organization list. This PR fixes it.

Fixes #10002 


https://github.com/calcom/cal.com/assets/20976813/16c3b0dc-a195-431c-9eef-dc75be245348



## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try to reject an unverified organization as an admin. 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
