### PR TITLE
fix: team event emails; sending & email subject

### DIFF
--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -7,6 +7,7 @@ export type EventNameObjectType = {
   attendeeName: string;
   eventType: string;
   eventName?: string | null;
+  teamName?: string | null;
   host: string;
   location?: string;
   bookingFields?: Prisma.JsonObject;
@@ -17,7 +18,7 @@ export function getEventName(eventNameObj: EventNameObjectType, forAttendeeView 
   if (!eventNameObj.eventName)
     return eventNameObj.t("event_between_users", {
       eventName: eventNameObj.eventType,
-      host: eventNameObj.host,
+      host: eventNameObj.teamName || eventNameObj.host,
       attendeeName: eventNameObj.attendeeName,
       interpolation: {
         escapeValue: false,

--- a/packages/emails/templates/organizer-scheduled-email.ts
+++ b/packages/emails/templates/organizer-scheduled-email.ts
@@ -70,16 +70,7 @@ export default class OrganizerScheduledEmail extends BaseEmail {
 
   protected getNodeMailerPayload(): Record<string, unknown> {
     const clonedCalEvent = cloneDeep(this.calEvent);
-
-    const toAddresses = [this.calEvent.organizer.email];
-    if (this.calEvent.team) {
-      this.calEvent.team.members.forEach((member) => {
-        const memberAttendee = this.calEvent.attendees.find((attendee) => attendee.email === member.email);
-        if (memberAttendee) {
-          toAddresses.push(memberAttendee.email);
-        }
-      });
-    }
+    const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
 
     return {
       icalEvent: {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -997,6 +997,8 @@ async function handler(
     attendeeName: fullName || "Nameless",
     eventType: eventType.title,
     eventName: eventType.eventName,
+    // we send on behalf of team if >1 round robin attendee | collective
+    teamName: eventType.schedulingType === "COLLECTIVE" || users.length > 1 ? eventType.team?.name : null,
     // TODO: Can we have an unnamed organizer? If not, I would really like to throw an error here.
     host: organizerUser.name || "Nameless",
     location: bookingLocation,

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -43,7 +43,6 @@ const user: User & { credentials: Credential[] } = {
   locale: "en",
   email: "john.doe@example.com",
   name: "John doe",
-  avatar: "",
   destinationCalendar: null,
   hideBranding: true,
   brandColor: "#797979",

--- a/packages/prisma/selects/user.ts
+++ b/packages/prisma/selects/user.ts
@@ -40,7 +40,6 @@ export const userSelect = Prisma.validator<Prisma.UserArgs>()({
     allowDynamicBooking: true,
     destinationCalendar: true,
     locale: true,
-    avatar: true,
     hideBranding: true,
     theme: true,
     brandColor: true,


### PR DESCRIPTION
## What does this PR do?

* Ensures email is sent to organizer & team members
* Fixes title for > 1 person events; preferring the team name (defaulting to host if not available)
* Removes another case of `avatar`
