### PR TITLE
fix: add check for parentId

### DIFF
--- a/apps/api/pages/api/teams/_post.ts
+++ b/apps/api/pages/api/teams/_post.ts
@@ -68,6 +68,18 @@ async function postHandler(req: NextApiRequest) {
     }
   }
 
+  // Check if parentId is related to this user
+  if (data.parentId) {
+    const parentTeam = await prisma.team.findFirst({
+      where: { id: data.parentId, members: { some: { userId, role: { in: ["OWNER", "ADMIN"] } } } },
+    });
+    if (!parentTeam)
+      throw new HttpError({
+        statusCode: 401,
+        message: "Unauthorized: Invalid parent id. You can only use parent id of your own teams.",
+      });
+  }
+
   // TODO: Perhaps there is a better fix for this?
   const cloneData: typeof data & {
     metadata: NonNullable<typeof data.metadata> | undefined;


### PR DESCRIPTION
## What does this PR do?

This PR adds parentId check to prevent use of non related parentId in update team api. 

Fixes #13077 

![Issue 5-3 sol1](https://github.com/calcom/cal.com/assets/40472653/5f548819-a2d9-4c8b-bb84-23c4305fb1cc)
![Issue 5-3 sol2](https://github.com/calcom/cal.com/assets/40472653/a88ae97b-5cfb-41f4-9f3b-8ad94eaa8f56)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)