### PR TITLE
chore: [app dir bootstrapping 4.1] check nullability of navigation hook return values part 2

### DIFF
--- a/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarSettingsModal.tsx
+++ b/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarSettingsModal.tsx
@@ -47,7 +47,7 @@ export function OverlayCalendarSettingsModal(props: IOverlayCalendarContinueModa
   const searchParams = useSearchParams();
   const setOverlayBusyDates = useOverlayCalendarStore((state) => state.setOverlayBusyDates);
   const { data, isLoading } = trpc.viewer.connectedCalendars.useQuery(undefined, {
-    enabled: !!props.open || !!searchParams.get("overlayCalendar"),
+    enabled: !!props.open || Boolean(searchParams?.get("overlayCalendar")),
   });
   const { toggleValue, hasItem, set } = useLocalSet<{
     credentialId: number;

--- a/packages/features/ee/payments/components/Payment.tsx
+++ b/packages/features/ee/payments/components/Payment.tsx
@@ -94,7 +94,7 @@ const PaymentForm = (props: Props) => {
       location?: string;
     } = {
       uid: props.booking.uid,
-      email: searchParams.get("email"),
+      email: searchParams?.get("email"),
     };
     if (paymentOption === "HOLD" && "setupIntent" in props.payment.data) {
       payload = await stripe.confirmSetup({

--- a/packages/features/embed/Embed.tsx
+++ b/packages/features/embed/Embed.tsx
@@ -61,7 +61,7 @@ function useRouterHelpers() {
   const pathname = usePathname();
 
   const goto = (newSearchParams: Record<string, string>) => {
-    const newQuery = new URLSearchParams(searchParams);
+    const newQuery = new URLSearchParams(searchParams ?? undefined);
     Object.keys(newSearchParams).forEach((key) => {
       newQuery.set(key, newSearchParams[key]);
     });
@@ -70,7 +70,7 @@ function useRouterHelpers() {
   };
 
   const removeQueryParams = (queryParams: string[]) => {
-    const params = new URLSearchParams(searchParams);
+    const params = new URLSearchParams(searchParams ?? undefined);
 
     queryParams.forEach((param) => {
       params.delete(param);
@@ -529,7 +529,7 @@ const EmbedTypeCodeAndPreviewDialogContent = ({
   );
 
   const s = (href: string) => {
-    const _searchParams = new URLSearchParams(searchParams);
+    const _searchParams = new URLSearchParams(searchParams ?? undefined);
     const [a, b] = href.split("=");
     _searchParams.set(a, b);
     return `${pathname?.split("?")[0] ?? ""}?${_searchParams.toString()}`;

--- a/packages/lib/payment/handlePayment.ts
+++ b/packages/lib/payment/handlePayment.ts
@@ -2,13 +2,13 @@ import type { AppCategories, Prisma } from "@prisma/client";
 
 import appStore from "@calcom/app-store";
 import type { EventTypeAppsList } from "@calcom/app-store/utils";
-import type { EventTypeModel } from "@calcom/prisma/zod";
+import type { CompleteEventType } from "@calcom/prisma/zod";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 import type { IAbstractPaymentService, PaymentApp } from "@calcom/types/PaymentService";
 
 const handlePayment = async (
   evt: CalendarEvent,
-  selectedEventType: Pick<Zod.infer<typeof EventTypeModel>, "metadata" | "title">,
+  selectedEventType: Pick<CompleteEventType, "metadata" | "title">,
   paymentAppCredentials: {
     key: Prisma.JsonValue;
     appId: EventTypeAppsList;


### PR DESCRIPTION
## What does this PR do?

(This is second part of https://github.com/calcom/cal.com/pull/12005)

This PR enforces nullability checks for return values from `useParams` and `useSearchParams`.
If a page has neither `getServerSideProps` not `getInitialProps`, Next.js will optimize it statically. This makes the `usePathname` and `useSearchParams` equal `null` until the router becomes available during hydration.

If you add the app directory to the web directory and run yarn build, the types will be updated by Next.js builder/plugin and the projects will then include the compat type definitions provided by Next.js.

This mechanism is coded here: https://github.com/vercel/next.js/blob/524b31513a58e58e15862ac8aa3f27da8a47a267/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts#L54

The example compat type definition is here: https://github.com/vercel/next.js/blob/524b31513a58e58e15862ac8aa3f27da8a47a267/packages/next/navigation-types/compat/navigation.d.ts

## Requirement/Documentation
https://nextjs.org/docs/app/api-reference/functions/use-pathname
https://nextjs.org/docs/app/api-reference/functions/use-search-params
https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization

## Type of change
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?
The app should work exactly as worked before.

Since nullability issues (TypeErrors) have not been observed before, this change should only satisfy the TS compiler.

Caveats:
1. The prerendered pages doesn't have the `useSearchParams` and `usePathname` return values on the prerender. Other pages don't have these values on the first render. The code should not allow:
    a) running write operation on first render (with e.g. `useEffect`) that use values from these hooks.
    b) running read operations unconditionally based on the values from these hooks.

One idea was to wrap each component with a HOC that:
1) returns `null` when `useSearchParams` or `usePathname` are `null`
2) otherwise, it passes non-empty `searchParams` and `pathname` as props to the wrapped component.
One problem is possible flickering stemming from a lot of components appearing when these two values become available.

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
