### PR TITLE
fix: slot start times with interrupted availabilities 

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -166,41 +166,21 @@ function buildSlotsWithDateRanges({
 
     let slotStartTime = range.start.isAfter(startTimeWithMinNotice) ? range.start : startTimeWithMinNotice;
 
-    let previousStartTime;
-    // check if we we already have slots on that day (in organizer's timezone)
-    if (
-      slots.length &&
-      dayjs
-        .utc(range.start)
-        .add(range.start.utcOffset())
-        .isSame(dayjs.utc(slots[slots.length - 1].time).add(slots[slots.length - 1].time.utcOffset()), "day")
-    ) {
-      previousStartTime = slots[slots.length - 1].time;
-    }
+    let interval = 15;
 
-    if (!previousStartTime) {
-      let interval = 15;
+    const intervalsWithDefinedStartTimes = [60, 30, 20, 10];
 
-      const intervalsWithDefinedStartTimes = [60, 30, 20, 10];
-
-      for (let i = 0; i < intervalsWithDefinedStartTimes.length; i++) {
-        if (frequency % intervalsWithDefinedStartTimes[i] === 0) {
-          interval = intervalsWithDefinedStartTimes[i];
-          break;
-        }
+    for (let i = 0; i < intervalsWithDefinedStartTimes.length; i++) {
+      if (frequency % intervalsWithDefinedStartTimes[i] === 0) {
+        interval = intervalsWithDefinedStartTimes[i];
+        break;
       }
-
-      slotStartTime =
-        slotStartTime.utc().minute() % interval !== 0
-          ? slotStartTime
-              .startOf("hour")
-              .add(Math.ceil(slotStartTime.minute() / interval) * interval, "minute")
-          : slotStartTime;
-    } else {
-      const minuteOffset =
-        Math.ceil(slotStartTime.diff(previousStartTime, "minutes") / frequency) * frequency;
-      slotStartTime = previousStartTime.add(minuteOffset, "minutes");
     }
+
+    slotStartTime =
+      slotStartTime.utc().minute() % interval !== 0
+        ? slotStartTime.startOf("hour").add(Math.ceil(slotStartTime.minute() / interval) * interval, "minute")
+        : slotStartTime;
 
     // Adding 1 minute to date ranges that end at midnight to ensure that the last slot is included
     const rangeEnd = range.end


### PR DESCRIPTION
## What does this PR do?

Before we calculated our slot start times like that: 
If the first slot is at 8:30 and it's a 195-minute long event (3h and 15 min) we would only allow the following slots => 8:00, 11:15, 14:30, 17:45, etc. 

This caused issues when availabilities were interrupted and some slots a user would expect did not show up. 

#### For example: 

Availability: 
<img width="563" alt="Screenshot 2023-07-14 at 11 21 52" src="https://github.com/calcom/cal.com/assets/30310907/234f9618-285b-4d57-b7d9-d86abe1e88fc">

Slots before: 
<img width="279" alt="Screenshot 2023-07-14 at 11 24 14" src="https://github.com/calcom/cal.com/assets/30310907/013c74bb-2815-4485-bd07-17950d8933d9">

Slots after: 
<img width="276" alt="Screenshot 2023-07-14 at 11 23 51" src="https://github.com/calcom/cal.com/assets/30310907/9d12c835-2cc1-4df9-a1a7-3cbce5cd8bb1">

Fixes #10133
(Also #10161 has fixes for #10133)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Test my examples provided above
