### PR TITLE
fix: add formatDuration function to format the duration of bookings

### DIFF
--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -27,12 +27,14 @@ export type EventTypeDescriptionProps = {
   isPublic?: boolean;
 };
 
-const formatDuration = (dur: number) => {
-  return dur < 60
-    ? `${dur} m`
-    : dur % 60 === 0
-    ? `${dur / 60} hours`
-    : `${Math.floor(dur / 60)} hours ${dur % 60} m`;
+const formatDuration = (dur: number): string => {
+  if (dur < 60) {
+    return `${dur} m`;
+  }
+  if (dur % 60 === 0) {
+    return `${dur / 60} hours`;
+  }
+  return `${Math.floor(dur / 60)} hours ${dur % 60} m`;
 };
 
 export const EventTypeDescription = ({

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -27,6 +27,14 @@ export type EventTypeDescriptionProps = {
   isPublic?: boolean;
 };
 
+const formatDuration = (dur) => {
+  return dur < 60
+    ? `${dur} m`
+    : dur % 60 === 0
+    ? `${dur / 60} hours`
+    : `${Math.floor(dur / 60)} hours ${dur % 60} m`;
+};
+
 export const EventTypeDescription = ({
   eventType,
   className,
@@ -61,14 +69,14 @@ export const EventTypeDescription = ({
             eventType.metadata.multipleDuration.map((dur, idx) => (
               <li key={idx}>
                 <Badge variant="gray" startIcon={Clock}>
-                  {dur}m
+                  {formatDuration(dur)}
                 </Badge>
               </li>
             ))
           ) : (
             <li>
               <Badge variant="gray" startIcon={Clock}>
-                {eventType.length}m
+                {formatDuration(eventType.length)}
               </Badge>
             </li>
           )}

--- a/packages/features/eventtypes/components/EventTypeDescription.tsx
+++ b/packages/features/eventtypes/components/EventTypeDescription.tsx
@@ -27,7 +27,7 @@ export type EventTypeDescriptionProps = {
   isPublic?: boolean;
 };
 
-const formatDuration = (dur) => {
+const formatDuration = (dur: number) => {
   return dur < 60
     ? `${dur} m`
     : dur % 60 === 0


### PR DESCRIPTION
## What does this PR do?
This will display anything under 60 minutes as e.g. 48 minutes. Longer durations like 245 minutes will be displayed as "4 hours 5 m" instead of "245m". 

Fixes #12631

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.