### PR TITLE
chore: reducing team next data

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -112,9 +112,8 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
     </ul>
   );
 
-  const SubTeams = () => {
-    console.log({ members: team.members });
-    return team.children.length ? (
+  const SubTeams = () =>
+    team.children.length ? (
       <ul className="divide-subtle border-subtle bg-default !static w-full divide-y rounded-md border">
         {team.children.map((ch, i) => (
           <li key={i} className="hover:bg-muted w-full">
@@ -162,7 +161,6 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
         </div>
       </div>
     );
-  };
 
   return (
     <>

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -112,8 +112,9 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
     </ul>
   );
 
-  const SubTeams = () =>
-    team.children.length ? (
+  const SubTeams = () => {
+    console.log({ members: team.members });
+    return team.children.length ? (
       <ul className="divide-subtle border-subtle bg-default !static w-full divide-y rounded-md border">
         {team.children.map((ch, i) => (
           <li key={i} className="hover:bg-muted w-full">
@@ -129,7 +130,8 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
                   <span className="text-default text-sm font-bold">{ch.name}</span>
                   <span className="text-subtle block text-xs">
                     {t("number_member", {
-                      count: ch.members.filter((mem) => mem.user.username !== null).length,
+                      count: team.members.filter((mem) => mem.subteams?.includes(ch.slug) && mem.accepted)
+                        .length,
                     })}
                   </span>
                 </div>
@@ -138,9 +140,9 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
                 className="mr-6"
                 size="sm"
                 truncateAfter={4}
-                items={ch.members
-                  .filter((mem) => mem.user.username !== null)
-                  .map(({ user: member }) => ({
+                items={team.members
+                  .filter((mem) => mem.subteams?.includes(ch.slug) && mem.accepted)
+                  .map((member) => ({
                     alt: member.name || "",
                     image: `/${member.username}/avatar.png`,
                     title: member.name || "",
@@ -160,6 +162,7 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
         </div>
       </div>
     );
+  };
 
   return (
     <>
@@ -316,7 +319,9 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       name: member.name,
       id: member.id,
       bio: member.bio,
+      subteams: member.subteams,
       username: member.username,
+      accepted: member.accepted,
       safeBio: markdownToSafeHTML(member.bio || ""),
     };
   });

--- a/packages/lib/server/queries/teams/index.ts
+++ b/packages/lib/server/queries/teams/index.ts
@@ -28,6 +28,15 @@ export async function getTeamWithMembers(args: {
         externalId: true,
       },
     },
+    teams: {
+      select: {
+        team: {
+          select: {
+            slug: true,
+          },
+        },
+      },
+    },
     selectedCalendars: true,
     credentials: {
       select: {
@@ -68,16 +77,6 @@ export async function getTeamWithMembers(args: {
         name: true,
         logo: true,
         slug: true,
-        members: {
-          select: {
-            user: {
-              select: {
-                name: true,
-                username: true,
-              },
-            },
-          },
-        },
       },
     },
     members: {
@@ -142,6 +141,9 @@ export async function getTeamWithMembers(args: {
       role: obj.role,
       accepted: obj.accepted,
       disableImpersonation: obj.disableImpersonation,
+      subteams: orgSlug
+        ? obj.user.teams.filter((obj) => obj.team.slug !== orgSlug).map((obj) => obj.team.slug)
+        : null,
       avatar: `${WEBAPP_URL}/${obj.user.username}/avatar.png`,
       connectedApps: obj?.user?.credentials?.map((cred) => {
         const appSlug = cred.app?.slug;


### PR DESCRIPTION
## What does this PR do?

Org profile page included each member in each subteam to show in which subteam they belong too. Taking into account each subteam member is also a member of the org itself, this PR removes the members object by each children team to rely on the org members.

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Creating an org and subteams and inviting people to the subteam will continue to show the correct membership in the org profile for each subteam.