### PR TITLE
fix: ZodError in auth/oauth/authorize

### DIFF
--- a/apps/web/pages/auth/oauth2/authorize.tsx
+++ b/apps/web/pages/auth/oauth2/authorize.tsx
@@ -18,7 +18,7 @@ export default function Authorize() {
   const router = useRouter();
   const searchParams = useCompatSearchParams();
 
-  const client_id = searchParams?.get("client_id") as string;
+  const client_id = (searchParams?.get("client_id") as string) || "";
   const state = searchParams?.get("state") as string;
   const scope = searchParams?.get("scope") as string;
 


### PR DESCRIPTION
## What does this PR do?

Fixes ZodError that happens when client_id is not set in query string. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

