### PR TITLE
fix: invitation to a team using username

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -22,6 +22,7 @@ import {
   getIsOrgVerified,
   sendVerificationEmail,
   createAndAutoJoinIfInOrg,
+  throwUsernameDoesNotExistError,
 } from "./utils";
 
 type InviteMemberOptions = {
@@ -51,11 +52,14 @@ export const inviteMemberHandler = async ({ ctx, input }: InviteMemberOptions) =
     });
     const invitee = await getUserToInviteOrThrowIfExists({
       usernameOrEmail,
-      orgId: input.teamId,
       isOrg: input.isOrg,
     });
 
     if (!invitee) {
+      const isInputEmail = isEmail(usernameOrEmail);
+      if (!isInputEmail) {
+        throwUsernameDoesNotExistError(usernameOrEmail);
+      }
       checkInputEmailIsValid(usernameOrEmail);
 
       // valid email given, create User and add to team

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -14,7 +14,6 @@ import {
   getTeamOrThrow,
   getEmailsToInvite,
   getUserToInviteOrThrowIfExists,
-  checkInputEmailIsValid,
   getOrgConnectionInfo,
   createNewUserConnectToOrgIfExists,
   throwIfInviteIsToOrgAndUserExists,
@@ -61,8 +60,6 @@ export const inviteMemberHandler = async ({ ctx, input }: InviteMemberOptions) =
       if (!isEmail(usernameOrEmail)) {
         throwUsernameDoesNotExistInOrgError(usernameOrEmail);
       }
-
-      checkInputEmailIsValid(usernameOrEmail);
 
       // valid email given, create User and add to team
       await createNewUserConnectToOrgIfExists({

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -22,7 +22,7 @@ import {
   getIsOrgVerified,
   sendVerificationEmail,
   createAndAutoJoinIfInOrg,
-  throwUsernameDoesNotExistError,
+  throwUsernameDoesNotExistInOrgError,
 } from "./utils";
 
 type InviteMemberOptions = {
@@ -52,14 +52,16 @@ export const inviteMemberHandler = async ({ ctx, input }: InviteMemberOptions) =
     });
     const invitee = await getUserToInviteOrThrowIfExists({
       usernameOrEmail,
+      orgId: input.teamId,
       isOrg: input.isOrg,
     });
 
     if (!invitee) {
-      const isInputEmail = isEmail(usernameOrEmail);
-      if (!isInputEmail) {
-        throwUsernameDoesNotExistError(usernameOrEmail);
+      // if input is a username, throw error
+      if (!isEmail(usernameOrEmail)) {
+        throwUsernameDoesNotExistInOrgError(usernameOrEmail);
       }
+
       checkInputEmailIsValid(usernameOrEmail);
 
       // valid email given, create User and add to team

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -66,15 +66,17 @@ export async function getEmailsToInvite(usernameOrEmail: string | string[]) {
 
 export async function getUserToInviteOrThrowIfExists({
   usernameOrEmail,
+  orgId,
   isOrg,
 }: {
   usernameOrEmail: string;
+  orgId: number;
   isOrg?: boolean;
 }) {
   // Check if user exists in ORG or exists all together
   const invitee = await prisma.user.findFirst({
     where: {
-      OR: [{ username: usernameOrEmail }, { email: usernameOrEmail }],
+      OR: [{ username: usernameOrEmail, organizationId: orgId }, { email: usernameOrEmail }],
     },
   });
 
@@ -295,10 +297,10 @@ export function throwIfInviteIsToOrgAndUserExists(invitee: User, team: TeamWithP
   }
 }
 
-export function throwUsernameDoesNotExistError(username: string) {
+export function throwUsernameDoesNotExistInOrgError(username: string) {
   throw new TRPCError({
     code: "NOT_FOUND",
-    message: `User ${username} does not exist.`,
+    message: `User ${username} does not exist in the organization.`,
   });
 }
 

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -66,17 +66,15 @@ export async function getEmailsToInvite(usernameOrEmail: string | string[]) {
 
 export async function getUserToInviteOrThrowIfExists({
   usernameOrEmail,
-  orgId,
   isOrg,
 }: {
   usernameOrEmail: string;
-  orgId: number;
   isOrg?: boolean;
 }) {
   // Check if user exists in ORG or exists all together
   const invitee = await prisma.user.findFirst({
     where: {
-      OR: [{ username: usernameOrEmail, organizationId: orgId }, { email: usernameOrEmail }],
+      OR: [{ username: usernameOrEmail }, { email: usernameOrEmail }],
     },
   });
 
@@ -295,6 +293,13 @@ export function throwIfInviteIsToOrgAndUserExists(invitee: User, team: TeamWithP
       message: `You cannot add a user that already exists in Cal.com to an organization. If they wish to join via this email address, they must update their email address in their profile to that of your organization.`,
     });
   }
+}
+
+export function throwUsernameDoesNotExistError(username: string) {
+  throw new TRPCError({
+    code: "NOT_FOUND",
+    message: `User ${username} does not exist.`,
+  });
 }
 
 export function getIsOrgVerified(


### PR DESCRIPTION
## What does this PR do?

Fixes: #10726 
The issue mentions that we are unable to invite a user to a team using a username and have to enter an email address.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
Before fix: (An error gets displayed on the bottom-right corner)
![before-fix](https://github.com/calcom/cal.com/assets/48318416/ce4ff2a3-51ec-4516-af2e-796cba4f9f45)
After fix: (We can invite by username, and an invitation will show as pending without any errors)
![after-fix](https://github.com/calcom/cal.com/assets/48318416/b5247cfe-7c1f-4f2b-a2e5-7ffaf58e8468)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Note

- I haven't updated tests, as it was added by someone else under the same issue.
