### PR TITLE
fix: Creating New Bookings From Already Rescheduled Links

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -92,6 +92,7 @@ const querySchema = z.object({
   isSuccessBookingPage: stringToBoolean,
   formerTime: z.string().optional(),
   seatReferenceUid: z.string().optional(),
+  alreadyRescheduled: stringToBoolean,
 });
 
 export default function Success(props: SuccessProps) {
@@ -107,6 +108,7 @@ export default function Success(props: SuccessProps) {
     formerTime,
     email,
     seatReferenceUid,
+    alreadyRescheduled,
   } = querySchema.parse(routerQuery);
 
   const attendeeTimeZone = props?.bookingInfo?.attendees.find(
@@ -283,6 +285,9 @@ export default function Success(props: SuccessProps) {
       }
       return t(`needs_to_be_confirmed_or_rejected${titleSuffix}`);
     }
+    if (alreadyRescheduled) {
+      return t("below_are_the_details_of_your_rescheduled_meeting");
+    }
     return t(`emailed_you_and_attendees${titleSuffix}`);
   }
 
@@ -396,6 +401,8 @@ export default function Success(props: SuccessProps) {
                         : t("event_cancelled")
                       : props.recurringBookings
                       ? t("meeting_is_scheduled_recurring")
+                      : alreadyRescheduled
+                      ? t("meeting_is_already_rescheduled")
                       : t("meeting_is_scheduled")}
                   </h3>
                   <div className="mt-3">

--- a/apps/web/pages/reschedule/[uid].tsx
+++ b/apps/web/pages/reschedule/[uid].tsx
@@ -167,7 +167,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   if (bookingAlreadyRescheduled) {
     return {
       redirect: {
-        destination: `/booking/${booking.uid}`,
+        destination: `/booking/${booking.uid}?alreadyRescheduled=true`,
         permanent: false,
       },
     };

--- a/apps/web/pages/reschedule/[uid].tsx
+++ b/apps/web/pages/reschedule/[uid].tsx
@@ -73,21 +73,15 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       // There is not the last booking in the rescheduleChain
       if (bookingInRescheduleChain.rescheduledTo) {
         queryUid = bookingInRescheduleChain.rescheduledTo;
-        firstQuery = false;
       } else {
         allBookingsQueried = true;
       }
+
+      firstQuery = false;
     } else {
       const bookingQuery = await prisma.booking.findFirst({
         where: {
-          OR: [
-            {
-              uid: queryUid,
-            },
-            {
-              fromReschedule: queryUid,
-            },
-          ],
+          uid: queryUid,
         },
         select: {
           uid: true,
@@ -99,6 +93,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       // If somewhere along the chain was broken. Return the last found booking
       if (!bookingQuery) {
         allBookingsQueried = true;
+      } else {
+        bookingInRescheduleChain = bookingQuery;
       }
 
       // See if this booking was the last in the chain

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2192,5 +2192,7 @@
   "uprade_to_create_instant_bookings": "Upgrade to Enterprise and let guests join an instant call that attendees can jump straight into. This is only for team event types",
   "dont_want_to_wait": "Don't want to wait?",
   "meeting_started": "Meeting Started",
+  "meeting_is_already_rescheduled": "The meeting has already been rescheduled",
+  "below_are_the_details_of_your_rescheduled_meeting": "Below is the most current information for your booking",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -2230,6 +2230,7 @@ async function handler(
         data: {
           rescheduled: true,
           status: BookingStatus.CANCELLED,
+          rescheduledTo: booking.uid,
         },
       });
     }

--- a/packages/prisma/migrations/20231222030736_add_rescheduled_to_field/migration.sql
+++ b/packages/prisma/migrations/20231222030736_add_rescheduled_to_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Booking" ADD COLUMN     "rescheduledTo" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -443,6 +443,7 @@ model Booking {
   dynamicGroupSlugRef   String?
   rescheduled           Boolean?
   fromReschedule        String?
+  rescheduledTo         String?
   recurringEventId      String?
   smsReminderNumber     String?
   workflowReminders     WorkflowReminder[]


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR prevents new bookings from being created when the same reschedule link is used multiple times.

Fixes #12922

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a booking
- Reschedule a booking with link #1
- Try rescheduling with the same booking link
    - It should bring you back to the success page of the most recent booking

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
