### PR TITLE
fix: slot reservation uses wrong event length

### DIFF
--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -277,7 +277,7 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
   );
   const workingHours = getAggregateWorkingHours(userAvailability, eventType.schedulingType);
   const availabilityCheckProps = {
-    eventLength: eventType.length,
+    eventLength: eventType.slotInterval || input.duration || eventType.length,
     currentSeats,
   };
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -277,7 +277,7 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
   );
   const workingHours = getAggregateWorkingHours(userAvailability, eventType.schedulingType);
   const availabilityCheckProps = {
-    eventLength: eventType.slotInterval || input.duration || eventType.length,
+    eventLength: input.duration || eventType.length,
     currentSeats,
   };
 


### PR DESCRIPTION
## What does this PR do?

Fixes that for events with multiple duration, the slot reservation system uses the wrong event length to reserve slots.

## Requirement/Documentation

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- create event type with multiple durations choose 15 min and 120 min
- make 120 min the default duration 
- go to the event type link
- pick any 15min slot (for example 11:00-11:15) => this slot is reserved now
- Open a new browser tab with the event-type link
- check available slots for 15 min duration at the day you booked the event: 
   - expected slots: all slots except 11:00 should be here
   - before: all slots between 9:00 and 11:00 were missing
