### PR TITLE
fix: prevents warnings on branding call when unauthed

### DIFF
--- a/packages/features/ee/organizations/hooks/index.ts
+++ b/packages/features/ee/organizations/hooks/index.ts
@@ -1,5 +1,12 @@
+import { useSession } from "next-auth/react";
+
 import { trpc } from "@calcom/trpc/react";
 
 export function useOrgBrandingValues() {
-  return trpc.viewer.organizations.getBrand.useQuery().data;
+  const session = useSession();
+  return trpc.viewer.organizations.getBrand.useQuery(undefined, {
+    // Only fetch if we have a session to avoid flooding logs with errors
+    enabled: session.status === "authenticated",
+    initialData: null,
+  }).data;
 }


### PR DESCRIPTION
## What does this PR do?

IDK if this endpoint should be public or not so I've disable the called until we're logged in.

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- See console when unearthed. The warning should be gone
- When authed and if on an org, data should return normally.

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
