### PR TITLE
fix: organization-invitation e2e tests

### DIFF
--- a/apps/web/playwright/organization/organization-invitation.e2e.ts
+++ b/apps/web/playwright/organization/organization-invitation.e2e.ts
@@ -117,7 +117,7 @@ test.describe.serial("Organization", () => {
           page,
           emails,
           invitedUserEmail,
-          `${team.name}'s admin invited you to join the team ${org.name} on Cal.com`,
+          `${team.name}'s admin invited you to join the team ${team.name} of organization ${org.name} on Cal.com`,
           "signup?token"
         );
 


### PR DESCRIPTION
## What does this PR do?

Fixes failed e2e tests in `organization-invitation.e2e.ts`. Changed from https://github.com/calcom/cal.com/commit/68d40cabbe295d614ae568cd1b6f5a96dae90713  caused this

## How should this be tested?

- run `yarn e2e organization-invitation.e2e.ts`