### PR TITLE
bug: displays a toast when the timings are overriden for a date …

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1617,6 +1617,7 @@
   "date_overrides_unavailable": "Unavailable all day",
   "date_overrides_mark_all_day_unavailable_one": "Mark unavailable (All day)",
   "date_overrides_mark_all_day_unavailable_other": "Mark unavailable on selected dates",
+  "date_timings_overridden":"Timings Overridden",
   "date_overrides_add_btn": "Add Override",
   "date_overrides_update_btn": "Update Override",
   "event_type_duplicate_copy_text": "{{slug}}-copy",

--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -9,14 +9,15 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import type { WorkingHours } from "@calcom/types/schedule";
 import {
-  Dialog,
-  DialogContent,
-  DialogTrigger,
-  DialogHeader,
-  DialogClose,
-  Switch,
-  Form,
   Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTrigger,
+  Form,
+  Switch,
+  showToast,
 } from "@calcom/ui";
 
 import DatePicker from "../../calendars/DatePicker";
@@ -185,6 +186,9 @@ const DateOverrideForm = ({
               className="ml-2"
               color="primary"
               type="submit"
+              onClick={() => {
+                showToast(t("date_timings_overridden"), "success");
+              }}
               disabled={selectedDates.length === 0}
               data-testid="add-override-submit-btn">
               {value ? t("date_overrides_update_btn") : t("date_overrides_add_btn")}


### PR DESCRIPTION

## What does this PR do?

Adds a popup when the timings for a date are overridden

Fixes #11762


- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)



