### PR TITLE
feat: display long durations in hours on booking

### DIFF
--- a/apps/web/public/static/locales/ar/common.json
+++ b/apps/web/public/static/locales/ar/common.json
@@ -656,6 +656,7 @@
   "default_duration": "المدة الافتراضية",
   "default_duration_no_options": "يرجى اختيار المدد المتاحة أولاً",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "الدقائق",
   "round_robin": "الترتيب الدوري",
   "round_robin_description": "نقل الاجتماعات بشكل دوري بين أعضاء الفريق المتعددين.",

--- a/apps/web/public/static/locales/cs/common.json
+++ b/apps/web/public/static/locales/cs/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Výchozí doba trvání",
   "default_duration_no_options": "Nejprve vyberte dostupné doby trvání",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "min",
   "round_robin": "Plánování Round Robin",
   "round_robin_description": "Schůzky v řadě mezi několika členy týmu.",

--- a/apps/web/public/static/locales/da/common.json
+++ b/apps/web/public/static/locales/da/common.json
@@ -553,6 +553,7 @@
   "default_duration": "Standard varighed",
   "default_duration_no_options": "Vælg venligst tilgængelige varigheder først",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutter",
   "round_robin": "Round Robin",
   "round_robin_description": "Cyklusmøder mellem flere teammedlemmer.",

--- a/apps/web/public/static/locales/de/common.json
+++ b/apps/web/public/static/locales/de/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Standardlaufzeit",
   "default_duration_no_options": "Bitte wählen Sie zuerst die verfügbaren Laufzeiten aus",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuten",
   "round_robin": "Round Robin",
   "round_robin_description": "Treffen zwischen mehreren Teammitgliedern durchwechseln.",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -673,6 +673,7 @@
   "default_duration": "Default duration",
   "default_duration_no_options": "Please choose available durations first",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutes",
   "round_robin": "Round Robin",
   "round_robin_description": "Cycle meetings between multiple team members.",

--- a/apps/web/public/static/locales/es/common.json
+++ b/apps/web/public/static/locales/es/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Duración predeterminada",
   "default_duration_no_options": "Seleccione primero las duraciones disponibles",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutos",
   "round_robin": "Petición Firmada por Turnos",
   "round_robin_description": "Ciclo de reuniones entre varios miembros del equipo.",

--- a/apps/web/public/static/locales/fr/common.json
+++ b/apps/web/public/static/locales/fr/common.json
@@ -660,6 +660,7 @@
   "default_duration": "Durée par défaut",
   "default_duration_no_options": "Veuillez d'abord choisir les durées disponibles",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "minutes",
   "round_robin": "Round-robin",
   "round_robin_description": "Alternez vos rendez-vous entre plusieurs membres d'équipe.",

--- a/apps/web/public/static/locales/he/common.json
+++ b/apps/web/public/static/locales/he/common.json
@@ -656,6 +656,7 @@
   "default_duration": "משך הזמן המוגדר כברירת מחדל",
   "default_duration_no_options": "ראשית, אנא בחר משך זמינות",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "דקות",
   "round_robin": "לפי תורות",
   "round_robin_description": "פגישות מחזוריות בין חברי צוות מרובים.",

--- a/apps/web/public/static/locales/it/common.json
+++ b/apps/web/public/static/locales/it/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Durata predefinita",
   "default_duration_no_options": "Scegliere prima delle durate disponibili",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuti",
   "round_robin": "Round Robin",
   "round_robin_description": "Ciclo di riunioni tra più membri del team.",

--- a/apps/web/public/static/locales/ja/common.json
+++ b/apps/web/public/static/locales/ja/common.json
@@ -656,6 +656,7 @@
   "default_duration": "デフォルトの時間",
   "default_duration_no_options": "最初に空いている時間を選択してください",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "分",
   "round_robin": "ラウンドロビン",
   "round_robin_description": "複数のチームメンバー間のミーティングを定期化する。",

--- a/apps/web/public/static/locales/ko/common.json
+++ b/apps/web/public/static/locales/ko/common.json
@@ -656,6 +656,7 @@
   "default_duration": "기본 기간",
   "default_duration_no_options": "사용 가능한 기간을 먼저 선택하세요",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "분",
   "round_robin": "라운드 로빈",
   "round_robin_description": "여러 팀 구성원 간의 주기적인 회의",

--- a/apps/web/public/static/locales/nl/common.json
+++ b/apps/web/public/static/locales/nl/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Standaardduur",
   "default_duration_no_options": "Kies eerst de beschikbare duur",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuten",
   "round_robin": "Round Robin",
   "round_robin_description": "Afspraken wisselen tussen meerdere teamleden.",

--- a/apps/web/public/static/locales/no/common.json
+++ b/apps/web/public/static/locales/no/common.json
@@ -544,6 +544,7 @@
   "default_duration": "Standard varighet",
   "default_duration_no_options": "Vennligst velg tilgjengelige varigheter først",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutter",
   "round_robin": "Round Robin",
   "round_robin_description": "Varier møter mellom flere teammedlemmer.",

--- a/apps/web/public/static/locales/pl/common.json
+++ b/apps/web/public/static/locales/pl/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Domyślny czas trwania",
   "default_duration_no_options": "Proszę najpierw wybrać dostępne czasy trwania",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuty",
   "round_robin": "Round Robin",
   "round_robin_description": "Cykl spotkań między wieloma członkami zespołu.",

--- a/apps/web/public/static/locales/pt-BR/common.json
+++ b/apps/web/public/static/locales/pt-BR/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Duração padrão",
   "default_duration_no_options": "Escolha as durações disponíveis primeiro",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutos",
   "round_robin": "Round Robin",
   "round_robin_description": "Reuniões recorrentes entre vários membros da equipe.",

--- a/apps/web/public/static/locales/pt/common.json
+++ b/apps/web/public/static/locales/pt/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Duração predefinida",
   "default_duration_no_options": "Por favor, selecione primeiro as durações disponíveis",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minutos",
   "round_robin": "Round Robin",
   "round_robin_description": "Reuniões de ciclo entre vários membros da equipa.",

--- a/apps/web/public/static/locales/ro/common.json
+++ b/apps/web/public/static/locales/ro/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Durată implicită",
   "default_duration_no_options": "Alege mai întâi duratele disponibile",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minute",
   "round_robin": "Round Robin",
   "round_robin_description": "Întâlniri ciclice între mai mulţi membri ai echipei.",

--- a/apps/web/public/static/locales/ru/common.json
+++ b/apps/web/public/static/locales/ru/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Продолжительность по умолчанию",
   "default_duration_no_options": "Пожалуйста, выберите сначала доступную продолжительность",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "мин.",
   "round_robin": "По кругу",
   "round_robin_description": "Цикл встреч между несколькими членами команды.",

--- a/apps/web/public/static/locales/sr/common.json
+++ b/apps/web/public/static/locales/sr/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Podrazumevano trajanje",
   "default_duration_no_options": "Najpre izaberite dostupna trajanja",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuti",
   "round_robin": "Round Robin",
   "round_robin_description": "Ciklusirajte sastanke između više članova tima.",

--- a/apps/web/public/static/locales/sv/common.json
+++ b/apps/web/public/static/locales/sv/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Standardvaraktighet",
   "default_duration_no_options": "Välj först tillgänglig varaktighet",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Minuter",
   "round_robin": "Tur och ordning",
   "round_robin_description": "Variera möten mellan olika teammedlemmar.",

--- a/apps/web/public/static/locales/tr/common.json
+++ b/apps/web/public/static/locales/tr/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Varsayılan süre",
   "default_duration_no_options": "Lütfen önce uygun süreleri seçin",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Dakika",
   "round_robin": "Round Robin",
   "round_robin_description": "Toplantıları birden fazla ekip üyesi arasında döndürün.",

--- a/apps/web/public/static/locales/uk/common.json
+++ b/apps/web/public/static/locales/uk/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Тривалість за замовчуванням",
   "default_duration_no_options": "Спочатку виберіть доступні варіанти тривалості",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Хвилини",
   "round_robin": "Ротація",
   "round_robin_description": "Кілька учасників команди призначаються для нарад циклічно й по черзі.",

--- a/apps/web/public/static/locales/vi/common.json
+++ b/apps/web/public/static/locales/vi/common.json
@@ -656,6 +656,7 @@
   "default_duration": "Khoảng thời gian mặc định",
   "default_duration_no_options": "Vui lòng chọn trước tiên những khoảng thời gian khả dụng",
   "multiple_duration_mins": "{{count}}$t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "Phút",
   "round_robin": "Round Robin",
   "round_robin_description": "Luân phiên những cuộc họp giữa các thành viên trong nhóm.",

--- a/apps/web/public/static/locales/zh-CN/common.json
+++ b/apps/web/public/static/locales/zh-CN/common.json
@@ -656,6 +656,7 @@
   "default_duration": "默认时长",
   "default_duration_no_options": "请先选择可用时长",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "分钟",
   "round_robin": "轮流模式",
   "round_robin_description": "和多个团队成员之间轮流举行会议。",

--- a/apps/web/public/static/locales/zh-TW/common.json
+++ b/apps/web/public/static/locales/zh-TW/common.json
@@ -656,6 +656,7 @@
   "default_duration": "預設時間長度",
   "default_duration_no_options": "請先選擇可預約的時間長度",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "分鐘",
   "round_robin": "循環制",
   "round_robin_description": "與多位團隊成員進行週期會議。",

--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from "next-i18next";
 import { useEffect } from "react";
 
 import { useBookerStore } from "@calcom/features/bookings/Booker/store";
@@ -6,6 +7,21 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui";
 
 import type { PublicEvent } from "../../types";
+
+/** Only render in X hours if has for duration of HOURS_THRESHOLD mins more */
+const HOURS_THRESHOLD = 120;
+
+/** Render X mins as X hours or X hours Y mins instead of in minutes once above HOURS_THRESHOLD */
+const getDurationFormatted = (mins: number, t: TFunction) => {
+  if (mins < HOURS_THRESHOLD) return t("multiple_duration_timeUnit", { count: mins, unit: "minute" });
+  const hours = Math.floor(mins / 60);
+  mins %= 60;
+  if (mins === 0) return t("multiple_duration_timeUnit", { count: hours, unit: "hour" });
+  return `${t("multiple_duration_timeUnit", { count: hours, unit: "hour" })} ${t(
+    "multiple_duration_timeUnit",
+    { count: mins, unit: "minute" }
+  )}`;
+};
 
 export const EventDuration = ({ event }: { event: PublicEvent }) => {
   const { t } = useLocale();
@@ -25,7 +41,7 @@ export const EventDuration = ({ event }: { event: PublicEvent }) => {
   }, [selectedDuration, setSelectedDuration, event.metadata?.multipleDuration, event.length, isDynamicEvent]);
 
   if (!event?.metadata?.multipleDuration && !isDynamicEvent)
-    return <>{t("multiple_duration_mins", { count: event.length })}</>;
+    return <>{getDurationFormatted(event.length, t)}</>;
 
   const durations = event?.metadata?.multipleDuration || [15, 30, 60];
 

--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -65,7 +65,9 @@ export const EventDuration = ({ event }: { event: PublicEvent }) => {
             className={classNames(selectedDuration === duration && "bg-brand-default text-brand")}
             size="md"
             key={duration}
-            onClick={() => setSelectedDuration(duration)}>{`${duration} ${t("minute_timeUnit")}`}</Badge>
+            onClick={() => setSelectedDuration(duration)}>
+            {getDurationFormatted(duration, t)}
+          </Badge>
         ))}
     </div>
   );

--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -8,19 +8,29 @@ import { Badge } from "@calcom/ui";
 
 import type { PublicEvent } from "../../types";
 
-/** Only render in X hours if has for duration of HOURS_THRESHOLD mins more */
-const HOURS_THRESHOLD = 120;
-
-/** Render X mins as X hours or X hours Y mins instead of in minutes once above HOURS_THRESHOLD */
+/** Render X mins as X hours or X hours Y mins instead of in minutes once >= 60 minutes */
 const getDurationFormatted = (mins: number, t: TFunction) => {
-  if (mins < HOURS_THRESHOLD) return t("multiple_duration_timeUnit", { count: mins, unit: "minute" });
   const hours = Math.floor(mins / 60);
   mins %= 60;
-  if (mins === 0) return t("multiple_duration_timeUnit", { count: hours, unit: "hour" });
-  return `${t("multiple_duration_timeUnit", { count: hours, unit: "hour" })} ${t(
-    "multiple_duration_timeUnit",
-    { count: mins, unit: "minute" }
-  )}`;
+  // format minutes string
+  let minStr = "";
+  if (mins > 0) {
+    minStr =
+      mins === 1
+        ? t("minute_one", { count: 1 })
+        : t("multiple_duration_timeUnit", { count: mins, unit: "minute" });
+  }
+  // format hours string
+  let hourStr = "";
+  if (hours > 0) {
+    hourStr =
+      hours === 1
+        ? t("hour_one", { count: 1 })
+        : t("multiple_duration_timeUnit", { count: hours, unit: "hour" });
+  }
+
+  if (hourStr && minStr) return `${hourStr} ${minStr}`;
+  return hourStr || minStr;
 };
 
 export const EventDuration = ({ event }: { event: PublicEvent }) => {


### PR DESCRIPTION
## What does this PR do?

Fixes #12107

On the booking page, durations longer than a certain threshold should be rendered as X hours or X hours Y mins instead of in minutes.

120 minutes would be displayed as 2 hours ~but 90 minutes (< 120 minutes) would still be 90 mins, which would avoid the complexity of singular/plural translations (needing different translations for 1 hour and 2 hours).~

90 minutes would be displayed as 1 hour 30 mins


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

### Long duration (Bofore vs After)

<img width="227" alt="Screenshot 2023-12-02 at 10 59 41" src="https://github.com/calcom/cal.com/assets/23418428/2c4a643b-b180-4e62-ac1a-867f57dfb529">

<img width="200" alt="Screenshot 2023-12-02 at 11 14 00" src="https://github.com/calcom/cal.com/assets/23418428/abb32667-3718-45d8-baee-8502cec84f1b">

### Internationalization (Left: Japan, Right: Chinese)

<img width="232" alt="Screenshot 2023-12-02 at 11 20 36" src="https://github.com/calcom/cal.com/assets/23418428/1ab96e2c-08a4-4752-9dde-f0f37204e7f4">

<img width="119" alt="Screenshot 2023-12-02 at 11 20 51" src="https://github.com/calcom/cal.com/assets/23418428/e97d00e1-6279-42fe-824e-5eda6fb030c9">



## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

