### PR TITLE
perf: Improve getAggregatedAvailability by reducing reliance on Day.js

### DIFF
--- a/packages/core/getAggregatedAvailability.ts
+++ b/packages/core/getAggregatedAvailability.ts
@@ -22,25 +22,33 @@ export const getAggregatedAvailability = (
   return mergeOverlappingDateRanges(availability);
 };
 
+function isSameDay(date1: Date, date2: Date) {
+  return (
+    date1.getUTCFullYear() === date2.getUTCFullYear() &&
+    date1.getUTCMonth() === date2.getUTCMonth() &&
+    date1.getUTCDate() === date2.getUTCDate()
+  );
+}
+
 function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
-  const sortedDateRanges = dateRanges.sort((a, b) => a.start.diff(b.start)); //is it already sorted before?
+  dateRanges.sort((a, b) => a.start.valueOf() - b.start.valueOf());
 
   const mergedDateRanges: DateRange[] = [];
 
-  let currentRange = sortedDateRanges[0];
+  let currentRange = dateRanges[0];
   if (!currentRange) {
     return [];
   }
 
-  for (let i = 1; i < sortedDateRanges.length; i++) {
-    const nextRange = sortedDateRanges[i];
+  for (let i = 1; i < dateRanges.length; i++) {
+    const nextRange = dateRanges[i];
     if (
-      currentRange.start.utc().format("DD MM YY") === nextRange.start.utc().format("DD MM YY") &&
-      currentRange.end.isAfter(nextRange.start)
+      isSameDay(currentRange.start.toDate(), nextRange.start.toDate()) &&
+      currentRange.end.valueOf() > nextRange.start.valueOf()
     ) {
       currentRange = {
         start: currentRange.start,
-        end: currentRange.end.isAfter(nextRange.end) ? currentRange.end : nextRange.end,
+        end: currentRange.end.valueOf() > nextRange.end.valueOf() ? currentRange.end : nextRange.end,
       };
     } else {
       mergedDateRanges.push(currentRange);


### PR DESCRIPTION
## What does this PR do?

On large event types with a large pool of users and availabilities, the performance of day.js `diff` and `isAfter` add up. This change saves ~200ms on a 6 person event type and probably ends up shaving seconds on big event types.