### PR TITLE
fix: Hide expires on message if never expires is selected

### DIFF
--- a/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/packages/features/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -202,10 +202,10 @@ export default function ApiKeyDialogForm({
                   );
                 }}
               />
-              <span className="text-subtle mt-2 text-xs">
+              {!watchNeverExpires && <span className="text-subtle mt-2 text-xs">
                 {t("api_key_expires_on")}
                 <span className="font-bold"> {dayjs(expiryDate).format("DD-MM-YYYY")}</span>
-              </span>
+              </span>}
             </div>
           )}
 


### PR DESCRIPTION
I don't think it makes sense to show "This will expire on ..." when selecting "Never expires":

![CleanShot 2023-12-11 at 11 21 54@2x](https://github.com/calcom/cal.com/assets/667029/e3877c4b-344f-43c0-bc47-5a54b18e7d54)

Another option would be to change the message, happy to do that if you prefer 😊