### PR TITLE
fix: /event type settings/advanced/add to calendar input has double label & helper text

### DIFF
--- a/apps/web/components/eventtype/EventAdvancedTab.tsx
+++ b/apps/web/components/eventtype/EventAdvancedTab.tsx
@@ -153,6 +153,7 @@ export const EventAdvancedTab = ({ eventType, team }: Pick<EventTypeSetupProps, 
                     value={value ? value.externalId : undefined}
                     onChange={onChange}
                     hidePlaceholder
+                    hideAdvancedText
                   />
                 )}
               />


### PR DESCRIPTION
Fixes #12268

- [ ] Bug fix (non-breaking change which fixes an issue)
