### PR TITLE
fix: organizations some teams throw 404

### DIFF
--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -28,7 +28,10 @@ let subdomainRegExp = (exports.subdomainRegExp = getSubdomainRegExp(
 exports.orgHostPath = `^(?<orgSlug>${subdomainRegExp})\\.(?!vercel\.app).*`;
 
 let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes);
-exports.orgUserRoutePath = `/:user((?!${beforeRewriteExcludePages.join("|")}|_next|public)[a-zA-Z0-9\-_]+)`;
+exports.orgUserRoutePath = `/:user((?!${beforeRewriteExcludePages
+  .map((page) => `\\b${page}\\b`)
+  .join("|")}|_next|public)[a-zA-Z0-9\-_]+)`;
+
 exports.orgUserTypeRoutePath = `/:user((?!${beforeRewriteExcludePages.join(
   "/|"
 )}|_next/|public/)[^/]+)/:type((?!avatar\.png)[^/]+)`;


### PR DESCRIPTION
Fixes #12003

## Before
[Screencast from 31-10-23 05:00:23 PM IST.webm](https://github.com/calcom/cal.com/assets/32706411/6bb2d0c4-483d-45bf-bfb1-ef5051ee887b)

## After
[Screencast from 31-10-23 05:04:18 PM IST.webm](https://github.com/calcom/cal.com/assets/32706411/8ce7a2bd-6ec3-4d15-8662-51943c24eb4b)

The issue:
the regex was not allowing /team1 /team2 as we have /team as one of the route and is restricted
changed the regex to match the **whole word** "team" or "teams" or any other predefined route **exactly**.