### PR TITLE
perf: Remove organisation as it's unused in getBusyTimes (?)

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -198,8 +198,7 @@ export const getBusyCalendarTimes = async (
   withCredentials: CredentialPayload[],
   dateFrom: string,
   dateTo: string,
-  selectedCalendars: SelectedCalendar[],
-  organizationSlug?: string | null
+  selectedCalendars: SelectedCalendar[]
 ) => {
   let results: EventBusyDate[][] = [];
   const months = getMonths(dateFrom, dateTo);

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -14,7 +14,6 @@ export async function getBusyTimes(params: {
   credentials: Credential[];
   userId: number;
   username: string;
-  organizationSlug?: string | null | undefined;
   eventTypeId?: number;
   startTime: string;
   beforeEventBuffer?: number;
@@ -30,7 +29,6 @@ export async function getBusyTimes(params: {
     eventTypeId,
     startTime,
     endTime,
-    organizationSlug,
     beforeEventBuffer,
     afterEventBuffer,
     selectedCalendars,
@@ -165,8 +163,7 @@ export async function getBusyTimes(params: {
       credentials,
       startTime,
       endTime,
-      selectedCalendars,
-      organizationSlug
+      selectedCalendars
     );
     const endConnectedCalendarsGet = performance.now();
     logger.debug(

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -76,11 +76,6 @@ const getUser = (where: Prisma.UserWhereInput) =>
     select: {
       ...availabilityUserSelect,
       credentials: true,
-      organization: {
-        select: {
-          slug: true,
-        },
-      },
     },
   });
 

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -29,7 +29,6 @@ const availabilitySchema = z
     beforeEventBuffer: z.number().optional(),
     duration: z.number().optional(),
     withSource: z.boolean().optional(),
-    orgSlug: z.string().optional(),
   })
   .refine((data) => !!data.username || !!data.userId, "Either username or userId should be filled in.");
 
@@ -122,7 +121,6 @@ export async function getUserAvailability(
     afterEventBuffer?: number;
     beforeEventBuffer?: number;
     duration?: number;
-    orgSlug?: string;
   },
   initialData?: {
     user?: User;
@@ -130,17 +128,8 @@ export async function getUserAvailability(
     currentSeats?: CurrentSeats;
   }
 ) {
-  const {
-    username,
-    userId,
-    dateFrom,
-    dateTo,
-    eventTypeId,
-    afterEventBuffer,
-    beforeEventBuffer,
-    duration,
-    orgSlug,
-  } = availabilitySchema.parse(query);
+  const { username, userId, dateFrom, dateTo, eventTypeId, afterEventBuffer, beforeEventBuffer, duration } =
+    availabilitySchema.parse(query);
 
   if (!dateFrom.isValid() || !dateTo.isValid()) {
     throw new HttpError({ statusCode: 400, message: "Invalid time range given." });
@@ -148,7 +137,6 @@ export async function getUserAvailability(
 
   const where: Prisma.UserWhereInput = {};
   if (username) where.username = username;
-  if (orgSlug) where.organization = { slug: orgSlug };
   if (userId) where.id = userId;
 
   const user = initialData?.user || (await getUser(where));
@@ -172,7 +160,6 @@ export async function getUserAvailability(
     eventTypeId,
     userId: user.id,
     username: `${user.username}`,
-    organizationSlug: initialData?.user?.organization?.slug,
     beforeEventBuffer,
     afterEventBuffer,
     selectedCalendars: user.selectedCalendars,

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -220,13 +220,13 @@ export async function getSchedule(input: TGetScheduleInputSchema) {
 
   // we need to fetch all user credentials here as this cannot be supplied by external calls.
   const credentials = (
-    await prisma.credential.findMany({
+    (await prisma.credential.findMany({
       where: {
         userId: {
           in: usersWithoutCredentials.map((user) => user.id),
         },
       },
-    })
+    })) || []
   ).reduce((group: { [x: string]: Awaited<ReturnType<typeof prisma.credential.findMany>> }, credential) => {
     const { userId } = credential;
     if (!userId) return group;


### PR DESCRIPTION
## What does this PR do?

* Removes credentials from the getEventType call (part of other performance refactors)
* Remove organization slug as it was unused in getBusyTimes - but it was prop drilled all the way from getEventType, so I believe it can be removed.