### PR TITLE
fix: overlay-switch-media-query

### DIFF
--- a/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarContainer.tsx
+++ b/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarContainer.tsx
@@ -104,7 +104,11 @@ export function OverlayCalendarContainer() {
 
   return (
     <>
-      <div className={classNames("hidden gap-2", layout === "week_view" ? "lg:flex" : "md:flex")}>
+      <div
+        className={classNames(
+          "hidden gap-2",
+          layout === "week_view" || layout === "column_view" ? "xl:flex" : "md:flex"
+        )}>
         <div className="flex items-center gap-2 pr-2">
           <Switch
             data-testid="overlay-calendar-switch"


### PR DESCRIPTION
Improve media query on hiding overflow containter to prevent overflow on tablet devices