### PR TITLE
fix: fetching booking with null responses from API

### DIFF
--- a/apps/api/lib/validations/booking.ts
+++ b/apps/api/lib/validations/booking.ts
@@ -58,7 +58,7 @@ export const schemaBookingReadPublic = Booking.extend({
       })
     )
     .optional(),
-  responses: z.record(z.any()),
+  responses: z.record(z.any()).nullable(),
 }).pick({
   id: true,
   userId: true,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [#11626](https://github.com/calcom/cal.com/issues/11626)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- To reproduce the error, follow the steps in the issue (create a null response booking and fetch bookings)
- Without this patch you should get `invalid_type in 'responses': Expected object, received null`
- With this patch, you should get your bookings

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

