### PR TITLE
fix: add 2fa and email verification grace period

### DIFF
--- a/apps/web/pages/api/auth/two-factor/totp/disable.ts
+++ b/apps/web/pages/api/auth/two-factor/totp/disable.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { authenticator } from "otplib";
 
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { totpCheck } from "@calcom/lib/totp";
 import prisma from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/client";
 
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // If user has 2fa enabled, check if body.code is correct
-    const isValidToken = authenticator.check(req.body.code, secret);
+    const isValidToken = totpCheck(req.body.code, secret);
     if (!isValidToken) {
       return res.status(400).json({ error: ErrorCode.IncorrectTwoFactorCode });
 

--- a/apps/web/pages/api/auth/two-factor/totp/disable.ts
+++ b/apps/web/pages/api/auth/two-factor/totp/disable.ts
@@ -4,7 +4,7 @@ import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
-import { totpCheck } from "@calcom/lib/totp";
+import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 import prisma from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/client";
 
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // If user has 2fa enabled, check if body.code is correct
-    const isValidToken = totpCheck(req.body.code, secret);
+    const isValidToken = totpAuthenticatorCheck(req.body.code, secret);
     if (!isValidToken) {
       return res.status(400).json({ error: ErrorCode.IncorrectTwoFactorCode });
 

--- a/apps/web/pages/api/auth/two-factor/totp/enable.ts
+++ b/apps/web/pages/api/auth/two-factor/totp/enable.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { authenticator } from "otplib";
 
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { totpCheck } from "@calcom/lib/totp";
 import prisma from "@calcom/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -48,7 +48,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(500).json({ error: ErrorCode.InternalServerError });
   }
 
-  const isValidToken = authenticator.check(req.body.code, secret);
+  const isValidToken = totpCheck(req.body.code, secret);
   if (!isValidToken) {
     return res.status(400).json({ error: ErrorCode.IncorrectTwoFactorCode });
   }

--- a/apps/web/pages/api/auth/two-factor/totp/enable.ts
+++ b/apps/web/pages/api/auth/two-factor/totp/enable.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
-import { totpCheck } from "@calcom/lib/totp";
+import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 import prisma from "@calcom/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -48,7 +48,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(500).json({ error: ErrorCode.InternalServerError });
   }
 
-  const isValidToken = totpCheck(req.body.code, secret);
+  const isValidToken = totpAuthenticatorCheck(req.body.code, secret);
   if (!isValidToken) {
     return res.status(400).json({ error: ErrorCode.IncorrectTwoFactorCode });
   }

--- a/apps/web/playwright/login.2fa.e2e.ts
+++ b/apps/web/playwright/login.2fa.e2e.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import { authenticator } from "otplib";
 
 import { symmetricDecrypt } from "@calcom/lib/crypto";
-import { totpCheck } from "@calcom/lib/totp";
+import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 
 import { test } from "./lib/fixtures";
 
@@ -142,7 +142,7 @@ test.describe("2FA Tests", async () => {
 
 async function fillOtp({ page, secret, noRetry }: { page: Page; secret: string; noRetry?: boolean }) {
   let token = authenticator.generate(secret);
-  if (!noRetry && !totpCheck(token, secret)) {
+  if (!noRetry && !totpAuthenticatorCheck(token, secret)) {
     console.log("Token expired, Renerating.");
     // Maybe token was just about to expire, try again just once more
     token = authenticator.generate(secret);

--- a/apps/web/playwright/login.2fa.e2e.ts
+++ b/apps/web/playwright/login.2fa.e2e.ts
@@ -3,6 +3,7 @@ import { expect } from "@playwright/test";
 import { authenticator } from "otplib";
 
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { totpCheck } from "@calcom/lib/totp";
 
 import { test } from "./lib/fixtures";
 
@@ -141,7 +142,7 @@ test.describe("2FA Tests", async () => {
 
 async function fillOtp({ page, secret, noRetry }: { page: Page; secret: string; noRetry?: boolean }) {
   let token = authenticator.generate(secret);
-  if (!noRetry && !authenticator.check(token, secret)) {
+  if (!noRetry && !totpCheck(token, secret)) {
     console.log("Token expired, Renerating.");
     // Maybe token was just about to expire, try again just once more
     token = authenticator.generate(secret);

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -148,7 +148,10 @@ const providers: Provider[] = [
           throw new Error(ErrorCode.InternalServerError);
         }
 
-        const isValidToken = (await import("@calcom/lib/totp")).totpCheck(credentials.totpCode, secret);
+        const isValidToken = (await import("@calcom/lib/totp")).totpAuthenticatorCheck(
+          credentials.totpCode,
+          secret
+        );
         if (!isValidToken) {
           throw new Error(ErrorCode.IncorrectTwoFactorCode);
         }

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -148,7 +148,7 @@ const providers: Provider[] = [
           throw new Error(ErrorCode.InternalServerError);
         }
 
-        const isValidToken = (await import("otplib")).authenticator.check(credentials.totpCode, secret);
+        const isValidToken = (await import("@calcom/lib/totp")).totpCheck(credentials.totpCode, secret);
         if (!isValidToken) {
           throw new Error(ErrorCode.IncorrectTwoFactorCode);
         }

--- a/packages/lib/totp.ts
+++ b/packages/lib/totp.ts
@@ -12,7 +12,11 @@ import { keyDecoder, keyEncoder } from "@otplib/plugin-thirty-two";
  * @param opts - The AuthenticatorOptions object.
  * @param opts.window - The amount of past and future tokens considered valid. Either a single value or array of `[past, future]`. Default: `[1, 0]`
  */
-export const totpAuthenticatorCheck = (token: string, secret: string, opts: AuthenticatorOptions) => {
+export const totpAuthenticatorCheck = (
+  token: string,
+  secret: string,
+  opts: Partial<AuthenticatorOptions> = {}
+) => {
   const { window = [1, 0], ...rest } = opts;
   const authenticator = new Authenticator({
     createDigest,
@@ -33,7 +37,7 @@ export const totpAuthenticatorCheck = (token: string, secret: string, opts: Auth
  * @param opts - The TOTPOptions object.
  * @param opts.window - The amount of past and future tokens considered valid. Either a single value or array of `[past, future]`. Default: `[1, 0]`
  */
-export const totpRawCheck = (token: string, secret: string, opts: TOTPOptions) => {
+export const totpRawCheck = (token: string, secret: string, opts: Partial<TOTPOptions> = {}) => {
   const { window = [1, 0], ...rest } = opts;
   const authenticator = new TOTP({
     createDigest,

--- a/packages/lib/totp.ts
+++ b/packages/lib/totp.ts
@@ -1,25 +1,44 @@
-import { Authenticator } from "@otplib/core";
+import { Authenticator, TOTP } from "@otplib/core";
+import type { AuthenticatorOptions } from "@otplib/core/authenticator";
+import type { TOTPOptions } from "@otplib/core/totp";
 import { createDigest, createRandomBytes } from "@otplib/plugin-crypto";
 import { keyDecoder, keyEncoder } from "@otplib/plugin-thirty-two";
 
 /**
- * Checks the validity of a TOTP token.
+ * Checks the validity of a TOTP token using a base32-encoded secret.
  *
  * @param token - The token.
- * @param secret - The shared secret.
- * @param window - The amount of past and future tokens to be considered valid. Default: [1, 0]
+ * @param secret - The base32-encoded shared secret.
+ * @param opts - The AuthenticatorOptions object.
+ * @param opts.window - The amount of past and future tokens considered valid. Either a single value or array of `[past, future]`. Default: `[1, 0]`
  */
-export const totpCheck = (
-  token: string,
-  secret: string,
-  window: number | [past: number, future: number] = [1, 0]
-) => {
+export const totpAuthenticatorCheck = (token: string, secret: string, opts: AuthenticatorOptions) => {
+  const { window = [1, 0], ...rest } = opts;
   const authenticator = new Authenticator({
     createDigest,
     createRandomBytes,
     keyDecoder,
     keyEncoder,
     window,
+    ...rest,
+  });
+  return authenticator.check(token, secret);
+};
+
+/**
+ * Checks the validity of a TOTP token using a raw secret.
+ *
+ * @param token - The token.
+ * @param secret - The raw hex-encoded shared secret.
+ * @param opts - The TOTPOptions object.
+ * @param opts.window - The amount of past and future tokens considered valid. Either a single value or array of `[past, future]`. Default: `[1, 0]`
+ */
+export const totpRawCheck = (token: string, secret: string, opts: TOTPOptions) => {
+  const { window = [1, 0], ...rest } = opts;
+  const authenticator = new TOTP({
+    createDigest,
+    window,
+    ...rest,
   });
   return authenticator.check(token, secret);
 };

--- a/packages/lib/totp.ts
+++ b/packages/lib/totp.ts
@@ -1,0 +1,25 @@
+import { Authenticator } from "@otplib/core";
+import { createDigest, createRandomBytes } from "@otplib/plugin-crypto";
+import { keyDecoder, keyEncoder } from "@otplib/plugin-thirty-two";
+
+/**
+ * Checks the validity of a TOTP token.
+ *
+ * @param token - The token.
+ * @param secret - The shared secret.
+ * @param window - The amount of past and future tokens to be considered valid. Default: [1, 0]
+ */
+export const totpCheck = (
+  token: string,
+  secret: string,
+  window: number | [past: number, future: number] = [1, 0]
+) => {
+  const authenticator = new Authenticator({
+    createDigest,
+    createRandomBytes,
+    keyDecoder,
+    keyEncoder,
+    window,
+  });
+  return authenticator.check(token, secret);
+};

--- a/packages/trpc/server/routers/loggedInViewer/deleteMe.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/deleteMe.handler.ts
@@ -3,7 +3,7 @@ import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
 import { deleteWebUser as syncServicesDeleteWebUser } from "@calcom/lib/sync/SyncServiceManager";
-import { totpCheck } from "@calcom/lib/totp";
+import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 import { prisma } from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
@@ -65,7 +65,7 @@ export const deleteMeHandler = async ({ ctx, input }: DeleteMeOptions) => {
     }
 
     // If user has 2fa enabled, check if input.totpCode is correct
-    const isValidToken = totpCheck(input.totpCode, secret);
+    const isValidToken = totpAuthenticatorCheck(input.totpCode, secret);
     if (!isValidToken) {
       throw new Error(ErrorCode.IncorrectTwoFactorCode);
     }

--- a/packages/trpc/server/routers/loggedInViewer/deleteMe.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/deleteMe.handler.ts
@@ -1,10 +1,9 @@
-import { authenticator } from "otplib";
-
 import { deleteStripeCustomer } from "@calcom/app-store/stripepayment/lib/customer";
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
 import { deleteWebUser as syncServicesDeleteWebUser } from "@calcom/lib/sync/SyncServiceManager";
+import { totpCheck } from "@calcom/lib/totp";
 import { prisma } from "@calcom/prisma";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
@@ -66,7 +65,7 @@ export const deleteMeHandler = async ({ ctx, input }: DeleteMeOptions) => {
     }
 
     // If user has 2fa enabled, check if input.totpCode is correct
-    const isValidToken = authenticator.check(input.totpCode, secret);
+    const isValidToken = totpCheck(input.totpCode, secret);
     if (!isValidToken) {
       throw new Error(ErrorCode.IncorrectTwoFactorCode);
     }

--- a/packages/trpc/server/routers/viewer/auth/verifyCodeUnAuthenticated.handler.ts
+++ b/packages/trpc/server/routers/viewer/auth/verifyCodeUnAuthenticated.handler.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
-import { totp } from "otplib";
 
+import { totpRawCheck } from "@calcom/lib/totp";
 import type { ZVerifyCodeInputSchema } from "@calcom/prisma/zod-utils";
 
 import { TRPCError } from "@trpc/server";
@@ -18,8 +18,7 @@ export const verifyCodeUnAuthenticatedHandler = async ({ input }: VerifyTokenOpt
     .update(email + process.env.CALENDSO_ENCRYPTION_KEY)
     .digest("hex");
 
-  totp.options = { step: 900 };
-  const isValidToken = totp.check(code, secret);
+  const isValidToken = totpRawCheck(code, secret, { step: 900 });
 
   if (!isValidToken) throw new TRPCError({ code: "BAD_REQUEST", message: "invalid_code" });
 

--- a/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
@@ -1,8 +1,8 @@
 import { createHash } from "crypto";
-import { totp } from "otplib";
 
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { IS_PRODUCTION } from "@calcom/lib/constants";
+import { totpRawCheck } from "@calcom/lib/totp";
 import type { ZVerifyCodeInputSchema } from "@calcom/prisma/zod-utils";
 import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
 
@@ -31,8 +31,7 @@ export const verifyCodeHandler = async ({ ctx, input }: VerifyCodeOptions) => {
     .update(email + process.env.CALENDSO_ENCRYPTION_KEY)
     .digest("hex");
 
-  totp.options = { step: 900 };
-  const isValidToken = totp.check(code, secret);
+  const isValidToken = totpRawCheck(code, secret, { step: 900 });
 
   if (!isValidToken) throw new TRPCError({ code: "BAD_REQUEST", message: "invalid_code" });
 


### PR DESCRIPTION
## What does this PR do?

Accept the previous TOTP code in addition to the current one.

This is in line with the recommendations in [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238#section-5.2:~:text=We%20RECOMMEND%20that%20at%20most%20one%0A%20%20%20time%20step%20is%20allowed%20as%20the%20network%20delay).

If you submit a TOTP token towards the end of the period, it will be invalid by the time you submit it. Came across this while working on #10600 and it's rather annoying.

This also fixes an issue where email verification codes could be invalid by the time they are received. With these changes, the codes are now valid for a duration of 15-30 minutes, instead of the previous 0-15 minutes.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Ensure 2FA is enabled.
2. Enter the current TOTP code during login
3. Only submit it in the next window, i.e. when a new code is showing in your authenticator
4. The previous code should be accepted with this fix.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
