### PR TITLE
fix: availability for org team event 

### DIFF
--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -66,6 +66,8 @@ export const useScheduleForEvent = ({
 
   const pathname = usePathname();
 
+  const isTeam = !!event.data?.team?.parentId;
+
   return useSchedule({
     username: usernameFromStore ?? username,
     eventSlug: eventSlugFromStore ?? eventSlug,
@@ -76,6 +78,6 @@ export const useScheduleForEvent = ({
     rescheduleUid,
     month: monthFromStore ?? month,
     duration: durationFromStore ?? duration,
-    isTeamEvent: pathname.indexOf("/team/") !== -1,
+    isTeamEvent: pathname.indexOf("/team/") !== -1 || isTeam,
   });
 };


### PR DESCRIPTION
## What does this PR do?

There was a bug that sometimes a org team event didn't use the correct availability. This happened when there existed a non org event with the same event type slug. Then the availability of this event type was used instead. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create an org 
- Create a team event with the slug 'test'
- Create another account with a normal team 
- Create a team event with the slug 'test'
- Before the fix, the org team event used the availability of the wrong event type => check that both event types show the correct slots

