### PR TITLE
fix: timezone of default schedule should change if profile timezone is updated

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -131,10 +131,15 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
       name: true,
       createdDate: true,
       locale: true,
+      schedules: {
+        select: {
+          id: true,
+        },
+      },
     },
   });
 
-  if (user.timeZone !== data.timeZone) {
+  if (user.timeZone !== data.timeZone && updatedUser.schedules.length > 0) {
     // on timezone change update timezone of default schedule
     const defaultScheduleId = await getDefaultScheduleId(user.id, prisma);
 

--- a/packages/trpc/server/routers/viewer/availability/schedule/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/schedule/create.handler.ts
@@ -54,6 +54,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
     },
   };
 
+  data.timeZone = user.timeZone;
+
   const schedule = await prisma.schedule.create({
     data,
   });


### PR DESCRIPTION
## What does this PR do?

What's currently happening? 
- When a schedule does not have timezone set in the db (which is the case if you never update your availability after creating it), then the schedule always has the timezone of the profile. 
- If a timezone is set, and the profile timezone is changed the schedule's timezones are not affected 

How do we want it? (discussed with @ciaranha) 
- When the timezone is changed in the profile, then the default timezone should also be changed to that timezone
- All other schedules should not be affected by the timezone change

Fixes #11452

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Create at least two availbilities 
- Change profile timezone 
- See that the timezone of the default availability changes and other timezones stay 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.