### PR TITLE
fix: webhooks for events with seats

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -158,8 +158,6 @@ async function handler(req: CustomRequest) {
     },
   });
 
-  const tOrganizer = await getTranslation(organizer.locale ?? "en", "common");
-
   const teamMembersPromises = [];
   const attendeesListPromises = [];
   const hostsPresent = !!bookingToDelete.eventType?.hosts;
@@ -192,6 +190,7 @@ async function handler(req: CustomRequest) {
 
   const attendeesList = await Promise.all(attendeesListPromises);
   const teamMembers = await Promise.all(teamMembersPromises);
+  const tOrganizer = await getTranslation(organizer.locale ?? "en", "common");
 
   const evt: CalendarEvent = {
     title: bookingToDelete?.title,
@@ -726,7 +725,7 @@ async function handleSeatedEventCancellation(
 
   const attendee = bookingToDelete?.attendees.find((attendee) => attendee.id === seatReference.attendeeId);
 
-  const formattedAttendee = attendee
+  evt.attendees = attendee
     ? [
         {
           ...attendee,
@@ -737,8 +736,6 @@ async function handleSeatedEventCancellation(
         },
       ]
     : [];
-
-  evt.attendees = formattedAttendee;
 
   const promises = webhooks.map((webhook) =>
     sendPayload(webhook.secret, WebhookTriggerEvents.BOOKING_CANCELLED, new Date().toISOString(), webhook, {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1755,19 +1755,6 @@ async function handler(
       smsReminderNumber: booking?.smsReminderNumber || undefined,
     };
 
-    try {
-      subscribersMeetingEnded.forEach((subscriber) => {
-        if (rescheduleUid && originalRescheduledBooking) {
-          cancelScheduledJobs(originalRescheduledBooking, undefined, true);
-        }
-        if (booking && booking.status === BookingStatus.ACCEPTED) {
-          scheduleTrigger(booking, subscriber.subscriberUrl, subscriber);
-        }
-      });
-    } catch (error) {
-      log.error("Error while running scheduledJobs for booking", error);
-    }
-
     await handleWebhookTrigger({ subscriberOptions, eventTrigger, webhookData });
 
     return resultBooking;

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1135,6 +1135,40 @@ async function handler(
     return deletedReferences;
   };
 
+  // data needed for triggering webhooks
+  const eventTypeInfo: EventTypeInfo = {
+    eventTitle: eventType.title,
+    eventDescription: eventType.description,
+    requiresConfirmation: requiresConfirmation || null,
+    price: paymentAppData.price,
+    currency: eventType.currency,
+    length: eventType.length,
+  };
+
+  const teamId = await getTeamId({ eventType });
+
+  const subscriberOptions: GetSubscriberOptions = {
+    userId: organizerUser.id,
+    eventTypeId,
+    triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
+    teamId,
+  };
+
+  const eventTrigger: WebhookTriggerEvents = rescheduleUid
+    ? WebhookTriggerEvents.BOOKING_RESCHEDULED
+    : WebhookTriggerEvents.BOOKING_CREATED;
+
+  subscriberOptions.triggerEvent = eventTrigger;
+
+  const subscriberOptionsMeetingEnded = {
+    userId: organizerUser.id,
+    eventTypeId,
+    triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
+    teamId,
+  };
+
+  const subscribersMeetingEnded = await getWebhooks(subscriberOptionsMeetingEnded);
+
   const handleSeats = async () => {
     let resultBooking:
       | (Partial<Booking> & {
@@ -1167,6 +1201,9 @@ async function handler(
         startTime: true,
         user: true,
         status: true,
+        smsReminderNumber: true,
+        endTime: true,
+        scheduledJobs: true,
       },
     });
 
@@ -1701,6 +1738,38 @@ async function handler(
       log.error("Error while scheduling workflow reminders", error);
     }
 
+    const webhookData = {
+      ...evt,
+      ...eventTypeInfo,
+      bookingId: booking?.id,
+      rescheduleUid,
+      rescheduleStartTime: originalRescheduledBooking?.startTime
+        ? dayjs(originalRescheduledBooking?.startTime).utc().format()
+        : undefined,
+      rescheduleEndTime: originalRescheduledBooking?.endTime
+        ? dayjs(originalRescheduledBooking?.endTime).utc().format()
+        : undefined,
+      metadata: { ...metadata, ...reqBody.metadata },
+      eventTypeId,
+      status: "ACCEPTED",
+      smsReminderNumber: booking?.smsReminderNumber || undefined,
+    };
+
+    try {
+      subscribersMeetingEnded.forEach((subscriber) => {
+        if (rescheduleUid && originalRescheduledBooking) {
+          cancelScheduledJobs(originalRescheduledBooking, undefined, true);
+        }
+        if (booking && booking.status === BookingStatus.ACCEPTED) {
+          scheduleTrigger(booking, subscriber.subscriberUrl, subscriber);
+        }
+      });
+    } catch (error) {
+      log.error("Error while running scheduledJobs for booking", error);
+    }
+
+    await handleWebhookTrigger({ subscriberOptions, eventTrigger, webhookData });
+
     return resultBooking;
   };
   // For seats, if the booking already exists then we want to add the new attendee to the existing booking
@@ -2231,14 +2300,6 @@ async function handler(
       }
     : undefined;
 
-  const eventTypeInfo: EventTypeInfo = {
-    eventTitle: eventType.title,
-    eventDescription: eventType.description,
-    requiresConfirmation: requiresConfirmation || null,
-    price: paymentAppData.price,
-    currency: eventType.currency,
-    length: eventType.length,
-  };
   const webhookData = {
     ...evt,
     ...eventTypeInfo,
@@ -2255,30 +2316,7 @@ async function handler(
     status: "ACCEPTED",
     smsReminderNumber: booking?.smsReminderNumber || undefined,
   };
-
-  const teamId = await getTeamId({ eventType });
-
-  const subscriberOptions: GetSubscriberOptions = {
-    userId: organizerUser.id,
-    eventTypeId,
-    triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
-    teamId,
-  };
-
   if (isConfirmedByDefault) {
-    const eventTrigger: WebhookTriggerEvents = rescheduleUid
-      ? WebhookTriggerEvents.BOOKING_RESCHEDULED
-      : WebhookTriggerEvents.BOOKING_CREATED;
-
-    subscriberOptions.triggerEvent = eventTrigger;
-
-    const subscriberOptionsMeetingEnded = {
-      userId: organizerUser.id,
-      eventTypeId,
-      triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
-      teamId,
-    };
-
     try {
       const subscribersMeetingEnded = await getWebhooks(subscriberOptionsMeetingEnded);
 


### PR DESCRIPTION
## What does this PR do?

Fixes that when an event with seats was booked webhooks didn't trigger.

Fixes #7950
Fixes #8644

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

  1. Create user webhook
  2. Go to [webhook.site](webhook.site)
  3.  Copy URL and paste as the subscriber URL 
  4.  Save webhook 
  5. Create an event with seats
  6. Book a seat => check if the webhook triggered
  8. Cancel seat => check if webhook triggered
  9. Now book two seats in the same slot (make sure you are not logged in as organizer) => check if the second one also triggers
  10. Cancel the second seat => check if it triggers

## Mandatory Tasks

  - [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
