### PR TITLE
fix: remove subteam logo

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 
 import { sdkActionManager, useIsEmbed } from "@calcom/embed-core/embed-iframe";
+import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
 import EventTypeDescription from "@calcom/features/eventtypes/components/EventTypeDescription";
 import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
@@ -43,6 +44,8 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
   const teamName = team.name || "Nameless Team";
   const isBioEmpty = !team.bio || !team.bio.replace("<p><br></p>", "").length;
   const metadata = teamMetadataSchema.parse(team.metadata);
+  const orgBranding = useOrgBranding();
+  console.log("orgBranding", !!orgBranding, !!team.parent);
 
   useEffect(() => {
     telemetry.event(
@@ -124,12 +127,6 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
             <li key={i} className="hover:bg-muted w-full">
               <Link href={`/${ch.slug}`} className="flex items-center justify-between">
                 <div className="flex items-center px-5 py-5">
-                  <Avatar
-                    size="md"
-                    imageSrc={`/team/${ch.slug}/avatar.png`}
-                    alt="Team Logo"
-                    className="inline-flex justify-center"
-                  />
                   <div className="ms-3 inline-block truncate">
                     <span className="text-default text-sm font-bold">{ch.name}</span>
                     <span className="text-subtle block text-xs">
@@ -185,9 +182,11 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
           <div className="relative">
             <Avatar
               alt={teamName}
-              imageSrc={`${WEBAPP_URL}/${team.metadata?.isOrganization ? "org" : "team"}/${
-                team.slug
-              }/avatar.png`}
+              imageSrc={
+                !!team.parent && !!orgBranding
+                  ? `${orgBranding?.fullDomain}/org/${orgBranding?.slug}/avatar.png`
+                  : `${WEBAPP_URL}/${team.metadata?.isOrganization ? "org" : "team"}/${team.slug}/avatar.png`
+              }
               size="lg"
             />
           </div>

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -45,7 +45,6 @@ function TeamPage({ team, isUnpublished, markdownStrippedBio, isValidOrgDomain }
   const isBioEmpty = !team.bio || !team.bio.replace("<p><br></p>", "").length;
   const metadata = teamMetadataSchema.parse(team.metadata);
   const orgBranding = useOrgBranding();
-  console.log("orgBranding", !!orgBranding, !!team.parent);
 
   useEffect(() => {
     telemetry.event(

--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -61,7 +61,7 @@ export const EventMembers = ({ schedulingType, users, profile, entity }: EventMe
     image: "logo" in profile && profile.logo ? `${profile.logo}` : undefined,
     alt: profile.name || undefined,
     href: profile.username
-      ? `${CAL_URL}` + (pathname.indexOf("/team/") !== -1 ? "/team" : "") + `/${profile.username}`
+      ? `${CAL_URL}${pathname.indexOf("/team/") !== -1 ? "/team" : ""}/${profile.username}`
       : undefined,
   });
 

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -176,30 +176,37 @@ const ProfileView = () => {
                   mutation.mutate({ id: team.id, ...variables });
                 }
               }}>
-              <div className="flex items-center">
-                <Controller
-                  control={form.control}
-                  name="logo"
-                  render={({ field: { value } }) => (
-                    <>
-                      <Avatar alt="" imageSrc={getPlaceholderAvatar(value, team?.name as string)} size="lg" />
-                      <div className="ms-4">
-                        <ImageUploader
-                          target="avatar"
-                          id="avatar-upload"
-                          buttonMsg={t("update")}
-                          handleAvatarChange={(newLogo) => {
-                            form.setValue("logo", newLogo);
-                          }}
-                          imageSrc={value}
-                        />
-                      </div>
-                    </>
-                  )}
-                />
-              </div>
-
-              <hr className="border-subtle my-8" />
+              {!team.parent && (
+                <>
+                  <div className="flex items-center">
+                    <Controller
+                      control={form.control}
+                      name="logo"
+                      render={({ field: { value } }) => (
+                        <>
+                          <Avatar
+                            alt=""
+                            imageSrc={getPlaceholderAvatar(value, team?.name as string)}
+                            size="lg"
+                          />
+                          <div className="ms-4">
+                            <ImageUploader
+                              target="avatar"
+                              id="avatar-upload"
+                              buttonMsg={t("update")}
+                              handleAvatarChange={(newLogo) => {
+                                form.setValue("logo", newLogo);
+                              }}
+                              imageSrc={value}
+                            />
+                          </div>
+                        </>
+                      )}
+                    />
+                  </div>
+                  <hr className="border-subtle my-8" />
+                </>
+              )}
 
               <Controller
                 control={form.control}

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -375,11 +375,13 @@ const SettingsSidebarContainer = ({
                                       <ChevronRight className="h-4 w-4" />
                                     )}
                                   </div>
-                                  <img
-                                    src={getPlaceholderAvatar(team.logo, team?.name as string)}
-                                    className="h-[16px] w-[16px] self-start rounded-full stroke-[2px] ltr:mr-2 rtl:ml-2 md:mt-0"
-                                    alt={team.name || "Team logo"}
-                                  />
+                                  {!team.parentId && (
+                                    <img
+                                      src={getPlaceholderAvatar(team.logo, team?.name as string)}
+                                      className="h-[16px] w-[16px] self-start rounded-full stroke-[2px] ltr:mr-2 rtl:ml-2 md:mt-0"
+                                      alt={team.name || "Team logo"}
+                                    />
+                                  )}
                                   <p className="w-1/2 truncate">{team.name}</p>
                                   {!team.accepted && (
                                     <Badge className="ms-3" variant="orange">
@@ -517,11 +519,13 @@ const SettingsSidebarContainer = ({
                                       <ChevronRight className="h-4 w-4" />
                                     )}
                                   </div>
-                                  <img
-                                    src={getPlaceholderAvatar(otherTeam.logo, otherTeam?.name as string)}
-                                    className="h-[16px] w-[16px] self-start rounded-full stroke-[2px] ltr:mr-2 rtl:ml-2 md:mt-0"
-                                    alt={otherTeam.name || "Team logo"}
-                                  />
+                                  {!otherTeam.parentId && (
+                                    <img
+                                      src={getPlaceholderAvatar(otherTeam.logo, otherTeam?.name as string)}
+                                      className="h-[16px] w-[16px] self-start rounded-full stroke-[2px] ltr:mr-2 rtl:ml-2 md:mt-0"
+                                      alt={otherTeam.name || "Team logo"}
+                                    />
+                                  )}
                                   <p className="w-1/2 truncate">{otherTeam.name}</p>
                                 </div>
                               </CollapsibleTrigger>


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/11662

1) Remove subteam logo in sidebar

<img width="234" alt="Screenshot 2023-10-05 at 9 08 57 PM" src="https://github.com/calcom/cal.com/assets/53316345/50637655-ad0b-4cf4-89ef-cb79ab283c06">

2) Removed logo of team from here

<img width="1512" alt="Screenshot 2023-10-05 at 9 05 23 PM" src="https://github.com/calcom/cal.com/assets/53316345/80b01b56-2f25-446a-a5b2-8d562e853dc3">

3) Used Org logo on this page

<img width="1512" alt="Screenshot 2023-10-05 at 9 05 37 PM" src="https://github.com/calcom/cal.com/assets/53316345/d87daeb5-f9cb-4ef3-a7fd-c544a0d49d47">

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
