### PR TITLE
fix: link to org settings

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -828,7 +828,7 @@ function SideBar({ bannersHeight, user }: SideBarProps) {
         <div className="flex h-full flex-col justify-between py-3 lg:pt-4">
           <header className="items-center justify-between md:hidden lg:flex">
             {!isOrgBrandingDataFetched ? null : orgBranding ? (
-              <Link href="/event-types" className="px-1.5">
+              <Link href="/settings/organizations/profile" className="px-1.5">
                 <div className="flex items-center gap-2 font-medium">
                   <Avatar
                     alt={`${orgBranding.name} logo`}


### PR DESCRIPTION
link to [settings/organizations/profile](https://app.cal.com/settings/organizations/profile) vs /event-types when clicking org name and logo
![image](https://github.com/calcom/cal.com/assets/8019099/ded54c5a-e01b-4616-b89a-a2d4c6051055)
