### PR TITLE
fix: SWR cache header on Vercel

### DIFF
--- a/packages/trpc/server/createNextApiHandler.ts
+++ b/packages/trpc/server/createNextApiHandler.ts
@@ -58,19 +58,35 @@ export function createNextApiHandler(router: AnyRouter, isPublic = false, namesp
 
       if (isPublic && paths) {
         const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+        const FIVE_MINUTES_IN_SECONDS = 5 * 60;
         const cacheRules = {
-          session: `no-cache`,
-          i18n: `no-cache`,
-          // Revalidation time here should be 1 second, per https://github.com/calcom/cal.com/pull/6823#issuecomment-1423215321
-          "slots.getSchedule": `no-cache`, // FIXME
-          cityTimezones: `max-age=${ONE_DAY_IN_SECONDS}, stale-while-revalidate`,
-          "features.map": `max-age=${ONE_DAY_IN_SECONDS}, stale-while-revalidate`, // "map" - Feature Flag Map
+          session: "no-cache",
+
+          // i18n data is user specific and thus should not be cached
+          i18n: "no-cache",
+
+          // FIXME: Using `max-age=1, stale-while-revalidate=60` fails some booking tests.
+          "slots.getSchedule": `no-cache`,
+
+          // Timezones are hardly updated. No need to burden the servers with requests for this by keeping low max-age.
+          // Keep it cached for a day and then give it 60 seconds more at most to be updated.
+          cityTimezones: `max-age=${ONE_DAY_IN_SECONDS}, stale-while-revalidate=60`,
+
+          // Feature Flags change but it might be okay to have a 5 minute cache to avoid burdening the servers with requests for this.
+          // Note that feature flags can be used to quickly kill a feature if it's not working as expected. So, we have to keep fresh time lesser than the deployment time atleast
+          "features.map": `max-age=${FIVE_MINUTES_IN_SECONDS}, stale-while-revalidate=60`, // "map" - Feature Flag Map
         } as const;
 
         const prependNamespace = (key: string) =>
           (namespace ? `${namespace}.${key}` : key) as keyof typeof cacheRules;
         const matchedPath = paths.find((v) => prependNamespace(v) in cacheRules);
-        if (matchedPath) defaultHeaders.headers["cache-control"] = cacheRules[prependNamespace(matchedPath)];
+        if (matchedPath) {
+          const cacheRule = cacheRules[prependNamespace(matchedPath)];
+
+          // We must set cdn-cache-control as well to ensure that Vercel doesn't strip stale-while-revalidate
+          // https://vercel.com/docs/concepts/edge-network/caching#:~:text=If%20you%20set,in%20the%20response.
+          defaultHeaders.headers["cache-control"] = defaultHeaders.headers["cdn-cache-control"] = cacheRule;
+        }
       }
 
       return defaultHeaders;


### PR DESCRIPTION
## What does this PR do?
Fixes CAL-2298

- Ensures that the cache-control header is available to browser

features.map request is honouring the cache-control on browser as well as VERCEL servers/cache now.
<img width="1240" alt="image" src="https://github.com/calcom/cal.com/assets/1780212/7218f3a3-c830-4335-b1ab-86c8cbdbdf0b">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
