### PR TITLE
fix: Username check for sign-up with invitation in org context

### DIFF
--- a/packages/lib/validateUsernameInOrg.ts
+++ b/packages/lib/validateUsernameInOrg.ts
@@ -21,6 +21,17 @@ export const validateUsernameInOrg = async (usernameSlug: string, teamId: number
       },
     });
 
+    const usersFound = await prisma.user.findMany({
+      where: {
+        organizationId: teamId,
+      },
+      select: {
+        username: true,
+      },
+    });
+
+    takenSlugs = usersFound.map((user) => user.username);
+
     // If only one team is found and it has a parent, then it's an child team
     // and we can use the parent id to find all the teams that belong to this org
     if (teamsFound && teamsFound.length === 1 && teamsFound[0].parentId) {
@@ -34,9 +45,9 @@ export const validateUsernameInOrg = async (usernameSlug: string, teamId: number
           slug: true,
         },
       });
-      takenSlugs = childTeams.map((team) => team.slug);
+      takenSlugs = takenSlugs.concat(childTeams.map((team) => team.slug));
     } else {
-      takenSlugs = teamsFound.map((team) => team.slug);
+      takenSlugs = takenSlugs.concat(teamsFound.map((team) => team.slug));
     }
 
     return !takenSlugs.includes(slugify(usernameSlug));


### PR DESCRIPTION
## What does this PR do?

Usernames were not being checked correctly when creating an account using sign-up flow with an invitation token in an organization context.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Invite someone to an org and have them follow the create account link, selecting a knowingly unused username to see go through sign-up without any error.