### PR TITLE
fix: alby payment isPaid always false on create

### DIFF
--- a/packages/app-store/alby/lib/PaymentService.ts
+++ b/packages/app-store/alby/lib/PaymentService.ts
@@ -74,7 +74,7 @@ export class PaymentService implements IAbstractPaymentService {
           currency: payment.currency,
           data: Object.assign(
             {},
-            { invoice: { ...invoice, isPaid: await invoice.isPaid() } }
+            { invoice: { ...invoice, isPaid: false } }
           ) as unknown as Prisma.InputJsonValue,
           fee: 0,
           refunded: false,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes alby payment creation
isPaid is always false on creation, no need to await

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
