### PR TITLE
fix: subteam invitation without teamId associated

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -239,19 +239,19 @@ export async function sendVerificationEmail({
 }) {
   const token: string = randomBytes(32).toString("hex");
 
-  if (!connectionInfo.autoAccept) {
-    await prisma.verificationToken.create({
-      data: {
-        identifier: usernameOrEmail,
-        token,
-        expires: new Date(new Date().setHours(168)), // +1 week
-        team: {
-          connect: {
-            id: connectionInfo.orgId || input.teamId,
-          },
+  await prisma.verificationToken.create({
+    data: {
+      identifier: usernameOrEmail,
+      token,
+      expires: new Date(new Date().setHours(168)), // +1 week
+      team: {
+        connect: {
+          id: connectionInfo.orgId || input.teamId,
         },
       },
-    });
+    },
+  });
+  if (!connectionInfo.autoAccept) {
     await sendTeamInviteEmail({
       language: translation,
       from: ctx.user.name || `${team.name}'s admin`,
@@ -262,15 +262,6 @@ export async function sendVerificationEmail({
       isOrg: input.isOrg,
     });
   } else {
-    // we have already joined the team in createNewUserConnectToOrgIfExists so we dont need to connect via token
-    await prisma.verificationToken.create({
-      data: {
-        identifier: usernameOrEmail,
-        token,
-        expires: new Date(new Date().setHours(168)), // +1 week
-      },
-    });
-
     await sendOrganizationAutoJoinEmail({
       language: translation,
       from: ctx.user.name || `${team.name}'s admin`,


### PR DESCRIPTION
## What does this PR do?

When someone invites a user to a subteam, we need the invitation token to have the teamId associated as the signup with a token relies on the associated teamId to determine it's a valid token.

Fixes #11203 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See linked issue for steps.