### PR TITLE
chore: Fix NODE_OPTIONS error

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -2,7 +2,7 @@ name: Check types
 on:
   workflow_call:
 env:
-  NODE_OPTIONS: "--max-old-space-size=8192"
+  NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   check-types:
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -1,7 +1,8 @@
 name: E2E App-Store Apps Tests
 on:
   workflow_call:
-
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   e2e-app-store:
     timeout-minutes: 20
@@ -29,11 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=4096"' >> $GITHUB_ENV
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - uses: ./.github/actions/cache-db
-        env: 
+        env:
           DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
           E2E_TEST_CALCOM_QA_EMAIL: ${{ secrets.E2E_TEST_CALCOM_QA_EMAIL }}
           E2E_TEST_CALCOM_QA_PASSWORD: ${{ secrets.E2E_TEST_CALCOM_QA_PASSWORD }}

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -1,7 +1,8 @@
 name: E2E Embed React tests and booking flow (for non-embed as well)
 on:
   workflow_call:
-
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   e2e-embed:
     timeout-minutes: 20
@@ -24,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=4096"' >> $GITHUB_ENV
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -1,7 +1,8 @@
 name: E2E Embed Core tests and booking flow (for non-embed as well)
 on:
   workflow_call:
-
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   e2e-embed:
     timeout-minutes: 20
@@ -29,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=4096"' >> $GITHUB_ENV
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,8 @@
 name: E2E tests
-
 on:
   workflow_call:
-
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   e2e:
     timeout-minutes: 20
@@ -28,7 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=4096"' >> $GITHUB_ENV
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
       - uses: ./.github/actions/cache-db

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
-      - run: echo 'NODE_OPTIONS="--max_old_space_size=6144"' >> $GITHUB_ENV
       - uses: ./.github/actions/yarn-install
       # Should be an 8GB machine as per https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
       - run: yarn test


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub actions errors "Can't store NODE_OPTIONS output parameter using '$GITHUB_ENV' command." This is no longer allowed by [GitHub](https://github.blog/changelog/2023-10-05-github-actions-node_options-is-now-restricted-from-github_env/#:~:text=Due%20to%20security%20restrictions%2C%20users,parameter%20using%20'%24GITHUB_ENV'%20command.). 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Ensure we no longer see these errors in the GitHub actions output when the pre-release checks are run
