### PR TITLE
fix: added validation for empty reset password field

### DIFF
--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -3,7 +3,7 @@ import { getCsrfToken } from "next-auth/react";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import type { CSSProperties } from "react";
-import React from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -24,6 +24,8 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: Props) 
   const formMethods = useForm<{ new_password: string }>();
   const success = formMethods.formState.isSubmitSuccessful;
   const loading = formMethods.formState.isSubmitting;
+  const [isEmpty, setIsEmpty] = useState<boolean>(true);
+  const passwordValue = formMethods.watch("new_password");
 
   const submitChangePassword = async ({ password, requestId }: { password: string; requestId: string }) => {
     const res = await fetch("/api/auth/reset-password", {
@@ -74,6 +76,14 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: Props) 
       </>
     );
   };
+  useEffect(() => {
+    // disbale Reset Password button if password input field is empty
+    if (passwordValue) {
+      setIsEmpty(passwordValue.length === 0);
+      return;
+    }
+    setIsEmpty(true);
+  }, [passwordValue]);
 
   return (
     <AuthContainer
@@ -123,7 +133,7 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: Props) 
                 loading={loading}
                 color="primary"
                 type="submit"
-                disabled={loading}
+                disabled={loading || isEmpty}
                 className="w-full justify-center">
                 {t("reset_password")}
               </Button>

--- a/apps/web/pages/auth/forgot-password/[id].tsx
+++ b/apps/web/pages/auth/forgot-password/[id].tsx
@@ -3,7 +3,6 @@ import { getCsrfToken } from "next-auth/react";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import type { CSSProperties } from "react";
-import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -24,8 +23,8 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: Props) 
   const formMethods = useForm<{ new_password: string }>();
   const success = formMethods.formState.isSubmitSuccessful;
   const loading = formMethods.formState.isSubmitting;
-  const [isEmpty, setIsEmpty] = useState<boolean>(true);
   const passwordValue = formMethods.watch("new_password");
+  const isEmpty = passwordValue?.length === 0;
 
   const submitChangePassword = async ({ password, requestId }: { password: string; requestId: string }) => {
     const res = await fetch("/api/auth/reset-password", {
@@ -76,14 +75,6 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: Props) 
       </>
     );
   };
-  useEffect(() => {
-    // disbale Reset Password button if password input field is empty
-    if (passwordValue) {
-      setIsEmpty(passwordValue.length === 0);
-      return;
-    }
-    setIsEmpty(true);
-  }, [passwordValue]);
 
   return (
     <AuthContainer


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
I made changes to the code in apps/web/pages/auth/forgot-password/[id].tsx to address the problem.

Fixes #10463 

https://github.com/calcom/cal.com/assets/110765105/a367065a-5416-4669-a639-191dfe9bfbd4

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

none
## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

Navigate to password reset page
Enter email to receive reset password Link
Open password reset mail and click on "Change Password"
Try to click on Reset Password without entering any input in password input field

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.






