### PR TITLE
fix: weekly limits

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -42,6 +42,7 @@ const getEventType = async (id: number) => {
       bookingLimits: true,
       durationLimits: true,
       timeZone: true,
+      length: true,
       metadata: true,
       schedule: {
         select: {
@@ -374,7 +375,7 @@ const getBusyTimesFromDurationLimits = async (
 
     // loop through all dates and check if we have reached the limit
     for (const date of dates) {
-      let total = duration ?? 0;
+      let total = (duration || eventType?.length) ?? 0;
       const startDate = date.startOf(filter);
       const endDate = date.endOf(filter);
 

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -166,8 +166,9 @@ export async function getUserAvailability(
 
   const busyTimes = await getBusyTimes({
     credentials: user.credentials,
-    startTime: dateFrom.toISOString(),
-    endTime: dateTo.toISOString(),
+    // needed to correctly apply limits (weeks can be part of two months)
+    startTime: dateFrom.startOf("week").toISOString(),
+    endTime: dateTo.endOf("week").toISOString(),
     eventTypeId,
     userId: user.id,
     username: `${user.username}`,


### PR DESCRIPTION
## What does this PR do?

This addresses two bugs related to weekly events, relating to:

1. All non-variable length event types
2. Weeks spanning two months

Fixes #10361
Fixes #10402

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. **Fixed length events**
- Limit a 30min event to 30min per week
- Book once
- See that the entire week is blocked

2. **Week in two months**
- Limit any event to 1 booking (or 1 length of event) per week
- Book in week that ends in next month, e.g. Mon 31 Jul
- See that you are unable to book 1-5 Aug

Availability and booking page tests are passing, but might make sense to add a new test to prevent regressions. Bug (2) was probably always there, but not (1).

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
