### PR TITLE
fix: issue with date overrides in some timezones

### DIFF
--- a/packages/lib/date-ranges.test.ts
+++ b/packages/lib/date-ranges.test.ts
@@ -112,6 +112,35 @@ describe("buildDateRanges", () => {
       end: dayjs("2023-06-14T16:00:00Z").tz(timeZone),
     });
   });
+  it("should return correct date ranges if date override would already already be the next day in utc timezone", () => {
+    const items = [
+      {
+        date: new Date(Date.UTC(2023, 5, 13)),
+        startTime: new Date(Date.UTC(0, 0, 0, 22, 0)),
+        endTime: new Date(Date.UTC(0, 0, 0, 23, 0)),
+      },
+      {
+        days: [1, 2, 3, 4, 5],
+        startTime: new Date(Date.UTC(2023, 5, 12, 8, 0)),
+        endTime: new Date(Date.UTC(2023, 5, 12, 17, 0)),
+      },
+    ];
+    const timeZone = "America/New_York";
+
+    const dateFrom = dayjs("2023-06-13T00:00:00Z");
+    const dateTo = dayjs("2023-06-15T00:00:00Z");
+
+    const results = buildDateRanges({ availability: items, timeZone, dateFrom, dateTo });
+
+    expect(results[0]).toEqual({
+      start: dayjs("2023-06-14T02:00:00Z").tz(timeZone),
+      end: dayjs("2023-06-14T03:00:00Z").tz(timeZone),
+    });
+    expect(results[1]).toEqual({
+      start: dayjs("2023-06-14T12:00:00Z").tz(timeZone),
+      end: dayjs("2023-06-14T21:00:00Z").tz(timeZone),
+    });
+  });
 });
 
 describe("subtract", () => {

--- a/packages/lib/date-ranges.ts
+++ b/packages/lib/date-ranges.ts
@@ -52,9 +52,11 @@ export function processDateOverride({ item, timeZone }: { item: DateOverride; ti
   const startTime = dayjs(item.startTime).utc().subtract(dayjs().tz(timeZone).utcOffset(), "minute");
   const endTime = dayjs(item.endTime).utc().subtract(dayjs().tz(timeZone).utcOffset(), "minute");
 
+  const diffDays = startTime.startOf("day").diff(dayjs.utc(item.startTime).startOf("day"), "day");
+
   return {
-    start: date.hour(startTime.hour()).minute(startTime.minute()).second(0).tz(timeZone),
-    end: date.hour(endTime.hour()).minute(endTime.minute()).second(0).tz(timeZone),
+    start: date.add(diffDays, "day").hour(startTime.hour()).minute(startTime.minute()).second(0).tz(timeZone),
+    end: date.add(diffDays, "day").hour(endTime.hour()).minute(endTime.minute()).second(0).tz(timeZone),
   };
 }
 
@@ -105,7 +107,7 @@ export function groupByDate(ranges: DateRange[]): { [x: string]: DateRange[] } {
       },
       currentValue
     ) => {
-      const dateString = dayjs.utc(currentValue.start).format("YYYY-MM-DD");
+      const dateString = dayjs(currentValue.start).format("YYYY-MM-DD");
 
       previousValue[dateString] =
         typeof previousValue[dateString] === "undefined"


### PR DESCRIPTION
## What does this PR do?

Fixes issues with date overrides shown on wrong day + wrong slots blocked off. 
This happened when working hours or date overrides in UTC time belonged to the next day or the day before

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Test the following availabilities and see if the correct slots are shown. Make sure to set Timezone, Working Hours and Date Overrides as shown in screenshots.

<img width="1089" alt="Screenshot 2023-07-19 at 19 42 26" src="https://github.com/calcom/cal.com/assets/30310907/a92c6dbb-558e-4a3d-aad7-bff719abcbbf">

<img width="1148" alt="Screenshot 2023-07-19 at 19 44 23" src="https://github.com/calcom/cal.com/assets/30310907/bb7801de-75af-498f-989b-ad1bb89af6cf">
(what's important here: Timezone, adding a date override on Friday from 22:00PM - 23:00PM)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
