### PR TITLE
fix: Allow attendee first and last name from attendee name when name …

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/customTemplate.ts
@@ -48,14 +48,27 @@ const customTemplate = (
 
   const currentTimeFormat = timeFormat || TimeFormat.TWELVE_HOUR;
 
+  const attendeeNameWords = variables.attendeeName?.trim().split(" ");
+  const attendeeNameWordCount = attendeeNameWords?.length ?? 0;
+
+  const attendeeFirstName = variables.attendeeFirstName
+    ? variables.attendeeFirstName
+    : attendeeNameWords?.[0] ?? "";
+
+  const attendeeLastName = variables.attendeeLastName
+    ? variables.attendeeLastName
+    : attendeeNameWordCount > 1
+    ? attendeeNameWords![attendeeNameWordCount - 1]
+    : "";
+
   let dynamicText = text
     .replaceAll("{EVENT_NAME}", variables.eventName || "")
     .replaceAll("{ORGANIZER}", variables.organizerName || "")
     .replaceAll("{ATTENDEE}", variables.attendeeName || "")
     .replaceAll("{ORGANIZER_NAME}", variables.organizerName || "") //old variable names
     .replaceAll("{ATTENDEE_NAME}", variables.attendeeName || "") //old variable names
-    .replaceAll("{ATTENDEE_FIRST_NAME}", variables.attendeeFirstName || "")
-    .replaceAll("{ATTENDEE_LAST_NAME}", variables.attendeeLastName || "")
+    .replaceAll("{ATTENDEE_FIRST_NAME}", attendeeFirstName)
+    .replaceAll("{ATTENDEE_LAST_NAME}", attendeeLastName)
     .replaceAll("{EVENT_DATE}", translatedDate)
     .replaceAll("{EVENT_TIME}", variables.eventDate?.format(currentTimeFormat) || "")
     .replaceAll("{START_TIME}", variables.eventDate?.format(currentTimeFormat) || "")


### PR DESCRIPTION
## What does this PR do?

In custom templates generated from workflow, you could not use {ATTENDEE_FIRST_NAME} or {ATTENDEE_LAST_NAME} when name was not split on event type. Modified this logic as per the issue.

Fixes #11279 

## Requirement/Documentation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create an event type where name is not split into first and last name.
- Create a custom workflow where we use {ATTENDEE_FIRST_NAME} or {ATTENDEE_LAST_NAME} in email template.
- Create booking for that event and check the custom workflow email.
- Test scenarios with name with only 1 word or more than 1 word.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
