### PR TITLE
fix: admin org list without members

### DIFF
--- a/packages/features/ee/organizations/pages/settings/admin/AdminOrgPage.tsx
+++ b/packages/features/ee/organizations/pages/settings/admin/AdminOrgPage.tsx
@@ -59,7 +59,9 @@ function AdminOrgTable() {
                 </div>
               </Cell>
               <Cell widthClassNames="w-auto">
-                <span className="break-all">{org.members[0].user.email}</span>
+                <span className="break-all">
+                  {org.members.length ? org.members[0].user.email : "No members"}
+                </span>
               </Cell>
               <Cell>
                 <div className="space-x-2">


### PR DESCRIPTION
## What does this PR do?

Fixing the list or orgs in admins settings, accounting for orgs without members

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Create a bunch of orgs and as an admin of the Cal.com instance see them in the list in settings.

