### PR TITLE
fix: Signup options are not disabled

### DIFF
--- a/apps/web/pages/auth/login.tsx
+++ b/apps/web/pages/auth/login.tsx
@@ -251,6 +251,7 @@ inferSSRProps<typeof _getServerSideProps> & WithNonceProps<{}>) {
                   <Button
                     color="secondary"
                     className="w-full justify-center"
+                    disabled={formState.isSubmitting}
                     data-testid="google"
                     StartIcon={FaGoogle}
                     onClick={async (e) => {

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -323,6 +323,7 @@ export default function Signup({
                   !!formMethods.formState.errors.email ||
                   !formMethods.getValues("email") ||
                   !formMethods.getValues("password") ||
+                  isSubmitting ||
                   usernameTaken
                 }>
                 {premiumUsername && !usernameTaken
@@ -388,7 +389,8 @@ export default function Signup({
                       !!formMethods.formState.errors.username ||
                       !!formMethods.formState.errors.email ||
                       premiumUsername ||
-                      isSubmitting
+                      isSubmitting ||
+                      isGoogleLoading
                     }
                     className={classNames(
                       "w-full justify-center rounded-md text-center",

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -204,7 +204,6 @@ export default function Signup({
   const isOrgInviteByLink = orgSlug && !prepopulateFormValues?.username;
 
   const signUp: SubmitHandler<FormValues> = async (data) => {
-    setClickObserve(true);
     await fetch("/api/auth/signup", {
       body: JSON.stringify({
         ...data,
@@ -235,7 +234,6 @@ export default function Signup({
       })
       .catch((err) => {
         formMethods.setError("apiError", { message: err.message });
-        setClickObserve(false);
       });
   };
 
@@ -379,7 +377,6 @@ export default function Signup({
                         return;
                       }
                       router.push(GOOGLE_AUTH_URL);
-                      setClickObserve(false);
                     }}>
                     Google
                   </Button>
@@ -391,7 +388,7 @@ export default function Signup({
                       !!formMethods.formState.errors.username ||
                       !!formMethods.formState.errors.email ||
                       premiumUsername ||
-                      clickObserve
+                      isSubmitting
                     }
                     className={classNames(
                       "w-full justify-center rounded-md text-center",
@@ -400,13 +397,12 @@ export default function Signup({
                         : ""
                     )}
                     onClick={() => {
-                      setClickObserve(true);
                       if (!formMethods.getValues("username")) {
                         formMethods.trigger("username");
                       }
                       if (!formMethods.getValues("email")) {
                         formMethods.trigger("email");
-                        setClickObserve(false);
+
                         return;
                       }
                       const username = formMethods.getValues("username");

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -204,6 +204,7 @@ export default function Signup({
   const isOrgInviteByLink = orgSlug && !prepopulateFormValues?.username;
 
   const signUp: SubmitHandler<FormValues> = async (data) => {
+    setClickObserve(true);
     await fetch("/api/auth/signup", {
       body: JSON.stringify({
         ...data,
@@ -234,6 +235,7 @@ export default function Signup({
       })
       .catch((err) => {
         formMethods.setError("apiError", { message: err.message });
+        setClickObserve(false);
       });
   };
 
@@ -377,6 +379,7 @@ export default function Signup({
                         return;
                       }
                       router.push(GOOGLE_AUTH_URL);
+                      setClickObserve(false);
                     }}>
                     Google
                   </Button>
@@ -387,7 +390,8 @@ export default function Signup({
                     disabled={
                       !!formMethods.formState.errors.username ||
                       !!formMethods.formState.errors.email ||
-                      premiumUsername
+                      premiumUsername ||
+                      clickObserve
                     }
                     className={classNames(
                       "w-full justify-center rounded-md text-center",
@@ -396,11 +400,13 @@ export default function Signup({
                         : ""
                     )}
                     onClick={() => {
+                      setClickObserve(true);
                       if (!formMethods.getValues("username")) {
                         formMethods.trigger("username");
                       }
                       if (!formMethods.getValues("email")) {
                         formMethods.trigger("email");
+                        setClickObserve(false);
                         return;
                       }
                       const username = formMethods.getValues("username");


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #12586 (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->



## Type of change

<!-- Please delete bullets that are not relevant. -->

-  Bug fix (non-breaking change which fixes an issue)
  <b>Major Issue:</b> While clicking on signup button there is no actions provided to disable the other signup options resulting in the main issue. Fixed it by creating a boolean state clickObserv which helps in disabling the other signup buttons when one is clicked.
--
<b>Minor Issue 1:</b> There are 2 options to improve the user experience in this case. Either by loading the verification page only after the verify_email_page_body is loaded or by changing the verify_email_page_body with a spin loader.
--
<b>Minor Issue 2:</b> This is happening because those routes are not protected. It's not like you are navigated to delete survey page on back click. If you  open any other page before signup you will be redirected to that particular page on clicking back as those routes are not protected and there is no conditions for visiting any route. From my opinion this is not considered as a minor issue but it's a major issue.
<b>Regarding the Suggestion:</b> As per my thought, Instead of navigating them directly to dashboard page we can add a skip or "do it later" button and let the user decide that he need to verify the email or access the dashboard.



## How should this be tested?
[fixed_disabling.webm](https://github.com/calcom/cal.com/assets/70286186/8c8afc1c-e4e2-4f15-a4b0-07c29e95c665)

As you see in the video that the other buttons got disabled when click on create account. Same happens if user clicked on any other signup option


