### PR TITLE
fix: build locale based on validated codes and regions

### DIFF
--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { dir } from "i18next";
 import type { Session } from "next-auth";
 import { SessionProvider, useSession } from "next-auth/react";
 import { EventCollectionProvider } from "next-collect/client";
@@ -78,18 +79,7 @@ const CustomI18nextProvider = (props: AppPropsWithoutNonce) => {
 
   useEffect(() => {
     window.document.documentElement.lang = locale;
-
-    let direction = window.document.dir || "ltr";
-
-    try {
-      const intlLocale = new Intl.Locale(locale);
-      // @ts-expect-error INFO: Typescript does not know about the Intl.Locale textInfo attribute
-      direction = intlLocale.textInfo?.direction;
-    } catch (error) {
-      console.error(error);
-    }
-
-    window.document.dir = direction;
+    window.document.dir = dir(locale);
   }, [locale]);
 
   const clientViewerI18n = useViewerI18n(locale);

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -79,6 +79,7 @@ const CustomI18nextProvider = (props: AppPropsWithoutNonce) => {
 
   useEffect(() => {
     try {
+      // @ts-expect-error TS2790: The operand of a 'delete' operator must be optional.
       delete window.document.documentElement["lang"];
 
       window.document.documentElement.lang = locale;

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from "http";
+import { dir } from "i18next";
 import type { NextPageContext } from "next";
 import type { DocumentContext, DocumentProps } from "next/document";
 import Document, { Head, Html, Main, NextScript } from "next/document";
@@ -50,21 +51,15 @@ class MyDocument extends Document<Props> {
   render() {
     const { isEmbed, embedColorScheme } = this.props;
     const newLocale = this.props.newLocale || "en";
+    const newDir = dir(newLocale);
 
     const nonceParsed = z.string().safeParse(this.props.nonce);
     const nonce = nonceParsed.success ? nonceParsed.data : "";
 
-    const intlLocale = new Intl.Locale(newLocale);
-    // @ts-expect-error INFO: Typescript does not know about the Intl.Locale textInfo attribute
-    const direction = intlLocale.textInfo?.direction;
-    if (!direction) {
-      throw new Error("NodeJS major breaking change detected, use getTextInfo() instead.");
-    }
-
     return (
       <Html
         lang={newLocale}
-        dir={direction}
+        dir={newDir}
         style={embedColorScheme ? { colorScheme: embedColorScheme as string } : undefined}>
         <Head nonce={nonce}>
           <script

--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -52,7 +52,151 @@ test.describe("unauthorized user sees correct translations (ar)", async () => {
   });
 });
 
-test.describe("authorized user sees correct translations (de) [locale1]", async () => {
+test.describe("unauthorized user sees correct translations (zh)", async () => {
+  test.use({
+    locale: "zh",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=zh]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("欢迎回来", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("unauthorized user sees correct translations (zh-CN)", async () => {
+  test.use({
+    locale: "zh-CN",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=zh-CN]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("欢迎回来", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("unauthorized user sees correct translations (zh-TW)", async () => {
+  test.use({
+    locale: "zh-TW",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=zh-TW]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("歡迎回來", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("unauthorized user sees correct translations (pt)", async () => {
+  test.use({
+    locale: "pt",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=pt]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("Olá novamente", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("unauthorized user sees correct translations (pt-br)", async () => {
+  test.use({
+    locale: "pt-br",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=pt-br]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("Bem-vindo(a) novamente", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("unauthorized user sees correct translations (es-419)", async () => {
+  test.use({
+    locale: "es-419",
+  });
+
+  test("should use correct translations and html attributes", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("load");
+
+    await page.locator("html[lang=es-419]").waitFor({ state: "attached" });
+    await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+    {
+      const locator = page.getByText("Bienvenido de nuevo", { exact: true });
+      expect(await locator.count()).toEqual(1);
+    }
+
+    {
+      const locator = page.getByText("Welcome back", { exact: true });
+      expect(await locator.count()).toEqual(0);
+    }
+  });
+});
+
+test.describe("authorized user sees correct translations (de)", async () => {
   test.use({
     locale: "en",
   });
@@ -124,6 +268,78 @@ test.describe("authorized user sees correct translations (de) [locale1]", async 
   });
 });
 
+test.describe("authorized user sees correct translations (pt-br)", async () => {
+  test.use({
+    locale: "en",
+  });
+
+  test("should return correct translations and html attributes", async ({ page, users }) => {
+    await test.step("should create a pt-br user", async () => {
+      const user = await users.create({
+        locale: "pt-br",
+      });
+      await user.apiLogin();
+    });
+
+    await test.step("should navigate to /event-types and show Brazil-Portuguese translations", async () => {
+      await page.goto("/event-types");
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator("html[lang=pt-br]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+      {
+        const locator = page.getByText("Tipos de Eventos", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Event Types", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+
+    await test.step("should navigate to /bookings and show Brazil-Portuguese translations", async () => {
+      await page.goto("/bookings");
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator("html[lang=pt-br]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+      {
+        const locator = page.getByText("Reservas", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+
+    await test.step("should reload the /bookings and show Brazil-Portuguese translations", async () => {
+      await page.reload();
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator("html[lang=pt-br]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+      {
+        const locator = page.getByText("Reservas", { exact: true });
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Bookings", { exact: true });
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+  });
+});
+
 test.describe("authorized user sees correct translations (ar)", async () => {
   test.use({
     locale: "en",
@@ -137,7 +353,7 @@ test.describe("authorized user sees correct translations (ar)", async () => {
       await user.apiLogin();
     });
 
-    await test.step("should navigate to /event-types and show German translations", async () => {
+    await test.step("should navigate to /event-types and show Arabic translations", async () => {
       await page.goto("/event-types");
 
       await page.waitForLoadState("networkidle");
@@ -156,7 +372,7 @@ test.describe("authorized user sees correct translations (ar)", async () => {
       }
     });
 
-    await test.step("should navigate to /bookings and show German translations", async () => {
+    await test.step("should navigate to /bookings and show Arabic translations", async () => {
       await page.goto("/bookings");
 
       await page.waitForLoadState("networkidle");
@@ -175,7 +391,7 @@ test.describe("authorized user sees correct translations (ar)", async () => {
       }
     });
 
-    await test.step("should reload the /bookings and show German translations", async () => {
+    await test.step("should reload the /bookings and show Arabic translations", async () => {
       await page.reload();
 
       await page.waitForLoadState("networkidle");
@@ -247,6 +463,68 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
 
       {
         const locator = page.getByText("عام", { exact: true }); // "general"
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Allgemein", { exact: true }); // "general"
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+  });
+});
+
+test.describe("authorized user sees changed translations (de->pt-BR) [locale1]", async () => {
+  test.use({
+    locale: "en",
+  });
+
+  test("should return correct translations and html attributes", async ({ page, users }) => {
+    await test.step("should create a de user", async () => {
+      const user = await users.create({
+        locale: "de",
+      });
+      await user.apiLogin();
+    });
+
+    await test.step("should change the language and show Brazil-Portuguese translations", async () => {
+      await page.goto("/settings/my-account/general");
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator(".bg-default > div > div:nth-child(2)").first().click();
+      await page.locator("#react-select-2-option-14").click();
+
+      await page.getByRole("button", { name: "Aktualisieren" }).click();
+
+      await page
+        .getByRole("button", { name: "Einstellungen erfolgreich aktualisiert" })
+        .waitFor({ state: "visible" });
+
+      await page.locator("html[lang=pt-BR]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+      {
+        const locator = page.getByText("Geral", { exact: true }); // "general"
+        expect(await locator.count()).toBeGreaterThanOrEqual(1);
+      }
+
+      {
+        const locator = page.getByText("Allgemein", { exact: true }); // "general"
+        expect(await locator.count()).toEqual(0);
+      }
+    });
+
+    await test.step("should reload and show Brazil-Portuguese translations", async () => {
+      await page.reload();
+
+      await page.waitForLoadState("networkidle");
+
+      await page.locator("html[lang=pt-BR]").waitFor({ state: "attached" });
+      await page.locator("html[dir=ltr]").waitFor({ state: "attached" });
+
+      {
+        const locator = page.getByText("Geral", { exact: true }); // "general"
         expect(await locator.count()).toBeGreaterThanOrEqual(1);
       }
 

--- a/packages/config/next-i18next.config.js
+++ b/packages/config/next-i18next.config.js
@@ -33,6 +33,10 @@ const config = {
       "zh-TW",
     ],
   },
+  fallbackLng: {
+    default: ["en"],
+    zh: ["zh-CN"],
+  },
   reloadOnPrerender: process.env.NODE_ENV !== "production",
 };
 

--- a/packages/features/auth/lib/getLocale.ts
+++ b/packages/features/auth/lib/getLocale.ts
@@ -29,5 +29,16 @@ export const getLocale = async (req: GetTokenParams["req"]): Promise<string> => 
 
   const languages = acceptLanguage ? parse(acceptLanguage) : [];
 
-  return languages[0]?.code || "en";
+  const code: string = languages[0]?.code ?? "";
+  const region: string = languages[0]?.region ?? "";
+
+  // the code should consist of 2 or 3 lowercase letters
+  // the regex underneath is more permissive
+  const testedCode = /^[a-zA-Z]+$/.test(code) ? code : "en";
+
+  // the code should consist of either 2 uppercase letters or 3 digits
+  // the regex underneath is more permissive
+  const testedRegion = /^[a-zA-Z0-9]+$/.test(region) ? region : "";
+
+  return `${testedCode}${testedRegion !== "" ? "-" : ""}${testedRegion}`;
 };


### PR DESCRIPTION
## What does this PR do?

This PR replaces the inference of locale direction using the `Intl.Locale` function with the `dir` function from the `i18next` library (defined [here](https://github.com/i18next/i18next/blob/f6aea8d40039e4593dfcb0dabb54ad6d1ba14f85/src/i18next.js#L507)).

The `i18next` library is the parent library of `next-i18next`, where the latter is explicitly used in this project.

This PR introduces a fallback for the Simplified Chinese language (`zh`), which is the regionalized Simplied Chinese used in the PRCh.

This PR introduces multiple tests to verify correct inference of locale and direction for:
* unauthorized users with Chinese and Portuguese locale and regions,
* authorized users with Portuguese locale and regions.

I found that [this Next.js snippet](https://github.com/vercel/next.js/blob/1609da2d9552fed48ab45969bdc5631230c6d356/packages/next/src/shared/lib/router/router.ts#L1786 ) changes the `lang` attribute of the `HTML` element, which might result in a race condition with the update on the same attribute (that's why the `locale1` test was flaky).
It turns out the race condition happened before in the codebase [here](https://github.com/intuita-inc/cal.com-demo/blob/c4b9a9e2f471cb603cab5e5dff9feaebb6c12eb2/apps/web/components/I18nLanguageHandler.tsx#L59).

## Fixes # (issue)
https://threads.com/34541951212?s=qxMqBH7J4vmD83KCfe7Qcf
Referenced here:
https://github.com/calcom/cal.com/pull/11833
https://github.com/calcom/cal.com/pull/11885

## Requirement/Documentation
Good to read:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#language_tag_syntax

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
1. On every page, we have valid language and direction, stemming from the user's settings (for logged in users) or the browser settings. The language and direction needs to be put into the html attributes at all times.
2. An un-logged-in users that use Simplified Chinese should see that language as it's used in the PRCh.
3. An un-logged-in users that use `es-419` should see the Spanish language.
4. An un-logged-in users that use `pt-br` (Brazilian Portuguese) should see that localization.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
