### PR TITLE
fix: Missing subteam URL [CAL-2240]

### DIFF
--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -7,6 +7,8 @@ import { useState, useLayoutEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
+import { getOrgFullDomain } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -35,7 +37,6 @@ import {
 import { ExternalLink, Link as LinkIcon, Trash2, LogOut } from "@calcom/ui/components/icon";
 
 import { getLayout } from "../../../settings/layouts/SettingsLayout";
-import { extractDomainFromWebsiteUrl } from "../../organizations/lib/utils";
 
 const regex = new RegExp("^[a-zA-Z0-9-]*$");
 
@@ -57,6 +58,7 @@ const ProfileView = () => {
   const utils = trpc.useContext();
   const session = useSession();
   const [firstRender, setFirstRender] = useState(true);
+  const orgBranding = useOrgBranding();
 
   useLayoutEffect(() => {
     document.body.focus();
@@ -220,8 +222,8 @@ const ProfileView = () => {
                       label={t("team_url")}
                       value={value}
                       addOnLeading={
-                        team.parent
-                          ? `${team.parent.slug}.${extractDomainFromWebsiteUrl}/`
+                        team.parent && orgBranding
+                          ? getOrgFullDomain(orgBranding?.slug, { protocol: false })
                           : `${WEBAPP_URL}/team/`
                       }
                       onChange={(e) => {


### PR DESCRIPTION
## What does this PR do?

When showing org sub-team URL, we relied on parent slug, when it could happen that the org is unpublished, making the parent slug null.

<kbd><img width="981" alt="image" src="https://github.com/calcom/cal.com/assets/467258/9032ddce-cbce-4a53-aafd-123a1d3bf5fd"></kbd>

Fixes #10374 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Create an org and add a sub-team, then go to the team profile and see the Team URL show up correctly.