### PR TITLE
fix: redirect to calendar options page when Google calendar is not selected

### DIFF
--- a/packages/app-store/googlecalendar/api/callback.ts
+++ b/packages/app-store/googlecalendar/api/callback.ts
@@ -19,6 +19,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const state = decodeOAuthState(req);
 
   if (typeof code !== "string") {
+    res.redirect(getInstalledAppPath({}));
     throw new HttpError({ statusCode: 400, message: "`code` must be a string" });
   }
 


### PR DESCRIPTION
## What does this PR do?
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [12233](https://github.com/calcom/cal.com/issues/12233)
This change ensures that when Google Calendar is not selected instead of showing the JSON error in the UI, the user is redirected back to the Calendar options page.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
The bug when Google Calendar is not selected
Loom Video: https://www.loom.com/share/31f7f0ee042c4ba5b68a94969b6a6279?sid=02758f14-cc66-4b82-a9a2-ffc4ebc7b408

The current resolution when Google Calendar is not selected
Loom Video: 
https://www.loom.com/share/7ecb19571a0c45cb8db4652a3846ac27?sid=8b1e4062-1027-48b5-8daa-2a244c3ed66c

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

This change requires Google client_id and Google client_secret

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- What are the minimal test data to have?
1. Create a new user with a verified email in the db
2. Add  client_id and client_secret in the app model for google-calendar
3. Navigate to the page <baseurl>/getting-started/connected-calendar

- What is expected (happy path) to have (input and output)?
When permissions are not given to access Google Calendar, user should be redirected to 
<baseurl>/getting-started/connected-calendar



## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
