### PR TITLE
fix: remove avatar form user select when loading insights

### DIFF
--- a/packages/features/insights/components/TotalBookingUsersTable.tsx
+++ b/packages/features/insights/components/TotalBookingUsersTable.tsx
@@ -21,7 +21,7 @@ export const TotalBookingUsersTable = ({
                   <Avatar
                     alt={item.user.name || ""}
                     size="sm"
-                    imageSrc={item.user.avatar}
+                    imageSrc={"/" + item.user.username + "/avatar.png"}
                     title={item.user.name || ""}
                     className="m-2"
                   />

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -73,7 +73,6 @@ const UserSelect = {
   id: true,
   name: true,
   email: true,
-  avatar: true,
   username: true,
 };
 


### PR DESCRIPTION
## What does this PR do?

- Removes avatar from user select, there are times when on Production loading the avatar will load the full blob making the response larger than 4MB that Vercel limits on api responses.

Fixes #11351 


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- I haven't added tests that prove my fix is effective or that my feature works
