### PR TITLE
fix: validate if the parsed locale is alphabetical

### DIFF
--- a/packages/features/auth/lib/getLocale.ts
+++ b/packages/features/auth/lib/getLocale.ts
@@ -28,6 +28,7 @@ export const getLocale = async (req: GetTokenParams["req"]): Promise<string> => 
     req.headers instanceof Headers ? req.headers.get("accept-language") : req.headers["accept-language"];
 
   const languages = acceptLanguage ? parse(acceptLanguage) : [];
+  const code: string = languages[0]?.code ?? "";
 
-  return languages[0]?.code || "en";
+  return /^[a-zA-Z]+$/.test(code) ? code : "en";
 };


### PR DESCRIPTION
## What does this PR do?

It validates if the locale coming from parsing the `accept-language-parser` library is alphabetical (e.g. `en`, `de`, etc.).
In case of some bots, the header might contain the asterisk locale (`*`), which we simply should convert to `en`.

Fixes # (issue)
It fixes the 500 errors for HEAD requests, likely coming from the crawlers or bots, potentially CDN.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
We should check if:
1. we still get 500 errors for specific HEAD requests
2. users with rational locale settings in the browser should access the page in their locale

## Checklist
- I haven't checked if my PR needs changes to the documentation
