### PR TITLE
chore: Make embed and app-store tests required

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -109,7 +109,7 @@ jobs:
     secrets: inherit
 
   required:
-    needs: [lint, type-check, test, build, e2e]
+    needs: [lint, type-check, test, build, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
Make Embed and AppStore tests required.
These tests are skipped automatically if there isn't a related change but if they ran, we should not let a PR merge without them being passing.