### PR TITLE
fix: changed color of request reschedule icon to improve visibility

### DIFF
--- a/apps/web/components/dialog/RescheduleDialog.tsx
+++ b/apps/web/components/dialog/RescheduleDialog.tsx
@@ -44,7 +44,7 @@ export const RescheduleDialog = (props: IRescheduleDialog) => {
       <DialogContent enableOverflow>
         <div className="flex flex-row space-x-3">
           <div className="flex h-10 w-10 flex-shrink-0 justify-center rounded-full bg-[#FAFAFA]">
-            <Clock className="m-auto h-6 w-6" />
+            <Clock className=" light:bg-invert m-auto h-6 w-6 dark:invert" />
           </div>
           <div className="pt-1">
             <DialogHeader title={t("send_reschedule_request")} />


### PR DESCRIPTION
## What does this PR do?
**This pr changed the clock icon color so that it can be visible on both light and dark mode** 

Fixes #11829 
Before making change
![ff](https://github.com/calcom/cal.com/assets/66114276/d7525e9c-4629-4036-ba05-d7d8a9d80a13)

## After making changes
**Dark Mode** 
![image](https://github.com/calcom/cal.com/assets/66114276/aa2fcd9b-74dc-42ee-aed2-78be50245f29)

**Light mode**
![image](https://github.com/calcom/cal.com/assets/66114276/541e03a2-3860-436d-94b0-2e3163960f18)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Create a new booking
- After that go to upcoming booking section and request reschedule and check the reschedule icon.
