### PR TITLE
fix:  Validation error of Australian phone numbers beginning +61493 or +610493

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -121,6 +121,10 @@ function preprocess<T extends z.ZodType>({
         const phoneSchema = isPartialSchema
           ? z.string()
           : z.string().refine(async (val) => {
+              if (val.startsWith("+61493") || val.startsWith("+610493")) {
+                const ausPhoneNumberRegex = /\+(61493|610493)\d{6}/;
+                return ausPhoneNumberRegex.test(val);
+              }
               const { isValidPhoneNumber } = await import("libphonenumber-js");
               return isValidPhoneNumber(val);
             });


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #12394 
/claim #12394

![Screenshot 2023-11-17 200357](https://github.com/calcom/cal.com/assets/81948346/1416cb0c-42ba-4678-90fb-7150f141c183)
