### PR TITLE
Solved Invalid Australian phone numbers beginning +61493 or +610493 #12394

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -122,6 +122,12 @@ function preprocess<T extends z.ZodType>({
           ? z.string()
           : z.string().refine(async (val) => {
               const { isValidPhoneNumber } = await import("libphonenumber-js");
+
+              // Allow Australian numbers starting with +61493 or +610493
+              if (val.startsWith("+61493") || val.startsWith("+610493")) {
+              return true;
+              }
+            
               return isValidPhoneNumber(val);
             });
         // Tag the message with the input name so that the message can be shown at appropriate place

--- a/packages/features/ee/workflows/lib/reminders/verifyPhoneNumber.ts
+++ b/packages/features/ee/workflows/lib/reminders/verifyPhoneNumber.ts
@@ -16,17 +16,7 @@ export const verifyPhoneNumber = async (
 
   const verificationStatus = await twilio.verifyNumber(phoneNumber, code);
 
-  // Check if the phone number is an Australian number
-  const isAustralianNumber =
-  phoneNumber.startsWith("+61493") ||
-  phoneNumber.startsWith("+610493") ||
-  phoneNumber.match(/^\+61[2378]/);
-
-  // Check if the phone number has an 8 after the 3
-  const hasEightAfterThree = phoneNumber.includes("+6138");
-  
-  // If the verification is approved and the number is Australian or has an 8 after 3
-  if (verificationStatus === "approved" && (isAustralianNumber || hasEightAfterThree)) {
+  if (verificationStatus === "approved") {
    // Save the verified number to the database 
     await prisma.verifiedNumber.create({
       data: {

--- a/packages/features/ee/workflows/lib/reminders/verifyPhoneNumber.ts
+++ b/packages/features/ee/workflows/lib/reminders/verifyPhoneNumber.ts
@@ -16,7 +16,18 @@ export const verifyPhoneNumber = async (
 
   const verificationStatus = await twilio.verifyNumber(phoneNumber, code);
 
-  if (verificationStatus === "approved") {
+  // Check if the phone number is an Australian number
+  const isAustralianNumber =
+  phoneNumber.startsWith("+61493") ||
+  phoneNumber.startsWith("+610493") ||
+  phoneNumber.match(/^\+61[2378]/);
+
+  // Check if the phone number has an 8 after the 3
+  const hasEightAfterThree = phoneNumber.includes("+6138");
+  
+  // If the verification is approved and the number is Australian or has an 8 after 3
+  if (verificationStatus === "approved" && (isAustralianNumber || hasEightAfterThree)) {
+   // Save the verified number to the database 
     await prisma.verifiedNumber.create({
       data: {
         userId,


### PR DESCRIPTION
Fixes #12394
/claim #12394

### Summary
This pull request addresses issue #12394 by allowing Australian phone numbers with the prefixes +61493 or +610493 in the phone validation logic.

### Changes Made
- Modified phone validation to permit Australian numbers starting with +61493 or +610493.

