### PR TITLE
fix: booking error in case of no calendar credential but stray destinationCalendar

### DIFF
--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -574,24 +574,25 @@ export default class EventManager {
             (c) => c.type === destination.integration
           );
           // It might not be the first connected calendar as it seems that the order is not guaranteed to be ascending of credentialId.
-          const firstCalendarCredential = destinationCalendarCredentials[0];
+          const firstCalendarCredential = destinationCalendarCredentials[0] as
+            | (typeof destinationCalendarCredentials)[number]
+            | undefined;
 
           if (!firstCalendarCredential) {
             log.warn(
               "No other credentials found of the same type as the destination calendar. Falling back to first connected calendar"
             );
             await fallbackToFirstConnectedCalendar();
+          } else {
+            log.warn(
+              "No credentialId found for destination calendar, falling back to first found calendar of same type as destination calendar",
+              safeStringify({
+                destination: getPiiFreeDestinationCalendar(destination),
+                firstConnectedCalendar: getPiiFreeCredential(firstCalendarCredential),
+              })
+            );
+            createdEvents.push(await createEvent(firstCalendarCredential, event));
           }
-
-          log.warn(
-            "No credentialId found for destination calendar, falling back to first found calendar",
-            safeStringify({
-              destination: getPiiFreeDestinationCalendar(destination),
-              firstConnectedCalendar: getPiiFreeCredential(firstCalendarCredential),
-            })
-          );
-
-          createdEvents.push(await createEvent(firstCalendarCredential, event));
         }
       }
     } else {


### PR DESCRIPTION
## What does this PR do?

Fixes #12464

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Install Google Calendar
2. Ensure that it is selected as destinationCalendar for an event
3. Set credentialId to null for the destinationCalendar
4. Delete the Credential - Ensure that app isn't opened in any of the tabs(going to app pages would cleanup the invalid destinationCalendar)
5. Try and do a booking and you would be able to replicate the error.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works