### PR TITLE
fix: middleware logic Routing Forms

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -79,8 +79,8 @@ const routingForms = {
   handle: (url: URL) => {
     // Next.config.js Redirects don't handle Client Side navigations and we need that.
     // So, we add the rewrite here instead.
-    if (url.pathname.startsWith("/routing-forms/")) {
-      url.pathname = url.pathname.replace(/^\/routing-forms\//, "/apps/routing-forms/");
+    if (url.pathname.startsWith("/routing-forms")) {
+      url.pathname = url.pathname.replace(/^\/routing-forms($|\/)/, "/apps/routing-forms/");
       return NextResponse.rewrite(url);
     }
 
@@ -90,11 +90,11 @@ const routingForms = {
       return NextResponse.rewrite(url);
     }
   },
-  // Matcher paths that are required by the handle function to work
-  paths: ["/apps/routing_forms/:path*", "/routing-forms/:path*"],
 };
 
 export const config = {
+  // Next.js Doesn't support spread operator in config matcher, so, we must list all paths explicitly here.
+  // https://github.com/vercel/next.js/discussions/42458
   matcher: [
     "/((?!_next|.*avatar.png$|favicon.ico$).*)",
     "/api/collect-events/:path*",
@@ -102,7 +102,12 @@ export const config = {
     "/:path*/embed",
     "/api/trpc/:path*",
     "/auth/login",
-    ...routingForms.paths,
+
+    /**
+     * Paths required by routingForms.handle
+     */
+    "/apps/routing_forms/:path*",
+    "/routing-forms/:path*",
   ],
 };
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -86,7 +86,7 @@ const routingForms = {
 
     // Don't 404 old routing_forms links
     if (url.pathname.startsWith("/apps/routing_forms")) {
-      url.pathname = url.pathname.replace(/^\/apps\/routing_forms\//, "/apps/routing-forms/");
+      url.pathname = url.pathname.replace(/^\/apps\/routing_forms($|\/)/, "/apps/routing-forms/");
       return NextResponse.rewrite(url);
     }
   },


### PR DESCRIPTION
## What does this PR do?

Fixes following:
- Super important fix, spread operator doesn't work with config.matcher of middleware. So, even though it's working with Next.js, it might not work with Vercel.
<img width="663" alt="Screenshot 2023-07-27 at 12 57 11 PM" src="https://github.com/calcom/cal.com/assets/1780212/00d7b264-b289-4598-8a4d-104f639c7ce4">

- 404 on /apps/routing_forms
- 404 on /routing-forms

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Visit  /apps/routing_forms and  /routing-forms. They should not be 404
- Visit /routing-forms/forms - It should also work

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
