### PR TITLE
fix: removing next steps 

### DIFF
--- a/packages/emails/src/templates/TeamInviteEmail.tsx
+++ b/packages/emails/src/templates/TeamInviteEmail.tsx
@@ -78,13 +78,13 @@ export const TeamInviteEmail = (
           marginTop: "48px",
           lineHeightStep: "24px",
         }}>
-        <>
+        {/* <>
           {props.language("email_no_user_invite_steps_intro", {
             entity: props.language(props.isOrg ? "organization" : "team").toLowerCase(),
           })}
-        </>
+        </> */}
       </p>
-
+      {/* 
       {!props.isCalcomMember && (
         <div style={{ display: "flex", flexDirection: "column", gap: "32px" }}>
           <EmailStep
@@ -120,7 +120,7 @@ export const TeamInviteEmail = (
             }
           />
         </div>
-      )}
+      )} */}
 
       <div className="">
         <p

--- a/packages/emails/src/templates/TeamInviteEmail.tsx
+++ b/packages/emails/src/templates/TeamInviteEmail.tsx
@@ -84,7 +84,7 @@ export const TeamInviteEmail = (
           })}
         </>
       </p>
-
+      {/* 
       {!props.isCalcomMember && (
         <div style={{ display: "flex", flexDirection: "column", gap: "32px" }}>
           <EmailStep
@@ -120,7 +120,7 @@ export const TeamInviteEmail = (
             }
           />
         </div>
-      )}
+      )} */}
 
       <div className="">
         <p


### PR DESCRIPTION
Fixes: #12521 CAL-2755

Removes next steps from the team invite email 

We will be migrating to react.email shortly which should help us iron out these types of bugs