### PR TITLE
fix: name value can be `undefined` for existing `name` type fields

### DIFF
--- a/packages/features/form-builder/utils.ts
+++ b/packages/features/form-builder/utils.ts
@@ -18,7 +18,7 @@ export const preprocessNameFieldDataWithVariant = (
 
 export const getFullName = (name: string | { firstName: string; lastName?: string }) => {
   if (!name) {
-    return name;
+    return "";
   }
   let nameString = "";
   if (typeof name === "string") {


### PR DESCRIPTION
## What does this PR do?

Fixes booking page crash when a user has a legacy `name` type of field which was simply a text field. Now, `name` field is much more than that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Add a "short text" user field. Go to DB and change it's type to 'name'(because name type can't be added from UI. User had it already as it was allowed earlier but wasn't useful)
<img width="562" alt="Screenshot 2023-07-21 at 8 23 37 PM" src="https://github.com/calcom/cal.com/assets/1780212/cc1fa3bc-24df-40b0-bb33-18ac5d6b2889">

- Now try booking the page and observe the crash.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works

##  Couple of findings

	- I should really not have assumed that the value can't be `undefined` [here](https://github.com/calcom/cal.com/blob/5bb39dda3a81070b26c43665d6ed20d123638317/packages/features/form-builder/Components.tsx#L84).  TypeScript didn't catch it because we [do type assertions here.](https://github.com/calcom/cal.com/blob/5bb39dda3a81070b26c43665d6ed20d123638317/packages/features/form-builder/FormBuilderField.tsx#L211)
	- I thought about the possibility of someone having a `name` type of field already but missed testing it out in the final PR. It could have been caught
	- This bug doesn't affect anyone else that doesn't have a 'name' type of field added already.
