### PR TITLE
fix: added placeholder enter_email in Add guests field

### DIFF
--- a/packages/features/bookings/lib/getBookingFields.ts
+++ b/packages/features/bookings/lib/getBookingFields.ts
@@ -253,6 +253,7 @@ export const ensureBookingInputsHaveSystemFields = ({
       name: "guests",
       required: false,
       hidden: disableGuests,
+      defaultPlaceholder: 'enter_email',
       sources: [
         {
           label: "Default",


### PR DESCRIPTION
## What does this PR do?
It adds enter_email placeholder in Add guests  field.

Fixes #11094 
 
<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

