### PR TITLE
fix: Check for same day, not with <=

### DIFF
--- a/packages/features/calendars/lib/getAvailableDatesInMonth.timezone.test.ts
+++ b/packages/features/calendars/lib/getAvailableDatesInMonth.timezone.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 
+import dayjs from "@calcom/dayjs";
 import { getAvailableDatesInMonth } from "@calcom/features/calendars/lib/getAvailableDatesInMonth";
 import { daysInMonth, yyyymmdd } from "@calcom/lib/date-fns";
 
@@ -66,7 +67,8 @@ describe("Test Suite: Date Picker", () => {
 
     test("it returns the correct responses end of month", () => {
       // test a date at one minute past midnight, end of month.
-      vi.useFakeTimers().setSystemTime(new Date("2023-10-31T00:00:01.000Z"));
+      // we use dayjs() as the system timezone can still modify the Date.
+      vi.useFakeTimers().setSystemTime(dayjs().endOf("month").startOf("day").add(1, "second").toDate());
 
       const currentDate = new Date();
       const result = getAvailableDatesInMonth({

--- a/packages/features/calendars/lib/getAvailableDatesInMonth.timezone.test.ts
+++ b/packages/features/calendars/lib/getAvailableDatesInMonth.timezone.test.ts
@@ -63,5 +63,21 @@ describe("Test Suite: Date Picker", () => {
       vi.setSystemTime(vi.getRealSystemTime());
       vi.useRealTimers();
     });
+
+    test("it returns the correct responses end of month", () => {
+      // test a date at one minute past midnight, end of month.
+      vi.useFakeTimers().setSystemTime(new Date("2023-10-31T00:00:01.000Z"));
+
+      const currentDate = new Date();
+      const result = getAvailableDatesInMonth({
+        browsingDate: currentDate,
+      });
+
+      expect(result).toHaveLength(1);
+
+      // Undo the forced time we applied earlier, reset to system default.
+      vi.setSystemTime(vi.getRealSystemTime());
+      vi.useRealTimers();
+    });
   });
 });

--- a/packages/features/calendars/lib/getAvailableDatesInMonth.ts
+++ b/packages/features/calendars/lib/getAvailableDatesInMonth.ts
@@ -1,3 +1,4 @@
+import dayjs from "@calcom/dayjs";
 import { daysInMonth, yyyymmdd } from "@calcom/lib/date-fns";
 
 // calculate the available dates in the month:
@@ -21,7 +22,9 @@ export function getAvailableDatesInMonth({
   );
   for (
     let date = browsingDate > minDate ? browsingDate : minDate;
-    date <= lastDateOfMonth;
+    // Check if date is before the last date of the month
+    // or is the same day, in the same month, in the same year.
+    date < lastDateOfMonth || dayjs(date).isSame(lastDateOfMonth, "day");
     date = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1)
   ) {
     // intersect included dates


### PR DESCRIPTION
## What does this PR do?

Checking <= checks the current date is before or equal to midnight end of the month, so it won't return the last day on the last day. 

<img width="1100" alt="image" src="https://github.com/calcom/cal.com/assets/1046695/27d3ccb4-fddc-4049-bad5-74d801b03981">
