### PR TITLE
fix: Italics not being shown in the description after saving

### DIFF
--- a/packages/lib/turndownService.ts
+++ b/packages/lib/turndownService.ts
@@ -31,6 +31,13 @@ turndownService.addRule("enter", {
   },
 });
 
+turndownService.addRule("ignoreEmphasized", {
+  filter: "em",
+  replacement: function (content) {
+    return content;
+  },
+});
+
 function isShiftEnter(node: HTMLElement) {
   let currentNode: HTMLElement | null | ParentNode = node;
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This fixes the issue of Italic text not showing in the description of the event after saving the event.
The issue was caused due to the way Rich Text editor formats the HTML for the italic text. It wraps the italic text in the `<i>` as well as `<em>` tag. And the HTML-to-makdown library that is being used was adding `_` twice making it bold rather than italic. 

## Change Made
Added a rule in the turndownService (HTML-to-markdown) to ignore the `<em>` tag. This prevents the double `_`

Fixes #10828 

 Loom Video: [Video Link](https://www.loom.com/share/332c978222f4442d8e44b425e908d2dd?sid=c395198f-bbd5-42d8-b73e-834523ff5c2b)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Try creating a new event and in the description try making text Italic. It should work as intended. Earlier the italic text was being shown as bold text on saving the event.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

