### PR TITLE
chore: cron workflow tidying

### DIFF
--- a/.github/workflows/cron-bookingReminder.yml
+++ b/.github/workflows/cron-bookingReminder.yml
@@ -5,7 +5,7 @@ on:
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
     # Runs “At every 15th minute.” (see https://crontab.guru)
-    - cron: "0/15 * * * *"
+    - cron: "*/15 * * * *"
 jobs:
   cron-bookingReminder:
     env:

--- a/.github/workflows/cron-bookingReminder.yml
+++ b/.github/workflows/cron-bookingReminder.yml
@@ -4,8 +4,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At minute 0, 15, 30, and 45.” (see https://crontab.guru)
-    - cron: "0,15,30,45 * * * *"
+    # Runs “At every 15th minute.” (see https://crontab.guru)
+    - cron: "0/15 * * * *"
 jobs:
   cron-bookingReminder:
     env:
@@ -20,4 +20,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/cron-bookingReminder.yml
+++ b/.github/workflows/cron-bookingReminder.yml
@@ -4,7 +4,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At every 15th minute.” (see https://crontab.guru)
+    # Runs "At every 15th minute." (see https://crontab.guru)
     - cron: "*/15 * * * *"
 jobs:
   cron-bookingReminder:

--- a/.github/workflows/cron-downgradeUsers.yml
+++ b/.github/workflows/cron-downgradeUsers.yml
@@ -5,7 +5,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “Every month at 1st (see https://crontab.guru)
+    # Runs “At 00:00 on day-of-month 1.” (see https://crontab.guru)
     - cron: "0 0 1 * *"
 jobs:
   cron-downgradeUsers:
@@ -21,4 +21,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/cron-downgradeUsers.yml
+++ b/.github/workflows/cron-downgradeUsers.yml
@@ -5,7 +5,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At 00:00 on day-of-month 1.” (see https://crontab.guru)
+    # Runs "At 00:00 on day-of-month 1." (see https://crontab.guru)
     - cron: "0 0 1 * *"
 jobs:
   cron-downgradeUsers:

--- a/.github/workflows/cron-scheduleEmailReminders.yml
+++ b/.github/workflows/cron-scheduleEmailReminders.yml
@@ -4,7 +4,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At every 15th minute.” (see https://crontab.guru)
+    # Runs "At every 15th minute." (see https://crontab.guru)
     - cron: "*/15 * * * *"
 jobs:
   cron-scheduleEmailReminders:

--- a/.github/workflows/cron-scheduleEmailReminders.yml
+++ b/.github/workflows/cron-scheduleEmailReminders.yml
@@ -5,7 +5,7 @@ on:
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
     # Runs “At every 15th minute.” (see https://crontab.guru)
-    - cron: "0/15 * * * *"
+    - cron: "*/15 * * * *"
 jobs:
   cron-scheduleEmailReminders:
     env:

--- a/.github/workflows/cron-scheduleEmailReminders.yml
+++ b/.github/workflows/cron-scheduleEmailReminders.yml
@@ -4,8 +4,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At minute 0, 15, 30, and 45.” (see https://crontab.guru)
-    - cron: "0,15,30,45 * * * *"
+    # Runs “At every 15th minute.” (see https://crontab.guru)
+    - cron: "0/15 * * * *"
 jobs:
   cron-scheduleEmailReminders:
     env:
@@ -20,4 +20,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/cron-scheduleSMSReminders.yml
+++ b/.github/workflows/cron-scheduleSMSReminders.yml
@@ -4,7 +4,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At every 15th minute.” (see https://crontab.guru)
+    # Runs "At every 15th minute." (see https://crontab.guru)
     - cron: "*/15 * * * *"
 jobs:
   cron-scheduleSMSReminders:

--- a/.github/workflows/cron-scheduleSMSReminders.yml
+++ b/.github/workflows/cron-scheduleSMSReminders.yml
@@ -4,8 +4,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At minute 0, 15, 30, and 45.” (see https://crontab.guru)
-    - cron: "0,15,30,45 * * * *"
+    # Runs “At every 15th minute.” (see https://crontab.guru)
+    - cron: "0/15 * * * *"
 jobs:
   cron-scheduleSMSReminders:
     env:
@@ -20,4 +20,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/cron-scheduleSMSReminders.yml
+++ b/.github/workflows/cron-scheduleSMSReminders.yml
@@ -5,7 +5,7 @@ on:
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
     # Runs “At every 15th minute.” (see https://crontab.guru)
-    - cron: "0/15 * * * *"
+    - cron: "*/15 * * * *"
 jobs:
   cron-scheduleSMSReminders:
     env:

--- a/.github/workflows/cron-scheduleWhatsappReminders.yml
+++ b/.github/workflows/cron-scheduleWhatsappReminders.yml
@@ -5,7 +5,7 @@ on:
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
     # Runs “At every 15th minute.” (see https://crontab.guru)
-    - cron: "0/15 * * * *"
+    - cron: "*/15 * * * *"
 jobs:
   cron-scheduleWhatsappReminders:
     env:

--- a/.github/workflows/cron-scheduleWhatsappReminders.yml
+++ b/.github/workflows/cron-scheduleWhatsappReminders.yml
@@ -4,8 +4,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At minute 0, 15, 30, and 45.” (see https://crontab.guru)
-    - cron: "0,15,30,45 * * * *"
+    # Runs “At every 15th minute.” (see https://crontab.guru)
+    - cron: "0/15 * * * *"
 jobs:
   cron-scheduleWhatsappReminders:
     env:
@@ -20,4 +20,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/cron-scheduleWhatsappReminders.yml
+++ b/.github/workflows/cron-scheduleWhatsappReminders.yml
@@ -4,7 +4,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At every 15th minute.” (see https://crontab.guru)
+    # Runs "At every 15th minute." (see https://crontab.guru)
     - cron: "*/15 * * * *"
 jobs:
   cron-scheduleWhatsappReminders:

--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -8,7 +8,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At 00:00.” (see https://crontab.guru)
+    # Runs “At 00:00.” every day (see https://crontab.guru)
     - cron: "0 0 * * *"
   workflow_dispatch:
 jobs:

--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -8,7 +8,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At 00:00.” every day (see https://crontab.guru)
+    # Runs "At 00:00." every day (see https://crontab.guru)
     - cron: "0 0 * * *"
   workflow_dispatch:
 jobs:

--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -8,7 +8,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs every day (see https://crontab.guru)
+    # Runs “At 00:00.” (see https://crontab.guru)
     - cron: "0 0 * * *"
   workflow_dispatch:
 jobs:

--- a/.github/workflows/cron-syncAppMeta.yml
+++ b/.github/workflows/cron-syncAppMeta.yml
@@ -5,7 +5,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “At 00:00 on day-of-month 1.” (see https://crontab.guru)
+    # Runs "At 00:00 on day-of-month 1." (see https://crontab.guru)
     - cron: "0 0 1 * *"
 jobs:
   cron-syncAppMeta:

--- a/.github/workflows/cron-syncAppMeta.yml
+++ b/.github/workflows/cron-syncAppMeta.yml
@@ -5,7 +5,7 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “Every month at 1st (see https://crontab.guru)
+    # Runs “At 00:00 on day-of-month 1.” (see https://crontab.guru)
     - cron: "0 0 1 * *"
 jobs:
   cron-syncAppMeta:
@@ -21,4 +21,4 @@ jobs:
             -X POST \
             -H 'content-type: application/json' \
             -H 'authorization: ${{ secrets.CRON_API_KEY }}' \
-            --fail
+            -sSf

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -1,7 +1,7 @@
 name: Submodule Sync
 on:
   schedule:
-    # Runs “At minute 15 past every 4th hour.” (see https://crontab.guru)
+    # Runs "At minute 15 past every 4th hour." (see https://crontab.guru)
     - cron: "15 */4 * * *"
   workflow_dispatch: ~
 jobs:

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -1,6 +1,7 @@
 name: Submodule Sync
 on:
   schedule:
+    # Runs “At minute 15 past every 4th hour.” (see https://crontab.guru)
     - cron: "15 */4 * * *"
   workflow_dispatch: ~
 jobs:


### PR DESCRIPTION
## What does this PR do?

Did some cron + curl tidying while reading through the codebase. Pasted crontab.guru output for easy read and verify. The curl flags will reduce unecessary progress meter output in the logs, while retaining previous --fail functionality.

Before:
![pre](https://github.com/calcom/cal.com/assets/55853254/69ff0207-1b77-4516-9ac2-6af47c79b385)

After:
![post](https://github.com/calcom/cal.com/assets/55853254/7bcad3d7-6adb-4e0f-8379-5422b2a676f4)


## Requirement/Documentation

N/A

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Cron schedule step values are [supported by Github](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule:~:text=/-,Step%20values,-20/15%20*%20*%20*%20*) and the curl flags are standard.

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
