### PR TITLE
feat: support `firstName` and `lastName` query params

### DIFF
--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -153,6 +153,25 @@ test.describe("Manage Booking Questions", () => {
           });
         });
       });
+
+      await test.step("Verify that we can prefill name field with firstName,lastName query params", async () => {
+        const searchParams = new URLSearchParams();
+        searchParams.append("firstName", "John");
+        searchParams.append("lastName", "Doe");
+        await doOnFreshPreviewWithSearchParams(searchParams, page, context, async (page) => {
+          await selectFirstAvailableTimeSlotNextMonth(page);
+          await expectSystemFieldsToBeThereOnBookingPage({
+            page,
+            isFirstAndLastNameVariant: true,
+            values: {
+              name: {
+                firstName: "John",
+                lastName: "Doe",
+              },
+            },
+          });
+        });
+      });
     });
   });
 

--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -473,8 +473,16 @@ function useInitialFormValues({
         view: rescheduleUid ? "reschedule" : "booking",
       });
 
+      // Routing Forms don't support Split full name(because no Form Builder in there), so user needs to create two fields in there themselves. If they name these fields, `firstName` and `lastName`, we can prefill the Booking Form with them
+      // Once we support formBuilder in Routing Forms, we should be able to forward JSON form of name field value to Booking Form and prefill it there without having these two query params separately.
+      const firstNameQueryParam = searchParams?.get("firstName");
+      const lastNameQueryParam = searchParams?.get("lastName");
+
       const parsedQuery = await querySchema.parseAsync({
         ...routerQuery,
+        name:
+          searchParams?.get("name") ||
+          (firstNameQueryParam ? `${firstNameQueryParam} ${lastNameQueryParam}` : null),
         // `guest` because we need to support legacy URL with `guest` query param support
         // `guests` because the `name` of the corresponding bookingField is `guests`
         guests: searchParams?.getAll("guests") || searchParams?.getAll("guest"),


### PR DESCRIPTION
## What does this PR do?

Closes #11291

[Demo Loom](https://www.loom.com/share/033fb175476a40c3a2412e22bac344a9)

## Type of change
- [x] Improvement

## How should this be tested?
- Create an event type and enable Split full name option for name field
- Create a Routing Form and add two short text fields with identifiers `firstName` and `lastName`. Configure that form to Route to the event type 
- Now submit the Routing Form with firstName and lastName prefilled and noticed that when you reach Booking Form page those would be prefilled in Booking Form as well.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

