### PR TITLE
perf: Increased memory/vCPU for slots perf

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -7,10 +7,10 @@
   ],
   "functions": {
     "pages/api/trpc/public/[trpc].ts": {
-      "memory": 768
+      "memory": 3008
     },
     "pages/api/trpc/slots/[trpc].ts": {
-      "memory": 768
+      "memory": 3008
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

After testing on dev environments, it's clear the `slots.getSchedule` endpoint needs more processing power. Since Vercel memory settings directly correlate to vCPUs allocated, we are increasing this value. 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Ensure the function has the correct memory after deployment on Vercel
