### PR TITLE
feat: add oldBookingId to reschedule bookings payload

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -2378,6 +2378,7 @@ async function handler(
     ...eventTypeInfo,
     bookingId: booking?.id,
     rescheduleUid,
+    oldBookingId: originalRescheduledBooking?.id || undefined,
     rescheduleStartTime: originalRescheduledBooking?.startTime
       ? dayjs(originalRescheduledBooking?.startTime).utc().format()
       : undefined,


### PR DESCRIPTION
## What does this PR do?

Adds `oldBookingId` to reschedule bookings payload so that it is easily re-usable via API. Without old booking ids within the payload of rescheduled bookings, there's no way for the users to get the old booking information via API as API fetches bookings by id and not by uid.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- NA

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Regular bookings should work and send payload as per usual (check webhook)
- Rescheduled bookings webhook payload should now contain `oldBookingId` field with the value of the booking id that was rescheduled

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
