### PR TITLE
fix: buffer dropdown text

### DIFF
--- a/apps/web/components/eventtype/EventLimitsTab.tsx
+++ b/apps/web/components/eventtype/EventLimitsTab.tsx
@@ -189,7 +189,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupProps, "eventTy
                     value: 0,
                   },
                   ...[5, 10, 15, 20, 30, 45, 60, 90, 120].map((minutes) => ({
-                    label: `minutes ${t("minutes")}`,
+                    label: `${minutes} ${t("minutes")}`,
                     value: minutes,
                   })),
                 ];
@@ -225,7 +225,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupProps, "eventTy
                     value: 0,
                   },
                   ...[5, 10, 15, 20, 30, 45, 60, 90, 120].map((minutes) => ({
-                    label: `minutes ${t("minutes")}`,
+                    label: `${minutes} ${t("minutes")}`,
                     value: minutes,
                   })),
                 ];
@@ -272,7 +272,7 @@ export const EventLimitsTab = ({ eventType }: Pick<EventTypeSetupProps, "eventTy
                     value: -1,
                   },
                   ...[5, 10, 15, 20, 30, 45, 60, 75, 90, 105, 120].map((minutes) => ({
-                    label: `minutes ${t("minutes")}`,
+                    label: `${minutes} ${t("minutes")}`,
                     value: minutes,
                   })),
                 ];


### PR DESCRIPTION
## What does this PR do?

Before: 
<img width="492" alt="Screenshot 2023-10-05 at 09 40 52" src="https://github.com/calcom/cal.com/assets/30310907/b2d9fcef-6155-4a8f-971c-76c78145789f">

After: 
<img width="497" alt="Screenshot 2023-10-05 at 09 38 45" src="https://github.com/calcom/cal.com/assets/30310907/0044f7a0-172c-4014-97dd-ffe3f097d180">

