### PR TITLE
fix: URL query not passed on when there's only one EventType is active

### DIFF
--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -2,6 +2,7 @@ import type { DehydratedState } from "@tanstack/react-query";
 import classNames from "classnames";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
+import { stringify } from "querystring";
 import { Toaster } from "react-hot-toast";
 import type { z } from "zod";
 
@@ -391,10 +392,16 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
   // if profile only has one public event-type, redirect to it
   if (eventTypes.length === 1 && context.query.redirect !== "false") {
+    const {
+      // So it doesn't display in the Link
+      user: _user,
+      ...query
+    } = context.query;
+
     return {
       redirect: {
         permanent: false,
-        destination: `/${user.username}/${eventTypes[0].slug}`,
+        destination: `/${user.username}/${eventTypes[0].slug}?${stringify(query)}`,
       },
     };
   }


### PR DESCRIPTION
## What does this PR do?

Fixes #12758

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/26aa36c87fed4127ba57a2dfc25990aa?sid=ad43cea2-3e7a-4943-b0ed-03b20287137c
## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

Steps to Reproduce
- Leave only one event type active for a user
- Navigate to the user's main calendar url and include some parameters e.g., cal.com/username?email=user.com
- Due to the auto redirect, the URL parameters are not passed to the booking page


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
