### PR TITLE
chore: Remove need for force merges

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,9 +27,7 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(**.md)"
-              - "!(.github/CODEOWNERS)"
-              - "!(*.yml)"
+              - "!(.github/workflows/*.yml)"
   type-check:
     name: Type check
     needs: [changes]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,7 @@ jobs:
             source-files:
               - "!**.md"
               - "!.github/CODEOWNERS"
+              - "!.github/workflows/**"
   type-check:
     name: Type check
     if: steps.changes.outputs.source-files == "true"
@@ -60,10 +61,10 @@ jobs:
     secrets: inherit
 
   required:
-    needs: [lint, type-check, test, build]
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes, lint, type-check, test, build]
+    if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: needs.changes.outputs.source-files == "true" && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(**.md|.github/CODEOWNERS|.github/workflows/**/*)"
+              - "!(**.md|.github/CODEOWNERS)"
   type-check:
     name: Type check
     needs: [changes]
@@ -62,13 +62,6 @@ jobs:
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
-
-  show-output:
-    needs: [changes]
-    if: always()
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - run: echo ${{ needs.changes.outputs.has-files-requiring-all-checks }}
 
   required:
     needs: [changes, lint, type-check, test, build]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,7 @@ jobs:
             has-files-requiring-all-checks:
               - "!(**.md)"
               - "!(.github/CODEOWNERS)"
-              - "!(.github/workflows/*)"
-              - "!(.github/workflows/**/*)"
+              - "!(*.yml)"
   type-check:
     name: Type check
     needs: [changes]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           filters: |
             source-files:
-              - "**.md"
-              - ".github/CODEOWNERS"
+              - "!**.md"
+              - "!.github/CODEOWNERS"
   type-check:
     name: Type check
     if: steps.changes.outputs.source-files == "true"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,8 +59,7 @@ jobs:
     secrets: inherit
 
   analyze:
-    needs: build
-    needs: [changes]
+    needs: [build, changes]
     if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,35 +33,35 @@ jobs:
   type-check:
     name: Type check
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == true }}
+    if: ${{ needs.changes.outputs.source-files == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == true }}
+    if: ${{ needs.changes.outputs.source-files == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == true }}
+    if: ${{ needs.changes.outputs.source-files == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == true }}
+    if: ${{ needs.changes.outputs.source-files == 'true' }}
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     name: Analyze Build
     needs: [build, changes]
-    if: ${{ needs.changes.outputs.source-files == true }}
+    if: ${{ needs.changes.outputs.source-files == 'true' }}
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
@@ -78,5 +78,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.source-files == true && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
+        if: needs.changes.outputs.source-files == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,34 +33,34 @@ jobs:
   type-check:
     name: Type check
     needs: [changes]
-    if: needs.changes.outputs.source-files == 'true'
+    if: needs.changes.outputs.source-files == true
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
     needs: [changes]
-    if: needs.changes.outputs.source-files == 'true"
+    if: needs.changes.outputs.source-files == true
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes]
-    if: needs.changes.outputs.source-files == 'true'
+    if: needs.changes.outputs.source-files == true
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
     needs: [changes]
-    if: needs.changes.outputs.source-files == 'true'
+    if: needs.changes.outputs.source-files == true
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     needs: [build, changes]
-    if: needs.changes.outputs.source-files == 'true'
+    if: needs.changes.outputs.source-files == true
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
@@ -70,5 +70,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.source-files == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
+        if: needs.changes.outputs.source-files == true && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,8 +70,7 @@ jobs:
     if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - name: Show output
-      - run: echo ${{ needs.changes.outputs.source-files }}
       - name: fail if conditional jobs failed
+        run: echo ${{ needs.changes.outputs.source-files }}
         if: needs.changes.outputs.source-files == true && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,13 @@ jobs:
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
+  show-output:
+    needs: [changes]
+    if: always()
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - run: echo ${{ needs.changes.outputs.source-files }}
+
   required:
     needs: [changes, lint, type-check, test, build]
     if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,34 +33,34 @@ jobs:
   type-check:
     name: Type check
     needs: [changes]
-    if: needs.changes.outputs.source-files == "true"
+    if: needs.changes.outputs.source-files == 'true'
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
     needs: [changes]
-    if: needs.changes.outputs.source-files == "true"
+    if: needs.changes.outputs.source-files == 'true"
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes]
-    if: needs.changes.outputs.source-files == "true"
+    if: needs.changes.outputs.source-files == 'true'
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
     needs: [changes]
-    if: needs.changes.outputs.source-files == "true"
+    if: needs.changes.outputs.source-files == 'true'
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     needs: [build, changes]
-    if: needs.changes.outputs.source-files == "true"
+    if: needs.changes.outputs.source-files == 'true'
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
@@ -70,5 +70,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.source-files == "true" && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
+        if: needs.changes.outputs.source-files == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,5 +46,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(.github/workflows/*.yml)"
+              - "!(**.md|.github/CODEOWNERS|.github/workflows/**/*)"
   type-check:
     name: Type check
     needs: [changes]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,9 +4,6 @@ on:
   pull_request_target:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - ".github/CODEOWNERS"
   merge_group:
   workflow_dispatch:
 
@@ -15,34 +12,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    permissions:
+      pull-requests: read
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/dangerous-git-checkout
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            source-files:
+              - "**.md"
+              - ".github/CODEOWNERS"
   type-check:
     name: Type check
+    if: steps.changes.outputs.source-files == "true"
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
+    if: steps.changes.outputs.source-files == "true"
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
+    if: steps.changes.outputs.source-files == "true"
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
+    if: steps.changes.outputs.source-files == "true"
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     needs: build
+    if: steps.changes.outputs.source-files == "true"
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
   required:
     needs: [lint, type-check, test, build]
-    if: always()
+    if: steps.changes.outputs.source-files == "true"
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,34 +33,35 @@ jobs:
   type-check:
     name: Type check
     needs: [changes]
-    if: needs.changes.outputs.source-files == true
+    if: ${{ needs.changes.outputs.source-files == true }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
     needs: [changes]
-    if: needs.changes.outputs.source-files == true
+    if: ${{ needs.changes.outputs.source-files == true }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes]
-    if: needs.changes.outputs.source-files == true
+    if: ${{ needs.changes.outputs.source-files == true }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
     needs: [changes]
-    if: needs.changes.outputs.source-files == true
+    if: ${{ needs.changes.outputs.source-files == true }}
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
+    name: Analyze Build
     needs: [build, changes]
-    if: needs.changes.outputs.source-files == true
+    if: ${{ needs.changes.outputs.source-files == true }}
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
@@ -69,6 +70,8 @@ jobs:
     if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Show output
+      - run: echo ${{ needs.changes.outputs.source-files }}
       - name: fail if conditional jobs failed
         if: needs.changes.outputs.source-files == true && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      source-files: ${{ steps.filter.outputs.source-files }}
+      has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
@@ -26,42 +26,43 @@ jobs:
         id: filter
         with:
           filters: |
-            source-files:
+            has-files-requiring-all-checks:
               - "!**.md"
               - "!.github/CODEOWNERS"
+              - "!.github/workflows/*"
               - "!.github/workflows/**/*"
   type-check:
     name: Type check
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
     needs: [changes]
-    if: ${{ needs.changes.outputs.source-files == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     name: Analyze Build
     needs: [build, changes]
-    if: ${{ needs.changes.outputs.source-files == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 
@@ -70,7 +71,7 @@ jobs:
     if: always()
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - run: echo ${{ needs.changes.outputs.source-files }}
+      - run: echo ${{ needs.changes.outputs.has-files-requiring-all-checks }}
 
   required:
     needs: [changes, lint, type-check, test, build]
@@ -78,5 +79,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.source-files == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
+        if: needs.changes.outputs.has-files-requiring-all-checks == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,31 +32,36 @@ jobs:
               - "!.github/workflows/**"
   type-check:
     name: Type check
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes]
+    if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   test:
     name: Unit tests
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes]
+    if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   lint:
     name: Linters
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes]
+    if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   build:
     name: Production build
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes]
+    if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/production-build.yml
     secrets: inherit
 
   analyze:
     needs: build
-    if: steps.changes.outputs.source-files == "true"
+    needs: [changes]
+    if: needs.changes.outputs.source-files == "true"
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,5 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        run: echo ${{ needs.changes.outputs.source-files }}
         if: needs.changes.outputs.source-files == true && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,9 +28,9 @@ jobs:
           filters: |
             has-files-requiring-all-checks:
               - "!**.md"
-              - "!.github/CODEOWNERS"
-              - "!.github/workflows/*"
-              - "!.github/workflows/**/*"
+              - "!./.github/CODEOWNERS"
+              - "!./.github/workflows/*"
+              - "!./.github/workflows/**/*"
   type-check:
     name: Type check
     needs: [changes]
@@ -61,7 +61,7 @@ jobs:
 
   analyze:
     name: Analyze Build
-    needs: [build, changes]
+    needs: [changes, build]
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/nextjs-bundle-analysis.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!**.md"
-              - "!./.github/CODEOWNERS"
-              - "!./.github/workflows/*"
-              - "!./.github/workflows/**/*"
+              - "!(**.md)"
+              - "!(.github/CODEOWNERS)"
+              - "!(.github/workflows/*)"
+              - "!(.github/workflows/**/*)"
   type-check:
     name: Type check
     needs: [changes]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
             source-files:
               - "!**.md"
               - "!.github/CODEOWNERS"
-              - "!.github/workflows/**"
+              - "!.github/workflows/**/*"
   type-check:
     name: Type check
     needs: [changes]


### PR DESCRIPTION
## What does this PR do?

Only runs required jobs when the files changed require it. At the moment, we are not running jobs for CODEOWNERS and .md files but the glob expression can easily be updated as we go.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Make sure that all of the required jobs still run on most PRs where any file except what's in the glob expression is matched. 
