### PR TITLE
fix: Bring back dir attr using Intl

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -52,9 +52,7 @@ class MyDocument extends Document<Props> {
     const nonce = nonceParsed.success ? nonceParsed.data : "";
 
     const intlLocale = new Intl.Locale(newLocale);
-    // INFO: Typescript does not know about the Intl.Locale textInfo attribute
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
+    // @ts-expect-error INFO: Typescript does not know about the Intl.Locale textInfo attribute
     const direction = intlLocale.textInfo?.direction;
     if (!direction) {
       throw new Error("NodeJS major breaking change detected, use getTextInfo() instead.");

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -52,6 +52,7 @@ class MyDocument extends Document<Props> {
     const nonce = nonceParsed.success ? nonceParsed.data : "";
 
     const intlLocale = new Intl.Locale(newLocale);
+    // INFO: Typescript does not know about the Intl.Locale textInfo attribute
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     const direction = intlLocale.textInfo?.direction;

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -50,9 +50,19 @@ class MyDocument extends Document<Props> {
 
     const nonceParsed = z.string().safeParse(this.props.nonce);
     const nonce = nonceParsed.success ? nonceParsed.data : "";
+
+    const intlLocale = new Intl.Locale(newLocale);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const direction = intlLocale.textInfo?.direction;
+    if (!direction) {
+      throw new Error("NodeJS major breaking change detected, use getTextInfo() instead.");
+    }
+
     return (
       <Html
         lang={newLocale}
+        dir={direction}
         style={embedColorScheme ? { colorScheme: embedColorScheme as string } : undefined}>
         <Head nonce={nonce}>
           <script


### PR DESCRIPTION
## What does this PR do?

Uses experimental intl features to determine dir, but as it's server only we can depend on it for as long our nodejs version remains the same. Added an internal error to be very vocal when this changes.

Fixes #11805