### PR TITLE
fix: remove max width from bookings page

### DIFF
--- a/packages/features/bookings/layout/BookingLayout.tsx
+++ b/packages/features/bookings/layout/BookingLayout.tsx
@@ -36,14 +36,14 @@ export default function BookingLayout({
 }: { children: React.ReactNode } & ComponentProps<typeof Shell>) {
   return (
     <Shell {...rest} hideHeadingOnMobile>
-      <div className="flex max-w-6xl flex-col">
+      <div className="flex flex-col">
         <div className="flex flex-col flex-wrap lg:flex-row">
           <HorizontalTabs tabs={tabs} />
           <div className="max-w-full overflow-x-auto xl:ml-auto">
             <FiltersContainer />
           </div>
         </div>
-        <main className="w-full max-w-6xl">{children}</main>
+        <main className="w-full">{children}</main>
       </div>
     </Shell>
   );


### PR DESCRIPTION
## What does this PR do?

Remove the max width from the bookings container

Fixes #10124 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
![image](https://github.com/calcom/cal.com/assets/49095575/de7e1a9f-4763-4c60-97d6-0427293db70c)


## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  
## How should this be tested?

Go to the bookings page and see whether there is a maximum width applied on the container

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
