### PR TITLE
fix: ternary operator with lenght causing 0

### DIFF
--- a/apps/web/pages/event-types/[type]/index.tsx
+++ b/apps/web/pages/event-types/[type]/index.tsx
@@ -503,7 +503,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
         </Form>
       </EventTypeSingleLayout>
 
-      {slugExistsChildrenDialogOpen.length && (
+      {slugExistsChildrenDialogOpen.length ? (
         <ManagedEventTypeDialog
           slugExistsChildrenDialogOpen={slugExistsChildrenDialogOpen}
           isLoading={formMethods.formState.isSubmitting}
@@ -518,7 +518,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
             setSlugExistsChildrenDialogOpen([]);
           }}
         />
-      )}
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
PSA: dont use `length` with `&&` to prevent trailing 0's