### PR TITLE
fix: fix-team-invite-username

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -76,7 +76,12 @@ export async function getUserToInviteOrThrowIfExists({
   // Check if user exists in ORG or exists all together
   const invitee = await prisma.user.findFirst({
     where: {
-      OR: [{ username: usernameOrEmail, organizationId: orgId }, { email: usernameOrEmail }],
+      OR: [
+        // If isOrg is true, query with username and organizationId
+        // If isOrg is false, query with username
+        isOrg ? { username: usernameOrEmail, organizationId: orgId } : { username: usernameOrEmail },
+        { email: usernameOrEmail },
+      ],
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes #10993 
Fixes the issue where users can invite members using username and email

I modified the query to include a conditional check `isOrg` to determine whether organizationId should be considered in the filter.

When isOrg is true, the query filters for the combination of username and organizationId and when isOrg is false, the query only filters based on username.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
