### PR TITLE
fix: Missing border-subtle for the API key 

### DIFF
--- a/apps/web/pages/settings/developer/api-keys.tsx
+++ b/apps/web/pages/settings/developer/api-keys.tsx
@@ -57,7 +57,7 @@ const ApiKeysView = () => {
           <div>
             {isLoading ? null : data?.length ? (
               <>
-                <div className="mb-8 mt-6 rounded-md border">
+                <div className="border-subtle mb-8 mt-6 rounded-md border">
                   {data.map((apiKey, index) => (
                     <ApiKeyListItem
                       key={apiKey.id}

--- a/packages/features/ee/api-keys/components/ApiKeyListItem.tsx
+++ b/packages/features/ee/api-keys/components/ApiKeyListItem.tsx
@@ -40,7 +40,7 @@ const ApiKeyListItem = ({
   return (
     <div
       key={apiKey.id}
-      className={classNames("flex w-full justify-between p-4", lastItem ? "" : "border-b")}>
+      className={classNames("flex w-full justify-between p-4", lastItem ? "" : "border-subtle border-b")}>
       <div>
         <p className="font-medium"> {apiKey?.note ? apiKey.note : t("api_key_no_note")}</p>
         <div className="flex items-center space-x-3.5">


### PR DESCRIPTION
## What does this PR do?
Added the missing CSS class `border-subtle` to API keys 
Fixes #10829 

![image](https://github.com/calcom/cal.com/assets/55000107/f6e60f21-0319-4dbd-b696-dc18e921d06e)
