### PR TITLE
fix: hasTeamPlan with accepted prop

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/hasTeamPlan.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/hasTeamPlan.handler.ts
@@ -12,6 +12,7 @@ export const hasTeamPlanHandler = async ({ ctx }: HasTeamPlanOptions) => {
 
   const hasTeamPlan = await prisma.membership.findFirst({
     where: {
+      accepted: true,
       userId,
       team: {
         slug: {


### PR DESCRIPTION
## What does this PR do?

- Reported bug was there was no info to show when an user invited but not accepted membership can view insights page but without any data.
- Empty state on the page shouldn't be anymore since a user with any team membership will always have their default insights.
- Add accepted = true when querying if user hasTeamPlan enabled.

Fixes #7974

## Requirement/Documentation

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

  - Are there environment variables that should be set? No.
  - What are the minimal test data to have? Running yarn seed-insights can help
  - What is expected (happy path) to have (input and output)? User invited to team but not accepted should not be able to see insights page.
  - Any other important info that could help to test that PR. None

## Mandatory Tasks

  - [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
