### PR TITLE
fix: Toggling really fast throws internal errors

### DIFF
--- a/packages/features/calendars/CalendarSwitch.tsx
+++ b/packages/features/calendars/CalendarSwitch.tsx
@@ -67,7 +67,7 @@ const CalendarSwitch = (props: ICalendarSwitchProps) => {
       },
       onError() {
         setCheckedInternal(false);
-        showToast(`Something went wrong when toggling "${title}""`, "error");
+        showToast(`Something went wrong when toggling "${title}"`, "error");
       },
     }
   );
@@ -77,9 +77,10 @@ const CalendarSwitch = (props: ICalendarSwitchProps) => {
         <Switch
           id={externalId}
           checked={checkedInternal}
-          onCheckedChange={(isOn: boolean) => {
+          disabled={mutation.isLoading}
+          onCheckedChange={async (isOn: boolean) => {
             setCheckedInternal(isOn);
-            mutation.mutate({ isOn });
+            await mutation.mutate({ isOn });
           }}
         />
       </div>


### PR DESCRIPTION
## What does this PR do?

Fixes UI issue that causes "An operation failed because it depends on one or more records that were required but not found. Record to delete does not exist."