### PR TITLE
fix: set nextjs version to 13.4.6

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,7 +33,7 @@
     "@sentry/nextjs": "^7.73.0",
     "bcryptjs": "^2.4.3",
     "memory-cache": "^0.2.0",
-    "next": "^13.4.6",
+    "next": "13.4.6",
     "next-api-middleware": "^1.0.1",
     "next-axiom": "^0.17.0",
     "next-swagger-doc": "^0.3.6",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -20,7 +20,7 @@
     "@radix-ui/react-slider": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.0",
     "@radix-ui/react-tooltip": "^1.0.0",
-    "next": "^13.4.6",
+    "next": "13.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook-addon-next-router": "^4.0.2",

--- a/apps/swagger/package.json
+++ b/apps/swagger/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "highlight.js": "^11.6.0",
     "isarray": "2.0.5",
-    "next": "^13.4.6",
+    "next": "13.4.6",
     "openapi-snippet": "^0.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -91,7 +91,7 @@
     "memory-cache": "^0.2.0",
     "micro": "^10.0.1",
     "mime-types": "^2.1.35",
-    "next": "^13.4.6",
+    "next": "13.4.6",
     "next-auth": "^4.22.1",
     "next-axiom": "^0.17.0",
     "next-collect": "^0.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,7 @@
     "cmk": "^0.1.1",
     "downshift": "^6.1.9",
     "lucide-react": "^0.171.0",
-    "next": "^13.4.6",
+    "next": "13.4.6",
     "next-seo": "^6.0.0",
     "react": "^18.2.0",
     "react-colorful": "^5.6.0",


### PR DESCRIPTION
## What does this PR do?
Sets the nextjs version to 13.4.6 (strictly) so it cannot be implicitly changed when other packages (ai package) have higher version of nextjs.

Fixes # (issue)
This PR will resolve the [issue](https://github.com/calcom/cal.com/issues/12503) with crash on `getting-started` page that was caused by new `useParams` behavior in next 13.5.4. 
In next 13.4.6 useParams always returns null and in next 13.5.4 it will return an object that has `undefined` value for optiona catch-all route. 
 
<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update