### PR TITLE
fix: Routing Forms - Forward Query Params and show the error message in case of validation error in headless router

### DIFF
--- a/packages/app-store/routing-forms/playwright/tests/basic.e2e.ts
+++ b/packages/app-store/routing-forms/playwright/tests/basic.e2e.ts
@@ -304,12 +304,14 @@ test.describe("Routing Forms", () => {
       await users.logout();
       page.goto(`/router?form=${routingForm.id}&Test field=event-routing`);
       await page.waitForURL((url) => {
-        return url.pathname.endsWith("/pro/30min");
+        return url.pathname.endsWith("/pro/30min") && url.searchParams.get("Test field") === "event-routing";
       });
 
       page.goto(`/router?form=${routingForm.id}&Test field=external-redirect`);
       await page.waitForURL((url) => {
-        return url.hostname.includes("google.com");
+        return (
+          url.hostname.includes("google.com") && url.searchParams.get("Test field") === "external-redirect"
+        );
       });
 
       await page.goto(`/router?form=${routingForm.id}&Test field=custom-page`);

--- a/packages/app-store/routing-forms/trpc/response.handler.ts
+++ b/packages/app-store/routing-forms/trpc/response.handler.ts
@@ -73,12 +73,14 @@ export const responseHandler = async ({ ctx, input }: ResponseHandlerOptions) =>
         }
         return !schema.safeParse(fieldValue).success;
       })
-      .map((f) => ({ label: f.label, type: f.type }));
+      .map((f) => ({ label: f.label, type: f.type, value: response[f.id]?.value }));
 
     if (invalidFields.length) {
       throw new TRPCError({
         code: "BAD_REQUEST",
-        message: `Invalid fields ${invalidFields.map((f) => `${f.label}: ${f.type}`)}`,
+        message: `Invalid value for fields ${invalidFields
+          .map((f) => `'${f.label}' with value '${f.value}' should be valid ${f.type}`)
+          .join(", ")}`,
       });
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes following.
- If wrong email is provided, the headless router was crashing instead of gracefully handling and showing a proper error message.
- On successful submission, the query params weren't forwarded and thus they weren't prefillable in Booking Form

Also, updated existing test to verify that query params are forwarded in both external URL redirect and event-type redirect for headless router.

[After fix Demo](https://www.loom.com/share/75ca07cdf24d428da9b8e55daa0564de)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Create a Routing Form with an email type field and name that field `email` only. Set it up to route to an event-type. Use headless router URL(https://app.cal.local:3000/router?form={FORM_ID}&email=invalid_email). Notice that you won't see a crash now instead you would see an error message.
<img width="1193" alt="Screenshot 2023-09-13 at 10 40 05 PM" src="https://github.com/calcom/cal.com/assets/1780212/0ba7da61-a79a-421c-ae28-e3cfe1e136f9">
- Correct the values and visit the URL again https://app.cal.local:3000/router?form={FORM_ID}&email=john@example.com. Now notice that on redirecting to event-type booking page both the query params are forwarded, on going to the booking form, you would see email prefilled.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

