### PR TITLE
fix: by-pass global unubsribe for from transactional emails

### DIFF
--- a/packages/emails/templates/_base-email.ts
+++ b/packages/emails/templates/_base-email.ts
@@ -48,6 +48,17 @@ export default class BaseEmail {
     const payload = this.getNodeMailerPayload();
     const parseSubject = z.string().safeParse(payload?.subject);
     const payloadWithUnEscapedSubject = {
+      headers: {
+        "X-SMTPAPI": JSON.stringify({
+          filters: {
+            bypass_list_management: {
+              settings: {
+                enable: 1,
+              },
+            },
+          },
+        }),
+      },
       ...payload,
       ...(parseSubject.success && { subject: decodeHTML(parseSubject.data) }),
     };


### PR DESCRIPTION
## What does this PR do?

Adds headers to nodemailer to ignore Unsubscribes for Transactional Mails from Sendgrid.
