### PR TITLE
perf: Improved buildDateRanges performance + cleanup

### DIFF
--- a/packages/core/getAggregatedAvailability.ts
+++ b/packages/core/getAggregatedAvailability.ts
@@ -3,10 +3,7 @@ import { intersect } from "@calcom/lib/date-ranges";
 import { SchedulingType } from "@calcom/prisma/enums";
 
 export const getAggregatedAvailability = (
-  userAvailability: (Omit<
-    Awaited<ReturnType<Awaited<typeof import("./getUserAvailability")>["getUserAvailability"]>>,
-    "currentSeats"
-  > & { user?: { isFixed?: boolean } })[],
+  userAvailability: { dateRanges: DateRange[]; user?: { isFixed?: boolean } }[],
   schedulingType: SchedulingType | null
 ): DateRange[] => {
   const fixedHosts = userAvailability.filter(

--- a/packages/lib/date-ranges.ts
+++ b/packages/lib/date-ranges.ts
@@ -93,7 +93,7 @@ export function buildDateRanges({
     ...groupedDateOverrides,
   }).map(
     // remove 0-length overrides that were kept to cancel out working dates until now.
-    (ranges) => ranges.filter((range) => !range.start.isSame(range.end))
+    (ranges) => ranges.filter((range) => range.start.valueOf() !== range.end.valueOf())
   );
 
   return dateRanges.flat();

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1,7 +1,6 @@
 import { countBy } from "lodash";
 import { v4 as uuid } from "uuid";
 
-import { getAggregateWorkingHours } from "@calcom/core/getAggregateWorkingHours";
 import { getAggregatedAvailability } from "@calcom/core/getAggregatedAvailability";
 import type { CurrentSeats } from "@calcom/core/getUserAvailability";
 import { getUserAvailability } from "@calcom/core/getUserAvailability";
@@ -240,8 +239,6 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
     usersWithCredentials.map(async (currentUser) => {
       const {
         busy,
-        workingHours,
-        dateOverrides,
         dateRanges,
         currentSeats: _currentSeats,
         timeZone,
@@ -259,11 +256,8 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
         { user: currentUser, eventType, currentSeats }
       );
       if (!currentSeats && _currentSeats) currentSeats = _currentSeats;
-
       return {
         timeZone,
-        workingHours,
-        dateOverrides,
         dateRanges,
         busy,
         user: currentUser,
@@ -271,11 +265,6 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
     })
   );
 
-  // flattens availability of multiple users
-  const dateOverrides = userAvailability.flatMap((availability) =>
-    availability.dateOverrides.map((override) => ({ userId: availability.user.id, ...override }))
-  );
-  const workingHours = getAggregateWorkingHours(userAvailability, eventType.schedulingType);
   const availabilityCheckProps = {
     eventLength: input.duration || eventType.length,
     currentSeats,
@@ -298,8 +287,6 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
   const timeSlots = getSlots({
     inviteeDate: startTime,
     eventLength: input.duration || eventType.length,
-    workingHours,
-    dateOverrides,
     offsetStart: eventType.offsetStart,
     dateRanges: getAggregatedAvailability(userAvailability, eventType.schedulingType),
     minimumBookingNotice: eventType.minimumBookingNotice,


### PR DESCRIPTION
## What does this PR do?

* Cleans up workingHours/dateOverrides
* Dayjs isSame is very slow - using valueOf (to get the numeric value) and checking for sameness is much faster.
* Cleans up the getAggregatedAvailability typing.