### PR TITLE
feat: check availability only for first two occurrences while booking a recurring event

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -413,13 +413,14 @@ async function ensureAvailableUsers(
         recurringDatesInfo?.currentRecurringIndex === 0 &&
         recurringDatesInfo.allRecurringDates
       ) {
-        const allBookingDates = recurringDatesInfo.allRecurringDates.map((strDate) => new Date(strDate));
+        const firstTwoRecurringDates = recurringDatesInfo.allRecurringDates.slice(0, 2);
+        const firstTwoBookingDates = firstTwoRecurringDates.map((strDate) => new Date(strDate));
         // Go through each date for the recurring event and check if each one's availability
         // DONE: Decreased computational complexity from O(2^n) to O(n) by refactoring this loop to stop
         // running at the first unavailable time.
         let i = 0;
-        while (!foundConflict && i < allBookingDates.length) {
-          foundConflict = checkForConflicts(bufferedBusyTimes, allBookingDates[i++], duration);
+        while (!foundConflict && i < firstTwoBookingDates.length) {
+          foundConflict = checkForConflicts(bufferedBusyTimes, firstTwoBookingDates[i++], duration);
         }
       } else {
         foundConflict = checkForConflicts(bufferedBusyTimes, input.dateFrom, duration);

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -413,8 +413,9 @@ async function ensureAvailableUsers(
         recurringDatesInfo?.currentRecurringIndex === 0 &&
         recurringDatesInfo.allRecurringDates
       ) {
-        const firstTwoRecurringDates = recurringDatesInfo.allRecurringDates.slice(0, 2);
-        const firstTwoBookingDates = firstTwoRecurringDates.map((strDate) => new Date(strDate));
+        const firstTwoBookingDates = recurringDatesInfo.allRecurringDates
+          .slice(0, 2)
+          .map((strDate) => new Date(strDate));
         // Go through each date for the recurring event and check if each one's availability
         // DONE: Decreased computational complexity from O(2^n) to O(n) by refactoring this loop to stop
         // running at the first unavailable time.


### PR DESCRIPTION
## What does this PR do?

In recurring events, check for availability conflicts only for the first two occurrences.

Fixes #11654 

## Requirement/Documentation

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Create recurring event.
Have multiple occurrences for the event (preferably greater than 2).
Make sure to have availability conflicts for the occurrences past the first two occurrences.
Event should be allowed to create.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
