### PR TITLE
fix:added limit for duration of event type

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -241,6 +241,7 @@ export default function CreateEventTypeDialog({
                     type="number"
                     required
                     min="10"
+                    max="7260"
                     placeholder="15"
                     label={t("duration")}
                     className="pr-4"

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -8,7 +8,7 @@ export const createEventTypeInput = z.object({
   title: z.string().min(1),
   slug: imports.eventTypeSlug,
   description: z.string().nullish(),
-  length: z.number().int(),
+  length: z.number().int().max(7260),
   hidden: z.boolean(),
   teamId: z.number().int().nullish(),
   schedulingType: z.nativeEnum(SchedulingType).nullish(),


### PR DESCRIPTION
## What does this PR do?

adds limit to length of event type in frontend as well as backend 

Fixes #12509 
<img width="545" alt="Screenshot 2023-12-03 at 12 24 26 AM" src="https://github.com/calcom/cal.com/assets/100336545/f1dc596f-120f-4d20-9b62-cd11180fb915">


