### PR TITLE
chore: Upgrade buildjet cache action to v3

### DIFF
--- a/.github/actions/yarn-playwright-install/action.yml
+++ b/.github/actions/yarn-playwright-install/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache playwright binaries
       id: playwright-cache
-      uses: buildjet/cache@v2
+      uses: buildjet/cache@v3
       with:
         path: |
           ~/Library/Caches/ms-playwright


### PR DESCRIPTION
## What does this PR do?

Gets rid of warnings in GitHub actions executions and makes our usage of this action all in sync at v3.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure the playwright install is cached properly
