### PR TITLE
fix: add metadata to stripe payment intent

### DIFF
--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -50,7 +50,8 @@ export class PaymentService implements IAbstractPaymentService {
     payment: Pick<Prisma.PaymentUncheckedCreateInput, "amount" | "currency">,
     bookingId: Booking["id"],
     bookerEmail: string,
-    paymentOption: PaymentOption
+    paymentOption: PaymentOption,
+    eventTitle?: string
   ) {
     try {
       // Ensure that the payment service can support the passed payment option
@@ -78,6 +79,12 @@ export class PaymentService implements IAbstractPaymentService {
         currency: this.credentials.default_currency,
         payment_method_types: ["card"],
         customer: customer.id,
+        metadata: {
+          identifier: "cal.com",
+          bookingId,
+          bookerEmail,
+          eventName: eventTitle || "",
+        },
       };
 
       const paymentIntent = await this.stripe.paymentIntents.create(params, {

--- a/packages/lib/payment/handlePayment.ts
+++ b/packages/lib/payment/handlePayment.ts
@@ -59,7 +59,8 @@ const handlePayment = async (
       },
       booking.id,
       bookerEmail,
-      paymentOption
+      paymentOption,
+      evt.title
     );
   }
 

--- a/packages/types/PaymentService.d.ts
+++ b/packages/types/PaymentService.d.ts
@@ -14,7 +14,8 @@ export interface IAbstractPaymentService {
     payment: Pick<Prisma.PaymentUncheckedCreateInput, "amount" | "currency">,
     bookingId: Booking["id"],
     bookerEmail: string,
-    paymentOption: PaymentOption
+    paymentOption: PaymentOption,
+    eventTitle?: string
   ): Promise<Payment>;
   /* This method is to collect card details to charge at a later date ex. no-show fees */
   collectCard(


### PR DESCRIPTION
## What does this PR do?

- Add booking and event metadata to payment intent stripe

Fixes #10678 

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No
- What are the minimal test data to have? Stripe app setup on event type
- What is expected (happy path) to have (input and output)? In stripe dashboard payment intent you should see new metadata to identify that this payment came from cal.com.
- Any other important info that could help to test that PR. No

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
- I haven't added tests that prove my fix is effective or that my feature works
