### PR TITLE
fix: inconsistent timezones in e2e tests

### DIFF
--- a/apps/web/playwright/fixtures/bookings.ts
+++ b/apps/web/playwright/fixtures/bookings.ts
@@ -3,12 +3,15 @@ import type { Booking, Prisma } from "@prisma/client";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 
-import dayjs from "@calcom/dayjs";
+import _dayjs from "@calcom/dayjs";
 import { prisma } from "@calcom/prisma";
 
 const translator = short();
 
 type BookingFixture = ReturnType<typeof createBookingFixture>;
+
+// We default all dayjs calls to use Europe/London timezone
+const dayjs = (...args: Parameters<typeof _dayjs>) => _dayjs(...args).tz("Europe/London");
 
 // creates a user fixture instance and stores the collection
 export const createBookingsFixture = (page: Page) => {

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -4,7 +4,6 @@ import { Prisma as PrismaType } from "@prisma/client";
 import { hashSync as hash } from "bcryptjs";
 import type { API } from "mailhog";
 
-import dayjs from "@calcom/dayjs";
 import stripe from "@calcom/features/ee/payments/server/stripe";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -12,7 +11,7 @@ import { prisma } from "@calcom/prisma";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 
 import { selectFirstAvailableTimeSlotNextMonth, teamEventSlug, teamEventTitle } from "../lib/testUtils";
-import type { TimeZoneEnum } from "./types";
+import { TimeZoneEnum } from "./types";
 
 // Don't import hashPassword from app as that ends up importing next-auth and initializing it before NEXTAUTH_URL can be updated during tests.
 export function hashPassword(password: string) {
@@ -477,7 +476,7 @@ const createUser = (workerInfo: WorkerInfo, opts?: CustomUserOpts | null): Prism
     password: hashPassword(uname),
     emailVerified: new Date(),
     completedOnboarding: opts?.completedOnboarding ?? true,
-    timeZone: opts?.timeZone ?? dayjs.tz.guess(),
+    timeZone: opts?.timeZone ?? TimeZoneEnum.UK,
     locale: opts?.locale ?? "en",
     schedules:
       opts?.completedOnboarding ?? true

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -483,6 +483,7 @@ const createUser = (workerInfo: WorkerInfo, opts?: CustomUserOpts | null): Prism
         ? {
             create: {
               name: "Working Hours",
+              timeZone: opts?.timeZone ?? TimeZoneEnum.UK,
               availability: {
                 createMany: {
                   data: getAvailabilityFromSchedule(DEFAULT_SCHEDULE),

--- a/apps/web/playwright/wipe-my-cal.e2e.ts
+++ b/apps/web/playwright/wipe-my-cal.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import dayjs from "@calcom/dayjs";
+import _dayjs from "@calcom/dayjs";
 import prisma from "@calcom/prisma";
 
 import { test } from "./lib/fixtures";
@@ -8,6 +8,9 @@ import { test } from "./lib/fixtures";
 test.describe.configure({ mode: "parallel" });
 
 test.afterEach(({ users }) => users.deleteAll());
+
+// We default all dayjs calls to use Europe/London timezone
+const dayjs = (...args: Parameters<typeof _dayjs>) => _dayjs(...args).tz("Europe/London");
 
 test.describe("Wipe my Cal App Test", () => {
   test("Browse upcoming bookings and validate button shows and triggering wipe my cal button", async ({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,6 +55,14 @@ if (IS_EMBED_REACT_TEST) {
   });
 }
 
+const DEFAULT_CHROMIUM = {
+  ...devices["Desktop Chrome"],
+  timezoneId: "Europe/London",
+  locale: "en-US",
+  /** If navigation takes more than this, then something's wrong, let's fail fast. */
+  navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
+};
+
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -86,13 +94,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: {
-        ...devices["Desktop Chrome"],
-        timezoneId: "Europe/London",
-        locale: "en-US",
-        /** If navigation takes more than this, then something's wrong, let's fail fast. */
-        navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
-      },
+      use: DEFAULT_CHROMIUM,
     },
     {
       name: "@calcom/app-store",
@@ -101,12 +103,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: {
-        ...devices["Desktop Chrome"],
-        locale: "en-US",
-        /** If navigation takes more than this, then something's wrong, let's fail fast. */
-        navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
-      },
+      use: DEFAULT_CHROMIUM,
     },
     {
       name: "@calcom/embed-core",
@@ -129,9 +126,7 @@ const config: PlaywrightTestConfig = {
       },
       testMatch: /.*\.e2e\.tsx?/,
       use: {
-        ...devices["Desktop Chrome"],
-        timezoneId: "Europe/London",
-        locale: "en-US",
+        ...DEFAULT_CHROMIUM,
         baseURL: "http://localhost:3101/",
       },
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -88,6 +88,7 @@ const config: PlaywrightTestConfig = {
       },
       use: {
         ...devices["Desktop Chrome"],
+        timezoneId: "Europe/London",
         locale: "en-US",
         /** If navigation takes more than this, then something's wrong, let's fail fast. */
         navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
@@ -102,6 +103,7 @@ const config: PlaywrightTestConfig = {
       },
       use: {
         ...devices["Desktop Chrome"],
+        timezoneId: "Europe/London",
         locale: "en-US",
         /** If navigation takes more than this, then something's wrong, let's fail fast. */
         navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
@@ -114,7 +116,12 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: { ...devices["Desktop Chrome"], locale: "en-US", baseURL: "http://localhost:3100/" },
+      use: {
+        ...devices["Desktop Chrome"],
+        timezoneId: "Europe/London",
+        locale: "en-US",
+        baseURL: "http://localhost:3100/",
+      },
     },
     {
       name: "@calcom/embed-react",
@@ -123,7 +130,12 @@ const config: PlaywrightTestConfig = {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
       testMatch: /.*\.e2e\.tsx?/,
-      use: { ...devices["Desktop Chrome"], locale: "en-US", baseURL: "http://localhost:3101/" },
+      use: {
+        ...devices["Desktop Chrome"],
+        timezoneId: "Europe/London",
+        locale: "en-US",
+        baseURL: "http://localhost:3101/",
+      },
     },
     {
       name: "@calcom/embed-core--firefox",
@@ -132,7 +144,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: { ...devices["Desktop Firefox"] },
+      use: { ...devices["Desktop Firefox"], timezoneId: "Europe/London" },
     },
     {
       name: "@calcom/embed-core--webkit",
@@ -141,7 +153,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: { ...devices["Desktop Safari"] },
+      use: { ...devices["Desktop Safari"], timezoneId: "Europe/London" },
     },
   ],
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -103,7 +103,6 @@ const config: PlaywrightTestConfig = {
       },
       use: {
         ...devices["Desktop Chrome"],
-        timezoneId: "Europe/London",
         locale: "en-US",
         /** If navigation takes more than this, then something's wrong, let's fail fast. */
         navigationTimeout: DEFAULT_NAVIGATION_TIMEOUT,
@@ -118,7 +117,6 @@ const config: PlaywrightTestConfig = {
       },
       use: {
         ...devices["Desktop Chrome"],
-        timezoneId: "Europe/London",
         locale: "en-US",
         baseURL: "http://localhost:3100/",
       },
@@ -144,7 +142,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: { ...devices["Desktop Firefox"], timezoneId: "Europe/London" },
+      use: { ...devices["Desktop Firefox"] },
     },
     {
       name: "@calcom/embed-core--webkit",
@@ -153,7 +151,7 @@ const config: PlaywrightTestConfig = {
       expect: {
         timeout: DEFAULT_EXPECT_TIMEOUT,
       },
-      use: { ...devices["Desktop Safari"], timezoneId: "Europe/London" },
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 };


### PR DESCRIPTION
## What does this PR do?

refs #2337

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Up until recently, running e2e tests locally didn't take into account local timezones. Now it seems like it is and is triggering the update timezone popup, getting tests to timeout.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

On a browser with a different timezone (like America/Mazatlan), run e2e tests. The popup should not appear.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

