### PR TITLE
fix: #11077 Team event types have no padding at the bottom.

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -873,7 +873,7 @@ const Main = ({
             <MobileTeamsTab eventTypeGroups={data.eventTypeGroups} />
           ) : (
             data.eventTypeGroups.map((group: EventTypeGroup, index: number) => (
-              <div className="flex flex-col" key={group.profile.slug}>
+              <div className="mt-4 flex flex-col" key={group.profile.slug}>
                 <EventTypeListHeading
                   profile={group.profile}
                   membershipCount={group.metadata.membershipCount}


### PR DESCRIPTION
## What does this PR do?

It added the space on Team events

Fixes #11077 

Here is the ScreenShot
![image](https://github.com/calcom/cal.com/assets/99652555/051d50ec-4101-4e06-890f-a40b72929eba)
