### PR TITLE
fix: Handle non-org team with same slug as the organization's requestedSlug

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -235,7 +235,7 @@ const nextConfig = {
         ? [
             {
               ...matcherConfigRootPath,
-              destination: "/team/:orgSlug",
+              destination: "/team/:orgSlug?isOrgProfile=1",
             },
             {
               ...matcherConfigUserRoute,

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -1,3 +1,9 @@
+// This route is reachable by
+// 1. /team/[slug]
+// 2. / (when on org domain e.g. http://calcom.cal.com/. This is through a rewrite from next.config.js)
+// Also the getServerSideProps and default export are reused by
+// 1. org/[orgSlug]/team/[slug]
+// 2. org/[orgSlug]/[user]/[type]
 import classNames from "classnames";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
@@ -12,6 +18,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
 import useTheme from "@calcom/lib/hooks/useTheme";
+import logger from "@calcom/lib/logger";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { getTeamWithMembers } from "@calcom/lib/server/queries/teams";
 import slugify from "@calcom/lib/slugify";
@@ -34,7 +41,7 @@ import { ssrInit } from "@server/lib/ssr";
 import { getTemporaryOrgRedirect } from "../../lib/getTemporaryOrgRedirect";
 
 export type PageProps = inferSSRProps<typeof getServerSideProps>;
-
+const log = logger.getSubLogger({ prefix: ["team/[slug]"] });
 function TeamPage({
   team,
   isUnpublished,
@@ -277,12 +284,23 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   );
   const isOrgContext = isValidOrgDomain && currentOrgDomain;
 
+  // Provided by Rewrite from next.config.js
+  const isOrgProfile = context.query?.isOrgProfile === "1";
   const flags = await getFeatureFlagMap(prisma);
+  const isOrganizationFeatureEnabled = flags["organizations"];
+
+  log.debug("getServerSideProps", {
+    isOrgProfile,
+    isOrganizationFeatureEnabled,
+    isValidOrgDomain,
+    currentOrgDomain,
+  });
+
   const team = await getTeamWithMembers({
     slug: slugify(slug ?? ""),
     orgSlug: currentOrgDomain,
     isTeamView: true,
-    isOrgView: isValidOrgDomain && context.resolvedUrl === "/",
+    isOrgView: isValidOrgDomain && isOrgProfile,
   });
 
   if (!isOrgContext && slug) {
@@ -299,17 +317,12 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   const ssr = await ssrInit(context);
   const metadata = teamMetadataSchema.parse(team?.metadata ?? {});
-  console.info("gSSP, team/[slug] - ", {
-    isValidOrgDomain,
-    currentOrgDomain,
-    ALLOWED_HOSTNAMES: process.env.ALLOWED_HOSTNAMES,
-    flags: JSON.stringify(flags),
-  });
+
   // Taking care of sub-teams and orgs
   if (
     (!isValidOrgDomain && team?.parent) ||
     (!isValidOrgDomain && !!metadata?.isOrganization) ||
-    flags["organizations"] !== true
+    !isOrganizationFeatureEnabled
   ) {
     return { notFound: true } as const;
   }


### PR DESCRIPTION
## What does this PR do?

The fix is in 2 parts
1.  Preventing the scenario where requestedSlug for an org is allowed to be same as a non-org team slug
2. Handle the scenario where even if there are conflicting slugs, it should retrieve the ORG only and not any team for Org Profile(i.e. https://calcom.cal.com would always serve an ORG, it can't serve a team)

[Demo before and After fix](https://www.loom.com/share/20c3d1fd570147f0baaa13987f90c90c)

More context in [internal thread](https://threads.com/thread/34543004525/34543097153?s=8eiMC4zWbUVBQoBeWWKne8)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [x] Create a team(T1) with a slug(Slug1) outside any organization.
- [x] Try creating an org(O1) with the same slug. Locally, you would have to set[ IS_TEAM_BILLING_ENABLED=1](https://github.com/calcom/cal.com/blob/987751beed3cfc736eed3f1474c02e6d83af0e67/packages/lib/constants.ts#L90) temporarily to create a scenario when instead of adding a slug to the Organization, we would add `requestedSlug` instead.
  With this branch, it won't be allowed but in main it is allowed.
- [x] Once the Org is created. Try accessing that org, e.g. http://calcom.cal.local:3000
- [x] Notice that you would see the team T1 instead of org O1

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
