### PR TITLE
fix: Missing avatar for non-migrated users on team booking page

### DIFF
--- a/apps/web/pages/api/user/avatar.ts
+++ b/apps/web/pages/api/user/avatar.ts
@@ -34,13 +34,35 @@ async function getIdentityData(req: NextApiRequest) {
     : null;
 
   if (username) {
-    const user = await prisma.user.findFirst({
+    let user = await prisma.user.findFirst({
       where: {
         username,
         organization: orgQuery,
       },
       select: { avatar: true, email: true },
     });
+
+    /**
+     * TEMPORARY CODE STARTS - TO BE REMOVED after mono-user schema is implemented
+     * Try the non-org user temporarily to support users part of a team but not part of the organization
+     * This is needed because of a situation where we migrate a user and the team to ORG but not all the users in the team to the ORG.
+     * Eventually, all users will be migrated to the ORG but this is when user by user migration happens initially.
+     */
+    // No user found in the org, try the non-org user that might be part of the team that's part of an org
+    if (!user && orgQuery) {
+      // The only side effect this code could have is that it could serve the avatar of a non-org member from the org domain but as long as the username isn't taken by an org member.
+      user = await prisma.user.findFirst({
+        where: {
+          username,
+          organization: null,
+        },
+        select: { avatar: true, email: true },
+      });
+    }
+    /**
+     * TEMPORARY CODE ENDS
+     */
+
     return {
       name: username,
       email: user?.email,
@@ -48,6 +70,7 @@ async function getIdentityData(req: NextApiRequest) {
       org,
     };
   }
+
   if (teamname) {
     const team = await prisma.team.findFirst({
       where: {


### PR DESCRIPTION
## What does this PR do?

More details https://threads.com/thread/34542069818/34542958382?s=o3wzwcB72cJdWsJyxNvd8o

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Use /moveToOrg endpoint to move a user to an org along with his team
- Go to the team booking page and notice that the user who was moved has the correct avatar but who wasn't moved doesn't have the avatar. This PR fixes the issue.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
