### PR TITLE
fix: Remove count from query to update schedule

### DIFF
--- a/packages/trpc/server/routers/viewer/availability/schedule/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/schedule/update.handler.ts
@@ -109,7 +109,6 @@ export const updateHandler = async ({ input, ctx }: UpdateOptions) => {
       timeZone: true,
       eventType: {
         select: {
-          _count: true,
           id: true,
           eventName: true,
         },


### PR DESCRIPTION
## What does this PR do?

Related to https://github.com/calcom/cal.com/pull/10954, this fixes an extremely slow query that is being run quite a lot, especially considering we have a tRPC bug on the front end triggering lots of calls to update schedule.
![54fab6b9-eab1-4271-a830-c6fdc88362d2](https://github.com/calcom/cal.com/assets/2538462/6a52492b-902d-4fa1-acd5-f81959e56ba3)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure you can properly update schedules

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
