### PR TITLE
fix: If the input type "Name" is selected, the label can't be changed from our default label "Your Name"

### DIFF
--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -532,7 +532,6 @@ function FieldLabel({ field }: { field: RhfFormField }) {
   const variantsConfig = field.variantsConfig;
   const variantsConfigVariants = variantsConfig?.variants;
   const defaultVariant = fieldTypeConfigVariantsConfig?.defaultVariant;
-
   if (!fieldTypeConfigVariants || !variantsConfig) {
     if (fieldsThatSupportLabelAsSafeHtml.includes(field.type)) {
       return (
@@ -553,10 +552,8 @@ function FieldLabel({ field }: { field: RhfFormField }) {
       "Field has `variantsConfig` but no `defaultVariant`" + JSON.stringify(fieldTypeConfigVariantsConfig)
     );
   }
-
   const label =
     variantsConfigVariants?.[variant as keyof typeof fieldTypeConfigVariants]?.fields?.[0]?.label || "";
-
   return <span>{t(label)}</span>;
 }
 

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -530,7 +530,9 @@ function FieldLabel({ field }: { field: RhfFormField }) {
   const fieldTypeConfigVariantsConfig = fieldTypeConfig?.variantsConfig;
   const fieldTypeConfigVariants = fieldTypeConfigVariantsConfig?.variants;
   const variantsConfig = field.variantsConfig;
+  const variantsConfigVariants = variantsConfig?.variants;
   const defaultVariant = fieldTypeConfigVariantsConfig?.defaultVariant;
+
   if (!fieldTypeConfigVariants || !variantsConfig) {
     if (fieldsThatSupportLabelAsSafeHtml.includes(field.type)) {
       return (
@@ -551,7 +553,11 @@ function FieldLabel({ field }: { field: RhfFormField }) {
       "Field has `variantsConfig` but no `defaultVariant`" + JSON.stringify(fieldTypeConfigVariantsConfig)
     );
   }
-  return <span>{t(fieldTypeConfigVariants[variant as keyof typeof fieldTypeConfigVariants].label)}</span>;
+
+  const label =
+    variantsConfigVariants?.[variant as keyof typeof fieldTypeConfigVariants]?.fields?.[0]?.label || "";
+
+  return <span>{t(label)}</span>;
 }
 
 function VariantSelector() {


### PR DESCRIPTION
## What does this PR do?

If we wanted to update the label for field types of config variants in field form of event's booking question, it was not updating in the main ui. In this PR, now instead of showing the default label for config variants we get their dynamic values and show them on the UI.


Fixes #10390

https://www.loom.com/share/4927bb0ca9d848f7b6ea60679072c4af


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

The user can edit the event and from advanced setting he can edit the "name" field and change the label.
 

