### PR TITLE
fix: Remove background colour from avatar 

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -369,7 +369,7 @@ function UserDropdown({ small }: UserDropdownProps) {
           <span
             className={classNames(
               small ? "h-4 w-4" : "h-5 w-5 ltr:mr-2 rtl:ml-2",
-              "relative flex-shrink-0 rounded-full bg-gray-300"
+              "relative flex-shrink-0 rounded-full "
             )}>
             <Avatar
               size={small ? "xs" : "xsm"}


### PR DESCRIPTION
Hard to see but the avatar had a tiny gap of margin 

We dont use the background for this anymore so its not needed.

Before: 
![CleanShot 2023-09-01 at 16 42 38](https://github.com/calcom/cal.com/assets/55134778/78a28171-c94f-4dc7-95ff-58630c1024ae)

After: 
![CleanShot 2023-09-01 at 16 41 26](https://github.com/calcom/cal.com/assets/55134778/848415a8-4873-4fdd-abe1-637b7d72bbeb)
