### PR TITLE
fix: count without where clause is total users regardless of selection

### DIFF
--- a/apps/api/pages/api/users/_get.ts
+++ b/apps/api/pages/api/users/_get.ts
@@ -40,7 +40,7 @@ export async function getHandler(req: NextApiRequest) {
   // If user is not ADMIN, return only his data.
   if (!isAdmin) where.id = userId;
   const [total, data] = await prisma.$transaction([
-    prisma.user.count(),
+    prisma.user.count({ where }),
     prisma.user.findMany({ where, take, skip }),
   ]);
   const users = schemaUsersReadPublic.parse(data);


### PR DESCRIPTION
## What does this PR do?

Straightforward fix to keep the count function from reporting the total user count but rather the paginated result.