### PR TITLE
fix: #10423 private link glitch

### DIFF
--- a/apps/web/pages/event-types/[type]/index.tsx
+++ b/apps/web/pages/event-types/[type]/index.tsx
@@ -247,6 +247,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
       durationLimits: eventType.durationLimits || undefined,
       length: eventType.length,
       hidden: eventType.hidden,
+      hashedLink: eventType.hashedLink?.link || undefined,
       periodDates: {
         startDate: periodDates.startDate,
         endDate: periodDates.endDate,


### PR DESCRIPTION
## What does this PR do?
Fixes: #10423 

The problem in code was that if value of private link is changed then the link will still be visible but if after the reload we change the event name to something else and save it then the hashed link value is not added so when refreshed it again it wasnt able to recieve the previous hashedLink value. so I have just added a conditional value if value is already there then it will use previous value or it will be undefined. I hope this solution is correct.

@PeerRich can you check this PR

https://github.com/calcom/cal.com/assets/30045569/b4fff678-450f-4eff-9029-d51338747528


