### PR TITLE
fix: missing types export from @calcom/embed-react (ECMAScript modules)

### DIFF
--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -39,7 +39,8 @@
   "exports": {
     ".": {
       "import": "./dist/Cal.es.mjs",
-      "require": "./dist/Cal.umd.js"
+      "require": "./dist/Cal.umd.js",
+      "types": "./dist/embed-react/src/index.d.ts"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #11408 