### PR TITLE
fix: missing translation for additional notes workflow variable

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1183,6 +1183,7 @@
   "event_time_variable": "Event time",
   "timezone_variable": "Timezone",
   "location_variable": "Location",
+  "additional_notes_variable": "Additional notes",
   "organizer_name_variable": "Organizer name",
   "app_upgrade_description": "In order to use this feature, you need to upgrade to a Pro account.",
   "invalid_number": "Invalid phone number",


### PR DESCRIPTION
## What does this PR do?

Adds missing translation for {ADDITIONAL_NOTES} workflow variable. 

Before: {ADDITIONAL_NOTES_VARIABLE}

Now: 
![Screenshot 2023-07-25 at 14 00 06](https://github.com/calcom/cal.com/assets/30310907/a48a306a-7ec2-4960-9bb1-c7f16ffedd6c)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
