### PR TITLE
fix: booking timeslots

### DIFF
--- a/packages/core/getAggregatedAvailability.ts
+++ b/packages/core/getAggregatedAvailability.ts
@@ -53,6 +53,6 @@ function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
 function isCurrentRangeOverlappingNext(currentRange: DateRange, nextRange: DateRange): boolean {
   return (
     currentRange.start.valueOf() <= nextRange.start.valueOf() &&
-    currentRange.end.valueOf() >= nextRange.start.valueOf()
+    currentRange.end.valueOf() > nextRange.start.valueOf()
   );
 }

--- a/packages/core/getAggregatedAvailability.ts
+++ b/packages/core/getAggregatedAvailability.ts
@@ -22,14 +22,6 @@ export const getAggregatedAvailability = (
   return mergeOverlappingDateRanges(availability);
 };
 
-function isSameDay(date1: Date, date2: Date) {
-  return (
-    date1.getUTCFullYear() === date2.getUTCFullYear() &&
-    date1.getUTCMonth() === date2.getUTCMonth() &&
-    date1.getUTCDate() === date2.getUTCDate()
-  );
-}
-
 function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
   dateRanges.sort((a, b) => a.start.valueOf() - b.start.valueOf());
 
@@ -42,10 +34,8 @@ function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
 
   for (let i = 1; i < dateRanges.length; i++) {
     const nextRange = dateRanges[i];
-    if (
-      isSameDay(currentRange.start.toDate(), nextRange.start.toDate()) &&
-      currentRange.end.valueOf() > nextRange.start.valueOf()
-    ) {
+
+    if (isCurrentRangeOverlappingNext(currentRange, nextRange)) {
       currentRange = {
         start: currentRange.start,
         end: currentRange.end.valueOf() > nextRange.end.valueOf() ? currentRange.end : nextRange.end,
@@ -58,4 +48,11 @@ function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
   mergedDateRanges.push(currentRange);
 
   return mergedDateRanges;
+}
+
+function isCurrentRangeOverlappingNext(currentRange: DateRange, nextRange: DateRange): boolean {
+  return (
+    currentRange.start.valueOf() <= nextRange.start.valueOf() &&
+    currentRange.end.valueOf() >= nextRange.start.valueOf()
+  );
 }

--- a/packages/core/getAggregatedAvailability/date-range-utils/mergeOverlappingDateRanges/index.ts
+++ b/packages/core/getAggregatedAvailability/date-range-utils/mergeOverlappingDateRanges/index.ts
@@ -1,28 +1,6 @@
 import type { DateRange } from "@calcom/lib/date-ranges";
-import { intersect } from "@calcom/lib/date-ranges";
-import { SchedulingType } from "@calcom/prisma/enums";
 
-export const getAggregatedAvailability = (
-  userAvailability: { dateRanges: DateRange[]; user?: { isFixed?: boolean } }[],
-  schedulingType: SchedulingType | null
-): DateRange[] => {
-  const fixedHosts = userAvailability.filter(
-    ({ user }) => !schedulingType || schedulingType === SchedulingType.COLLECTIVE || user?.isFixed
-  );
-
-  const dateRangesToIntersect = fixedHosts.map((s) => s.dateRanges);
-
-  const unfixedHosts = userAvailability.filter(({ user }) => user?.isFixed !== true);
-  if (unfixedHosts.length) {
-    dateRangesToIntersect.push(unfixedHosts.flatMap((s) => s.dateRanges));
-  }
-
-  const availability = intersect(dateRangesToIntersect);
-
-  return mergeOverlappingDateRanges(availability);
-};
-
-function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
+export function mergeOverlappingDateRanges(dateRanges: DateRange[]) {
   dateRanges.sort((a, b) => a.start.valueOf() - b.start.valueOf());
 
   const mergedDateRanges: DateRange[] = [];

--- a/packages/core/getAggregatedAvailability/date-range-utils/mergeOverlappingDateRanges/mergeOverlappingDateRanges.test.ts
+++ b/packages/core/getAggregatedAvailability/date-range-utils/mergeOverlappingDateRanges/mergeOverlappingDateRanges.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import type { DateRange } from "@calcom/lib/date-ranges";
+
+import { mergeOverlappingDateRanges } from ".";
+
+const november2 = "2023-11-02";
+const november3 = "2023-11-03";
+
+describe("mergeOverlappingDateRanges", () => {
+  it("should merge all ranges into one when one range includes all others", () => {
+    const dateRanges = [
+      createDateRange(`${november2}T23:00:00.000Z`, `${november3}T07:00:00.000Z`), // Includes all others
+      createDateRange(`${november2}T23:15:00.000Z`, `${november3}T00:00:00.000Z`),
+      createDateRange(`${november3}T00:15:00.000Z`, `${november3}T01:00:00.000Z`),
+      createDateRange(`${november3}T01:15:00.000Z`, `${november3}T02:00:00.000Z`),
+    ];
+
+    const mergedRanges = mergeOverlappingDateRanges(dateRanges);
+    expect(mergedRanges).toHaveLength(1);
+    expect(mergedRanges[0].start.isSame(dayjs(dateRanges[0].start))).toBe(true);
+    expect(mergedRanges[0].end.isSame(dayjs(dateRanges[0].end))).toBe(true);
+  });
+
+  it("should merge only overlapping ranges over 2 days and leave non-overlapping ranges as is", () => {
+    const dateRanges = [
+      createDateRange(`${november2}T23:00:00.000Z`, `${november3}T07:00:00.000Z`),
+      createDateRange(`${november3}T05:00:00.000Z`, `${november3}T06:00:00.000Z`),
+      createDateRange(`${november3}T08:00:00.000Z`, `${november3}T10:00:00.000Z`), // This range should not be merged
+    ];
+
+    const mergedRanges = mergeOverlappingDateRanges(dateRanges);
+    expect(mergedRanges).toHaveLength(2);
+    expect(mergedRanges[0].start.isSame(dayjs(dateRanges[0].start))).toBe(true);
+    expect(mergedRanges[0].end.isSame(dayjs(dateRanges[0].end))).toBe(true);
+    expect(mergedRanges[1].start.isSame(dayjs(dateRanges[2].start))).toBe(true);
+    expect(mergedRanges[1].end.isSame(dayjs(dateRanges[2].end))).toBe(true);
+  });
+
+  it("should merge ranges that overlap on the same day", () => {
+    const dateRanges = [
+      createDateRange(`${november2}T01:00:00.000Z`, `${november2}T04:00:00.000Z`),
+      createDateRange(`${november2}T02:00:00.000Z`, `${november2}T03:00:00.000Z`), // This overlaps with the first range
+      createDateRange(`${november2}T05:00:00.000Z`, `${november2}T06:00:00.000Z`), // This doesn't overlap with above
+    ];
+
+    const mergedRanges = mergeOverlappingDateRanges(dateRanges);
+    expect(mergedRanges).toHaveLength(2);
+    expect(mergedRanges[0].start.isSame(dayjs(dateRanges[0].start))).toBe(true);
+    expect(mergedRanges[0].end.isSame(dayjs(dateRanges[0].end))).toBe(true);
+    expect(mergedRanges[1].start.isSame(dayjs(dateRanges[2].start))).toBe(true);
+    expect(mergedRanges[1].end.isSame(dayjs(dateRanges[2].end))).toBe(true);
+  });
+});
+
+function createDateRange(start: string, end: string): DateRange {
+  return {
+    start: dayjs(start),
+    end: dayjs(end),
+  };
+}

--- a/packages/core/getAggregatedAvailability/index.ts
+++ b/packages/core/getAggregatedAvailability/index.ts
@@ -1,0 +1,25 @@
+import type { DateRange } from "@calcom/lib/date-ranges";
+import { intersect } from "@calcom/lib/date-ranges";
+import { SchedulingType } from "@calcom/prisma/enums";
+
+import { mergeOverlappingDateRanges } from "./date-range-utils/mergeOverlappingDateRanges";
+
+export const getAggregatedAvailability = (
+  userAvailability: { dateRanges: DateRange[]; user?: { isFixed?: boolean } }[],
+  schedulingType: SchedulingType | null
+): DateRange[] => {
+  const fixedHosts = userAvailability.filter(
+    ({ user }) => !schedulingType || schedulingType === SchedulingType.COLLECTIVE || user?.isFixed
+  );
+
+  const dateRangesToIntersect = fixedHosts.map((s) => s.dateRanges);
+
+  const unfixedHosts = userAvailability.filter(({ user }) => user?.isFixed !== true);
+  if (unfixedHosts.length) {
+    dateRangesToIntersect.push(unfixedHosts.flatMap((s) => s.dateRanges));
+  }
+
+  const availability = intersect(dateRangesToIntersect);
+
+  return mergeOverlappingDateRanges(availability);
+};


### PR DESCRIPTION
## What does this PR do?

Fixes #12142

Fixes `mergeOverlappingDateRanges` not properly merging date ranges if first starts at day X and ends at day X + 1 but second date range starts and ends in X + 1 while starting after and ending before the first one.

### How it was before
Lets say `mergeOverlappingDateRanges` took the given `dateRanges` below as argument. You see that first one starts November 2, 23:00 and ends November 3, 07:00 and all other date ranges are within its range.

```
  {
    "start": "2023-11-02T23:00:00.000Z",
    "end": "2023-11-03T07:00:00.000Z"
  },
  {
    "start": "2023-11-02T23:15:00.000Z",
    "end": "2023-11-03T00:00:00.000Z"
  },
  {
    "start": "2023-11-03T00:15:00.000Z",
    "end": "2023-11-03T01:00:00.000Z"
  },
  {
    "start": "2023-11-03T01:15:00.000Z",
    "end": "2023-11-03T02:00:00.000Z"
  },
```

then it didn't merge them and returned what's below. It should have only returned the first entry because it covers all other date ranges.
```
  {
    "start": "2023-11-02T23:00:00.000Z",
    "end": "2023-11-03T07:00:00.000Z"
  },
  {
    "start": "2023-11-03T00:15:00.000Z",
    "end": "2023-11-03T01:00:00.000Z"
  },
  {
    "start": "2023-11-03T01:15:00.000Z",
    "end": "2023-11-03T02:00:00.000Z"
  }
```

because within the function there is conditional
```
if (
    isSameDay(currentRange.start.toDate(), nextRange.start.toDate()) &&
    currentRange.end.valueOf() > nextRange.start.valueOf()
) {
```

where `isSameDay` is
```
function isSameDay(date1: Date, date2: Date) {
  return (
    date1.getUTCFullYear() === date2.getUTCFullYear() &&
    date1.getUTCMonth() === date2.getUTCMonth() &&
    date1.getUTCDate() === date2.getUTCDate()
  );
}
```

### How it is now
We have a new `isCurrentRangeOverlappingNext` function for the if block that does not check the start based on the same day but based on timestamp value.

Given as input:
```
  {
    "start": "2023-11-02T23:00:00.000Z",
    "end": "2023-11-03T07:00:00.000Z"
  },
  {
    "start": "2023-11-02T23:15:00.000Z",
    "end": "2023-11-03T00:00:00.000Z"
  },
  {
    "start": "2023-11-03T00:15:00.000Z",
    "end": "2023-11-03T01:00:00.000Z"
  },
  {
    "start": "2023-11-03T01:15:00.000Z",
    "end": "2023-11-03T02:00:00.000Z"
  }
```

it returns
```
  {
    "start": "2023-11-02T23:00:00.000Z",
    "end": "2023-11-03T07:00:00.000Z"
  }
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Test data above is from Australia/Brisbane example below (scenario 1)

### Scenario 1
Create user 1 and user 2 with availabilities like below and Australia/Brisbane timezone. Then, create a round robin event where both of those users take part in. Check the booking page and see that there are no duplicate timetable entries and timetable entries are in ascending order.

<img width="1048" alt="Screenshot 2023-11-02 at 12 26 05" src="https://github.com/calcom/cal.com/assets/42170848/470b957b-c6d2-4746-9dfd-be196cc9ce62">


---

<img width="1004" alt="Screenshot 2023-11-02 at 12 26 02" src="https://github.com/calcom/cal.com/assets/42170848/72229cc8-e5c2-4c5b-85fa-991a6bd6d6a7">


---

<img width="1093" alt="Screenshot 2023-11-02 at 10 30 27" src="https://github.com/calcom/cal.com/assets/42170848/ab44b8fa-9a58-409e-b421-b74a268096b6">

### Scenario 2
Change availability timezones to Europe/Rome and check the round robin booking page again. Timetable entries are in order and there are no duplicates.


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

