### PR TITLE
fix: Limit Booking Frequency

### DIFF
--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -211,3 +211,120 @@ export async function getBusyTimes(params: {
 }
 
 export default getBusyTimes;
+
+// this funcationality cannot be imolpemented in getBusyTime because it has optional and eventTypeId and while searching for bookings it doesnt use eventTypeId filter which can fetch unnecessary bookings
+export async function getEventBookingsForPeriod(params: {
+  userId: number;
+  eventTypeId: number;
+  startTime: string;
+  endTime: string;
+  seatedEvent?: boolean;
+}) {
+  const { userId, eventTypeId, startTime, endTime, seatedEvent } = params;
+  logger.silly(
+    `Fetch bookings from Cal Bookings in range ${startTime} to ${endTime} for input ${JSON.stringify({
+      userId,
+      eventTypeId,
+      status: BookingStatus.ACCEPTED,
+    })}`
+  );
+  // get user email for attendee checking.
+  const user = await prisma.user.findUniqueOrThrow({
+    where: {
+      id: userId,
+    },
+    select: {
+      email: true,
+    },
+  });
+
+  /**
+   * A user is considered busy within a given time period if there
+   * is a booking they own OR attend.
+   *
+   * Performs a query for all bookings where:
+   *   - The given booking is owned by this user, or..
+   *   - The current user has a different booking at this time he/she attends
+   *
+   * See further discussion within this GH issue:
+   * https://github.com/calcom/cal.com/issues/6374
+   *
+   * NOTE: Changes here will likely require changes to some mocking
+   *  logic within getSchedule.test.ts:addBookings
+   */
+  performance.mark("prismaBookingGetStart");
+
+  const sharedQuery = {
+    startTime: { gte: new Date(startTime) },
+    endTime: { lte: new Date(endTime) },
+    status: {
+      in: [BookingStatus.ACCEPTED],
+    },
+  };
+  // Find bookings that block this user from hosting further bookings.
+  const bookings = await prisma.booking.findMany({
+    where:
+      // User is primary host (individual events, or primary organizer)
+      {
+        ...sharedQuery,
+        eventTypeId,
+        userId,
+      },
+    select: {
+      id: true,
+      startTime: true,
+      endTime: true,
+      title: true,
+      eventType: {
+        select: {
+          id: true,
+          seatsPerTimeSlot: true,
+        },
+      },
+      ...(seatedEvent && {
+        _count: {
+          select: {
+            seatsReferences: true,
+          },
+        },
+      }),
+    },
+  });
+
+  const bookingSeatCountMap: { [x: string]: number } = {};
+  const busyTimes = bookings.reduce(
+    (aggregate: EventBusyDetails[], { id, startTime, endTime, eventType, title, ...rest }) => {
+      if (rest._count?.seatsReferences) {
+        const bookedAt = dayjs(startTime).utc().format() + "<>" + dayjs(endTime).utc().format();
+        bookingSeatCountMap[bookedAt] = bookingSeatCountMap[bookedAt] || 0;
+        bookingSeatCountMap[bookedAt]++;
+        // Seat references on the current event are non-blocking until the event is fully booked.
+        if (
+          // there are still seats available.
+          bookingSeatCountMap[bookedAt] < (eventType?.seatsPerTimeSlot || 1) &&
+          // and this is the seated event, other event types should be blocked.
+          eventTypeId === eventType?.id
+        ) {
+          // then we do not add the booking to the busyTimes.
+          return aggregate;
+        }
+        // if it does get blocked at this point; we remove the bookingSeatCountMap entry
+        // doing this allows using the map later to remove the ranges from calendar busy times.
+        delete bookingSeatCountMap[bookedAt];
+      }
+      aggregate.push({
+        start: dayjs(startTime).toDate(),
+        end: dayjs(endTime).toDate(),
+        title,
+        source: `eventType-${eventType?.id}-booking-${id}`,
+      });
+      return aggregate;
+    },
+    []
+  );
+
+  logger.silly(`Bookings from Cal Bookings for eventId: ${eventTypeId} ${JSON.stringify(busyTimes)}`);
+  performance.mark("prismaBookingGetEnd");
+  performance.measure(`prisma booking get took $1'`, "prismaBookingGetStart", "prismaBookingGetEnd");
+  return busyTimes;
+}

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -193,7 +193,7 @@ export async function getUserAvailability(
   const durationLimits = parseDurationLimit(eventType?.durationLimits);
 
   // PER_YEAR has been taken care individually inside getBusyTimesFromBookingLimits and getBusyTimesFromDurationLimits
-  const intervalLimitKeys: (keyof IntervalLimit)[] = ["PER_MONTH", "PER_WEEK"];
+  const intervalLimitKeys: (keyof IntervalLimit)[] = ["PER_MONTH", "PER_WEEK", "PER_DAY"];
   let startDate: Dayjs = dateFrom;
   let endDate: Dayjs = dateTo;
 
@@ -201,7 +201,7 @@ export async function getUserAvailability(
   if (eventTypeId && (bookingLimits || durationLimits)) {
     for (const key of intervalLimitKeys) {
       if ((bookingLimits && key in bookingLimits) || (durationLimits && key in durationLimits)) {
-        const filter = key.split("_")[1].toLowerCase() as "week" | "month";
+        const filter = key.split("_")[1].toLowerCase() as "week" | "month" | "day";
         startDate = dayjs.min(startDate, startDate.startOf(filter));
         endDate = dayjs.max(endDate, endDate.endOf(filter));
       }


### PR DESCRIPTION
## What does this PR do?

fixes a booking issue which allowed for event bookings even though the limits were placed.

Fixes #10361 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

-Put a limit on weekly bookings to 1 and create an event towards the end of the month (say 31st Jul) and the entire week (1st Aug) should be blocked. 
- Put a limit on monthly bookings to 1 and make sure that there is a booking in the same month but before today. There should not be any slots available in the month.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
