### PR TITLE
fix: impersonation for orgs

### DIFF
--- a/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
+++ b/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
@@ -72,6 +72,67 @@ export function checkPermission(session: Session | null) {
   }
 }
 
+async function getImpersonatedUser({
+  session,
+  teamId,
+  creds,
+}: {
+  session: Session | null;
+  teamId: number | undefined;
+  creds: Credentials | null;
+}) {
+  let TeamWhereClause: Prisma.MembershipWhereInput = {
+    disableImpersonation: false, // Ensure they have impersonation enabled
+    accepted: true, // Ensure they are apart of the team and not just invited.
+    team: {
+      id: teamId, // Bring back only the right team
+    },
+  };
+
+  // If you are an admin we dont need to follow this flow -> We can just follow the usual flow
+  // If orgId and teamId are the same we can follow the same flow
+  if (session?.user.org?.id && session.user.org.id !== teamId && session?.user.role !== "ADMIN") {
+    TeamWhereClause = {
+      disableImpersonation: false,
+      accepted: true,
+      team: {
+        id: session.user.org.id,
+      },
+    };
+  }
+
+  // Get user who is being impersonated
+  const impersonatedUser = await prisma.user.findFirst({
+    where: {
+      OR: [{ username: creds?.username }, { email: creds?.username }],
+    },
+    select: {
+      id: true,
+      username: true,
+      role: true,
+      name: true,
+      email: true,
+      organizationId: true,
+      disableImpersonation: true,
+      locale: true,
+      teams: {
+        where: TeamWhereClause,
+        select: {
+          teamId: true,
+          disableImpersonation: true,
+          role: true,
+        },
+      },
+    },
+  });
+
+  if (!impersonatedUser) {
+    throw new Error("This user does not exist");
+  }
+
+  return impersonatedUser;
+}
+
 const ImpersonationProvider = CredentialsProvider({
   id: "impersonation-auth",
   name: "Impersonation",
@@ -89,55 +150,7 @@ const ImpersonationProvider = CredentialsProvider({
     checkUserIdentifier(creds);
     checkPermission(session);
 
-    let TeamWhereClause: Prisma.MembershipWhereInput = {
-      disableImpersonation: false, // Ensure they have impersonation enabled
-      accepted: true, // Ensure they are apart of the team and not just invited.
-      team: {
-        id: teamId, // Bring back only the right team
-      },
-    };
-
-    // If you are an admin we dont need to follow this flow -> We can just follow the usual flow
-    // If orgId and teamId are the same we can follow the same flow
-    if (session?.user.org?.id && session.user.org.id !== teamId && session?.user.role !== "ADMIN") {
-      TeamWhereClause = {
-        disableImpersonation: false,
-        accepted: true,
-        team: {
-          id: session.user.org.id,
-        },
-      };
-    }
-
-    // Get user who is being impersonated
-    const impersonatedUser = await prisma.user.findFirst({
-      where: {
-        OR: [{ username: creds?.username }, { email: creds?.username }],
-      },
-      select: {
-        id: true,
-        username: true,
-        role: true,
-        name: true,
-        email: true,
-        organizationId: true,
-        disableImpersonation: true,
-        locale: true,
-        teams: {
-          where: TeamWhereClause,
-          select: {
-            teamId: true,
-            disableImpersonation: true,
-            role: true,
-          },
-        },
-      },
-    });
-
-    // Check if impersonating is allowed for this user
-    if (!impersonatedUser) {
-      throw new Error("This user does not exist");
-    }
+    const impersonatedUser = await getImpersonatedUser({ session, teamId, creds });
 
     if (session?.user.role === "ADMIN") {
       if (impersonatedUser.disableImpersonation) {

--- a/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
+++ b/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
@@ -64,7 +64,10 @@ export function checkUserIdentifier(creds: Partial<Credentials>) {
 }
 
 export function checkPermission(session: Session | null) {
-  if (session?.user.role !== "ADMIN" && process.env.NEXT_PUBLIC_TEAM_IMPERSONATION === "false") {
+  if (
+    (session?.user.role !== "ADMIN" && process.env.NEXT_PUBLIC_TEAM_IMPERSONATION === "false") ||
+    !session?.user
+  ) {
     throw new Error("You do not have permission to do this.");
   }
 }

--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -321,7 +321,7 @@ export default function MemberListItem(props: Props) {
               onSubmit={async (e) => {
                 e.preventDefault();
                 await signIn("impersonation-auth", {
-                  username: props.member.username || props.member.email,
+                  username: props.member.email,
                   teamId: props.team.id,
                 });
                 setShowImpersonateModal(false);

--- a/packages/features/users/components/UserTable/ImpersonationMemberModal.tsx
+++ b/packages/features/users/components/UserTable/ImpersonationMemberModal.tsx
@@ -27,7 +27,7 @@ export function ImpersonationMemberModal(props: { state: State; dispatch: Dispat
           onSubmit={async (e) => {
             e.preventDefault();
             await signIn("impersonation-auth", {
-              username: user.username || user.email,
+              username: user.email,
               teamId: teamId,
             });
             props.dispatch({


### PR DESCRIPTION
Fixes impersonation in an org context:

How to test:
Org admins/owners can impersonate anyone in the org if they have impersonation enabeld
Org Team owners/admins can impersonate anyone in THAT org team if they have impersonation enabled 

Normal team/admin impersonation should remain the same