### PR TITLE
chore: reduce team data footprint

### DIFF
--- a/packages/features/ee/organizations/context/provider.ts
+++ b/packages/features/ee/organizations/context/provider.ts
@@ -10,10 +10,15 @@ import type { teamMetadataSchema } from "@calcom/prisma/zod-utils";
  */
 export type OrganizationBranding =
   | ({
+      /** 1 */
       id: number;
+      /** Acme */
       name?: string;
+      /** acme */
       slug: string;
+      /** https://acme.cal.com */
       fullDomain: string;
+      /** cal.com */
       domainSuffix: string;
     } & z.infer<typeof teamMetadataSchema>)
   | null

--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -121,7 +121,7 @@ export default function MemberListItem(props: Props) {
   const bookerUrlWithoutProtocol = bookerUrl.replace(/^https?:\/\//, "");
   const bookingLink = !!props.member.username && `${bookerUrlWithoutProtocol}/${props.member.username}`;
   const isAdmin = props.team && ["ADMIN", "OWNER"].includes(props.team.membership?.role);
-  const appList = props.member.connectedApps.map(({ logo, name, externalId }) => {
+  const appList = props.member.connectedApps?.map(({ logo, name, externalId }) => {
     return logo ? (
       externalId ? (
         <div className="ltr:mr-2 rtl:ml-2 ">

--- a/packages/features/ee/teams/components/TeamInviteList.tsx
+++ b/packages/features/ee/teams/components/TeamInviteList.tsx
@@ -11,7 +11,6 @@ interface Props {
     id?: number;
     name?: string | null;
     slug?: string | null;
-    logo?: string | null;
     bio?: string | null;
     hideBranding?: boolean | undefined;
     role: MembershipRole;

--- a/packages/features/ee/teams/components/TeamInviteListItem.tsx
+++ b/packages/features/ee/teams/components/TeamInviteListItem.tsx
@@ -1,5 +1,5 @@
 import classNames from "@calcom/lib/classNames";
-import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { MembershipRole } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
@@ -20,7 +20,6 @@ interface Props {
     id?: number;
     name?: string | null;
     slug?: string | null;
-    logo?: string | null;
     bio?: string | null;
     hideBranding?: boolean | undefined;
     role: MembershipRole;
@@ -66,7 +65,7 @@ export default function TeamInviteListItem(props: Props) {
     <div className="flex">
       <Avatar
         size="mdLg"
-        imageSrc={getPlaceholderAvatar(team?.logo, team?.name as string)}
+        imageSrc={`${WEBAPP_URL}/team/${team.slug}/avatar.png`}
         alt="Team Logo"
         className=""
       />

--- a/packages/features/ee/teams/pages/team-members-view.tsx
+++ b/packages/features/ee/teams/pages/team-members-view.tsx
@@ -149,7 +149,6 @@ const MembersView = () => {
                       {
                         id: team.id,
                         accepted: team.membership.accepted || false,
-                        logo: team.logo,
                         name: team.name,
                         slug: team.slug,
                         role: team.membership.role,

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -94,7 +94,6 @@ const ProfileView = () => {
         if (team) {
           form.setValue("name", team.name || "");
           form.setValue("slug", team.slug || "");
-          form.setValue("logo", team.logo || "");
           form.setValue("bio", team.bio || "");
           if (team.slug === null && (team?.metadata as Prisma.JsonObject)?.requestedSlug) {
             form.setValue("slug", ((team?.metadata as Prisma.JsonObject)?.requestedSlug as string) || "");
@@ -165,7 +164,6 @@ const ProfileView = () => {
               handleSubmit={(values) => {
                 if (team) {
                   const variables = {
-                    logo: values.logo,
                     name: values.name,
                     slug: values.slug,
                     bio: values.bio,

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -6,6 +6,7 @@ export const CALCOM_ENV = process.env.CALCOM_ENV || process.env.NODE_ENV;
 export const IS_PRODUCTION = CALCOM_ENV === "production";
 export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === "production";
 
+/** https://app.cal.com */
 export const WEBAPP_URL =
   process.env.NEXT_PUBLIC_WEBAPP_URL ||
   VERCEL_URL ||

--- a/packages/lib/server/queries/teams/index.ts
+++ b/packages/lib/server/queries/teams/index.ts
@@ -15,19 +15,16 @@ export async function getTeamWithMembers(args: {
   slug?: string;
   userId?: number;
   orgSlug?: string | null;
+  isTeamView?: boolean;
+  isOrgView?: boolean;
 }) {
-  const { id, slug, userId, orgSlug } = args;
+  const { id, slug, userId, orgSlug, isTeamView, isOrgView } = args;
   const userSelect = Prisma.validator<Prisma.UserSelect>()({
     username: true,
     email: true,
     name: true,
     id: true,
     bio: true,
-    destinationCalendar: {
-      select: {
-        externalId: true,
-      },
-    },
     teams: {
       select: {
         team: {
@@ -37,7 +34,6 @@ export async function getTeamWithMembers(args: {
         },
       },
     },
-    selectedCalendars: true,
     credentials: {
       select: {
         app: {
@@ -58,7 +54,6 @@ export async function getTeamWithMembers(args: {
     id: true,
     name: true,
     slug: true,
-    logo: true,
     bio: true,
     hideBranding: true,
     hideBookATeamMember: true,
@@ -136,8 +131,9 @@ export async function getTeamWithMembers(args: {
   // This should improve performance saving already app data found.
   const appDataMap = new Map();
   const members = team.members.map((obj) => {
+    const { credentials, ...restUser } = obj.user;
     return {
-      ...obj.user,
+      ...restUser,
       role: obj.role,
       accepted: obj.accepted,
       disableImpersonation: obj.disableImpersonation,
@@ -145,24 +141,26 @@ export async function getTeamWithMembers(args: {
         ? obj.user.teams.filter((obj) => obj.team.slug !== orgSlug).map((obj) => obj.team.slug)
         : null,
       avatar: `${WEBAPP_URL}/${obj.user.username}/avatar.png`,
-      connectedApps: obj?.user?.credentials?.map((cred) => {
-        const appSlug = cred.app?.slug;
-        let appData = appDataMap.get(appSlug);
+      connectedApps: !isTeamView
+        ? credentials?.map((cred) => {
+            const appSlug = cred.app?.slug;
+            let appData = appDataMap.get(appSlug);
 
-        if (!appData) {
-          appData = getAppFromSlug(appSlug);
-          appDataMap.set(appSlug, appData);
-        }
+            if (!appData) {
+              appData = getAppFromSlug(appSlug);
+              appDataMap.set(appSlug, appData);
+            }
 
-        const isCalendar = cred?.app?.categories?.includes("calendar") ?? false;
-        const externalId = isCalendar ? cred.destinationCalendars?.[0]?.externalId : null;
-        return {
-          name: appData?.name ?? null,
-          logo: appData?.logo ?? null,
-          app: cred.app,
-          externalId: externalId ?? null,
-        };
-      }),
+            const isCalendar = cred?.app?.categories?.includes("calendar") ?? false;
+            const externalId = isCalendar ? cred.destinationCalendars?.[0]?.externalId : null;
+            return {
+              name: appData?.name ?? null,
+              logo: appData?.logo ?? null,
+              app: cred.app,
+              externalId: externalId ?? null,
+            };
+          })
+        : null,
     };
   });
 
@@ -182,7 +180,7 @@ export async function getTeamWithMembers(args: {
         token.expires > new Date(new Date().setHours(24))
     ),
     metadata: teamMetadataSchema.parse(team.metadata),
-    eventTypes,
+    eventTypes: !isOrgView ? eventTypes : null,
     members,
   };
 }

--- a/packages/ui/components/unpublished-entity/UnpublishedEntity.tsx
+++ b/packages/ui/components/unpublished-entity/UnpublishedEntity.tsx
@@ -22,8 +22,13 @@ export function UnpublishedEntity(props: UnpublishedEntityProps) {
         }
         headline={t("team_is_unpublished", {
           team: props.name,
+          defaultValue: `${props.name} is unpublished`,
         })}
-        description={t(`${props.orgSlug ? "org" : "team"}_is_unpublished_description`)}
+        description={t(`${props.orgSlug ? "org" : "team"}_is_unpublished_description`, {
+          defaultValue: `This ${
+            props.orgSlug ? "organization" : "team"
+          } link is currently not available. Please contact the organization owner or ask them to publish it.`,
+        })}
       />
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

The function `getTeamWithMembers` is being used in very different places for very different reasons, and yet, the returned object keeps getting bigger satisfying the need of just one or two places but having a big impact in key places where every byte matters. This is why this PR reduced the returned object footprint when a team profile page uses it and even more when a org profile page uses it.

Also, a few i18n strings have now a default value and logo is not returned anymore from the mentioned function, opting to go with the `avatar.png` alternative.

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

No actual change on functionality, only making a function more flexible according to the context in which is being called. 