### PR TITLE
fix: Missing border-subtle for the API key #10829

### DIFF
--- a/apps/web/pages/settings/developer/api-keys.tsx
+++ b/apps/web/pages/settings/developer/api-keys.tsx
@@ -57,7 +57,7 @@ const ApiKeysView = () => {
           <div>
             {isLoading ? null : data?.length ? (
               <>
-                <div className="mb-8 mt-6 rounded-md border">
+                <div className="border-subtle mb-8 mt-6 rounded-md border">
                   {data.map((apiKey, index) => (
                     <ApiKeyListItem
                       key={apiKey.id}


### PR DESCRIPTION
Added the border-subtle CSS class to API keys

## What does this PR do?


Fixes #10829

![Api_key_border_changes](https://github.com/calcom/cal.com/assets/52532308/9dcecd73-fc3a-40a8-9718-65e8e2640e36)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
