### PR TITLE
revert: "perf: Increased memory/vCPU for slots perf (#12387)"

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -7,10 +7,10 @@
   ],
   "functions": {
     "pages/api/trpc/public/[trpc].ts": {
-      "memory": 3008
+      "memory": 768
     },
     "pages/api/trpc/slots/[trpc].ts": {
-      "memory": 3008
+      "memory": 768
     }
   }
 }


### PR DESCRIPTION
This reverts commit 0b96ef54768408d223d8703a1f1e9d6ce78ce7c3.

## What does this PR do?

After running the public tRPC endpoint at 3008MB of memory on Vercel, we saw a decrease in response times by 200-300ms on average but they are still around 900ms-1s for the getSchedule endpoint, which is nowhere near what we are seeing on dev environments. Reverting until we find the root cause of the slowness (likely DB)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)