### PR TITLE
fix: Overlaying of Override button by toast on mobile.

### DIFF
--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -179,7 +179,7 @@ const DateOverrideForm = ({
                 color="primary"
                 type="submit"
                 onClick={() => {
-                  showToast(t("date_successfully_added"), "success");
+                  showToast(t("date_successfully_added"), "success", 500);
                 }}
                 disabled={selectedDates.length === 0}
                 data-testid="add-override-submit-btn">


### PR DESCRIPTION
## What does this PR do?

Fixes #11814

Environment : Production

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->


- This is applicable on mobile screen.
- Upon multiple override requests, toast used to hide the Add Override Button for too long.
- Now make an add override request, the  toasts now stays on for lesser duration.

https://github.com/calcom/cal.com/assets/122738012/55b29115-ce17-445a-80d5-1327f30ebc18
