### PR TITLE
chore: Use apiLogin instead of user.login in e2e tests

### DIFF
--- a/apps/web/playwright/login.2fa.e2e.ts
+++ b/apps/web/playwright/login.2fa.e2e.ts
@@ -24,7 +24,7 @@ test.describe("2FA Tests", async () => {
       const user = await users.create();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const userPassword = user.username!;
-      await user.login();
+      await user.apiLogin();
 
       // expects the home page for an authorized user
       await page.goto("/settings/security/two-factor-auth");
@@ -94,7 +94,7 @@ test.describe("2FA Tests", async () => {
       const user = await users.create();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const userPassword = user.username!;
-      await user.login();
+      await user.apiLogin();
 
       // expects the home page for an authorized user
       await page.goto("/settings/security/two-factor-auth");

--- a/apps/web/playwright/login.e2e.ts
+++ b/apps/web/playwright/login.e2e.ts
@@ -16,7 +16,7 @@ test.describe("user can login & logout succesfully", async () => {
     // log in trail user
     await test.step("Log in", async () => {
       const user = await users.create();
-      await user.login();
+      await user.apiLogin();
 
       const shellLocator = page.locator(`[data-testid=dashboard-shell]`);
 

--- a/apps/web/playwright/login.e2e.ts
+++ b/apps/web/playwright/login.e2e.ts
@@ -16,7 +16,7 @@ test.describe("user can login & logout succesfully", async () => {
     // log in trail user
     await test.step("Log in", async () => {
       const user = await users.create();
-      await user.apiLogin();
+      await user.login();
 
       const shellLocator = page.locator(`[data-testid=dashboard-shell]`);
 

--- a/apps/web/playwright/workflow.e2e.ts
+++ b/apps/web/playwright/workflow.e2e.ts
@@ -17,7 +17,7 @@ test.describe("Workflow tests", () => {
       async ({ page, users }) => {
         const user = await users.create();
         const [eventType] = user.eventTypes;
-        await user.login();
+        await user.apiLogin();
         await page.goto(`/workflows`);
 
         await page.click('[data-testid="create-button"]');

--- a/packages/app-store/typeform/playwright/tests/basic.e2e.ts
+++ b/packages/app-store/typeform/playwright/tests/basic.e2e.ts
@@ -16,7 +16,7 @@ const installApps = async (page: Page, users: Fixtures["users"]) => {
       hasTeam: true,
     }
   );
-  await user.login();
+  await user.apiLogin();
   await page.goto(`/apps/typeform`);
   await page.click('[data-testid="install-app-button"]');
   (await page.waitForSelector('[data-testid="install-app-button-personal"]')).click();


### PR DESCRIPTION
Saves a few seconds per use of user.login