### PR TITLE
fix: allow usernames across Cal.com to be invited into teams

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -76,7 +76,7 @@ export async function getUserToInviteOrThrowIfExists({
   // Check if user exists in ORG or exists all together
   const invitee = await prisma.user.findFirst({
     where: {
-      OR: [{ username: usernameOrEmail, organizationId: orgId }, { email: usernameOrEmail }],
+      OR: [{ username: usernameOrEmail }, { email: usernameOrEmail }],
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

In issue #10726, users are seeing an error message when inviting a team member using their Cal.com username. I found that the check for `{ username: usernameOrEmail, organizationId: orgId }` containing `organizationId: orgId` limits the lookup to only within an organization. In order to open up the username lookups to Cal.com, removing `organizationId: orgId` would fix it.

Screenshot from the issue:
![image](https://github.com/calcom/cal.com/assets/20612193/05be7798-bad3-4a45-aa65-61d9b8b46111)

Fixes #10726
https://github.com/calcom/cal.com/issues/10726

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

The issue can be tested using the following steps:

1. Go to Cal.com dashboard > Teams (on the left menubar) OR https://cal.com/teams when logged in
2. Select an existing team or click Create team button
3. Click on Add member and type the username of the person intending to be invited
4. The username of the Cal.com user should get an invite and the error related to `Invite failed because ${email} is not a valid email address` will be gone when typing usernames.

- Are there environment variables that should be set? No
- What are the minimal test data to have? Have a Cal.com user, a team, and a valid username of a member to be invited
- What is expected (happy path) to have (input and output)? A user should get an invite and no error related to username (invalid email) be thrown.
- Any other important info that could help to test that PR N/A

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

