### PR TITLE
fix: prisma import in extract user route in Cal AI

### DIFF
--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/ai",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "author": "Cal.com Inc.",
   "dependencies": {

--- a/apps/ai/src/utils/extractUsers.ts
+++ b/apps/ai/src/utils/extractUsers.ts
@@ -1,8 +1,10 @@
+import prisma from "@calcom/prisma";
+
+import type { UserList } from "../types/user";
+
 /*
  * Extracts usernames (@Example) and emails (hi@example.com) from a string
  */
-import type { UserList } from "../types/user";
-
 export const extractUsers = async (text: string) => {
   const usernames = text.match(/(?<![a-zA-Z0-9_.])@[a-zA-Z0-9_]+/g)?.map((username) => username.slice(1));
   const emails = text.match(/[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+/g);

--- a/turbo.json
+++ b/turbo.json
@@ -47,6 +47,7 @@
     },
     "@calcom/ai#build": {
       "env": [
+        "FRONTEND_URL",
         "BACKEND_URL",
         "APP_ID",
         "APP_URL",


### PR DESCRIPTION
One line fix to extract users route. Previously prisma was not imported - but since it was tested locally, where prisma is globally declared, we missed this!