### PR TITLE
chore: remove dynamic loading of EventTypeDescription on event-types page

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -13,7 +13,7 @@ import { getLayout } from "@calcom/features/MainLayout";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import useIntercom from "@calcom/features/ee/support/lib/intercom/useIntercom";
 import { EventTypeEmbedButton, EventTypeEmbedDialog } from "@calcom/features/embed/EventTypeEmbed";
-import { EventTypeDescriptionLazy as EventTypeDescription } from "@calcom/features/eventtypes/components";
+import { EventTypeDescription } from "@calcom/features/eventtypes/components";
 import CreateEventTypeDialog from "@calcom/features/eventtypes/components/CreateEventTypeDialog";
 import { DuplicateDialog } from "@calcom/features/eventtypes/components/DuplicateDialog";
 import { TeamsFilter } from "@calcom/features/filters/components/TeamsFilter";


### PR DESCRIPTION

## What does this PR do?

Removes dynamic loading of EventTypeDescription component on event-type page. 
We noticed that dynamic loading EventTypeDescription can cause description blinking when using mobile network. Also, we noticed [significant improvement of lighthouse performance score](https://www.notion.so/intuita/Event-types-page-performance-check-340a33fbc95a45549ac92dde272d0057?pvs=4#ef59a757005541dd8a6f9d17f92dc65c) both for desktop and mobile devices when dynamic lEventTypeDescription loading  is removed. 


Fixes description blinking issue on event-types page

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

[event-types performance metrics](https://www.notion.so/intuita/Event-types-page-performance-check-340a33fbc95a45549ac92dde272d0057#ef59a757005541dd8a6f9d17f92dc65c)
<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

