### PR TITLE
fix: org shell and org user settings avatars + org owner username

### DIFF
--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -17,7 +17,6 @@ import type { VerticalTabItemProps } from "@calcom/ui";
 import { Badge, Button, ErrorBoundary, Skeleton, useMeta, VerticalTabItem } from "@calcom/ui";
 import {
   ArrowLeft,
-  Building,
   ChevronDown,
   ChevronRight,
   CreditCard,
@@ -77,7 +76,6 @@ const tabs: VerticalTabItemProps[] = [
   {
     name: "organization",
     href: "/settings/organizations",
-    icon: Building,
     children: [
       {
         name: "profile",
@@ -147,6 +145,9 @@ const useTabs = () => {
       tab.name = user?.name || "my_account";
       tab.icon = undefined;
       tab.avatar = `${orgBranding?.fullDomain ?? WEBAPP_URL}/${session?.data?.user?.username}/avatar.png`;
+    } else if (tab.href === "/settings/organizations") {
+      tab.name = orgBranding?.name || "organization";
+      tab.avatar = `${orgBranding?.fullDomain}/org/${orgBranding?.slug}/avatar.png`;
     } else if (
       tab.href === "/settings/security" &&
       user?.identityProvider === IdentityProvider.GOOGLE &&

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ComponentProps } from "react";
 import React, { Suspense, useEffect, useState } from "react";
 
+import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import Shell from "@calcom/features/shell/Shell";
 import { classNames } from "@calcom/lib";
 import { HOSTED_CAL_FEATURES, WEBAPP_URL } from "@calcom/lib/constants";
@@ -137,6 +138,7 @@ const organizationRequiredKeys = ["organization"];
 const useTabs = () => {
   const session = useSession();
   const { data: user } = trpc.viewer.me.useQuery();
+  const orgBranding = useOrgBranding();
 
   const isAdmin = session.data?.user.role === UserPermissionRole.ADMIN;
 
@@ -144,7 +146,7 @@ const useTabs = () => {
     if (tab.href === "/settings/my-account") {
       tab.name = user?.name || "my_account";
       tab.icon = undefined;
-      tab.avatar = WEBAPP_URL + "/" + session?.data?.user?.username + "/avatar.png";
+      tab.avatar = `${orgBranding?.fullDomain ?? WEBAPP_URL}/${session?.data?.user?.username}/avatar.png`;
     } else if (
       tab.href === "/settings/security" &&
       user?.identityProvider === IdentityProvider.GOOGLE &&

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -833,7 +833,7 @@ function SideBar({ bannersHeight, user }: SideBarProps) {
                 <div className="flex items-center gap-2 font-medium">
                   <Avatar
                     alt={`${orgBranding.name} logo`}
-                    imageSrc={`${orgBranding.fullDomain}/avatar.png`}
+                    imageSrc={`${orgBranding.fullDomain}/org/${orgBranding.slug}/avatar.png`}
                     size="xsm"
                   />
                   <p className="text line-clamp-1 text-sm">

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -14,6 +14,7 @@ import {
   WEBAPP_URL,
 } from "@calcom/lib/constants";
 import { getTranslation } from "@calcom/lib/server/i18n";
+import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
 
@@ -126,7 +127,7 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
 
     const createOwnerOrg = await prisma.user.create({
       data: {
-        username: adminUsername,
+        username: slugify(adminUsername),
         email: adminEmail,
         emailVerified: new Date(),
         password: hashedPassword,


### PR DESCRIPTION
## What does this PR do?

Org avatars were not behaving as expected in the App shell as well as in Settings alongside user avatar, that's fixed. And also added Org avatar and name to the "🏢 Organization" section in settings to follow what user profile was doing (checked with @ciaranha). Also fixing org owner username to be properly slugified.

| Before | After |
|--------|--------|
| <img width="203" alt="image" src="https://github.com/calcom/cal.com/assets/467258/e185e509-d689-4268-82c2-88c0bac3bff2"> | <img width="203" alt="image" src="https://github.com/calcom/cal.com/assets/467258/00103d92-67e7-478e-8dfc-fe15164d8c04"> |

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See screenshot how we now show correctly user and org avatar/name in settings side bar