### PR TITLE
fix: remove double call on useSchedule()

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -49,7 +49,7 @@ const BookerComponent = ({
    * Prioritize dateSchedule load
    * Component will render but use data already fetched from here, and no duplicate requests will be made
    * */
-  useScheduleForEvent({
+  const schedule = useScheduleForEvent({
     prefetchNextMonth: false,
     username,
     eventSlug,
@@ -93,7 +93,7 @@ const BookerComponent = ({
   );
 
   const date = dayjs(selectedDate).format("YYYY-MM-DD");
-  const schedule = useScheduleForEvent({ prefetchNextMonth: true });
+
   const nonEmptyScheduleDays = useNonEmptyScheduleDays(schedule?.data?.slots).filter(
     (slot) => dayjs(selectedDate).diff(slot, "day") <= 0
   );
@@ -109,7 +109,7 @@ const BookerComponent = ({
       ? totalWeekDays
       : 0;
 
-  //Taking one more avaliable slot(extraDays + 1) to claculate the no of days in between, that next and prev button need to shift.
+  // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
   if (nonEmptyScheduleDays.length !== 0)
     columnViewExtraDays.current =

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -31,7 +31,7 @@ export const useSchedule = ({
   const nextMonthDayjs = monthDayjs.add(monthCount ? monthCount : 1, "month");
   // Why the non-null assertions? All of these arguments are checked in the enabled condition,
   // and the query will not run if they are null. However, the check in `enabled` does
-  // no satisfy typscript.
+  // no satisfy typescript.
   return trpc.viewer.public.slots.getSchedule.useQuery(
     {
       isTeamEvent,


### PR DESCRIPTION
## What does this PR do?

Remove double call on useSchedule

Fixes #11138

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No.
- What are the minimal test data to have? Test data any teampro account and 1 event type
- What is expected (happy path) to have (input and output)?  Go to /booking/teampro/30min and see only 1 network call
- Any other important info that could help to test that PR

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
