### PR TITLE
fix: API to return hosts on event types response

### DIFF
--- a/apps/api/pages/api/event-types/[id]/_get.ts
+++ b/apps/api/pages/api/event-types/[id]/_get.ts
@@ -51,6 +51,7 @@ export async function getHandler(req: NextApiRequest) {
       customInputs: true,
       team: { select: { slug: true } },
       users: true,
+      hosts: { select: { userId: true, isFixed: true } },
       owner: { select: { username: true, id: true } },
       children: { select: { id: true, userId: true } },
     },

--- a/apps/api/pages/api/event-types/_get.ts
+++ b/apps/api/pages/api/event-types/_get.ts
@@ -45,6 +45,7 @@ async function getHandler(req: NextApiRequest) {
       customInputs: true,
       team: { select: { slug: true } },
       users: true,
+      hosts: { select: { userId: true, isFixed: true } },
       owner: { select: { username: true, id: true } },
       children: { select: { id: true, userId: true } },
     },


### PR DESCRIPTION
## What does this PR do?

- The event types `_get` and `/[id]/_get` now returns hosts for team event types, in the format:

```json
    "hosts": [
        {
            "isFixed": false,
            "userId": 123
        },
        {
            "isFixed": false,
            "userId": 456
        }
    ]
```

Fixes #12190 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- NA

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- GET `/event-types/[id]` & `/event-types/` API requests should now return with an array of hosts filled in for team event types with hosts set, unlike earlier when it would always be empty. 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
