### PR TITLE
chore: remove tailwind-scrollbar warning

### DIFF
--- a/packages/config/tailwind-preset.js
+++ b/packages/config/tailwind-preset.js
@@ -151,7 +151,7 @@ module.exports = {
   plugins: [
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
-    require("tailwind-scrollbar"),
+    require("tailwind-scrollbar")({ nocompatible: true }),
     require("tailwindcss-radix")(),
     require("@savvywombat/tailwindcss-grid-areas"),
     plugin(({ addVariant }) => {
@@ -168,6 +168,6 @@ module.exports = {
     }),
   ],
   variants: {
-    scrollbar: ["rounded", "dark"],
+    scrollbar: ["dark"],
   },
 };


### PR DESCRIPTION
## What does this PR do?

Super minor fix, it removes deprecation console warning from `tailwind-scrollbar` plugin

```
DEPRECATION: adding rounded classes via the variants array is deprecated. Use nocompatible mode instead (i.e. when adding the plugin, use `scrollbarPlugin({ nocompatible: true })`)
```

More info: https://github.com/adoxography/tailwind-scrollbar#configuration

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

