### PR TITLE
feat: rank apps with most installed for a chosen category

### DIFF
--- a/apps/web/pages/apps/categories/[category].tsx
+++ b/apps/web/pages/apps/categories/[category].tsx
@@ -40,9 +40,11 @@ export default function Apps({ apps }: InferGetStaticPropsType<typeof getStaticP
         }>
         <div className="mb-16">
           <div className="grid-col-1 grid grid-cols-1 gap-3 md:grid-cols-3">
-            {apps.map((app) => {
-              return <AppCard key={app.slug} app={app} />;
-            })}
+            {apps
+              .sort((a, b) => (b.installCount || 0) - (a.installCount || 0))
+              .map((app) => {
+                return <AppCard key={app.slug} app={app} />;
+              })}
           </div>
         </div>
       </Shell>


### PR DESCRIPTION
## What does this PR do?

This features sorts the apps in descending order(from most installed to least installed) for the chosen category

Fixes #10751 
/claim #10751 

Screenshots:
<img width="493" alt="Screenshot 2023-08-15 at 1 37 45 AM" src="https://github.com/calcom/cal.com/assets/24358668/168fb30b-2a6a-41e8-8abe-740e1db6ca36">

<img width="1176" alt="Screenshot 2023-08-15 at 1 38 24 AM" src="https://github.com/calcom/cal.com/assets/24358668/5cf35ce8-ba43-40d5-ab9f-633d7de1694c">


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
