### PR TITLE
fix: organisation subteams should have org logo

### DIFF
--- a/apps/web/pages/event-types/index.tsx
+++ b/apps/web/pages/event-types/index.tsx
@@ -714,7 +714,7 @@ const EventTypeListHeading = ({
       <Avatar
         alt={profile?.name || ""}
         href={teamId ? `/settings/teams/${teamId}/profile` : "/settings/my-account/profile"}
-        imageSrc={`${bookerUrl}${teamId ? "/team" : ""}/${profile.slug}/avatar.png`}
+        imageSrc={`${bookerUrl}/${profile.slug}/avatar.png`}
         size="md"
         className="mt-1 inline-flex justify-center"
       />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR removes string prepended to slug as it is already added in profile.slug

Fixes #12956 

![Screenshot 2023-12-28 at 11 08 17 PM](https://github.com/calcom/cal.com/assets/40472653/0f061d72-8d77-49e4-84df-fec2a560016e)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Login
- Create new team
- Go to Settings -> Teams
- Upload logo
- Go back to /event-types page
