### PR TITLE
chore: ensure compat type definitions do not break existing types

### DIFF
--- a/packages/lib/hooks/useRouterQuery.ts
+++ b/packages/lib/hooks/useRouterQuery.ts
@@ -3,8 +3,13 @@ import { useSearchParams } from "next/navigation";
 /**
  * An alternative to Object.fromEntries that allows duplicate keys.
  */
-function fromEntriesWithDuplicateKeys(entries: ReturnType<ReturnType<typeof useSearchParams>["entries"]>) {
+function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, string]> | null) {
   const result: Record<string, string | string[]> = {};
+
+  if (entries === null) {
+    return result;
+  }
+
   // Consider setting atleast ES2015 as target
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -31,6 +36,6 @@ function fromEntriesWithDuplicateKeys(entries: ReturnType<ReturnType<typeof useS
  */
 export const useRouterQuery = () => {
   const searchParams = useSearchParams();
-  const routerQuery = fromEntriesWithDuplicateKeys(searchParams.entries());
+  const routerQuery = fromEntriesWithDuplicateKeys(searchParams?.entries() ?? null);
   return routerQuery;
 };

--- a/packages/lib/hooks/useTypedQuery.ts
+++ b/packages/lib/hooks/useTypedQuery.ts
@@ -96,7 +96,9 @@ export function useTypedQuery<T extends z.AnyZodObject>(schema: T) {
 
   // Remove all query params from the URL
   function removeAllQueryParams() {
-    router.replace(pathname);
+    if (pathname !== null) {
+      router.replace(pathname);
+    }
   }
 
   return {

--- a/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
+++ b/packages/lib/hooks/useUrlMatchesCurrentUrl.ts
@@ -7,7 +7,7 @@ export const useUrlMatchesCurrentUrl = (url: string) => {
   // It can certainly have null value https://nextjs.org/docs/app/api-reference/functions/use-pathname#:~:text=usePathname%20can%20return%20null%20when%20a%20fallback%20route%20is%20being%20rendered%20or%20when%20a%20pages%20directory%20page%20has%20been%20automatically%20statically%20optimized%20by%20Next.js%20and%20the%20router%20is%20not%20ready.
   const pathname = usePathname() as null | string;
   const searchParams = useSearchParams();
-  const query = searchParams.toString();
+  const query = searchParams?.toString();
   let pathnameWithQuery;
   if (query) {
     pathnameWithQuery = `${pathname}?${query}`;

--- a/packages/lib/next-seo.config.ts
+++ b/packages/lib/next-seo.config.ts
@@ -47,6 +47,12 @@ export const seoConfig: {
  * @param path NextJS' useRouter().asPath
  * @returns
  */
-export const buildCanonical = ({ origin, path }: { origin: Location["origin"]; path: Router["asPath"] }) => {
-  return `${origin}${path === "/" ? "" : path}`.split("?")[0];
+export const buildCanonical = ({
+  origin,
+  path,
+}: {
+  origin: Location["origin"];
+  path: Router["asPath"] | null;
+}) => {
+  return `${origin}${path === "/" ? "" : path ?? ""}`.split("?")[0];
 };

--- a/packages/lib/next-seo.config.ts
+++ b/packages/lib/next-seo.config.ts
@@ -54,5 +54,5 @@ export const buildCanonical = ({
   origin: Location["origin"];
   path: Router["asPath"] | null;
 }) => {
-  return `${origin}${path === "/" ? "" : path ?? ""}`.split("?")[0];
+  return `${origin}${path === "/" ? "" : path}`.split("?")[0];
 };

--- a/packages/ui/components/apps/AllApps.tsx
+++ b/packages/ui/components/apps/AllApps.tsx
@@ -109,12 +109,10 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
           <li
             key={pos}
             onClick={() => {
-              if (pathname === null) {
-                return;
-              }
-
               if (selectedCategory === cat) {
-                router.replace(pathname);
+                if (pathname !== null) {
+                  router.replace(pathname);
+                }
               } else {
                 const _searchParams = new URLSearchParams(searchParams ?? undefined);
                 _searchParams.set("category", cat);

--- a/packages/ui/components/apps/AllApps.tsx
+++ b/packages/ui/components/apps/AllApps.tsx
@@ -95,7 +95,9 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
         ref={ref}>
         <li
           onClick={() => {
-            router.replace(pathname);
+            if (pathname !== null) {
+              router.replace(pathname);
+            }
           }}
           className={classNames(
             selectedCategory === null ? "bg-emphasis text-default" : "bg-muted text-emphasis",
@@ -107,10 +109,14 @@ function CategoryTab({ selectedCategory, categories, searchText }: CategoryTabPr
           <li
             key={pos}
             onClick={() => {
+              if (pathname === null) {
+                return;
+              }
+
               if (selectedCategory === cat) {
                 router.replace(pathname);
               } else {
-                const _searchParams = new URLSearchParams(searchParams);
+                const _searchParams = new URLSearchParams(searchParams ?? undefined);
                 _searchParams.set("category", cat);
                 router.replace(`${pathname}?${_searchParams.toString()}`);
               }

--- a/packages/ui/components/apps/AppCard.tsx
+++ b/packages/ui/components/apps/AppCard.tsx
@@ -190,7 +190,9 @@ const InstallAppButtonChild = ({
   const mutation = useAddAppMutation(null, {
     onSuccess: (data) => {
       // Refresh SSR page content without actual reload
-      router.replace(pathname);
+      if (pathname !== null) {
+        router.replace(pathname);
+      }
       if (data?.setupPending) return;
       showToast(t("app_successfully_installed"), "success");
     },

--- a/packages/ui/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/components/breadcrumb/Breadcrumb.tsx
@@ -50,7 +50,7 @@ export const BreadcrumbContainer = () => {
   useEffect(() => {
     const rawPath = pathname; // Pathname doesn't include search params anymore
 
-    let pathArray = rawPath.split("/");
+    let pathArray = rawPath?.split("/") ?? [];
     pathArray.shift();
 
     pathArray = pathArray.filter((path) => path !== "");

--- a/packages/ui/components/createButton/CreateButton.tsx
+++ b/packages/ui/components/createButton/CreateButton.tsx
@@ -60,7 +60,7 @@ export function CreateButton(props: CreateBtnProps) {
 
   // inject selection data into url for correct router history
   const openModal = (option: Option) => {
-    const _searchParams = new URLSearchParams(searchParams);
+    const _searchParams = new URLSearchParams(searchParams ?? undefined);
     function setParamsIfDefined(key: string, value: string | number | boolean | null | undefined) {
       if (value !== undefined && value !== null) _searchParams.set(key, value.toString());
     }
@@ -136,7 +136,7 @@ export function CreateButton(props: CreateBtnProps) {
           </DropdownMenuContent>
         </Dropdown>
       )}
-      {searchParams.get("dialog") === "new" && CreateDialog}
+      {searchParams?.get("dialog") === "new" && CreateDialog}
     </>
   );
 }

--- a/packages/ui/components/dialog/Dialog.tsx
+++ b/packages/ui/components/dialog/Dialog.tsx
@@ -28,7 +28,7 @@ export function Dialog(props: DialogProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const newSearchParams = new URLSearchParams(searchParams);
+  const newSearchParams = new URLSearchParams(searchParams ?? undefined);
   const { children, name, ...dialogProps } = props;
 
   // only used if name is set


### PR DESCRIPTION
## What does this PR do?

This PR introduces changes to handle nullable return value from Next.js hooks (`useSearchParams`, `useParams`, `usePathname` and `useRouter`).
If you add the `app` directory to the `web` directory and run `yarn build`, the types will be updated by Next.js builder/plugin and the projects will then include the compat type definitions provided by Next.js.

This mechanism is coded here: https://github.com/vercel/next.js/blob/524b31513a58e58e15862ac8aa3f27da8a47a267/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts#L54

The example compat type definition is here: https://github.com/vercel/next.js/blob/524b31513a58e58e15862ac8aa3f27da8a47a267/packages/next/navigation-types/compat/navigation.d.ts

Fixes # (issue)
There is no reported issue, this problem becomes visible only when the `app` directory is added and someone runs `yarn type-check`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
This requires the entire app check, because I touched
* `fromEntriesWithDuplicateKeys` in `packages/lib/hooks/useRouterQuery.ts` which is used in `useRouterQuery`, which in turn is used in 19 pages
* the metadata generating utilities (`packages/lib/next-seo.config.ts`)

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
