### PR TITLE
fix: webhooks for managed event types

### DIFF
--- a/apps/web/pages/api/recorded-daily-video.ts
+++ b/apps/web/pages/api/recorded-daily-video.ts
@@ -34,13 +34,17 @@ const triggerWebhook = async ({
   booking: {
     userId: number | undefined;
     eventTypeId: number | null;
+    eventTypeParentId: number | null | undefined;
     teamId?: number | null;
   };
 }) => {
   const eventTrigger: WebhookTriggerEvents = "RECORDING_READY";
   // Send Webhook call if hooked to BOOKING.RECORDING_READY
+
+  const triggerForUser = !booking.teamId || (booking.teamId && booking.eventTypeParentId);
+
   const subscriberOptions = {
-    userId: booking.userId,
+    userId: triggerForUser ? booking.userId : null,
     eventTypeId: booking.eventTypeId,
     triggerEvent: eventTrigger,
     teamId: booking.teamId,
@@ -183,6 +187,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       booking: {
         userId: booking?.user?.id,
         eventTypeId: booking.eventTypeId,
+        eventTypeParentId: booking.eventType?.parentId,
         teamId,
       },
     });

--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -28,7 +28,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       };
     } else {
       where.userId = validKey.userId;
-      s;
     }
 
     const bookings = await prisma.booking.findMany({

--- a/packages/app-store/zapier/api/subscriptions/listBookings.ts
+++ b/packages/app-store/zapier/api/subscriptions/listBookings.ts
@@ -22,8 +22,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   try {
     const where: Prisma.BookingWhereInput = {};
-    if (validKey.teamId) where.eventType = { teamId: validKey.teamId };
-    else where.userId = validKey.userId;
+    if (validKey.teamId) {
+      where.eventType = {
+        OR: [{ teamId: validKey.teamId }, { parent: { teamId: validKey.teamId } }],
+      };
+    } else {
+      where.userId = validKey.userId;
+      s;
+    }
+
     const bookings = await prisma.booking.findMany({
       take: 3,
       where,

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -157,8 +157,10 @@ async function handler(req: CustomRequest) {
     },
   });
 
+  const triggerForUser = !teamId || (teamId && bookingToDelete.eventType?.parentId);
+
   const subscriberOptions = {
-    userId: bookingToDelete.userId,
+    userId: triggerForUser ? bookingToDelete.userId : null,
     eventTypeId: bookingToDelete.eventTypeId as number,
     triggerEvent: eventTrigger,
     teamId,

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -293,14 +293,16 @@ export async function handleConfirmation(args: {
       },
     });
 
+    const triggerForUser = !teamId || (teamId && booking.eventType?.parentId);
+
     const subscribersBookingCreated = await getWebhooks({
-      userId: booking.userId,
+      userId: triggerForUser ? booking.userId : null,
       eventTypeId: booking.eventTypeId,
       triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
       teamId,
     });
     const subscribersMeetingEnded = await getWebhooks({
-      userId: booking.userId,
+      userId: triggerForUser ? booking.userId : null,
       eventTypeId: booking.eventTypeId,
       triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
       teamId: booking.eventType?.teamId,

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1126,8 +1126,10 @@ async function handler(
 
   const teamId = await getTeamIdFromEventType({ eventType });
 
+  const triggerForUser = !teamId || (teamId && eventType.parentId);
+
   const subscriberOptions: GetSubscriberOptions = {
-    userId: organizerUser.id,
+    userId: triggerForUser ? organizerUser.id : null,
     eventTypeId,
     triggerEvent: WebhookTriggerEvents.BOOKING_CREATED,
     teamId,
@@ -1140,7 +1142,7 @@ async function handler(
   subscriberOptions.triggerEvent = eventTrigger;
 
   const subscriberOptionsMeetingEnded = {
-    userId: organizerUser.id,
+    userId: triggerForUser ? organizerUser.id : null,
     eventTypeId,
     triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
     teamId,

--- a/packages/features/webhooks/lib/getWebhooks.ts
+++ b/packages/features/webhooks/lib/getWebhooks.ts
@@ -10,16 +10,15 @@ export type GetSubscriberOptions = {
 };
 
 const getWebhooks = async (options: GetSubscriberOptions, prisma: PrismaClient = defaultPrisma) => {
-  const userId = options.teamId ? 0 : options.userId ?? 0;
+  const userId = options.userId ?? 0;
   const eventTypeId = options.eventTypeId ?? 0;
   const teamId = options.teamId ?? 0;
-
+  // if we have userId and teamId it is a managed event type and should trigger for team and user
   const allWebhooks = await prisma.webhook.findMany({
     where: {
       OR: [
         {
           userId,
-          teamId: null,
         },
         {
           eventTypeId,

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -30,7 +30,9 @@ export type WebhookDataType = CalendarEvent &
     downloadLink?: string;
   };
 
-function getZapierPayload(data: CalendarEvent & EventTypeInfo & { status?: string }): string {
+function getZapierPayload(
+  data: CalendarEvent & EventTypeInfo & { status?: string; createdAt: string }
+): string {
   const attendees = data.attendees.map((attendee) => {
     return {
       name: attendee.name,
@@ -69,6 +71,7 @@ function getZapierPayload(data: CalendarEvent & EventTypeInfo & { status?: strin
       length: data.length,
     },
     attendees: attendees,
+    createdAt: data.createdAt,
   };
   return JSON.stringify(body);
 }
@@ -112,7 +115,7 @@ const sendPayload = async (
 
   /* Zapier id is hardcoded in the DB, we send the raw data for this case  */
   if (appId === "zapier") {
-    body = getZapierPayload(data);
+    body = getZapierPayload({ ...data, createdAt });
   } else if (template) {
     body = applyTemplate(template, { ...data, triggerEvent, createdAt }, contentType);
   } else {

--- a/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
@@ -248,9 +248,12 @@ export const requestRescheduleHandler = async ({ ctx, input }: RequestReschedule
         parentId: bookingToReschedule?.eventType?.parentId ?? null,
       },
     });
+
+    const triggerForUser = !teamId || (teamId && bookingToReschedule.eventType?.parentId);
+
     // Send Webhook call if hooked to BOOKING.CANCELLED
     const subscriberOptions = {
-      userId: bookingToReschedule.userId,
+      userId: triggerForUser ? bookingToReschedule.userId : null,
       eventTypeId: bookingToReschedule.eventTypeId as number,
       triggerEvent: eventTrigger,
       teamId,


### PR DESCRIPTION
## What does this PR do?

Webhooks for managed event types should trigger for team webhooks and user webhooks. Before they only triggerd for team webhooks. Also fixes that listBookings (for Zapier) now returns bookings from managed events when using user or team API key. 

Fixes #10940

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a managed event type
- Create a team webhook and a user webhook that triggers when booking is created (use webhook.site)
- Book managed event type, see that webhooks triggered twice (once for users, once for team)
- Test other webhook triggers + test booking normal user event type and team event type (round robin, collective)
