### PR TITLE
fix: Allow org creation with conflicting slug and renaming team slug during migration

### DIFF
--- a/apps/web/pages/api/orgMigration/moveTeamToOrg.ts
+++ b/apps/web/pages/api/orgMigration/moveTeamToOrg.ts
@@ -40,7 +40,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ message: JSON.stringify(parsedBody.error) });
   }
 
-  const { teamId, targetOrgId, moveMembers } = parsedBody.data;
+  const { teamId, targetOrgId, moveMembers, teamSlugInOrganization } = parsedBody.data;
   const isAllowed = isAdmin;
   if (!isAllowed) {
     return res.status(403).json({ message: "Not Authorized" });
@@ -48,7 +48,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     await moveTeamToOrg({
-      targetOrgId,
+      targetOrg: {
+        id: targetOrgId,
+        teamSlug: teamSlugInOrganization,
+      },
       teamId,
       moveMembers,
     });

--- a/apps/web/pages/settings/admin/orgMigrations/moveTeamToOrg.tsx
+++ b/apps/web/pages/settings/admin/orgMigrations/moveTeamToOrg.tsx
@@ -21,6 +21,7 @@ export const getFormSchema = (t: TFunction) => {
     teamId: z.number().or(getStringAsNumberRequiredSchema(t)),
     targetOrgId: z.number().or(getStringAsNumberRequiredSchema(t)),
     moveMembers: z.boolean(),
+    teamSlugInOrganization: z.string(),
   });
 };
 
@@ -102,6 +103,12 @@ export default function MoveTeamToOrg() {
             label="Team ID"
             required
             placeholder="Enter teamId to move to org"
+          />
+          <TextField
+            {...register("teamSlugInOrganization")}
+            label="New Slug"
+            required
+            placeholder="Team slug in the Organization"
           />
           <TextField
             {...register("targetOrgId")}

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -334,6 +334,14 @@ export const teamMetadataSchema = z
     isOrganizationVerified: z.boolean().nullable(),
     isOrganizationConfigured: z.boolean().nullable(),
     orgAutoAcceptEmail: z.string().nullable(),
+    migratedToOrgFrom: z
+      .object({
+        teamSlug: z.string().or(z.null()).optional(),
+        lastMigrationTime: z.string().optional(),
+        reverted: z.boolean().optional(),
+        lastRevertTime: z.string().optional(),
+      })
+      .optional(),
   })
   .partial()
   .nullable();


### PR DESCRIPTION
## What does this PR do?

- Now an organization can be created with the `requestedSlug` same as a team's slug. It allows then moving that team to the organization itself. It is a common scenario when a team upgrades to be come an organization
- Org Migration - Allow renaming team slug which is a common scenario when team's migrate to an organization e.g. calcom-engineering -> engineering inside calcom org.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
