### PR TITLE
fix: event duration can be 0

### DIFF
--- a/apps/web/pages/event-types/[type]/index.tsx
+++ b/apps/web/pages/event-types/[type]/index.tsx
@@ -376,8 +376,11 @@ const EventTypePage = (props: EventTypeSetupProps) => {
       bookerLayouts,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       multipleDurationEnabled,
+      length,
       ...input
     } = values;
+
+    if (!Number(length)) throw new Error(t("event_setup_length_error"));
 
     if (bookingLimits) {
       const isValid = validateIntervalLimitOrder(bookingLimits);
@@ -396,7 +399,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
       if (metadata?.multipleDuration.length < 1) {
         throw new Error(t("event_setup_multiple_duration_error"));
       } else {
-        if (!input.length && !metadata?.multipleDuration?.includes(input.length)) {
+        if (!length && !metadata?.multipleDuration?.includes(length)) {
           throw new Error(t("event_setup_multiple_duration_default_error"));
         }
       }
@@ -410,6 +413,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
     const { availability, ...rest } = input;
     updateMutation.mutate({
       ...rest,
+      length,
       locations,
       recurringEvent,
       periodStartDate: periodDates.startDate,
@@ -467,8 +471,11 @@ const EventTypePage = (props: EventTypeSetupProps) => {
               seatsPerTimeSlotEnabled,
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               multipleDurationEnabled,
+              length,
               ...input
             } = values;
+
+            if (!Number(length)) throw new Error(t("event_setup_length_error"));
 
             if (bookingLimits) {
               const isValid = validateIntervalLimitOrder(bookingLimits);
@@ -487,7 +494,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
               if (metadata?.multipleDuration.length < 1) {
                 throw new Error(t("event_setup_multiple_duration_error"));
               } else {
-                if (!input.length && !metadata?.multipleDuration?.includes(input.length)) {
+                if (!length && !metadata?.multipleDuration?.includes(length)) {
                   throw new Error(t("event_setup_multiple_duration_default_error"));
                 }
               }
@@ -496,6 +503,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
             const { availability, ...rest } = input;
             updateMutation.mutate({
               ...rest,
+              length,
               locations,
               recurringEvent,
               periodStartDate: periodDates.startDate,

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2044,5 +2044,6 @@
   "include_calendar_event": "Include calendar event",
   "recently_added":"Recently added",
   "no_members_found": "No members found",
+  "event_setup_length_error":"Event Setup: The duration must be at least 1 minute.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -56,6 +56,7 @@ model EventType {
   position                        Int                     @default(0)
   /// @zod.custom(imports.eventTypeLocations)
   locations                       Json?
+  /// @zod.min(1)
   length                          Int
   offsetStart                     Int                     @default(0)
   hidden                          Boolean                 @default(false)


### PR DESCRIPTION
## What does this PR do?

Fixes: It is possible to book a event with *length* of 0. This is possible when saving the form from a tab other than the *Event Setup*.

![image](https://github.com/calcom/cal.com/assets/86384652/b56b19a1-d4fe-4d79-bad3-391b223fbbbd)

https://github.com/calcom/cal.com/assets/86384652/e07c35ab-bba8-4c80-824d-e7b5fa5868c6

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
