### PR TITLE
fix: re-render on booker

### DIFF
--- a/packages/features/bookings/Booker/components/EventMeta.tsx
+++ b/packages/features/bookings/Booker/components/EventMeta.tsx
@@ -1,6 +1,5 @@
 import { m } from "framer-motion";
 import dynamic from "next/dynamic";
-import { useEffect } from "react";
 import { shallow } from "zustand/shallow";
 
 import { useEmbedUiConfig, useIsEmbed } from "@calcom/embed-core/embed-iframe";
@@ -37,13 +36,6 @@ export const EventMeta = () => {
   const embedUiConfig = useEmbedUiConfig();
   const isEmbed = useIsEmbed();
   const hideEventTypeDetails = isEmbed ? embedUiConfig.hideEventTypeDetails : false;
-
-  useEffect(() => {
-    if (!selectedDuration && event?.length) {
-      setSelectedDuration(event.length);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [event?.length, selectedDuration]);
 
   if (hideEventTypeDetails) {
     return null;

--- a/packages/features/bookings/components/AvailableTimes.tsx
+++ b/packages/features/bookings/components/AvailableTimes.tsx
@@ -11,6 +11,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button, SkeletonText } from "@calcom/ui";
 
 import { useBookerStore } from "../Booker/store";
+import { useEvent } from "../Booker/utils/event";
 import { getQueryParam } from "../Booker/utils/query-param";
 import { useTimePreferences } from "../lib";
 import { useCheckOverlapWithOverlay } from "../lib/useCheckOverlapWithOverlay";
@@ -51,9 +52,9 @@ const SlotItem = ({
   const overlayCalendarToggled =
     getQueryParam("overlayCalendar") === "true" || localStorage.getItem("overlayCalendarSwitchDefault");
   const [timeFormat, timezone] = useTimePreferences((state) => [state.timeFormat, state.timezone]);
-  const selectedDuration = useBookerStore((state) => state.selectedDuration);
   const bookingData = useBookerStore((state) => state.bookingData);
   const layout = useBookerStore((state) => state.layout);
+  const { data: event } = useEvent();
   const hasTimeSlots = !!seatsPerTimeSlot;
   const computedDateWithUsersTimezone = dayjs.utc(slot.time).tz(timezone);
 
@@ -67,11 +68,12 @@ const SlotItem = ({
 
   const offset = (usersTimezoneDate.utcOffset() - nowDate.utcOffset()) / 60;
 
-  const { isOverlapping, overlappingTimeEnd, overlappingTimeStart } = useCheckOverlapWithOverlay(
-    computedDateWithUsersTimezone,
-    selectedDuration,
-    offset
-  );
+  const { isOverlapping, overlappingTimeEnd, overlappingTimeStart } = useCheckOverlapWithOverlay({
+    start: computedDateWithUsersTimezone,
+    selectedDuration: event?.length ?? 0,
+    offset,
+  });
+
   const [overlapConfirm, setOverlapConfirm] = useState(false);
 
   const onButtonClick = useCallback(() => {

--- a/packages/features/bookings/lib/useCheckOverlapWithOverlay.tsx
+++ b/packages/features/bookings/lib/useCheckOverlapWithOverlay.tsx
@@ -9,7 +9,15 @@ function getCurrentTime(date: Date) {
   return `${hours}:${minutes}`;
 }
 
-export function useCheckOverlapWithOverlay(start: Dayjs, selectedDuration: number | null, offset: number) {
+export function useCheckOverlapWithOverlay({
+  start,
+  selectedDuration,
+  offset,
+}: {
+  start: Dayjs;
+  selectedDuration: number | null;
+  offset: number;
+}) {
   const overlayBusyDates = useOverlayCalendarStore((state) => state.overlayBusyDates);
 
   let overlappingTimeStart: string | null = null;


### PR DESCRIPTION
Moves duration to the useEvent call which pulls from trpc cache
![CleanShot 2023-10-24 at 15 27 50](https://github.com/calcom/cal.com/assets/55134778/e946af59-d565-4373-af3d-f6d4176101b2)
![CleanShot 2023-10-24 at 15 27 54](https://github.com/calcom/cal.com/assets/55134778/fcbcc339-15bf-4ee6-b8b4-a75718e926ff)
Network call down to 1 from 2 as reported in thread: https://threads.com/messages/648066a6-127a-4519-b3cf-c9a2d7ba9c5a?messageID=0ee75155-786f-485c-9e33-1626b0018f01
![CleanShot 2023-10-24 at 15 28 07](https://github.com/calcom/cal.com/assets/55134778/17028a48-34ae-4eff-b987-e2432500be0f)
