### PR TITLE
fix: team members not showing up in org members list

### DIFF
--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -130,7 +130,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Accept any child team invites for orgs and create a membership for the org itself
       if (team.parentId) {
-        // Create or Upate membership for the organization itself
+        // Create (when invite link is used) or Update (when regular email invitation is used) membership for the organization itself
         await prisma.membership.upsert({
           where: {
             userId_teamId: { userId: user.id, teamId: team.parentId },

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -130,15 +130,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Accept any child team invites for orgs and create a membership for the org itself
       if (team.parentId) {
-        // Create a membership for the organization itself
-        await prisma.membership.create({
-          data: {
+        // Create or Upate membership for the organization itself
+        await prisma.membership.upsert({
+          where: {
+            userId_teamId: { userId: user.id, teamId: team.parentId },
+          },
+          update: {
+            accepted: true,
+          },
+          create: {
             userId: user.id,
             teamId: team.parentId,
             accepted: true,
             role: MembershipRole.MEMBER,
           },
         });
+
         // We do a membership update twice so we can join the ORG invite if the user is invited to a team witin a ORG
         await prisma.membership.updateMany({
           where: {

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -130,6 +130,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Accept any child team invites for orgs and create a membership for the org itself
       if (team.parentId) {
+        // Create a membership for the organization itself
+        await prisma.membership.create({
+          data: {
+            userId: user.id,
+            teamId: team.parentId,
+            accepted: true,
+            role: MembershipRole.MEMBER,
+          },
+        });
         // We do a membership update twice so we can join the ORG invite if the user is invited to a team witin a ORG
         await prisma.membership.updateMany({
           where: {


### PR DESCRIPTION
## What does this PR do?

Fixes: If members were invite to subteam of an org using copy link then their name was not showing up in members list of org because no membership record was created  for org and only for subteam



1) Invite user to subteam of an org by copy link
2) Check subteam members and org members

https://github.com/calcom/cal.com/pull/11449/files#r1330703314



## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)