### PR TITLE
fix: disable create team button for non admins

### DIFF
--- a/packages/features/ee/teams/components/CreateANewTeamForm.tsx
+++ b/packages/features/ee/teams/components/CreateANewTeamForm.tsx
@@ -67,7 +67,7 @@ export const CreateANewTeamForm = () => {
         <div className="mb-8">
           {serverErrorMessage && (
             <div className="mb-4">
-              <Alert severity="error" message={serverErrorMessage} />
+              <Alert severity="error" message={t(serverErrorMessage)} />
             </div>
           )}
 

--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -97,7 +97,7 @@ export function TeamsListing() {
 
       {invites.length > 0 && (
         <div className="bg-subtle mb-6 rounded-md p-5">
-          <Label className=" text-emphasis pb-2 font-semibold">{t("pending_invites")}</Label>
+          <Label className="text-emphasis pb-2  font-semibold">{t("pending_invites")}</Label>
           <TeamList teams={invites} pending />
         </div>
       )}
@@ -133,7 +133,7 @@ export function TeamsListing() {
             buttonRaw={
               <Button
                 color="secondary"
-                disabled={isCreateTeamButtonDisabled}
+                disabled={!!isCreateTeamButtonDisabled}
                 tooltip={
                   isCreateTeamButtonDisabled ? t("org_admins_can_create_new_teams") : t("create_new_team")
                 }

--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -46,6 +46,8 @@ export function TeamsListing() {
   const teams = useMemo(() => data?.filter((m) => m.accepted) || [], [data]);
   const invites = useMemo(() => data?.filter((m) => !m.accepted) || [], [data]);
 
+  const isCreateTeamButtonDisabled = user?.organizationId && !user?.organization?.isOrgAdmin;
+
   const features = [
     {
       icon: <Users className="h-5 w-5 text-red-500" />,
@@ -131,7 +133,11 @@ export function TeamsListing() {
             buttonRaw={
               <Button
                 color="secondary"
-                href={`${WEBAPP_URL}/settings/teams/new?returnTo=${WEBAPP_URL}/teams`}>
+                disabled={isCreateTeamButtonDisabled}
+                tooltip={
+                  isCreateTeamButtonDisabled ? t("org_admins_can_create_new_teams") : t("create_new_team")
+                }
+                onClick={() => router.push(`${WEBAPP_URL}/settings/teams/new?returnTo=${WEBAPP_URL}/teams`)}>
                 {t(`create_new_team`)}
               </Button>
             }


### PR DESCRIPTION
## What does this PR do?

Fixes https://linear.app/calcom/issue/CAL-2492/non-admin-team-member-can-see-the-option-to-create-a-team

<img width="1216" alt="Screenshot 2023-09-21 at 2 56 56 AM" src="https://github.com/calcom/cal.com/assets/53316345/ded2fd44-7f07-40a0-bb39-7a9fb0d97ed9">




## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
