### PR TITLE
fix: [main] Signup can't be done for email matching org domain 

### DIFF
--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -75,6 +75,7 @@ function UsernameField({
   setUsernameTaken,
   orgSlug,
   usernameTaken,
+  disabled,
   ...props
 }: React.ComponentProps<typeof TextField> & {
   username: string;
@@ -92,6 +93,8 @@ function UsernameField({
     if (formState.isSubmitting || formState.isSubmitSuccessful) return;
 
     async function checkUsername() {
+      // If the username can't be changed, there is no point in doing the username availability check
+      if (disabled) return;
       if (!debouncedUsername) {
         setPremium(false);
         setUsernameTaken(false);
@@ -103,11 +106,20 @@ function UsernameField({
       });
     }
     checkUsername();
-  }, [debouncedUsername, setPremium, setUsernameTaken, formState.isSubmitting, formState.isSubmitSuccessful]);
+  }, [
+    debouncedUsername,
+    setPremium,
+    disabled,
+    orgSlug,
+    setUsernameTaken,
+    formState.isSubmitting,
+    formState.isSubmitSuccessful,
+  ]);
 
   return (
     <div>
       <TextField
+        disabled={disabled}
         {...props}
         {...register("username")}
         data-testid="signup-usernamefield"

--- a/apps/web/playwright/organization/organization-invitation.e2e.ts
+++ b/apps/web/playwright/organization/organization-invitation.e2e.ts
@@ -392,7 +392,7 @@ async function signupFromEmailInviteLink({
   const signupPage = await context.newPage();
 
   signupPage.goto(inviteLink);
-  await signupPage.waitForLoadState("networkidle");
+  await signupPage.locator(`[data-testid="signup-usernamefield"]`).waitFor({ state: "visible" });
   await expect(signupPage.locator(`[data-testid="signup-usernamefield"]`)).toBeDisabled();
   expect(await signupPage.locator(`[data-testid="signup-usernamefield"]`).inputValue()).toBe(
     expectedUsername


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where signup can't be done for email matching org domain due to username availability check disabling Signup button. Regression from #12854 that couldn't be caught because e2e didn't run before merge.

Also fixes, flaky test


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (Unit/Integration/E2E or any other test)

## How should this be tested?
- Invite an email matching org domain 
- Try to signup using the invite link

## Tests Status - Passing
https://github.com/calcom/cal.com/actions/runs/7257524229

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


