### PR TITLE
chore: make Embed and AppStore Tests required

### DIFF
--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   e2e-app-store:
     timeout-minutes: 20
-    name: E2E App-Store Apps
+    name: E2E App Store (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: buildjet-4vcpu-ubuntu-2204
     services:
       postgres:
@@ -15,6 +15,11 @@ jobs:
           POSTGRES_DB: calendso
         ports:
           - 5432:5432
+    strategy:
+      fail-fast: false
+      matrix:
+        ## There aren't many tests for AppStore. So, just start with 2 shards. Increase if needed.
+        shard: [1, 2]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,12 +31,12 @@ jobs:
       - uses: ./.github/actions/cache-db
       - uses: ./.github/actions/cache-build
       - name: Run Tests
-        run: yarn test-e2e:app-store
+        run: yarn e2e:app-store --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           DEPLOYSENTINEL_API_KEY: ${{ secrets.DEPLOYSENTINEL_API_KEY }}
       - name: Upload Test Results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test-results
-          path: test-results
+          name: app-store-results-${{ matrix.shard }}_${{ strategy.job-total }}
+          path: app-store-results

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -1,10 +1,11 @@
-name: E2E Embed tests and booking flow(for non-embed as well)
+name: E2E Embed React tests and booking flow(for non-embed as well)
 on:
   workflow_call:
 
 jobs:
   e2e-embed:
     timeout-minutes: 20
+    name: E2E Embed React (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: buildjet-4vcpu-ubuntu-2204
     services:
       postgres:
@@ -14,6 +15,11 @@ jobs:
           POSTGRES_DB: calendso
         ports:
           - 5432:5432
+    strategy:
+      fail-fast: false
+      matrix:
+        ## There aren't many tests for embed-react. So, just start with 2 shards. Increase if needed.
+        shard: [1, 2]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +32,7 @@ jobs:
       - uses: ./.github/actions/cache-build
       - name: Run Tests
         run: |
-          yarn test-e2e:embed-react
+          yarn e2e:embed-react --shard=${{ matrix.shard }}/${{ strategy.job-total }}
           yarn workspace @calcom/embed-react packaged:tests
         env:
           DEPLOYSENTINEL_API_KEY: ${{ secrets.DEPLOYSENTINEL_API_KEY }}
@@ -34,5 +40,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test-results
-          path: test-results
+          name: embed-react-results-${{ matrix.shard }}_${{ strategy.job-total }}
+          path: embed-react-results

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,10 +1,11 @@
-name: E2E Embed tests and booking flow(for non-embed as well)
+name: E2E Embed Core tests and booking flow(for non-embed as well)
 on:
   workflow_call:
 
 jobs:
   e2e-embed:
     timeout-minutes: 20
+    name: E2E Embed Core (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: buildjet-4vcpu-ubuntu-2204
     services:
       postgres:
@@ -14,6 +15,11 @@ jobs:
           POSTGRES_DB: calendso
         ports:
           - 5432:5432
+    strategy:
+      fail-fast: false
+      matrix:
+        ## There aren't many tests for embed-core. So, just start with 2 shards. Increase if needed.
+        shard: [1, 2]
 
     steps:
       - uses: actions/checkout@v3
@@ -25,12 +31,12 @@ jobs:
       - uses: ./.github/actions/cache-db
       - uses: ./.github/actions/cache-build
       - name: Run Tests
-        run: yarn test-e2e:embed
+        run: yarn e2e:embed --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           DEPLOYSENTINEL_API_KEY: ${{ secrets.DEPLOYSENTINEL_API_KEY }}
       - name: Upload Test Results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test-results
-          path: test-results
+          name: embed-core-results-${{ matrix.shard }}_${{ strategy.job-total }}
+          path: embed-core-results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,21 +84,18 @@ jobs:
 
   e2e-app-store:
     name: E2E App Store tests
-    if: ${{ needs.changes.outputs.app-store == 'true' }}
     needs: [changes, lint, build]
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
     name: E2E embeds tests
-    if: ${{ needs.changes.outputs.embed == 'true' }}
     needs: [changes, lint, build]
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
     name: E2E React embeds tests
-    if: ${{ needs.changes.outputs.embed-react == 'true' }}
     needs: [changes, lint, build]
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit
@@ -109,7 +106,7 @@ jobs:
     secrets: inherit
 
   required:
-    needs: [lint, type-check, test, build, e2e]
+    needs: [lint, type-check, test, build, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
## What does this PR do?

Make all tests required now. 
A recent regression that could have been avoided if embed tests were required #10357


Side Note: Marked it High Priority as it's quick to merge and super important to have these tests block PR merge considering recent regression as well.
