### PR TITLE
fix: google calendar busy times

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -102,18 +102,21 @@ const BookerComponent = ({
   const bookerLayouts = event.data?.profile?.bookerLayouts || defaultBookerLayoutSettings;
   const animationScope = useBookerResizeAnimation(layout, bookerState);
   const totalWeekDays = 7;
-  const addonDays =
-    nonEmptyScheduleDays.length < extraDays
-      ? (extraDays - nonEmptyScheduleDays.length + 1) * totalWeekDays
-      : nonEmptyScheduleDays.length === extraDays
-      ? totalWeekDays
-      : 0;
+  const addonDays = nonEmptyScheduleDays.length < extraDays ? extraDays - nonEmptyScheduleDays.length + 2 : 0;
 
   // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
   if (nonEmptyScheduleDays.length !== 0)
     columnViewExtraDays.current =
-      Math.abs(dayjs(selectedDate).diff(availableSlots[availableSlots.length - 2], "day")) + addonDays;
+      Math.abs(
+        dayjs(selectedDate).diff(
+          availableSlots[
+            availableSlots.length <= extraDays ? availableSlots.length - 1 : availableSlots.length - 2
+          ],
+          "day"
+        )
+      ) + addonDays;
+
   const prefetchNextMonth =
     dayjs(date).month() !== dayjs(date).add(columnViewExtraDays.current, "day").month();
   const monthCount =

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -118,6 +118,7 @@ const BookerComponent = ({
       ) + addonDays;
 
   const prefetchNextMonth =
+    layout === BookerLayouts.COLUMN_VIEW &&
     dayjs(date).month() !== dayjs(date).add(columnViewExtraDays.current, "day").month();
   const monthCount =
     dayjs(date).add(1, "month").month() !== dayjs(date).add(columnViewExtraDays.current, "day").month()

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -102,21 +102,18 @@ const BookerComponent = ({
   const bookerLayouts = event.data?.profile?.bookerLayouts || defaultBookerLayoutSettings;
   const animationScope = useBookerResizeAnimation(layout, bookerState);
   const totalWeekDays = 7;
-  const addonDays = nonEmptyScheduleDays.length < extraDays ? extraDays - nonEmptyScheduleDays.length + 2 : 0;
+  const addonDays =
+    nonEmptyScheduleDays.length < extraDays
+      ? (extraDays - nonEmptyScheduleDays.length + 1) * totalWeekDays
+      : nonEmptyScheduleDays.length === extraDays
+      ? totalWeekDays
+      : 0;
 
   // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
   if (nonEmptyScheduleDays.length !== 0)
     columnViewExtraDays.current =
-      Math.abs(
-        dayjs(selectedDate).diff(
-          availableSlots[
-            availableSlots.length <= extraDays ? availableSlots.length - 1 : availableSlots.length - 2
-          ],
-          "day"
-        )
-      ) + addonDays;
-
+      Math.abs(dayjs(selectedDate).diff(availableSlots[availableSlots.length - 2], "day")) + addonDays;
   const prefetchNextMonth =
     layout === BookerLayouts.COLUMN_VIEW &&
     dayjs(date).month() !== dayjs(date).add(columnViewExtraDays.current, "day").month();


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following issue:
Busy times from Google Calendar didn't block out slots anymore after Nov 4. I could reproduce that with having everything set to NY timezone, but this probably also happens in other timezones.

The reason for that, is that the request `https://www.googleapis.com/calendar/v3/freeBusy` was throwing `The requested time range is too long`. 

Fixes #11688

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Connect Google calendar
- Add a busy event to calendar
- Check if the slots are blocked off in the availability (test after Nov 4)