### PR TITLE
chore(prisma): undo skipped type checks

### DIFF
--- a/apps/web/test/lib/checkBookingLimits.test.ts
+++ b/apps/web/test/lib/checkBookingLimits.test.ts
@@ -23,7 +23,6 @@ const MOCK_DATA: Mockdata = {
 
 describe("Check Booking Limits Tests", () => {
   it("Should return no errors", async () => {
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(0);
     expect(
       checkBookingLimits(MOCK_DATA.bookingLimits, MOCK_DATA.startDate, MOCK_DATA.id)
@@ -31,7 +30,6 @@ describe("Check Booking Limits Tests", () => {
   });
   it("Should throw an error", async () => {
     // Mock there being two a day
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(2);
     expect(
       checkBookingLimits(MOCK_DATA.bookingLimits, MOCK_DATA.startDate, MOCK_DATA.id)
@@ -39,7 +37,6 @@ describe("Check Booking Limits Tests", () => {
   });
 
   it("Should pass with multiple booking limits", async () => {
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(0);
     expect(
       checkBookingLimits(
@@ -53,7 +50,6 @@ describe("Check Booking Limits Tests", () => {
     ).resolves.toBeTruthy();
   });
   it("Should pass with multiple booking limits with one undefined", async () => {
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(0);
     expect(
       checkBookingLimits(
@@ -67,7 +63,6 @@ describe("Check Booking Limits Tests", () => {
     ).resolves.toBeTruthy();
   });
   it("Should handle mutiple limits correctly", async () => {
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(1);
     expect(
       checkBookingLimit({
@@ -77,7 +72,6 @@ describe("Check Booking Limits Tests", () => {
         eventId: MOCK_DATA.id,
       })
     ).resolves.not.toThrow();
-    // @ts-expect-error Prisma v5 typings are not yet available
     prismaMock.booking.count.mockResolvedValue(3);
     expect(
       checkBookingLimit({

--- a/apps/web/test/lib/handleChildrenEventTypes.test.ts
+++ b/apps/web/test/lib/handleChildrenEventTypes.test.ts
@@ -10,7 +10,6 @@ import type { CompleteEventType, CompleteWorkflowsOnEventTypes } from "@calcom/p
 
 const mockFindFirstEventType = (data?: Partial<CompleteEventType>) => {
   const eventType = buildEventType(data as Partial<EventType>);
-  // @ts-expect-error Prisma v5 typings are not yet available
   prismaMock.eventType.findFirst.mockResolvedValue(eventType as EventType);
   return eventType;
 };
@@ -31,7 +30,7 @@ describe("handleChildrenEventTypes", () => {
   describe("Shortcircuits", () => {
     it("Returns message 'No managed event type'", async () => {
       mockFindFirstEventType();
-      // @ts-expect-error Prisma v5 typings are not yet available
+
       const result = await updateChildrenEventTypes({
         eventTypeId: 1,
         oldEventType: { children: [], team: { name: "" } },
@@ -40,7 +39,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(result.newUserIds).toEqual(undefined);
@@ -60,7 +58,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(result.newUserIds).toEqual(undefined);
@@ -86,7 +83,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(result.newUserIds).toEqual(undefined);
@@ -116,7 +112,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(prismaMock.eventType.create).toHaveBeenCalledWith({
@@ -163,7 +158,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: "somestring",
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(prismaMock.eventType.update).toHaveBeenCalledWith({
@@ -197,7 +191,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(result.newUserIds).toEqual([]);
@@ -222,7 +215,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       // Have been called
@@ -253,7 +245,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(prismaMock.eventType.create).toHaveBeenCalledWith({
@@ -300,7 +291,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(prismaMock.eventType.update).toHaveBeenCalledWith({
@@ -359,7 +349,6 @@ describe("handleChildrenEventTypes", () => {
         currentUserId: 1,
         hashedLink: undefined,
         connectedLink: null,
-        // @ts-expect-error Prisma v5 typings are not yet available
         prisma: prismaMock,
       });
       expect(prismaMock.eventType.create).toHaveBeenCalledWith({

--- a/apps/web/test/lib/team-event-types.test.ts
+++ b/apps/web/test/lib/team-event-types.test.ts
@@ -33,10 +33,7 @@ it("can find lucky user with maximize availability", async () => {
   });
   const users = [user1, user2];
   // TODO: we may be able to use native prisma generics somehow?
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   prismaMock.user.findMany.mockResolvedValue(users);
-  // @ts-expect-error Prisma v5 typings are not yet available
   prismaMock.booking.findMany.mockResolvedValue([]);
 
   await expect(

--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from "@prisma/client";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
+import type { DeepMockProxy } from "vitest-mock-extended";
 
 import { sendSlugReplacementEmail } from "@calcom/emails/email-manager";
 import { getTranslation } from "@calcom/lib/server/i18n";
@@ -41,7 +42,7 @@ interface handleChildrenEventTypesProps {
         };
       }[]
     | undefined;
-  prisma: PrismaClient;
+  prisma: PrismaClient | DeepMockProxy<PrismaClient>;
 }
 
 const sendAllSlugReplacementEmails = async (


### PR DESCRIPTION
## What does this PR do?

This PR restores the types as they mostly were before the Prisma Accelerate extension was used. The original issue that prompted introducing a bunch of `@ts-expect-error` is tracked in the Prisma repository https://github.com/prisma/prisma/issues/21136.

## Requirement/Documentation

n/a

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

n/a

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

✅
