### PR TITLE
Fix #10021 Changes save button color from secondary to primary.

### DIFF
--- a/packages/ui/components/image-uploader/ImageUploader.tsx
+++ b/packages/ui/components/image-uploader/ImageUploader.tsx
@@ -211,7 +211,7 @@ export default function ImageUploader({
           </div>
         </div>
         <div className="mt-5 flex flex-row-reverse gap-x-2 sm:mt-4">
-          <DialogClose color="secondary" onClick={() => showCroppedImage(croppedAreaPixels)}>
+          <DialogClose color="primary" onClick={() => showCroppedImage(croppedAreaPixels)}>
             {t("save")}
           </DialogClose>
           <DialogClose color="minimal">{t("cancel")}</DialogClose>


### PR DESCRIPTION
## What does this PR do?

This PR changes Button color from secondary to primary.


Fixes # 10021

##Before 
![cal com-issue-10021-before](https://github.com/calcom/cal.com/assets/100031493/67657e41-383d-4702-a033-e8b0cf11c79c)

##After 
<img width="943" alt="cal com-issue-10021" src="https://github.com/calcom/cal.com/assets/100031493/e6be9eee-685e-41d9-b59c-b1d2f3930539">


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
Try changing the profile avatar in profile section under my-account in settings, You notice when click on change avatar a modal pops and changes have been made to save button.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


