### PR TITLE
chore: Remove invalid DATABASE_URL 'with' value

### DIFF
--- a/.github/actions/cache-db/action.yml
+++ b/.github/actions/cache-db/action.yml
@@ -24,7 +24,6 @@ runs:
       with:
         path: ${{ inputs.path }}
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.path }}-${{ env.key-1 }}-${{ env.key-2 }}
-        DATABASE_URL: ${{ inputs.DATABASE_URL }}
     - run: echo ${{ env.E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS }} && yarn db-seed
       if: steps.cache-db.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
## What does this PR do?

We already pass this value through the environment variables section. DATABASE_URL is not a valid "with" value for the buildjet/cache@v3 action.

Error: Unexpected input(s) 'DATABASE_URL', valid inputs are ['path', 'key', 'restore-keys', 'upload-chunk-size', 'enableCrossOsArchive', 'fail-on-cache-miss', 'lookup-only']

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Make sure the cache-db action is not affected

