### PR TITLE
fix: fetching team with parent

### DIFF
--- a/packages/lib/server/queries/teams/index.ts
+++ b/packages/lib/server/queries/teams/index.ts
@@ -99,7 +99,7 @@ export async function getTeamWithMembers(args: {
   const where: Prisma.TeamFindFirstArgs["where"] = {};
 
   if (userId) where.members = { some: { userId } };
-  if (orgSlug) {
+  if (orgSlug && orgSlug !== slug) {
     where.parent = getSlugOrRequestedSlug(orgSlug);
   }
   if (id) where.id = id;


### PR DESCRIPTION
## What does this PR do?

Making sure we select the parent team on an org context (present orgSlug) and a different slug than the orgSlug.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create an org and have billing enabled
2. Before paying the subscription, see the org is shown as unpublished
3. After paying the subscription, the org public profile shows up instead of a 404 error

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
