### PR TITLE
style: Conformation --> Confirmation

### DIFF
--- a/apps/web/public/static/locales/ar/common.json
+++ b/apps/web/public/static/locales/ar/common.json
@@ -1074,7 +1074,7 @@
   "event_cancelled": "تم إلغاء هذا الحدث",
   "emailed_information_about_cancelled_event": "لقد أرسلنا إليك وإلى الحاضرين الآخرين بريداً إلكترونياً لإعلامهم.",
   "this_input_will_shown_booking_this_event": "سيُعرَض هذا المُدخَل عند حجز هذا الحدث",
-  "meeting_url_in_conformation_email": "عنوان رابط الاجتماع موجود في رسالة التأكيد الإلكترونية",
+  "meeting_url_in_confirmation_email": "عنوان رابط الاجتماع موجود في رسالة التأكيد الإلكترونية",
   "url_start_with_https": "يجب أن يبدأ العنوان بـ http:// أو https://",
   "number_provided": "سيتم توفير رقم الهاتف",
   "before_event_trigger": "قبل بدء الحدث",

--- a/apps/web/public/static/locales/cs/common.json
+++ b/apps/web/public/static/locales/cs/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Tato událost je zrušena",
   "emailed_information_about_cancelled_event": "Poslali jsme vám a ostatním účastníkům informační e-mail.",
   "this_input_will_shown_booking_this_event": "Toto pole se zobrazí při rezervaci této události",
-  "meeting_url_in_conformation_email": "Adresa URL schůzky je v potvrzovacím e-mailu",
+  "meeting_url_in_confirmation_email": "Adresa URL schůzky je v potvrzovacím e-mailu",
   "url_start_with_https": "Adresa URL musí začínat http:// nebo https://",
   "number_provided": "Bude uvedeno telefonní číslo",
   "before_event_trigger": "před zahájením události",

--- a/apps/web/public/static/locales/da/common.json
+++ b/apps/web/public/static/locales/da/common.json
@@ -960,7 +960,7 @@
   "reschedule_placeholder": "Lad andre vide, hvorfor du har brug for at omlægge",
   "emailed_information_about_cancelled_event": "Vi har sendt en e-mail til dig og de andre deltagere for at give dem besked.",
   "this_input_will_shown_booking_this_event": "Dette input vil blive vist ved booking af denne begivenhed",
-  "meeting_url_in_conformation_email": "Møde-url er i bekræftelses-mailen",
+  "meeting_url_in_confirmation_email": "Møde-url er i bekræftelses-mailen",
   "url_start_with_https": "URL'en skal starte med http:// eller https://",
   "number_provided": "Telefonnummer vil blive angivet",
   "before_event_trigger": "før begivenheden starter",

--- a/apps/web/public/static/locales/de/common.json
+++ b/apps/web/public/static/locales/de/common.json
@@ -1095,7 +1095,7 @@
   "event_cancelled": "Dieser Termin ist abgesagt",
   "emailed_information_about_cancelled_event": "Wir haben Ihnen und den anderen Teilnehmern eine E-Mail gesendet, damit alle Bescheid wissen.",
   "this_input_will_shown_booking_this_event": "Diese Eingabe wird bei der Buchung dieses Termins angezeigt",
-  "meeting_url_in_conformation_email": "Termin-URL ist in der Bestätigungsmail",
+  "meeting_url_in_confirmation_email": "Termin-URL ist in der Bestätigungsmail",
   "url_start_with_https": "URL muss mit http:// oder https:// beginnen",
   "number_provided": "Telefonnummer wird angegeben",
   "before_event_trigger": "vor Beginn des Termins",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1098,7 +1098,7 @@
   "event_cancelled": "This event is canceled",
   "emailed_information_about_cancelled_event": "We emailed you and the other attendees to let them know.",
   "this_input_will_shown_booking_this_event": "This input will be shown when booking this event",
-  "meeting_url_in_conformation_email": "Meeting url is in the confirmation email",
+  "meeting_url_in_confirmation_email": "Meeting url is in the confirmation email",
   "url_start_with_https": "URL needs to start with http:// or https://",
   "number_provided": "Phone number will be provided",
   "before_event_trigger": "before event starts",

--- a/apps/web/public/static/locales/es/common.json
+++ b/apps/web/public/static/locales/es/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Este evento se canceló",
   "emailed_information_about_cancelled_event": "Le enviamos un correo electrónico a usted y a los demás asistentes para informarles.",
   "this_input_will_shown_booking_this_event": "Esta entrada se mostrará al reservar este evento.",
-  "meeting_url_in_conformation_email": "La URL de la reunión está en el correo de confirmación",
+  "meeting_url_in_confirmation_email": "La URL de la reunión está en el correo de confirmación",
   "url_start_with_https": "La URL debe empezar por http:// o https://",
   "number_provided": "Se proporcionará el número de teléfono",
   "before_event_trigger": "antes del inicio del evento",

--- a/apps/web/public/static/locales/fr/common.json
+++ b/apps/web/public/static/locales/fr/common.json
@@ -1098,7 +1098,7 @@
   "event_cancelled": "Cet événement est annulé",
   "emailed_information_about_cancelled_event": "Nous vous avons envoyé un e-mail à vous et aux autres participants pour les en informer.",
   "this_input_will_shown_booking_this_event": "Ce champ sera affiché lors de la réservation de cet événement.",
-  "meeting_url_in_conformation_email": "Le lien du rendez-vous est dans l'e-mail de confirmation",
+  "meeting_url_in_confirmation_email": "Le lien du rendez-vous est dans l'e-mail de confirmation",
   "url_start_with_https": "Le lien doit commencer par http:// ou https://",
   "number_provided": "Un numéro de téléphone sera fourni",
   "before_event_trigger": "avant le début de l'événement",

--- a/apps/web/public/static/locales/he/common.json
+++ b/apps/web/public/static/locales/he/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "האירוע בוטל",
   "emailed_information_about_cancelled_event": "שלחנו לך ולשאר המשתתפים הודעת דוא״ל כדי ליידע אותם על כך.",
   "this_input_will_shown_booking_this_event": "הקלט יוצג בעת הזמנת אירוע זה",
-  "meeting_url_in_conformation_email": "כתובת ה-URL של הפגישה נמצאת בהודעת הדוא״ל שנשלחה לאישור הפגישה",
+  "meeting_url_in_confirmation_email": "כתובת ה-URL של הפגישה נמצאת בהודעת הדוא״ל שנשלחה לאישור הפגישה",
   "url_start_with_https": "כתובת ה-URL צריכה להתחיל עם הקידומת http://‎ או https://‎",
   "number_provided": "מספר הטלפון יסופק",
   "before_event_trigger": "לפני שהאירוע מתחיל",

--- a/apps/web/public/static/locales/it/common.json
+++ b/apps/web/public/static/locales/it/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Questo evento è stato cancellato",
   "emailed_information_about_cancelled_event": "Abbiamo inviato un'e-mail di notifica a te e agli altri partecipanti.",
   "this_input_will_shown_booking_this_event": "Questo input verrà mostrato durante la prenotazione di questo evento",
-  "meeting_url_in_conformation_email": "L'URL della riunione è riportato nell'e-mail di conferma",
+  "meeting_url_in_confirmation_email": "L'URL della riunione è riportato nell'e-mail di conferma",
   "url_start_with_https": "L'URL deve iniziare con http:// o https://",
   "number_provided": "Verrà fornito il numero di telefono",
   "before_event_trigger": "prima dell'inizio dell'evento",

--- a/apps/web/public/static/locales/ja/common.json
+++ b/apps/web/public/static/locales/ja/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "このイベントはキャンセルされました",
   "emailed_information_about_cancelled_event": "あなたと他の出席者に電子メールでお知らせしました。",
   "this_input_will_shown_booking_this_event": "この入力は、このイベントを予約する際に表示されます",
-  "meeting_url_in_conformation_email": "ミーティングURLは確認メールに記載されています",
+  "meeting_url_in_confirmation_email": "ミーティングURLは確認メールに記載されています",
   "url_start_with_https": "URLは、http://またはhttps://で始まる必要があります",
   "number_provided": "電話番号が提供されます",
   "before_event_trigger": "イベント開始前に",

--- a/apps/web/public/static/locales/ko/common.json
+++ b/apps/web/public/static/locales/ko/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "이 이벤트는 취소되었습니다",
   "emailed_information_about_cancelled_event": "귀하와 다른 참석자들에게 이메일로 알려 드렸습니다.",
   "this_input_will_shown_booking_this_event": "이 입력은 이 이벤트를 예약할 때 표시됩니다.",
-  "meeting_url_in_conformation_email": "회의 URL은 확인 이메일에 있습니다",
+  "meeting_url_in_confirmation_email": "회의 URL은 확인 이메일에 있습니다",
   "url_start_with_https": "URL은 http:// 또는 https://로 시작해야 합니다",
   "number_provided": "전화 번호는 제공됩니다",
   "before_event_trigger": "이벤트 시작 전",

--- a/apps/web/public/static/locales/nl/common.json
+++ b/apps/web/public/static/locales/nl/common.json
@@ -1079,7 +1079,7 @@
   "event_cancelled": "Deze gebeurtenis is geannuleerd",
   "emailed_information_about_cancelled_event": "We hebben u en de andere deelnemers een e-mail gestuurd om hen te informeren.",
   "this_input_will_shown_booking_this_event": "Deze invoer wordt getoond tijdens het boeken van dit evenement",
-  "meeting_url_in_conformation_email": "De vergader-URL wordt vermeld in de bevestigings-e-mail",
+  "meeting_url_in_confirmation_email": "De vergader-URL wordt vermeld in de bevestigings-e-mail",
   "url_start_with_https": "URL moet beginnen met http:// of https://",
   "number_provided": "Telefoonnummer wordt verstrekt",
   "before_event_trigger": "voordat de gebeurtenis begint",

--- a/apps/web/public/static/locales/no/common.json
+++ b/apps/web/public/static/locales/no/common.json
@@ -941,7 +941,7 @@
   "reschedule_placeholder": "Fortell andre hvorfor du må endre tidspunktet",
   "emailed_information_about_cancelled_event": "Vi sendte deg og de andre deltakerne en e-post for å informere.",
   "this_input_will_shown_booking_this_event": "Dette inputfeltet vil vises når man booker denne hendelsen",
-  "meeting_url_in_conformation_email": "Møte-url ligger i e-postbekreftelsen",
+  "meeting_url_in_confirmation_email": "Møte-url ligger i e-postbekreftelsen",
   "url_start_with_https": "URL må begynne med http:// eller https://",
   "number_provided": "Telefonnummer vil bli oppgitt",
   "before_event_trigger": "før hendelsen starter",

--- a/apps/web/public/static/locales/pl/common.json
+++ b/apps/web/public/static/locales/pl/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "To wydarzenie zostało anulowane",
   "emailed_information_about_cancelled_event": "Wysłaliśmy wiadomość e-mail Tobie i innym uczestnikom, aby ich o tym poinformować.",
   "this_input_will_shown_booking_this_event": "To wejście zostanie wyświetlone podczas rezerwacji tego wydarzenia",
-  "meeting_url_in_conformation_email": "Adres URL spotkania znajduje się w wiadomości e-mail z potwierdzeniem",
+  "meeting_url_in_confirmation_email": "Adres URL spotkania znajduje się w wiadomości e-mail z potwierdzeniem",
   "url_start_with_https": "Adres URL musi zaczynać się od http:// lub https://",
   "number_provided": "Numer telefonu zostanie podany.",
   "before_event_trigger": "przed rozpoczęciem wydarzenia",

--- a/apps/web/public/static/locales/pt-BR/common.json
+++ b/apps/web/public/static/locales/pt-BR/common.json
@@ -1091,7 +1091,7 @@
   "event_cancelled": "Este evento foi cancelado",
   "emailed_information_about_cancelled_event": "Avisamos por e-mail aos outros participantes e a você.",
   "this_input_will_shown_booking_this_event": "Este campo será mostrado na reserva deste evento",
-  "meeting_url_in_conformation_email": "O URL da reunião está no e-mail de confirmação",
+  "meeting_url_in_confirmation_email": "O URL da reunião está no e-mail de confirmação",
   "url_start_with_https": "O URL precisa começar com http:// ou https://",
   "number_provided": "O número de telefone será fornecido",
   "before_event_trigger": "antes do início do evento",

--- a/apps/web/public/static/locales/pt/common.json
+++ b/apps/web/public/static/locales/pt/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Este evento foi cancelado",
   "emailed_information_about_cancelled_event": "Enviámos um email com o aviso para si e para os restantes participantes.",
   "this_input_will_shown_booking_this_event": "Este campo será mostrado na reserva deste evento",
-  "meeting_url_in_conformation_email": "O URL da reunião está no email de confirmação",
+  "meeting_url_in_confirmation_email": "O URL da reunião está no email de confirmação",
   "url_start_with_https": "O URL tem de começar por http:// ou https://",
   "number_provided": "Será fornecido um número de telefone",
   "before_event_trigger": "antes do evento iniciar",

--- a/apps/web/public/static/locales/ro/common.json
+++ b/apps/web/public/static/locales/ro/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Acest eveniment este anulat",
   "emailed_information_about_cancelled_event": "V-am trimis un e-mail de informare dvs. și celorlalți participanți.",
   "this_input_will_shown_booking_this_event": "Datele introduse vor fi afișate la rezervarea acestui eveniment",
-  "meeting_url_in_conformation_email": "Adresa URL a întâlnirii este în e-mailul de confirmare",
+  "meeting_url_in_confirmation_email": "Adresa URL a întâlnirii este în e-mailul de confirmare",
   "url_start_with_https": "Adresa URL trebuie să înceapă cu http:// or https://",
   "number_provided": "Numărul de telefon va fi furnizat",
   "before_event_trigger": "înainte de începerea evenimentului",

--- a/apps/web/public/static/locales/ru/common.json
+++ b/apps/web/public/static/locales/ru/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Это событие отменено",
   "emailed_information_about_cancelled_event": "Мы сообщили об этом вам и другим участникам по электронной почте.",
   "this_input_will_shown_booking_this_event": "Этот вопрос будет показан при бронировании события по этому шаблону",
-  "meeting_url_in_conformation_email": "Ссылка на встречу находится в письме с подтверждением",
+  "meeting_url_in_confirmation_email": "Ссылка на встречу находится в письме с подтверждением",
   "url_start_with_https": "URL-адрес должен начинаться с http:// или https://",
   "number_provided": "Будет указан номер телефона",
   "before_event_trigger": "до начала события",

--- a/apps/web/public/static/locales/sr/common.json
+++ b/apps/web/public/static/locales/sr/common.json
@@ -1076,7 +1076,7 @@
   "event_cancelled": "Ovaj događaj je otkazan",
   "emailed_information_about_cancelled_event": "Poslali smo imejl vama i drugim polaznicima kao obaveštenje.",
   "this_input_will_shown_booking_this_event": "Ovaj unos će biti prikazan kad se rezerviše ovaj događaj",
-  "meeting_url_in_conformation_email": "Url za sastanak je u imejlu za potvrdu",
+  "meeting_url_in_confirmation_email": "Url za sastanak je u imejlu za potvrdu",
   "url_start_with_https": "Potrebno je URL da počinje sa http:// or https://",
   "number_provided": "Broj telefona će biti dostavljen",
   "before_event_trigger": "pre početka događaja",

--- a/apps/web/public/static/locales/sv/common.json
+++ b/apps/web/public/static/locales/sv/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Den här händelsen är inställd",
   "emailed_information_about_cancelled_event": "Vi mejlade dig och de andra deltagarna för att informera om detta.",
   "this_input_will_shown_booking_this_event": "Detta visas vid bokning av denna händelse",
-  "meeting_url_in_conformation_email": "Mötets webbadress finns i bekräftelsemejlet",
+  "meeting_url_in_confirmation_email": "Mötets webbadress finns i bekräftelsemejlet",
   "url_start_with_https": "Webbadress behöver inledas med http:// eller https://",
   "number_provided": "Telefonnummer kommer att anges",
   "before_event_trigger": "innan händelsen startar",

--- a/apps/web/public/static/locales/tr/common.json
+++ b/apps/web/public/static/locales/tr/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Bu etkinlik iptal edildi",
   "emailed_information_about_cancelled_event": "Sizi ve diğer katılımcıları bilgilendirmek için bir e-posta gönderdik.",
   "this_input_will_shown_booking_this_event": "Bu girdi, bu etkinlik için rezervasyon yapılırken gösterilecek",
-  "meeting_url_in_conformation_email": "Toplantı URL'si onay e-postasında mevcut",
+  "meeting_url_in_confirmation_email": "Toplantı URL'si onay e-postasında mevcut",
   "url_start_with_https": "URL'nin http:// veya https:// ile başlaması gerekiyor",
   "number_provided": "Telefon numarası sağlanacaktır",
   "before_event_trigger": "etkinlik başlamadan önce",

--- a/apps/web/public/static/locales/uk/common.json
+++ b/apps/web/public/static/locales/uk/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Цей захід скасовано",
   "emailed_information_about_cancelled_event": "Ми сповістили вас та інших учасників електронною поштою.",
   "this_input_will_shown_booking_this_event": "Це поле введення буде показано під час бронювання часу для цього заходу",
-  "meeting_url_in_conformation_email": "URL-адресу наради вказано в листі з підтвердженням",
+  "meeting_url_in_confirmation_email": "URL-адресу наради вказано в листі з підтвердженням",
   "url_start_with_https": "URL-адреса має починатися з http:// або https://",
   "number_provided": "Номер телефону буде надано",
   "before_event_trigger": "до початку заходу",

--- a/apps/web/public/static/locales/vi/common.json
+++ b/apps/web/public/static/locales/vi/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "Sự kiện này bị huỷ",
   "emailed_information_about_cancelled_event": "Chúng tôi đã gửi email cho bạn và những người tham dự khác để cho họ biết.",
   "this_input_will_shown_booking_this_event": "Trường này sẽ được hiển thị khi đặt sự kiện này",
-  "meeting_url_in_conformation_email": "Url cuộc họp nằm trong email xác nhận",
+  "meeting_url_in_confirmation_email": "Url cuộc họp nằm trong email xác nhận",
   "url_start_with_https": "URL cần bắt đầu bằng http:// hoặc https://",
   "number_provided": "Số điện thoại sẽ được cung ứng",
   "before_event_trigger": "trước khi sự kiện bắt đầu",

--- a/apps/web/public/static/locales/zh-CN/common.json
+++ b/apps/web/public/static/locales/zh-CN/common.json
@@ -1079,7 +1079,7 @@
   "event_cancelled": "此活动已取消",
   "emailed_information_about_cancelled_event": "我们已向您和其他参与者发送电子邮件来通知他们。",
   "this_input_will_shown_booking_this_event": "在预约此活动时将显示该输入框",
-  "meeting_url_in_conformation_email": "会议链接含在确认电子邮件中",
+  "meeting_url_in_confirmation_email": "会议链接含在确认电子邮件中",
   "url_start_with_https": "链接需要以 http:// 或 https:// 开头",
   "number_provided": "将提供电话号码",
   "before_event_trigger": "活动开始前",

--- a/apps/web/public/static/locales/zh-TW/common.json
+++ b/apps/web/public/static/locales/zh-TW/common.json
@@ -1075,7 +1075,7 @@
   "event_cancelled": "此活動已取消",
   "emailed_information_about_cancelled_event": "我們已給您和其他與會者發送通知電子郵件。",
   "this_input_will_shown_booking_this_event": "輸入欄會在預約此活動的時候顯示",
-  "meeting_url_in_conformation_email": "會議網址請參見確認電子郵件",
+  "meeting_url_in_confirmation_email": "會議網址請參見確認電子郵件",
   "url_start_with_https": "URL 需要以 http:// 或 https:// 開頭",
   "number_provided": "將提供電話號碼",
   "before_event_trigger": "活動開始前",

--- a/packages/app-store/locations.ts
+++ b/packages/app-store/locations.ts
@@ -403,7 +403,7 @@ export function getSuccessPageLocationMessage(
       locationToDisplay == t("web_conference");
     } else if (isConfirmed) {
       locationToDisplay =
-        getHumanReadableLocationValue(location, t) + ": " + t("meeting_url_in_conformation_email");
+        getHumanReadableLocationValue(location, t) + ": " + t("meeting_url_in_confirmation_email");
     } else {
       locationToDisplay = t("web_conferencing_details_to_follow");
     }


### PR DESCRIPTION
## What does this PR do?
Switches key name "meeting_link_in_conformation_email" to "meeting_link_in_confirmation_email" . Reading through codebase to try to build enough context to try to maybe contribute to some of the other issues, I noticed what I think is a typo in this variable name. 

Fixes # (issue)
No issue / visual changes

## Requirement/Documentation


## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)


## How should this be tested?

I ran "yarn test" locally to test and checked that the booking info page shows this text still: 
![Screenshot 2023-08-31 185001](https://github.com/calcom/cal.com/assets/5819478/6c3a2cb2-0e40-4f84-8ef0-1d41ee686e6a)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

