### PR TITLE
fix: add booking form prefill e2e test

### DIFF
--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -222,7 +222,7 @@ test.describe("prefill", () => {
 
     await test.step("from session", async () => {
       await selectFirstAvailableTimeSlotNextMonth(page);
-      await expect(page.locator('[name="name"]')).toHaveValue(prefill.name);
+      await expect(page.locator('[name="name"]')).toHaveValue(prefill.name || "");
       await expect(page.locator('[name="email"]')).toHaveValue(prefill.email);
     });
 

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -213,3 +213,43 @@ test.describe("pro user", () => {
     expect(firstSlotAvailableText).toContain("9:00");
   });
 });
+
+test.describe("prefill", () => {
+  test("logged in", async ({ page, users }) => {
+    const prefill = await users.create();
+    await prefill.apiLogin();
+    await page.goto("/pro/30min");
+
+    await test.step("from session", async () => {
+      await selectFirstAvailableTimeSlotNextMonth(page);
+      await expect(page.locator('[name="name"]')).toHaveValue(prefill.name);
+      await expect(page.locator('[name="email"]')).toHaveValue(prefill.email);
+    });
+
+    await test.step("from query params", async () => {
+      const url = new URL(page.url());
+      url.searchParams.set("name", testName);
+      url.searchParams.set("email", testEmail);
+      await page.goto(url.toString());
+
+      await expect(page.locator('[name="name"]')).toHaveValue(testName);
+      await expect(page.locator('[name="email"]')).toHaveValue(testEmail);
+    });
+  });
+
+  test("logged out", async ({ page, users }) => {
+    await page.goto("/pro/30min");
+
+    await test.step("from query params", async () => {
+      await selectFirstAvailableTimeSlotNextMonth(page);
+
+      const url = new URL(page.url());
+      url.searchParams.set("name", testName);
+      url.searchParams.set("email", testEmail);
+      await page.goto(url.toString());
+
+      await expect(page.locator('[name="name"]')).toHaveValue(testName);
+      await expect(page.locator('[name="email"]')).toHaveValue(testEmail);
+    });
+  });
+});

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -216,7 +216,7 @@ test.describe("pro user", () => {
 
 test.describe("prefill", () => {
   test("logged in", async ({ page, users }) => {
-    const prefill = await users.create();
+    const prefill = await users.create({ name: "Prefill User" });
     await prefill.apiLogin();
     await page.goto("/pro/30min");
 

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -369,7 +369,7 @@ const createUser = (workerInfo: WorkerInfo, opts?: CustomUserOpts | null): Prism
   const uname = `${opts?.username || "user"}-${workerInfo.workerIndex}-${Date.now()}`;
   return {
     username: uname,
-    name: opts?.name || "Default Name",
+    name: opts?.name,
     email: `${uname}@example.com`,
     password: hashPassword(uname),
     emailVerified: new Date(),

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -315,7 +315,6 @@ const createUserFixture = (user: UserWithIncludes, page: Page) => {
     name: user.name,
     username: user.username,
     email: user.email,
-    name: user.name,
     eventTypes: user.eventTypes,
     routingForms: user.routingForms,
     self,

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -314,6 +314,8 @@ const createUserFixture = (user: UserWithIncludes, page: Page) => {
     id: user.id,
     name: user.name,
     username: user.username,
+    email: user.email,
+    name: user.name,
     eventTypes: user.eventTypes,
     routingForms: user.routingForms,
     self,
@@ -367,7 +369,7 @@ const createUser = (workerInfo: WorkerInfo, opts?: CustomUserOpts | null): Prism
   const uname = `${opts?.username || "user"}-${workerInfo.workerIndex}-${Date.now()}`;
   return {
     username: uname,
-    name: opts?.name,
+    name: opts?.name || "Default Name",
     email: `${uname}@example.com`,
     password: hashPassword(uname),
     emailVerified: new Date(),


### PR DESCRIPTION
## What does this PR do?

Ensures that booking form is prefilled:
- from session when logged in
- from query params regardless of auth

Fixes #10242 

Prevents regressions:
- [x] #10227

## New features

- users fixture `create()` method now returns email and name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

```
yarn e2e -g prefill
```

