### PR TITLE
chore: Allow labeler action to use workflow_dispatch

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,11 @@
 name: "Pull Request Labeler"
 on:
+<<<<<<< Updated upstream
   - pull_request_target
+=======
+  pull_request_target:
+  workflow_dispatch:
+>>>>>>> Stashed changes
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,7 @@
 name: "Pull Request Labeler"
 on:
-<<<<<<< Updated upstream
-  - pull_request_target
-=======
   pull_request_target:
   workflow_dispatch:
->>>>>>> Stashed changes
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What does this PR do?

To be able to run this action manually, we need to use `workflow_dispatch` and not `workflow_call`.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)
