### PR TITLE
feat: POST/PATCH `availabilities` API to accept `date` field

### DIFF
--- a/apps/api/lib/validations/availability.ts
+++ b/apps/api/lib/validations/availability.ts
@@ -26,6 +26,7 @@ const schemaAvailabilityCreateParams = z
     startTime: z.date().or(z.string()),
     endTime: z.date().or(z.string()),
     days: z.array(z.number()).optional(),
+    date: z.date().or(z.string()).optional(),
   })
   .strict();
 
@@ -34,6 +35,7 @@ const schemaAvailabilityEditParams = z
     startTime: z.date().or(z.string()).optional(),
     endTime: z.date().or(z.string()).optional(),
     days: z.array(z.number()).optional(),
+    date: z.date().or(z.string()).optional(),
   })
   .strict();
 

--- a/apps/api/lib/validations/schedule.ts
+++ b/apps/api/lib/validations/schedule.ts
@@ -21,7 +21,16 @@ export const schemaSchedulePublic = z
   .merge(
     z.object({
       availability: z
-        .array(Availability.pick({ id: true, eventTypeId: true, days: true, startTime: true, endTime: true }))
+        .array(
+          Availability.pick({
+            id: true,
+            eventTypeId: true,
+            date: true,
+            days: true,
+            startTime: true,
+            endTime: true,
+          })
+        )
         .transform((v) =>
           v.map((item) => ({
             ...item,


### PR DESCRIPTION
## What does this PR do?
- currently there is no way via the API to create an 'override' availability.
- This is due to the endpoint not accepting the `date` field.
- Also includes date on schedule response so users can determine what day the override is actually for. 

Fixes #12191
https://github.com/calcom/cal.com/issues/12191

## Requirement/Documentation
- unsure how to update API documentation

## Type of change
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?
- passing a `date` field along on a POST or PATCH  on the `availabilities` endpoint, should create that availability as an override on the Schedule.

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
