### PR TITLE
fix: Set the limit of Occurrences

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -507,7 +507,7 @@
   "your_name": "Your name",
   "your_full_name": "Your full name",
   "no_name":"No name",
-  "enter_number_between_range": "Please enter a number between 1 and 20.",
+  "enter_number_between_range": "Please enter a number between 1 and {{maxOccurences}}",
   "email_address": "Email address",
   "enter_valid_email": "Please enter a valid email",
   "location": "Location",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -507,6 +507,7 @@
   "your_name": "Your name",
   "your_full_name": "Your full name",
   "no_name":"No name",
+  "enter_number_between_range": "Please enter a number between 1 and 20.",
   "email_address": "Email address",
   "enter_valid_email": "Please enter a valid email",
   "location": "Location",

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -81,7 +81,7 @@ export type BookerStore = {
   recurringEventCount: number | null;
   setRecurringEventCount(count: number | null): void;
   /**
-   * Number of input occurences count.
+   * Input occurrence count.
    */
   occurenceCount: number | null;
   setOccurenceCount(count: number | null): void;

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -6,8 +6,7 @@ import { BookerLayouts } from "@calcom/prisma/zod-utils";
 
 import type { GetBookingType } from "../lib/get-booking";
 import type { BookerState, BookerLayout } from "./types";
-import { validateLayout } from "./utils/layout";
-import { updateQueryParam, getQueryParam, removeQueryParam } from "./utils/query-param";
+import { updateQueryParam, getQueryParam } from "./utils/query-param";
 
 /**
  * Arguments passed into store initializer, containing
@@ -82,6 +81,11 @@ export type BookerStore = {
   recurringEventCount: number | null;
   setRecurringEventCount(count: number | null): void;
   /**
+   * Number of input occurences count.
+   */
+  occurenceCount: number | null;
+  setOccurenceCount(count: number | null): void;
+  /**
    * If booking is being rescheduled or it has seats, it receives a rescheduleUid or bookingUid
    * the current booking details are passed in. The `bookingData`
    * object is something that's fetched server side.
@@ -128,7 +132,7 @@ export const useBookerStore = create<BookerStore>((set, get) => ({
     if (["week_view", "column_view"].includes(layout) && !get().selectedDate) {
       set({ selectedDate: dayjs().format("YYYY-MM-DD") });
     }
-    updateQueryParam("layout", layout)
+    updateQueryParam("layout", layout);
     return set({ layout });
   },
   selectedDate: getQueryParam("date") || null,
@@ -232,6 +236,8 @@ export const useBookerStore = create<BookerStore>((set, get) => ({
   },
   recurringEventCount: null,
   setRecurringEventCount: (recurringEventCount: number | null) => set({ recurringEventCount }),
+  occurenceCount: null,
+  setOccurenceCount: (occurenceCount: number | null) => set({ occurenceCount }),
   rescheduleUid: null,
   bookingData: null,
   bookingUid: null,

--- a/packages/features/bookings/components/event-meta/Occurences.tsx
+++ b/packages/features/bookings/components/event-meta/Occurences.tsx
@@ -68,6 +68,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
         max="20"
         defaultValue={occurrenceCount}
         onChange={(event) => {
+          setOccurrenceCount(parseInt(event?.target.value));
           const pattern = /^(1[0-9]|20|[1-9])$/;
           if (!pattern.test(event?.target.value)) {
             setWarning(true);
@@ -75,7 +76,6 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
           } else {
             setWarning(false);
             setRecurringEventCount(parseInt(event?.target.value));
-            setOccurrenceCount(parseInt(event?.target.value));
           }
         }}
       />

--- a/packages/features/bookings/components/event-meta/Occurences.tsx
+++ b/packages/features/bookings/components/event-meta/Occurences.tsx
@@ -11,6 +11,7 @@ import { useTimePreferences } from "../../lib";
 import type { PublicEvent } from "../../types";
 
 export const EventOccurences = ({ event }: { event: PublicEvent }) => {
+  const [occurrenceCount, setOccurrenceCount] = useState(event?.recurringEvent?.count);
   const { t, i18n } = useLocale();
   const [setRecurringEventCount, recurringEventCount] = useBookerStore((state) => [
     state.setRecurringEventCount,
@@ -65,7 +66,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
         type="number"
         min="1"
         max="20"
-        defaultValue={event.recurringEvent.count}
+        defaultValue={occurrenceCount}
         onChange={(event) => {
           const pattern = /^(1[0-9]|20|[1-9])$/;
           if (!pattern.test(event?.target.value)) {
@@ -74,6 +75,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
           } else {
             Setwarning(false);
             setRecurringEventCount(parseInt(event?.target.value));
+            setOccurrenceCount(parseInt(event?.target.value));
           }
         }}
       />

--- a/packages/features/bookings/components/event-meta/Occurences.tsx
+++ b/packages/features/bookings/components/event-meta/Occurences.tsx
@@ -20,7 +20,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
   const selectedTimeslot = useBookerStore((state) => state.selectedTimeslot);
   const bookerState = useBookerStore((state) => state.state);
   const { timezone, timeFormat } = useTimePreferences();
-  const [warning, Setwarning] = useState(false);
+  const [warning, setWarning] = useState(false);
   // Set initial value in booker store.
   useEffect(() => {
     if (!event.recurringEvent?.count) return;
@@ -70,10 +70,10 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
         onChange={(event) => {
           const pattern = /^(1[0-9]|20|[1-9])$/;
           if (!pattern.test(event?.target.value)) {
-            Setwarning(true);
+            setWarning(true);
             setRecurringEventCount(recurringEventCount);
           } else {
-            Setwarning(false);
+            setWarning(false);
             setRecurringEventCount(parseInt(event?.target.value));
             setOccurrenceCount(parseInt(event?.target.value));
           }

--- a/packages/features/bookings/components/event-meta/Occurences.tsx
+++ b/packages/features/bookings/components/event-meta/Occurences.tsx
@@ -11,7 +11,7 @@ import { useTimePreferences } from "../../lib";
 import type { PublicEvent } from "../../types";
 
 export const EventOccurences = ({ event }: { event: PublicEvent }) => {
-  const [occurrenceCount, setOccurrenceCount] = useState(event?.recurringEvent?.count);
+  const maxOccurences = event.recurringEvent?.count;
   const { t, i18n } = useLocale();
   const [setRecurringEventCount, recurringEventCount] = useBookerStore((state) => [
     state.setRecurringEventCount,
@@ -24,9 +24,8 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
   // Set initial value in booker store.
   useEffect(() => {
     if (!event.recurringEvent?.count) return;
-    setRecurringEventCount(event.recurringEvent.count);
-  }, [setRecurringEventCount, event.recurringEvent]);
-
+    setRecurringEventCount(recurringEventCount || event.recurringEvent.count);
+  }, [setRecurringEventCount, event.recurringEvent, recurringEventCount]);
   if (!event.recurringEvent) return null;
 
   if (bookerState === "booking" && recurringEventCount && selectedTimeslot) {
@@ -65,14 +64,14 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
         className="my-1 mr-3 inline-flex h-[26px] w-[46px] px-1 py-0"
         type="number"
         min="1"
-        max="20"
-        defaultValue={occurrenceCount}
+        max={maxOccurences}
+        defaultValue={recurringEventCount || event.recurringEvent.count}
         onChange={(event) => {
-          setOccurrenceCount(parseInt(event?.target.value));
-          const pattern = /^(1[0-9]|20|[1-9])$/;
-          if (!pattern.test(event?.target.value)) {
+          const pattern = /^(?=.*[0-9])\S+$/;
+          const inputValue = parseInt(event.target.value);
+          if (!pattern.test(event.target.value) || inputValue < 1 || inputValue > maxOccurences) {
             setWarning(true);
-            setRecurringEventCount(recurringEventCount);
+            setRecurringEventCount(maxOccurences);
           } else {
             setWarning(false);
             setRecurringEventCount(parseInt(event?.target.value));
@@ -85,7 +84,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
       })}
       {warning && (
         <div className="-ml-4 mr-4 mt-2 flex">
-          <Alert severity="warning" title={t("enter_number_between_range")} />
+          <Alert severity="warning" title={t("enter_number_between_range", { maxOccurences })} />
         </div>
       )}
     </>

--- a/packages/features/bookings/components/event-meta/Occurences.tsx
+++ b/packages/features/bookings/components/event-meta/Occurences.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useBookerStore } from "@calcom/features/bookings/Booker/store";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { parseRecurringDates } from "@calcom/lib/parse-dates";
 import { getRecurringFreq } from "@calcom/lib/recurringStrings";
-import { Tooltip } from "@calcom/ui";
+import { Tooltip, Alert } from "@calcom/ui";
 import { Input } from "@calcom/ui";
 
 import { useTimePreferences } from "../../lib";
@@ -19,7 +19,7 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
   const selectedTimeslot = useBookerStore((state) => state.selectedTimeslot);
   const bookerState = useBookerStore((state) => state.state);
   const { timezone, timeFormat } = useTimePreferences();
-
+  const [warning, Setwarning] = useState(false);
   // Set initial value in booker store.
   useEffect(() => {
     if (!event.recurringEvent?.count) return;
@@ -63,14 +63,29 @@ export const EventOccurences = ({ event }: { event: PublicEvent }) => {
       <Input
         className="my-1 mr-3 inline-flex h-[26px] w-[46px] px-1 py-0"
         type="number"
+        min="1"
+        max="20"
         defaultValue={event.recurringEvent.count}
         onChange={(event) => {
-          setRecurringEventCount(parseInt(event?.target.value));
+          const pattern = /^(1[0-9]|20|[1-9])$/;
+          if (!pattern.test(event?.target.value)) {
+            Setwarning(true);
+            setRecurringEventCount(recurringEventCount);
+          } else {
+            Setwarning(false);
+            setRecurringEventCount(parseInt(event?.target.value));
+          }
         }}
       />
+
       {t("occurrence", {
         count: recurringEventCount || event.recurringEvent.count,
       })}
+      {warning && (
+        <div className="-ml-4 mr-4 mt-2 flex">
+          <Alert severity="warning" title={t("enter_number_between_range")} />
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
A warning alert will be visible if the input value is not a number and between the range. If the value is not between the range, then the occurrence value is set to default value. And also it is responsive.

Fixes #10204 
Fixes #10280
Fixes #10207 

loom video:- https://www.loom.com/share/bf6253b371f447409ce6c5ffdcf1ad48?sid=964b7646-bf0e-43aa-9a54-5e449d58317f




## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

