### PR TITLE
fix: Embed: data-cal-origin not used by modal(which is used by both element click popup and floating button popup)

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -236,7 +236,7 @@ export class Cal {
   }: {
     calLink: string;
     queryObject?: PrefillAndIframeAttrsConfig & { guest?: string | string[] };
-    calOrigin?: string;
+    calOrigin: string | null;
   }) {
     const iframe = (this.iframe = document.createElement("iframe"));
     iframe.className = "cal-embed";
@@ -473,10 +473,12 @@ class CalApi {
     }
 
     config.embedType = "inline";
+    const calConfig = this.cal.getConfig();
 
     const iframe = this.cal.createIframe({
       calLink,
       queryObject: withColorScheme(Cal.getQueryObject(config), containerEl),
+      calOrigin: calConfig.calOrigin,
     });
 
     iframe.style.height = "100%";
@@ -555,6 +557,7 @@ class CalApi {
   modal({
     calLink,
     config = {},
+    calOrigin,
     __prerender = false,
   }: {
     calLink: string;
@@ -607,6 +610,7 @@ class CalApi {
       iframe = this.cal.createIframe({
         calLink,
         queryObject,
+        calOrigin: calOrigin || null,
       });
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #12073

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Set `data-cal-origin` on the element click popup button and see that the cal link is still being opened from default app.cal.local:3000 and not the provided value

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
