### PR TITLE
chore: stop using telemetry for website

### DIFF
--- a/packages/lib/telemetry.ts
+++ b/packages/lib/telemetry.ts
@@ -19,9 +19,6 @@ export const telemetryEventTypes = {
   onboardingStarted: "onboarding_started",
   signup: "signup",
   team_created: "team_created",
-  website: {
-    pageView: "website_page_view",
-  },
   slugReplacementAction: "slug_replacement_action",
   org_created: "org_created",
 };


### PR DESCRIPTION
we using vercel analytics