### PR TITLE
fix: eventName variables

### DIFF
--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -57,10 +57,12 @@ export function getEventName(eventNameObj: EventNameObjectType, forAttendeeView 
         if (variable === bookingField) {
           let fieldValue;
           if (eventNameObj.bookingFields) {
-            fieldValue =
-              eventNameObj.bookingFields[
-                bookingField as keyof typeof eventNameObj.bookingFields
-              ]?.value?.toString();
+            const field = eventNameObj.bookingFields[bookingField as keyof typeof eventNameObj.bookingFields];
+            if (typeof field === "object" && "value" in field) {
+              fieldValue = field?.value?.toString();
+            } else {
+              fieldValue = field?.toString();
+            }
           }
           dynamicEventName = dynamicEventName.replace(`{${variable}}`, fieldValue || "");
         }

--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -58,7 +58,7 @@ export function getEventName(eventNameObj: EventNameObjectType, forAttendeeView 
           let fieldValue;
           if (eventNameObj.bookingFields) {
             const field = eventNameObj.bookingFields[bookingField as keyof typeof eventNameObj.bookingFields];
-            if (typeof field === "object" && "value" in field) {
+            if (field && typeof field === "object" && "value" in field) {
               fieldValue = field?.value?.toString();
             } else {
               fieldValue = field?.toString();

--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -58,7 +58,9 @@ export function getEventName(eventNameObj: EventNameObjectType, forAttendeeView 
           let fieldValue;
           if (eventNameObj.bookingFields) {
             fieldValue =
-              eventNameObj.bookingFields[bookingField as keyof typeof eventNameObj.bookingFields]?.toString();
+              eventNameObj.bookingFields[
+                bookingField as keyof typeof eventNameObj.bookingFields
+              ]?.value?.toString();
           }
           dynamicEventName = dynamicEventName.replace(`{${variable}}`, fieldValue || "");
         }


### PR DESCRIPTION
## What does this PR do?


Fixes https://github.com/calcom/cal.com/issues/10916

<img width="1092" alt="Screenshot 2023-08-24 at 1 08 47 PM" src="https://github.com/calcom/cal.com/assets/53316345/ca20243d-66f9-47ce-82fa-5642d2a251e1">


## How to test ?

1) Go to advanced setting of any event type
2) Create a booking question with identifier "company" and short text.
3) edit event name in advanced setting and name is Your Name x {company}
4) Book a meeting and then cancel it to get the cancellation email. 

Check the subject of cancelled email of both organizer and attendee

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
