### PR TITLE
fix: Fix recurring booking failure due to rate limiting

### DIFF
--- a/apps/api/pages/api/bookings/_post.ts
+++ b/apps/api/pages/api/bookings/_post.ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest } from "next";
 
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
-import getIP from "@calcom/lib/getIP";
 import { defaultResponder } from "@calcom/lib/server";
 
 /**
@@ -207,15 +205,8 @@ import { defaultResponder } from "@calcom/lib/server";
 async function handler(req: NextApiRequest) {
   const { userId, isAdmin } = req;
   if (isAdmin) req.userId = req.body.userId || userId;
-  const userIp = getIP(req);
 
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: userIp,
-  });
-
-  const booking = await handleNewBooking(req);
-  return booking;
+  return await handleNewBooking(req);
 }
 
 export default defaultResponder(handler);

--- a/apps/api/pages/api/bookings/_post.ts
+++ b/apps/api/pages/api/bookings/_post.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest } from "next";
 
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import getIP from "@calcom/lib/getIP";
 import { defaultResponder } from "@calcom/lib/server";
 
 /**
@@ -205,6 +207,13 @@ import { defaultResponder } from "@calcom/lib/server";
 async function handler(req: NextApiRequest) {
   const { userId, isAdmin } = req;
   if (isAdmin) req.userId = req.body.userId || userId;
+  const userIp = getIP(req);
+
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: userIp,
+  });
+
   const booking = await handleNewBooking(req);
   return booking;
 }

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -2,9 +2,18 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import getIP from "@calcom/lib/getIP";
 import { defaultResponder } from "@calcom/lib/server";
 
 async function handler(req: NextApiRequest & { userId?: number }, res: NextApiResponse) {
+  const userIp = getIP(req);
+
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: userIp,
+  });
+
   const session = await getServerSession({ req, res });
   /* To mimic API behavior and comply with types */
   req.userId = session?.user?.id || -1;

--- a/apps/web/pages/api/book/recurring-event.ts
+++ b/apps/web/pages/api/book/recurring-event.ts
@@ -3,12 +3,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
 import type { BookingResponse, RecurringBookingCreateBody } from "@calcom/features/bookings/types";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import getIP from "@calcom/lib/getIP";
 import { defaultResponder } from "@calcom/lib/server";
 import type { AppsStatus } from "@calcom/types/Calendar";
 
 // @TODO: Didn't look at the contents of this function in order to not break old booking page.
 
 async function handler(req: NextApiRequest & { userId?: number }, res: NextApiResponse) {
+  const userIp = getIP(req);
+
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: userIp,
+  });
   const data: RecurringBookingCreateBody[] = req.body;
   const session = await getServerSession({ req, res });
   const createdBookings: BookingResponse[] = [];

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -51,10 +51,8 @@ import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
 import { cancelScheduledJobs, scheduleTrigger } from "@calcom/features/webhooks/lib/scheduleTrigger";
 import { isPrismaObjOrUndefined, parseRecurringEvent } from "@calcom/lib";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { getDefaultEvent, getUsernameList } from "@calcom/lib/defaultEvents";
 import { getErrorFromUnknown } from "@calcom/lib/errors";
-import getIP from "@calcom/lib/getIP";
 import getPaymentAppData from "@calcom/lib/getPaymentAppData";
 import { getTeamIdFromEventType } from "@calcom/lib/getTeamIdFromEventType";
 import { HttpError } from "@calcom/lib/http-error";
@@ -630,12 +628,6 @@ async function handler(
   }
 ) {
   const { userId } = req;
-  const userIp = getIP(req);
-
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: userIp,
-  });
 
   // handle dynamic user
   let eventType =


### PR DESCRIPTION
## What does this PR do?

"core" has a limit of 10 requests every 60s. Due to `handleNewBooking` called from `recurring-event` handler multiple times depending on the recurrence, it can fail.

Moved the rateLimiting logic to **actual route** to guarantee that it's called once per route.

Note: I think we should have some eslint rule to disallow rateLimiting in non api route files because it can accidentally cause issues. cc @sean-brydon @keithwillcode 

![image](https://github.com/calcom/cal.com/assets/1780212/97ec190b-3996-4366-b333-ea7a1e3f5a00)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Create a stash account and setup env variables
- Reduce the "core" limit here to a small number say 2(https://github.com/calcom/cal.com/blob/15734921d34dec3af2b5a37ffa0e95fbde680541/packages/lib/rateLimit.ts#L58)
- Try booking a recurring event in main and it will fail(num intervals should alteast be 3)
- In this branch, it will pass
- Also, test that if in less than a minute 3 normals bookings are done. Third one fails.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
