### PR TITLE
chore: fix "trialing new team plan" message

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -132,7 +132,7 @@
   "upgrade_to_per_seat": "Upgrade to Per-Seat",
   "seat_options_doesnt_support_confirmation": "Seats option doesn't support confirmation requirement",
   "team_upgrade_seats_details": "Of the {{memberCount}} members in your team, {{unpaidCount}} seat(s) are unpaid. At ${{seatPrice}}/month per seat the estimated total cost of your membership is ${{totalCost}}/month.",
-  "team_upgrade_banner_description": "Thank you for trialing our new team plan. We noticed your team \"{{teamName}}\" needs to be upgraded.",
+  "team_upgrade_banner_description": "You haven't finished your team setup. Your team \"{{teamName}}\" needs to be upgraded.",
   "upgrade_banner_action": "Upgrade here",
   "team_upgraded_successfully": "Your team was upgraded successfully!",
   "org_upgrade_banner_description": "Thank you for trialing our Organization plan. We noticed your Organization \"{{teamName}}\" needs to be upgraded.",


### PR DESCRIPTION
this message: 
![CleanShot 2023-08-01 at 16 03 36@2x](https://github.com/calcom/cal.com/assets/8019099/d3fec349-e102-47a2-8046-b66c68e52b83)

is not correct

better:

![CleanShot 2023-08-01 at 16 04 30@2x](https://github.com/calcom/cal.com/assets/8019099/ec8b6bdb-745b-498d-9540-5ff0c7980b3a)

