### PR TITLE
fix: Added step to create env file for bundle analysis

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -7,8 +7,13 @@ on:
       - main
 
 jobs:
+  env:
+    name: Create env file
+    uses: ./.github/workflows/env-create-file.yml
+    secrets: inherit
   build:
     name: Production build
+    needs: env
     if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/production-build.yml
     secrets: inherit


### PR DESCRIPTION
## What does this PR do?

Fixes issue where main builds no longer have a valid env file to use while running the bundle analysis workflow.

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

  - When another commit goes into main, the bundle analysis action should not fail.

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.