### PR TITLE
fix: Use only the first connected calendar as fallback to create event

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -231,7 +231,7 @@ export const createEvent = async (
 
   log.debug(
     "Creating calendar event",
-    JSON.stringify({
+    safeStringify({
       calEvent: getPiiFreeCalendarEvent(calEvent),
     })
   );
@@ -267,11 +267,20 @@ export const createEvent = async (
         })
     : undefined;
   if (!creationResult) {
-    logger.silly("createEvent failed", { success, uid, creationResult, originalEvent: calEvent, calError });
+    logger.error(
+      "createEvent failed",
+      safeStringify({
+        success,
+        uid,
+        creationResult,
+        originalEvent: getPiiFreeCalendarEvent(calEvent),
+        calError,
+      })
+    );
   }
   log.debug(
     "Created calendar event",
-    JSON.stringify({
+    safeStringify({
       calEvent: getPiiFreeCalendarEvent(calEvent),
       creationResult,
     })

--- a/packages/lib/piiFreeData.ts
+++ b/packages/lib/piiFreeData.ts
@@ -78,11 +78,11 @@ export function getPiiFreeDestinationCalendar(destinationCalendar: Partial<Desti
   return {
     integration: destinationCalendar.integration,
     userId: destinationCalendar.userId,
+    credentialId: destinationCalendar.credentialId,
     /**
      * Let's just get a boolean value for PII sensitive fields so that we atleast know if it's present or not
      */
     externalId: !!destinationCalendar.externalId,
-    credentialId: !!destinationCalendar.credentialId,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a scenario where duplicate calendar events are created across calendars. Actual steps to replicate the scenario aren't clear, but it happens when credentialId isn't set on the **destinationCalendar**.

In this case we now use the first connected calendar as the fallback instead of all connected calendars.

Ideally, this shouldn't be the case that there is a destination calendar with no credentialId, but this is damage control.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Install Google Calendar twice with two different accounts
- Choose the first calendar as the destinationCalendar in an event type
- Go to DB studio and manually set the credentialId to null for that destinationCalendar
<img width="1081" alt="image" src="https://github.com/calcom/cal.com/assets/1780212/e6008381-53cc-403c-9424-ebb366286f7d">
- Now, create a booking for the event and it would landup in both the Google calendars. This scenario is now fixed and it would go to only one calendar and we would log a warning in that scenario.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works -> I will be adding test for this scenario in the PR https://github.com/calcom/cal.com/pull/11670/files as there is some groundwork there that's been done to make it easy.
