### PR TITLE
fix: adding a new workflow step that requires kyc verification

### DIFF
--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -39,6 +39,7 @@ interface IAddActionDialog {
     senderId?: string,
     senderName?: string
   ) => void;
+  setKYCVerificationDialogOpen: () => void;
 }
 
 interface ISelectActionOption {
@@ -56,7 +57,7 @@ type AddActionFormValues = {
 
 export const AddActionDialog = (props: IAddActionDialog) => {
   const { t } = useLocale();
-  const { isOpenDialog, setIsOpenDialog, addAction } = props;
+  const { isOpenDialog, setIsOpenDialog, addAction, setKYCVerificationDialogOpen } = props;
   const [isPhoneNumberNeeded, setIsPhoneNumberNeeded] = useState(false);
   const [isSenderIdNeeded, setIsSenderIdNeeded] = useState(false);
   const [isEmailAddressNeeded, setIsEmailAddressNeeded] = useState(false);
@@ -168,7 +169,10 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                       className="text-sm"
                       defaultValue={actionOptions[0]}
                       onChange={handleSelectAction}
-                      options={actionOptions}
+                      options={actionOptions.map((option) => ({
+                        ...option,
+                        verificationAction: () => setKYCVerificationDialogOpen(),
+                      }))}
                       isOptionDisabled={(option: {
                         label: string;
                         value: WorkflowActions;

--- a/packages/features/ee/workflows/components/WorkflowDetailsPage.tsx
+++ b/packages/features/ee/workflows/components/WorkflowDetailsPage.tsx
@@ -219,6 +219,7 @@ export default function WorkflowDetailsPage(props: Props) {
         isOpenDialog={isAddActionDialogOpen}
         setIsOpenDialog={setIsAddActionDialogOpen}
         addAction={addAction}
+        setKYCVerificationDialogOpen={() => setKYCVerificationDialogOpen(true)}
       />
       <KYCVerificationDialog
         isOpenDialog={isKYCVerificationDialogOpen}

--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -603,7 +603,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       if (isSMSOrWhatsappAction(s.action) && !hasPaidPlan) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
-      if (isTextMessageToAttendeeAction(s.action)) {
+      if (!isKYCVerified && isTextMessageToAttendeeAction(s.action)) {
         throw new TRPCError({ code: "UNAUTHORIZED", message: "Account needs to be verified" });
       }
       const { id: _stepId, ...stepToAdd } = s;


### PR DESCRIPTION
## What does this PR do?

Fixes that a verified user could not add a new step with 'sms to attendee'. It was throwing UNAUTHORIZED 'Account needs to be verified'.

Also, added verify badge to the actions dropdown in the 'Add Action' Modal. 

Before: 
<img width="538" alt="Screenshot 2023-08-23 at 13 54 01" src="https://github.com/calcom/cal.com/assets/30310907/16e490a5-ffd5-4984-b6bb-5bbfb52cf4fd">

After: 
<img width="538" alt="Screenshot 2023-08-23 at 13 53 12" src="https://github.com/calcom/cal.com/assets/30310907/b76b11e8-4825-48cf-9460-a69fd0fdd888">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a new workflow with a KYC verified user 
- Add new action 'send SMS to attendee + add template text 
- Save workflow
- See that workflow is successfully saved
