### PR TITLE
perf: Move query to get just the user email to the main get query

### DIFF
--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -13,6 +13,7 @@ import type { EventBusyDetails } from "@calcom/types/Calendar";
 export async function getBusyTimes(params: {
   credentials: Credential[];
   userId: number;
+  userEmail: string;
   username: string;
   eventTypeId?: number;
   startTime: string;
@@ -27,6 +28,7 @@ export async function getBusyTimes(params: {
   const {
     credentials,
     userId,
+    userEmail,
     username,
     eventTypeId,
     startTime,
@@ -45,15 +47,6 @@ export async function getBusyTimes(params: {
       status: BookingStatus.ACCEPTED,
     })}`
   );
-  // get user email for attendee checking.
-  const user = await prisma.user.findUniqueOrThrow({
-    where: {
-      id: userId,
-    },
-    select: {
-      email: true,
-    },
-  });
 
   /**
    * A user is considered busy within a given time period if there
@@ -97,7 +90,7 @@ export async function getBusyTimes(params: {
           ...sharedQuery,
           attendees: {
             some: {
-              email: user.email,
+              email: userEmail,
             },
           },
         },

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -180,6 +180,7 @@ export const getUserAvailability = async function getUsersWorkingHoursLifeTheUni
     endTime: getBusyTimesEnd,
     eventTypeId,
     userId: user.id,
+    userEmail: user.email,
     username: `${user.username}`,
     beforeEventBuffer,
     afterEventBuffer,

--- a/packages/prisma/selects/user.ts
+++ b/packages/prisma/selects/user.ts
@@ -23,7 +23,6 @@ export const availabilityUserSelect = Prisma.validator<Prisma.UserSelect>()({
 });
 
 export const baseUserSelect = Prisma.validator<Prisma.UserSelect>()({
-  email: true,
   name: true,
   destinationCalendar: true,
   locale: true,
@@ -36,7 +35,6 @@ export const baseUserSelect = Prisma.validator<Prisma.UserSelect>()({
 
 export const userSelect = Prisma.validator<Prisma.UserArgs>()({
   select: {
-    email: true,
     name: true,
     allowDynamicBooking: true,
     destinationCalendar: true,

--- a/packages/prisma/selects/user.ts
+++ b/packages/prisma/selects/user.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 export const availabilityUserSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
   timeZone: true,
+  email: true,
   bufferTime: true,
   startTime: true,
   username: true,


### PR DESCRIPTION
## What does this PR do?

Less queries = huge performance increase for large event types. (for an event type with 60 attendees this change reduces 60x async outbound calls))