### PR TITLE
fix: updating workflow with new step and new active event type

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -629,11 +629,10 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   });
 
   if (addedSteps) {
-    const eventTypesToCreateReminders = activeOn.map((activeEventType) => {
-      if (activeEventType && !newEventTypes.includes(activeEventType)) {
-        return activeEventType;
-      }
-    });
+    const eventTypesToCreateReminders = activeOn.filter(
+      (eventType) => eventType && !newEventTypes.includes(eventType)
+    );
+
     const promiseAddedSteps = addedSteps.map(async (step) => {
       if (step) {
         const { senderName, ...newStep } = step;

--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -621,11 +621,9 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   });
 
   if (addedSteps) {
-    const eventTypesToCreateReminders = activeOn.map((activeEventType) => {
-      if (activeEventType && !newEventTypes.includes(activeEventType)) {
-        return activeEventType;
-      }
-    });
+    const eventTypesToCreateReminders = activeOn.filter(
+      (activeEventType) => activeEventType && !newEventTypes.includes(activeEventType)
+    );
     const promiseAddedSteps = addedSteps.map(async (step) => {
       if (step) {
         const { senderName, ...newStep } = step;

--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -130,18 +130,15 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     )
     .flat();
 
-  const newActiveEventTypes = activeOn.filter((eventType) => {
-    if (
+  const newActiveEventTypes = activeOn.filter(
+    (eventType) =>
       !oldActiveOnEventTypes ||
       !oldActiveOnEventTypes
         .map((oldEventType) => {
           return oldEventType.eventTypeId;
         })
         .includes(eventType)
-    ) {
-      return eventType;
-    }
-  });
+  );
 
   //check if new event types belong to user or team
   for (const newEventTypeId of newActiveEventTypes) {
@@ -177,11 +174,9 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   }
 
   //remove all scheduled Email and SMS reminders for eventTypes that are not active any more
-  const removedEventTypes = oldActiveOnEventTypeIds.filter((eventTypeId) => {
-    if (!activeOnWithChildren.includes(eventTypeId)) {
-      return eventTypeId;
-    }
-  });
+  const removedEventTypes = oldActiveOnEventTypeIds.filter(
+    (eventTypeId) => !activeOnWithChildren.includes(eventTypeId)
+  );
 
   const remindersToDeletePromise: Prisma.PrismaPromise<
     {
@@ -471,11 +466,9 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         },
       });
       //cancel all reminders of step and create new ones (not for newEventTypes)
-      const remindersToUpdate = remindersFromStep.filter((reminder) => {
-        if (reminder.booking?.eventTypeId && !newEventTypes.includes(reminder.booking?.eventTypeId)) {
-          return reminder;
-        }
-      });
+      const remindersToUpdate = remindersFromStep.filter(
+        (reminder) => reminder.booking?.eventTypeId && !newEventTypes.includes(reminder.booking?.eventTypeId)
+      );
 
       //cancel all workflow reminders from steps that were edited
       // FIXME: async calls into ether
@@ -488,11 +481,10 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
           deleteScheduledWhatsappReminder(reminder.id, reminder.referenceId);
         }
       });
-      const eventTypesToUpdateReminders = activeOn.filter((eventTypeId) => {
-        if (!newEventTypes.includes(eventTypeId)) {
-          return eventTypeId;
-        }
-      });
+
+      const eventTypesToUpdateReminders = activeOn.filter(
+        (eventTypeId) => !newEventTypes.includes(eventTypeId)
+      );
       if (
         eventTypesToUpdateReminders &&
         (trigger === WorkflowTriggerEvents.BEFORE_EVENT || trigger === WorkflowTriggerEvents.AFTER_EVENT)
@@ -629,10 +621,11 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   });
 
   if (addedSteps) {
-    const eventTypesToCreateReminders = activeOn.filter(
-      (eventType) => eventType && !newEventTypes.includes(eventType)
-    );
-
+    const eventTypesToCreateReminders = activeOn.map((activeEventType) => {
+      if (activeEventType && !newEventTypes.includes(activeEventType)) {
+        return activeEventType;
+      }
+    });
     const promiseAddedSteps = addedSteps.map(async (step) => {
       if (step) {
         const { senderName, ...newStep } = step;


### PR DESCRIPTION
## What does this PR do?

Fixes issue that a workflow with an added step and a new active event types couldn't be saved because `booking.findMany()` failed. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create Workflow with before event trigger 
- Add a step 
- add an event type in the dropdown 
- Test if saving the workflow is successful

