### PR TITLE
Fix: Inconsistencies Between Installed & Settings Pages

### DIFF
--- a/packages/features/apps/components/DisconnectIntegration.tsx
+++ b/packages/features/apps/components/DisconnectIntegration.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { trpc } from "@calcom/trpc/react";
 import type { ButtonProps } from "@calcom/ui";
-import { Button, ConfirmationDialogContent, Dialog, DialogTrigger, showToast } from "@calcom/ui";
+import { Button, ConfirmationDialogContent, Dialog, DialogTrigger } from "@calcom/ui";
 import { Trash } from "@calcom/ui/components/icon";
 
 export default function DisconnectIntegration({
@@ -13,6 +12,7 @@ export default function DisconnectIntegration({
   isGlobal,
   onSuccess,
   buttonProps,
+  onClick,
 }: {
   credentialId: number;
   label?: string;
@@ -20,25 +20,26 @@ export default function DisconnectIntegration({
   isGlobal?: boolean;
   onSuccess?: () => void;
   buttonProps?: ButtonProps;
+  onClick: () => void;
 }) {
   const { t } = useLocale();
   const [modalOpen, setModalOpen] = useState(false);
-  const utils = trpc.useContext();
+  // const utils = trpc.useContext();
 
-  const mutation = trpc.viewer.deleteCredential.useMutation({
-    onSuccess: () => {
-      showToast(t("app_removed_successfully"), "success");
-      setModalOpen(false);
-      onSuccess && onSuccess();
-    },
-    onError: () => {
-      showToast(t("error_removing_app"), "error");
-      setModalOpen(false);
-    },
-    async onSettled() {
-      await utils.viewer.connectedCalendars.invalidate();
-    },
-  });
+  // const mutation = trpc.viewer.deleteCredential.useMutation({
+  //   onSuccess: () => {
+  //     showToast(t("app_removed_successfully"), "success");
+  //     setModalOpen(false);
+  //     onSuccess && onSuccess();
+  //   },
+  //   onError: () => {
+  //     showToast(t("error_removing_app"), "error");
+  //     setModalOpen(false);
+  //   },
+  //   async onSettled() {
+  //     await utils.viewer.connectedCalendars.invalidate();
+  //   },
+  // });
 
   return (
     <>
@@ -58,8 +59,10 @@ export default function DisconnectIntegration({
           variety="danger"
           title={t("remove_app")}
           confirmBtnText={t("yes_remove_app")}
-          onConfirm={() => {
-            mutation.mutate({ id: credentialId });
+          onConfirm={async () => {
+            // mutation.mutate({ id: credentialId });
+            await onClick();
+            setModalOpen(false);
           }}>
           <p className="mt-5">{t("are_you_sure_you_want_to_remove_this_app")}</p>
         </ConfirmationDialogContent>

--- a/packages/features/calendars/CalendarListCustom.tsx
+++ b/packages/features/calendars/CalendarListCustom.tsx
@@ -1,0 +1,170 @@
+import Link from "next/link";
+import { Fragment } from "react";
+
+import DisconnectIntegration from "@calcom/features/apps/components/DisconnectIntegration";
+import { CalendarSwitch } from "@calcom/features/calendars/CalendarSwitch";
+import { classNames } from "@calcom/lib";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Alert, Badge, ListItem, ListItemText, ListItemTitle, List } from "@calcom/ui";
+
+import AdditionalCalendarSelector from "@components/apps/AdditionalCalendarSelector";
+
+type fn = ({
+  isOn,
+  credentialId,
+  externalId,
+  type,
+  title,
+}: {
+  title: string;
+  isOn: boolean;
+  credentialId: number;
+  externalId: string;
+  type: string;
+}) => Promise<void>;
+type fnw = ({
+  isOn,
+  credentialId,
+  externalId,
+  type,
+  title,
+}: {
+  title: string;
+  isOn: boolean;
+  credentialId: number;
+  externalId: string;
+  type: string;
+}) => void;
+
+type CalendarListCustomProps = {
+  data: any;
+  isForm?: boolean;
+  onCalendarRemove: (id: number) => void;
+  onCalendarSwitchToggle: fn | fnw;
+};
+// const ta = trpc.viewer.connectedCalendars.useQuery();
+// type query = typeof ta.data;
+const CalendarListCustom = ({
+  data,
+  onCalendarRemove,
+  isForm = false,
+  onCalendarSwitchToggle,
+}: CalendarListCustomProps) => {
+  const { t } = useLocale();
+  console.log("data", data);
+  return (
+    <div>
+      <div className="border-subtle mt-8 flex items-center  justify-between rounded-t-lg border px-4 py-6 sm:px-6">
+        <div>
+          <h4 className="text-emphasis text-base font-semibold leading-5">{t("check_for_conflicts")}</h4>
+          <p className="text-default text-sm leading-tight">{t("select_calendars")}</p>
+        </div>
+        {!isForm && <AdditionalCalendarSelector isLoading={false} />}
+      </div>
+      <List
+        className={`border-subtle flex flex-col gap-6 border border-t-0 p-6 ${
+          isForm ? "border-b-0" : "rounded-b-lg"
+        }`}
+        noBorderTreatment>
+        {data?.connectedCalendars.map((item) => (
+          <Fragment key={item.credentialId}>
+            {item.error && item.error.message && (
+              <Alert
+                severity="warning"
+                key={item.credentialId}
+                title={t("calendar_connection_fail")}
+                message={item.error.message}
+                className="mb-4 mt-4"
+                actions={
+                  <>
+                    {/* @TODO: add a reconnect button, that calls add api and delete old credential */}
+                    <DisconnectIntegration
+                      onClick={() => onCalendarRemove(item.credentialId)}
+                      credentialId={item.credentialId}
+                      trashIcon
+                      //   onSuccess={() => query.refetch()}
+                      buttonProps={{
+                        className: "border border-default py-[2px]",
+                        color: "secondary",
+                      }}
+                    />
+                  </>
+                }
+              />
+            )}
+            {item?.error === undefined && item.calendars && !item?.removed && (
+              <ListItem className="flex-col rounded-lg">
+                <div className="flex w-full flex-1 items-center space-x-3 p-4 rtl:space-x-reverse">
+                  {
+                    // eslint-disable-next-line @next/next/no-img-element
+                    item.integration.logo && (
+                      <img
+                        className={classNames(
+                          "h-10 w-10",
+                          item.integration.logo.includes("-dark") && "dark:invert"
+                        )}
+                        src={item.integration.logo}
+                        alt={item.integration.title}
+                      />
+                    )
+                  }
+                  <div className="flex-grow truncate pl-2">
+                    <ListItemTitle component="h3" className="mb-1 space-x-2 rtl:space-x-reverse">
+                      <Link href={`/apps/${item.integration.slug}`}>
+                        {item.integration.name || item.integration.title}
+                      </Link>
+                      {data?.destinationCalendar?.credentialId === item.credentialId && (
+                        <Badge variant="green">Default</Badge>
+                      )}
+                    </ListItemTitle>
+                    <ListItemText component="p">{item.integration.description}</ListItemText>
+                  </div>
+                  <div>
+                    <DisconnectIntegration
+                      onClick={() => onCalendarRemove(item.credentialId)}
+                      trashIcon
+                      credentialId={item.credentialId}
+                      buttonProps={{ className: "border border-default" }}
+                    />
+                  </div>
+                </div>
+                <div className="border-subtle w-full border-t">
+                  <p className="text-subtle px-2 pt-4 text-sm">{t("toggle_calendars_conflict")}</p>
+                  <ul className="space-y-4 p-4">
+                    {item.calendars.map((cal) => (
+                      <CalendarSwitch
+                        key={cal.externalId}
+                        // credentialId={cal.credentialId}
+                        onCheckedChange={async () =>
+                          await onCalendarSwitchToggle({
+                            credentialId: cal.credentialId,
+                            externalId: cal.externalId,
+                            type: item.integration.type,
+                            title: cal.name || "Nameless calendar",
+                            isOn: !(
+                              cal.isSelected ||
+                              (!isForm && cal.externalId === data?.destinationCalendar?.externalId)
+                            ),
+                          })
+                        }
+                        externalId={cal.externalId}
+                        title={cal.name || "Nameless calendar"}
+                        name={cal.name || "Nameless calendar"}
+                        // type={item.integration.type}
+                        isChecked={
+                          cal.isSelected ||
+                          (!isForm && cal.externalId === data?.destinationCalendar?.externalId)
+                        }
+                      />
+                    ))}
+                  </ul>
+                </div>
+              </ListItem>
+            )}
+          </Fragment>
+        ))}
+      </List>
+    </div>
+  );
+};
+export default CalendarListCustom;

--- a/packages/features/calendars/CalendarSwitch.tsx
+++ b/packages/features/calendars/CalendarSwitch.tsx
@@ -1,98 +1,114 @@
-import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { classNames } from "@calcom/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { trpc } from "@calcom/trpc/react";
-import { showToast, Switch } from "@calcom/ui";
+import { Switch } from "@calcom/ui";
 import { ArrowLeft, RotateCw } from "@calcom/ui/components/icon";
 
 interface ICalendarSwitchProps {
   title: string;
   externalId: string;
-  type: string;
+  // type: string;
   isChecked: boolean;
+  onCheckedChange: () => void;
   name: string;
-  isLastItemInList?: boolean;
+  // isLastItemInList?: boolean;
   destination?: boolean;
-  credentialId: number;
+  // credentialId: number;
+  // isLoading: boolean;
 }
-const CalendarSwitch = (props: ICalendarSwitchProps) => {
-  const { title, externalId, type, isChecked, name, isLastItemInList = false, credentialId } = props;
-  const [checkedInternal, setCheckedInternal] = useState(isChecked);
-  const utils = trpc.useContext();
+const CalendarSwitch = ({
+  title,
+  name,
+  externalId,
+  isChecked,
+  onCheckedChange,
+  destination,
+}: // isLoading,
+ICalendarSwitchProps) => {
+  // const { title, externalId, type, isChecked, name, isLastItemInList = false, credentialId } = props;
+  // const [checkedInternal, setCheckedInternal] = useState(isChecked);
+  // const utils = trpc.useContext();
   const { t } = useLocale();
-  const mutation = useMutation<
-    unknown,
-    unknown,
-    {
-      isOn: boolean;
-    }
-  >(
-    async ({ isOn }: { isOn: boolean }) => {
-      const body = {
-        integration: type,
-        externalId: externalId,
-      };
+  const [isLoading, setIsLoading] = useState(false);
+  // const mutation = useMutation<
+  //   unknown,
+  //   unknown,
+  //   {
+  //     isOn: boolean;
+  //   }
+  // >(
+  //   async ({ isOn }: { isOn: boolean }) => {
+  //     const body = {
+  //       integration: type,
+  //       externalId: externalId,
+  //     };
 
-      if (isOn) {
-        const res = await fetch("/api/availability/calendar", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ ...body, credentialId }),
-        });
+  //     if (isOn) {
+  //       const res = await fetch("/api/availability/calendar", {
+  //         method: "POST",
+  //         headers: {
+  //           "Content-Type": "application/json",
+  //         },
+  //         body: JSON.stringify({ ...body, credentialId }),
+  //       });
 
-        if (!res.ok) {
-          throw new Error("Something went wrong");
-        }
-      } else {
-        const res = await fetch(`/api/availability/calendar?${new URLSearchParams(body)}`, {
-          method: "DELETE",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
+  //       if (!res.ok) {
+  //         throw new Error("Something went wrong");
+  //       }
+  //     } else {
+  //       const res = await fetch(`/api/availability/calendar?${new URLSearchParams(body)}`, {
+  //         method: "DELETE",
+  //         headers: {
+  //           "Content-Type": "application/json",
+  //         },
+  //       });
 
-        if (!res.ok) {
-          throw new Error("Something went wrong");
-        }
-      }
-    },
-    {
-      async onSettled() {
-        await utils.viewer.integrations.invalidate();
-        await utils.viewer.connectedCalendars.invalidate();
-      },
-      onError() {
-        setCheckedInternal(false);
-        showToast(`Something went wrong when toggling "${title}""`, "error");
-      },
-    }
-  );
+  //       if (!res.ok) {
+  //         throw new Error("Something went wrong");
+  //       }
+  //     }
+  //   },
+  //   {
+  //     async onSettled() {
+  //       await utils.viewer.integrations.invalidate();
+  //       await utils.viewer.connectedCalendars.invalidate();
+  //     },
+  //     onError() {
+  //       setCheckedInternal(false);
+  //       showToast(`Something went wrong when toggling "${title}""`, "error");
+  //     },
+  //   }
+  // );
   return (
     <div className={classNames("my-2 flex flex-row items-center")}>
       <div className="flex pl-2">
         <Switch
           id={externalId}
-          checked={checkedInternal}
-          onCheckedChange={(isOn: boolean) => {
-            setCheckedInternal(isOn);
-            mutation.mutate({ isOn });
+          // checked={checkedInternal}
+          checked={isChecked}
+          // onCheckedChange={(isOn: boolean) => {
+          //   setCheckedInternal(isOn);
+          //   mutation.mutate({ isOn });
+          // }}
+          onCheckedChange={async () => {
+            setIsLoading(true);
+            await onCheckedChange();
+            setIsLoading(false);
           }}
         />
       </div>
       <label className="ml-3 text-sm font-medium leading-5" htmlFor={externalId}>
         {name}
       </label>
-      {!!props.destination && (
+      {!!destination && (
         <span className="bg-subtle text-default ml-8 inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-normal sm:ml-4">
           <ArrowLeft className="h-4 w-4" />
           {t("adding_events_to")}
         </span>
       )}
-      {mutation.isLoading && <RotateCw className="text-muted h-4 w-4 animate-spin ltr:ml-1 rtl:mr-1" />}
+      {/* {mutation.isLoading && <RotateCw className="text-muted h-4 w-4 animate-spin ltr:ml-1 rtl:mr-1" />} */}
+      {isLoading && <RotateCw className="text-muted h-4 w-4 animate-spin ltr:ml-1 rtl:mr-1" />}
     </div>
   );
 };

--- a/packages/features/calendars/DestinationCalendar.tsx
+++ b/packages/features/calendars/DestinationCalendar.tsx
@@ -1,0 +1,33 @@
+import DestinationCalendarSelector from "@calcom/features/calendars/DestinationCalendarSelector";
+import type { DestinationCalendarSelectorProps } from "@calcom/features/calendars/DestinationCalendarSelector";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Label } from "@calcom/ui";
+
+type Props = {
+  isForm?: boolean;
+} & DestinationCalendarSelectorProps;
+
+const DestinationCalendarComponent = ({ isForm = false, ...rest }: Props) => {
+  const { t } = useLocale();
+  return (
+    <div>
+      <div className="border-subtle mt-8 rounded-t-lg border px-4 py-6 sm:px-6">
+        <h2 className="text-emphasis mb-1 text-base font-bold leading-5 tracking-wide">
+          {t("add_to_calendar")}
+        </h2>
+        <p className="text-subtle text-sm leading-tight">{t("add_to_calendar_description")}</p>
+      </div>
+      <div
+        className={`border-subtle flex w-full flex-col space-y-3 border border-x ${
+          isForm ? "border-y-0" : "rounded-b-lg border-t-0"
+        } px-4 py-6 sm:px-6`}>
+        <div>
+          <Label className="text-default mb-0 font-medium">{t("add_events_to")}</Label>
+          <DestinationCalendarSelector hidePlaceholder {...rest} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DestinationCalendarComponent;

--- a/packages/features/calendars/DestinationCalendarSelector.tsx
+++ b/packages/features/calendars/DestinationCalendarSelector.tsx
@@ -9,7 +9,7 @@ import { trpc } from "@calcom/trpc/react";
 import { Select, Badge } from "@calcom/ui";
 import { Check } from "@calcom/ui/components/icon";
 
-interface Props {
+export interface DestinationCalendarSelectorProps {
   onChange: (value: { externalId: string; integration: string }) => void;
   isLoading?: boolean;
   hidePlaceholder?: boolean;
@@ -55,7 +55,7 @@ const DestinationCalendarSelector = ({
   hideAdvancedText,
   maxWidth,
   destinationCalendar,
-}: Props): JSX.Element | null => {
+}: DestinationCalendarSelectorProps): JSX.Element | null => {
   const { t } = useLocale();
   const query = trpc.viewer.connectedCalendars.useQuery();
   const [selectedOption, setSelectedOption] = useState<{


### PR DESCRIPTION
## What does this PR do?

Fixes #12367 (issue) (Attempt)

An unrefined attempt to figure out, if the desired solution is this method ?

To reuse the *CalendarListComponent* within two pages which have different logic, I lifted the logic from leaf nodes to parents node a bit.

The setting page requires the logic to be of a form.
While the installed_apps page requires the logic to be more direct.

@joeauyeung Is your desired solution somewhere in the ballpark to this? If so I can proceed further and make it more robust as It contains bugs and types issues. or you can explain a bit how you want it to be solved.

![Screenshot 2023-11-25 at 14-17-49 Calendars Cal](https://github.com/calcom/cal.com/assets/86384652/f2e12995-c6ad-4d69-90ff-05fa122e38eb)
![Screenshot 2023-11-25 at 14-20-11 Installed Apps Cal](https://github.com/calcom/cal.com/assets/86384652/74c186ec-c1d6-4ec3-8685-4497fcbc180a)

