### PR TITLE
fix: no feedback on buttons on /getting-started page.

### DIFF
--- a/apps/web/components/getting-started/components/AppConnectionItem.tsx
+++ b/apps/web/components/getting-started/components/AppConnectionItem.tsx
@@ -28,7 +28,7 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
             color="secondary"
             disabled={installed}
             type="button"
-            loading={buttonProps?.isLoading || false}
+            loading={buttonProps?.isLoading}
             onClick={(event) => {
               // Save cookie key to return url step
               document.cookie = `return-to=${window.location.href};path=/;max-age=3600;SameSite=Lax`;

--- a/apps/web/components/getting-started/components/AppConnectionItem.tsx
+++ b/apps/web/components/getting-started/components/AppConnectionItem.tsx
@@ -28,6 +28,7 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
             color="secondary"
             disabled={installed}
             type="button"
+            loading={buttonProps?.isLoading || false}
             onClick={(event) => {
               // Save cookie key to return url step
               document.cookie = `return-to=${window.location.href};path=/;max-age=3600;SameSite=Lax`;

--- a/packages/app-store/components.tsx
+++ b/packages/app-store/components.tsx
@@ -34,6 +34,7 @@ export const InstallAppButtonWithoutPlanCheck = (
           onClick: () => {
             mutation.mutate({ type: props.type });
           },
+          isLoading: mutation.isLoading,
         })}
       </>
     );

--- a/packages/app-store/types.d.ts
+++ b/packages/app-store/types.d.ts
@@ -34,6 +34,7 @@ export interface InstallAppButtonProps {
     renderProps: ButtonProps & {
       /** Tells that the default render component should be used */
       useDefaultComponent?: boolean;
+      isLoading?: boolean;
     }
   ) => JSX.Element;
   onChanged?: () => unknown;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the buttons feedback on the onboarding pages like `/getting-started/connected-calendar`

Fixes #10061

[Screencast from 2023-07-14 06-24-08.webm](https://github.com/calcom/cal.com/assets/101047627/6c68395c-db7a-4d24-b184-99e7e1b665c1)

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.