### PR TITLE
fix: #11275 Jitsi self hosted URls fix

### DIFF
--- a/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
@@ -26,7 +26,7 @@ const JitsiVideoApiAdapter = (): VideoApiAdapter => {
       
       
       // Ensure the host URL starts with the correct protocol
-      const selfHostedJitsiUrl = ensureProtocol(appKeys.YourJitsiURL as string);
+      const selfHostedJitsiUrl = ensureProtocol(appKeys.jitsiHost as string);
 
       const hostUrl = (selfHostedJitsiUrl as string) || "https://meet.jit.si/cal";
 

--- a/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
@@ -7,6 +7,13 @@ import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapt
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 import { metadata } from "../_metadata";
 
+const ensureProtocol = (url: string): string => {
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return "https://" + url; // default to https if not specified
+  }
+  return url;
+};
+
 const JitsiVideoApiAdapter = (): VideoApiAdapter => {
   return {
     getAvailability: () => {
@@ -16,7 +23,13 @@ const JitsiVideoApiAdapter = (): VideoApiAdapter => {
       const appKeys = await getAppKeysFromSlug(metadata.slug);
 
       const meetingPattern = (appKeys.jitsiPathPattern as string) || "{uuid}";
-      const hostUrl = (appKeys.jitsiHost as string) || "https://meet.jit.si/cal";
+      
+      
+      // Ensure the host URL starts with the correct protocol
+      const selfHostedJitsiUrl = ensureProtocol(appKeys.YourJitsiURL as string);
+
+      const hostUrl = (selfHostedJitsiUrl as string) || "https://meet.jit.si/cal";
+
 
       //Allows "/{Type}-with-{Attendees}" slug
       const meetingID = meetingPattern

--- a/packages/app-store/jitsivideo/zod.ts
+++ b/packages/app-store/jitsivideo/zod.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const appKeysSchema = z.object({
-  YourJitsiURL: z.string().optional(),
+  jitsiHost: z.string().optional(),
   jitsiPathPattern: z.string().optional(),
 });
 

--- a/packages/app-store/jitsivideo/zod.ts
+++ b/packages/app-store/jitsivideo/zod.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const appKeysSchema = z.object({
-  jitsiHost: z.string().optional(),
+  YourJitsiURL: z.string().optional(),
   jitsiPathPattern: z.string().optional(),
 });
 


### PR DESCRIPTION
## What does this PR do?
Made self hosted jitsi links working, admin user can  change the "JITSI_URL" inside the admin key manager


Fixes issue #11275

/claim #11275

 Loom Video: https://www.loom.com/share/Apps-or-Calcom-13-September-2023-f620a0d2d00840e8992098155e9ce75c?sid=502da561-78de-401e-8644-c24945f06bd7

