### PR TITLE
fix: #11397 request for reschedule did not cancel initial meeting

### DIFF
--- a/packages/core/videoClient.ts
+++ b/packages/core/videoClient.ts
@@ -149,7 +149,7 @@ const updateMeeting = async (
   };
 };
 
-const deleteMeeting = async (credential: CredentialPayload, uid: string): Promise<unknown> => {
+const deleteMeeting = async (credential: CredentialPayload | null, uid: string): Promise<unknown> => {
   if (credential) {
     const videoAdapter = (await getVideoAdapters([credential]))[0];
     logger.debug("videoAdapter inside deleteMeeting", { credential, uid });

--- a/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
@@ -205,10 +205,15 @@ export const requestRescheduleHandler = async ({ ctx, input }: RequestReschedule
       if (!bookingRef.uid) return;
 
       if (bookingRef.type.endsWith("_calendar")) {
-        const calendar = await getCalendar(credentialsMap.get(bookingRef.type));
+        const calendar = await getCalendar(
+          credentials.find((cred) => cred.id === bookingRef?.credentialId) || null
+        );
         return calendar?.deleteEvent(bookingRef.uid, builder.calendarEvent, bookingRef.externalCalendarId);
       } else if (bookingRef.type.endsWith("_video")) {
-        return deleteMeeting(credentialsMap.get(bookingRef.type), bookingRef.uid);
+        return deleteMeeting(
+          credentials.find((cred) => cred?.id === bookingRef?.credentialId) || null,
+          bookingRef.uid
+        );
       }
     })
   );


### PR DESCRIPTION
## What does this PR do?

Fixes #11397 

Was able to recreate the scenario. 
This happens when user has added google calendar with **multliple** google accounts or **multiple google calendars**.
With only single google calendar / account , initial meeting is cancelled as expected.

Note: Here google_calendar is taken as example, the issue applies to any other calendar (outlook, apple, etc..) as well.

## Requirement/Documentation
**Root cause:**
At this loc : https://github.com/calcom/cal.com/blob/b413f0a60917f8fbbd2eca5fa104c5ba3fd1df7f/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts#L196
we are using map to store credential with **key as credential type**.
So, if there are multiple google_calendar credentials in table, the map always stores the credential of last or second google_calendar instance.

And at this loc : https://github.com/calcom/cal.com/blob/b413f0a60917f8fbbd2eca5fa104c5ba3fd1df7f/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts#L208
we are fetching credential from the above map (**having wrong credential** if we are trying to delete event in first google_calendar added)

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Configure multiple google calendars.
2. Book a event using one of the google calendar.
3. Raise request to reschedule.
4. Check if event is deleted in google calendar.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.