### PR TITLE
fix: newLocale fallback to 'en' locale

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -46,7 +46,8 @@ class MyDocument extends Document<Props> {
   }
 
   render() {
-    const { isEmbed, embedColorScheme, newLocale } = this.props;
+    const { isEmbed, embedColorScheme } = this.props;
+    const newLocale = this.props.newLocale || "en";
 
     const nonceParsed = z.string().safeParse(this.props.nonce);
     const nonce = nonceParsed.success ? nonceParsed.data : "";


### PR DESCRIPTION
## What does this PR do?

If newLocale is falsy we default to "en"