### PR TITLE
fix: meeting url variable in workflow notifitcations

### DIFF
--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -39,13 +39,13 @@ export async function handleConfirmation(args: {
       title: string;
       teamId?: number | null;
       parentId?: number | null;
-      metadata?: Prisma.JsonValue;
       workflows?: {
         workflow: Workflow & {
           steps: WorkflowStep[];
         };
       }[];
     } | null;
+    metadata?: Prisma.JsonValue;
     eventTypeId: number | null;
     smsReminderNumber: string | null;
     userId: number | null;
@@ -157,7 +157,10 @@ export async function handleConfirmation(args: {
             create: scheduleResult.referencesToCreate,
           },
           paid,
-          metadata: { ...recurringBooking.metadata, videoCallUrl },
+          metadata: {
+            ...(typeof recurringBooking.metadata === "object" ? recurringBooking.metadata : {}),
+            videoCallUrl,
+          },
         },
         select: {
           eventType: {
@@ -209,7 +212,7 @@ export async function handleConfirmation(args: {
         references: {
           create: scheduleResult.referencesToCreate,
         },
-        metadata: { ...booking.metadata, videoCallUrl },
+        metadata: { ...(typeof booking.metadata === "object" ? booking.metadata : {}), videoCallUrl },
       },
       select: {
         eventType: {

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -36,6 +36,7 @@ export async function handleConfirmation(args: {
       length: number;
       price: number;
       requiresConfirmation: boolean;
+      metadata?: Prisma.JsonValue;
       title: string;
       teamId?: number | null;
       parentId?: number | null;

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -2524,7 +2524,7 @@ async function handler(
         ...evt,
         ...{ metadata: metadataFromEvent, eventType: { slug: eventType.slug } },
       },
-      isNotConfirmed: evt.requiresConfirmation || false,
+      isNotConfirmed: !isConfirmedByDefault,
       isRescheduleEvent: !!rescheduleUid,
       isFirstRecurringEvent: true,
       hideBranding: !!eventType.owner?.hideBranding,

--- a/packages/lib/payment/getBooking.ts
+++ b/packages/lib/payment/getBooking.ts
@@ -30,6 +30,7 @@ export async function getBooking(bookingId: number) {
       ...bookingMinimalSelect,
       responses: true,
       eventType: true,
+      metadata: true,
       smsReminderNumber: true,
       location: true,
       eventTypeId: true,

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -48,6 +48,7 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
       attendees: true,
       eventTypeId: true,
       responses: true,
+      metadata: true,
       eventType: {
         select: {
           id: true,


### PR DESCRIPTION
## What does this PR do?

Fixes that the {MEETING_URL} from custom workflow templates wasn't populated for event types that require confirmation or payment.

Also fixes that confirmation emails were still sent after they were confirmed even when the default confirmation emails were disabled. 

Fixes #10758

## Requirement/Documentation

Have Sendgrid set up to send workflow emails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a workflow that triggers when new event is booked & sends email to attendees
- Add a custom emails template with {MEETING_URL} variable
- Set active on an event type that requires confrimation 
- Book event type 
- Confirm booking 
- Check if email has meeting url

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

