### PR TITLE
fix: increased the clickable area for the 'x' button in add guests

### DIFF
--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -259,7 +259,7 @@ export const Components: Record<FieldType, Component> = {
                         !readOnly ? (
                           <Tooltip content="Remove email">
                             <button
-                              className="m-1 disabled:hover:cursor-not-allowed"
+                              className="m-1 px-3 disabled:hover:cursor-not-allowed"
                               type="button"
                               onClick={() => {
                                 value.splice(index, 1);

--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -36,7 +36,7 @@ type AddonProps = {
 const Addon = ({ isFilled, children, className, error }: AddonProps) => (
   <div
     className={classNames(
-      "addon-wrapper border-default [input:hover_+_&]:border-emphasis [input:hover_+_&]:border-l-default [&:has(+_input:hover)]:border-emphasis [&:has(+_input:hover)]:border-r-default h-9 border px-3",
+      "addon-wrapper border-default [input:hover_+_&]:border-emphasis [input:hover_+_&]:border-l-default [&:has(+_input:hover)]:border-emphasis [&:has(+_input:hover)]:border-r-default h-9 border ",
       isFilled && "bg-subtle",
       className
     )}>


### PR DESCRIPTION
## What does this PR do?

This PR makes the 'x' button user friendly by increasing the clickable area.
I removed the padding from the parent div and added it to the button.

Fixes #11423 


https://github.com/calcom/cal.com/assets/71056030/28906939-5c16-4e7d-b616-699199061df4


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Schedule a meeting and then click on Add guests

