### PR TITLE
fix: Prefill not working if firstAndLastName variant enabled in name field and `name` doesn't have any space

### DIFF
--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -135,6 +135,24 @@ test.describe("Manage Booking Questions", () => {
           });
         });
       });
+
+      await test.step("Verify that we can prefill name field with no lastname", async () => {
+        const searchParams = new URLSearchParams();
+        searchParams.append("name", "FirstName");
+        await doOnFreshPreviewWithSearchParams(searchParams, page, context, async (page) => {
+          await selectFirstAvailableTimeSlotNextMonth(page);
+          await expectSystemFieldsToBeThereOnBookingPage({
+            page,
+            isFirstAndLastNameVariant: true,
+            values: {
+              name: {
+                firstName: "FirstName",
+                lastName: "",
+              },
+            },
+          });
+        });
+      });
     });
   });
 
@@ -499,6 +517,27 @@ async function doOnFreshPreview(
   persistTab = false
 ) {
   const previewTabPage = await openBookingFormInPreviewTab(context, page);
+  await callback(previewTabPage);
+  if (!persistTab) {
+    await previewTabPage.close();
+  }
+  return previewTabPage;
+}
+
+async function doOnFreshPreviewWithSearchParams(
+  searchParams: URLSearchParams,
+  page: Page,
+  context: PlaywrightTestArgs["context"],
+  callback: (page: Page) => Promise<void>,
+  persistTab = false
+) {
+  const previewUrl = (await page.locator('[data-testid="preview-button"]').getAttribute("href")) || "";
+  const previewUrlObj = new URL(previewUrl);
+  searchParams.forEach((value, key) => {
+    previewUrlObj.searchParams.append(key, value);
+  });
+  const previewTabPage = await context.newPage();
+  await previewTabPage.goto(previewUrlObj.toString());
   await callback(previewTabPage);
   if (!persistTab) {
     await previewTabPage.close();

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -123,9 +123,7 @@ export const bookingResponses = z
       nonEmptyString(),
       z.object({
         firstName: nonEmptyString(),
-        lastName: nonEmptyString()
-          .refine((value: string) => value.trim().length > 0)
-          .optional(),
+        lastName: z.string().optional(),
       }),
     ]),
     guests: z.array(z.string()).optional(),


### PR DESCRIPTION
## What does this PR do?

Fixes the following error and avoid prefilling failure if **name** prefill param is provided without lastname. It happens only when firstAndLastName variant is enabled.
![image](https://github.com/calcom/cal.com/assets/1780212/c701eb43-5c86-4e24-b3a7-488b0114b63d)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Enable 'Split Full Name' toggle in booking questions  of an event-type
- Prefill name param during the booking as ?name=John&email=john@example.com. Notice that both email and name aren't prefilled. Because there is an error during zod validation, entire prefill is rejected and nothing is prefilled.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.