### PR TITLE
fix: include eventTypeId in BOOKING_CANCELLED event

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -227,6 +227,7 @@ async function handler(req: CustomRequest) {
     type: bookingToDelete?.eventType?.slug as string,
     description: bookingToDelete?.description || "",
     customInputs: isPrismaObjOrUndefined(bookingToDelete.customInputs),
+    eventTypeId: bookingToDelete.eventTypeId as number,
     ...getCalEventResponses({
       bookingFields: bookingToDelete.eventType?.bookingFields ?? null,
       booking: bookingToDelete,


### PR DESCRIPTION
## What does this PR do?

This addresses one missing field in webhook events as mentioned here: #12286. My integration is breaking because this field is missing.

## Requirement/Documentation

This updates the actual payload to be in line with the current documentation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

I could not find any unit tests to update for this, happy to do so if I missed them.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
