### PR TITLE
fix: variables for custom webhook payload

### DIFF
--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -77,9 +77,7 @@ function getZapierPayload(
 }
 
 function applyTemplate(template: string, data: WebhookDataType, contentType: ContentType) {
-  const organizer = JSON.stringify(data.organizer);
-  const attendees = JSON.stringify(data.attendees);
-  const formattedData = { ...data, metadata: JSON.stringify(data.metadata), organizer, attendees };
+  const formattedData = data;
 
   const compiled = compile(template)(formattedData).replace(/&quot;/g, '"');
 

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -77,9 +77,7 @@ function getZapierPayload(
 }
 
 function applyTemplate(template: string, data: WebhookDataType, contentType: ContentType) {
-  const formattedData = data;
-
-  const compiled = compile(template)(formattedData).replace(/&quot;/g, '"');
+  const compiled = compile(template)(data).replace(/&quot;/g, '"');
 
   if (contentType === "application/json") {
     return JSON.stringify(jsonParse(compiled));


### PR DESCRIPTION
## What does this PR do?

This PR fixes the variables organizer, attendees and metadata in the custom webhook payload. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create Webhook use https://webhook.site/ for subscriber url
- Define custom webhook payload: 
```
{
  "content": "A new event has been scheduled",
  "type": "{{type}}",
  "name": "{{title}}",
  "organizer": "{{organizer.name}}",
  "meetingLink": "{{metadata.videoCallUrl}}",
}
```
- Book a meeting
- See if payload of triggered webhook shows the variables correctly