### PR TITLE
fix: team booking page having same slug as the org

### DIFF
--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -288,7 +288,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     slug: slugify(slug ?? ""),
     orgSlug: currentOrgDomain,
     isTeamView: true,
-    isOrgView: isValidOrgDomain && isOrgProfile,
+    getOrgOnly: isValidOrgDomain && isOrgProfile,
   });
 
   if (!isOrgContext && slug) {

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -288,7 +288,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     slug: slugify(slug ?? ""),
     orgSlug: currentOrgDomain,
     isTeamView: true,
-    getOrgOnly: isValidOrgDomain && isOrgProfile,
+    isOrgView: isValidOrgDomain && isOrgProfile,
   });
 
   if (!isOrgContext && slug) {

--- a/packages/lib/server/queries/teams/index.ts
+++ b/packages/lib/server/queries/teams/index.ts
@@ -1,20 +1,14 @@
-import type { Membership } from "@prisma/client";
 import { Prisma } from "@prisma/client";
-import type { z } from "zod";
 
 import { getAppFromSlug } from "@calcom/app-store/utils";
-import {
-  getOrgFullOrigin,
-  whereClauseForOrgWithSlugOrRequestedSlug,
-} from "@calcom/ee/organizations/lib/orgDomains";
+import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import prisma, { baseEventTypeSelect } from "@calcom/prisma";
 import { SchedulingType } from "@calcom/prisma/enums";
-import { EventTypeMetaDataSchema, teamMetadataSchema } from "@calcom/prisma/zod-utils";
+import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 
 import { WEBAPP_URL } from "../../../constants";
-import logger from "../../../logger";
+import { getTeam, getOrg } from "../../repository/team";
 
-const log = logger.getSubLogger({ prefix: ["queries", "teams"] });
 export type TeamWithMembers = Awaited<ReturnType<typeof getTeamWithMembers>>;
 
 export async function getTeamWithMembers(args: {
@@ -27,9 +21,9 @@ export async function getTeamWithMembers(args: {
   /**
    * If true, means that you are fetching an organization and not a team
    */
-  getOrgOnly?: boolean;
+  isOrgView?: boolean;
 }) {
-  const { id, slug, userId, orgSlug, isTeamView, getOrgOnly: isOrgView, includeTeamLogo } = args;
+  const { id, slug, userId, orgSlug, isTeamView, isOrgView, includeTeamLogo } = args;
 
   // This should improve performance saving already app data found.
   const appDataMap = new Map();
@@ -80,11 +74,10 @@ export async function getTeamWithMembers(args: {
     throw new Error("Must provide either id or slug");
   }
 
-  const team = await getTeamOrOrg({
+  const arg = {
     lookupBy,
     forOrgWithSlug: orgSlug ?? null,
     isOrg: !!isOrgView,
-    includeTeamLogo,
     teamSelect: {
       id: true,
       name: true,
@@ -145,21 +138,19 @@ export async function getTeamWithMembers(args: {
         },
       },
     },
-  });
+  } as const;
 
-  if (!team) return null;
+  const teamOrOrg = isOrgView ? await getOrg(arg) : await getTeam(arg);
 
-  const members = team.members.map((obj) => {
-    // We need to do type assertion here because Prisma and TypeScript aren't playing well together and TS complains that obj doesn't have user.
-    const m = obj as Membership & { user: Prisma.UserGetPayload<{ select: typeof userSelect }> };
-    if (m.user === undefined) throw new Error("team.members.[0].user must be selected");
+  if (!teamOrOrg) return null;
 
+  const members = teamOrOrg.members.map((m) => {
     const { credentials, ...restUser } = m.user;
     return {
       ...restUser,
-      role: obj.role,
-      accepted: obj.accepted,
-      disableImpersonation: obj.disableImpersonation,
+      role: m.role,
+      accepted: m.accepted,
+      disableImpersonation: m.disableImpersonation,
       subteams: orgSlug
         ? m.user.teams
             .filter((membership) => membership.team.slug !== orgSlug)
@@ -190,15 +181,15 @@ export async function getTeamWithMembers(args: {
     };
   });
 
-  const eventTypes = team.eventTypes.map((eventType) => ({
+  const eventTypes = teamOrOrg.eventTypes.map((eventType) => ({
     ...eventType,
     metadata: EventTypeMetaDataSchema.parse(eventType.metadata),
   }));
   // Don't leak invite tokens to the frontend
-  const { inviteTokens, ...teamWithoutInviteTokens } = team;
+  const { inviteTokens, ...teamWithoutInviteTokens } = teamOrOrg;
 
   // Don't leak stripe payment ids
-  const teamMetadata = team.metadata;
+  const teamMetadata = teamOrOrg.metadata;
   const {
     paymentId: _,
     subscriptionId: __,
@@ -211,7 +202,7 @@ export async function getTeamWithMembers(args: {
     /** To prevent breaking we only return non-email attached token here, if we have one */
     inviteToken: inviteTokens.find(
       (token) =>
-        token.identifier === `invite-link-for-teamId-${team.id}` &&
+        token.identifier === `invite-link-for-teamId-${teamOrOrg.id}` &&
         token.expires > new Date(new Date().setHours(24))
     ),
     metadata: restTeamMetadata,
@@ -253,100 +244,4 @@ export async function isTeamMember(userId: number, teamId: number) {
       accepted: true,
     },
   }));
-}
-
-async function getTeamOrOrg<TeamSel extends Prisma.TeamSelect>({
-  lookupBy,
-  forOrgWithSlug: forOrgWithSlug,
-  isOrg,
-  teamSelect,
-}: {
-  lookupBy: (
-    | {
-        id: number;
-      }
-    | {
-        slug: string;
-      }
-  ) & {
-    havingMemberWithId?: number;
-  };
-  /**
-   * If we are fetching a team, this is the slug of the organization that the team belongs to.
-   */
-  forOrgWithSlug: string | null;
-  /**
-   * If true, means that we need to fetch an organization with the given slug. Otherwise, we need to fetch a team with the given slug.
-   */
-  isOrg: boolean;
-  teamSelect: TeamSel;
-}) : Promise<Omit<Prisma.TeamGetPayload<{select:TeamSel}>, 'metadata'> & {metadata: z.infer<typeof teamMetadataSchema>} | null>  {
-  const where: Prisma.TeamFindFirstArgs["where"] = {};
-
-  if (lookupBy.havingMemberWithId) where.members = { some: { userId: lookupBy.havingMemberWithId } };
-
-  log.debug({
-    orgSlug: forOrgWithSlug,
-    teamLookupBy: lookupBy,
-    isOrgView: isOrg,
-    where,
-  });
-
-  if ("id" in lookupBy) {
-    where.id = lookupBy.id;
-  } else {
-    where.slug = lookupBy.slug;
-  }
-
-  if (isOrg) {
-    // We must fetch only the organization here.
-    // Note that an organization and a team that doesn't belong to an organization, both have parentId null
-    // If the organization has null slug(but requestedSlug is 'test') and the team also has slug 'test', we can't distinguish them without explicitly checking the metadata.isOrganization
-    // Note that, this isn't possible now to have same requestedSlug as the slug of a team not part of an organization. This is legacy teams handling mostly. But it is still safer to be sure that you are fetching an Organization only in case of isOrgView
-    where.metadata = {
-      path: ["isOrganization"],
-      equals: true,
-    };
-    // We must fetch only the team here.
-  } else {
-    if (forOrgWithSlug) {
-      where.parent = whereClauseForOrgWithSlugOrRequestedSlug(forOrgWithSlug);
-    }
-  }
-
-  const teams = await prisma.team.findMany({
-    where,
-    select: teamSelect,
-  });
-
-  const teamsWithParsedMetadata = teams
-    .map((team) => ({
-      ...team,
-      // Using Type assertion here because we know that the metadata is present and Prisma and TypeScript aren't playing well together
-      metadata: teamMetadataSchema.parse((team as {metadata: z.infer<typeof teamMetadataSchema>}).metadata),
-    }))
-    // In cases where there are many teams with the same slug, we need to find out the one and only one that matches our criteria
-    .filter((team) => {
-      // We need an org if isOrgView otherwise we need a team
-      return isOrg ? team.metadata?.isOrganization : !team.metadata?.isOrganization;
-    });
-
-  if (teamsWithParsedMetadata.length > 1) {
-    log.error("Found more than one team/Org. We should be doing something wrong.", {
-      isOrgView: isOrg,
-      where,
-      teams: teamsWithParsedMetadata.map((team) => {
-        const t = team as unknown as { id: number; slug: string }
-        return {
-          id: t.id,
-          slug: t.slug,
-        };
-      }),
-    });
-  }
-
-  const team = teamsWithParsedMetadata[0];
-  if (!team) return null;
-  // HACK: I am not sure how to make Prisma in peace with TypeScript with this repository pattern
-  return team as any
 }

--- a/packages/lib/server/repository/team.test.ts
+++ b/packages/lib/server/repository/team.test.ts
@@ -1,0 +1,275 @@
+import prismaMock from "../../../../tests/libs/__mocks__/prismaMock";
+
+import { it, describe, expect } from "vitest";
+
+import { getTeam, getOrg } from "./team";
+
+const sampleTeamProps = {
+  logo: null,
+  appLogo: null,
+  bio: null,
+  description: null,
+  hideBranding: false,
+  isPrivate: false,
+  appIconLogo: null,
+  hideBookATeamMember: false,
+  createdAt: new Date(),
+  theme: null,
+  brandColor: "",
+  darkBrandColor: "",
+  parentId: null,
+  timeFormat: null,
+  timeZone: "",
+  weekStart: "",
+};
+
+describe("getOrg", () => {
+  it("should return an Organization correctly by slug even if there is a team with the same slug", async () => {
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: 101,
+        name: "Test Team",
+        slug: "test-slug",
+        metadata: {
+          isOrganization: true,
+        },
+      },
+    ]);
+
+    const org = await getOrg({
+      lookupBy: {
+        slug: "test-slug",
+      },
+      forOrgWithSlug: null,
+      teamSelect: {
+        id: true,
+        slug: true,
+      },
+    });
+
+    const firstFindManyCallArguments = prismaMock.team.findMany.mock.calls[0];
+
+    expect(firstFindManyCallArguments[0]).toEqual({
+      where: {
+        slug: "test-slug",
+        metadata: {
+          path: ["isOrganization"],
+          equals: true,
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        metadata: true,
+      },
+    });
+    expect(org.metadata.isOrganization).toBe(true);
+  });
+
+  it("should not return an org result if metadata.isOrganization isn't true", async () => {
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: 101,
+        name: "Test Team",
+        slug: "test-slug",
+        metadata: {},
+        ...sampleTeamProps,
+      },
+    ]);
+
+    const org = await getOrg({
+      lookupBy: {
+        slug: "test-slug",
+      },
+      forOrgWithSlug: null,
+      teamSelect: {
+        id: true,
+        slug: true,
+      },
+    });
+
+    const firstFindManyCallArguments = prismaMock.team.findMany.mock.calls[0];
+
+    expect(firstFindManyCallArguments[0]).toEqual({
+      where: {
+        slug: "test-slug",
+        metadata: {
+          path: ["isOrganization"],
+          equals: true,
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        metadata: true,
+      },
+    });
+    expect(org).toBe(null);
+  });
+
+  it("should error if metadata isn't valid", async () => {
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: 101,
+        name: "Test Team",
+        slug: "test-slug",
+        metadata: [],
+        ...sampleTeamProps,
+      },
+    ]);
+
+    await expect(() =>
+      getOrg({
+        lookupBy: {
+          slug: "test-slug",
+        },
+        forOrgWithSlug: null,
+        teamSelect: {
+          id: true,
+          slug: true,
+        },
+      })
+    ).rejects.toThrow("invalid_type");
+  });
+});
+
+describe("getTeam", () => {
+  it("should return a team correctly by slug even if there is an org by that slug", async () => {
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: 101,
+        name: "Test Team",
+        slug: "test-slug",
+        metadata: null,
+        ...sampleTeamProps,
+      },
+    ]);
+
+    await getTeam({
+      lookupBy: {
+        slug: "test-slug",
+      },
+      forOrgWithSlug: null,
+      teamSelect: {
+        id: true,
+        slug: true,
+        name: true,
+      },
+    });
+
+    const firstFindManyCallArguments = prismaMock.team.findMany.mock.calls[0];
+
+    expect(firstFindManyCallArguments[0]).toEqual({
+      where: {
+        slug: "test-slug",
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        metadata: true,
+      },
+    });
+  });
+
+  it("should return a team by slug within an org", async () => {
+    prismaMock.team.findMany.mockResolvedValue([
+      {
+        id: 101,
+        name: "Test Team",
+        slug: "test-slug",
+        parentId: 100,
+        metadata: null,
+        ...sampleTeamProps,
+      },
+    ]);
+
+    await getTeam({
+      lookupBy: {
+        slug: "team-in-test-org",
+      },
+      forOrgWithSlug: "test-org",
+      teamSelect: {
+        id: true,
+        slug: true,
+        name: true,
+      },
+    });
+
+    const firstFindManyCallArguments = prismaMock.team.findMany.mock.calls[0];
+
+    expect(firstFindManyCallArguments[0]).toEqual({
+      where: {
+        slug: "team-in-test-org",
+        parent: {
+          OR: [
+            {
+              slug: "test-org",
+            },
+            {
+              metadata: {
+                path: ["requestedSlug"],
+                equals: "test-org",
+              },
+            },
+          ],
+          metadata: {
+            path: ["isOrganization"],
+            equals: true,
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        metadata: true,
+      },
+    });
+  });
+
+  it("should return a team by requestedSlug within an org", async () => {
+    prismaMock.team.findMany.mockResolvedValue([]);
+    await getTeam({
+      lookupBy: {
+        slug: "test-team",
+      },
+      forOrgWithSlug: "test-org",
+      teamSelect: {
+        id: true,
+        slug: true,
+        name: true,
+      },
+    });
+    const firstFindManyCallArguments = prismaMock.team.findMany.mock.calls[0];
+
+    expect(firstFindManyCallArguments[0]).toEqual({
+      where: {
+        slug: "test-team",
+        parent: {
+          metadata: {
+            path: ["isOrganization"],
+            equals: true,
+          },
+          OR: [
+            {
+              slug: "test-org",
+            },
+            {
+              metadata: {
+                path: ["requestedSlug"],
+                equals: "test-org",
+              },
+            },
+          ],
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        metadata: true,
+      },
+    });
+  });
+});

--- a/packages/lib/server/repository/team.test.ts
+++ b/packages/lib/server/repository/team.test.ts
@@ -63,7 +63,7 @@ describe("getOrg", () => {
         metadata: true,
       },
     });
-    expect(org.metadata?.isOrganization).toBe(true);
+    expect(org?.metadata?.isOrganization).toBe(true);
   });
 
   it("should not return an org result if metadata.isOrganization isn't true", async () => {

--- a/packages/lib/server/repository/team.ts
+++ b/packages/lib/server/repository/team.ts
@@ -1,0 +1,149 @@
+import type { Prisma } from "@prisma/client";
+import type { z } from "zod";
+
+import { whereClauseForOrgWithSlugOrRequestedSlug } from "@calcom/ee/organizations/lib/orgDomains";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
+
+type TeamGetPayloadWithParsedMetadata<TeamSelect extends Prisma.TeamSelect> =
+  | (Omit<Prisma.TeamGetPayload<{ select: TeamSelect }>, "metadata"> & {
+      metadata: z.infer<typeof teamMetadataSchema>;
+    })
+  | null;
+
+type GetTeamOrOrgArg<TeamSelect extends Prisma.TeamSelect> = {
+  lookupBy: (
+    | {
+        id: number;
+      }
+    | {
+        slug: string;
+      }
+  ) & {
+    havingMemberWithId?: number;
+  };
+  /**
+   * If we are fetching a team, this is the slug of the organization that the team belongs to.
+   */
+  forOrgWithSlug: string | null;
+  /**
+   * If true, means that we need to fetch an organization with the given slug. Otherwise, we need to fetch a team with the given slug.
+   */
+  isOrg: boolean;
+  teamSelect: TeamSelect;
+};
+
+const log = logger.getSubLogger({ prefix: ["repository", "team"] });
+
+/**
+ * Get's the team or organization with the given slug or id reliably along with parsed metadata.
+ */
+async function getTeamOrOrg<TeamSelect extends Prisma.TeamSelect>({
+  lookupBy,
+  forOrgWithSlug: forOrgWithSlug,
+  isOrg,
+  teamSelect,
+}: GetTeamOrOrgArg<TeamSelect>): Promise<TeamGetPayloadWithParsedMetadata<TeamSelect>> {
+  const where: Prisma.TeamFindFirstArgs["where"] = {};
+  teamSelect = {
+    ...teamSelect,
+    metadata: true,
+  };
+  if (lookupBy.havingMemberWithId) where.members = { some: { userId: lookupBy.havingMemberWithId } };
+
+  if ("id" in lookupBy) {
+    where.id = lookupBy.id;
+  } else {
+    where.slug = lookupBy.slug;
+  }
+
+  if (isOrg) {
+    // We must fetch only the organization here.
+    // Note that an organization and a team that doesn't belong to an organization, both have parentId null
+    // If the organization has null slug(but requestedSlug is 'test') and the team also has slug 'test', we can't distinguish them without explicitly checking the metadata.isOrganization
+    // Note that, this isn't possible now to have same requestedSlug as the slug of a team not part of an organization. This is legacy teams handling mostly. But it is still safer to be sure that you are fetching an Organization only in case of isOrgView
+    where.metadata = {
+      path: ["isOrganization"],
+      equals: true,
+    };
+    // We must fetch only the team here.
+  } else {
+    if (forOrgWithSlug) {
+      where.parent = whereClauseForOrgWithSlugOrRequestedSlug(forOrgWithSlug);
+    }
+  }
+
+  log.debug({
+    orgSlug: forOrgWithSlug,
+    teamLookupBy: lookupBy,
+    isOrgView: isOrg,
+    where,
+  });
+
+  // teamSelect extends Prisma.TeamSelect but still teams doesn't contain a valid team as per TypeScript and thus it doesn't consider it having team.metadata, team.id and other fields
+  // This is the reason below code is using a lot of assertions.
+  const teams = await prisma.team.findMany({
+    where,
+    select: teamSelect,
+  });
+
+  const teamsWithParsedMetadata = teams
+    .map((team) => ({
+      ...team,
+      // Using Type assertion here because we know that the metadata is present and Prisma and TypeScript aren't playing well together
+      metadata: teamMetadataSchema.parse((team as { metadata: z.infer<typeof teamMetadataSchema> }).metadata),
+    }))
+    // In cases where there are many teams with the same slug, we need to find out the one and only one that matches our criteria
+    .filter((team) => {
+      console.log(team.metadata);
+      // We need an org if isOrgView otherwise we need a team
+      return isOrg ? team.metadata?.isOrganization : !team.metadata?.isOrganization;
+    });
+
+  if (teamsWithParsedMetadata.length > 1) {
+    log.error("Found more than one team/Org. We should be doing something wrong.", {
+      isOrgView: isOrg,
+      where,
+      teams: teamsWithParsedMetadata.map((team) => {
+        const t = team as unknown as { id: number; slug: string };
+        return {
+          id: t.id,
+          slug: t.slug,
+        };
+      }),
+    });
+  }
+
+  const team = teamsWithParsedMetadata[0];
+  if (!team) return null;
+  // HACK: I am not sure how to make Prisma in peace with TypeScript with this repository pattern
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return team as any;
+}
+
+export async function getTeam<TeamSelect extends Prisma.TeamSelect>({
+  lookupBy,
+  forOrgWithSlug: forOrgWithSlug,
+  teamSelect,
+}: Omit<GetTeamOrOrgArg<TeamSelect>, "isOrg">): Promise<TeamGetPayloadWithParsedMetadata<TeamSelect>> {
+  return getTeamOrOrg({
+    lookupBy,
+    forOrgWithSlug: forOrgWithSlug,
+    isOrg: false,
+    teamSelect,
+  });
+}
+
+export async function getOrg<TeamSelect extends Prisma.TeamSelect>({
+  lookupBy,
+  forOrgWithSlug: forOrgWithSlug,
+  teamSelect,
+}: Omit<GetTeamOrOrgArg<TeamSelect>, "isOrg">): Promise<TeamGetPayloadWithParsedMetadata<TeamSelect>> {
+  return getTeamOrOrg({
+    lookupBy,
+    forOrgWithSlug: forOrgWithSlug,
+    isOrg: true,
+    teamSelect,
+  });
+}

--- a/packages/lib/server/repository/team.ts
+++ b/packages/lib/server/repository/team.ts
@@ -96,7 +96,6 @@ async function getTeamOrOrg<TeamSelect extends Prisma.TeamSelect>({
     }))
     // In cases where there are many teams with the same slug, we need to find out the one and only one that matches our criteria
     .filter((team) => {
-      console.log(team.metadata);
       // We need an org if isOrgView otherwise we need a team
       return isOrg ? team.metadata?.isOrganization : !team.metadata?.isOrganization;
     });


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where depending on which team would be fetched first by prisma(which is usually last-modified first), sometimes Org is served for a team page because of slug confusion

Also added a repository for team to kickoff moving to repository pattern for querying. 

## Motivation to move to the pattern along with this bug fix
- The issue arose because we can't query the team and org by slug reliably because slugs aren't unique in table, so we need well tested code to handle that querying thing
- Going forward we plan to move `metadata.isOrganization` to a column so that querying is faster and more reliable and then we would just need to modify the repository code.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
