### PR TITLE
chore: [app dir bootstrapping 1] generate nonce with native crypto API

### DIFF
--- a/apps/web/lib/buildNonce.test.ts
+++ b/apps/web/lib/buildNonce.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+
+import { buildNonce } from "./buildNonce";
+
+describe("buildNonce", () => {
+  it("should return an empty string for an empty array", () => {
+    const nonce = buildNonce(new Uint8Array());
+
+    expect(nonce).toEqual("");
+    expect(atob(nonce).length).toEqual(0);
+  });
+
+  it("should return a base64 string for values from 0 to 63", () => {
+    const array = Array(22)
+      .fill(0)
+      .map((_, i) => i);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("ABCDEFGHIJKLMNOPQRSTQQ==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for values from 64 to 127", () => {
+    const array = Array(22)
+      .fill(0)
+      .map((_, i) => i + 64);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("ABCDEFGHIJKLMNOPQRSTQQ==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for values from 128 to 191", () => {
+    const array = Array(22)
+      .fill(0)
+      .map((_, i) => i + 128);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("ABCDEFGHIJKLMNOPQRSTQQ==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for values from 192 to 255", () => {
+    const array = Array(22)
+      .fill(0)
+      .map((_, i) => i + 192);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("ABCDEFGHIJKLMNOPQRSTQQ==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for values from 0 to 42", () => {
+    const array = Array(22)
+      .fill(0)
+      .map((_, i) => 2 * i);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("ACEGIKMOQSUWYacegikmgg==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for 0 values", () => {
+    const array = Array(22)
+      .fill(0)
+      .map(() => 0);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("AAAAAAAAAAAAAAAAAAAAAA==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+
+  it("should return a base64 string for 0xFF values", () => {
+    const array = Array(22)
+      .fill(0)
+      .map(() => 0xff);
+    const nonce = buildNonce(new Uint8Array(array));
+
+    expect(nonce.length).toEqual(24);
+    expect(nonce).toEqual("////////////////////ww==");
+
+    expect(atob(nonce).length).toEqual(16);
+  });
+});

--- a/apps/web/lib/buildNonce.ts
+++ b/apps/web/lib/buildNonce.ts
@@ -1,0 +1,46 @@
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*
+The buildNonce array allows a randomly generated 22-unsigned-byte array
+and returns a 24-ASCII character string that mimics a base64-string.
+*/
+
+export const buildNonce = (uint8array: Uint8Array): string => {
+  // the random uint8array should contain 22 bytes
+  // 22 bytes mimic the base64-encoded 16 bytes
+  // base64 encodes 6 bits (log2(64)) with 8 bits (64 allowed characters)
+  // thus ceil(16*8/6) gives us 22 bytes
+  if (uint8array.length != 22) {
+    return "";
+  }
+
+  // for each random byte, we take:
+  // a) only the last 6 bits (so we map them to the base64 alphabet)
+  // b) for the last byte, we are interested in two bits
+  // explaination:
+  // 16*8 bits = 128 bits of information (order: left->right)
+  // 22*6 bits = 132 bits (order: left->right)
+  // thus the last byte has 4 redundant (least-significant, right-most) bits
+  // it leaves the last byte with 2 bits of information before the redundant bits
+  // so the bitmask is 0x110000 (2 bits of information, 4 redundant bits)
+  const bytes = uint8array.map((value, i) => {
+    if (i < 20) {
+      return value & 0b111111;
+    }
+
+    return value & 0b110000;
+  });
+
+  const nonceCharacters: string[] = [];
+
+  bytes.forEach((value) => {
+    nonceCharacters.push(BASE64_ALPHABET.charAt(value));
+  });
+
+  // base64-encoded strings can be padded with 1 or 2 `=`
+  // since 22 % 4 = 2, we pad with two `=`
+  nonceCharacters.push("==");
+
+  // the end result has 22 information and 2 padding ASCII characters = 24 ASCII characters
+  return nonceCharacters.join("");
+};

--- a/apps/web/lib/csp.ts
+++ b/apps/web/lib/csp.ts
@@ -1,9 +1,10 @@
-import crypto from "crypto";
 import type { IncomingMessage, OutgoingMessage } from "http";
 import { z } from "zod";
 
 import { IS_PRODUCTION } from "@calcom/lib/constants";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+
+import { buildNonce } from "@lib/buildNonce";
 
 function getCspPolicy(nonce: string) {
   //TODO: Do we need to explicitly define it in turbo.json
@@ -59,7 +60,7 @@ export function csp(req: IncomingMessage | null, res: OutgoingMessage | null) {
   }
   const CSP_POLICY = process.env.CSP_POLICY;
   const cspEnabledForInstance = CSP_POLICY;
-  const nonce = crypto.randomBytes(16).toString("base64");
+  const nonce = buildNonce(crypto.getRandomValues(new Uint8Array(22)));
 
   const parsedUrl = new URL(req.url, "http://base_url");
   const cspEnabledForPage = cspEnabledForInstance && isPagePathRequest(parsedUrl);


### PR DESCRIPTION
## What does this PR do?

This PR replaces the usage of Node.js `crypto` module with native `crypto` API.
If the app router is used, the Node.js `crypto` module can no longer be used within middleware functions.
Otherwise, we run into the following error: https://nextjs.org/docs/messages/node-module-in-edge-runtime
You can also read: https://github.com/vercel/next.js/discussions/47314

I found a solution like this: https://gist.github.com/themikefuller/c1de46cbbdad02645b9dc006baedf88e but honestly, I find it hard to understand. Please take into account that `window.btoa` and `window.atob` operate on binary strings, as per https://developer.mozilla.org/en-US/docs/Web/API/btoa, which might be confusing in terms of conversion, code points, etc.

Since the nonce is just a string per documentation, https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce, not necessarily a base64 string, I came up with the following solution
* let's generate 22 random bytes using the native `crypto` API
* let's cut them all to 6 bits and replace these 6 bits with the base64 ASCII characters
* let's add `==` as padding
* we end up with a 24-ASCII-character string that is a valid base64 string (which means it contains the proper base64 characters and can be reverted into the initial non-encoded blob, but the latter step is not required unless YOU ACTUALLY DECODE THE NONCES).

Please note I did not convert any buffer value to base64, I generated a string that looks as if it was encoded from some value.

## Requirement/Documentation
1. https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce
2. https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
3. https://en.wikipedia.org/wiki/Base64#Output_padding
4. https://nextjs.org/docs/pages/api-reference/edge#unsupported-apis
5. https://vercel.com/templates/next.js/edge-functions-crypto

## Type of change

<!-- Please delete bullets that are not relevant. -->
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
The flow on Chrome:
1. Go to any page that uses nonces (e.g. login page, signup page)
2. Open the Developer Tools
3. Check the request to the HTML page that you are currently viewing (you'd probably have to reload the page to see it)
4. Go to Headers, Response Headers and look for `Content-Security-Policy-Report-Only:`
5. The header should contain the nonce value explicitly, 
6. Go to Response tab and look for `nonce` in the returned HTML. You should see the same value in around 46 places, usually in `<script>` tags.

Trivia:
You won't see `nonce` value in the HTML within the Elements tab. The reason is apparently security. 

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
