### PR TITLE
fix: unnecessary whitespace in profile

### DIFF
--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -46,7 +46,7 @@ export const EventTypeDescription = ({
         {eventType.description && (
           <div
             className={classNames(
-              "text-subtle max-w-[280px] break-words py-1 text-sm sm:max-w-[500px] [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600",
+              "text-subtle max-w-[280px] break-words py-1 text-sm sm:max-w-[650px] [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600",
               shortenDescription ? "line-clamp-4" : ""
             )}
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
before
![image](https://github.com/calcom/cal.com/assets/8019099/6fd4d3a4-7b03-425a-8da3-d1f7932a02b1)

after

![image](https://github.com/calcom/cal.com/assets/8019099/3d2e2d48-182f-4cc4-a07d-959edeb58a03)
