### PR TITLE
chore: Stop closing stale PRs

### DIFF
--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -17,10 +17,11 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
+          days-before-close: -1
           days-before-issue-stale: 60
           days-before-issue-close: -1
           days-before-pr-stale: 14
-          days-before-pr-close: 7
+          days-before-pr-close: -1
           stale-pr-message: "This PR is being marked as stale due to inactivity."
           close-pr-message: "This PR is being closed due to inactivity. Please reopen if work is intended to be continued."
           operations-per-run: 100


### PR DESCRIPTION
## What does this PR do?

Stops automatically closing PRs that have been marked as stale. Leaving the `close-pr-message` configured so we can easily revert to the same message as before in the future if desired.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)
