### PR TITLE
fix: 11378 editor toolbar to left

### DIFF
--- a/packages/ui/components/editor/stylesEditor.css
+++ b/packages/ui/components/editor/stylesEditor.css
@@ -121,6 +121,9 @@ pre::-webkit-scrollbar-thumb {
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
   vertical-align: middle;
+  justify-content: end;
+  border-bottom-color: var(--cal-border);
+  border-bottom-width: 1px;
 }
 
 .toolbar button.toolbar-item {


### PR DESCRIPTION
closes https://github.com/calcom/cal.com/issues/11378

changed the stylng of toolbar and also shifted toolbar to left in editor.
made border in bottom of toobar 