### PR TITLE
fix: #10614 - made nodemailer compatible with mailhog smtp server.

### DIFF
--- a/packages/lib/serverConfig.ts
+++ b/packages/lib/serverConfig.ts
@@ -13,10 +13,12 @@ function detectTransport(): SendmailTransport.Options | SMTPConnection.Options |
     const transport = {
       host: process.env.EMAIL_SERVER_HOST,
       port,
-      auth: {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      },
+      auth: process.env.EMAIL_SERVER_PASSWORD
+        ? {
+            user: process.env.EMAIL_SERVER_USER,
+            pass: process.env.EMAIL_SERVER_PASSWORD,
+          }
+        : undefined,
       secure: port === 465,
       tls: {
         rejectUnauthorized: !isENVDev,

--- a/packages/lib/serverConfig.ts
+++ b/packages/lib/serverConfig.ts
@@ -13,17 +13,18 @@ function detectTransport(): SendmailTransport.Options | SMTPConnection.Options |
     const transport = {
       host: process.env.EMAIL_SERVER_HOST,
       port,
-      auth: process.env.EMAIL_SERVER_PASSWORD
-        ? {
-            user: process.env.EMAIL_SERVER_USER,
-            pass: process.env.EMAIL_SERVER_PASSWORD,
-          }
-        : undefined,
       secure: port === 465,
       tls: {
         rejectUnauthorized: !isENVDev,
       },
     };
+
+    if (process.env.EMAIL_SERVER_USER && process.env.EMAIL_SERVER_PASSWORD) {
+      transport["auth"] = {
+        user: process.env.EMAIL_SERVER_USER,
+        pass: process.env.EMAIL_SERVER_PASSWORD,
+      };
+    }
 
     return transport;
   }

--- a/packages/lib/serverConfig.ts
+++ b/packages/lib/serverConfig.ts
@@ -10,21 +10,23 @@ function detectTransport(): SendmailTransport.Options | SMTPConnection.Options |
 
   if (process.env.EMAIL_SERVER_HOST) {
     const port = parseInt(process.env.EMAIL_SERVER_PORT || "");
+    const auth =
+      process.env.EMAIL_SERVER_USER && process.env.EMAIL_SERVER_PASSWORD
+        ? {
+            user: process.env.EMAIL_SERVER_USER,
+            pass: process.env.EMAIL_SERVER_PASSWORD,
+          }
+        : undefined;
+
     const transport = {
       host: process.env.EMAIL_SERVER_HOST,
       port,
+      auth,
       secure: port === 465,
       tls: {
         rejectUnauthorized: !isENVDev,
       },
     };
-
-    if (process.env.EMAIL_SERVER_USER && process.env.EMAIL_SERVER_PASSWORD) {
-      transport["auth"] = {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      };
-    }
 
     return transport;
   }


### PR DESCRIPTION
## What does this PR do?

Allow nodemailer to send message locally to mailhog smtp server.

Fixes #10614


https://github.com/calcom/cal.com/assets/71682713/ea66294f-e19a-4e39-90d9-0b0381071238

