### PR TITLE
fix: booking failure when we don't find credential matching the destination calendar integration name

### DIFF
--- a/apps/web/test/utils/bookingScenario/expects.ts
+++ b/apps/web/test/utils/bookingScenario/expects.ts
@@ -25,7 +25,7 @@ declare global {
           noIcs?: true;
           ics?: {
             filename: string;
-            iCalUID: string;
+            iCalUID?: string;
           };
         },
         to: string
@@ -41,9 +41,9 @@ expect.extend({
       //TODO: Support email HTML parsing to target specific elements
       htmlToContain?: string;
       to: string;
-      ics: {
+      ics?: {
         filename: string;
-        iCalUID: string;
+        iCalUID?: string;
       };
       noIcs: true;
     },
@@ -66,9 +66,10 @@ expect.extend({
     let isHtmlContained = true;
     let isToAddressExpected = true;
     const isIcsFilenameExpected = expectedEmail.ics ? ics?.filename === expectedEmail.ics.filename : true;
-    const isIcsUIDExpected = expectedEmail.ics
-      ? !!(icsObject ? icsObject[expectedEmail.ics.iCalUID] : null)
-      : true;
+    const isIcsUIDExpected =
+      expectedEmail.ics?.iCalUID !== undefined
+        ? !!(icsObject ? icsObject[expectedEmail.ics.iCalUID] : null)
+        : true;
 
     if (expectedEmail.htmlToContain) {
       isHtmlContained = testEmail.html.includes(expectedEmail.htmlToContain);
@@ -95,12 +96,12 @@ expect.extend({
         }
 
         if (!isIcsFilenameExpected) {
-          return `ICS Filename is not as expected. Expected:${expectedEmail.ics.filename} isn't equal to ${ics?.filename}`;
+          return `ICS Filename is not as expected. Expected:${expectedEmail.ics?.filename} isn't equal to ${ics?.filename}`;
         }
 
         if (!isIcsUIDExpected) {
           return `ICS UID is not as expected. Expected:${
-            expectedEmail.ics.iCalUID
+            expectedEmail.ics?.iCalUID
           } isn't present in ${JSON.stringify(icsObject)}`;
         }
         throw new Error("Unknown error");
@@ -187,7 +188,7 @@ export function expectSuccessfulBookingCreationEmails({
   emails: Fixtures["emails"];
   organizer: { email: string; name: string };
   booker: { email: string; name: string };
-  iCalUID: string;
+  iCalUID?: string;
 }) {
   expect(emails).toHaveEmail(
     {

--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -368,8 +368,9 @@ export default class EventManager {
         [] as DestinationCalendar[]
       );
       for (const destination of destinationCalendars) {
-        loggerWithEventDetails.silly("Creating Calendar event", JSON.stringify({ destination }));
+        loggerWithEventDetails.debug("Creating Calendar event", safeStringify({ destination }));
         if (destination.credentialId) {
+          loggerWithEventDetails.silly("destination has credentialId");
           let credential = this.calendarCredentials.find((c) => c.id === destination.credentialId);
           if (!credential) {
             // Fetch credential from DB
@@ -410,7 +411,6 @@ export default class EventManager {
             loggerWithEventDetails.warn(
               `No credentialId found for destination calendar, falling back to first found credential matching  destination.integration=${destination.integration}`,
               safeStringify({
-                event: getPiiFreeEventType(event),
                 destination: getPiiFreeDestinationCalendar(destination),
                 firstConnectedCalendar: getPiiFreeCredential(firstCalendarCredential),
               })


### PR DESCRIPTION
## What does this PR do?

![image](https://github.com/calcom/cal.com/assets/1780212/acfe57ea-e948-42f4-aaed-5a8f711e420b)
Ideally this should't be the case that there is a destinationCalendar but it has no credential. It looks like some of the existing event-types might have this problem.
Regression from #11668 
## Requirement/Documentation


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- 

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.