### PR TITLE
fix: Add 240 and 480 mins. options for multiple duration events

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -131,12 +131,12 @@ export const EventSetupTab = (
     };
   });
 
-  const multipleDurationOptions = [5, 10, 15, 20, 25, 30, 45, 50, 60, 75, 80, 90, 120, 150, 180].map(
-    (mins) => ({
-      value: mins,
-      label: t("multiple_duration_mins", { count: mins }),
-    })
-  );
+  const multipleDurationOptions = [
+    5, 10, 15, 20, 25, 30, 45, 50, 60, 75, 80, 90, 120, 150, 180, 240, 480,
+  ].map((mins) => ({
+    value: mins,
+    label: t("multiple_duration_mins", { count: mins }),
+  }));
 
   const [selectedMultipleDuration, setSelectedMultipleDuration] = useState<
     MultiValue<{


### PR DESCRIPTION
## What does this PR do?

This allows for event types where bookers can select half-day (4 hours) or full-day (8 hours) durations.

Fixes #10181.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

See comment https://github.com/calcom/cal.com/issues/10181#issuecomment-1671588333.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

(It's actually a small improvement on an existing feature, so not really a bug fix but also not really a new feature)

## How should this be tested?

Check that an event type can be created where the booker can choose between 240 and 480 minutes.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
