### PR TITLE
fix: incorrect error messsage for invalid login credentials

### DIFF
--- a/apps/web/pages/auth/login.tsx
+++ b/apps/web/pages/auth/login.tsx
@@ -69,7 +69,7 @@ export default function Login({
   const errorMessages: { [key: string]: string } = {
     // [ErrorCode.SecondFactorRequired]: t("2fa_enabled_instructions"),
     // Don't leak information about whether an email is registered or not
-    [ErrorCode.IncorrectUsernamePassword]: t("incorrect_username_password"),
+    [ErrorCode.IncorrectEmailPassword]: t("incorrect_email_password"),
     [ErrorCode.IncorrectTwoFactorCode]: `${t("incorrect_2fa_code")} ${t("please_try_again")}`,
     [ErrorCode.InternalServerError]: `${t("something_went_wrong")} ${t("please_try_again_and_contact_us")}`,
     [ErrorCode.ThirdPartyIdentityProviderEnabled]: t("account_created_with_identity_provider"),

--- a/apps/web/playwright/login.e2e.ts
+++ b/apps/web/playwright/login.e2e.ts
@@ -58,7 +58,7 @@ test.describe("Login and logout tests", () => {
 
   test.describe("Login flow validations", async () => {
     test("Should warn when user does not exist", async ({ page }) => {
-      const alertMessage = (await localize("en"))("incorrect_username_password");
+      const alertMessage = (await localize("en"))("incorrect_email_password");
 
       // Login with a non-existent user
       const never = "never";
@@ -69,7 +69,7 @@ test.describe("Login and logout tests", () => {
     });
 
     test("Should warn when password is incorrect", async ({ page, users }) => {
-      const alertMessage = (await localize("en"))("incorrect_username_password");
+      const alertMessage = (await localize("en"))("incorrect_email_password");
       // by default password===username with the users fixture
       const pro = await users.create({ username: "pro" });
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -477,7 +477,7 @@
   "max_limit_allowed_hint": "Must be {{limit}} or fewer characters long",
   "invalid_password_hint": "The password must be a minimum of {{passwordLength}} characters long containing at least one number and have a mixture of uppercase and lowercase letters",
   "incorrect_password": "Password is incorrect.",
-  "incorrect_username_password": "Username or password is incorrect.",
+  "incorrect_email_password": "Email or password is incorrect.",
   "use_setting": "Use setting",
   "am_pm": "am/pm",
   "time_options": "Time options",

--- a/packages/features/auth/lib/ErrorCode.ts
+++ b/packages/features/auth/lib/ErrorCode.ts
@@ -1,5 +1,5 @@
 export enum ErrorCode {
-  IncorrectUsernamePassword = "incorrect-username-password",
+  IncorrectEmailPassword = "incorrect-email-password",
   UserNotFound = "user-not-found",
   IncorrectPassword = "incorrect-password",
   UserMissingPassword = "missing-password",

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -100,7 +100,7 @@ const providers: Provider[] = [
 
       // Don't leak information about it being username or password that is invalid
       if (!user) {
-        throw new Error(ErrorCode.IncorrectUsernamePassword);
+        throw new Error(ErrorCode.IncorrectEmailPassword);
       }
 
       await checkRateLimitAndThrowError({
@@ -112,16 +112,16 @@ const providers: Provider[] = [
       }
 
       if (!user.password && user.identityProvider !== IdentityProvider.CAL && !credentials.totpCode) {
-        throw new Error(ErrorCode.IncorrectUsernamePassword);
+        throw new Error(ErrorCode.IncorrectEmailPassword);
       }
 
       if (user.password || !credentials.totpCode) {
         if (!user.password) {
-          throw new Error(ErrorCode.IncorrectUsernamePassword);
+          throw new Error(ErrorCode.IncorrectEmailPassword);
         }
         const isCorrectPassword = await verifyPassword(credentials.password, user.password);
         if (!isCorrectPassword) {
-          throw new Error(ErrorCode.IncorrectUsernamePassword);
+          throw new Error(ErrorCode.IncorrectEmailPassword);
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

fixing the incorrect error message displayed on the cal.com login page. The error message is updated to accurately state "Email or password is incorrect" instead of "Username or password is incorrect."

Fixes #10088 

![Screenshot from 2023-07-13 05-34-09](https://github.com/calcom/cal.com/assets/101047627/68d6c295-59e6-4d9d-8305-a368c03de8cf)


## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Chore (refactoring code, technical debt, workflow improvements)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update


## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
