### PR TITLE
perf: Fix slowest db query (again)

### DIFF
--- a/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/schedule/get.handler.ts
@@ -32,7 +32,6 @@ export const getHandler = async ({ ctx, input }: GetOptions) => {
       timeZone: true,
       eventType: {
         select: {
-          _count: true,
           id: true,
           eventName: true,
           team: {


### PR DESCRIPTION
## What does this PR do?

This was originally fixed in #10842 but reintroduced as part of #10738. This is the slowest query in our database now averaging over a second to run.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Same as #10842 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
