### PR TITLE
fix: subteam invite org acceptance

### DIFF
--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -15,7 +15,6 @@ import { signupSchema } from "@calcom/prisma/zod-utils";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  debugger;
   if (req.method !== "POST") {
     return res.status(405).end();
   }

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -15,6 +15,7 @@ import { signupSchema } from "@calcom/prisma/zod-utils";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  debugger;
   if (req.method !== "POST") {
     return res.status(405).end();
   }
@@ -130,16 +131,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Accept any child team invites for orgs and create a membership for the org itself
       if (team.parentId) {
-        // Create a membership for the organization itself
-        await prisma.membership.create({
-          data: {
-            userId: user.id,
-            teamId: team.parentId,
-            accepted: true,
-            role: MembershipRole.MEMBER,
-          },
-        });
-
         // We do a membership update twice so we can join the ORG invite if the user is invited to a team witin a ORG
         await prisma.membership.updateMany({
           where: {

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -302,7 +302,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const isOrganization = tokenTeam.metadata?.isOrganization || tokenTeam?.parentId !== null;
   // If we are dealing with an org, the slug may come from the team itself or its parent
   const orgSlug = isOrganization
-    ? tokenTeam.slug || tokenTeam.metadata?.requestedSlug || tokenTeam.parent?.slug
+    ? tokenTeam.metadata?.requestedSlug || tokenTeam.parent?.slug || tokenTeam.slug
     : null;
 
   // Org context shouldn't check if a username is premium

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -257,7 +257,7 @@ export async function sendVerificationEmail({
       expires: new Date(new Date().setHours(168)), // +1 week
       team: {
         connect: {
-          id: connectionInfo.orgId || input.teamId,
+          id: input.teamId,
         },
       },
     },


### PR DESCRIPTION
## What does this PR do?

As we decided to handle membership to an org when inviting even if we invite to a subteam, we need to fix the exact moments where those memberships are created and accepted, which is why this PR addresses that clearing code that was not needed anymore in certain places.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create an org
2. Create a subteam
3. Invite someone to a subteam and have that person accept the invitation -> membership for org and subteam created and accepted
4. Invite someone else to the org and have that person accept the invitation -> membership for the org created and accepted