### PR TITLE
fix: insights upgrade screen has no title and subtitle for upgrade screen

### DIFF
--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -57,7 +57,7 @@ export default function InsightsPage() {
 
   return (
     <div>
-      <ShellMain hideHeadingOnMobile>
+      <ShellMain heading="insights" subtitle={t("insights_subtitle")}>
         <UpgradeTip
           title={t("make_informed_decisions")}
           description={t("make_informed_decisions_description")}

--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -57,7 +57,7 @@ export default function InsightsPage() {
 
   return (
     <div>
-      <ShellMain heading="insights" subtitle={t("insights_subtitle")}>
+      <ShellMain heading="Insights" subtitle={t("insights_subtitle")}>
         <UpgradeTip
           title={t("make_informed_decisions")}
           description={t("make_informed_decisions_description")}


### PR DESCRIPTION
Address the issue where the "Insights Upgrade" screen was missing a title and subtitle. Resolve this problem by adding the necessary headline and subtitle to the screen, ensuring consistency with routing forms and providing a more informative user experience.
#11319
