### PR TITLE
fix: page navigation with iframes

### DIFF
--- a/apps/web/components/apps/AppPage.tsx
+++ b/apps/web/components/apps/AppPage.tsx
@@ -126,7 +126,7 @@ export const AppPage = ({
                 <div
                   key={`iframe-${index}`}
                   className="mr-4 max-h-full min-h-[315px] min-w-[90%] max-w-full snap-center last:mb-0 lg:mb-4 lg:mr-0 [&_iframe]:h-full [&_iframe]:min-h-[315px] [&_iframe]:w-full">
-                  <iframe allowFullScreen {...descriptionItem.iframe} />
+                  <iframe key={`iframe_${index}`} allowFullScreen {...descriptionItem.iframe} />
                 </div>
               ) : (
                 <img

--- a/packages/features/embed/lib/EmbedTabs.tsx
+++ b/packages/features/embed/lib/EmbedTabs.tsx
@@ -47,19 +47,17 @@ export const tabs = [
             className="text-default bg-default selection:bg-subtle h-[calc(100%-50px)] font-mono"
             style={{ resize: "none", overflow: "auto" }}
             readOnly
-            value={
-              `<!-- Cal ${embedType} embed code begins -->\n` +
-              (embedType === "inline"
+            value={`<!-- Cal ${embedType} embed code begins -->\n${
+              embedType === "inline"
                 ? `<div style="width:${getDimension(previewState.inline.width)};height:${getDimension(
                     previewState.inline.height
                   )};overflow:scroll" id="my-cal-inline"></div>\n`
-                : "") +
-              `<script type="text/javascript">
+                : ""
+            }<script type="text/javascript">
   ${embedSnippetString}
   ${getEmbedTypeSpecificString({ embedFramework: "HTML", embedType, calLink, previewState, embedCalOrigin })}
   </script>
-  <!-- Cal ${embedType} embed code ends -->`
-            }
+  <!-- Cal ${embedType} embed code ends -->`}
           />
           <p className="text-subtle hidden text-sm">{t("need_help_embedding")}</p>
         </>
@@ -95,10 +93,10 @@ export const tabs = [
             readOnly
             style={{ resize: "none", overflow: "auto" }}
             value={`/* First make sure that you have installed the package */
-  
+
   /* If you are using yarn */
   // yarn add @calcom/embed-react
-  
+
   /* If you are using npm */
   // npm install @calcom/embed-react
   ${getEmbedTypeSpecificString({ embedFramework: "react", embedType, calLink, previewState, embedCalOrigin })}
@@ -126,6 +124,7 @@ export const tabs = [
       }
       return (
         <iframe
+          key={EMBED_PREVIEW_HTML_URL}
           ref={ref as typeof ref & MutableRefObject<HTMLIFrameElement>}
           data-testid="embed-preview"
           className="h-[100vh] border"


### PR DESCRIPTION
/claim #11558

## What does this PR do?

Iframe shares browser history, this messesup navigating pages back & forth if the same iframe is reused. To solve this, we need to recreate the iframe for every src url, as we are using react by passing `key` prop react dom interprets it as new element and it solves problem.

## Requirement/Documentation

NA

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Cal embed on any web page shouldn't break browser's history stack, navigation (back & forward push) should work fine.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings
- I have checked if new and existing unit tests pass locally with my changes
