### PR TITLE
fix: multiple duration when booking

### DIFF
--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -9,9 +9,10 @@ import type { PublicEvent } from "../../types";
 
 export const EventDuration = ({ event }: { event: PublicEvent }) => {
   const { t } = useLocale();
-  const [selectedDuration, setSelectedDuration] = useBookerStore((state) => [
+  const [selectedDuration, setSelectedDuration, state] = useBookerStore((state) => [
     state.selectedDuration,
     state.setSelectedDuration,
+    state.state,
   ]);
 
   const isDynamicEvent = "isDynamic" in event && event.isDynamic;
@@ -30,14 +31,16 @@ export const EventDuration = ({ event }: { event: PublicEvent }) => {
 
   return (
     <div className="flex flex-wrap gap-2">
-      {durations.map((duration) => (
-        <Badge
-          variant="gray"
-          className={classNames(selectedDuration === duration && "bg-brand-default text-brand")}
-          size="md"
-          key={duration}
-          onClick={() => setSelectedDuration(duration)}>{`${duration} ${t("minute_timeUnit")}`}</Badge>
-      ))}
+      {durations
+        .filter((dur) => state !== "booking" || dur === selectedDuration)
+        .map((duration) => (
+          <Badge
+            variant="gray"
+            className={classNames(selectedDuration === duration && "bg-brand-default text-brand")}
+            size="md"
+            key={duration}
+            onClick={() => setSelectedDuration(duration)}>{`${duration} ${t("minute_timeUnit")}`}</Badge>
+        ))}
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?

When on a multiple duration event type of any sort, you could choose a different duration in the booking form which could be outside availability. This restricts choosing a different duration from that booker state.

https://github.com/calcom/cal.com/assets/467258/5bcd1023-9bd1-46ad-8034-f9d1a333645f

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Create a multiple duration event type and when booking see that you can select a duration but can't choose a different one in the booking form state.