### PR TITLE
fix: remove slug check to determine if user has team plan

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/hasTeamPlan.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/hasTeamPlan.handler.ts
@@ -14,11 +14,6 @@ export const hasTeamPlanHandler = async ({ ctx }: HasTeamPlanOptions) => {
     where: {
       accepted: true,
       userId,
-      team: {
-        slug: {
-          not: null,
-        },
-      },
     },
   });
   return { hasTeamPlan: !!hasTeamPlan };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #12468 (issue)

The trpc query that searched if an user had a team plan was checking if the team had a slug. It seems that unpublished teams don't have a slug, so that was the problem.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/44f1f61f49dc4d3ca63e60b05a0c0e27?sid=34d0747b-68c8-4747-97c3-818ebefbac7b

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
  - No
- What are the minimal test data to have?
  - run `yarn db-seed`
- What is expected (happy path) to have (input and output)?
  1. Delete all teams
  2. Create a new team
  3. Abort before publishing it
  4. Go back to `/teams`

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't added tests that prove my fix is effective or that my feature works
