### PR TITLE
fix: event type filter by team

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
@@ -301,12 +301,12 @@ export const getByViewerHandler = async ({ ctx, input }: GetByViewerOptions) => 
 
 export function getPrismaWhereUserIdFromFilter(
   userId: number,
-  filters: NonNullable<TEventTypeInputSchema>["filters"]
+  filters: NonNullable<TEventTypeInputSchema>["filters"] | undefined
 ) {
   if (!filters || !hasFilter(filters)) {
     return userId;
   } else if (filters.userIds?.[0] === userId) {
     return userId;
   }
-  return null;
+  return 0;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/10268
Fixes https://github.com/calcom/cal.com/issues/10537

On production you can filter by All,  Your Account, and combination of both Your Account and Team Name but not Team Name alone because in case no userId is passed as param we query for all event types with userId null. there could be many event types with userId null like in case of collective event types

## Type of change


## How to test ?

You won't be able to reproduce the bug locally unless you have hundreds/thousands of event-types with userId null in the local DB.


<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)