### PR TITLE
fix: Safari overflowing issues

### DIFF
--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -154,7 +154,7 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
                       <div className="flex flex-wrap items-center">
                         <h2 className=" text-default pr-2 text-sm font-semibold">{type.title}</h2>
                       </div>
-                      <EventTypeDescription eventType={type} isPublic={true} />
+                      <EventTypeDescription eventType={type} isPublic={true} shortenDescription />
                     </Link>
                   </div>
                 </div>

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -47,7 +47,7 @@ export const EventTypeDescription = ({
           <div
             className={classNames(
               "text-subtle line-clamp-3 break-words py-1 text-sm sm:max-w-[650px] [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600",
-              shortenDescription ? "line-clamp-4" : ""
+              shortenDescription ? "line-clamp-4 [&>*:not(:first-child)]:hidden" : ""
             )}
             dangerouslySetInnerHTML={{
               __html: eventType.descriptionAsSafeHTML || "",


### PR DESCRIPTION
Fixes: #11343

Reason for breaking - safari tried to display all child elements and since there was no space they all clipped (Drawback to using `dangerouslySetInnerHTML` they all just get placed there

Add hidden class to all children apart form the first child

Before:
![CleanShot 2023-09-15 at 14 42 11](https://github.com/calcom/cal.com/assets/55134778/33500665-c84f-49ad-be58-305abe718104)

After:
![CleanShot 2023-09-15 at 14 41 38](https://github.com/calcom/cal.com/assets/55134778/5afb6141-a2ee-4362-84a1-772d73fcbacb)
