### PR TITLE
fix: 2FA password visibility toggle show/hide state

### DIFF
--- a/apps/web/components/settings/EnableTwoFactorModal.tsx
+++ b/apps/web/components/settings/EnableTwoFactorModal.tsx
@@ -173,7 +173,6 @@ const EnableTwoFactorModal = ({ onEnable, onCancel, open, onOpenChange }: Enable
             <div className="mb-4">
               <PasswordField
                 label={t("password")}
-                type="password"
                 name="password"
                 id="password"
                 required


### PR DESCRIPTION
## What does this PR do?

Previously, when users attempted to enable two-factor authentication (2FA) on our platform, they encountered an issue with the password visibility toggle. Specifically, when they entered their current password for confirmation, it remained hidden, making it difficult to verify the input. However, with the recent code update, I have addressed this usability concern. Users can now see and toggle the visibility of their current password when confirming their choice to enable 2FA. This improvement enhances the overall user experience, making the process smoother and more intuitive.

 Loom Video: 
Before change :- https://www.loom.com/share/Profile-or-Calcom-14-September-2023-bb68faf8d15449f796f2ff3782a7825e?sid=ad9c41e0-0f20-4985-9a7f-217f6472775d 

### After Making change 
https://www.loom.com/share/Two-Factor-Authentication-or-Calcom-14-September-2023-1ac49793c94f4ed9a8e19489d0b95458?sid=afe90a92-892a-4061-b007-64be4b4a2454

![image](https://github.com/calcom/cal.com/assets/66114276/06864a7f-6b1f-41f9-b764-62beae84e66f)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Open your cal account 
2. Go to settings tab to enable 2FA under security tab of settings sidebar.
3.For enabling 2 factor auth, enter your password and click on eye icon to view your password and you wont be able to see. 
4. After this pr changes gets merged, we can easily toggle the visibility of password.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

