### PR TITLE
chore: [app-router-migration 21] Migrate "/d/*" pages

### DIFF
--- a/apps/web/app/AppDirSSRHOC.tsx
+++ b/apps/web/app/AppDirSSRHOC.tsx
@@ -2,16 +2,20 @@ import type { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { notFound, redirect } from "next/navigation";
 
 export const withAppDir =
-  (getServerSideProps: GetServerSideProps) => async (context: GetServerSidePropsContext) => {
+  <T extends Record<string, any>>(getServerSideProps: GetServerSideProps<T>) =>
+  async (context: GetServerSidePropsContext): Promise<T> => {
     const ssrResponse = await getServerSideProps(context);
 
     if ("redirect" in ssrResponse) {
       redirect(ssrResponse.redirect.destination);
     }
-
     if ("notFound" in ssrResponse) {
       notFound();
     }
 
-    return ssrResponse.props;
+    return {
+      ...ssrResponse.props,
+      // includes dehydratedState required for future page trpcPropvider
+      ...("trpcState" in ssrResponse.props && { dehydratedState: ssrResponse.props.trpcState }),
+    };
   };

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -1,0 +1,113 @@
+import LegacyPage from "@pages/d/[link]/[slug]";
+import { ssrInit } from "app/_trpc/ssrInit";
+import { _generateMetadata } from "app/_utils";
+import { WithLayout } from "app/layoutHOC";
+import type { GetServerSidePropsContext } from "next";
+import { notFound } from "next/navigation";
+import { z } from "zod";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { getBookingForReschedule, getMultipleDurationValue } from "@calcom/features/bookings/lib/get-booking";
+import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
+import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
+import slugify from "@calcom/lib/slugify";
+import prisma from "@calcom/prisma";
+
+export const generateMetadata = async () =>
+  await _generateMetadata(
+    (t) => t("appearance"),
+    (t) => t("appearance_description")
+  );
+
+async function getPageProps(context: GetServerSidePropsContext) {
+  const ssr = await ssrInit();
+
+  const session = await getServerSession({ req: context.req });
+  const { link, slug } = paramsSchema.parse(context.params);
+  const { rescheduleUid, duration: queryDuration } = context.query;
+  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req);
+  const org = isValidOrgDomain ? currentOrgDomain : null;
+
+  const hashedLink = await prisma.hashedLink.findUnique({
+    where: {
+      link,
+    },
+    select: {
+      eventTypeId: true,
+      eventType: {
+        select: {
+          users: {
+            select: {
+              username: true,
+            },
+          },
+          team: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const username = hashedLink?.eventType.users[0]?.username;
+
+  if (!hashedLink || !username) {
+    return notFound();
+  }
+
+  const user = await prisma.user.findFirst({
+    where: {
+      username,
+      organization: isValidOrgDomain
+        ? {
+            slug: currentOrgDomain,
+          }
+        : null,
+    },
+    select: {
+      away: true,
+      hideBranding: true,
+    },
+  });
+
+  if (!user) {
+    return notFound();
+  }
+
+  let booking: GetBookingType | null = null;
+  if (rescheduleUid) {
+    booking = await getBookingForReschedule(`${rescheduleUid}`, session?.user?.id);
+  }
+
+  const isTeamEvent = !!hashedLink.eventType?.team?.id;
+
+  // We use this to both prefetch the query on the server,
+  // as well as to check if the event exist, so we c an show a 404 otherwise.
+  const eventData = await ssr.viewer.public.event.fetch({ username, eventSlug: slug, isTeamEvent, org });
+
+  if (!eventData) {
+    return notFound();
+  }
+
+  return {
+    entity: eventData.entity,
+    duration: getMultipleDurationValue(eventData.metadata?.multipleDuration, queryDuration, eventData.length),
+    booking,
+    away: user?.away,
+    user: username,
+    slug,
+    dehydratedState: await ssr.dehydrate(),
+    isBrandingHidden: user?.hideBranding,
+    // Sending the team event from the server, because this template file
+    // is reused for both team and user events.
+    isTeamEvent,
+    hashedLink: link,
+  };
+}
+
+const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
+
+// @ts-expect-error getData arg
+export default WithLayout({ getLayout: null, Page: LegacyPage, getData: getPageProps });

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -130,4 +130,4 @@ const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s)
 
 // @ts-expect-error arg
 const getData = withAppDir<PageProps>(getPageProps);
-export default WithLayout({ getLayout: null, Page: LegacyPage, getData });
+export default WithLayout({ getLayout: null, Page: LegacyPage, getData })<"P">;

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -116,7 +116,7 @@ async function getPageProps(context: GetServerSidePropsContext) {
     away: user?.away,
     user: username,
     slug,
-    dehydratedState: await ssr.dehydrate(),
+    dehydratedState: ssr.dehydrate(),
     isBrandingHidden: user?.hideBranding,
     // Sending the team event from the server, because this template file
     // is reused for both team and user events.

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -13,7 +13,6 @@ import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import { trpc } from "@calcom/trpc/react";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
@@ -26,6 +25,7 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
 
   const { entity, booking, user, slug, isTeamEvent } = pageProps;
   const rescheduleUid = booking?.uid;
+  const { trpc } = await import("@calcom/trpc");
   const { data: event } = trpc.viewer.public.event.useQuery(
     { username: user ?? "", eventSlug: slug ?? "", isTeamEvent, org: entity.orgSlug ?? null },
     { refetchOnWindowFocus: false }

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -27,7 +27,7 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
   const { entity, booking, user, slug, isTeamEvent } = pageProps;
   const rescheduleUid = booking?.uid;
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username: user, eventSlug: slug, isTeamEvent, org: entity.orgSlug ?? null },
+    { username: user ?? "", eventSlug: slug ?? "", isTeamEvent, org: entity.orgSlug ?? null },
     { refetchOnWindowFocus: false }
   );
   const profileName = event?.profile?.name ?? "";
@@ -39,8 +39,6 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
 };
 
 async function getPageProps(context: GetServerSidePropsContext) {
-  const ssr = await ssrInit(context);
-
   const session = await getServerSession({ req: context.req });
   const { link, slug } = paramsSchema.parse(context.params);
   const { rescheduleUid, duration: queryDuration } = context.query;
@@ -101,6 +99,7 @@ async function getPageProps(context: GetServerSidePropsContext) {
   }
 
   const isTeamEvent = !!hashedLink.eventType?.team?.id;
+  const ssr = await ssrInit(context);
 
   // We use this to both prefetch the query on the server,
   // as well as to check if the event exist, so we c an show a 404 otherwise.

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -1,4 +1,5 @@
-import LegacyPage from "@pages/d/[link]/[slug]";
+import LegacyPage, { type PageProps } from "@pages/d/[link]/[slug]";
+import { withAppDir } from "app/AppDirSSRHOC";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 import type { GetServerSidePropsContext } from "next";
@@ -127,4 +128,6 @@ async function getPageProps(context: GetServerSidePropsContext) {
 
 const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
 
-export default WithLayout({ getLayout: null, Page: LegacyPage, getData: getPageProps });
+// @ts-expect-error arg
+const getData = withAppDir<PageProps>(getPageProps);
+export default WithLayout({ getLayout: null, Page: LegacyPage, getData });

--- a/apps/web/app/future/getting-started/[[...step]]/page.tsx
+++ b/apps/web/app/future/getting-started/[[...step]]/page.tsx
@@ -1,7 +1,6 @@
 import LegacyPage from "@pages/getting-started/[[...step]]";
 import { WithLayout } from "app/layoutHOC";
-import type { GetServerSidePropsContext } from "next";
-import { cookies, headers } from "next/headers";
+import { type GetServerSidePropsContext } from "next";
 import { redirect } from "next/navigation";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
@@ -10,10 +9,7 @@ import prisma from "@calcom/prisma";
 import { ssrInit } from "@server/lib/ssr";
 
 const getData = async (ctx: GetServerSidePropsContext) => {
-  const req = { headers: headers(), cookies: cookies() };
-
-  //@ts-expect-error Type '{ headers: ReadonlyHeaders; cookies: ReadonlyRequestCookies; }' is not assignable to type 'NextApiRequest
-  const session = await getServerSession({ req });
+  const session = await getServerSession({ req: ctx.req });
 
   if (!session?.user?.id) {
     return redirect("/auth/login");

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { GetServerSidePropsContext } from "next";
 import { z } from "zod";
 

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -18,7 +18,7 @@ import type { EmbedProps } from "@lib/withEmbedSsr";
 
 import PageWrapper from "@components/PageWrapper";
 
-type PageProps = inferSSRProps<typeof getServerSideProps> & EmbedProps;
+type PageProps = Omit<inferSSRProps<typeof getServerSideProps>, "trpcState"> & EmbedProps;
 
 export default function Type({
   slug,

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -18,7 +18,7 @@ import type { EmbedProps } from "@lib/withEmbedSsr";
 
 import PageWrapper from "@components/PageWrapper";
 
-type PageProps = Omit<inferSSRProps<typeof getServerSideProps>, "trpcState"> & EmbedProps;
+export type PageProps = Omit<inferSSRProps<typeof getServerSideProps>, "trpcState"> & EmbedProps;
 
 export default function Type({
   slug,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR migrates the `/d/*` page group to the app directory (which runs under the App Router).
- The migrated page exists under `/future` and is accessible at all times.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)


## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
