### PR TITLE
fix: update package.json to export typescript types

### DIFF
--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -39,7 +39,8 @@
   "exports": {
     ".": {
       "import": "./dist/Cal.es.mjs",
-      "require": "./dist/Cal.umd.js"
+      "require": "./dist/Cal.umd.js",
+      "types": "./dist/embed-react/src/index.d.ts"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
updated package to fix the problem of types not properly exported so it fails at build time if you are using typescript and also not type completions and erros while working with typescript

## What does this PR do?

<!-- added the types to the export object in the package.json of the react-embed to fix type erros and erros at build time -->

Fixes#11301  # 11408


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- try adding the package as a dependency to a react typescript project import it and then try building the project  -->

- Are there environment variables that should be set? no
- What are the minimal test data to have? a react-ts template with the react embed import as a dependecy 
- What is expected (happy path) to have (input and output)? the project builds correctly
- Any other important info that could help to test that PR

## Mandatory Tasks

- [* ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->


