### PR TITLE
fix: add missing booking paid webhook trigger to dropdwon

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -407,6 +407,7 @@
   "booking_requested": "Booking Requested",
   "meeting_ended": "Meeting Ended",
   "form_submitted": "Form Submitted",
+  "booking_paid": "Booking Paid",
   "event_triggers": "Event Triggers",
   "subscriber_url": "Subscriber URL",
   "create_new_webhook": "Create a new webhook",

--- a/packages/features/webhooks/components/WebhookForm.tsx
+++ b/packages/features/webhooks/components/WebhookForm.tsx
@@ -35,6 +35,7 @@ const WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2: Record<string, WebhookTriggerEve
     { value: WebhookTriggerEvents.BOOKING_REJECTED, label: "booking_rejected" },
     { value: WebhookTriggerEvents.BOOKING_REQUESTED, label: "booking_requested" },
     { value: WebhookTriggerEvents.BOOKING_RESCHEDULED, label: "booking_rescheduled" },
+    { value: WebhookTriggerEvents.BOOKING_PAID, label: "booking_paid" },
     { value: WebhookTriggerEvents.MEETING_ENDED, label: "meeting_ended" },
     { value: WebhookTriggerEvents.RECORDING_READY, label: "recording_ready" },
   ],

--- a/packages/lib/date-fns/index.ts
+++ b/packages/lib/date-fns/index.ts
@@ -32,10 +32,10 @@ export const formatTime = (
 
 /**
  * Checks if a provided timeZone string is recognized as a valid timezone by dayjs.
- * 
+ *
  * @param {string} timeZone - The timezone string to be verified.
  * @returns {boolean} - Returns 'true' if the provided timezone string is recognized as a valid timezone by dayjs. Otherwise, returns 'false'.
- * 
+ *
  */
 export const isSupportedTimeZone = (timeZone: string) => {
   try {
@@ -45,7 +45,6 @@ export const isSupportedTimeZone = (timeZone: string) => {
     return false;
   }
 };
-
 
 /**
  * Returns a localized and translated date or time, based on the native


### PR DESCRIPTION
## What does this PR do?

This PR adds the Booking Paid trigger for webhooks to the dropdown. 

<img width="827" alt="Screenshot 2023-07-18 at 15 28 42" src="https://github.com/calcom/cal.com/assets/30310907/4bf382c7-9ba8-4eec-b488-9ab68a041324">

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
