### PR TITLE
docs: Remove duplicate CALENDSO key setup from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ echo 'NEXT_PUBLIC_DEBUG=1' >> .env
 
 1. Copy and paste your `DATABASE_URL` from `.env` to `.env.appStore`.
 
-1. Set a 24 character random string in your `.env` file for the `CALENDSO_ENCRYPTION_KEY` (You can use a command like `openssl rand -base64 24` to generate one).
 1. Set up the database using the Prisma schema (found in `packages/prisma/schema.prisma`)
 
    In a development environment, run:


### PR DESCRIPTION
## What does this PR do?

In the README where it mentioned how to setup the project in development, the CALENDSO key setup was being mentioned twice:
1. While setting up the .env and,
2. While setting up the database manually.

This is a possible duplication.

Fixes # (issue)

Since the CALENDSO key is mentioned in the setting up .env part in the README, this PR removes the second time the same step is mentioned.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
