### PR TITLE
fix: auto-approve crowdin translations uploaded from GitHub

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -21,10 +21,18 @@ jobs:
       - name: crowdin action
         uses: crowdin/github-action@v1.13.0
         with:
+          # upload sources
           upload_sources: true
+          
+          # upload translations (& auto-approve 'em)
+          upload_translations_args: '--auto-approve-imported'
           upload_translations: true
-          download_translations: true
           push_translations: true
+          
+          # download translations
+          download_translations: true
+          
+          # GH config
           commit_message: "New Crowdin translations by Github Action"
           localization_branch_name: main
           create_pull_request: false

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: crowdin action
-        uses: crowdin/github-action@v1.5.0
+        uses: crowdin/github-action@v1.13.0
         with:
           # upload sources
           upload_sources: true

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: crowdin action
-        uses: crowdin/github-action@v1.13.0
+        uses: crowdin/github-action@v1.5.0
         with:
           # upload sources
           upload_sources: true


### PR DESCRIPTION
## What does this PR do?
Another attempt to fix the crowdin action so that it will first upload any translations set in GitHub.

- After having updated the crowdin github action, this PR merges the changes previously merged (and thus overwritten) by:
- https://github.com/calcom/cal.com/pull/10416

Please refer to the linked PR from @sajanlamsal for any context.

Fixes # https://github.com/calcom/cal.com/issues/11354

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- the following commit from the crowdin bot (triggered by GitHub Action) shall _not_ overwrite the changes in this PR.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

