### PR TITLE
fix: support subteam in org redirection

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -450,6 +450,13 @@ const nextConfig = {
       },
       {
         source: "/support",
+        missing: [
+          {
+            type: "header",
+            key: "host",
+            value: orgHostPath,
+          },
+        ],
         destination: "/event-types?openIntercom=true",
         permanent: true,
       },


### PR DESCRIPTION
## What does this PR do?

Using the slug "support" for a subteam within an org was clashing with our "Support" redirection which opened up Intercom in the event types page. This PR fixes that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create an org
2. Create a subteam with slug "support"
3. Visit public profile of the created subteam
4. You should be able to see the profile page and not be redirected to event types page with intercom opened