### PR TITLE
fix: [CAL-2593]  Uploading a CSV File does not comma separate the values

### DIFF
--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -143,11 +143,24 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
 
     if (file) {
       const reader = new FileReader();
-
+      const emailRegex = /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i;
       reader.onload = (e) => {
         const contents = e?.target?.result as string;
-        const values = contents?.split(",").map((email) => email.trim().toLocaleLowerCase());
-        newMemberFormMethods.setValue("emailOrUsername", values);
+        const lines = contents.split("\n");
+        const validEmails = [];
+        for (const line of lines) {
+          const columns = line.split(",");
+          for (const column of columns) {
+            const email = column.trim().toLowerCase();
+
+            if (emailRegex.test(email)) {
+              validEmails.push(email);
+              break; // Stop checking columns if a valid email is found in this line
+            }
+          }
+        }
+
+        newMemberFormMethods.setValue("emailOrUsername", validEmails);
       };
 
       reader.readAsText(file);

--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -149,7 +149,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
         const lines = contents.split("\n");
         const validEmails = [];
         for (const line of lines) {
-          const columns = line.split(",");
+          const columns = line.split(/,|;|\|| /);
           for (const column of columns) {
             const email = column.trim().toLowerCase();
 


### PR DESCRIPTION
## What does this PR do?
This pr separates the valid email addresses so that team owners can bulk import their team members using a CSV file. When a user uploads the CSV file, it goes through every column because we don't know in which column the email is present. It checks whether it is a valid email; if it is, then it adds it to the email list and moves to the next line.

Fixes #11742 

Before Change 
 Loom Video: https://www.loom.com/share/b616e942a55141fbb62cb96366c10d4a?sid=67a9582f-a0d7-41ce-9a89-492a7490d6d4

After making changes
Loom Video: https://www.loom.com/share/857d4a5d5b9d44f498c3b0db23920bba?sid=2153fb9e-813c-44a0-b434-17fe769ae9a5

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a team
- Go to settings/teams and then choose the team you had created
- Go to members section of that team
- Click on add and import bulk members.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
