### PR TITLE
fix: smaller date overwrite when no date is selected

### DIFF
--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -139,7 +139,7 @@ const DateOverrideForm = ({
         );
         onClose();
       }}
-      className="p-6 sm:flex sm:p-0">
+      className="p-6 sm:flex sm:p-0 md:flex-col lg:flex-col xl:flex-row">
       <div
         className={classNames(
           selectedDates[0] && "sm:border-subtle w-full sm:border-r sm:pr-6",
@@ -220,7 +220,7 @@ const DateOverrideInputDialog = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{Trigger}</DialogTrigger>
 
-      <DialogContent enableOverflow={enableOverflow} size="md" className="p-0">
+      <DialogContent enableOverflow={enableOverflow} size="md" className="p-0 md:w-auto">
         <DateOverrideForm
           excludedDates={excludedDates}
           {...passThroughProps}


### PR DESCRIPTION
## What does this PR do?

Fixes #11106 

By default, for md size or greater DialogContent had w-full. I changed it to md:w-auto which solved the problem of extra blank space besides the date picker. But by doing this, the date picker got shrinked in md and lg size as there was not enough space available. So i made it flex-col for md and lg size in form which made conditional rendering below date picker instead of right side. And for xl and greater flex-row which made conditional rendering right side as expected. With this solution, it is working fine in all screen sizes and the issue is fixed.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
