### PR TITLE
fix: add node-mocks-http to web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -168,6 +168,7 @@
     "module-alias": "^2.2.2",
     "msw": "^0.42.3",
     "node-html-parser": "^6.1.10",
+    "node-mocks-http": "^1.11.0",
     "postcss": "^8.4.18",
     "tailwindcss": "^3.3.1",
     "tailwindcss-animate": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,6 +4604,7 @@ __metadata:
     next-seo: ^6.0.0
     next-themes: ^0.2.0
     node-html-parser: ^6.1.10
+    node-mocks-http: ^1.11.0
     nodemailer: ^6.7.8
     otplib: ^12.0.1
     postcss: ^8.4.18


### PR DESCRIPTION
Fix potential build failure due to node-mocks-http dep missing in web.