### PR TITLE
fix: Broken embed in incognito of chrome

### DIFF
--- a/packages/features/bookings/Booker/components/LargeCalendar.tsx
+++ b/packages/features/bookings/Booker/components/LargeCalendar.tsx
@@ -4,6 +4,7 @@ import dayjs from "@calcom/dayjs";
 import { Calendar } from "@calcom/features/calendars/weeklyview";
 import type { CalendarEvent } from "@calcom/features/calendars/weeklyview/types/events";
 import type { CalendarAvailableTimeslots } from "@calcom/features/calendars/weeklyview/types/state";
+import { localStorage } from "@calcom/lib/webstorage";
 
 import { useBookerStore } from "../store";
 import { useEvent, useScheduleForEvent } from "../utils/event";

--- a/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarContainer.tsx
+++ b/packages/features/bookings/Booker/components/OverlayCalendar/OverlayCalendarContainer.tsx
@@ -8,6 +8,7 @@ import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import { useTimePreferences } from "@calcom/features/bookings/lib";
 import { classNames } from "@calcom/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { Button, Switch } from "@calcom/ui";
 import { Settings } from "@calcom/ui/components/icon";

--- a/packages/features/bookings/Booker/components/hooks/useLocalSet.tsx
+++ b/packages/features/bookings/Booker/components/hooks/useLocalSet.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { localStorage } from "@calcom/lib/webstorage";
+
 export interface HasExternalId {
   externalId: string;
 }

--- a/packages/features/bookings/components/AvailableTimes.tsx
+++ b/packages/features/bookings/components/AvailableTimes.tsx
@@ -8,6 +8,7 @@ import dayjs from "@calcom/dayjs";
 import type { Slots } from "@calcom/features/schedules";
 import { classNames } from "@calcom/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { localStorage } from "@calcom/lib/webstorage";
 import { Button, SkeletonText } from "@calcom/ui";
 
 import { useBookerStore } from "../Booker/store";

--- a/packages/lib/webstorage.ts
+++ b/packages/lib/webstorage.ts
@@ -1,5 +1,5 @@
 /**
- * Provides a wrapper around localStorage to avoid errors in case of restricted storage access.
+ * Provides a wrapper around localStorage(and sessionStorage(TODO when needed)) to avoid errors in case of restricted storage access.
  *
  * TODO: In case of an embed if localStorage is not available(third party), use localStorage of parent(first party) that contains the iframe.
  */
@@ -22,6 +22,14 @@ export const localStorage = {
       // In case storage is restricted. Possible reasons
       // 1. Third Party Context in Chrome Incognito mode.
       // 2. Storage limit reached
+      return;
+    }
+  },
+  removeItem: (key: string) => {
+    try {
+      // eslint-disable-next-line @calcom/eslint/avoid-web-storage
+      window.localStorage.removeItem(key);
+    } catch (e) {
       return;
     }
   },


### PR DESCRIPTION
## What does this PR do?

Fixes #12298
- Use localStorage from `@calcom/webStorage` instead of native `localStorage`, so that uncaught errors are handled.
- Newly added localStorage usage of getting `overlayCalendarSwitchDefault` is the reason behind it breaking.

**Note:** Latest chrome atleast 119(latest version) as this behaviour fixed automatically where accessing `localStorage` throws error, so as people update to latest versions of chrome, this problem should be solved for good anyway. 

To be able to replicate this behaviour make sure that Third party cookies are blocked. If that doesn't work, you can explicitly disable [chrome://flags/#third-party-storage-partitioning](chrome://flags/#third-party-storage-partitioning) flag
<img width="850" alt="Screenshot 2023-11-10 at 12 38 37 PM" src="https://github.com/calcom/cal.com/assets/1780212/a49c45c4-324e-4258-bbc7-21f549ccbd3a">


**Side Note:**  There is an ESLint rule that errors when using `localStorage` but it currently only detects `window.localStorage` usage and thus couldn't detect these issues as `localStorage` was used without using `window`.
One way to fix it could be to start using `webStorage.localStorage` everywhere and then we can prevent `window.localStorage` and `localStorage` usages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?



## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Important Note
- Couldn't add Checkly test because it doesn't allow controlling the browser version and it is fixed in latest chrome.
