### PR TITLE
fix: Fix embed iframe still visible even after closing the embed.

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -372,7 +372,9 @@ export class Cal {
         // Right now it would wait for embed-iframe.js bundle to be loaded as well. We can speed that up by inlining the JS that informs about color-scheme being set in the HTML.
         // But it's okay to do it here for now because the embedded calLink also keeps itself hidden till it receives `parentKnowsIframeReady` message(It has it's own reasons for that)
         // Once the embedded calLink starts not hiding the document, we should optimize this line to make the iframe visible earlier than this.
-        this.iframe.style.visibility = "visible";
+
+        // Imp: Don't use visiblity:visible as that would make the iframe show even if the host element of the shadowRoot has visiblity:visible set. Just reset the visibility to default
+        this.iframe.style.visibility = "";
       }
       this.doInIframe({ method: "parentKnowsIframeReady" } as const);
       this.iframeDoQueue.forEach((doInIframeArg) => {

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -373,7 +373,7 @@ export class Cal {
         // But it's okay to do it here for now because the embedded calLink also keeps itself hidden till it receives `parentKnowsIframeReady` message(It has it's own reasons for that)
         // Once the embedded calLink starts not hiding the document, we should optimize this line to make the iframe visible earlier than this.
 
-        // Imp: Don't use visiblity:visible as that would make the iframe show even if the host element of the shadowRoot has visiblity:visible set. Just reset the visibility to default
+        // Imp: Don't use visiblity:visible as that would make the iframe show even if the host element(A paren tof the iframe) has visiblity:hidden set. Just reset the visibility to default
         this.iframe.style.visibility = "";
       }
       this.doInIframe({ method: "parentKnowsIframeReady" } as const);


### PR DESCRIPTION
## What does this PR do?

Reported here
https://discord.com/channels/1125390093386010654/1131929046209527860/1131929046209527860

The issue simply happened because` visiblity:visible` when set on a child of an element that has `visiblity:hidden`, makes the child element visible 🤯 This doesn't work like `display:none` works. 
When an modal is closed, we set `visiblity:hidden` on the <cal-modal> element but due to a recent change we started setting visibllity:visible on iframe directly. This caused overlay to be hidden but iframe to be still shown


After: https://www.loom.com/share/3182731598ed475cb2b82d43572c8b18
Before: https://www.loom.com/share/7a1a2217b77649f299c0400c926ea4fd

A regression from #10265. A seemingly simple change.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
See the loom

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works


## Followup
- [x] https://github.com/calcom/cal.com/issues/10322