### PR TITLE
chore: [app dir bootstrapping 3] check nullability in AppListCard

### DIFF
--- a/apps/web/components/AppListCard.tsx
+++ b/apps/web/components/AppListCard.tsx
@@ -60,14 +60,18 @@ export default function AppListCard(props: AppListCardProps) {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (shouldHighlight && highlight) {
-      const timer = setTimeout(() => {
-        setHighlight(false);
+    if (shouldHighlight && highlight && searchParams !== null && pathname !== null) {
+      timeoutRef.current = setTimeout(() => {
         const _searchParams = new URLSearchParams(searchParams);
         _searchParams.delete("hl");
-        router.replace(`${pathname}?${_searchParams.toString()}`);
+        _searchParams.delete("category"); // this comes from params, not from search params
+
+        setHighlight(false);
+
+        const stringifiedSearchParams = _searchParams.toString();
+
+        router.replace(`${pathname}${stringifiedSearchParams !== "" ? `?${stringifiedSearchParams}` : ""}`);
       }, 3000);
-      timeoutRef.current = timer;
     }
     return () => {
       if (timeoutRef.current) {
@@ -75,8 +79,7 @@ export default function AppListCard(props: AppListCardProps) {
         timeoutRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [highlight, pathname, router, searchParams, shouldHighlight]);
 
   return (
     <div className={classNames(highlight && "dark:bg-muted bg-yellow-100")}>

--- a/apps/web/playwright/app-list-card.e2e.ts
+++ b/apps/web/playwright/app-list-card.e2e.ts
@@ -1,0 +1,14 @@
+import { test } from "./lib/fixtures";
+
+test.describe("AppListCard", async () => {
+  test("should remove the highlight from the URL", async ({ page, users }) => {
+    const user = await users.create({});
+    await user.apiLogin();
+
+    await page.goto("/apps/installed/conferencing?hl=daily-video");
+
+    await page.waitForLoadState();
+
+    await page.waitForURL("/apps/installed/conferencing");
+  });
+});


### PR DESCRIPTION
## What does this PR do?
After adding the app directory, the `next build` step will change the definitions of `usePathname` and `useSearchParams` hooks by creating new type definitions in `.next` directory. This will ensure that the return types contain null.
Actually, the return types can be nullable in the `pages` router under specific circumstances outlined here:
1. https://nextjs.org/docs/app/api-reference/functions/use-search-params
2. https://nextjs.org/docs/app/api-reference/functions/use-pathname

## Type of change
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
This PR does no change in behavior.
1. Go to https://app.cal.com/apps/installed/conferencing?hl=daily-video
2. The Cal Video should be highlighted for 3 seconds
3. The highlight disappears and you get redirected to https://app.cal.com/apps/installed/conferencing?category=conferencing

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
