### PR TITLE
fix: If Invalid Calendar Credentials Then Skip Listing Calendars [CAL-2340]

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/deleteCredential.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/deleteCredential.handler.ts
@@ -304,22 +304,26 @@ export const deleteCredentialHandler = async ({ ctx, input }: DeleteCredentialOp
 
   // If it's a calendar remove it from the SelectedCalendars
   if (credential.app?.categories.includes(AppCategories.calendar)) {
-    const calendar = await getCalendar(credential);
+    try {
+      const calendar = await getCalendar(credential);
 
-    const calendars = await calendar?.listCalendars();
+      const calendars = await calendar?.listCalendars();
 
-    if (calendars && calendars.length > 0) {
-      calendars.map(async (cal) => {
-        await prisma.selectedCalendar.delete({
-          where: {
-            userId_integration_externalId: {
-              userId: user.id,
-              externalId: cal.externalId,
-              integration: cal.integration as string,
+      if (calendars && calendars.length > 0) {
+        calendars.map(async (cal) => {
+          await prisma.selectedCalendar.delete({
+            where: {
+              userId_integration_externalId: {
+                userId: user.id,
+                externalId: cal.externalId,
+                integration: cal.integration as string,
+              },
             },
-          },
+          });
         });
-      });
+      }
+    } catch {
+      console.log(`Error deleting selected calendars for user ${user.id} and calendar ${credential.appId}`);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR wraps listing deleted selected calendars in a try/catch block so if the credentials are invalid the user are still able to delete the calendar app.

Fixes #10719 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Add GCal
- In the DB manipulate the access token to make it an invalid credential
- Delete the integration

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
