### PR TITLE
fix: about section unnecessary scrollbar

### DIFF
--- a/packages/ui/components/editor/Editor.tsx
+++ b/packages/ui/components/editor/Editor.tsx
@@ -90,7 +90,11 @@ export const Editor = (props: TextEditorProps) => {
                   className="editor-input"
                 />
               }
-              placeholder={<div className="text-muted -mt-11 p-3 text-sm">{props.placeholder || ""}</div>}
+              placeholder={
+                props?.placeholder ? (
+                  <div className="text-muted -mt-11 p-3 text-sm">{props.placeholder}</div>
+                ) : null
+              }
               ErrorBoundary={LexicalErrorBoundary}
             />
             <ListPlugin />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #10036 (issue)

[fix.webm](https://github.com/calcom/cal.com/assets/86384652/0aacb004-6c4d-41ae-a1bf-01e6b2019244)

When there is no placeholder given to the Editor component, it still inserts a empty div element which cause the unnecessary scrollbar.
So a quick check on the placeholder prop fixes the unnecessary scrollbar



 

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

