### PR TITLE
fix: Next/previous buttons on week view move 8 instead of 7 days

### DIFF
--- a/packages/features/bookings/Booker/components/Header.tsx
+++ b/packages/features/bookings/Booker/components/Header.tsx
@@ -91,7 +91,7 @@ export function Header({
             color="minimal"
             StartIcon={ChevronLeft}
             aria-label="Previous Day"
-            onClick={() => addToSelectedDate(-extraDays - 1)}
+            onClick={() => addToSelectedDate(-extraDays)}
           />
           <Button
             className="group rtl:mr-1 rtl:rotate-180"
@@ -99,7 +99,7 @@ export function Header({
             color="minimal"
             StartIcon={ChevronRight}
             aria-label="Next Day"
-            onClick={() => addToSelectedDate(extraDays + 1)}
+            onClick={() => addToSelectedDate(extraDays)}
           />
           {selectedDateMin3DaysDifference && (
             <Button


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue in week view of event preview where the next and previous button moves 8 instead of 7 days.

Fixes #10739

 Loom Video: https://www.loom.com/share/bed0e6695feb429aa843e045cb3b4ee3?sid=2ef6ac3e-fdd1-49e2-832a-073933c2c179

## Requirement/Documentation

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [+] Bug fix (non-breaking change which fixes an issue)
- 
## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [+] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.