### PR TITLE
chore: e2e tests for oAuth flow

### DIFF
--- a/apps/api/v2/src/modules/auth/decorators/get-user/get-user.decorator.ts
+++ b/apps/api/v2/src/modules/auth/decorators/get-user/get-user.decorator.ts
@@ -6,6 +6,10 @@ export const GetUser = createParamDecorator<keyof User | (keyof User)[], Executi
   const request = ctx.switchToHttp().getRequest();
   const user = request.user as User;
 
+  if (!user) {
+    throw new Error("GetUser decorator : User not found");
+  }
+
   if (Array.isArray(data)) {
     return data.reduce((prev, curr) => {
       return {

--- a/apps/api/v2/src/modules/auth/guards/organization-roles/organization-roles.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/organization-roles/organization-roles.guard.ts
@@ -10,7 +10,7 @@ export class OrganizationRolesGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const requiredRoles = this.reflector.get(Roles, context.getHandler());
 
-    if (!requiredRoles.length || !Object.keys(requiredRoles).length) {
+    if (!requiredRoles?.length || !Object.keys(requiredRoles)?.length) {
       return true;
     }
 

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
@@ -1,144 +1,175 @@
+import { bootstrap } from "@/app";
 import { AppModule } from "@/app.module";
 import { HttpExceptionFilter } from "@/filters/http-exception.filter";
 import { PrismaExceptionFilter } from "@/filters/prisma-exception.filter";
 import { ZodExceptionFilter } from "@/filters/zod-exception.filter";
 import { AuthModule } from "@/modules/auth/auth.module";
 import { OAuthAuthorizeInput } from "@/modules/oauth-clients/inputs/authorize.input";
+import { ExchangeAuthorizationCodeInput } from "@/modules/oauth-clients/inputs/exchange-code.input";
 import { OAuthClientModule } from "@/modules/oauth-clients/oauth-client.module";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { UsersModule } from "@/modules/users/users.module";
 import { INestApplication } from "@nestjs/common";
+import { NestExpressApplication } from "@nestjs/platform-express";
 import { Test, TestingModule } from "@nestjs/testing";
-import { Membership, PlatformOAuthClient, Team, User } from "@prisma/client";
+import { PlatformOAuthClient, Team, User } from "@prisma/client";
 import * as request from "supertest";
-import { MembershipRepositoryFixture } from "test/fixtures/repository/membership.repository.fixture";
 import { OAuthClientRepositoryFixture } from "test/fixtures/repository/oauth-client.repository.fixture";
 import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.fixture";
 import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
 import { withNextAuth } from "test/utils/withNextAuth";
 
-describe("OAuthFlow Endpoints", () => {
-  let app: INestApplication;
-  let oauthClientRepositoryFixture: OAuthClientRepositoryFixture;
-  let testClient: PlatformOAuthClient;
-  const userEmail = "user@api.com";
-  let authorizationCode: string | null;
-  let refreshToken: string;
-  let membership: Membership;
-  let organization: Team;
-  let teamRepositoryFixture: TeamRepositoryFixture;
-  let usersFixtures: UserRepositoryFixture;
-  let membershipFixtures: MembershipRepositoryFixture;
-  let user: User;
+import { X_CAL_SECRET_KEY } from "@calcom/platform-constants";
 
-  beforeAll(async () => {
-    const moduleRef: TestingModule = await withNextAuth(
-      userEmail,
-      Test.createTestingModule({
+describe("OAuthFlow Endpoints", () => {
+  describe("User Not Authenticated", () => {
+    let appWithoutAuth: INestApplication;
+
+    beforeAll(async () => {
+      const moduleRef = await Test.createTestingModule({
         providers: [PrismaExceptionFilter, HttpExceptionFilter, ZodExceptionFilter],
         imports: [AppModule, OAuthClientModule, UsersModule, AuthModule, PrismaModule],
-      })
-    ).compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-
-    // Setup OAuthClientRepositoryFixture
-    oauthClientRepositoryFixture = new OAuthClientRepositoryFixture(moduleRef);
-    teamRepositoryFixture = new TeamRepositoryFixture(moduleRef);
-    usersFixtures = new UserRepositoryFixture(moduleRef);
-    membershipFixtures = new MembershipRepositoryFixture(moduleRef);
-
-    // Create a test OAuth client
-    user = await usersFixtures.create({
-      email: userEmail,
+      }).compile();
+      appWithoutAuth = moduleRef.createNestApplication();
+      bootstrap(appWithoutAuth as NestExpressApplication);
+      await appWithoutAuth.init();
     });
-    organization = await teamRepositoryFixture.create({ name: "organization" });
-    membership = await membershipFixtures.addUserToOrg(user, organization, "OWNER", true);
-    testClient = await createOAuthClient(organization.id);
+
+    it(`POST /oauth/:clientId/authorize missing Cookie with user`, () => {
+      return request(appWithoutAuth.getHttpServer()).post("/api/v2/oauth/100/authorize").expect(401);
+    });
+
+    it(`POST /oauth/:clientId/exchange missing Authorization Bearer token`, () => {
+      return request(appWithoutAuth.getHttpServer()).post("/api/v2/oauth/100/exchange").expect(400);
+    });
+
+    it(`POST /oauth/:clientId/refresh missing ${X_CAL_SECRET_KEY} header with secret`, () => {
+      return request(appWithoutAuth.getHttpServer()).post("/api/v2/oauth/100/refresh").expect(401);
+    });
+
+    afterAll(async () => {
+      await appWithoutAuth.close();
+    });
   });
 
-  async function createOAuthClient(organizationId: number) {
-    const data = {
-      logo: "logo-url",
-      name: "name",
-      redirectUris: ["redirect-uri"],
-      permissions: 32,
-    };
-    const secret = "secret";
+  describe("User Authenticated", () => {
+    let app: INestApplication;
 
-    const client = await oauthClientRepositoryFixture.create(organizationId, data, secret);
-    return client;
-  }
+    let usersRepositoryFixtures: UserRepositoryFixture;
+    let organizationsRepositoryFixture: TeamRepositoryFixture;
+    let oAuthClientsRepositoryFixture: OAuthClientRepositoryFixture;
 
-  describe("Authorize Endpoint", () => {
-    it.only("POST /oauth/:clientId/authorize", async () => {
-      const body: OAuthAuthorizeInput = {
-        redirectUri: testClient.redirectUris[0],
+    let user: User;
+    let organization: Team;
+    let oAuthClient: PlatformOAuthClient;
+
+    let authorizationCode: string | null;
+    let refreshToken: string;
+
+    beforeAll(async () => {
+      const userEmail = "developer@platform.com";
+
+      const moduleRef: TestingModule = await withNextAuth(
+        userEmail,
+        Test.createTestingModule({
+          providers: [PrismaExceptionFilter, HttpExceptionFilter, ZodExceptionFilter],
+          imports: [AppModule, OAuthClientModule, UsersModule, AuthModule, PrismaModule],
+        })
+      ).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+
+      oAuthClientsRepositoryFixture = new OAuthClientRepositoryFixture(moduleRef);
+      organizationsRepositoryFixture = new TeamRepositoryFixture(moduleRef);
+      usersRepositoryFixtures = new UserRepositoryFixture(moduleRef);
+
+      user = await usersRepositoryFixtures.create({
+        email: userEmail,
+      });
+      organization = await organizationsRepositoryFixture.create({ name: "organization" });
+      oAuthClient = await createOAuthClient(organization.id);
+    });
+
+    async function createOAuthClient(organizationId: number) {
+      const data = {
+        logo: "logo-url",
+        name: "name",
+        redirectUris: ["redirect-uri.com"],
+        permissions: 32,
       };
+      const secret = "secret";
 
-      const REDIRECT_STATUS = 302;
+      const client = await oAuthClientsRepositoryFixture.create(organizationId, data, secret);
+      return client;
+    }
 
-      const response = await request(app.getHttpServer())
-        .post(`/oauth/${testClient.id}/authorize`)
-        .send(body)
-        .expect(REDIRECT_STATUS);
+    describe("Authorize Endpoint", () => {
+      it("POST /oauth/:clientId/authorize", async () => {
+        const body: OAuthAuthorizeInput = {
+          redirectUri: oAuthClient.redirectUris[0],
+        };
 
-      console.log("asap response", JSON.stringify(response, null, 2));
+        const REDIRECT_STATUS = 302;
 
-      const baseUrl = "http://www.localhost/";
-      const redirectUri = new URL(response.header.location, baseUrl);
-      authorizationCode = redirectUri.searchParams.get("code");
-      expect(authorizationCode).toBeDefined();
+        const response = await request(app.getHttpServer())
+          .post(`/oauth/${oAuthClient.id}/authorize`)
+          .send(body)
+          .expect(REDIRECT_STATUS);
+
+        const baseUrl = "http://www.localhost/";
+        const redirectUri = new URL(response.header.location, baseUrl);
+        authorizationCode = redirectUri.searchParams.get("code");
+        expect(authorizationCode).toBeDefined();
+      });
     });
-  });
 
-  // describe('Exchange Endpoint', () => {
-  //   it('POST /oauth/:clientId/exchange', async () => {
-  //     const authorizationToken = 'Bearer exampleBearerToken';
-  //     const body = {
-  //       clientSecret: testClient.secret,
-  //       code: authorizationCode,
-  //     };
+    describe("Exchange Endpoint", () => {
+      it("POST /oauth/:clientId/exchange", async () => {
+        const authorizationToken = `Bearer ${authorizationCode}`;
+        const body: ExchangeAuthorizationCodeInput = {
+          clientSecret: oAuthClient.secret,
+        };
 
-  //     const response = await request(app.getHttpServer())
-  //       .post(`/oauth/${testClient.id}/exchange`)
-  //       .set('Authorization', authorizationToken)
-  //       .send(body)
-  //       .expect(200);
+        const response = await request(app.getHttpServer())
+          .post(`/oauth/${oAuthClient.id}/exchange`)
+          .set("Authorization", authorizationToken)
+          .send(body)
+          .expect(200);
 
-  //     expect(response.body).toHaveProperty('data');
-  //     expect(response.body.data).toHaveProperty('accessToken');
-  //     expect(response.body.data).toHaveProperty('refreshToken');
-  //     refreshToken = response.body.data.refreshToken;
-  //   });
-  // });
+        expect(response.body).toHaveProperty("data");
+        expect(response.body.data).toHaveProperty("accessToken");
+        expect(response.body.data).toHaveProperty("refreshToken");
+        refreshToken = response.body.data.refreshToken;
+      });
+    });
 
-  // describe('Refresh Token Endpoint', () => {
-  //   it('POST /oauth/:clientId/refresh', () => {
-  //     const secretKey = testClient.secret;
-  //     const body = {
-  //       refreshToken,
-  //     };
+    describe("Refresh Token Endpoint", () => {
+      it("POST /oauth/:clientId/refresh", () => {
+        const secretKey = oAuthClient.secret;
+        const body = {
+          refreshToken,
+        };
 
-  //     return request(app.getHttpServer())
-  //       .post(`/oauth/${testClient.id}/refresh`)
-  //       .set('x-cal-secret-key', secretKey)
-  //       .send(body)
-  //       .expect(200)
-  //       .then((response) => {
-  //         expect(response.body).toHaveProperty('data');
-  //         expect(response.body.data).toHaveProperty('accessToken');
-  //         expect(response.body.data).toHaveProperty('refreshToken');
-  //       });
-  //   });
-  // });
+        return request(app.getHttpServer())
+          .post(`/oauth/${oAuthClient.id}/refresh`)
+          .set("x-cal-secret-key", secretKey)
+          .send(body)
+          .expect(200)
+          .then((response) => {
+            expect(response.body).toHaveProperty("data");
+            expect(response.body.data).toHaveProperty("accessToken");
+            expect(response.body.data).toHaveProperty("refreshToken");
+          });
+      });
+    });
 
-  afterAll(async () => {
-    await oauthClientRepositoryFixture.delete(testClient.id);
-    await teamRepositoryFixture.delete(organization.id);
-    await usersFixtures.delete(user.id);
+    afterAll(async () => {
+      await oAuthClientsRepositoryFixture.delete(oAuthClient.id);
+      await organizationsRepositoryFixture.delete(organization.id);
+      await usersRepositoryFixtures.delete(user.id);
 
-    await app.close();
+      await app.close();
+    });
   });
 });

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
@@ -120,6 +120,7 @@ describe("OAuthFlow Endpoints", () => {
         const baseUrl = "http://www.localhost/";
         const redirectUri = new URL(response.header.location, baseUrl);
         authorizationCode = redirectUri.searchParams.get("code");
+
         expect(authorizationCode).toBeDefined();
       });
     });
@@ -137,9 +138,9 @@ describe("OAuthFlow Endpoints", () => {
           .send(body)
           .expect(200);
 
-        expect(response.body).toHaveProperty("data");
-        expect(response.body.data).toHaveProperty("accessToken");
-        expect(response.body.data).toHaveProperty("refreshToken");
+        expect(response.body?.data?.accessToken).toBeDefined();
+        expect(response.body?.data?.refreshToken).toBeDefined();
+
         refreshToken = response.body.data.refreshToken;
       });
     });
@@ -157,9 +158,8 @@ describe("OAuthFlow Endpoints", () => {
           .send(body)
           .expect(200)
           .then((response) => {
-            expect(response.body).toHaveProperty("data");
-            expect(response.body.data).toHaveProperty("accessToken");
-            expect(response.body.data).toHaveProperty("refreshToken");
+            expect(response.body?.data?.accessToken).toBeDefined();
+            expect(response.body?.data?.refreshToken).toBeDefined();
           });
       });
     });

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.e2e-spec.ts
@@ -1,0 +1,144 @@
+import { AppModule } from "@/app.module";
+import { HttpExceptionFilter } from "@/filters/http-exception.filter";
+import { PrismaExceptionFilter } from "@/filters/prisma-exception.filter";
+import { ZodExceptionFilter } from "@/filters/zod-exception.filter";
+import { AuthModule } from "@/modules/auth/auth.module";
+import { OAuthAuthorizeInput } from "@/modules/oauth-clients/inputs/authorize.input";
+import { OAuthClientModule } from "@/modules/oauth-clients/oauth-client.module";
+import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { UsersModule } from "@/modules/users/users.module";
+import { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Membership, PlatformOAuthClient, Team, User } from "@prisma/client";
+import * as request from "supertest";
+import { MembershipRepositoryFixture } from "test/fixtures/repository/membership.repository.fixture";
+import { OAuthClientRepositoryFixture } from "test/fixtures/repository/oauth-client.repository.fixture";
+import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.fixture";
+import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
+import { withNextAuth } from "test/utils/withNextAuth";
+
+describe("OAuthFlow Endpoints", () => {
+  let app: INestApplication;
+  let oauthClientRepositoryFixture: OAuthClientRepositoryFixture;
+  let testClient: PlatformOAuthClient;
+  const userEmail = "user@api.com";
+  let authorizationCode: string | null;
+  let refreshToken: string;
+  let membership: Membership;
+  let organization: Team;
+  let teamRepositoryFixture: TeamRepositoryFixture;
+  let usersFixtures: UserRepositoryFixture;
+  let membershipFixtures: MembershipRepositoryFixture;
+  let user: User;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await withNextAuth(
+      userEmail,
+      Test.createTestingModule({
+        providers: [PrismaExceptionFilter, HttpExceptionFilter, ZodExceptionFilter],
+        imports: [AppModule, OAuthClientModule, UsersModule, AuthModule, PrismaModule],
+      })
+    ).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    // Setup OAuthClientRepositoryFixture
+    oauthClientRepositoryFixture = new OAuthClientRepositoryFixture(moduleRef);
+    teamRepositoryFixture = new TeamRepositoryFixture(moduleRef);
+    usersFixtures = new UserRepositoryFixture(moduleRef);
+    membershipFixtures = new MembershipRepositoryFixture(moduleRef);
+
+    // Create a test OAuth client
+    user = await usersFixtures.create({
+      email: userEmail,
+    });
+    organization = await teamRepositoryFixture.create({ name: "organization" });
+    membership = await membershipFixtures.addUserToOrg(user, organization, "OWNER", true);
+    testClient = await createOAuthClient(organization.id);
+  });
+
+  async function createOAuthClient(organizationId: number) {
+    const data = {
+      logo: "logo-url",
+      name: "name",
+      redirectUris: ["redirect-uri"],
+      permissions: 32,
+    };
+    const secret = "secret";
+
+    const client = await oauthClientRepositoryFixture.create(organizationId, data, secret);
+    return client;
+  }
+
+  describe("Authorize Endpoint", () => {
+    it.only("POST /oauth/:clientId/authorize", async () => {
+      const body: OAuthAuthorizeInput = {
+        redirectUri: testClient.redirectUris[0],
+      };
+
+      const REDIRECT_STATUS = 302;
+
+      const response = await request(app.getHttpServer())
+        .post(`/oauth/${testClient.id}/authorize`)
+        .send(body)
+        .expect(REDIRECT_STATUS);
+
+      console.log("asap response", JSON.stringify(response, null, 2));
+
+      const baseUrl = "http://www.localhost/";
+      const redirectUri = new URL(response.header.location, baseUrl);
+      authorizationCode = redirectUri.searchParams.get("code");
+      expect(authorizationCode).toBeDefined();
+    });
+  });
+
+  // describe('Exchange Endpoint', () => {
+  //   it('POST /oauth/:clientId/exchange', async () => {
+  //     const authorizationToken = 'Bearer exampleBearerToken';
+  //     const body = {
+  //       clientSecret: testClient.secret,
+  //       code: authorizationCode,
+  //     };
+
+  //     const response = await request(app.getHttpServer())
+  //       .post(`/oauth/${testClient.id}/exchange`)
+  //       .set('Authorization', authorizationToken)
+  //       .send(body)
+  //       .expect(200);
+
+  //     expect(response.body).toHaveProperty('data');
+  //     expect(response.body.data).toHaveProperty('accessToken');
+  //     expect(response.body.data).toHaveProperty('refreshToken');
+  //     refreshToken = response.body.data.refreshToken;
+  //   });
+  // });
+
+  // describe('Refresh Token Endpoint', () => {
+  //   it('POST /oauth/:clientId/refresh', () => {
+  //     const secretKey = testClient.secret;
+  //     const body = {
+  //       refreshToken,
+  //     };
+
+  //     return request(app.getHttpServer())
+  //       .post(`/oauth/${testClient.id}/refresh`)
+  //       .set('x-cal-secret-key', secretKey)
+  //       .send(body)
+  //       .expect(200)
+  //       .then((response) => {
+  //         expect(response.body).toHaveProperty('data');
+  //         expect(response.body.data).toHaveProperty('accessToken');
+  //         expect(response.body.data).toHaveProperty('refreshToken');
+  //       });
+  //   });
+  // });
+
+  afterAll(async () => {
+    await oauthClientRepositoryFixture.delete(testClient.id);
+    await teamRepositoryFixture.delete(organization.id);
+    await usersFixtures.delete(user.id);
+
+    await app.close();
+  });
+});

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -53,6 +53,17 @@ export class OAuthFlowController {
       throw new BadRequestException("Invalid 'redirect_uri' value.");
     }
 
+    const alreadyAuthorized = await this.tokensRepository.getAuthorizationTokenByClientUserIds(
+      clientId,
+      userId
+    );
+
+    if (alreadyAuthorized) {
+      throw new BadRequestException(
+        `User with id=${userId} has already authorized client with id=${clientId}.`
+      );
+    }
+
     const { id } = await this.tokensRepository.createAuthorizationToken(clientId, userId);
 
     return res.redirect(`${body.redirectUri}?code=${id}`);

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -65,13 +65,16 @@ export class OAuthFlowController {
     @Param("clientId") clientId: string,
     @Body() body: ExchangeAuthorizationCodeInput
   ): Promise<ApiResponse<{ accessToken: string; refreshToken: string }>> {
-    const bearerToken = authorization.replace("Bearer ", "").trim();
-    if (!bearerToken) {
+    const authorizeEndpointCode = authorization.replace("Bearer ", "").trim();
+    if (!authorizeEndpointCode) {
       throw new BadRequestException("Missing 'Bearer' Authorization header.");
     }
 
-    const { accessToken: accessToken, refreshToken: refreshToken } =
-      await this.oAuthFlowService.exchangeAuthorizationToken(bearerToken, clientId, body.clientSecret);
+    const { accessToken, refreshToken } = await this.oAuthFlowService.exchangeAuthorizationToken(
+      authorizeEndpointCode,
+      clientId,
+      body.clientSecret
+    );
 
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -30,6 +30,15 @@ export class TokensRepository {
     });
   }
 
+  async getAuthorizationTokenByClientUserIds(clientId: string, userId: number) {
+    return this.dbRead.prisma.platformAuthorizationToken.findFirst({
+      where: {
+        platformOAuthClientId: clientId,
+        userId: userId,
+      },
+    });
+  }
+
   async createOAuthTokens(clientId: string, ownerId: number) {
     const accessExpiry = DateTime.now().plus({ days: 1 }).startOf("day").toJSDate();
     const refreshExpiry = DateTime.now().plus({ year: 1 }).startOf("day").toJSDate();

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -43,10 +43,14 @@ export class TokensRepository {
     const accessExpiry = DateTime.now().plus({ days: 1 }).startOf("day").toJSDate();
     const refreshExpiry = DateTime.now().plus({ year: 1 }).startOf("day").toJSDate();
 
+    const issuedAtTime = Math.floor(Date.now() / 1000);
+
     const [accessToken, refreshToken] = await this.dbWrite.prisma.$transaction([
       this.dbWrite.prisma.accessToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "access_token", clientId })),
+          secret: this.jwtService.sign(
+            JSON.stringify({ type: "access_token", clientId, ownerId, iat: issuedAtTime })
+          ),
           expiresAt: accessExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: ownerId } },
@@ -54,7 +58,9 @@ export class TokensRepository {
       }),
       this.dbWrite.prisma.refreshToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "refresh_token", clientId })),
+          secret: this.jwtService.sign(
+            JSON.stringify({ type: "refresh_token", clientId, ownerId, iat: issuedAtTime })
+          ),
           expiresAt: refreshExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: ownerId } },
@@ -97,6 +103,8 @@ export class TokensRepository {
     const accessExpiry = DateTime.now().plus({ days: 1 }).startOf("day").toJSDate();
     const refreshExpiry = DateTime.now().plus({ year: 1 }).startOf("day").toJSDate();
 
+    const issuedAtTime = Math.floor(Date.now() / 1000);
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, _refresh, accessToken, refreshToken] = await this.dbWrite.prisma.$transaction([
       this.dbWrite.prisma.accessToken.deleteMany({
@@ -105,7 +113,9 @@ export class TokensRepository {
       this.dbWrite.prisma.refreshToken.delete({ where: { secret: refreshTokenSecret } }),
       this.dbWrite.prisma.accessToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "access_token", clientId })),
+          secret: this.jwtService.sign(
+            JSON.stringify({ type: "access_token", clientId, userId: tokenUserId, iat: issuedAtTime })
+          ),
           expiresAt: accessExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: tokenUserId } },
@@ -113,7 +123,9 @@ export class TokensRepository {
       }),
       this.dbWrite.prisma.refreshToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "refresh_token", clientId })),
+          secret: this.jwtService.sign(
+            JSON.stringify({ type: "refresh_token", clientId, userId: tokenUserId, iat: issuedAtTime })
+          ),
           expiresAt: refreshExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: tokenUserId } },

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -105,7 +105,7 @@ export class TokensRepository {
       this.dbWrite.prisma.refreshToken.delete({ where: { secret: refreshTokenSecret } }),
       this.dbWrite.prisma.accessToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "access_token", clientId: clientId })),
+          secret: this.jwtService.sign(JSON.stringify({ type: "access_token", clientId })),
           expiresAt: accessExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: tokenUserId } },
@@ -113,7 +113,7 @@ export class TokensRepository {
       }),
       this.dbWrite.prisma.refreshToken.create({
         data: {
-          secret: this.jwtService.sign(JSON.stringify({ type: "refresh_token", clientId: clientId })),
+          secret: this.jwtService.sign(JSON.stringify({ type: "refresh_token", clientId })),
           expiresAt: refreshExpiry,
           client: { connect: { id: clientId } },
           owner: { connect: { id: tokenUserId } },

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1067,8 +1067,8 @@ model PlatformOAuthClient {
 model PlatformAuthorizationToken {
   id String @id @default(cuid())
 
-  owner  User                @relation(fields: [userId], references: [id])
-  client PlatformOAuthClient @relation(fields: [platformOAuthClientId], references: [id])
+  owner  User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  client PlatformOAuthClient @relation(fields: [platformOAuthClientId], references: [id], onDelete: Cascade)
 
   platformOAuthClientId String @map("platform_oauth_client_id")
   userId                Int    @map("user_id")


### PR DESCRIPTION
## What does this PR do?

1. Adds [e2e tests](https://github.com/calcom/cal.com/pull/13005/files#diff-422165fb6312839fa18ca19a56694ed0d5403d1c30660471b9973bcec145c1c3) for oAuth flow "oauth/authorize", "oauth/exchange" and "oauth/refresh" endpoints.
2. Refactors [oauth-flow.controller.ts](https://github.com/calcom/cal.com/pull/13005/files#diff-4ffbb95eedb8475fde14ad22e1b89de33d1cfc1a24f727ab63132792a017fef8) "/authorize" endpoint - if userId was already authorized for an oAuth client, then throw "BadRequestException" error explaining that. Alternatively, the request could proceed and return "id" aka authorize "code", but then it would be prone to getting existing codes using brute forcing. Next, in the "/exchange" endpoint rename "const bearerToken" to "const authorizeEndpointCode" to better explain the relationship that the code in the Authorization Bearer token has to come from the "/authorize" endpoint.
3. Refactors [tokens.repository.ts](https://github.com/calcom/cal.com/pull/13005/files#diff-f8a987668cfc396b4d9e47fb3de02e037f85bfb27b4e03cb2d37aae634abb4bb) - prior to this PR when creating access and refresh tokens and then re-creating them, "secret" of the keys were generated the same, but in prisma schema "AccessToken.secret" and "RefreshToken.secret" are unique fields, meaning that when re-creating access tokens using the "oauth/refresh" endpoint resulted in unique key constraint. To accommodate that add "iat" (issued at time in seconds, not milliseconds to match JWT specification) to the payload resulting in a unique secret each time.
4. Refactors [schema.prisma](https://github.com/calcom/cal.com/pull/13005/files#diff-56fa4d384ba6fb94b130e9eb42c5cad00734b025ebd6c197f76873469725ae87) "PlatformAuthorizationToken" model - if  the owner or client of the authorization token were to be deleted, the authorization token was not deleted, so cascade delete it.
5. Adds null checks for [get-user.decorator](https://github.com/calcom/cal.com/pull/13005/files#diff-7de2273ac638e08a574833d70cc18124b98e04b2eaf8946bdc4281b065cb8a27), [organization-roles.guard](https://github.com/calcom/cal.com/pull/13005/files#diff-e8d2c7f0be80ca4c67a2af4cec5c591055c1e9081753d3d2381fb49a5cb951ef). 