### PR TITLE
feat: Don't run middleware on _next, .*avatar.png & favicon.ico

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -78,7 +78,7 @@ const middleware: NextMiddleware = async (req) => {
 
 export const config = {
   matcher: [
-    "/:path*",
+    "/((?!_next|.*avatar.png$|favicon.ico$).*)",
     "/api/collect-events/:path*",
     "/api/auth/:path*",
     "/apps/routing_forms/:path*",


### PR DESCRIPTION
## What does this PR do?

Reduce middleware activity for _next/* avatar.png & favicon.icon