### PR TITLE
fix: Prevent possible reason behind avatar infinite redirect

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -238,6 +238,7 @@ async function getAvatarToSet(avatar: string | null | undefined) {
     } else {
       // Non Base64 avatar currently could only be the dynamic avatar URL(i.e. /{USER}/avatar.png). If we allow setting that URL, we would get infinite redirects on /user/avatar.ts endpoint
       log.warn("Non Base64 avatar, ignored it", { avatar });
+      // `undefined` would not ignore the avatar, but `null` would remove it. So, we return `undefined` here.
       return undefined;
     }
   }

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -22,6 +22,7 @@ import { TRPCError } from "@trpc/server";
 import { getDefaultScheduleId } from "../viewer/availability/util";
 import { updateUserMetadataAllowedKeys, type TUpdateProfileInputSchema } from "./updateProfile.schema";
 
+const log = logger.getSubLogger({ prefix: ["updateProfile"] });
 type UpdateProfileOptions = {
   ctx: {
     user: NonNullable<TrpcSessionUser>;
@@ -35,6 +36,7 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
   const userMetadata = handleUserMetadata({ ctx, input });
   const data: Prisma.UserUpdateInput = {
     ...input,
+    avatar: await getAvatarToSet(input.avatar),
     metadata: userMetadata,
   };
 
@@ -60,12 +62,6 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
         throw new TRPCError({ code: "BAD_REQUEST", message: response.message });
       }
     }
-  }
-  if (input.avatar) {
-    data.avatar = await resizeBase64Image(input.avatar);
-  }
-  if (input.avatar === null) {
-    data.avatar = null;
   }
 
   if (isPremiumUsername) {
@@ -234,3 +230,20 @@ const handleUserMetadata = ({ ctx, input }: UpdateProfileOptions) => {
   // Required so we don't override and delete saved values
   return { ...userMetadata, ...cleanMetadata };
 };
+
+async function getAvatarToSet(avatar: string | null | undefined) {
+  if (avatar) {
+    if (avatar.startsWith("data:image")) {
+      return await resizeBase64Image(avatar);
+    } else {
+      // Non Base64 avatar currently could only be the dynamic avatar URL(i.e. /{USER}/avatar.png). If we allow setting that URL, we would get infinite redirects on /user/avatar.ts endpoint
+      log.warn("Non Base64 avatar, ignored it", { avatar });
+      return undefined;
+    }
+  }
+
+  if (avatar === null) {
+    return null;
+  }
+  return avatar;
+}

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -232,19 +232,15 @@ const handleUserMetadata = ({ ctx, input }: UpdateProfileOptions) => {
 };
 
 async function getAvatarToSet(avatar: string | null | undefined) {
-  if (avatar) {
-    if (avatar.startsWith("data:image")) {
-      return await resizeBase64Image(avatar);
-    } else {
-      // Non Base64 avatar currently could only be the dynamic avatar URL(i.e. /{USER}/avatar.png). If we allow setting that URL, we would get infinite redirects on /user/avatar.ts endpoint
-      log.warn("Non Base64 avatar, ignored it", { avatar });
-      // `undefined` would not ignore the avatar, but `null` would remove it. So, we return `undefined` here.
-      return undefined;
-    }
+  if (avatar === null || avatar === undefined) {
+    return avatar;
   }
 
-  if (avatar === null) {
-    return null;
+  if (!avatar.startsWith("data:image")) {
+    // Non Base64 avatar currently could only be the dynamic avatar URL(i.e. /{USER}/avatar.png). If we allow setting that URL, we would get infinite redirects on /user/avatar.ts endpoint
+    log.warn("Non Base64 avatar, ignored it", { avatar });
+    // `undefined` would not ignore the avatar, but `null` would remove it. So, we return `undefined` here.
+    return undefined;
   }
-  return avatar;
+  return await resizeBase64Image(avatar);
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #12102

[Before and After fix loom](https://www.loom.com/share/abb4cc151916423e850a32bbbf4c4326)

**NOTE:** Because avatar is stored wrongly in DB, a re-upload is required.

**More important note:** As avatar endpoint is cached by Cloudflare/Vercel, even though it would fix the avatar in DB, it would probably not fix the issue immediately. After the cache expires, which is probably a day, the problem would automatically solve for users who have re-uploaded the avatar.

The caching thing is supposed to be solved in a better way in #12018 or a followup of it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See loom

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
