### PR TITLE
fix: rescheduling in require confirmation

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1374,7 +1374,8 @@ async function handler(
             }
           }
 
-          if (noEmail !== true) {
+          if (noEmail !== true && (!requiresConfirmation || isOrganizerRescheduling)) {
+            console.log("NO_EMAIL_RESCHEDULE", requiresConfirmation, isOrganizerRescheduling);
             const copyEvent = cloneDeep(evt);
             await sendRescheduledEmails({
               ...copyEvent,
@@ -1494,12 +1495,15 @@ async function handler(
             ? calendarResult?.updatedEvent[0]?.iCalUID
             : calendarResult?.updatedEvent?.iCalUID || undefined;
 
-          // TODO send reschedule emails to attendees of the old booking
-          await sendRescheduledEmails({
-            ...copyEvent,
-            additionalNotes, // Resets back to the additionalNote input and not the override value
-            cancellationReason: "$RCH$" + (rescheduleReason ? rescheduleReason : ""), // Removable code prefix to differentiate cancellation from rescheduling for email
-          });
+          if (!requiresConfirmation || isOrganizerRescheduling) {
+            console.log("SEND_RESCHEDULED", requiresConfirmation, isOrganizerRescheduling);
+            // TODO send reschedule emails to attendees of the old booking
+            await sendRescheduledEmails({
+              ...copyEvent,
+              additionalNotes, // Resets back to the additionalNote input and not the override value
+              cancellationReason: "$RCH$" + (rescheduleReason ? rescheduleReason : ""), // Removable code prefix to differentiate cancellation from rescheduling for email
+            });
+          }
 
           // Update the old booking with the cancelled status
           await prisma.booking.update({
@@ -2097,7 +2101,8 @@ async function handler(
           videoCallUrl = metadata.hangoutLink || videoCallUrl || updatedEvent?.url;
         }
       }
-      if (noEmail !== true) {
+      if (noEmail !== true && (!requiresConfirmation || isOrganizerRescheduling)) {
+        console.log("TEST_SEND_RESCHEDULED", requiresConfirmation, isOrganizerRescheduling);
         const copyEvent = cloneDeep(evt);
         await sendRescheduledEmails({
           ...copyEvent,

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1375,7 +1375,6 @@ async function handler(
           }
 
           if (noEmail !== true && (!requiresConfirmation || isOrganizerRescheduling)) {
-            console.log("NO_EMAIL_RESCHEDULE", requiresConfirmation, isOrganizerRescheduling);
             const copyEvent = cloneDeep(evt);
             await sendRescheduledEmails({
               ...copyEvent,
@@ -1496,7 +1495,6 @@ async function handler(
             : calendarResult?.updatedEvent?.iCalUID || undefined;
 
           if (!requiresConfirmation || isOrganizerRescheduling) {
-            console.log("SEND_RESCHEDULED", requiresConfirmation, isOrganizerRescheduling);
             // TODO send reschedule emails to attendees of the old booking
             await sendRescheduledEmails({
               ...copyEvent,
@@ -2102,7 +2100,6 @@ async function handler(
         }
       }
       if (noEmail !== true && (!requiresConfirmation || isOrganizerRescheduling)) {
-        console.log("TEST_SEND_RESCHEDULED", requiresConfirmation, isOrganizerRescheduling);
         const copyEvent = cloneDeep(evt);
         await sendRescheduledEmails({
           ...copyEvent,


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/11075

BEFORE:

Meeting has been rescheduled email and calendar event after submitting booking without confirming the meeting (require confirmation event type).

<img width="1086" alt="Screenshot 2023-09-05 at 7 45 44 PM" src="https://github.com/calcom/cal.com/assets/53316345/574c8d2f-3698-44ea-9466-aef162e09dd5">

AFTER:-

event scheduled email and calendar event created only after "awaiting approval" meeting has been confirmed.

<img width="1086" alt="Screenshot 2023-09-05 at 7 47 22 PM" src="https://github.com/calcom/cal.com/assets/53316345/af19ccea-d418-4a40-a9c6-88782522df53">


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1) Create a requires confirmation event type
2) open incognito tab or another browser and book a meeting (Attendee)
3) Confirm the booking (Organizer) and attendee would get meeting schedule email
4) Get the reschedule link from attendee's email and reschedule the booking

Both attendee and organiser shouldn't get booking email or calendar event  before organiser has accepted the meeting


