### PR TITLE
feat: added social links to public page

### DIFF
--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import type { DehydratedState } from "@tanstack/react-query";
 import classNames from "classnames";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";

--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -27,7 +27,7 @@ import { RedirectType, type EventType, type User } from "@calcom/prisma/client";
 import { baseEventTypeSelect } from "@calcom/prisma/selects";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import { HeadSeo, UnpublishedEntity } from "@calcom/ui";
-import { Verified, ArrowRight } from "@calcom/ui/components/icon";
+import { Verified, ArrowRight, Linkedin, Twitter } from "@calcom/ui/components/icon";
 
 import type { EmbedProps } from "@lib/withEmbedSsr";
 
@@ -43,6 +43,10 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
   const [user] = users; //To be used when we only have a single user, not dynamic group
   useTheme(profile.theme);
   const { t } = useLocale();
+
+  const linkedinLink = (user?.metadata as Prisma.JsonObject)?.linkedinLink as string;
+  const Xlink = (user?.metadata as Prisma.JsonObject)?.XLink as string;
+  const showSocial = Xlink || linkedinLink;
 
   const isBioEmpty = !user.bio || !user.bio.replace("<p><br></p>", "").length;
 
@@ -117,6 +121,26 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
                   className="  text-subtle break-words text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
                   dangerouslySetInnerHTML={{ __html: props.safeBio }}
                 />
+              </>
+            )}
+            {showSocial && (
+              <>
+                <div className="flex items-center justify-center space-x-4 py-4">
+                  {linkedinLink && (
+                    <div>
+                      <Link href={linkedinLink} target="_blank">
+                        <Linkedin />
+                      </Link>
+                    </div>
+                  )}
+                  {Xlink && (
+                    <div>
+                      <Link href={Xlink} target="_blank">
+                        <Twitter />
+                      </Link>
+                    </div>
+                  )}
+                </div>
               </>
             )}
           </div>
@@ -229,7 +253,7 @@ export type UserPageProps = {
     organizationSlug: string | null;
     allowSEOIndexing: boolean;
   };
-  users: Pick<User, "away" | "name" | "username" | "bio" | "verified">[];
+  users: Pick<User, "away" | "name" | "username" | "bio" | "verified" | "metadata">[];
   themeBasis: string | null;
   markdownStrippedBio: string;
   safeBio: string;
@@ -374,6 +398,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
         bio: user.bio,
         away: user.away,
         verified: user.verified,
+        metadata: user.metadata,
       })),
       entity: {
         isUnpublished: org?.slug === null,

--- a/apps/web/pages/settings/my-account/profile.tsx
+++ b/apps/web/pages/settings/my-account/profile.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { Prisma } from "@prisma/client";
 import { signOut, useSession } from "next-auth/react";
 import type { BaseSyntheticEvent } from "react";
 import React, { useRef, useState } from "react";
@@ -70,11 +71,14 @@ interface DeleteAccountValues {
 }
 
 type FormValues = {
+  metadata: object;
   username: string;
   avatar: string | null;
   name: string;
   email: string;
   bio: string;
+  linkedinLink: string;
+  XLink: string;
 };
 
 const checkIfItFallbackImage = (fetchedImgSrc: string) => {
@@ -236,6 +240,9 @@ const ProfileView = () => {
     name: user.name || "",
     email: user.email || "",
     bio: user.bio || "",
+    linkedinLink: ((user?.metadata as Prisma.JsonObject)?.linkedinLink as string) || "",
+    XLink: ((user?.metadata as Prisma.JsonObject)?.XLink as string) || "",
+    metadata: { linkedinLink: "", XLink: "" },
   };
 
   return (
@@ -261,6 +268,11 @@ const ProfileView = () => {
             // Opens a dialog warning the change
             setConfirmAuthEmailChangeWarningDialogOpen(true);
           } else {
+            values.metadata = {
+              linkedinLink: values.linkedinLink,
+              XLink: values.XLink,
+            };
+
             updateProfileMutation.mutate(values);
           }
         }}
@@ -421,6 +433,8 @@ const ProfileForm = ({
       }),
     email: z.string().email(),
     bio: z.string(),
+    linkedinLink: z.string(),
+    XLink: z.string(),
   });
 
   const formMethods = useForm<FormValues>({
@@ -487,6 +501,12 @@ const ProfileForm = ({
         </div>
         <div className="mt-6">
           <TextField label={t("email")} hint={t("change_email_hint")} {...formMethods.register("email")} />
+        </div>
+        <div className="mt-6">
+          <TextField label="Linkedin Link" {...formMethods.register("linkedinLink")} />
+        </div>
+        <div className="mt-6">
+          <TextField label="X Link" {...formMethods.register("XLink")} />
         </div>
         <div className="mt-6">
           <Label>{t("about")}</Label>

--- a/apps/web/pages/settings/my-account/profile.tsx
+++ b/apps/web/pages/settings/my-account/profile.tsx
@@ -503,7 +503,7 @@ const ProfileForm = ({
           <TextField label={t("email")} hint={t("change_email_hint")} {...formMethods.register("email")} />
         </div>
         <div className="mt-6">
-          <TextField label="Linkedin Link" {...formMethods.register("linkedinLink")} />
+          <TextField label="LinkedIn Link" {...formMethods.register("linkedinLink")} />
         </div>
         <div className="mt-6">
           <TextField label="X Link" {...formMethods.register("XLink")} />

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -315,6 +315,8 @@ export const userMetadata = z
         appLink: z.string().optional(),
       })
       .optional(),
+    linkedinLink: z.string().optional(),
+    XLink: z.string().optional(),
     defaultBookerLayouts: bookerLayouts.optional(),
   })
   .nullable();

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.schema.ts
@@ -6,6 +6,8 @@ import { bookerLayouts, userMetadata } from "@calcom/prisma/zod-utils";
 export const updateUserMetadataAllowedKeys = z.object({
   sessionTimeout: z.number().optional(), // Minutes
   defaultBookerLayouts: bookerLayouts.optional(),
+  linkedinLink: z.string().optional(),
+  XLink: z.string().optional(),
 });
 
 export const ZUpdateProfileInputSchema = z.object({


### PR DESCRIPTION
## What does this PR do?

This PR gives users the option to add their  LinkedIn and Twitter links to the public page.
I have stored the links to Twitter and LinkedIn in the metadata columns of users

Fixes #11933 


 Loom Video: https://www.loom.com/share/31240d32f5484ff0beb91fe172ccc121


## Requirement/Documentation

## Type of change

<!-- Please delete bullets that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


## How should this be tested?

Go to my account settings page and add your LinkedIn and twitter links. go to your public profile page and click on links

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
