### PR TITLE
fix: adding managed event type to workflow

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -86,13 +86,16 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
 
   const hasOrgsPlan = IS_SELF_HOSTED || ctx.user.organizationId;
 
+  const where: Prisma.EventTypeWhereInput = {};
+  where.id = {
+    in: activeOn,
+  };
+  if (userWorkflow.teamId) {
+    //all children managed event types are added after
+    where.parentId = null;
+  }
   const activeOnEventTypes = await ctx.prisma.eventType.findMany({
-    where: {
-      id: {
-        in: activeOn,
-      },
-      parentId: null,
-    },
+    where,
     select: {
       id: true,
       children: {


### PR DESCRIPTION
## What does this PR do?

Fixes that managed event type couldn't be added to a user workflow. It didn't throw any error, but the managed event type just got ignored. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create managed event type and assign yourself
- Create a new user workflow
- Add managed event type in the dropdown
- Click save
- Go back to workflow and check if managed event type is checked in dropdown
