### PR TITLE
fix: When Installing Calendar App, Set Primary Calendar As Selected Calendar

### DIFF
--- a/packages/app-store/larkcalendar/api/callback.ts
+++ b/packages/app-store/larkcalendar/api/callback.ts
@@ -89,6 +89,32 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
       });
     }
 
+    const primaryCalendarResponse = await fetch(
+      `https://${LARK_HOST}/open-apis/calendar/v4/calendars/primary`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${key.access_token}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (primaryCalendarResponse.status === 200) {
+      const primaryCalendar = await primaryCalendarResponse.json();
+
+      if (primaryCalendar.data.calendars.calendar.calendar_id && req.session?.user?.id) {
+        await prisma.selectedCalendar.create({
+          data: {
+            userId: req.session?.user.id,
+            integration: "lark_calendar",
+            externalId: primaryCalendar.data.calendars.calendar.calendar_id as string,
+            credentialId: currentCredential?.id,
+          },
+        });
+      }
+    }
+
     res.redirect(
       getSafeRedirectUrl(state?.returnTo) ??
         getInstalledAppPath({ variant: "calendar", slug: "lark-calendar" })


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR sets the primary/default calendar of a calendar integration as the first selected calendar on install. 

The calendars that have this ability are:
- Google Calendar
- Outlook
- Zoho
- Lark

Once #12011 is merged we can add a test for this

![CleanShot 2023-11-08 at 22 17 13](https://github.com/calcom/cal.com/assets/65426560/11a53dc7-c7cf-4c0d-8dc0-3f2fcdd17e64)


Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Install the calendars that are included in this PR
- On the installed page, the primary calendar should already be selected

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
