### PR TITLE
fix: Disable source maps which looks to be infinitely looping

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -161,7 +161,7 @@ const nextConfig = {
     ...i18n,
     localeDetection: false,
   },
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
   /* We already do type check on GH actions */
   typescript: {
     ignoreBuildErrors: !!process.env.CI,


### PR DESCRIPTION
## What does this PR do?

Disables source maps to determine culprit of high memory usage.