### PR TITLE
fix: org username check for dynamic and signup

### DIFF
--- a/packages/app-store/salesforce/lib/CalendarService.ts
+++ b/packages/app-store/salesforce/lib/CalendarService.ts
@@ -196,7 +196,6 @@ export default class SalesforceCalendarService implements Calendar {
   }
 
   async createEvent(event: CalendarEvent): Promise<NewCalendarEventType> {
-    debugger;
     const contacts = await this.salesforceContactSearch(event);
     if (contacts.length) {
       if (contacts.length == event.attendees.length) {

--- a/packages/lib/validateUsername.ts
+++ b/packages/lib/validateUsername.ts
@@ -9,7 +9,9 @@ export const validateUsername = async (username: string, email: string, organiza
     where: {
       ...(organizationId ? { organizationId } : {}),
       OR: [
-        { username },
+        // When inviting to org, invited user gets created with username now, so in an org context we
+        // can't check for username as it will exist on signup
+        ...(!organizationId ? [{ username }] : [{}]),
         {
           AND: [
             { email },

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -202,7 +202,11 @@ export async function getEventType(
   };
 }
 
-export async function getDynamicEventType(input: TGetScheduleInputSchema) {
+export async function getDynamicEventType(
+  input: TGetScheduleInputSchema,
+  organizationDetails: { currentOrgDomain: string | null; isValidOrgDomain: boolean }
+) {
+  const { currentOrgDomain, isValidOrgDomain } = organizationDetails;
   // For dynamic booking, we need to get and update user credentials, schedule and availability in the eventTypeObject as they're required in the new availability logic
   if (!input.eventTypeSlug) {
     throw new TRPCError({
@@ -220,6 +224,7 @@ export async function getDynamicEventType(input: TGetScheduleInputSchema) {
           ? [input.usernameList]
           : [],
       },
+      organization: isValidOrgDomain && currentOrgDomain ? getSlugOrRequestedSlug(currentOrgDomain) : null,
     },
     select: {
       allowDynamicBooking: true,
@@ -246,7 +251,9 @@ export function getRegularOrDynamicEventType(
   organizationDetails: { currentOrgDomain: string | null; isValidOrgDomain: boolean }
 ) {
   const isDynamicBooking = input.usernameList && input.usernameList.length > 1;
-  return isDynamicBooking ? getDynamicEventType(input) : getEventType(input, organizationDetails);
+  return isDynamicBooking
+    ? getDynamicEventType(input, organizationDetails)
+    : getEventType(input, organizationDetails);
 }
 
 export async function getAvailableSlots({ input, ctx }: GetScheduleOptions) {


### PR DESCRIPTION
## What does this PR do?

Dynamic event types involving usernames shared with orgs was picking up the incorrect availability for calculation. Also, username existence check in an org context was broken now that we define username upon invitation, this fixes that too.

Fixes #11386

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Have two users with the same usernames, one belonging to an org and another as plain user, change availability to be different between them and try to book a dynamic event with the plain user with another person in the app, it was picking up availability for both usernames inside and out the org. Also, invite a person to an org and use the invitation link in the email, it was throwing an error as username already existed.