### PR TITLE
fix: prevents prisma idle connections

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,7 +3550,7 @@ __metadata:
     postcss: ^8.4.18
     react: ^18.2.0
     react-dom: ^18.2.0
-    tailwindcss: ^3.3.3
+    tailwindcss: ^3.3.1
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -3644,7 +3644,7 @@ __metadata:
     "@calcom/ui": "*"
     "@headlessui/react": ^1.5.0
     "@heroicons/react": ^1.0.6
-    "@prisma/client": ^5.4.2
+    "@prisma/client": ^5.3.0
     "@tailwindcss/forms": ^0.5.2
     "@types/node": 16.9.1
     "@types/react": 18.0.26
@@ -8245,7 +8245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:^5.4.2":
+"@prisma/client@npm:^5.3.0, @prisma/client@npm:^5.4.2":
   version: 5.4.2
   resolution: "@prisma/client@npm:5.4.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,7 +3550,7 @@ __metadata:
     postcss: ^8.4.18
     react: ^18.2.0
     react-dom: ^18.2.0
-    tailwindcss: ^3.3.1
+    tailwindcss: ^3.3.3
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -3644,7 +3644,7 @@ __metadata:
     "@calcom/ui": "*"
     "@headlessui/react": ^1.5.0
     "@heroicons/react": ^1.0.6
-    "@prisma/client": ^5.3.0
+    "@prisma/client": ^5.4.2
     "@tailwindcss/forms": ^0.5.2
     "@types/node": 16.9.1
     "@types/react": 18.0.26
@@ -8245,7 +8245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:^5.3.0, @prisma/client@npm:^5.4.2":
+"@prisma/client@npm:^5.4.2":
   version: 5.4.2
   resolution: "@prisma/client@npm:5.4.2"
   dependencies:


### PR DESCRIPTION
## What does this PR do?


Seems like in PR #10687 the global guard that prevented a lot of idle instances got replaced. Left a comment in [the specific line in here](https://github.com/calcom/cal.com/pull/10687/files#r1370735278).

This PR Makes sure that both the extended and unextended prisma clients are reused a much as possible.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- yarn build
- yarn e2e
- yarn test
- On staging/QA measure the idle connections over time. It should be under the limit.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't added tests that prove my fix is effective or that my feature works
