### PR TITLE
fix: Onboarding wizard improvements [CAL-2229]

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserSettings.tsx
+++ b/apps/web/components/getting-started/steps-views/UserSettings.tsx
@@ -15,6 +15,7 @@ import { UsernameAvailabilityField } from "@components/ui/UsernameAvailability";
 
 interface IUserSettingsProps {
   nextStep: () => void;
+  hideUsername?: boolean;
 }
 
 const UserSettings = (props: IUserSettingsProps) => {
@@ -66,8 +67,8 @@ const UserSettings = (props: IUserSettingsProps) => {
   return (
     <form onSubmit={onSubmit}>
       <div className="space-y-6">
-        {/* Username textfield */}
-        <UsernameAvailabilityField />
+        {/* Username textfield: when not coming from signup */}
+        {!props.hideUsername && <UsernameAvailabilityField />}
 
         {/* Full name textfield */}
         <div className="w-full">

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -198,13 +198,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         id: foundToken.id,
       },
     });
+  } else {
+    await sendEmailVerification({
+      email: userEmail,
+      username,
+      language,
+    });
   }
-
-  await sendEmailVerification({
-    email: userEmail,
-    username,
-    language,
-  });
 
   res.status(201).json({ message: "Created user" });
 }

--- a/apps/web/pages/getting-started/[[...step]].tsx
+++ b/apps/web/pages/getting-started/[[...step]].tsx
@@ -42,6 +42,7 @@ const stepTransform = (step: (typeof steps)[number]) => {
 
 const stepRouteSchema = z.object({
   step: z.array(z.enum(steps)).default([INITIAL_STEP]),
+  from: z.string().optional(),
 });
 
 // TODO: Refactor how steps work to be contained in one array/object. Currently we have steps,initalsteps,headers etc. These can all be in one place
@@ -52,6 +53,7 @@ const OnboardingPage = () => {
 
   const result = stepRouteSchema.safeParse(router.query);
   const currentStep = result.success ? result.data.step[0] : INITIAL_STEP;
+  const from = result.success ? result.data.from : "";
 
   const headers = [
     {
@@ -141,7 +143,9 @@ const OnboardingPage = () => {
             </div>
             <StepCard>
               <Suspense fallback={<Loader />}>
-                {currentStep === "user-settings" && <UserSettings nextStep={() => goToIndex(1)} />}
+                {currentStep === "user-settings" && (
+                  <UserSettings nextStep={() => goToIndex(1)} hideUsername={from === "signup"} />
+                )}
                 {currentStep === "connected-calendar" && <ConnectedCalendars nextStep={() => goToIndex(2)} />}
 
                 {currentStep === "connected-video" && <ConnectedVideoStep nextStep={() => goToIndex(3)} />}

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -78,9 +78,11 @@ export default function Signup({ prepopulateFormValues, token, orgSlug }: Signup
         const verifyOrGettingStarted = flags["email-verification"] ? "auth/verify-email" : "getting-started";
         await signIn<"credentials">("credentials", {
           ...data,
-          callbackUrl: router.query.callbackUrl
-            ? `${WEBAPP_URL}/${router.query.callbackUrl}`
-            : `${WEBAPP_URL}/${verifyOrGettingStarted}`,
+          callbackUrl: `${
+            router.query.callbackUrl
+              ? `${WEBAPP_URL}/${router.query.callbackUrl}`
+              : `${WEBAPP_URL}/${verifyOrGettingStarted}`
+          }?from=signup`,
         });
       })
       .catch((err) => {


### PR DESCRIPTION
## What does this PR do?

When a user created their user through an org invitation, they picked up a username that will then be presented again to be picked in the onboarding wizard. That part was hidden when coming from signup.

<kbd><img src="https://github.com/calcom/cal.com/assets/467258/c6a370e5-8ef7-4fb5-b460-cfce8d10ed6a" /></kbd>

Also, a verification email was being sent to the invited user even after creating an account accepting the invitation clicking on the button of the invitation email, which was redundant, so the verification email was also refactored to no be sent for org signup.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Invite a user to an organization and click the button of the email to create an account. Username in onboarding wizard should not be shown, and verification email should not be sent.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
