### PR TITLE
feat: Add password checks for password-reset

### DIFF
--- a/apps/web/pages/api/auth/reset-password.ts
+++ b/apps/web/pages/api/auth/reset-password.ts
@@ -52,9 +52,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
     });
 
+    await expireResetPasswordRequest(rawRequestId);
+
     return res.status(201).json({ message: "Password reset." });
   } catch (reason) {
     console.error(reason);
     return res.status(500).json({ message: "Unable to create password reset request" });
   }
+}
+
+async function expireResetPasswordRequest(rawRequestId: string) {
+  await prisma.resetPasswordRequest.update({
+    where: {
+      id: rawRequestId,
+    },
+    data: {
+      // We set the expiry to now to invalidate the request
+      expires: new Date(),
+    },
+  });
 }

--- a/apps/web/pages/api/auth/reset-password.ts
+++ b/apps/web/pages/api/auth/reset-password.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { hashPassword } from "@calcom/features/auth/lib/hashPassword";
+import { validPassword } from "@calcom/features/auth/lib/validPassword";
 import prisma from "@calcom/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -34,6 +35,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (!maybeUser) {
       return res.status(400).json({ message: "Couldn't find an account for this email" });
+    }
+
+    if (!validPassword(rawPassword)) {
+      return res.status(400).json({ message: "Password does not meet the requirements" });
     }
 
     const hashedPassword = await hashPassword(rawPassword);

--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -23,6 +23,10 @@ type Props = {
 
 export default function Page({ resetPasswordRequest, csrfToken }: Props) {
   const { t } = useLocale();
+  const formMethods = useForm<{ new_password: string }>();
+  const success = formMethods.formState.isSubmitSuccessful;
+  const loading = formMethods.formState.isSubmitting;
+
   const submitChangePassword = async ({ password, requestId }: { password: string; requestId: string }) => {
     const res = await fetch("/api/auth/reset-password", {
       method: "POST",
@@ -77,10 +81,6 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
     const now = dayjs();
     return dayjs(resetPasswordRequest.expires).isBefore(now);
   }, [resetPasswordRequest]);
-
-  const formMethods = useForm<{ new_password: string }>();
-  const success = formMethods.formState.isSubmitSuccessful;
-  const loading = formMethods.formState.isSubmitting;
 
   return (
     <AuthContainer

--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -6,11 +6,12 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import type { CSSProperties } from "react";
 import React, { useMemo } from "react";
+import { useForm } from "react-hook-form";
 
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import prisma from "@calcom/prisma";
-import { Button, TextField } from "@calcom/ui";
+import { Button, PasswordField, Form } from "@calcom/ui";
 
 import PageWrapper from "@components/PageWrapper";
 import AuthContainer from "@components/ui/AuthContainer";
@@ -26,8 +27,6 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
   const [loading, setLoading] = React.useState(false);
   const [, setError] = React.useState<{ message: string } | null>(null);
   const [success, setSuccess] = React.useState(false);
-
-  const [password, setPassword] = React.useState("");
 
   const submitChangePassword = async ({ password, requestId }: { password: string; requestId: string }) => {
     try {
@@ -100,6 +99,8 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
     return dayjs(resetPasswordRequest.expires).isBefore(now);
   }, [resetPasswordRequest]);
 
+  const formMethods = useForm<{ new_password: string }>();
+
   return (
     <AuthContainer
       showLogo
@@ -109,8 +110,9 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
       {isRequestExpired && <Expired />}
       {!isRequestExpired && !success && (
         <>
-          <form
+          <Form
             className="space-y-6"
+            form={formMethods}
             style={
               {
                 "--cal-brand": "#111827",
@@ -119,36 +121,30 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
                 "--cal-brand-subtle": "#9CA3AF",
               } as CSSProperties
             }
-            onSubmit={async (e) => {
-              e.preventDefault();
-
-              if (!password) {
-                return;
-              }
-
-              if (loading) {
-                return;
-              }
-
+            handleSubmit={async (values) => {
               setLoading(true);
               setError(null);
               setSuccess(false);
 
-              await debouncedChangePassword({ password, requestId: resetPasswordRequest.id });
-            }}
-            action="#">
+              await debouncedChangePassword({
+                password: values.new_password,
+                requestId: resetPasswordRequest.id,
+              });
+            }}>
             <input name="csrfToken" type="hidden" defaultValue={csrfToken} hidden />
             <div className="mt-1">
-              <TextField
+              <PasswordField
+                {...formMethods.register("new_password", {
+                  minLength: {
+                    message: t("password_hint_min"),
+                    value: 7, // We don't have user here so we can't check if they are admin or not
+                  },
+                  pattern: {
+                    message: "Should contain a number, uppercase and lowercase letters",
+                    value: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).*$/gm,
+                  },
+                })}
                 label={t("new_password")}
-                onChange={(e) => {
-                  setPassword(e.target.value);
-                }}
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="password"
-                required
               />
             </div>
 
@@ -162,7 +158,7 @@ export default function Page({ resetPasswordRequest, csrfToken }: Props) {
                 {t("reset_password")}
               </Button>
             </div>
-          </form>
+          </Form>
         </>
       )}
       {!isRequestExpired && success && (

--- a/apps/web/playwright/auth/forgot-password.e2e.ts
+++ b/apps/web/playwright/auth/forgot-password.e2e.ts
@@ -24,8 +24,8 @@ test("Can reset forgotten password", async ({ page, users }) => {
 
   // Wait for page to fully load
   await page.waitForSelector("text=Reset Password");
-  // Fill input[name="password"]
-  await page.fill('input[name="password"]', newPassword);
+  // Fill input[name="new_password"]
+  await page.fill('input[name="new_password"]', newPassword);
 
   // Click text=Submit
   await page.click('button[type="submit"]');

--- a/apps/web/playwright/auth/forgot-password.e2e.ts
+++ b/apps/web/playwright/auth/forgot-password.e2e.ts
@@ -8,7 +8,7 @@ test("Can reset forgotten password", async ({ page, users }) => {
   // eslint-disable-next-line playwright/no-skipped-test
   test.skip(process.env.NEXT_PUBLIC_IS_E2E !== "1", "It shouldn't if we can't skip email");
   const user = await users.create();
-  const newPassword = `${user.username}-123`;
+  const newPassword = `${user.username}-123CAL`; // To match the password policy
   // Got to reset password flow
   await page.goto("/auth/forgot-password");
 


### PR DESCRIPTION
## What does this PR do?

for some reason forgot password-reset page lost its validation to check password validity 
<img width="633" alt="CleanShot 2023-07-10 at 17 41 33@2x" src="https://github.com/calcom/cal.com/assets/55134778/2749f77d-2982-4179-b9ed-b8eccca29ba2">
<img width="622" alt="CleanShot 2023-07-10 at 17 41 37@2x" src="https://github.com/calcom/cal.com/assets/55134778/7d1a3d10-5c49-4e84-bf0c-c8882b334960">
<img width="796" alt="CleanShot 2023-07-10 at 17 41 41@2x" src="https://github.com/calcom/cal.com/assets/55134778/c2326578-1d92-4dd9-9f07-cb7c9142ec2e">
<img width="548" alt="CleanShot 2023-07-10 at 17 42 04@2x" src="https://github.com/calcom/cal.com/assets/55134778/541f2d5c-3296-430a-ab70-044371d54180">

How to test: 
* Invalid password -> Error
* Valid password -> success
