### PR TITLE
fix: booking day wrong in booking list

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -230,6 +230,7 @@ function BookingListItem(booking: BookingItemProps) {
   };
 
   const startTime = dayjs(booking.startTime)
+    .tz(user?.timeZone)
     .locale(language)
     .format(isUpcoming ? "ddd, D MMM" : "D MMMM YYYY");
   const [isOpenRescheduleDialog, setIsOpenRescheduleDialog] = useState(false);


### PR DESCRIPTION
## What does this PR do?

Fixes the following scenario: 

User Timezone: New York 

If there is a booking at 11:00 PM on 9th of November, it was shown on Nov 10th in the list of upcoming bookings: 
<img width="196" alt="Screenshot 2023-10-19 at 17 17 25" src="https://github.com/calcom/cal.com/assets/30310907/8a84a2af-da64-476c-9203-6123db362a70">

It's showed the day of the UTC time. 
