### PR TITLE
fix: Return all responses in booking api

### DIFF
--- a/apps/api/lib/validations/booking.ts
+++ b/apps/api/lib/validations/booking.ts
@@ -58,6 +58,7 @@ export const schemaBookingReadPublic = Booking.extend({
       })
     )
     .optional(),
+  responses: z.record(z.any()),
 }).pick({
   id: true,
   userId: true,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 Because of validation, only the stock fields were returned in the `responses` in the booking API. This change allows all custom field responses to be returned as well.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
- Make a booking with custom questions in the registration form. 
- Call the `/bookings` endpoint
- Validate that all responses to custom questions come in in addition to the stock set (eg name, notes, email, etc)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
