### PR TITLE
chore: sync platform branch with main

### DIFF
--- a/.github/workflows/sync-platform-branch.yml
+++ b/.github/workflows/sync-platform-branch.yml
@@ -1,0 +1,20 @@
+name: Sync platform branch with the main branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Sync with main
+      run: |
+        git checkout platform
+        git pull origin main
+        git push origin platform


### PR DESCRIPTION
It was decided to kickstart v2 API on the newly created `platform` branch.

This PR adds an action that will sync `platform` branch with `main` each time code is merged in the `main`.