### PR TITLE
fix: Fixed SVG icons on light and dark mode

### DIFF
--- a/apps/web/components/eventtype/EventSetupTab.tsx
+++ b/apps/web/components/eventtype/EventSetupTab.tsx
@@ -13,7 +13,6 @@ import type { EventLocationType } from "@calcom/app-store/locations";
 import { getEventLocationType, MeetLocationType, LocationType } from "@calcom/app-store/locations";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
-import cx from "@calcom/lib/classNames";
 import { CAL_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { md } from "@calcom/lib/markdownIt";
@@ -302,13 +301,7 @@ export const EventSetupTab = (
                     <div className="flex items-center">
                       <img
                         src={eventLocationType.iconUrl}
-                        className={cx(
-                          "h-4 w-4",
-                          // invert all the icons except app icons
-                          eventLocationType.iconUrl &&
-                            eventLocationType.iconUrl.includes("-dark") &&
-                            "dark:invert"
-                        )}
+                        className="h-4 w-4 dark:invert-[.65]"
                         alt={`${eventLocationType.label} logo`}
                       />
                       <span className="ms-1 line-clamp-1 text-sm">{`${eventLabel} ${

--- a/apps/web/components/ui/form/LocationSelect.tsx
+++ b/apps/web/components/ui/form/LocationSelect.tsx
@@ -22,14 +22,7 @@ export type GroupOptionType = GroupBase<LocationOption>;
 const OptionWithIcon = ({ icon, label }: { icon?: string; label: string }) => {
   return (
     <div className="flex items-center gap-3">
-      {icon && (
-        <img
-          src={icon}
-          alt="cover"
-          // invert all the icons except app icons
-          className={classNames(icon.includes("-dark") && "dark:invert", "h-3.5 w-3.5")}
-        />
-      )}
+      {icon && <img src={icon} alt="cover" className="h-3.5 w-3.5 dark:invert-[.65]" />}
       <span className={classNames("text-sm font-medium")}>{label}</span>
     </div>
   );

--- a/packages/features/bookings/components/event-meta/AvailableEventLocations.tsx
+++ b/packages/features/bookings/components/event-meta/AvailableEventLocations.tsx
@@ -21,11 +21,7 @@ function RenderIcon({
   return (
     <img
       src={eventLocationType.iconUrl}
-      className={classNames(
-        "me-[10px] h-4 w-4 opacity-70 dark:opacity-100",
-        eventLocationType.iconUrl?.includes("-dark") ? "dark:invert-[.65]" : "",
-        eventLocationType.iconUrl?.includes("-dark") && isTooltip && "invert"
-      )}
+      className="me-[10px] h-4 w-4 opacity-70 invert-[.65] dark:invert-0"
       alt={`${eventLocationType.label} icon`}
     />
   );


### PR DESCRIPTION
## What does this PR do?
Fixed SVG icons behaviour on light and dark modes

Fixes #11170

Before:
![Capture](https://github.com/calcom/cal.com/assets/109150688/ea278a5c-5464-4e26-903f-a4807c6dc520)
![Screenshot (62)](https://github.com/calcom/cal.com/assets/109150688/7114fcf1-8931-4675-9068-65abc8db6bed)
![Screenshot (63)](https://github.com/calcom/cal.com/assets/109150688/6fb8aeb5-ab27-4715-b1ad-5d38a329872b)

After:
![Capture1](https://github.com/calcom/cal.com/assets/109150688/d67cab59-01f2-4214-a9f3-2f1450ffc272)
![Capture2](https://github.com/calcom/cal.com/assets/109150688/795f5400-84c9-4ec0-a7f0-25a8c2ba44c8)
![Screenshot (64)](https://github.com/calcom/cal.com/assets/109150688/4fd5a10d-08df-4687-89ea-86ed98cc5c60)
![Screenshot (65)](https://github.com/calcom/cal.com/assets/109150688/5d6929dd-88dd-4f7a-8b1b-5dc650e20f25)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- I haven't checked if my changes generate no new warnings
