### PR TITLE
fix: Button icons tooltips opening out of view due to padding issue

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -1008,7 +1008,7 @@ function MainContainer({
     <main className="bg-default relative z-0 flex-1 focus:outline-none">
       {/* show top navigation for md and smaller (tablet and phones) */}
       {TopNavContainerProp}
-      <div className="max-w-full px-2 py-4 lg:px-6">
+      <div className="max-w-full px-2 pb-4 pt-8 lg:px-6">
         <ErrorBoundary>
           {!props.withoutMain ? <ShellMain {...props}>{props.children}</ShellMain> : props.children}
         </ErrorBoundary>


### PR DESCRIPTION
## What does this PR do?

Increased the padding at the top of the event types screen so now the tooltips are in view.

Fixes #11812 

<img width="1440" alt="Screenshot 2023-10-11 at 4 44 08 PM" src="https://github.com/calcom/cal.com/assets/94699055/a9f7ffc3-ae3f-4cfa-ab31-54d29feae957">

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
