### PR TITLE
feat: Add 300s accelerate cache to feature flags

### DIFF
--- a/packages/features/flags/server/router.ts
+++ b/packages/features/flags/server/router.ts
@@ -8,6 +8,7 @@ export const featureFlagRouter = router({
     const { prisma } = ctx;
     return prisma.feature.findMany({
       orderBy: { slug: "asc" },
+      cacheStrategy: { swr: 300, ttl: 300 },
     });
   }),
   map: publicProcedure.query(async ({ ctx }) => {

--- a/packages/features/flags/server/utils.ts
+++ b/packages/features/flags/server/utils.ts
@@ -5,6 +5,7 @@ import type { AppFlags } from "../config";
 export async function getFeatureFlagMap(prisma: PrismaClient) {
   const flags = await prisma.feature.findMany({
     orderBy: { slug: "asc" },
+    cacheStrategy: { swr: 300, ttl: 300 },
   });
   return flags.reduce<AppFlags>((acc, flag) => {
     acc[flag.slug as keyof AppFlags] = flag.enabled;


### PR DESCRIPTION
## What does this PR do?

Adds 300s cache to feature flags, which does mean that feature flag changes take 5m to take effect but also means a lot less database calls.