### PR TITLE
fix: Fixed 10080 settings sidebar scrolling issue

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -185,11 +185,13 @@ const BackButtonInSidebar = ({ name }: { name: string }) => {
 interface SettingsSidebarContainerProps {
   className?: string;
   navigationIsOpenedOnMobile?: boolean;
+  bannersHeight?: number;
 }
 
 const SettingsSidebarContainer = ({
   className = "",
   navigationIsOpenedOnMobile,
+  bannersHeight,
 }: SettingsSidebarContainerProps) => {
   const { t } = useLocale();
   const router = useRouter();
@@ -218,6 +220,7 @@ const SettingsSidebarContainer = ({
 
   return (
     <nav
+      style={{ maxHeight: `calc(100vh - ${bannersHeight}px)`, top: `${bannersHeight}px` }}
       className={classNames(
         "no-scrollbar bg-muted fixed bottom-0 left-0 top-0 z-20 flex max-h-screen w-56 flex-col space-y-1 overflow-x-hidden overflow-y-scroll px-2 pb-3 transition-transform max-lg:z-10 lg:sticky lg:flex",
         className,
@@ -473,17 +476,10 @@ export default function SettingsLayout({
       hideHeadingOnMobile
       {...rest}
       SidebarContainer={
-        <>
-          {/* Mobile backdrop */}
-          {sideContainerOpen && (
-            <button
-              onClick={() => setSideContainerOpen(false)}
-              className="fixed left-0 top-0 z-10 h-full w-full bg-black/50">
-              <span className="sr-only">{t("hide_navigation")}</span>
-            </button>
-          )}
-          <SettingsSidebarContainer navigationIsOpenedOnMobile={sideContainerOpen} />
-        </>
+        <SidebarContainerElement
+          sideContainerOpen={sideContainerOpen}
+          setSideContainerOpen={setSideContainerOpen}
+        />
       }
       drawerState={state}
       MobileNavigationContainer={null}
@@ -501,6 +497,36 @@ export default function SettingsLayout({
     </Shell>
   );
 }
+
+const SidebarContainerElement = ({
+  sideContainerOpen,
+  bannersHeight,
+  setSideContainerOpen,
+}: SidebarContainerElementProps) => {
+  const { t } = useLocale();
+  return (
+    <>
+      {/* Mobile backdrop */}
+      {sideContainerOpen && (
+        <button
+          onClick={() => setSideContainerOpen(false)}
+          className="fixed left-0 top-0 z-10 h-full w-full bg-black/50">
+          <span className="sr-only">{t("hide_navigation")}</span>
+        </button>
+      )}
+      <SettingsSidebarContainer
+        navigationIsOpenedOnMobile={sideContainerOpen}
+        bannersHeight={bannersHeight}
+      />
+    </>
+  );
+};
+
+type SidebarContainerElementProps = {
+  sideContainerOpen?: boolean;
+  bannersHeight?: number;
+  setSideContainerOpen?: React.Dispatch<React.SetStateAction>;
+};
 
 export const getLayout = (page: React.ReactElement) => <SettingsLayout>{page}</SettingsLayout>;
 

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -523,9 +523,9 @@ const SidebarContainerElement = ({
 };
 
 type SidebarContainerElementProps = {
-  sideContainerOpen?: boolean;
+  sideContainerOpen: boolean;
   bannersHeight?: number;
-  setSideContainerOpen?: React.Dispatch<React.SetStateAction>;
+  setSideContainerOpen: React.Dispatch<React.SetStateAction>;
 };
 
 export const getLayout = (page: React.ReactElement) => <SettingsLayout>{page}</SettingsLayout>;

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -525,7 +525,7 @@ const SidebarContainerElement = ({
 type SidebarContainerElementProps = {
   sideContainerOpen: boolean;
   bannersHeight?: number;
-  setSideContainerOpen: React.Dispatch<React.SetStateAction>;
+  setSideContainerOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const getLayout = (page: React.ReactElement) => <SettingsLayout>{page}</SettingsLayout>;

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -4,8 +4,8 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
-import type { Dispatch, ReactNode, SetStateAction } from "react";
-import React, { Fragment, useEffect, useState, useRef, useMemo } from "react";
+import type { Dispatch, ReactNode, SetStateAction, ReactElement } from "react";
+import React, { Fragment, useEffect, useState, useRef, useMemo, cloneElement } from "react";
 import { Toaster } from "react-hot-toast";
 
 import dayjs from "@calcom/dayjs";
@@ -218,7 +218,11 @@ const Layout = (props: LayoutProps) => {
       <div className="flex min-h-screen flex-col">
         <AppTop setBannersHeight={setBannersHeight} />
         <div className="flex flex-1" data-testid="dashboard-shell">
-          {props.SidebarContainer || <SideBarContainer bannersHeight={bannersHeight} />}
+          {props.SidebarContainer ? (
+            cloneElement(props.SidebarContainer, { bannersHeight })
+          ) : (
+            <SideBarContainer bannersHeight={bannersHeight} />
+          )}
           <div className="flex w-0 flex-1 flex-col">
             <MainContainer {...props} />
           </div>
@@ -240,7 +244,7 @@ type LayoutProps = {
   CTA?: ReactNode;
   large?: boolean;
   MobileNavigationContainer?: ReactNode;
-  SidebarContainer?: ReactNode;
+  SidebarContainer?: ReactElement;
   TopNavContainer?: ReactNode;
   drawerState?: DrawerState;
   HeadingLeftIcon?: ReactNode;


### PR DESCRIPTION
## What does this PR do?

fixes #10080 

Video Link : https://drive.google.com/file/d/1gMdWe0NhVEB6i2pXIzfTpelFNvQKGL5E/view?usp=sharing

Hi @Jaibles @PeerRich @Udit-takkar 
Hope you are doing well.
After hours of debugging to find the exact root cause. This is what I found:
Issue and Fix Summary:

1. The Issue #10080 is not because of z-index. Infact the sidebar & mainPage are having position Sticky elements with appropriate z-index. The topbar is a static element but child of Sticky Element.
2. But the issue is because we havent given max-height and top property's values for settings SideBar.
3. I had tested the same fix on mobile -> It works as expected
4. I had used React.cloneElement using which we can pass an extra prop _bannersHeight_ [top banner height] to props.SidebarContainer [settings Sidebar]
5. I had used _bannersHeight_ in props.SidebarContainer [settings Sidebar] for top and max-height
6. I feel there is no need to change anything with topBar.


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

When Any topBar is present (eg: Organisation Upgrade Banner) -> Go Settings Page -> scroll through the sidebar present in Settings Page
Video Link : https://drive.google.com/file/d/1gMdWe0NhVEB6i2pXIzfTpelFNvQKGL5E/view?usp=sharing

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


