### PR TITLE
fix: slugify username at sign up and username change within app

### DIFF
--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
-
+import slugify from "@calcom/lib/slugify";
 import { checkPremiumUsername } from "@calcom/features/ee/common/lib/checkPremiumUsername";
 import { getOrgFullDomain } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { isSAMLLoginEnabled } from "@calcom/features/ee/sso/lib/saml";
@@ -54,6 +54,7 @@ export default function Signup({ prepopulateFormValues, token, orgSlug }: Signup
   };
 
   const signUp: SubmitHandler<FormValues> = async (data) => {
+    data.username = slugify(data.username);
     await fetch("/api/auth/signup", {
       body: JSON.stringify({
         ...data,


### PR DESCRIPTION
## What does this PR do?

replaces all '+' with '-' in the username string.

Fixes # https://github.com/calcom/cal.com/issues/10078


## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

Did console.log to check the new string in the browser console. Got the desired log in the browser. Could not test the functionality e2e in local for sign up because sign up functionality doesn't work in local.

![image](https://github.com/calcom/cal.com/assets/33975149/2f38d65d-c04e-4608-be2d-91bff3d29018)

Testing for username change within app defined with images below.

![image](https://github.com/calcom/cal.com/assets/33975149/8dd7da3a-6582-4df3-a524-0164cb46c55f)

![image](https://github.com/calcom/cal.com/assets/33975149/4c81c3b5-e031-4f1b-a9a2-4bc5a92fa4e9)

![image](https://github.com/calcom/cal.com/assets/33975149/10713b9a-f062-4fd1-b18b-be79f4d437b2)

some test cases I used and result
++x  => x
ayush+go => ayush-go
v+1 => v-1
v+++ => v
++ => empty string

Reviewer can also try once using my code on local and test further. 

## Mandatory Tasks

  - [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

