### PR TITLE
chor: Transform + usernames to - on token initiation

### DIFF
--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -272,6 +272,9 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     username = available ? username : suggestion || username;
   }
 
+  // Transform all + to - in username
+  username = username.replace(/\+/g, "-");
+
   return {
     props: {
       ...props,


### PR DESCRIPTION
When invited with an email that is X+Y we used to infer the username as X+Y however we don't allow +s in our usernames

transform to - so we can improve this flow  
<img width="1437" alt="CleanShot 2023-08-10 at 10 32 59@2x" src="https://github.com/calcom/cal.com/assets/55134778/7ea0a737-7276-42f8-9877-2ae0387e1ce2">
