### PR TITLE
fix: Webhook settings list not having enough padding on the top

### DIFF
--- a/packages/features/webhooks/pages/webhooks-view.tsx
+++ b/packages/features/webhooks/pages/webhooks-view.tsx
@@ -78,7 +78,7 @@ const WebhooksView = () => {
             <></>
           )
         }
-        borderInShellHeader={!(data && data.webhookGroups.length > 0)}
+        borderInShellHeader={data && data.profiles.length === 1}
       />
       <div>
         <WebhooksList webhooksByViewer={data} />


### PR DESCRIPTION
fix this Webhook settings list not having enough padding on the top as suggested in comment of issue
Fixes #11875 