### PR TITLE
fix: darker the highlighted child component (App store and Installed Apps) nav section.

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -657,7 +657,7 @@ const NavigationItem: React.FC<{
           className={classNames(
             "[&[aria-current='page']]:bg-emphasis  text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium",
             isChild
-              ? `[&[aria-current='page']]:text-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 [&[aria-current='page']]:bg-transparent ${
+              ? `hidden h-8 pl-16 lg:flex lg:pl-11 [&[aria-current='page']]:bg-transparent [&[aria-current='page']]:font-black ${
                   props.index === 0 ? "mt-0" : "mt-px"
                 }`
               : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",


### PR DESCRIPTION
## What does this PR do?

At the side nav bar, when you click on the App Store or Installed Apps section. The section will be highlighted with the dark black color.

Fixes #10553


https://github.com/calcom/cal.com/assets/71682713/5d9ecfc1-a6aa-4326-862b-21ac8a2885da



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


