### PR TITLE
chore: avoid i18n strings in org profile

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -115,41 +115,46 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
   const SubTeams = () =>
     team.children.length ? (
       <ul className="divide-subtle border-subtle bg-default !static w-full divide-y rounded-md border">
-        {team.children.map((ch, i) => (
-          <li key={i} className="hover:bg-muted w-full">
-            <Link href={`/${ch.slug}`} className="flex items-center justify-between">
-              <div className="flex items-center px-5 py-5">
-                <Avatar
-                  size="md"
-                  imageSrc={getPlaceholderAvatar(ch?.logo, ch?.name as string)}
-                  alt="Team Logo"
-                  className="inline-flex justify-center"
-                />
-                <div className="ms-3 inline-block truncate">
-                  <span className="text-default text-sm font-bold">{ch.name}</span>
-                  <span className="text-subtle block text-xs">
-                    {t("number_member", {
-                      count: team.members.filter((mem) => mem.subteams?.includes(ch.slug) && mem.accepted)
-                        .length,
-                    })}
-                  </span>
+        {team.children.map((ch, i) => {
+          const memberCount = team.members.filter(
+            (mem) => mem.subteams?.includes(ch.slug) && mem.accepted
+          ).length;
+          return (
+            <li key={i} className="hover:bg-muted w-full">
+              <Link href={`/${ch.slug}`} className="flex items-center justify-between">
+                <div className="flex items-center px-5 py-5">
+                  <Avatar
+                    size="md"
+                    imageSrc={getPlaceholderAvatar(ch?.logo, ch?.name as string)}
+                    alt="Team Logo"
+                    className="inline-flex justify-center"
+                  />
+                  <div className="ms-3 inline-block truncate">
+                    <span className="text-default text-sm font-bold">{ch.name}</span>
+                    <span className="text-subtle block text-xs">
+                      {t("number_member", {
+                        count: memberCount,
+                        defaultValue: `${memberCount} member${memberCount > 1 ? "s" : ""}`,
+                      })}
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <AvatarGroup
-                className="mr-6"
-                size="sm"
-                truncateAfter={4}
-                items={team.members
-                  .filter((mem) => mem.subteams?.includes(ch.slug) && mem.accepted)
-                  .map((member) => ({
-                    alt: member.name || "",
-                    image: `/${member.username}/avatar.png`,
-                    title: member.name || "",
-                  }))}
-              />
-            </Link>
-          </li>
-        ))}
+                <AvatarGroup
+                  className="mr-6"
+                  size="sm"
+                  truncateAfter={4}
+                  items={team.members
+                    .filter((mem) => mem.subteams?.includes(ch.slug) && mem.accepted)
+                    .map((member) => ({
+                      alt: member.name || "",
+                      image: `/${member.username}/avatar.png`,
+                      title: member.name || "",
+                    }))}
+                />
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     ) : (
       <div className="space-y-6" data-testid="event-types">
@@ -252,7 +257,6 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
 }
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const ssr = await ssrInit(context);
   const slug = Array.isArray(context.query?.slug) ? context.query.slug.pop() : context.query.slug;
   const { isValidOrgDomain, currentOrgDomain } = orgDomainConfig(
     context.req.headers.host ?? "",
@@ -260,12 +264,15 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   );
   const flags = await getFeatureFlagMap(prisma);
   const team = await getTeamWithMembers({ slug, orgSlug: currentOrgDomain });
+  const ssr = await ssrInit(context, {
+    noI18nPreload: isValidOrgDomain,
+  });
   const metadata = teamMetadataSchema.parse(team?.metadata ?? {});
-  console.warn("gSSP, team/[slug] - ", {
+  console.info("gSSP, team/[slug] - ", {
     isValidOrgDomain,
     currentOrgDomain,
     ALLOWED_HOSTNAMES: process.env.ALLOWED_HOSTNAMES,
-    flags: JSON.stringify,
+    flags: JSON.stringify(flags),
   });
   // Taking care of sub-teams and orgs
   if (

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -265,7 +265,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const flags = await getFeatureFlagMap(prisma);
   const team = await getTeamWithMembers({ slug, orgSlug: currentOrgDomain });
   const ssr = await ssrInit(context, {
-    noI18nPreload: isValidOrgDomain,
+    noI18nPreload: isValidOrgDomain && !team?.parent,
   });
   const metadata = teamMetadataSchema.parse(team?.metadata ?? {});
   console.info("gSSP, team/[slug] - ", {

--- a/apps/web/server/lib/ssr.ts
+++ b/apps/web/server/lib/ssr.ts
@@ -14,7 +14,7 @@ import { appRouter } from "@calcom/trpc/server/routers/_app";
  * Automatically prefetches i18n based on the passed in `context`-object to prevent i18n-flickering.
  * Make sure to `return { props: { trpcState: ssr.dehydrate() } }` at the end.
  */
-export async function ssrInit(context: GetServerSidePropsContext) {
+export async function ssrInit(context: GetServerSidePropsContext, options?: { noI18nPreload: boolean }) {
   const ctx = await createContext(context);
   const locale = await getLocaleFromRequest(context.req);
   const i18n = await serverSideTranslations(locale, ["common", "vital"]);
@@ -27,7 +27,9 @@ export async function ssrInit(context: GetServerSidePropsContext) {
 
   await Promise.allSettled([
     // always preload "viewer.public.i18n"
-    ssr.viewer.public.i18n.prefetch({ locale, CalComVersion: CALCOM_VERSION }),
+    !options?.noI18nPreload
+      ? ssr.viewer.public.i18n.prefetch({ locale, CalComVersion: CALCOM_VERSION })
+      : Promise.resolve({}),
     // So feature flags are available on first render
     ssr.viewer.features.map.prefetch(),
     // Provides a better UX to the users who have already upgraded.


### PR DESCRIPTION
## What does this PR do?

Organization profiles don't much i18n strings to experience a string flickering so this PR introduces a way to not load all i18n strings for SSR to be used in the presence of an org profile. Also added a default value for the only visible string in an org profile to avoid flickering. This will help reduce the footprint of `NEXT_DATA` object which can't prevent to load an org profile when a lot of sub-teams and members belong to it.

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

Do `yarn build` and `yarn start` and create an org with a bunch of sub-teams and members in them. You will see the org profile with a much smaller `NEXT_DATA` object in the page.