### PR TITLE
fix: firefox scrollbars

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -216,6 +216,7 @@ html.todesktop nav a svg{
     .no-scrollbar {
       -ms-overflow-style: none; /* IE and Edge */
       scrollbar-width: none; /* Firefox */
+      overflow: hidden !important;
     }
   }
 }


### PR DESCRIPTION
fixed scrollbar bug for booking page tabs

## What does this PR do?
This pull request resolves the bug where the scrollbars would show up on the "Bookings" page tabs.

## Type of change
added "overflow": hidden !important to the global.css file
