### PR TITLE
fix: Remove/Update behaviour of date-overrides

### DIFF
--- a/apps/web/pages/availability/[schedule].tsx
+++ b/apps/web/pages/availability/[schedule].tsx
@@ -53,7 +53,7 @@ type AvailabilityFormValues = {
 };
 
 const DateOverride = ({ workingHours }: { workingHours: WorkingHours[] }) => {
-  const { remove, append, update, fields } = useFieldArray<AvailabilityFormValues, "dateOverrides">({
+  const { remove, append, replace, fields } = useFieldArray<AvailabilityFormValues, "dateOverrides">({
     name: "dateOverrides",
   });
   const { t } = useLocale();
@@ -72,7 +72,7 @@ const DateOverride = ({ workingHours }: { workingHours: WorkingHours[] }) => {
         <DateOverrideList
           excludedDates={fields.map((field) => yyyymmdd(field.ranges[0].start))}
           remove={remove}
-          update={update}
+          replace={replace}
           items={fields}
           workingHours={workingHours}
         />

--- a/packages/features/schedules/components/DateOverrideList.tsx
+++ b/packages/features/schedules/components/DateOverrideList.tsx
@@ -23,19 +23,25 @@ const useSettings = () => {
 const DateOverrideList = ({
   items,
   remove,
-  update,
+  replace,
   workingHours,
   excludedDates = [],
 }: {
   remove: UseFieldArrayRemove;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  update: any;
+  replace: any;
   items: { ranges: TimeRange[]; id: string }[];
   workingHours: WorkingHours[];
   excludedDates?: string[];
 }) => {
   const { t, i18n } = useLocale();
   const { hour12 } = useSettings();
+
+  const unsortedFieldArrayMap = items.reduce(
+    (map: { [id: string]: number }, { id }, index) => ({ ...map, [id]: index }),
+    {}
+  );
+
   if (!items.length) {
     return <></>;
   }
@@ -54,7 +60,7 @@ const DateOverrideList = ({
 
   return (
     <ul className="border-subtle rounded border" data-testid="date-overrides-list">
-      {items.sort(sortByDate).map((item, index) => (
+      {items.sort(sortByDate).map((item) => (
         <li key={item.id} className="border-subtle flex justify-between border-b px-5 py-4 last:border-b-0">
           <div>
             <h3 className="text-emphasis text-sm">
@@ -80,9 +86,9 @@ const DateOverrideList = ({
               workingHours={workingHours}
               value={item.ranges}
               onChange={(ranges) => {
-                update(index, {
-                  ranges,
-                });
+                // update has very weird side-effects with sorting.
+                replace([...items.filter((currentItem) => currentItem.id !== item.id), { ranges }]);
+                delete unsortedFieldArrayMap[item.id];
               }}
               Trigger={
                 <DialogTrigger asChild>
@@ -102,7 +108,7 @@ const DateOverrideList = ({
                 color="destructive"
                 variant="icon"
                 StartIcon={Trash2}
-                onClick={() => remove(index)}
+                onClick={() => remove(unsortedFieldArrayMap[item.id])}
               />
             </Tooltip>
           </div>


### PR DESCRIPTION
## What does this PR do?

This is not the cleanest approach, but the existing mechanism didn't work in a few situations because of the date sort. The update caused a re-render that caused an invalid unsortedFieldArrayMap.

Reproduction/how to test: 

**Updating bug was hit when you changed the date and it went before another date (re-ordering)**; which then modified the wrong date override. This PR replaces the entire array which retains the correct sort order by brute force.

**Delete bug was encountered if the sorted order was not the same as the filtered order, which depends on the order you created the date overrides in**. This PR implements an original order before the sort causing the right item to be removed.

Fixes #8043

