### PR TITLE
chore: add tests for locale and directionality; set html.dir when the session locale is available

### DIFF
--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "next-themes";
 import type { AppProps as NextAppProps, AppProps as NextJsAppProps } from "next/app";
 import type { ParsedUrlQuery } from "querystring";
 import type { PropsWithChildren, ReactNode } from "react";
+import { useEffect } from "react";
 
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
 import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/providerDynamic";
@@ -75,6 +76,22 @@ const CustomI18nextProvider = (props: AppPropsWithoutNonce) => {
   const session = useSession();
   const locale = session?.data?.user.locale ?? props.pageProps.newLocale;
 
+  useEffect(() => {
+    window.document.documentElement.lang = locale;
+
+    let direction = window.document.dir || "ltr";
+
+    try {
+      const intlLocale = new Intl.Locale(locale);
+      // @ts-expect-error INFO: Typescript does not know about the Intl.Locale textInfo attribute
+      direction = intlLocale.textInfo?.direction;
+    } catch (error) {
+      console.error(error);
+    }
+
+    window.document.dir = direction;
+  }, [locale]);
+
   const clientViewerI18n = useViewerI18n(locale);
   const i18n = clientViewerI18n.data?.i18n;
 
@@ -82,6 +99,7 @@ const CustomI18nextProvider = (props: AppPropsWithoutNonce) => {
     ...props,
     pageProps: {
       ...props.pageProps,
+
       ...i18n,
     },
   };

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -2,7 +2,6 @@ import type { IncomingMessage } from "http";
 import type { AppContextType } from "next/dist/shared/lib/utils";
 import React from "react";
 
-import { getLocale } from "@calcom/features/auth/lib/getLocale";
 import { trpc } from "@calcom/trpc/react";
 
 import type { AppProps } from "@lib/app-providers";
@@ -28,6 +27,7 @@ MyApp.getInitialProps = async (ctx: AppContextType) => {
   let newLocale = "en";
 
   if (req) {
+    const { getLocale } = await import("@calcom/features/auth/lib/getLocale");
     newLocale = await getLocale(req as IncomingMessage & { cookies: Record<string, any> });
   } else if (typeof window !== "undefined" && window.calNewLocale) {
     newLocale = window.calNewLocale;

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -4,7 +4,6 @@ import type { DocumentContext, DocumentProps } from "next/document";
 import Document, { Head, Html, Main, NextScript } from "next/document";
 import { z } from "zod";
 
-import { getLocale } from "@calcom/features/auth/lib/getLocale";
 import { IS_PRODUCTION } from "@calcom/lib/constants";
 
 import { csp } from "@lib/csp";
@@ -28,9 +27,12 @@ class MyDocument extends Document<Props> {
       setHeader(ctx, "x-csp", "initialPropsOnly");
     }
 
-    const newLocale = ctx.req
-      ? await getLocale(ctx.req as IncomingMessage & { cookies: Record<string, any> })
-      : "en";
+    const getLocaleModule = ctx.req ? await import("@calcom/features/auth/lib/getLocale") : null;
+
+    const newLocale =
+      ctx.req && getLocaleModule
+        ? await getLocaleModule.getLocale(ctx.req as IncomingMessage & { cookies: Record<string, any> })
+        : "en";
 
     const asPath = ctx.asPath || "";
     // Use a dummy URL as default so that URL parsing works for relative URLs as well. We care about searchParams and pathname only

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -28,7 +28,7 @@ test.describe("unauthorized user sees correct translations (de)", async () => {
   });
 });
 
-test.describe("unauthorized user sees correct locale (ar)", async () => {
+test.describe("unauthorized user sees correct translations (ar)", async () => {
   test.use({
     locale: "ar",
   });
@@ -132,7 +132,7 @@ test.describe("authorized user sees correct translations (de)", async () => {
   });
 });
 
-test.describe("authorized user sees correct translations (ar) [locale1]", async () => {
+test.describe("authorized user sees correct translations (ar)", async () => {
   test.use({
     locale: "en",
   });
@@ -201,6 +201,41 @@ test.describe("authorized user sees correct translations (ar) [locale1]", async 
         const locator = page.getByText("Bookings", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    });
+  });
+});
+
+test.describe("authorized user sees changed translations (de->ar) [locale1]", async () => {
+  test.use({
+    locale: "en",
+  });
+
+  test("should return correct translations and html attributes", async ({ page, users }) => {
+    await test.step("should create a de user", async () => {
+      const user = await users.create({
+        locale: "de",
+      });
+      await user.apiLogin();
+    });
+
+    await test.step("should change the language and show Arabic translations", async () => {
+      await page.goto("/settings/my-account/general");
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator(".bg-default > div > div:nth-child(2)").first().click();
+      await page.locator("#react-select-2-option-0").click();
+
+      await page.getByRole("button", { name: "Aktualisieren" }).click();
+
+      await page
+        .getByRole("button", { name: "Einstellungen erfolgreich aktualisiert" })
+        .waitFor({ state: "visible" });
 
       const htmlLocator = page.locator("html");
 

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -2,6 +2,8 @@ import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
 
+test.describe.configure({ mode: "serial" });
+
 test.describe("unauthorized user sees correct translations (de)", async () => {
   test.use({
     locale: "de",
@@ -12,19 +14,21 @@ test.describe("unauthorized user sees correct translations (de)", async () => {
     await page.waitForLoadState("load");
 
     {
-      const locator = page.getByText("Willkommen zurück");
+      const locator = page.getByText("Willkommen zurück", { exact: true });
       expect(await locator.count()).toEqual(1);
     }
 
     {
-      const locator = page.getByText("Welcome back");
+      const locator = page.getByText("Welcome back", { exact: true });
       expect(await locator.count()).toEqual(0);
     }
 
-    const htmlLocator = page.locator("html");
+    // const htmlLocator = page.locator("html");
 
-    expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-    expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+    // expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+    // expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+    await page.locator("html[lang=de]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
   });
 });
 
@@ -38,23 +42,25 @@ test.describe("unauthorized user sees correct translations (ar)", async () => {
     await page.waitForLoadState("load");
 
     {
-      const locator = page.getByText("أهلاً بك من جديد");
+      const locator = page.getByText("أهلاً بك من جديد", { exact: true });
       expect(await locator.count()).toEqual(1);
     }
 
     {
-      const locator = page.getByText("Welcome back");
+      const locator = page.getByText("Welcome back", { exact: true });
       expect(await locator.count()).toEqual(0);
     }
 
-    const htmlLocator = page.locator("html");
+    // const htmlLocator = page.locator("html");
 
-    expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-    expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    // expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+    // expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+    await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
   });
 });
 
-test.describe("authorized user sees correct translations (de)", async () => {
+test.describe("authorized user sees correct translations (de) [locale1]", async () => {
   test.use({
     locale: "en",
   });
@@ -73,19 +79,21 @@ test.describe("authorized user sees correct translations (de)", async () => {
       await page.waitForLoadState("networkidle");
 
       {
-        const locator = page.getByText("Ereignistypen");
+        const locator = page.getByText("Ereignistypen", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
       }
 
       {
-        const locator = page.getByText("Event Types");
+        const locator = page.getByText("Event Types", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      //   const htmlLocator = page.locator("html");
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
     });
 
     await test.step("should navigate to /bookings and show German translations", async () => {
@@ -103,10 +111,12 @@ test.describe("authorized user sees correct translations (de)", async () => {
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+      //   const htmlLocator = page.locator("html");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
     });
 
     await test.step("should reload the /bookings and show German translations", async () => {
@@ -124,10 +134,12 @@ test.describe("authorized user sees correct translations (de)", async () => {
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      //   const htmlLocator = page.locator("html");
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
     });
   });
 });
@@ -151,19 +163,21 @@ test.describe("authorized user sees correct translations (ar)", async () => {
       await page.waitForLoadState("networkidle");
 
       {
-        const locator = page.getByText("أنواع الحدث");
+        const locator = page.getByText("أنواع الحدث", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
       }
 
       {
-        const locator = page.getByText("Event Types");
+        const locator = page.getByText("Event Types", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      //   const htmlLocator = page.locator("html");
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
 
     await test.step("should navigate to /bookings and show German translations", async () => {
@@ -181,10 +195,12 @@ test.describe("authorized user sees correct translations (ar)", async () => {
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      //   const htmlLocator = page.locator("html");
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
 
     await test.step("should reload the /bookings and show German translations", async () => {
@@ -202,15 +218,17 @@ test.describe("authorized user sees correct translations (ar)", async () => {
         expect(await locator.count()).toEqual(0);
       }
 
-      const htmlLocator = page.locator("html");
+      //   const htmlLocator = page.locator("html");
 
-      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
   });
 });
 
-test.describe("authorized user sees changed translations (de->ar) [locale1]", async () => {
+test.describe("authorized user sees changed translations (de->ar)", async () => {
   test.use({
     locale: "en",
   });
@@ -243,12 +261,12 @@ test.describe("authorized user sees changed translations (de->ar) [locale1]", as
       expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
 
       {
-        const locator = page.getByText("عام"); // "general"
+        const locator = page.getByText("عام", { exact: true }); // "general"
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
       }
 
       {
-        const locator = page.getByText("Allgemein"); // "general"
+        const locator = page.getByText("Allgemein", { exact: true }); // "general"
         expect(await locator.count()).toEqual(0);
       }
     });
@@ -259,12 +277,12 @@ test.describe("authorized user sees changed translations (de->ar) [locale1]", as
       await page.waitForLoadState("networkidle");
 
       {
-        const locator = page.getByText("عام"); // "general"
+        const locator = page.getByText("عام", { exact: true }); // "general"
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
       }
 
       {
-        const locator = page.getByText("Allgemein"); // "general"
+        const locator = page.getByText("Allgemein", { exact: true }); // "general"
         expect(await locator.count()).toEqual(0);
       }
 

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -241,6 +241,37 @@ test.describe("authorized user sees changed translations (de->ar) [locale1]", as
 
       expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
       expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+
+      {
+        const locator = page.getByText("عام"); // "general"
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Allgemein"); // "general"
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+
+    await test.step("should reload and show Arabic translations", async () => {
+      await page.reload();
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("عام"); // "general"
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Allgemein"); // "general"
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
     });
   });
 });

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -13,6 +13,9 @@ test.describe("unauthorized user sees correct translations (de)", async () => {
     await page.goto("/");
     await page.waitForLoadState("load");
 
+    await page.locator("html[lang=de]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
     {
       const locator = page.getByText("Willkommen zurück", { exact: true });
       expect(await locator.count()).toEqual(1);
@@ -22,13 +25,6 @@ test.describe("unauthorized user sees correct translations (de)", async () => {
       const locator = page.getByText("Welcome back", { exact: true });
       expect(await locator.count()).toEqual(0);
     }
-
-    // const htmlLocator = page.locator("html");
-
-    // expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-    // expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
-    await page.locator("html[lang=de]").waitFor({ state: "attached" });
-    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
   });
 });
 
@@ -41,6 +37,9 @@ test.describe("unauthorized user sees correct translations (ar)", async () => {
     await page.goto("/");
     await page.waitForLoadState("load");
 
+    await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+    await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
+
     {
       const locator = page.getByText("أهلاً بك من جديد", { exact: true });
       expect(await locator.count()).toEqual(1);
@@ -50,13 +49,6 @@ test.describe("unauthorized user sees correct translations (ar)", async () => {
       const locator = page.getByText("Welcome back", { exact: true });
       expect(await locator.count()).toEqual(0);
     }
-
-    // const htmlLocator = page.locator("html");
-
-    // expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-    // expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
-    await page.locator("html[lang=ar]").waitFor({ state: "attached" });
-    await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
   });
 });
 
@@ -78,6 +70,9 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("Ereignistypen", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -87,13 +82,6 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
         const locator = page.getByText("Event Types", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      //   const htmlLocator = page.locator("html");
-
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
-      await page.locator("html[lang=de]").waitFor({ state: "attached" });
-      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
     });
 
     await test.step("should navigate to /bookings and show German translations", async () => {
@@ -101,6 +89,9 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("Buchungen", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -110,13 +101,6 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
         const locator = page.getByText("Bookings", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      await page.locator("html[lang=de]").waitFor({ state: "attached" });
-      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
-
-      //   const htmlLocator = page.locator("html");
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
     });
 
     await test.step("should reload the /bookings and show German translations", async () => {
@@ -124,6 +108,9 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=de]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("Buchungen", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -133,13 +120,6 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
         const locator = page.getByText("Bookings", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      //   const htmlLocator = page.locator("html");
-
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("de");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
-      await page.locator("html[lang=de]").waitFor({ state: "attached" });
-      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
     });
   });
 });
@@ -162,6 +142,9 @@ test.describe("authorized user sees correct translations (ar)", async () => {
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("أنواع الحدث", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -171,13 +154,6 @@ test.describe("authorized user sees correct translations (ar)", async () => {
         const locator = page.getByText("Event Types", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      //   const htmlLocator = page.locator("html");
-
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
-      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
-      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
 
     await test.step("should navigate to /bookings and show German translations", async () => {
@@ -185,6 +161,9 @@ test.describe("authorized user sees correct translations (ar)", async () => {
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("عمليات الحجز", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -194,13 +173,6 @@ test.describe("authorized user sees correct translations (ar)", async () => {
         const locator = page.getByText("Bookings", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      //   const htmlLocator = page.locator("html");
-
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
-      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
-      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
 
     await test.step("should reload the /bookings and show German translations", async () => {
@@ -208,6 +180,9 @@ test.describe("authorized user sees correct translations (ar)", async () => {
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("عمليات الحجز", { exact: true });
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -217,13 +192,6 @@ test.describe("authorized user sees correct translations (ar)", async () => {
         const locator = page.getByText("Bookings", { exact: true });
         expect(await locator.count()).toEqual(0);
       }
-
-      //   const htmlLocator = page.locator("html");
-
-      //   expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      //   expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
-      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
-      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
     });
   });
 });
@@ -255,10 +223,8 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
         .getByRole("button", { name: "Einstellungen erfolgreich aktualisiert" })
         .waitFor({ state: "visible" });
 
-      const htmlLocator = page.locator("html");
-
-      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
 
       {
         const locator = page.getByText("عام", { exact: true }); // "general"
@@ -276,6 +242,9 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
 
       await page.waitForLoadState("networkidle");
 
+      await page.locator("html[lang=ar]").waitFor({ state: "attached" });
+      await page.locator("html[dir=rtl]").waitFor({ state: "attached" });
+
       {
         const locator = page.getByText("عام", { exact: true }); // "general"
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
@@ -285,11 +254,6 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
         const locator = page.getByText("Allgemein", { exact: true }); // "general"
         expect(await locator.count()).toEqual(0);
       }
-
-      const htmlLocator = page.locator("html");
-
-      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
-      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
     });
   });
 });

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -1,0 +1,211 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+
+test.describe("unauthorized user sees correct translations (de)", async () => {
+  test.use({
+    locale: "de",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    {
+      const locator = page.getByText("Willkommen zurück");
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back");
+      expect(await locator.count()).toEqual(0);
+    }
+
+    const htmlLocator = page.locator("html");
+
+    expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+    expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+  });
+});
+
+test.describe("unauthorized user sees correct locale (ar)", async () => {
+  test.use({
+    locale: "ar",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    {
+      const locator = page.getByText("أهلاً بك من جديد");
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back");
+      expect(await locator.count()).toEqual(0);
+    }
+
+    const htmlLocator = page.locator("html");
+
+    expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+    expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+  });
+});
+
+test.describe("authorized user sees correct translations (de)", async () => {
+  test.use({
+    locale: "en",
+  });
+
+  test("should return correct translations and html attributes", async ({ page, users }) => {
+    await test.step("should create a de user", async () => {
+      const user = await users.create({
+        locale: "de",
+      });
+      await user.apiLogin();
+    });
+
+    await test.step("should navigate to /event-types and show German translations", async () => {
+      await page.goto("/event-types");
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("Ereignistypen");
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Event Types");
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+    });
+
+    await test.step("should navigate to /bookings and show German translations", async () => {
+      await page.goto("/bookings");
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("Buchungen", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+    });
+
+    await test.step("should reload the /bookings and show German translations", async () => {
+      await page.reload();
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("Buchungen", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("de");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("ltr");
+    });
+  });
+});
+
+test.describe("authorized user sees correct translations (ar) [locale1]", async () => {
+  test.use({
+    locale: "en",
+  });
+
+  test("should return correct translations and html attributes", async ({ page, users }) => {
+    await test.step("should create a de user", async () => {
+      const user = await users.create({
+        locale: "ar",
+      });
+      await user.apiLogin();
+    });
+
+    await test.step("should navigate to /event-types and show German translations", async () => {
+      await page.goto("/event-types");
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("أنواع الحدث");
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Event Types");
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    });
+
+    await test.step("should navigate to /bookings and show German translations", async () => {
+      await page.goto("/bookings");
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("عمليات الحجز", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    });
+
+    await test.step("should reload the /bookings and show German translations", async () => {
+      await page.reload();
+
+      await page.waitForLoadState("networkidle");
+
+      {
+        const locator = page.getByText("عمليات الحجز", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+
+      const htmlLocator = page.locator("html");
+
+      expect(await htmlLocator.getAttribute("lang")).toEqual("ar");
+      expect(await htmlLocator.getAttribute("dir")).toEqual("rtl");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

1. Adds tests for the locale and directionality inferring for signed-in and not-signed-in users
2. Loads `@calcom/features/auth/lib/getLocale` asynchronously in `_app` and `_document` files when in the server context; this should reduce the bundle size
3. The bugfix https://github.com/calcom/cal.com/pull/11831 did not change the `html.dir` and `html.lang` attributes, which is fixed and tested in this PR. This could be visible for users that use e.g. the Arabic language and would visit bookings, as their language uses RtL order instead of the default LtR.

Fixes # (issue)
The bugfix https://github.com/calcom/cal.com/pull/11831 did not change the `html.dir` and `html.lang` attributes, which is fixed and tested in this PR. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
1. The users that are not signed in should see the language stemming from the locale in the accept-language header
2. The logged in users should see the locale as it is set in the language config in their profiles. Moving between any pages should not result in different translations or different directions of text.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
