### PR TITLE
fix: Add attendees to getLuckyUser algorithm

### DIFF
--- a/apps/web/test/lib/team-event-types.test.ts
+++ b/apps/web/test/lib/team-event-types.test.ts
@@ -33,6 +33,7 @@ it("can find lucky user with maximize availability", async () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   prismaMock.user.findMany.mockResolvedValue(users);
+  prismaMock.booking.findMany.mockResolvedValue([]);
 
   await expect(
     getLuckyUser("MAXIMIZE_AVAILABILITY", {

--- a/packages/lib/server/getLuckyUser.ts
+++ b/packages/lib/server/getLuckyUser.ts
@@ -2,14 +2,15 @@ import type { User } from "@prisma/client";
 
 import prisma from "@calcom/prisma";
 
-async function leastRecentlyBookedUser<T extends Pick<User, "id">>({
+async function leastRecentlyBookedUser<T extends Pick<User, "id" | "email">>({
   availableUsers,
   eventTypeId,
 }: {
   availableUsers: T[];
   eventTypeId: number;
 }) {
-  const usersWithLastCreated = await prisma.user.findMany({
+  // First we get all organizers (fixed host/single round robin user)
+  const organizersWithLastCreated = await prisma.user.findMany({
     where: {
       id: {
         in: availableUsers.map((user) => user.id),
@@ -32,17 +33,63 @@ async function leastRecentlyBookedUser<T extends Pick<User, "id">>({
     },
   });
 
-  if (!usersWithLastCreated) {
-    throw new Error("Unable to find users by availableUser ids."); // should never happen.
-  }
-
-  const userIdAndAtCreatedPair = usersWithLastCreated.reduce(
-    (keyValuePair: { [key: number]: Date }, user) => {
+  const organizerIdAndAtCreatedPair = organizersWithLastCreated.reduce(
+    (keyValuePair: { [userId: number]: Date }, user) => {
       keyValuePair[user.id] = user.bookings[0]?.createdAt || new Date(0);
       return keyValuePair;
     },
     {}
   );
+
+  const bookings = await prisma.booking.findMany({
+    where: {
+      AND: [
+        {
+          eventTypeId,
+        },
+        {
+          attendees: {
+            some: {
+              email: {
+                in: availableUsers.map((user) => user.email),
+              },
+            },
+          },
+        },
+      ],
+    },
+    select: {
+      id: true,
+      createdAt: true,
+      attendees: {
+        select: {
+          email: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  const attendeeUserIdAndAtCreatedPair = bookings.reduce((aggregate: { [userId: number]: Date }, booking) => {
+    availableUsers.forEach((user) => {
+      if (aggregate[user.id]) return; // Bookings are ordered DESC, so if the reducer aggregate
+      // contains the user id, it's already got the most recent booking marked.
+      if (!booking.attendees.map((attendee) => attendee.email).includes(user.email)) return;
+      aggregate[user.id] = booking.createdAt;
+    });
+    return aggregate;
+  }, {});
+
+  const userIdAndAtCreatedPair = {
+    ...organizerIdAndAtCreatedPair,
+    ...attendeeUserIdAndAtCreatedPair,
+  };
+
+  if (!userIdAndAtCreatedPair) {
+    throw new Error("Unable to find users by availableUser ids."); // should never happen.
+  }
 
   const leastRecentlyBookedUser = availableUsers.sort((a, b) => {
     return userIdAndAtCreatedPair[a.id] > userIdAndAtCreatedPair[b.id] ? 1 : -1;
@@ -53,7 +100,7 @@ async function leastRecentlyBookedUser<T extends Pick<User, "id">>({
 
 // TODO: Configure distributionAlgorithm from the event type configuration
 // TODO: Add 'MAXIMIZE_FAIRNESS' algorithm.
-export async function getLuckyUser<T extends Pick<User, "id">>(
+export async function getLuckyUser<T extends Pick<User, "id" | "email">>(
   distributionAlgorithm: "MAXIMIZE_AVAILABILITY" = "MAXIMIZE_AVAILABILITY",
   { availableUsers, eventTypeId }: { availableUsers: T[]; eventTypeId: number }
 ) {


### PR DESCRIPTION
## What does this PR do?

Implementing fixed hosts brought in a breaking change to the leastRecently algorithm, excluding non-organizer RR attendees. This fixes that, fixed hosts are not part of the pool so are not added to the availableUsers array.

This is urgent, but it needs tests; so that's a follow up as high priority.