### PR TITLE
fix: Booking Confirmation Dialogbox

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -15,7 +15,7 @@ export function BookFormAsModal({ visible, onCancel }: { visible: boolean; onCan
   const selectedDuration = useBookerStore((state) => state.selectedDuration);
   const { data } = useEvent();
   const parsedSelectedTimeslot = dayjs(selectedTimeslot);
-  const { timeFormat } = useTimePreferences();
+  const { timeFormat ,timezone} = useTimePreferences();
 
   return (
     <Dialog open={visible} onOpenChange={onCancel}>
@@ -27,7 +27,7 @@ export function BookFormAsModal({ visible, onCancel }: { visible: boolean; onCan
         <div className="my-4 flex space-x-2 rounded-md leading-none">
           <Badge variant="grayWithoutHover" startIcon={Calendar} size="lg">
             <span>
-              {parsedSelectedTimeslot.format("LL")} {parsedSelectedTimeslot.format(timeFormat)}
+              {parsedSelectedTimeslot.format("LL")} {parsedSelectedTimeslot.tz(timezone).format(timeFormat)}
             </span>
           </Badge>
           {(selectedDuration || data?.length) && (


### PR DESCRIPTION
## What does this PR do?
fixes #10349  Booking Confirmation Dialogbox has different timezone when the screen size is changed this pr solves it

Fixes #10349 

https://github.com/calcom/cal.com/assets/88829894/67b742b2-9d3f-4b33-940a-20c621d51d30



## Requirement/Documentation
- There timezone issue when the user changes their screen to mobile it is showing the default set by the owner but it should the time in timezone of the user for their convenience so i have changed time zone to their timezone by using inbuilt function dayjs

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
