### PR TITLE
perf: Fix slowest db query

### DIFF
--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -43,11 +43,9 @@ export async function getServerSession(options: {
   const cachedSession = CACHE.get(JSON.stringify(token));
 
   if (cachedSession) {
-    console.log("-----------USING CACHED SESSION--------------");
     return cachedSession;
   }
 
-  console.log("------------GET USER IN getServerSession-----------");
   const user = await prisma.user.findUnique({
     where: {
       email: token.email.toLowerCase(),

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -43,9 +43,11 @@ export async function getServerSession(options: {
   const cachedSession = CACHE.get(JSON.stringify(token));
 
   if (cachedSession) {
+    console.log("-----------USING CACHED SESSION--------------");
     return cachedSession;
   }
 
+  console.log("------------GET USER IN getServerSession-----------");
   const user = await prisma.user.findUnique({
     where: {
       email: token.email.toLowerCase(),

--- a/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
@@ -30,13 +30,6 @@ export const getHandler = async ({ ctx, input }: GetOptions) => {
       name: true,
       availability: true,
       timeZone: true,
-      eventType: {
-        select: {
-          _count: true,
-          id: true,
-          eventName: true,
-        },
-      },
     },
   });
   if (!schedule || (schedule.userId !== user.id && !input.isManagedEventType)) {


### PR DESCRIPTION
## What does this PR do?

This query is taking 600ms on average and is called very frequently. Turns out the _count on the eventType was causing aggregate counts to happen on all relations. We weren't actually using any of this data.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Make sure availability schedules can be created and edited with no problem (both on individual schedule and on event types)