### PR TITLE
fix: [app dir bootstrapping 8] `useParamsWithFallback` hook and add tests

### DIFF
--- a/packages/lib/hooks/useParamsWithFallback.test.ts
+++ b/packages/lib/hooks/useParamsWithFallback.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { vi } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { useParamsWithFallback } from "./useParamsWithFallback";
+
+describe("useParamsWithFallback hook", () => {
+  it("should return router.query when router.query exists", () => {
+    vi.mock("next/navigation", () => ({
+      useParams: vi.fn().mockReturnValue(null),
+    }));
+
+    vi.mock("react", () => ({
+      useContext: vi.fn().mockReturnValue({ query: { id: 1 } }),
+    }));
+
+    const { result } = renderHook(() => useParamsWithFallback());
+
+    expect(result.current).toEqual({ id: 1 });
+  });
+
+  it("should return useParams() when router is undefined", () => {
+    vi.mock("next/navigation", () => ({
+      useParams: vi.fn().mockReturnValue({ id: 1 }),
+    }));
+
+    vi.mock("react", () => ({
+      useContext: vi.fn().mockReturnValue(undefined),
+    }));
+
+    const { result } = renderHook(() => useParamsWithFallback());
+
+    expect(result.current).toEqual({ id: 1 });
+  });
+
+  it("should return useParams() when router is null", () => {
+    vi.mock("next/navigation", () => ({
+      useParams: vi.fn().mockReturnValue({ id: 1 }),
+    }));
+
+    vi.mock("react", () => ({
+      useContext: vi.fn().mockReturnValue(null),
+    }));
+
+    const { result } = renderHook(() => useParamsWithFallback());
+
+    expect(result.current).toEqual({ id: 1 });
+  });
+});

--- a/packages/lib/hooks/useParamsWithFallback.test.ts
+++ b/packages/lib/hooks/useParamsWithFallback.test.ts
@@ -5,13 +5,13 @@ import { describe, expect, it } from "vitest";
 import { useParamsWithFallback } from "./useParamsWithFallback";
 
 describe("useParamsWithFallback hook", () => {
-  it("should return router.query when router.query exists", () => {
+  it("should return router.query when param is null", () => {
     vi.mock("next/navigation", () => ({
       useParams: vi.fn().mockReturnValue(null),
     }));
 
-    vi.mock("react", () => ({
-      useContext: vi.fn().mockReturnValue({ query: { id: 1 } }),
+    vi.mock("next/compat/router", () => ({
+      useRouter: vi.fn().mockReturnValue({ query: { id: 1 } }),
     }));
 
     const { result } = renderHook(() => useParamsWithFallback());
@@ -19,13 +19,13 @@ describe("useParamsWithFallback hook", () => {
     expect(result.current).toEqual({ id: 1 });
   });
 
-  it("should return useParams() when router is undefined", () => {
+  it("should return router.query when param is undefined", () => {
     vi.mock("next/navigation", () => ({
-      useParams: vi.fn().mockReturnValue({ id: 1 }),
+      useParams: vi.fn().mockReturnValue(undefined),
     }));
 
-    vi.mock("react", () => ({
-      useContext: vi.fn().mockReturnValue(undefined),
+    vi.mock("next/compat/router", () => ({
+      useRouter: vi.fn().mockReturnValue({ query: { id: 1 } }),
     }));
 
     const { result } = renderHook(() => useParamsWithFallback());
@@ -33,13 +33,27 @@ describe("useParamsWithFallback hook", () => {
     expect(result.current).toEqual({ id: 1 });
   });
 
-  it("should return useParams() when router is null", () => {
+  it("should return useParams() if it exists", () => {
     vi.mock("next/navigation", () => ({
       useParams: vi.fn().mockReturnValue({ id: 1 }),
     }));
 
-    vi.mock("react", () => ({
-      useContext: vi.fn().mockReturnValue(null),
+    vi.mock("next/compat/router", () => ({
+      useRouter: vi.fn().mockReturnValue(null),
+    }));
+
+    const { result } = renderHook(() => useParamsWithFallback());
+
+    expect(result.current).toEqual({ id: 1 });
+  });
+
+  it("should return useParams() if it exists", () => {
+    vi.mock("next/navigation", () => ({
+      useParams: vi.fn().mockReturnValue({ id: 1 }),
+    }));
+
+    vi.mock("next/compat/router", () => ({
+      useRouter: vi.fn().mockReturnValue({ query: { id: 2 } }),
     }));
 
     const { result } = renderHook(() => useParamsWithFallback());

--- a/packages/lib/hooks/useParamsWithFallback.ts
+++ b/packages/lib/hooks/useParamsWithFallback.ts
@@ -1,13 +1,25 @@
 "use client";
 
+import { RouterContext } from "next/dist/shared/lib/router-context";
 import { useParams } from "next/navigation";
-import { useRouter } from "next/router";
+import { useContext } from "react";
+
+interface Params {
+  [key: string]: string | string[];
+}
 
 /**
  * This hook is a workaround until pages are migrated to app directory.
  */
-export function useParamsWithFallback() {
-  const router = useRouter();
+export function useParamsWithFallback(): Params {
   const params = useParams();
-  return params || router.query;
+  // `Error: NextRouter was not mounted` is thrown if `useRouter` from `next/router` is called in App router.
+  // As can be seen in https://github.com/vercel/next.js/blob/e8a92a9507cff7d5f7b52701089d4b8141126a63/packages/next/src/client/router.ts#L132,
+  // `useRouter()` hook returns `React.useContext(RouterContext)`.
+  // Hence, We can directly use this value.
+  const router = useContext(RouterContext);
+  if (router) {
+    return (router.query ?? {}) as Params;
+  }
+  return params ?? {};
 }

--- a/packages/lib/hooks/useParamsWithFallback.ts
+++ b/packages/lib/hooks/useParamsWithFallback.ts
@@ -2,6 +2,7 @@
 
 import { useRouter as useCompatRouter } from "next/compat/router";
 import { useParams } from "next/navigation";
+import type { ParsedUrlQuery } from "querystring";
 
 interface Params {
   [key: string]: string | string[];
@@ -10,7 +11,7 @@ interface Params {
 /**
  * This hook is a workaround until pages are migrated to app directory.
  */
-export function useParamsWithFallback(): Params {
+export function useParamsWithFallback(): Params | ParsedUrlQuery {
   const params = useParams(); // always `null` in pages router
   const router = useCompatRouter(); // always `null` in app router
   return params ?? router?.query ?? {};

--- a/packages/lib/hooks/useParamsWithFallback.ts
+++ b/packages/lib/hooks/useParamsWithFallback.ts
@@ -1,8 +1,7 @@
 "use client";
 
-import { RouterContext } from "next/dist/shared/lib/router-context";
+import { useRouter as useCompatRouter } from "next/compat/router";
 import { useParams } from "next/navigation";
-import { useContext } from "react";
 
 interface Params {
   [key: string]: string | string[];
@@ -12,14 +11,7 @@ interface Params {
  * This hook is a workaround until pages are migrated to app directory.
  */
 export function useParamsWithFallback(): Params {
-  const params = useParams();
-  // `Error: NextRouter was not mounted` is thrown if `useRouter` from `next/router` is called in App router.
-  // As can be seen in https://github.com/vercel/next.js/blob/e8a92a9507cff7d5f7b52701089d4b8141126a63/packages/next/src/client/router.ts#L132,
-  // `useRouter()` hook returns `React.useContext(RouterContext)`.
-  // Hence, We can directly use this value.
-  const router = useContext(RouterContext);
-  if (router) {
-    return (router.query ?? {}) as Params;
-  }
-  return params ?? {};
+  const params = useParams(); // always `null` in pages router
+  const router = useCompatRouter(); // always `null` in app router
+  return params ?? router?.query ?? {};
 }

--- a/setupVitest.ts
+++ b/setupVitest.ts
@@ -1,3 +1,4 @@
+import { JSDOM } from "jsdom";
 import { vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 
@@ -5,3 +6,14 @@ const fetchMocker = createFetchMock(vi);
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMocker.enableMocks();
+
+const jsdom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+global.window = jsdom.window;
+global.document = jsdom.window.document;
+global.navigator = {
+  ...global.navigator,
+  userAgent: "node.js",
+};

--- a/setupVitest.ts
+++ b/setupVitest.ts
@@ -1,4 +1,3 @@
-import { JSDOM } from "jsdom";
 import { vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 
@@ -6,14 +5,3 @@ const fetchMocker = createFetchMock(vi);
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMocker.enableMocks();
-
-const jsdom = new JSDOM("<!doctype html><html><body></body></html>", {
-  url: "http://localhost",
-});
-
-global.window = jsdom.window;
-global.document = jsdom.window.document;
-global.navigator = {
-  ...global.navigator,
-  userAgent: "node.js",
-};

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -36,7 +36,7 @@ const workspaces = packagedEmbedTestsOnly
         test: {
           include: ["packages/**/*.{test,spec}.{ts,js}", "apps/**/*.{test,spec}.{ts,js}"],
           // TODO: Ignore the api until tests are fixed
-          exclude: ["**/node_modules/**/*", "packages/embeds/**/*"],
+          exclude: ["**/node_modules/**/*", "packages/embeds/**/*", "packages/lib/hooks/**/*"],
           setupFiles: ["setupVitest.ts"],
         },
       },
@@ -65,6 +65,13 @@ const workspaces = packagedEmbedTestsOnly
           include: ["packages/app-store/_components/**/*.{test,spec}.{ts,js,tsx}"],
           environment: "jsdom",
           setupFiles: ["packages/app-store/test-setup.ts"],
+        },
+      },
+      {
+        test: {
+          name: "@calcom/packages/lib/hooks",
+          include: ["packages/lib/hooks/**/*.{test,spec}.{ts,js}"],
+          environment: "jsdom",
         },
       },
     ];


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Bug: `Error: NextRouter was not mounted` is thrown if `useRouter` from `next/router` is called in App router. Since `useParamsWithFallback` is meant to be used in both page router and app router, this shouldn't happen. 
- How the bug was found: In order to migrate `pages/workflows/[workflow].tsx` to App router, I created a file at `app/workflows/[workflow]/page.tsx` that imports component from `@calcom/features/ee/workflows/pages/workflow`. The component at `@calcom/features/ee/workflows/pages/workflow` uses `useParamsWithFallback` hook, in which `useRouter` from `next/router` is called.
- Solution: Use next.js compat router (this doesn't throw error but rather returns null in app router)
- Extra Note: We added tests to ensure the functionality of the hook.

## Requirement/Documentation

- [Next.js doc stating that `useParams` returns `null` in Pages Router](https://nextjs.org/docs/app/api-reference/functions/use-params#returns)
- [next.js compat router](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/compat/router.ts)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. We added tests to ensure the functionality of the hook. Run `yarn vitest run packages/lib/hooks/useParamsWithFallback.test.ts`.
2. To test in real browser, try to call the hook `useParamsWithFallback` in any client component in app router page. You can go to this [branch](https://github.com/intuita-inc/cal.com-demo/tree/intuita/app-router-migration), create any dummy component in app router and call the hook from there.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.