### PR TITLE
fix: only set stripe app data if it requires payment

### DIFF
--- a/packages/app-store/stripepayment/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/stripepayment/components/EventTypeAppCardInterface.tsx
@@ -48,13 +48,15 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
       .trim();
 
   useEffect(() => {
-    if (!getAppData("currency")) {
-      setAppData("currency", currencyOptions[0].value);
+    if (requirePayment) {
+      if (!getAppData("currency")) {
+        setAppData("currency", currencyOptions[0].value);
+      }
+      if (!getAppData("paymentOption")) {
+        setAppData("paymentOption", paymentOptions[0].value);
+      }
     }
-    if (!getAppData("paymentOption")) {
-      setAppData("paymentOption", paymentOptions[0].value);
-    }
-  }, []);
+  }, [requirePayment, getAppData, setAppData]);
 
   return (
     <AppCard


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes Alby bug: cannot save app price in event type

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Manually


- What is expected (happy path) to have (input and output)? Alby app is saved without setting any stripe data


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
