### PR TITLE
chore: Add login to rewrites

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -226,6 +226,10 @@ const nextConfig = {
   },
   async rewrites() {
     const beforeFiles = [
+      {
+        source: "/login",
+        destination: "/auth/login",
+      },
       // These rewrites are other than booking pages rewrites and so that they aren't redirected to org pages ensure that they happen in beforeFiles
       ...(isOrganizationsEnabled
         ? [


### PR DESCRIPTION
## What does this PR do?

Aliases app.cal.com/login to app.cal.com/auth/login - no redirect as that's not needed.