### PR TITLE
fix: Teams listing and wrong avatars - Cross org boundary scenario

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -72,6 +72,7 @@ import useMeQuery from "@lib/hooks/useMeQuery";
 
 import PageWrapper from "@components/PageWrapper";
 import SkeletonLoader from "@components/eventtype/SkeletonLoader";
+import { UserAvatarGroup } from "@components/ui/avatar/UserAvatarGroup";
 
 type EventTypeGroups = RouterOutputs["viewer"]["eventTypes"]["getByViewer"]["eventTypeGroups"];
 type EventTypeGroupProfile = EventTypeGroups[number]["profile"];
@@ -398,23 +399,11 @@ export const EventTypeList = ({ group, groupIndex, readOnly, types }: EventTypeL
                   <div className="mt-4 hidden sm:mt-0 sm:flex">
                     <div className="flex justify-between space-x-2 rtl:space-x-reverse">
                       {type.team && !isManagedEventType && (
-                        <AvatarGroup
+                        <UserAvatarGroup
                           className="relative right-3 top-1"
                           size="sm"
                           truncateAfter={4}
-                          items={
-                            type?.users
-                              ? type.users.map(
-                                  (organizer: { name: string | null; username: string | null }) => ({
-                                    alt: organizer.name || "",
-                                    image: `${orgBranding?.fullDomain ?? WEBAPP_URL}/${
-                                      organizer.username
-                                    }/avatar.png`,
-                                    title: organizer.name || "",
-                                  })
-                                )
-                              : []
-                          }
+                          users={type?.users ?? []}
                         />
                       )}
                       {isManagedEventType && type?.children && type.children?.length > 0 && (

--- a/packages/lib/getEventTypeById.ts
+++ b/packages/lib/getEventTypeById.ts
@@ -4,10 +4,9 @@ import { getLocationGroupedOptions } from "@calcom/app-store/server";
 import type { StripeData } from "@calcom/app-store/stripepayment/lib/server";
 import { getEventTypeAppData } from "@calcom/app-store/utils";
 import type { LocationObject } from "@calcom/core/location";
-import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
 import { parseBookingLimit, parseDurationLimit, parseRecurringEvent } from "@calcom/lib";
-import { CAL_URL } from "@calcom/lib/constants";
+import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import type { PrismaClient } from "@calcom/prisma";
 import type { Credential } from "@calcom/prisma/client";
@@ -36,6 +35,7 @@ export default async function getEventTypeById({
     username: true,
     id: true,
     email: true,
+    organizationId: true,
     locale: true,
     defaultScheduleId: true,
   });
@@ -298,9 +298,7 @@ export default async function getEventTypeById({
   const eventTypeUsers: ((typeof eventType.users)[number] & { avatar: string })[] = eventType.users.map(
     (user) => ({
       ...user,
-      avatar: `${eventType.team?.parent?.slug ? getOrgFullOrigin(eventType.team?.parent?.slug) : CAL_URL}/${
-        user.username
-      }/avatar.png`,
+      avatar: getUserAvatarUrl(user),
     })
   );
 
@@ -346,11 +344,7 @@ export default async function getEventTypeById({
         .map((member) => {
           const user: typeof member.user & { avatar: string } = {
             ...member.user,
-            avatar: `${
-              eventTypeObject.team?.parent?.slug
-                ? getOrgFullOrigin(eventTypeObject.team?.parent?.slug)
-                : CAL_URL
-            }/${member.user.username}/avatar.png`,
+            avatar: getUserAvatarUrl(member.user),
           };
           return {
             ...user,

--- a/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
@@ -30,6 +30,7 @@ const userSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
   username: true,
   name: true,
+  organizationId: true,
 });
 
 const userEventTypeSelect = Prisma.validator<Prisma.EventTypeSelect>()({

--- a/packages/trpc/server/routers/viewer/teams/list.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/list.handler.ts
@@ -1,4 +1,3 @@
-import { isOrganisationAdmin } from "@calcom/lib/server/queries/organisations";
 import { prisma } from "@calcom/prisma";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
@@ -11,42 +10,12 @@ type ListOptions = {
 };
 
 export const listHandler = async ({ ctx }: ListOptions) => {
-  if (ctx.user?.organization?.id) {
-    const membershipsWithoutParent = await prisma.membership.findMany({
-      where: {
-        userId: ctx.user.id,
-        team: {
-          parent: {
-            is: {
-              id: ctx.user?.organization?.id,
-            },
-          },
-        },
-      },
-      include: {
-        team: {
-          include: {
-            inviteTokens: true,
-          },
-        },
-      },
-      orderBy: { role: "desc" },
-    });
-
-    const isOrgAdmin = !!(await isOrganisationAdmin(ctx.user.id, ctx.user.organization.id)); // Org id exists here as we're inside a conditional TS complaining for some reason
-
-    return membershipsWithoutParent.map(({ team: { inviteTokens, ..._team }, ...membership }) => ({
-      role: membership.role,
-      accepted: membership.accepted,
-      isOrgAdmin,
-      ..._team,
-      /** To prevent breaking we only return non-email attached token here, if we have one */
-      inviteToken: inviteTokens.find((token) => token.identifier === `invite-link-for-teamId-${_team.id}`),
-    }));
-  }
-
   const memberships = await prisma.membership.findMany({
     where: {
+      // Show all the teams this user belongs to regardless of the team being part of the user's org or not
+      // We don't want to restrict in the listing here. If we need to restrict a situation where a user is part of the org along with being part of a non-org team, we should do that instead of filtering out from here
+      // This became necessary when we started migrating user to Org, without migrating some teams of the user to the org
+      // Also, we would allow a user to be part of multiple orgs, then also it would be necessary.
       userId: ctx.user.id,
     },
     include: {


### PR DESCRIPTION
## What does this PR do?
- Fix avatar at more places(Scenario-1) Follows up on #12031
- For an org on /teams page, show teams that aren't part of org if the logged in user is part of them.(Scenario-2)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Scenario-1
- Create two users with same username(one in org and one outside). Notice that the avatar for the org user uses non-org user's avatar on Team Assignment page, event-types list. This bug is now fixed.

Scenario-2
- As an org user, make yourself part of a non-org team by directly creating a membership with that team
- Test that you can see the team in /teams when logged in as org member.


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
