### PR TITLE
fix: broken company profile link on team booking page

### DIFF
--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -1,3 +1,5 @@
+import { usePathname } from "next/navigation";
+
 import { getOrgFullDomain } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { CAL_URL, WEBAPP_URL } from "@calcom/lib/constants";
 import { SchedulingType } from "@calcom/prisma/enums";
@@ -26,6 +28,7 @@ type Avatar = {
 type AvatarWithRequiredImage = Avatar & { image: string };
 
 export const EventMembers = ({ schedulingType, users, profile, entity }: EventMembersProps) => {
+  const pathname = usePathname();
   const showMembers = schedulingType !== SchedulingType.ROUND_ROBIN;
   const shownUsers = showMembers ? users : [];
 
@@ -57,7 +60,9 @@ export const EventMembers = ({ schedulingType, users, profile, entity }: EventMe
     title: `${profile.name}`,
     image: "logo" in profile && profile.logo ? `${profile.logo}` : undefined,
     alt: profile.name || undefined,
-    href: profile.username ? `${CAL_URL}/${profile.username}` : undefined,
+    href: profile.username
+      ? `${CAL_URL}` + (pathname.indexOf("/team/") !== -1 ? "/team" : "") + `/${profile.username}`
+      : undefined,
   });
 
   const uniqueAvatars = avatars


### PR DESCRIPTION
Fixed broken company profile link on team booking page.

Fixes #10438

Video:

https://github.com/calcom/cal.com/assets/109150688/6bcbc5db-bb68-413c-a614-87332e197183


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
