### PR TITLE
fix: webhook fetch calls should be no-follow

### DIFF
--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -160,6 +160,7 @@ const _sendPayload = async (
       "Content-Type": contentType,
       "X-Cal-Signature-256": secretSignature,
     },
+    redirect: "manual",
     body,
   });
 
@@ -168,7 +169,11 @@ const _sendPayload = async (
   return {
     ok: response.ok,
     status: response.status,
-    message: text,
+    ...(text
+      ? {
+          message: text,
+        }
+      : {}),
   };
 };
 


### PR DESCRIPTION
## What does this PR do?

Disables redirects on webhook; non-backwards compatible; investigating impact hense drafted.