### PR TITLE
fix: Use user locale for sending password resets

### DIFF
--- a/apps/web/pages/api/auth/forgot-password.ts
+++ b/apps/web/pages/api/auth/forgot-password.ts
@@ -11,8 +11,6 @@ import { getTranslation } from "@calcom/lib/server/i18n";
 import prisma from "@calcom/prisma";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const t = await getTranslation(req.body.language ?? "en", "common");
-
   const email = z
     .string()
     .email()
@@ -47,6 +45,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         name: true,
         identityProvider: true,
         email: true,
+        locale: true,
       },
     });
 
@@ -56,6 +55,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         .status(200)
         .json({ message: "If this email exists in our system, you should receive a Reset email." });
     }
+
+    const t = await getTranslation(maybeUser.locale ?? "en", "common");
 
     const maybePreviousRequest = await prisma.resetPasswordRequest.findMany({
       where: {

--- a/apps/web/pages/auth/forgot-password/index.tsx
+++ b/apps/web/pages/auth/forgot-password/index.tsx
@@ -15,7 +15,7 @@ import PageWrapper from "@components/PageWrapper";
 import AuthContainer from "@components/ui/AuthContainer";
 
 export default function ForgotPassword({ csrfToken }: { csrfToken: string }) {
-  const { t, i18n } = useLocale();
+  const { t } = useLocale();
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<{ message: string } | null>(null);
   const [success, setSuccess] = React.useState(false);
@@ -31,7 +31,7 @@ export default function ForgotPassword({ csrfToken }: { csrfToken: string }) {
     try {
       const res = await fetch("/api/auth/forgot-password", {
         method: "POST",
-        body: JSON.stringify({ email: email, language: i18n.language }),
+        body: JSON.stringify({ email }),
         headers: {
           "Content-Type": "application/json",
         },


### PR DESCRIPTION
## What does this PR do?

Instead of passing through the browser locale it makes more sense of sending the email according to the locale configured by the user.