### PR TITLE
feat: Add & Edit event-type children via api to allow Managed Events

### DIFF
--- a/apps/api/pages/api/event-types/[id]/_patch.ts
+++ b/apps/api/pages/api/event-types/[id]/_patch.ts
@@ -209,15 +209,23 @@ export async function patchHandler(req: NextApiRequest) {
     hosts = [],
     bookingLimits,
     durationLimits,
-    /** FIXME: Updating event-type children from API not supported for now  */
-    children: _,
+    children: parsedChildren,
     ...parsedBody
   } = schemaEventTypeEditBodyParams.parse(body);
+
+  // validate children ownership
 
   const data: Prisma.EventTypeUpdateArgs["data"] = {
     ...parsedBody,
     bookingLimits: bookingLimits === null ? Prisma.DbNull : bookingLimits,
     durationLimits: durationLimits === null ? Prisma.DbNull : durationLimits,
+    ...(parsedChildren
+      ? {
+          children: {
+            connect: parsedChildren.map((child) => ({ id: child.id })),
+          },
+        }
+      : {}),
   };
 
   if (hosts) {

--- a/apps/api/pages/api/event-types/[id]/_patch.ts
+++ b/apps/api/pages/api/event-types/[id]/_patch.ts
@@ -213,16 +213,19 @@ export async function patchHandler(req: NextApiRequest) {
     ...parsedBody
   } = schemaEventTypeEditBodyParams.parse(body);
 
-  // validate children ownership
+  const validatedChildren =
+    parsedBody.teamId && parsedChildren
+      ? parsedChildren.filter((child) => isUserMemberOfTeam(parsedBody.teamId, child.userId))
+      : [];
 
   const data: Prisma.EventTypeUpdateArgs["data"] = {
     ...parsedBody,
     bookingLimits: bookingLimits === null ? Prisma.DbNull : bookingLimits,
     durationLimits: durationLimits === null ? Prisma.DbNull : durationLimits,
-    ...(parsedChildren
+    ...(validatedChildren
       ? {
           children: {
-            connect: parsedChildren.map((child) => ({ id: child.id })),
+            connect: validatedChildren.map((child) => ({ id: child.id })),
           },
         }
       : {}),

--- a/apps/api/pages/api/event-types/_post.ts
+++ b/apps/api/pages/api/event-types/_post.ts
@@ -273,7 +273,6 @@ async function postHandler(req: NextApiRequest) {
     ...parsedBody
   } = schemaEventTypeCreateBodyParams.parse(body || {});
 
-  // validate that these child event type owners are members of parent
   const validatedChildren =
     parsedBody.teamId && parsedChildren
       ? parsedChildren.filter((child) => isUserMemberOfTeam(parsedBody.teamId, child.userId))

--- a/apps/api/pages/api/event-types/_utils/checkUserMembership.ts
+++ b/apps/api/pages/api/event-types/_utils/checkUserMembership.ts
@@ -12,6 +12,12 @@ import { HttpError } from "@calcom/lib/http-error";
  *                     or if the user isn't a member of the associated team.
  */
 export default async function checkUserMembership(parentId: number, userId?: number) {
+  if (!userId) {
+    throw new HttpError({
+      statusCode: 400,
+      message: "Invalid request.",
+    });
+  }
   const parentEventType = await prisma.eventType.findUnique({
     where: {
       id: parentId,

--- a/apps/api/pages/api/event-types/_utils/isUserMemberOfTeam.ts
+++ b/apps/api/pages/api/event-types/_utils/isUserMemberOfTeam.ts
@@ -1,0 +1,24 @@
+import { HttpError } from "@calcom/lib/http-error";
+
+export default async function isUserMemberOfTeam(teamId?: number | null, userId?: number) {
+  if (!teamId || !userId) {
+    throw new HttpError({
+      statusCode: 400,
+      message: "Bad request.",
+    });
+  }
+  const teamMember = await prisma.membership.findFirst({
+    where: {
+      teamId: teamId,
+      userId: userId,
+      accepted: true,
+    },
+  });
+
+  if (!teamMember) {
+    throw new HttpError({
+      statusCode: 400,
+      message: "User is not a team member.",
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This PR follows up on #11714 and allows add and edit of children via API for Managed Events.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

- NA

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- API calls to event-type endpoint with Children array of structure:
```
{
  id: <eventTypeId>,
  userId: <userId>,
}
```
Should now connect the Managed Event with the Child in `children` field

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

