### PR TITLE
fix: mobile event types and avatars

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -363,7 +363,6 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
   }, []);
 
   if (!types.length) {
-    console.log({ teamId: group.teamId });
     return group.teamId ? <EmptyEventTypeList group={group} /> : <CreateFirstEventTypeView />;
   }
 

--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -108,8 +108,10 @@ const MobileTeamsTab: FC<MobileTeamsTabProps> = (props) => {
   const orgBranding = useOrgBranding();
   const tabs = eventTypeGroups.map((item) => ({
     name: item.profile.name ?? "",
-    href: item.teamId ? `/event-types?teamId=${item.teamId}` : "/event-types",
-    avatar: item.profile.image ?? `${orgBranding?.fullDomain ?? WEBAPP_URL}/${item.profile.slug}/avatar.png`,
+    href: item.teamId ? `/event-types?teamId=${item.teamId}` : "/event-types?noTeam",
+    avatar: orgBranding
+      ? `${orgBranding.fullDomain}${item.teamId ? "/team" : ""}/${item.profile.slug}/avatar.png`
+      : item.profile.image ?? `${WEBAPP_URL + (item.teamId && "/team")}/${item.profile.slug}/avatar.png`,
   }));
   const { data } = useTypedQuery(querySchema);
   const events = eventTypeGroups.filter((item) => item.teamId === data.teamId);
@@ -117,13 +119,15 @@ const MobileTeamsTab: FC<MobileTeamsTabProps> = (props) => {
   return (
     <div>
       <HorizontalTabs tabs={tabs} />
-      {events.length && (
+      {events.length > 0 ? (
         <EventTypeList
           types={events[0].eventTypes}
           group={events[0]}
           groupIndex={0}
           readOnly={events[0].metadata.readOnly}
         />
+      ) : (
+        <CreateFirstEventTypeView />
       )}
     </div>
   );
@@ -357,6 +361,11 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
       setNativeShare(false);
     }
   }, []);
+
+  if (!types.length) {
+    console.log({ teamId: group.teamId });
+    return group.teamId ? <EmptyEventTypeList group={group} /> : <CreateFirstEventTypeView />;
+  }
 
   const firstItem = types[0];
   const lastItem = types[types.length - 1];
@@ -712,7 +721,10 @@ const EventTypeListHeading = ({
       <Avatar
         alt={profile?.name || ""}
         href={teamId ? `/settings/teams/${teamId}/profile` : "/settings/my-account/profile"}
-        imageSrc={`${orgBranding?.fullDomain ?? WEBAPP_URL}/${profile.slug}/avatar.png` || undefined}
+        imageSrc={
+          `${orgBranding?.fullDomain ?? WEBAPP_URL}${teamId ? "/team" : ""}/${profile.slug}/avatar.png` ||
+          undefined
+        }
         size="md"
         className="mt-1 inline-flex justify-center"
       />
@@ -759,6 +771,12 @@ const CreateFirstEventTypeView = () => {
       Icon={LinkIcon}
       headline={t("new_event_type_heading")}
       description={t("new_event_type_description")}
+      className="mb-16"
+      buttonRaw={
+        <Button href="?dialog=new" variant="button">
+          {t("create")}
+        </Button>
+      }
     />
   );
 };
@@ -893,8 +911,10 @@ const Main = ({
                     groupIndex={index}
                     readOnly={group.metadata.readOnly}
                   />
-                ) : (
+                ) : group.teamId ? (
                   <EmptyEventTypeList group={group} />
+                ) : (
+                  <CreateFirstEventTypeView />
                 )}
               </div>
             ))

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -142,7 +142,7 @@ export default function Signup({ prepopulateFormValues, token, orgSlug }: Signup
                   <TextField
                     addOnLeading={
                       orgSlug
-                        ? getOrgFullDomain(orgSlug, { protocol: true })
+                        ? `${getOrgFullDomain(orgSlug, { protocol: true })}/`
                         : `${process.env.NEXT_PUBLIC_WEBSITE_URL}/`
                     }
                     {...register("username")}

--- a/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
@@ -275,8 +275,7 @@ export const getByViewerHandler = async ({ ctx, input }: GetByViewerOptions) => 
 
   const bookerUrl = await getBookerUrl(user);
   return {
-    // don't display event teams without event types,
-    eventTypeGroups: eventTypeGroups.filter((groupBy) => groupBy.parentId || !!groupBy.eventTypes?.length),
+    eventTypeGroups,
     // so we can show a dropdown when the user has teams
     profiles: eventTypeGroups.map((group) => ({
       ...group.profile,

--- a/packages/ui/components/empty-screen/EmptyScreen.tsx
+++ b/packages/ui/components/empty-screen/EmptyScreen.tsx
@@ -48,7 +48,13 @@ export function EmptyScreen({
           </div>
         )}
         <div className="flex max-w-[420px] flex-col items-center">
-          <h2 className="text-semibold font-cal text-emphasis mt-6 text-center text-xl">{headline}</h2>
+          <h2
+            className={classNames(
+              "text-semibold font-cal text-emphasis text-center text-xl",
+              Icon && "mt-6"
+            )}>
+            {headline}
+          </h2>
           {description && (
             <div className="text-default mb-8 mt-3 text-center text-sm font-normal leading-6">
               {description}


### PR DESCRIPTION
## What does this PR do?

Mobile event types needed some love, empty personal event types now show an empty state, and also some subteam avatars were not loading for orgs.

| Before | After |
|--------|--------|
| <kbd><img width="300" src="https://github.com/calcom/cal.com/assets/467258/7a6bad4d-f1b7-4a1d-aa10-0c783676599d" /></kbd> | <kbd><img width="300" src="https://github.com/calcom/cal.com/assets/467258/8dbbeb21-fe3e-43e3-83bf-77491f656522" /></kbd> |
| <kbd><img width="300" src="https://github.com/calcom/cal.com/assets/467258/09b7b449-52dd-4837-8e64-795da8a05dad" /></kbd> | <img width="300" alt="image" src="https://github.com/calcom/cal.com/assets/467258/16007a3b-a68b-4f7f-ab17-6226e334915e"> |

Same applies for desktop:

| Before | After |
|--------|--------|
| <kbd><img width="500" src="https://github.com/calcom/cal.com/assets/467258/a5d599f9-440c-4148-8fa1-8c22434c355f" /></kbd> | <kbd><img width="500" src="https://github.com/calcom/cal.com/assets/467258/dd1eccbf-66d2-410d-a3c1-1d7c519a216a" /></kbd> |

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Open event types page and shrink the window to get mobile treatment and see how it behaves like the pictures.
