### PR TITLE
fix: updating workflow that is active on managed event type

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -92,6 +92,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       id: {
         in: activeOn,
       },
+      parentId: null,
     },
     select: {
       id: true,


### PR DESCRIPTION
## What does this PR do?

Fixes issue that workflows that are active on managed event types could not be updated. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a managed event type and assign team members to it 
- Create a team workflow and set it active for the managed event type 
- Save workflow
- Go back to workflow 
- Click save again => this used to fail and works now

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
