### PR TITLE
fix: Blank state wouldn't set 'schedule'; resulting toggle had no effect

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -51,7 +51,14 @@ const getEventType = async (id: number) => {
       metadata: true,
       schedule: {
         select: {
-          availability: true,
+          availability: {
+            select: {
+              days: true,
+              date: true,
+              startTime: true,
+              endTime: true,
+            },
+          },
           timeZone: true,
         },
       },

--- a/packages/prisma/selects/user.ts
+++ b/packages/prisma/selects/user.ts
@@ -13,7 +13,14 @@ export const availabilityUserSelect = Prisma.validator<Prisma.UserSelect>()({
   // Relationships
   schedules: {
     select: {
-      availability: true,
+      availability: {
+        select: {
+          date: true,
+          startTime: true,
+          endTime: true,
+          days: true,
+        },
+      },
       timeZone: true,
       id: true,
     },

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -160,7 +160,14 @@ export async function getEventType(
       metadata: true,
       schedule: {
         select: {
-          availability: true,
+          availability: {
+            select: {
+              date: true,
+              startTime: true,
+              endTime: true,
+              days: true,
+            },
+          },
           timeZone: true,
         },
       },
@@ -191,6 +198,7 @@ export async function getEventType(
       },
     },
   });
+
   if (!eventType) {
     return null;
   }


### PR DESCRIPTION
## What does this PR do?

Fixes the common availability not having an effect if you didn't change the selected availability

Also minor performance improvement by requesting less data from availabilities. (just date,start,end,days)