### PR TITLE
fix Date overrides UI bug depending on screen size

### DIFF
--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -221,7 +221,14 @@ const DateOverrideInputDialog = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{Trigger}</DialogTrigger>
 
-      <DialogContent enableOverflow={enableOverflow} size="md" className="p-0">
+      <DialogContent
+        enableOverflow={enableOverflow}
+        size="md"
+        className="p-0"
+        style={{
+          maxHeight: isMobile ? "80vh" : "90vh",
+          overflowY: "auto",
+        }}>
         <DateOverrideForm
           excludedDates={excludedDates}
           {...passThroughProps}


### PR DESCRIPTION
Fix the screen sizing issue in the desktop app for date override

The date override feature faced a screen sizing bug that made the completion buttons inaccessible when the screen wasn't a specific size. This fix ensures proper screen sizing, allowing access to buttons and enabling scrolling to populate the bottom half of the date override popup.
#12406 