### PR TITLE
fix: Salesforce by wrapping the refresh logic in a try/catch

### DIFF
--- a/packages/app-store/salesforce/lib/CalendarService.ts
+++ b/packages/app-store/salesforce/lib/CalendarService.ts
@@ -73,28 +73,39 @@ export default class SalesforceCalendarService implements Calendar {
 
     const credentialKey = credential.key as unknown as ExtendedTokenResponse;
 
-    const response = await fetch("https://login.salesforce.com/services/oauth2/token", {
-      method: "POST",
-      body: new URLSearchParams({
-        grant_type: "refresh_token",
-        client_id: consumer_key,
-        client_secret: consumer_secret,
-        refresh_token: credentialKey.refresh_token,
-        format: "json",
-      }),
-    });
+    try {
+      /* XXX: This code results in 'Bad Request', which indicates something is wrong with our salesforce integration.
+              Needs further investigation ASAP */
+      const response = await fetch("https://login.salesforce.com/services/oauth2/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          client_id: consumer_key,
+          client_secret: consumer_secret,
+          refresh_token: credentialKey.refresh_token,
+        }),
+      });
 
-    if (response.statusText !== "OK") throw new HttpError({ statusCode: 400, message: response.statusText });
+      if (!response.ok) {
+        const message = `${response.statusText}: ${JSON.stringify(await response.json())}`;
+        throw new Error(message);
+      }
 
-    const accessTokenJson = await response.json();
+      const accessTokenJson = await response.json();
 
-    const accessTokenParsed: ParseRefreshTokenResponse<typeof salesforceTokenSchema> =
-      parseRefreshTokenResponse(accessTokenJson, salesforceTokenSchema);
+      const accessTokenParsed: ParseRefreshTokenResponse<typeof salesforceTokenSchema> =
+        parseRefreshTokenResponse(accessTokenJson, salesforceTokenSchema);
 
-    await prisma.credential.update({
-      where: { id: credential.id },
-      data: { key: { ...accessTokenParsed, refresh_token: credentialKey.refresh_token } },
-    });
+      await prisma.credential.update({
+        where: { id: credential.id },
+        data: { key: { ...accessTokenParsed, refresh_token: credentialKey.refresh_token } },
+      });
+    } catch (err: unknown) {
+      console.error(err); // log but proceed
+    }
 
     return new jsforce.Connection({
       clientId: consumer_key,


### PR DESCRIPTION
## What does this PR do?

Wrapping the refresh token logic in a try catch whilst we investigate why our salesforce integration returns:

Bad Request:
```json
{ "error":"invalid_grant", "error_description": "inactive organization" }
```