### PR TITLE
fix: e2e test for rescheduling overlapping time

### DIFF
--- a/apps/web/playwright/reschedule.e2e.ts
+++ b/apps/web/playwright/reschedule.e2e.ts
@@ -252,7 +252,7 @@ test.describe("Reschedule Tests", async () => {
     let firstOfNextMonth = dayjs().add(1, "month").startOf("month");
 
     // find first available slot of next month (available monday-friday)
-    while (!(firstOfNextMonth.day() >= 1 && firstOfNextMonth.day() <= 5)) {
+    while (firstOfNextMonth.day() < 1 || firstOfNextMonth.day() > 5) {
       firstOfNextMonth = firstOfNextMonth.add(1, "day");
     }
 


### PR DESCRIPTION
## What does this PR do?

The e2e test "Should be able to book slot that overlaps with original rescheduled booking" of reschedule.e2e.ts started failing today because it tried to book tomorrow which is a Saturday and the user is not available. 
This PR rewrites that e2e test to fix this issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)