### PR TITLE
feat: #11922 Allowed cancellation for Past time slots

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -129,10 +129,6 @@ async function handler(req: CustomRequest) {
     throw new HttpError({ statusCode: 400, message: "Booking not found" });
   }
 
-  if (userId !== bookingToDelete.user?.id && bookingToDelete.startTime < new Date()) {
-    throw new HttpError({ statusCode: 400, message: "Cannot cancel past events" });
-  }
-
   if (!bookingToDelete.userId) {
     throw new HttpError({ statusCode: 400, message: "User not found" });
   }


### PR DESCRIPTION
## What does this PR do?

Allow cancellation for Past time slots ( Bookings ). 
I have removed the conditional check which blocks past bookings from being cancelled.

/claim #11922

Fixes #11922 

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?

- Create a booking.
- Wait for the booking date time to be passed.
- Try to cancel the booking
- Please make sure that there is no error. And able to cancel

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
