### PR TITLE
fix: #10973 back button not working as expected in embed

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -45,8 +45,18 @@ type BookEventFormProps = {
 type DefaultValues = Record<string, unknown>;
 
 export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
+  let uid = "";
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation({
-    trpc: { context: { skipBatch: true } },
+    trpc: {
+      context: {
+        skipBatch: true,
+      },
+    },
+    onSuccess: (data) => {
+      // uid is required to pass as input to removeSelectedSlotMark endpoint
+      // as in case of embed, uid is not passed in cookie
+      uid = data?.uid;
+    },
   });
   const removeSelectedSlot = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation({
     trpc: { context: { skipBatch: true } },
@@ -82,7 +92,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
 
     return () => {
       if (eventType) {
-        removeSelectedSlot.mutate();
+        removeSelectedSlot.mutate({ uid: uid });
       }
       clearInterval(interval);
     };

--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -45,7 +45,7 @@ type BookEventFormProps = {
 type DefaultValues = Record<string, unknown>;
 
 export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
-  let uid = "";
+  const uid = useRef("");
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation({
     trpc: {
       context: {
@@ -55,7 +55,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
     onSuccess: (data) => {
       // uid is required to pass as input to removeSelectedSlotMark endpoint
       // as in case of embed, uid is not passed in cookie
-      uid = data?.uid;
+      uid.current = data?.uid;
     },
   });
   const removeSelectedSlot = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation({
@@ -92,7 +92,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
 
     return () => {
       if (eventType) {
-        removeSelectedSlot.mutate({ uid: uid });
+        removeSelectedSlot.mutate({ uid: uid.current });
       }
       clearInterval(interval);
     };

--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -34,6 +34,7 @@ import { Alert, Button, EmptyScreen, Form, showToast } from "@calcom/ui";
 import { Calendar } from "@calcom/ui/components/icon";
 
 import { useBookerStore } from "../../store";
+import { useSlotReservationId } from "../../useSlotReservationId";
 import { useEvent } from "../../utils/event";
 import { BookingFields } from "./BookingFields";
 import { FormSkeleton } from "./Skeleton";
@@ -45,7 +46,7 @@ type BookEventFormProps = {
 type DefaultValues = Record<string, unknown>;
 
 export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
-  const uid = useRef("");
+  const [slotReservationId, setSlotReservationId] = useSlotReservationId();
   const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation({
     trpc: {
       context: {
@@ -53,9 +54,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
       },
     },
     onSuccess: (data) => {
-      // uid is required to pass as input to removeSelectedSlotMark endpoint
-      // as in case of embed, uid is not passed in cookie
-      uid.current = data?.uid;
+      setSlotReservationId(data.uid);
     },
   });
   const removeSelectedSlot = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation({
@@ -92,7 +91,7 @@ export const BookEventForm = ({ onCancel }: BookEventFormProps) => {
 
     return () => {
       if (eventType) {
-        removeSelectedSlot.mutate({ uid: uid.current });
+        removeSelectedSlot.mutate({ uid: slotReservationId });
       }
       clearInterval(interval);
     };

--- a/packages/features/bookings/Booker/useSlotReservationId.ts
+++ b/packages/features/bookings/Booker/useSlotReservationId.ts
@@ -1,0 +1,15 @@
+// TODO: It would be lost on refresh, so we need to persist it.
+// Though, we are persisting it in a cookie(`uid` cookie is set through reserveSlot call)
+// but that becomes a third party cookie in context of embed and thus isn't accessible inside embed
+// So, we need to persist it in top window as first party cookie in that case.
+let slotReservationId: null | string = null;
+
+export const useSlotReservationId = () => {
+  function set(uid: string) {
+    slotReservationId = uid;
+  }
+  function get() {
+    return slotReservationId;
+  }
+  return [get(), set] as const;
+};

--- a/packages/trpc/server/routers/viewer/slots/_router.tsx
+++ b/packages/trpc/server/routers/viewer/slots/_router.tsx
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import publicProcedure from "../../../procedures/publicProcedure";
 import { router } from "../../../trpc";
 import { ZGetScheduleInputSchema } from "./getSchedule.schema";
+import { ZRemoveSelectedSlotInputSchema } from "./removeSelectedSlot.schema";
 import { ZReserveSlotInputSchema } from "./reserveSlot.schema";
 
 type SlotsRouterHandlerCache = {
@@ -49,12 +50,14 @@ export const slotsRouter = router({
     });
   }),
   // This endpoint has no dependencies, it doesn't need its own file
-  removeSelectedSlotMark: publicProcedure.mutation(async ({ ctx }) => {
-    const { req, prisma } = ctx;
-    const uid = req?.cookies?.uid;
-    if (uid) {
-      await prisma.selectedSlots.deleteMany({ where: { uid: { equals: uid } } });
-    }
-    return;
-  }),
+  removeSelectedSlotMark: publicProcedure
+    .input(ZRemoveSelectedSlotInputSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { req, prisma } = ctx;
+      const uid = req?.cookies?.uid || input?.uid;
+      if (uid) {
+        await prisma.selectedSlots.deleteMany({ where: { uid: { equals: uid } } });
+      }
+      return;
+    }),
 });

--- a/packages/trpc/server/routers/viewer/slots/_router.tsx
+++ b/packages/trpc/server/routers/viewer/slots/_router.tsx
@@ -54,7 +54,7 @@ export const slotsRouter = router({
     .input(ZRemoveSelectedSlotInputSchema)
     .mutation(async ({ input, ctx }) => {
       const { req, prisma } = ctx;
-      const uid = req?.cookies?.uid || input?.uid;
+      const uid = req?.cookies?.uid || input.uid;
       if (uid) {
         await prisma.selectedSlots.deleteMany({ where: { uid: { equals: uid } } });
       }

--- a/packages/trpc/server/routers/viewer/slots/removeSelectedSlot.schema.ts
+++ b/packages/trpc/server/routers/viewer/slots/removeSelectedSlot.schema.ts
@@ -1,0 +1,7 @@
+import type { z } from "zod";
+
+import { removeSelectedSlotSchema } from "./types";
+
+export const ZRemoveSelectedSlotInputSchema = removeSelectedSlotSchema;
+
+export type TRemoveSelectedSlotInputSchema = z.infer<typeof ZRemoveSelectedSlotInputSchema>;

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -86,5 +86,7 @@ export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => 
     }
   }
   res?.setHeader("Set-Cookie", serialize("uid", uid, { path: "/", sameSite: "lax" }));
-  return;
+  return {
+    uid: uid,
+  };
 };

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -59,5 +59,5 @@ export type Slot = {
 };
 
 export const removeSelectedSlotSchema = z.object({
-  uid: z.string().optional().nullable(),
+  uid: z.string().nullable(),
 });

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -57,3 +57,7 @@ export type Slot = {
   bookingUid?: string;
   users?: string[];
 };
+
+export const removeSelectedSlotSchema = z.object({
+  uid: z.string().optional().nullable(),
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #10973 

Below is the brief description or reproduction steps :
In **embed** scenario, 
1. Select an event type.
2. Select a date and then click on a time slot.
3. On the Confirm screen, click "Back". This will take you back to the screen where you just picked a time. The time you just selected will no longer be shown as available, even though you just selected it. The only way it will be available is if you come back after 5 minutes.

Video : Before fix : (Issue)
Slot is selected for Sep6th 10AM, Click on back button, same slot is **Not** selectable
https://www.loom.com/share/de09f1f4d43640c8989b929becf544d9?sid=5558af13-6384-4ef5-8929-bdb340307009

Video : After fix :
Slot is selected for Sep6th 10AM, Click on back button, same slot is selectable
https://www.loom.com/share/b4c8110bed594c31aaa188bc2f37eccc?sid=cc9ae96c-471a-4fba-9133-c9eb60c59a00
 

Root cause of issue:
In case of embed, the cookies are not set in requests to trpc.
The trpc endpoint "slots.removeSelectedSlotMark" relies on cookies in request to get the uid. And uses this uid to delete the selection mark in db.
Hence for embed case, it's (endpoint) not able to get uid from cookie, and the selection mark is not removed. So the slot is still reserved (even after user clicks on back button)

Implementaion / Fix :
uid is passed as an optional argument to the endpoint "slots.removeSelectedSlotMark"

## Type of change
- [v] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Refer above for steps to reproduce the issue and verify its working fine.

## Mandatory Tasks
- [v] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
