### PR TITLE
fix: If the labels are empty for inputs then show default values and also show the last label if the inputs are in split mode in event types.

### DIFF
--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -552,16 +552,21 @@ function FieldLabel({ field }: { field: RhfFormField }) {
       "Field has `variantsConfig` but no `defaultVariant`" + JSON.stringify(fieldTypeConfigVariantsConfig)
     );
   }
-  let label =
+  const label =
     variantsConfigVariants?.[variant as keyof typeof fieldTypeConfigVariants]?.fields
-      ?.map((field) => field?.label)
+      ?.map((field) => {
+        //if label is empty give it a default value
+        if (field?.label?.trim()?.length == 0) {
+          return t(
+            fieldTypeConfigVariants[variant as keyof typeof fieldTypeConfigVariants]?.fieldsMap[field?.name]
+              ?.defaultLabel || ""
+          );
+        }
+        return t(field?.label || "");
+      })
       ?.join(",") || "";
 
-  if (!label?.trim() || label?.trim() === ",")
-    label =
-      fieldTypeConfig?.variantsConfig?.variants[variant as keyof typeof fieldTypeConfigVariants]?.label || "";
-
-  return <span>{t(label)}</span>;
+  return <span>{label}</span>;
 }
 
 function VariantSelector() {

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -552,8 +552,15 @@ function FieldLabel({ field }: { field: RhfFormField }) {
       "Field has `variantsConfig` but no `defaultVariant`" + JSON.stringify(fieldTypeConfigVariantsConfig)
     );
   }
-  const label =
-    variantsConfigVariants?.[variant as keyof typeof fieldTypeConfigVariants]?.fields?.[0]?.label || "";
+  let label =
+    variantsConfigVariants?.[variant as keyof typeof fieldTypeConfigVariants]?.fields
+      ?.map((field) => field?.label)
+      ?.join(",") || "";
+
+  if (!label?.trim() || label?.trim() === ",")
+    label =
+      fieldTypeConfig?.variantsConfig?.variants[variant as keyof typeof fieldTypeConfigVariants]?.label || "";
+
   return <span>{t(label)}</span>;
 }
 

--- a/packages/features/form-builder/FormBuilderField.tsx
+++ b/packages/features/form-builder/FormBuilderField.tsx
@@ -12,7 +12,7 @@ import { Components, isValidValueProp } from "./Components";
 import { fieldTypesConfigMap } from "./fieldTypes";
 import { fieldsThatSupportLabelAsSafeHtml } from "./fieldsThatSupportLabelAsSafeHtml";
 import type { fieldsSchema } from "./schema";
-import { getVariantsConfig } from "./utils";
+import { getVariantsConfig, getVariantFieldLabel } from "./utils";
 
 type RhfForm = {
   fields: z.infer<typeof fieldsSchema>;
@@ -184,10 +184,12 @@ function getAndUpdateNormalizedValues(field: RhfFormFields[number], t: TFunction
     Object.entries(field.variantsConfig.variants).forEach(([variantName, variant]) => {
       variant.fields.forEach((variantField) => {
         const fieldTypeVariantsConfig = fieldTypesConfigMap[field.type]?.variantsConfig;
-        const defaultVariantFieldLabel =
-          fieldTypeVariantsConfig?.variants?.[variantName]?.fieldsMap[variantField.name]?.defaultLabel;
-
-        variantField.label = variantField.label || t(defaultVariantFieldLabel || "");
+        const fieldTypeVariantConfig = fieldTypeVariantsConfig?.variants[variantName];
+        variantField.label = getVariantFieldLabel({
+          variantField,
+          fieldTypeVariantConfig,
+          t,
+        });
       });
     });
   }

--- a/packages/features/form-builder/fieldTypes.ts
+++ b/packages/features/form-builder/fieldTypes.ts
@@ -155,3 +155,7 @@ export const fieldTypesConfigMap = configMap as Record<FieldType, z.infer<typeof
 Object.entries(fieldTypesConfigMap).forEach(([fieldType, config]) => {
   config.propsType = propsTypes[fieldType as keyof typeof fieldTypesConfigMap];
 });
+
+export type FieldTypeVariantConfig = NonNullable<
+  (typeof fieldTypesConfigMap)[keyof typeof fieldTypesConfigMap]["variantsConfig"]
+>["variants"][keyof (typeof fieldTypesConfigMap)[keyof typeof fieldTypesConfigMap]["variantsConfig"]];

--- a/packages/features/form-builder/schema.ts
+++ b/packages/features/form-builder/schema.ts
@@ -331,3 +331,6 @@ export const dbReadResponseSchema = z.union([
   // For variantsConfig case
   z.record(z.string()),
 ]);
+
+export type FieldSchema = z.infer<typeof fieldSchema>;
+export type VariantConfig = NonNullable<FieldSchema["variantsConfig"]>["variants"][string];

--- a/packages/features/form-builder/utils.ts
+++ b/packages/features/form-builder/utils.ts
@@ -1,6 +1,9 @@
+import type { TFunction } from "next-i18next";
 import type z from "zod";
 
+import type { FieldTypeVariantConfig } from "./fieldTypes";
 import { fieldTypesConfigMap } from "./fieldTypes";
+import type { VariantConfig } from "./schema";
 import type { fieldSchema } from "./schema";
 
 export const preprocessNameFieldDataWithVariant = (
@@ -67,3 +70,18 @@ export const getVariantsConfig = (field: Pick<z.infer<typeof fieldSchema>, "vari
   }
   return variantsConfig;
 };
+
+export function getVariantFieldLabel({
+  variantField,
+  fieldTypeVariantConfig,
+  t,
+}: {
+  variantField: VariantConfig["fields"][number];
+  fieldTypeVariantConfig: FieldTypeVariantConfig | undefined;
+  t: TFunction;
+}) {
+  if (!variantField.label?.trim()) {
+    return t(fieldTypeVariantConfig?.fieldsMap[variantField?.name]?.defaultLabel || "");
+  }
+  return variantField?.label || "";
+}


### PR DESCRIPTION
## What does this PR do?

This PR rectifies the label issue when  the label for field types of config variants in field form of event's booking question is split and shows default label if the label fields are empty

Fixes # (10390)

Before:
https://www.loom.com/share/63704afcc62b4253b26477f448de94ac
After:
https://www.loom.com/share/99a142ebd593499aa741251aac07226b


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
The user can edit the event and from advanced setting he can edit the "name" field and change the label in split mode.
Add empty label in all fields or any one field.


## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
