### PR TITLE
fix: Broken test after recent organization avatar revamp

### DIFF
--- a/apps/web/playwright/profile.e2e.ts
+++ b/apps/web/playwright/profile.e2e.ts
@@ -1,5 +1,3 @@
-import { expect } from "@playwright/test";
-
 import { test } from "./lib/fixtures";
 
 test.describe.configure({ mode: "parallel" });
@@ -19,6 +17,6 @@ test.describe("Teams", () => {
     await page.goto("/settings/my-account/profile");
 
     // check if user avatar is loaded
-    await expect(page.locator('[data-testid="organization-avatar"]')).toBeVisible();
+    await page.getByTestId("profile-upload-avatar").isVisible();
   });
 });


### PR DESCRIPTION
## What does this PR do?

organization-avatar no longer exists as a testid.