### PR TITLE
fix: Flaky 2FA test due to waiting redundant Enter

### DIFF
--- a/apps/web/playwright/login.2fa.e2e.ts
+++ b/apps/web/playwright/login.2fa.e2e.ts
@@ -36,7 +36,6 @@ test.describe("2FA Tests", async () => {
        */
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await fillOtp({ page, secret: "123456", noRetry: true });
-      await page.press('input[name="2fa6"]', "Enter");
       await expect(page.locator('[data-testid="error-submitting-code"]')).toBeVisible();
 
       await fillOtp({
@@ -44,7 +43,6 @@ test.describe("2FA Tests", async () => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         secret: secret!,
       });
-      await page.press('input[name="2fa6"]', "Enter");
 
       await expect(page.locator(`[data-testid=two-factor-switch][data-state="checked"]`)).toBeVisible();
 


### PR DESCRIPTION
## What does this PR do?

These occasionally fail depending on whether or not 2fa6 is dismissed or not.