### PR TITLE
fix: platform branch sync with main

### DIFF
--- a/.github/workflows/sync-platform-branch.yml
+++ b/.github/workflows/sync-platform-branch.yml
@@ -13,6 +13,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Fetch platform branch
+      run: git fetch origin platform
+
     - name: Sync with main
       run: |
         git checkout platform


### PR DESCRIPTION
The first run of #12525 resulted in

<img width="1040" alt="Screenshot 2023-11-24 at 15 22 34" src="https://github.com/calcom/cal.com/assets/42170848/939de0a7-3918-4ae1-8cf6-cd5a78bf1fa2">

because git does not know about the `platform` branch so we fetch it first before updating it.