### PR TITLE
chore: [app-router-migration 23] Migrate the "enterprise" page

### DIFF
--- a/apps/web/app/future/enterprise/layout.tsx
+++ b/apps/web/app/future/enterprise/layout.tsx
@@ -1,0 +1,5 @@
+import { WithLayout } from "app/layoutHOC";
+
+import { getLayout } from "@calcom/features/MainLayoutAppDir";
+
+export default WithLayout({ getLayout })<"L">;

--- a/apps/web/app/future/enterprise/page.tsx
+++ b/apps/web/app/future/enterprise/page.tsx
@@ -1,0 +1,11 @@
+import { _generateMetadata } from "app/_utils";
+
+import EnterprisePage from "@components/EnterprisePage";
+
+export const generateMetadata = async () =>
+  await _generateMetadata(
+    (t) => t("create_your_org"),
+    (t) => t("create_your_org_description")
+  );
+
+export default EnterprisePage;

--- a/apps/web/components/EnterprisePage.tsx
+++ b/apps/web/components/EnterprisePage.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ShellMain } from "@calcom/features/shell/Shell";
+import { UpgradeTip } from "@calcom/features/tips";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button, ButtonGroup } from "@calcom/ui";
+import { BarChart, CreditCard, Globe, Lock, Paintbrush, Users } from "@calcom/ui/components/icon";
+
+export default function EnterprisePage() {
+  const { t } = useLocale();
+
+  const features = [
+    {
+      icon: <Globe className="h-5 w-5 text-red-500" />,
+      title: t("branded_subdomain"),
+      description: t("branded_subdomain_description"),
+    },
+    {
+      icon: <BarChart className="h-5 w-5 text-blue-500" />,
+      title: t("org_insights"),
+      description: t("org_insights_description"),
+    },
+    {
+      icon: <Paintbrush className="h-5 w-5 text-pink-500" />,
+      title: t("extensive_whitelabeling"),
+      description: t("extensive_whitelabeling_description"),
+    },
+    {
+      icon: <Users className="h-5 w-5 text-orange-500" />,
+      title: t("unlimited_teams"),
+      description: t("unlimited_teams_description"),
+    },
+    {
+      icon: <CreditCard className="h-5 w-5 text-green-500" />,
+      title: t("unified_billing"),
+      description: t("unified_billing_description"),
+    },
+    {
+      icon: <Lock className="h-5 w-5 text-purple-500" />,
+      title: t("advanced_managed_events"),
+      description: t("advanced_managed_events_description"),
+    },
+  ];
+  return (
+    <div>
+      <ShellMain heading="Enterprise" subtitle={t("enterprise_description")}>
+        <UpgradeTip
+          plan="enterprise"
+          title={t("create_your_org")}
+          description={t("create_your_org_description")}
+          features={features}
+          background="/tips/enterprise"
+          buttons={
+            <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
+              <ButtonGroup>
+                <Button color="primary" href="https://i.cal.com/sales/enterprise?duration=25" target="_blank">
+                  {t("contact_sales")}
+                </Button>
+                <Button color="minimal" href="https://cal.com/enterprise" target="_blank">
+                  {t("learn_more")}
+                </Button>
+              </ButtonGroup>
+            </div>
+          }>
+          <>Create Org</>
+        </UpgradeTip>
+      </ShellMain>
+    </div>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@calcom/tsconfig": "*",
     "@calcom/ui": "*",
     "@daily-co/daily-js": "^0.37.0",
-    "@formkit/auto-animate": "^0.8.1",
+    "@formkit/auto-animate": "1.0.0-beta.5",
     "@glidejs/glide": "^3.5.2",
     "@hookform/error-message": "^2.0.0",
     "@hookform/resolvers": "^2.9.7",

--- a/apps/web/pages/enterprise/index.tsx
+++ b/apps/web/pages/enterprise/index.tsx
@@ -1,74 +1,17 @@
-import { getLayout } from "@calcom/features/MainLayout";
-import { ShellMain } from "@calcom/features/shell/Shell";
-import { UpgradeTip } from "@calcom/features/tips";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { Button, ButtonGroup } from "@calcom/ui";
-import { BarChart, CreditCard, Globe, Lock, Paintbrush, Users } from "@calcom/ui/components/icon";
+"use client";
 
+import { getLayout } from "@calcom/features/MainLayout";
+
+import EnterprisePage from "@components/EnterprisePage";
 import PageWrapper from "@components/PageWrapper";
 
-export default function EnterprisePage() {
-  const { t } = useLocale();
+const ProxifiedEnterprisePage = new Proxy<{
+  (): JSX.Element;
+  PageWrapper?: typeof PageWrapper;
+  getLayout?: typeof getLayout;
+}>(EnterprisePage, {});
 
-  const features = [
-    {
-      icon: <Globe className="h-5 w-5 text-red-500" />,
-      title: t("branded_subdomain"),
-      description: t("branded_subdomain_description"),
-    },
-    {
-      icon: <BarChart className="h-5 w-5 text-blue-500" />,
-      title: t("org_insights"),
-      description: t("org_insights_description"),
-    },
-    {
-      icon: <Paintbrush className="h-5 w-5 text-pink-500" />,
-      title: t("extensive_whitelabeling"),
-      description: t("extensive_whitelabeling_description"),
-    },
-    {
-      icon: <Users className="h-5 w-5 text-orange-500" />,
-      title: t("unlimited_teams"),
-      description: t("unlimited_teams_description"),
-    },
-    {
-      icon: <CreditCard className="h-5 w-5 text-green-500" />,
-      title: t("unified_billing"),
-      description: t("unified_billing_description"),
-    },
-    {
-      icon: <Lock className="h-5 w-5 text-purple-500" />,
-      title: t("advanced_managed_events"),
-      description: t("advanced_managed_events_description"),
-    },
-  ];
-  return (
-    <div>
-      <ShellMain heading="Enterprise" subtitle={t("enterprise_description")}>
-        <UpgradeTip
-          plan="enterprise"
-          title={t("create_your_org")}
-          description={t("create_your_org_description")}
-          features={features}
-          background="/tips/enterprise"
-          buttons={
-            <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
-              <ButtonGroup>
-                <Button color="primary" href="https://i.cal.com/sales/enterprise?duration=25" target="_blank">
-                  {t("contact_sales")}
-                </Button>
-                <Button color="minimal" href="https://cal.com/enterprise" target="_blank">
-                  {t("learn_more")}
-                </Button>
-              </ButtonGroup>
-            </div>
-          }>
-          <>Create Org</>
-        </UpgradeTip>
-      </ShellMain>
-    </div>
-  );
-}
+ProxifiedEnterprisePage.PageWrapper = PageWrapper;
+ProxifiedEnterprisePage.getLayout = getLayout;
 
-EnterprisePage.PageWrapper = PageWrapper;
-EnterprisePage.getLayout = getLayout;
+export default ProxifiedEnterprisePage;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@calcom/lib": "*",
     "@calcom/trpc": "*",
-    "@formkit/auto-animate": "^0.8.1",
+    "@formkit/auto-animate": "1.0.0-beta.5",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-popover": "^1.0.2",


### PR DESCRIPTION
## What does this PR do?

This PR migrates the `/enterprise` page to the app router, under `/future/enterprise`.

## Type of change
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
