### PR TITLE
chore: optimize `ssrInit` method with `Promise.all`

### DIFF
--- a/apps/web/server/lib/ssr.ts
+++ b/apps/web/server/lib/ssr.ts
@@ -16,7 +16,7 @@ import { appRouter } from "@calcom/trpc/server/routers/_app";
 export async function ssrInit(context: GetServerSidePropsContext) {
   const ctx = await createContext(context);
   const locale = getLocaleFromHeaders(context.req);
-  const i18n = await serverSideTranslations(getLocaleFromHeaders(context.req), ["common", "vital"]);
+  const i18n = await serverSideTranslations(locale, ["common", "vital"]);
 
   const ssr = createProxySSGHelpers({
     router: appRouter,
@@ -24,12 +24,14 @@ export async function ssrInit(context: GetServerSidePropsContext) {
     ctx: { ...ctx, locale, i18n },
   });
 
-  // always preload "viewer.public.i18n"
-  await ssr.viewer.public.i18n.fetch();
-  // So feature flags are available on first render
-  await ssr.viewer.features.map.prefetch();
-  // Provides a better UX to the users who have already upgraded.
-  await ssr.viewer.teams.hasTeamPlan.prefetch();
+  await Promise.all([
+    // always preload "viewer.public.i18n"
+    ssr.viewer.public.i18n.fetch(),
+    // So feature flags are available on first render
+    ssr.viewer.features.map.prefetch(),
+    // Provides a better UX to the users who have already upgraded.
+    ssr.viewer.teams.hasTeamPlan.prefetch(),
+  ]);
 
   return ssr;
 }


### PR DESCRIPTION
## What does this PR do?

Tiny optimization for `ssrInit` method. Right now it has 3 sequential async calls, but it would be better to use `Promise.all` instead. On my local machine it makes this call almost 2x faster (from 30ms to 15ms on average), it's really tiny gain, but it's basically free, so why not. Not sure how big the increase will be on production, but anyway, seems a good practice to not have waterfall calls like that. There are some other places like that, in the end it could be nice improvement piled up.


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

