### PR TITLE
fix: Fix avatar alligment

### DIFF
--- a/packages/ui/components/avatar/Avatar.tsx
+++ b/packages/ui/components/avatar/Avatar.tsx
@@ -40,7 +40,7 @@ export function Avatar(props: AvatarProps) {
   let avatar = (
     <AvatarPrimitive.Root
       className={classNames(
-        "bg-emphasis item-center relative aspect-square justify-center overflow-hidden rounded-full",
+        "bg-emphasis item-center relative inline-flex aspect-square justify-center overflow-hidden rounded-full",
         props.className,
         sizesPropsBySize[size]
       )}>


### PR DESCRIPTION
Fixes avatar alignment 

Before:
![Sizzy-MacBook Air brydon cal local 01Sep 12 52](https://github.com/calcom/cal.com/assets/55134778/8ec7fdcb-997c-4cc6-a64a-5a9d12f1cc18)
![Sizzy-iPad Pro 11 brydon cal local 01Sep 12 52](https://github.com/calcom/cal.com/assets/55134778/6bf28a28-a49a-43a7-8568-2cd1d03a6f6f)
![Sizzy-iPhone 14 brydon cal local 01Sep 12 52](https://github.com/calcom/cal.com/assets/55134778/c4ef3722-089f-44f3-b801-58bb31b2aeaf)

After:
![Sizzy-iPhone 14 app cal local 01Sep 12 56](https://github.com/calcom/cal.com/assets/55134778/fe52f3d4-7638-4d55-ae91-4fcb607bfdb1)
![Sizzy-iPad Pro 11 app cal local 01Sep 12 56](https://github.com/calcom/cal.com/assets/55134778/84f1b1a3-e965-4fb9-93fb-8f626f7b8f6c)
![Sizzy-MacBook Air app cal local 01Sep 12 56](https://github.com/calcom/cal.com/assets/55134778/d8179144-eefc-43ab-9aec-2af61b7e0b64)

Other avatars not effected:
![Sizzy-MacBook Air app cal local 01Sep 12 57](https://github.com/calcom/cal.com/assets/55134778/6bbcabfb-fa93-4435-9ca4-cd9c001395cc)
