### PR TITLE
refactor: Paypal App UI & UX

### DIFF
--- a/packages/app-store/paypal/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/paypal/components/EventTypeAppCardInterface.tsx
@@ -60,7 +60,7 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
                   min="0.5"
                   type="number"
                   required
-                  className="block w-full rounded-sm border-gray-300 pl-2 pr-12 text-sm"
+                  className="block w-full rounded-sm border-gray-300 pl-2 text-sm"
                   placeholder="Price"
                   onChange={(e) => {
                     setAppData("price", Number(e.target.value) * 100);


### PR DESCRIPTION
## What does this PR do?

The goal of this PR is to reduce friction when adding PayPal for events and improve user experience.
I recommend watching Loom video and then reading description below: https://www.loom.com/share/7b31f52e5da0474d88fddafd68134503?sid=e9de6867-9b5e-4a2b-949e-df14e1bd78a2

As a drive by fixed unrelated to this PR lint errors (1 import order and 2 unused variables). See [commit](https://github.com/calcom/cal.com/pull/11517/commits/1ebcaafe7efafea027baccebc9941f5dcbffbe22).

### Errors fixed
1 After enabling PayPal for an event and entering the amount and pressing save error "An unexpected error occurred. Try again." appeared in production, because by default "currency" app data is undefined. Now it has a default value if it's undefined and app works as expected. See commit [fix: dont show 'No selected currency' message since default already is selected](https://github.com/calcom/cal.com/commit/2f0fa0e8d83306b19a752df10ec9b8d1f1e7c235).

Before:
<img width="982" alt="Screenshot 2023-09-25 at 17 25 54" src="https://github.com/calcom/cal.com/assets/42170848/bb377a56-c76c-4530-b38c-bf537c1b596f">

After:
<img width="982" alt="Screenshot 2023-09-25 at 17 27 01" src="https://github.com/calcom/cal.com/assets/42170848/461cc3a5-572b-4b75-ad51-dee754012d79">


### UX improvements
1 Upon enabling PayPal for first time for event user sees "No selected currency" in the "Price" input even though it is already pre-selected under the "Currency" dropdown (1st screenshots above). Now "Price" input has pre-selected currency (2nd screenshots above) Otherwise "$" users needed to manually select USD even though it already appeared under "Currency" and for non "$" users it's unclear UX.  See commit [fix: dont show 'No selected currency' message since default already s](https://github.com/calcom/cal.com/commit/2f0fa0e8d83306b19a752df10ec9b8d1f1e7c235). Fixing this resolved Error above.

2 Whatever currency was selected under "Currency" the currency symbol in the "Price" input was always "$". So if someone selects "Euro" as "Currency" the price input symbol was still "$" but now it adapts to the currently selected currency. For all dollars be it "United States dollar" or "Australian dollar" the symbol is "$" and the same for krone be it Danish or Norwegian.  A further distinction could have been made to denote "Australian dollar" as "A$" but that overcomplicates the UX in my opinion. See commit [fix: corresponding symbol for selected currency](https://github.com/calcom/cal.com/commit/beb8f9ea7cfb2b7b7df45755e34f902b9955650f)

Before:
<img width="336" alt="Screenshot 2023-09-25 at 17 32 47" src="https://github.com/calcom/cal.com/assets/42170848/d29298df-814f-4c35-8c49-975519f15e73">

After (see € symbol):
<img width="294" alt="Screenshot 2023-09-25 at 17 32 56" src="https://github.com/calcom/cal.com/assets/42170848/66fa52b2-192c-409b-9c30-01f2715eb0e8">


### UI improvements
1 In the "Price" input increase / decrease arrows had big margin on the right. Removed it. See commit [refactor: price input margin](https://github.com/calcom/cal.com/commit/f3f82182b33e1fae415a5d6604a5f41839fceffd)

Before:
<img width="435" alt="Screenshot 2023-09-25 at 17 29 51" src="https://github.com/calcom/cal.com/assets/42170848/bbedaeda-1d87-472d-b100-d3cb35d8343e">

After:
<img width="293" alt="Screenshot 2023-09-25 at 17 29 55" src="https://github.com/calcom/cal.com/assets/42170848/43a86429-0f38-47f2-aa4d-c3b51818713c">

2 "Price" input had gray top and bottom margin. Removed it. See commit [refactor: price input remove border](https://github.com/calcom/cal.com/commit/63a186c19936f53cb3c1c23991c4c98e39f1cf2d)

Before:
<img width="440" alt="Screenshot 2023-09-25 at 17 29 37" src="https://github.com/calcom/cal.com/assets/42170848/282ad822-ac3e-4b50-8433-59c3596e28aa">

After:
<img width="287" alt="Screenshot 2023-09-25 at 17 29 42" src="https://github.com/calcom/cal.com/assets/42170848/6230c691-de63-4b5c-b8b8-a8a2e489921e">

3 PayPal app "Currency" and "Payment option" dropdowns were crowded so made it more spacious. See commit [refactor: more space for paypal inputs](https://github.com/calcom/cal.com/commit/e98b832aab101bd0c2086cbb595f65b324287350)

Before:
<img width="934" alt="Screenshot 2023-09-25 at 17 31 10" src="https://github.com/calcom/cal.com/assets/42170848/8d96ce1e-1f73-4668-8de7-75ade93c7bf4">

After:
<img width="938" alt="Screenshot 2023-09-25 at 17 31 16" src="https://github.com/calcom/cal.com/assets/42170848/643f47e9-0762-4611-bb11-88969ad6b4d8">

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

1. Enable Paypal to an event only input "Price" amount and press "Save".
2. Change currency and see currency symbol updating. Hit "Save", browse "Event Types" and see the corresponding currency appearing next to the price.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
