### PR TITLE
fix: showing profile settings of other teams

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -524,6 +524,12 @@ const SettingsSidebarContainer = ({
                               </CollapsibleTrigger>
                               <CollapsibleContent className="space-y-0.5">
                                 <VerticalTabItem
+                                  name={t("profile")}
+                                  href={`/settings/teams/${otherTeam.id}/profile`}
+                                  textClassNames="px-3 text-emphasis font-medium text-sm"
+                                  disableChevron
+                                />
+                                <VerticalTabItem
                                   name={t("members")}
                                   href={`/settings/organizations/teams/other/${otherTeam.id}/members`}
                                   textClassNames="px-3 text-emphasis font-medium text-sm"

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -525,7 +525,7 @@ const SettingsSidebarContainer = ({
                               <CollapsibleContent className="space-y-0.5">
                                 <VerticalTabItem
                                   name={t("profile")}
-                                  href={`/settings/teams/${otherTeam.id}/profile`}
+                                  href={`/settings/organizations/teams/other/${otherTeam.id}/profile`}
                                   textClassNames="px-3 text-emphasis font-medium text-sm"
                                   disableChevron
                                 />


### PR DESCRIPTION
## What does this PR do?

Showing "profile" setting of a team that the owner/admin does not belong to, to be able to customize it accordingly.

Fixes #11210 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create an org
2. Create a team without you as member
3. Go to settings and see "Other teams" in the side bar
4. See there is a "Profile" section of the created team you don't belong to