### PR TITLE
fix: text-emphasis removed

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -139,7 +139,7 @@ export const Meeting = ({ title, users = [], profile }: MeetingImageProps) => {
       <div tw="h-full flex flex-col justify-start">
         <div tw="flex items-center justify-center" style={{ fontFamily: "cal", fontWeight: 300 }}>
           <img src={`${CAL_URL}/${LOGO}`} width="350" alt="Logo" />
-          {avatars.length > 0 && <div tw="font-bold text-emphasis text-[92px] mx-8 bottom-2">/</div>}
+          {avatars.length > 0 && <div tw="font-bold text-[92px] mx-8 bottom-2">/</div>}
           <div tw="flex flex-row">
             {avatars.slice(0, 3).map((avatar) => (
               <img


### PR DESCRIPTION
## What does this PR do?

Fixes #11219   (Remove or replace text-emphasis from OG images)

Changes In Line no 142 of OgImages 

Tailwind CSS Not Provide Any Type Of Text-Emphasis




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

