### PR TITLE
fix: /event-type-single: Button icons tooltips opening out of view

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -250,7 +250,7 @@ function EventTypeSingleLayout({
       title={eventType.title + " | " + t("event_type")}
       heading={eventType.title}
       CTA={
-        <div className="flex items-center justify-end">
+        <div className="flex items-center justify-end p-2">
           {!eventType.metadata?.managedEventConfig && (
             <>
               <div


### PR DESCRIPTION
## What does this PR do?

fix: event-type-single: Button icons tooltips opening out of view due to padding issue
now
<img width="412" alt="Screenshot 2023-10-11 at 12 41 11 PM" src="https://github.com/calcom/cal.com/assets/116630390/377f149f-86bd-4a26-ab24-cbcbfa5b9d8b">

Fixes #11812 



