### PR TITLE
fix: skeleton width for settings menu in sidebar

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -974,7 +974,7 @@ function SideBar({ bannersHeight, user }: SideBarProps) {
                     <div className="flex">{t(item.name)}</div>
                   </span>
                 ) : (
-                  <SkeletonText style={{ width: `${item.name.length * 10}px` }} className="h-[20px]" />
+                  <SkeletonText className="h-[20px] w-full" />
                 )}
               </ButtonOrLink>
             </Tooltip>


### PR DESCRIPTION
## What does this PR do?

This PR fixes skeleton width for settings menu in sidebar

Fixes #13014 

![Screenshot 2024-01-03 at 9 27 45 PM](https://github.com/calcom/cal.com/assets/40472653/193e4911-3308-40a0-b363-a0a6360d4952)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)