### PR TITLE
fix: text colour for no-show acknowledgment

### DIFF
--- a/packages/features/ee/payments/components/Payment.tsx
+++ b/packages/features/ee/payments/components/Payment.tsx
@@ -147,7 +147,7 @@ const PaymentForm = (props: Props) => {
               formatParams: { amount: { currency: props.payment.currency } },
             })}
             onChange={(e) => setHoldAcknowledged(e.target.checked)}
-            descriptionClassName="text-blue-900 font-semibold"
+            descriptionClassName="text-info font-semibold"
           />
         </div>
       )}


### PR DESCRIPTION
## What does this PR do?

Fixes text colour of `No-Show fee` acknowledgment message. Previously `text-blue-900` was used, I replaced it with `text-info` which uses the text colour as shown below for the dark mode. There are no changes to light mode i.e., it is alright.

<img width="1440" alt="Screenshot 2023-10-29 at 12 33 19 PM 1" src="https://github.com/calcom/cal.com/assets/94699055/b595163c-485d-487f-8c0b-85bbce005cfc">

Fixes #12131 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.