### PR TITLE
chore: reset form on submission

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -125,6 +125,7 @@ export default function CreateEventTypeDialog({
         }),
         "success"
       );
+      form.reset();
     },
     onError: (err) => {
       if (err instanceof HttpError) {


### PR DESCRIPTION
<img width="1511" alt="Screenshot 2023-11-21 at 8 12 27 PM" src="https://github.com/calcom/cal.com/assets/53316345/7ec6160b-5441-494e-9294-21918f64dad5">


Reset create event type modal form

1) Open create event type modal
2) Fill the form and click 'Continue'