### PR TITLE
fix: pull managed event type bookings in zapier

### DIFF
--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -188,7 +188,7 @@ export async function listBookings(
         };
       } else {
         where.eventType = {
-          teamId: account.id,
+          OR: [{ teamId: account.id }, { parent: { teamId: account.id } }],
         };
       }
     }


### PR DESCRIPTION
## What does this PR do?

Managed event type bookings weren't pulled when testing zapier trigger (listBookings endpoint). This worked with API keys but not with OAuth