### PR TITLE
fix: Booking Form - Prefill username and email from session [New Booker Regression]

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 import type { TFunction } from "next-i18next";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef } from "react";
@@ -40,6 +41,7 @@ type BookEventFormProps = {
 };
 
 export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
+  const session = useSession();
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation({
     trpc: { context: { skipBatch: true } },
   });
@@ -114,8 +116,12 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
     });
 
     const defaultUserValues = {
-      email: rescheduleUid ? bookingData?.attendees[0].email : parsedQuery["email"] || "",
-      name: rescheduleUid ? bookingData?.attendees[0].name : parsedQuery["name"] || "",
+      email: rescheduleUid
+        ? bookingData?.attendees[0].email
+        : parsedQuery["email"] || session.data?.user?.email || "",
+      name: rescheduleUid
+        ? bookingData?.attendees[0].name
+        : parsedQuery["name"] || session.data?.user?.name || "",
     };
 
     if (!isRescheduling) {


### PR DESCRIPTION
## What does this PR do?

Fixes #10227

[After Fix Demo](https://www.loom.com/share/b4244d020c4140e894e482a10d08ef89)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Logged in Scenario
	- Test 1
		- Login to app
		- Visit app.cal.local:3000/pro/30min
		- See that your name and email address are prefilled there
	- Test 2
		- Visit http://app.cal.local:3000/pro/30min?name=john&email=john@doe.com
		- See that the prefill query params are prefilled in the form
- Non Logged in Scenario
	- Visit app.cal.local:3000/pro/30min
	- See  that the prefill query params are prefilled in the form


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
