### PR TITLE
fix: team availability slider overflow

### DIFF
--- a/packages/ui/components/data-table/DataTableToolbar.tsx
+++ b/packages/ui/components/data-table/DataTableToolbar.tsx
@@ -36,7 +36,7 @@ export function DataTableToolbar<TData>({
   const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
-    <div className="bg-default sticky top-[3rem] z-10 flex items-center justify-end space-x-2 py-4 md:top-0">
+    <div className="bg-default sticky top-[3rem] z-10 flex items-center justify-end space-x-2 py-[2.15rem] md:top-0">
       {searchKey && (
         <Input
           className="max-w-64 mb-0 mr-auto rounded-md"


### PR DESCRIPTION
## What does this PR do?

Fixes the team availability slider overflow bug without affecting `Organisation Members` table.

Fixes #12015 

https://github.com/calcom/cal.com/assets/94699055/cc19cfdc-4ad0-45a5-a28a-033ca3e8abed

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Create a team with a lot of members
2. Go to availability
3. Switch to `Team Availability`
4. Scroll and see the expected behaviour

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.