### PR TITLE
feat: abstracted jwt service

### DIFF
--- a/apps/api/v2/src/app.module.ts
+++ b/apps/api/v2/src/app.module.ts
@@ -2,6 +2,7 @@ import { AppLoggerMiddleware } from "@/app.logger.middleware";
 import appConfig from "@/config/app";
 import { AuthModule } from "@/modules/auth/auth.module";
 import { EndpointsModule } from "@/modules/endpoints.module";
+import { JwtModule } from "@/modules/jwt/jwt.module";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { MiddlewareConsumer, Module, NestModule } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
@@ -18,6 +19,7 @@ import { AppController } from "./app.controller";
     PrismaModule,
     EndpointsModule,
     AuthModule,
+    JwtModule,
   ],
   controllers: [AppController],
 })

--- a/apps/api/v2/src/modules/auth/auth.module.ts
+++ b/apps/api/v2/src/modules/auth/auth.module.ts
@@ -9,18 +9,10 @@ import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.se
 import { TokensModule } from "@/modules/tokens/tokens.module";
 import { UsersModule } from "@/modules/users/users.module";
 import { Module } from "@nestjs/common";
-import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 
 @Module({
-  imports: [
-    PassportModule,
-    JwtModule.register({}),
-    ApiKeyModule,
-    UsersModule,
-    MembershipsModule,
-    TokensModule,
-  ],
+  imports: [PassportModule, ApiKeyModule, UsersModule, MembershipsModule, TokensModule],
   providers: [
     ApiKeyAuthStrategy,
     NextAuthGuard,

--- a/apps/api/v2/src/modules/jwt/jwt.module.ts
+++ b/apps/api/v2/src/modules/jwt/jwt.module.ts
@@ -1,0 +1,12 @@
+import { getEnv } from "@/env";
+import { JwtService } from "@/modules/jwt/jwt.service";
+import { Global, Module } from "@nestjs/common";
+import { JwtModule as NestJwtModule } from "@nestjs/jwt";
+
+@Global()
+@Module({
+  imports: [NestJwtModule.register({ secret: getEnv("JWT_SECRET") })],
+  providers: [JwtService],
+  exports: [JwtService],
+})
+export class JwtModule {}

--- a/apps/api/v2/src/modules/jwt/jwt.service.ts
+++ b/apps/api/v2/src/modules/jwt/jwt.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@nestjs/common";
+import { JwtService as NestJwtService } from "@nestjs/jwt";
+
+@Injectable()
+export class JwtService {
+  constructor(private readonly nestJwtService: NestJwtService) {}
+
+  sign(payload: Record<any, any>) {
+    const issuedAtTime = this.getIssuedAtTime();
+
+    const token = this.nestJwtService.sign(JSON.stringify({ ...payload, iat: issuedAtTime }));
+
+    return token;
+  }
+
+  signAccessToken(payload: Record<any, any>) {
+    const issuedAtTime = this.getIssuedAtTime();
+
+    const accessToken = this.nestJwtService.sign(
+      JSON.stringify({ type: "access_token", ...payload, iat: issuedAtTime })
+    );
+
+    return accessToken;
+  }
+
+  signRefreshToken(payload: Record<any, any>) {
+    const issuedAtTime = this.getIssuedAtTime();
+
+    const accessToken = this.nestJwtService.sign(
+      JSON.stringify({ type: "refresh_token", ...payload, iat: issuedAtTime })
+    );
+
+    return accessToken;
+  }
+
+  getIssuedAtTime() {
+    // divided by 1000 because iat (issued at time) is in seconds (not milliseconds) as informed by JWT speficication
+    return Math.floor(Date.now() / 1000);
+  }
+}

--- a/apps/api/v2/src/modules/jwt/jwt.service.ts
+++ b/apps/api/v2/src/modules/jwt/jwt.service.ts
@@ -5,32 +5,21 @@ import { JwtService as NestJwtService } from "@nestjs/jwt";
 export class JwtService {
   constructor(private readonly nestJwtService: NestJwtService) {}
 
-  sign(payload: Record<any, any>) {
+  signAccessToken(payload: Payload) {
+    const accessToken = this.sign({ type: "access_token", ...payload });
+    return accessToken;
+  }
+
+  signRefreshToken(payload: Payload) {
+    const refreshToken = this.sign({ type: "refresh_token", ...payload });
+    return refreshToken;
+  }
+
+  sign(payload: Payload) {
     const issuedAtTime = this.getIssuedAtTime();
 
-    const token = this.nestJwtService.sign(JSON.stringify({ ...payload, iat: issuedAtTime }));
-
+    const token = this.nestJwtService.sign({ ...payload, iat: issuedAtTime });
     return token;
-  }
-
-  signAccessToken(payload: Record<any, any>) {
-    const issuedAtTime = this.getIssuedAtTime();
-
-    const accessToken = this.nestJwtService.sign(
-      JSON.stringify({ type: "access_token", ...payload, iat: issuedAtTime })
-    );
-
-    return accessToken;
-  }
-
-  signRefreshToken(payload: Record<any, any>) {
-    const issuedAtTime = this.getIssuedAtTime();
-
-    const accessToken = this.nestJwtService.sign(
-      JSON.stringify({ type: "refresh_token", ...payload, iat: issuedAtTime })
-    );
-
-    return accessToken;
   }
 
   getIssuedAtTime() {
@@ -38,3 +27,5 @@ export class JwtService {
     return Math.floor(Date.now() / 1000);
   }
 }
+
+type Payload = Record<string | number | symbol, any>;

--- a/apps/api/v2/src/modules/oauth-clients/oauth-client.module.ts
+++ b/apps/api/v2/src/modules/oauth-clients/oauth-client.module.ts
@@ -1,4 +1,3 @@
-import { getEnv } from "@/env";
 import { AuthModule } from "@/modules/auth/auth.module";
 import { MembershipsModule } from "@/modules/memberships/memberships.module";
 import { OAuthClientUsersController } from "@/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller";
@@ -11,17 +10,10 @@ import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { UsersModule } from "@/modules/users/users.module";
 import { Global, Module } from "@nestjs/common";
-import { JwtModule } from "@nestjs/jwt";
 
 @Global()
 @Module({
-  imports: [
-    PrismaModule,
-    AuthModule,
-    UsersModule,
-    MembershipsModule,
-    JwtModule.register({ secret: getEnv("JWT_SECRET") }),
-  ],
+  imports: [PrismaModule, AuthModule, UsersModule, MembershipsModule],
   providers: [OAuthClientRepository, OAuthClientCredentialsGuard, TokensRepository, OAuthFlowService],
   controllers: [OAuthClientUsersController, OAuthClientsController, OAuthFlowController],
   exports: [OAuthClientRepository, OAuthClientCredentialsGuard],

--- a/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
+++ b/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
@@ -1,7 +1,7 @@
+import { JwtService } from "@/modules/jwt/jwt.service";
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { Injectable } from "@nestjs/common";
-import { JwtService } from "@nestjs/jwt";
 import type { PlatformOAuthClient } from "@prisma/client";
 
 import type { CreateOAuthClientInput } from "@calcom/platform-types";
@@ -18,7 +18,7 @@ export class OAuthClientRepository {
     return this.dbWrite.prisma.platformOAuthClient.create({
       data: {
         ...data,
-        secret: await this.jwtService.signAsync(JSON.stringify(data)),
+        secret: this.jwtService.sign(data),
         organizationId,
       },
     });

--- a/apps/api/v2/src/modules/tokens/tokens.module.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.module.ts
@@ -1,16 +1,9 @@
-import { getEnv } from "@/env";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
 import { Module } from "@nestjs/common";
-import { JwtModule } from "@nestjs/jwt";
 
 @Module({
-  imports: [
-    JwtModule.register({
-      secret: getEnv("NEXTAUTH_SECRET"),
-    }),
-    PrismaModule,
-  ],
+  imports: [PrismaModule],
   providers: [TokensRepository],
   exports: [TokensRepository],
 })


### PR DESCRIPTION
## What does this PR do?

Instead of registering JwtModule of "@nestjs/jwt" in module that wants to use JwtService of "@nestjs/jwt", we now have globally injectable internal service [JwtService](https://github.com/calcom/cal.com/pull/13016/files#diff-ff54dd7218b6dd045ff50dd3f73fa4a4eb7fbfad5e53fef0d3fa039b1974fdc5) with 3 methods:
1. sign - creates jwt token using payload
2. signAccessToken - attaches type: access_token to payload
3. signRefreshToken - attaches type: refresh_token to payload

All of them attach iat (issuedAtTime) to the tokens. The JwtService under the hood uses logic of JwtModule and JwtService of "@nestjs/jwt" and all of the tokens are signed with the same JWT_SECRET secret. This prevents scattering secrets used for signing tokens into using only JWT_SECRET to sign and also standardizes payload using issuetAtTime and ensuring that tokens are always unique.

[tokens.repository.ts](https://github.com/calcom/cal.com/pull/13016/files#diff-f8a987668cfc396b4d9e47fb3de02e037f85bfb27b4e03cb2d37aae634abb4bb) and [oauth-client.repository.ts](https://github.com/calcom/cal.com/pull/13016/files#diff-804bc052b99345b2ed8d149e97bd1b1005d08d475212b80aa21f767ba2e8cda3) have been updated to use the new service.