### PR TITLE
fix: only use event type's webhooks

### DIFF
--- a/packages/features/instant-meeting/handleInstantMeeting.ts
+++ b/packages/features/instant-meeting/handleInstantMeeting.ts
@@ -31,15 +31,11 @@ const handleInstantMeetingWebhookTrigger = async (args: {
     const subscribers = await prisma.webhook.findMany({
       where: {
         AND: {
-          eventTypeId: {
-            equals: args.eventTypeId,
-          },
+          eventTypeId: args.eventTypeId,
           eventTriggers: {
             has: eventTrigger,
           },
-          active: {
-            equals: true,
-          },
+          active: true,
         },
       },
       select: {

--- a/packages/features/instant-meeting/handleInstantMeeting.ts
+++ b/packages/features/instant-meeting/handleInstantMeeting.ts
@@ -13,8 +13,6 @@ import {
   getCustomInputsResponses,
 } from "@calcom/features/bookings/lib/handleNewBooking";
 import { getFullName } from "@calcom/features/form-builder/utils";
-import type { GetSubscriberOptions } from "@calcom/features/webhooks/lib/getWebhooks";
-import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
 import { isPrismaObjOrUndefined } from "@calcom/lib";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -24,12 +22,35 @@ import prisma from "@calcom/prisma";
 import { BookingStatus, WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 const handleInstantMeetingWebhookTrigger = async (args: {
-  subscriberOptions: GetSubscriberOptions;
+  eventTypeId: number;
   webhookData: Record<string, unknown>;
 }) => {
   try {
     const eventTrigger = WebhookTriggerEvents.INSTANT_MEETING;
-    const subscribers = await getWebhooks(args.subscriberOptions);
+
+    const subscribers = await prisma.webhook.findMany({
+      where: {
+        AND: {
+          eventTypeId: {
+            equals: args.eventTypeId,
+          },
+          eventTriggers: {
+            has: eventTrigger,
+          },
+          active: {
+            equals: true,
+          },
+        },
+      },
+      select: {
+        id: true,
+        subscriberUrl: true,
+        payloadTemplate: true,
+        appId: true,
+        secret: true,
+      },
+    });
+
     const { webhookData } = args;
 
     const promises = subscribers.map((sub) => {
@@ -178,12 +199,6 @@ async function handler(req: NextApiRequest) {
   });
 
   // Trigger Webhook
-  const subscriberOptions: GetSubscriberOptions = {
-    userId: null,
-    eventTypeId: eventType.id,
-    triggerEvent: WebhookTriggerEvents.INSTANT_MEETING,
-    teamId: eventType.team.id,
-  };
 
   const webhookData = {
     triggerEvent: WebhookTriggerEvents.INSTANT_MEETING,
@@ -196,7 +211,7 @@ async function handler(req: NextApiRequest) {
   };
 
   await handleInstantMeetingWebhookTrigger({
-    subscriberOptions,
+    eventTypeId: eventType.id,
     webhookData,
   });
 


### PR DESCRIPTION
- Only get the event type's webhook with trigger as WebhookTriggerEvents.INSTANT_MEETING.

As we don't want to execute webhooks of all event types when instant meeting is booked. 

