### PR TITLE
fix: currency for event types

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -96,7 +96,7 @@ const querySchema = z.object({
 });
 
 export default function Success(props: SuccessProps) {
-  const { t } = useLocale();
+  const { t, i18n } = useLocale();
   const router = useRouter();
   const routerQuery = useRouterQuery();
   const pathname = usePathname();
@@ -477,6 +477,21 @@ export default function Success(props: SuccessProps) {
                           ) : (
                             locationToDisplay
                           )}
+                        </div>
+                      </>
+                    )}
+                    {props.paymentStatus && (
+                      <>
+                        <div className="mt-3 font-medium">
+                          {props.paymentStatus.paymentOption === "HOLD"
+                            ? t("complete_your_booking")
+                            : t("payment")}
+                        </div>
+                        <div className="col-span-2 mb-2 mt-3">
+                          {new Intl.NumberFormat(i18n.language, {
+                            style: "currency",
+                            currency: props.paymentStatus.currency,
+                          }).format(props.paymentStatus.amount / 100.0)}
                         </div>
                       </>
                     )}
@@ -1117,6 +1132,9 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     select: {
       success: true,
       refunded: true,
+      currency: true,
+      amount: true,
+      paymentOption: true,
     },
   });
 

--- a/packages/app-store/_utils/getEventTypeAppData.ts
+++ b/packages/app-store/_utils/getEventTypeAppData.ts
@@ -18,12 +18,14 @@ export const getEventTypeAppData = <T extends EventTypeAppsList>(
     return allowDataGet
       ? {
           ...appMetadata,
+          // We should favor eventType's price and currency over appMetadata's price and currency
+          price: eventType.price || appMetadata.price,
+          currency: eventType.currency || appMetadata.currency,
           // trackingId is legacy way to store value for TRACKING_ID. So, we need to support both.
           TRACKING_ID: appMetadata.TRACKING_ID || appMetadata.trackingId,
         }
       : null;
   }
-
   // Backward compatibility for existing event types.
   // TODO: After the new AppStore EventType App flow is stable, write a migration to migrate metadata to new format which will let us remove this compatibility code
   // Migration isn't being done right now, to allow a revert if needed

--- a/packages/lib/getEventTypeById.ts
+++ b/packages/lib/getEventTypeById.ts
@@ -227,7 +227,7 @@ export default async function getEventTypeById({
       app: {
         enabled: true,
         categories: {
-          hasSome: [AppCategories.conferencing, AppCategories.video],
+          hasSome: [AppCategories.conferencing, AppCategories.video, AppCategories.payment],
         },
       },
     },


### PR DESCRIPTION
## What does this PR do?

- Fixes event type metadata that wasn't getting payment app so it would save wrong data.
- fixes getEventTypeAppData to favour eventType price and currency over wrong app metadata.

Fixes #10682 
## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- I haven't added tests that prove my fix is effective or that my feature works
