### PR TITLE
chore: Fix UI NITs

### DIFF
--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -29,7 +29,6 @@ import {
 } from "@calcom/ui";
 import { ExternalLink, MoreHorizontal, Edit2, Lock, UserX } from "@calcom/ui/components/icon";
 
-import { useOrgBranding } from "../../organizations/context/provider";
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamAvailabilityModal from "./TeamAvailabilityModal";
 import TeamPill, { TeamRole } from "./TeamPill";
@@ -54,7 +53,6 @@ const checkIsOrg = (team: Props["team"]) => {
 
 export default function MemberListItem(props: Props) {
   const { t } = useLocale();
-  const orgBranding = useOrgBranding();
 
   const utils = trpc.useContext();
   const [showChangeMemberRoleModal, setShowChangeMemberRoleModal] = useState(false);
@@ -115,7 +113,7 @@ export default function MemberListItem(props: Props) {
   return (
     <li className="divide-subtle divide-y px-5">
       <div className="my-4 flex justify-between">
-        <div className="flex w-full flex-col justify-between sm:flex-row">
+        <div className="flex w-full flex-col justify-between truncate sm:flex-row">
           <div className="flex">
             <Avatar
               size="sm"

--- a/packages/features/ee/users/components/UsersTable.tsx
+++ b/packages/features/ee/users/components/UsersTable.tsx
@@ -109,7 +109,7 @@ function UsersTableBare() {
         onChange={(e) => setSearchTerm(e.target.value)}
       />
       <div
-        className="rounded-md border"
+        className="border-subtle rounded-md border"
         ref={tableContainerRef}
         onScroll={() => fetchMoreOnBottomReached()}
         style={{

--- a/packages/ui/components/data-table/index.tsx
+++ b/packages/ui/components/data-table/index.tsx
@@ -101,7 +101,7 @@ export function DataTable<TData, TValue>({
         tableCTA={tableCTA}
       />
       <div
-        className="rounded-md border"
+        className="border-subtle rounded-md border"
         ref={tableContainerRef}
         onScroll={onScroll}
         style={{

--- a/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
@@ -10,7 +10,7 @@ export interface NavTabProps {
 
 const HorizontalTabs = function ({ tabs, linkShallow, linkScroll, actions, ...props }: NavTabProps) {
   return (
-    <div className="mb-4 h-9 max-w-[calc(100%+40px)] lg:mb-5">
+    <div className="mb-4 h-9 max-w-full lg:mb-5">
       <nav
         className="no-scrollbar flex max-h-9 space-x-1 overflow-scroll rounded-md"
         aria-label="Tabs"

--- a/packages/ui/components/table/TableNew.tsx
+++ b/packages/ui/components/table/TableNew.tsx
@@ -36,7 +36,10 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
-      className={classNames("hover:bg-subtle data-[state=selected]:bg-subtle border-b", className)}
+      className={classNames(
+        "hover:bg-subtle data-[state=selected]:bg-subtle border-subtle border-b",
+        className
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
Booking overflow 
![CleanShot 2023-08-10 at 09 35 16](https://github.com/calcom/cal.com/assets/55134778/470e22f8-f82f-4e57-b6af-9817ee2abb3e)

Dark mode tables + overflow on long names
![CleanShot 2023-08-10 at 09 37 35](https://github.com/calcom/cal.com/assets/55134778/a95c9f84-2d75-4bad-a4c6-41cd445f5cdf)

Fixes overflow on long usernames on /teams/[id]/members
![CleanShot 2023-08-10 at 09 38 54](https://github.com/calcom/cal.com/assets/55134778/41747776-2a02-49a8-a9da-aeccbfd81974)


