### PR TITLE
feat: remove ISO date into UTC transformation

### DIFF
--- a/apps/api/lib/validations/schedule.ts
+++ b/apps/api/lib/validations/schedule.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import dayjs from "@calcom/dayjs";
 import { _ScheduleModel as Schedule, _AvailabilityModel as Availability } from "@calcom/prisma/zod";
 
 import { timeZone } from "./shared/timeZone";
@@ -22,13 +21,6 @@ export const schemaSchedulePublic = z
     z.object({
       availability: z
         .array(Availability.pick({ id: true, eventTypeId: true, days: true, startTime: true, endTime: true }))
-        .transform((v) =>
-          v.map((item) => ({
-            ...item,
-            startTime: dayjs.utc(item.startTime).format("HH:mm:ss"),
-            endTime: dayjs.utc(item.endTime).format("HH:mm:ss"),
-          }))
-        )
         .optional(),
     })
   );


### PR DESCRIPTION
## What does this PR do?

GET request from /schedules returns a resource with startTime and endTime not in ISO date string format 
Requests to the `/schedules` returns a resources with `startTime` and `endTime` is in ISO date string format, Earliar they comes in UTC date string format.

Fixes #10263 

### After
![Screenshot from 2023-07-21 12-35-49](https://github.com/calcom/cal.com/assets/101047627/c2787ed8-bb1a-42fb-af8d-25281574a625)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

By making a different request to the API with the help of **swagger**, 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.