### PR TITLE
fix: Change sidebar skeleton width to w-full, better for i18n

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -678,7 +678,7 @@ const NavigationItem: React.FC<{
               {item.badge && item.badge}
             </span>
           ) : (
-            <SkeletonText style={{ width: `${item.name.length * 10}px` }} className="h-[20px]" />
+            <SkeletonText className="h-[20px] w-full" />
           )}
         </Link>
       </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Spotted & fixed. Before and after:

![image](https://github.com/calcom/cal.com/assets/1046695/be3bd854-2273-45c4-99e4-02ff9be3d184)
![image](https://github.com/calcom/cal.com/assets/1046695/0c3333d4-16db-4762-97a3-600da59bcaa0)
