### PR TITLE
perf: Remove IP ban and tweak matcher accordingly

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,21 +1,13 @@
 import { get } from "@vercel/edge-config";
 import { collectEvents } from "next-collect/server";
 import type { NextMiddleware } from "next/server";
-import { NextResponse, userAgent } from "next/server";
+import { NextResponse } from "next/server";
 
-import { CONSOLE_URL, WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
-import { isIpInBanlist } from "@calcom/lib/getIP";
 import { extendEventData, nextCollectBasicSettings } from "@calcom/lib/telemetry";
 
 const middleware: NextMiddleware = async (req) => {
   const url = req.nextUrl;
   const requestHeaders = new Headers(req.headers);
-
-  if (isIpInBanlist(req) && url.pathname !== "/api/nope") {
-    // DDOS Prevention: Immediately end request with no response - Avoids a redirect as well initiated by NextAuth on invalid callback
-    req.nextUrl.pathname = "/api/nope";
-    return NextResponse.redirect(req.nextUrl);
-  }
 
   if (!url.pathname.startsWith("/api")) {
     //
@@ -36,21 +28,6 @@ const middleware: NextMiddleware = async (req) => {
       // show the default page if EDGE_CONFIG env var is missing,
       // but log the error to the console
       // console.error(error);
-    }
-  }
-
-  if (["/api/collect-events", "/api/auth"].some((p) => url.pathname.startsWith(p))) {
-    const callbackUrl = url.searchParams.get("callbackUrl");
-    const { isBot } = userAgent(req);
-
-    if (
-      isBot ||
-      (callbackUrl && ![CONSOLE_URL, WEBAPP_URL, WEBSITE_URL].some((u) => callbackUrl.startsWith(u))) ||
-      isIpInBanlist(req)
-    ) {
-      // DDOS Prevention: Immediately end request with no response - Avoids a redirect as well initiated by NextAuth on invalid callback
-      req.nextUrl.pathname = "/api/nope";
-      return NextResponse.redirect(req.nextUrl);
     }
   }
 
@@ -96,13 +73,9 @@ export const config = {
   // Next.js Doesn't support spread operator in config matcher, so, we must list all paths explicitly here.
   // https://github.com/vercel/next.js/discussions/42458
   matcher: [
-    "/((?!_next|.*avatar.png$|favicon.ico$).*)",
-    "/api/collect-events/:path*",
-    "/api/auth/:path*",
     "/:path*/embed",
     "/api/trpc/:path*",
     "/auth/login",
-
     /**
      * Paths required by routingForms.handle
      */


### PR DESCRIPTION
## What does this PR do?

* The IP ban feature in CloudFlare (for cal.com) actually works, we can use that instead of middleware and reduce our middleware executions.
* Also tweaks the matchers