### PR TITLE
chore: Remove cache-control and disable avatar cache

### DIFF
--- a/apps/web/pages/api/user/avatar.ts
+++ b/apps/web/pages/api/user/avatar.ts
@@ -105,8 +105,6 @@ async function getIdentityData(req: NextApiRequest) {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const identity = await getIdentityData(req);
   const img = identity?.avatar;
-  // We cache for one day
-  res.setHeader("Cache-Control", "s-maxage=86400, stale-while-revalidate=60");
   // If image isn't set or links to this route itself, use default avatar
   if (!img) {
     if (identity?.org) {


### PR DESCRIPTION
## What does this PR do?

This URL cannot be invalidated, so causes 1-day out of date avatars (or whenever the browser decides not to cache)