### PR TITLE
fix: Hotfix-bookings list breaks on unsupported timezone

### DIFF
--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -38,8 +38,12 @@ export const formatTime = (
  * 
  */
 export const isSupportedTimeZone = (timeZone: string) => {
-  const validTimezones = Intl.supportedValuesOf("timeZone");
-  return validTimezones.includes(timeZone);
+  try {
+    dayjs().tz(timeZone);
+    return true;
+  } catch (error) {
+    return false;
+  }
 };
 
 

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -31,6 +31,19 @@ export const formatTime = (
 };
 
 /**
+ * Checks if a provided timeZone string is recognized as a valid timezone by the Intl API.
+ * 
+ * @param {string} timeZone - The timezone string to be verified.
+ * @returns {boolean} - Returns 'true' if the provided timezone string is recognized as a valid timezone by the Intl API. Otherwise, returns 'false'.
+ * 
+ */
+export const isSupportedTimeZone = (timeZone: string) => {
+  const validTimezones = Intl.supportedValuesOf("timeZone");
+  return validTimezones.includes(timeZone);
+};
+
+
+/**
  * Returns a localized and translated date or time, based on the native
  * Intl.DateTimeFormat available to JS. Undefined values mean the browser's
  * locale will be used.

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -31,10 +31,10 @@ export const formatTime = (
 };
 
 /**
- * Checks if a provided timeZone string is recognized as a valid timezone by the Intl API.
+ * Checks if a provided timeZone string is recognized as a valid timezone by dayjs.
  * 
  * @param {string} timeZone - The timezone string to be verified.
- * @returns {boolean} - Returns 'true' if the provided timezone string is recognized as a valid timezone by the Intl API. Otherwise, returns 'false'.
+ * @returns {boolean} - Returns 'true' if the provided timezone string is recognized as a valid timezone by dayjs. Otherwise, returns 'false'.
  * 
  */
 export const isSupportedTimeZone = (timeZone: string) => {

--- a/packages/ui/components/popover/MeetingTimeInTimezones.tsx
+++ b/packages/ui/components/popover/MeetingTimeInTimezones.tsx
@@ -5,6 +5,7 @@ import {
   isNextDayInTimezone,
   isPreviousDayInTimezone,
   sortByTimezone,
+  isSupportedTimeZone,
 } from "@calcom/lib/date-fns";
 
 import { Globe } from "../icon";
@@ -34,8 +35,12 @@ const MeetingTimeInTimezones = ({
   endTime,
 }: MeetingTimeInTimezonesProps) => {
   if (!userTimezone || !attendees.length) return null;
-
-  const attendeeTimezones = attendees.map((attendee) => attendee.timeZone);
+  
+  // If attendeeTimezone is unsupported, we fallback to host timezone. Unsupported Attendee timezone can be used due to bad API booking request in the past | backward-compatibility
+  
+  const attendeeTimezones = attendees.map((attendee) => {
+    return isSupportedTimeZone(attendee.timeZone) ? attendee.timeZone : userTimezone;
+  });
   const uniqueTimezones = [userTimezone, ...attendeeTimezones].filter(
     (value, index, self) => self.indexOf(value) === index
   );


### PR DESCRIPTION
## What does this PR do?

This PR adds a fallback to unsupported attendee timezone which can be fed via the API, resulting in hard crash of the `/bookings` page in the cal.com UI. Currently we can create a booking with certain unsupported timezones via the API, however that is being sorted as well. The code changes in this PR would still be important for backwards compatibility, otherwise `/bookings/past` would remain broken due to old bookings of this nature.

Partly Fixes #10189 

[Loom Video](https://www.loom.com/share/41d770d44fb147978412398627af6a39?sid=8a742664-8f44-4df5-a26b-41c699dbf7ba)
[Loom Video #2](https://www.loom.com/share/ee9210314ef44887ae65daf0f017212d?sid=f3d854c8-5306-478a-9560-a40b613e8090)

## Type of change

<!-- Please delete bullets that are not relevant. -->

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How should this be tested?

  - What are the minimal test data to have?
    Create a new booking (either via API or via UI) and make sure that it has a unsupported timezone such as "America/Pacific". You can change the timezone of the attendee by going into the attendee table in prisma studio, if you create the booking via UI. 

  - What is expected (happy path) to have (input and output)?
     The /bookings/ page containing this booking should crash. Once my changes are applied, it shouldn't crash anymore

## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
