### PR TITLE
fix: icon in emails is considered a tracking pixel

### DIFF
--- a/packages/emails/src/components/LocationInfo.tsx
+++ b/packages/emails/src/components/LocationInfo.tsx
@@ -40,7 +40,7 @@ export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
             title={t("meeting_url")}
             style={{ color: "#101010" }}
             rel="noreferrer">
-            {providerName || "Link"} <CallToActionIcon iconName="linkIcon" />
+            {providerName || "Link"}
           </a>
         }
         extraInfo={


### PR DESCRIPTION
Email providers or clients which block tracking pixels could block this icon.

One example is Hey email provider which blocks any pixel tracking and renders a broken image.

It is a small enough image to be considered a tracking pixel and could result in a broken image in the email.

I don't find it necessary either.

## Requirement/Documentation

<img width="311" alt="Screenshot 2023-08-16 at 22 03 52" src="https://github.com/hkdobrev/cal.com/assets/506129/94bcf20f-3107-4e0c-a0a8-b4c51597515c">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
