### PR TITLE
fix: fix the padding and position of tabs on the Team Availability page and Organisation Members page

### DIFF
--- a/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
+++ b/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
@@ -193,6 +193,7 @@ export function AvailabilitySliderTable() {
       <>
         <div className="relative">
           <DataTable
+            searchKey="member"
             tableContainerRef={tableContainerRef}
             columns={memorisedColumns}
             onRowMouseclick={(row) => {

--- a/packages/ui/components/data-table/DataTableToolbar.tsx
+++ b/packages/ui/components/data-table/DataTableToolbar.tsx
@@ -36,7 +36,7 @@ export function DataTableToolbar<TData>({
   const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
-    <div className="bg-default sticky top-[3rem] z-10 flex items-center justify-end space-x-2 py-[2.15rem] md:top-0">
+    <div className="bg-default sticky top-[3rem] z-10 flex items-center justify-end space-x-2 py-4 md:top-0">
       {searchKey && (
         <Input
           className="max-w-64 mb-0 mr-auto rounded-md"


### PR DESCRIPTION
## What does this PR do?

The team availability page had a lot of padding which couldn't be fixed without breaking the organisation members page as both use the same `DataTable` component.

I added `Search` on the `Team Availability` page and also made some minor adjustment to CSS of sticky header for the `DataTable`.

Fixes #12025 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

1. Create a team, add a lot of members to it.
2. Go to Availability>Team Availability.
3. See the visual differences.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.