### PR TITLE
chore: [app-router-migration 13.5] Add ability to reuse legacy getServerSideProps and getStaticProps on the `/future` pages

### DIFF
--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -28,6 +28,10 @@ jobs:
         shard: [1, 2]
 
     steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -23,6 +23,10 @@ jobs:
         shard: [1, 2]
 
     steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -28,6 +28,10 @@ jobs:
         shard: [1, 2]
 
     steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5]
     steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,14 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  login:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
   changes:
     name: Detect changes
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/apps/web/app/WithAppDirSsg.tsx
+++ b/apps/web/app/WithAppDirSsg.tsx
@@ -1,0 +1,26 @@
+import type { GetStaticProps } from "next";
+import { notFound, redirect } from "next/navigation";
+
+import type { buildLegacyCtx } from "@lib/buildLegacyCtx";
+
+export const withAppDirSsg =
+  <T extends Record<string, any>>(getStaticProps: GetStaticProps<T>) =>
+  async (context: ReturnType<typeof buildLegacyCtx>) => {
+    const ssgResponse = await getStaticProps(context);
+
+    if ("redirect" in ssgResponse) {
+      redirect(ssgResponse.redirect.destination);
+    }
+
+    if ("notFound" in ssgResponse) {
+      notFound();
+    }
+
+    const props = await Promise.resolve(ssgResponse.props);
+
+    return {
+      ...ssgResponse.props,
+      // includes dehydratedState required for future page trpcPropvider
+      ...("trpcState" in props && { dehydratedState: props.trpcState }),
+    };
+  };

--- a/apps/web/app/WithAppDirSsg.tsx
+++ b/apps/web/app/WithAppDirSsg.tsx
@@ -1,11 +1,9 @@
-import type { GetStaticProps } from "next";
+import type { GetStaticProps, GetStaticPropsContext } from "next";
 import { notFound, redirect } from "next/navigation";
-
-import type { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 export const withAppDirSsg =
   <T extends Record<string, any>>(getStaticProps: GetStaticProps<T>) =>
-  async (context: ReturnType<typeof buildLegacyCtx>) => {
+  async (context: GetStaticPropsContext) => {
     const ssgResponse = await getStaticProps(context);
 
     if ("redirect" in ssgResponse) {

--- a/apps/web/app/WithAppDirSsr.tsx
+++ b/apps/web/app/WithAppDirSsr.tsx
@@ -1,21 +1,24 @@
 import type { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { notFound, redirect } from "next/navigation";
 
-export const withAppDir =
+export const withAppDirSsr =
   <T extends Record<string, any>>(getServerSideProps: GetServerSideProps<T>) =>
-  async (context: GetServerSidePropsContext): Promise<T> => {
+  async (context: GetServerSidePropsContext) => {
     const ssrResponse = await getServerSideProps(context);
 
     if ("redirect" in ssrResponse) {
       redirect(ssrResponse.redirect.destination);
     }
+
     if ("notFound" in ssrResponse) {
       notFound();
     }
 
+    const props = await Promise.resolve(ssrResponse.props);
+
     return {
-      ...ssrResponse.props,
+      ...props,
       // includes dehydratedState required for future page trpcPropvider
-      ...("trpcState" in ssrResponse.props && { dehydratedState: ssrResponse.props.trpcState }),
+      ...("trpcState" in props && { dehydratedState: props.trpcState }),
     };
   };

--- a/apps/web/app/future/apps/[slug]/layout.tsx
+++ b/apps/web/app/future/apps/[slug]/layout.tsx
@@ -1,3 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-export default WithLayout({ getLayout: null })<"L">;

--- a/apps/web/app/future/apps/[slug]/page.tsx
+++ b/apps/web/app/future/apps/[slug]/page.tsx
@@ -1,40 +1,27 @@
-import AppPage from "@pages/apps/[slug]/index";
+import Page from "@pages/apps/[slug]/index";
 import { Prisma } from "@prisma/client";
+import { withAppDirSsg } from "app/WithAppDirSsg";
 import { _generateMetadata } from "app/_utils";
-import fs from "fs";
-import matter from "gray-matter";
-import { notFound } from "next/navigation";
-import path from "path";
-import { z } from "zod";
+import { WithLayout } from "app/layoutHOC";
+import type { InferGetStaticPropsType } from "next";
+import { cookies, headers } from "next/headers";
 
-import { getAppWithMetadata } from "@calcom/app-store/_appRegistry";
-import { getAppAssetFullPath } from "@calcom/app-store/getAppAssetFullPath";
-import { APP_NAME, IS_PRODUCTION } from "@calcom/lib/constants";
+import { APP_NAME } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 
-const sourceSchema = z.object({
-  content: z.string(),
-  data: z.object({
-    description: z.string().optional(),
-    items: z
-      .array(
-        z.union([
-          z.string(),
-          z.object({
-            iframe: z.object({ src: z.string() }),
-          }),
-        ])
-      )
-      .optional(),
-  }),
-});
+import { getStaticProps } from "@lib/apps/[slug]/getStaticProps";
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+
+type Y = InferGetStaticPropsType<typeof getStaticProps>;
+const getData = withAppDirSsg<Y>(getStaticProps);
 
 export const generateMetadata = async ({ params }: { params: Record<string, string | string[]> }) => {
-  const { data } = await getPageProps({ params });
+  const legacyContext = buildLegacyCtx(headers(), cookies(), params);
+  const res = await getData(legacyContext);
 
   return await _generateMetadata(
-    () => `${data.name} | ${APP_NAME}`,
-    () => data.description
+    () => `${res?.data.name} | ${APP_NAME}`,
+    () => res?.data.description ?? ""
   );
 };
 
@@ -53,74 +40,6 @@ export const generateStaticParams = async () => {
   return [];
 };
 
-const getPageProps = async ({ params }: { params: Record<string, string | string[]> }) => {
-  if (typeof params?.slug !== "string") {
-    notFound();
-  }
-
-  const appMeta = await getAppWithMetadata({
-    slug: params?.slug,
-  });
-
-  const appFromDb = await prisma.app.findUnique({
-    where: { slug: params.slug.toLowerCase() },
-  });
-
-  const isAppAvailableInFileSystem = appMeta;
-  const isAppDisabled = isAppAvailableInFileSystem && (!appFromDb || !appFromDb.enabled);
-
-  if (!IS_PRODUCTION && isAppDisabled) {
-    return {
-      isAppDisabled: true as const,
-      data: {
-        ...appMeta,
-      },
-    };
-  }
-
-  if (!appFromDb || !appMeta || isAppDisabled) {
-    notFound();
-  }
-
-  const isTemplate = appMeta.isTemplate;
-  const appDirname = path.join(isTemplate ? "templates" : "", appFromDb.dirName);
-  const README_PATH = path.join(process.cwd(), "..", "..", `packages/app-store/${appDirname}/DESCRIPTION.md`);
-  const postFilePath = path.join(README_PATH);
-  let source = "";
-
-  try {
-    source = fs.readFileSync(postFilePath).toString();
-    source = source.replace(/{DESCRIPTION}/g, appMeta.description);
-  } catch (error) {
-    /* If the app doesn't have a README we fallback to the package description */
-    console.log(`No DESCRIPTION.md provided for: ${appDirname}`);
-    source = appMeta.description;
-  }
-
-  const result = matter(source);
-  const { content, data } = sourceSchema.parse({ content: result.content, data: result.data });
-  if (data.items) {
-    data.items = data.items.map((item) => {
-      if (typeof item === "string") {
-        return getAppAssetFullPath(item, {
-          dirName: appMeta.dirName,
-          isTemplate: appMeta.isTemplate,
-        });
-      }
-      return item;
-    });
-  }
-  return {
-    isAppDisabled: false as const,
-    source: { content, data },
-    data: appMeta,
-  };
-};
-
-export default async function Page({ params }: { params: Record<string, string | string[]> }) {
-  const pageProps = await getPageProps({ params });
-
-  return <AppPage {...pageProps} />;
-}
+export default WithLayout({ getLayout: null, Page, getData });
 
 export const dynamic = "force-static";

--- a/apps/web/app/future/apps/[slug]/page.tsx
+++ b/apps/web/app/future/apps/[slug]/page.tsx
@@ -15,8 +15,14 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 type Y = InferGetStaticPropsType<typeof getStaticProps>;
 const getData = withAppDirSsg<Y>(getStaticProps);
 
-export const generateMetadata = async ({ params }: { params: Record<string, string | string[]> }) => {
-  const legacyContext = buildLegacyCtx(headers(), cookies(), params);
+export const generateMetadata = async ({
+  params,
+  searchParams,
+}: {
+  params: Record<string, string | string[]>;
+  searchParams: { [key: string]: string | string[] | undefined };
+}) => {
+  const legacyContext = buildLegacyCtx(headers(), cookies(), params, searchParams);
   const res = await getData(legacyContext);
 
   return await _generateMetadata(

--- a/apps/web/app/future/apps/[slug]/setup/page.tsx
+++ b/apps/web/app/future/apps/[slug]/setup/page.tsx
@@ -1,8 +1,7 @@
-import SetupPage from "@pages/apps/[slug]/setup";
+import Page from "@pages/apps/[slug]/setup";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
-import type { GetServerSidePropsContext } from "next";
-import { cookies, headers } from "next/headers";
-import { notFound, redirect } from "next/navigation";
+import { WithLayout } from "app/layoutHOC";
 
 import { getServerSideProps } from "@calcom/app-store/_pages/setup/_getServerSideProps";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -14,23 +13,4 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
   );
 };
 
-const getPageProps = async ({ params }: { params: Record<string, string | string[]> }) => {
-  const req = { headers: headers(), cookies: cookies() };
-
-  const result = await getServerSideProps({ params, req } as unknown as GetServerSidePropsContext);
-
-  if (!result || "notFound" in result) {
-    notFound();
-  }
-
-  if ("redirect" in result) {
-    redirect(result.redirect.destination);
-  }
-
-  return result.props;
-};
-
-export default async function Page({ params }: { params: Record<string, string | string[]> }) {
-  const pageProps = await getPageProps({ params });
-  return <SetupPage {...pageProps} />;
-}
+export default WithLayout({ getLayout: null, Page, getData: withAppDirSsr(getServerSideProps) });

--- a/apps/web/app/future/apps/[slug]/setup/page.tsx
+++ b/apps/web/app/future/apps/[slug]/setup/page.tsx
@@ -2,6 +2,7 @@ import Page from "@pages/apps/[slug]/setup";
 import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
+import type { InferGetServerSidePropsType } from "next";
 
 import { getServerSideProps } from "@calcom/app-store/_pages/setup/_getServerSideProps";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -13,4 +14,8 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
   );
 };
 
-export default WithLayout({ getLayout: null, Page, getData: withAppDirSsr(getServerSideProps) });
+type T = InferGetServerSidePropsType<typeof getServerSideProps>;
+
+const getData = withAppDirSsr<T>(getServerSideProps);
+
+export default WithLayout({ getLayout: null, Page, getData });

--- a/apps/web/app/future/apps/categories/page.tsx
+++ b/apps/web/app/future/apps/categories/page.tsx
@@ -1,13 +1,11 @@
-import LegacyPage from "@pages/apps/categories/index";
+import Page from "@pages/apps/categories/index";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import type { GetServerSidePropsContext } from "next";
 
-import { getAppRegistry, getAppRegistryWithCredentials } from "@calcom/app-store/_appRegistry";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { APP_NAME } from "@calcom/lib/constants";
 
-import { ssrInit } from "@server/lib/ssr";
+import { getServerSideProps } from "@lib/apps/categories/getServerSideProps";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(
@@ -16,29 +14,4 @@ export const generateMetadata = async () => {
   );
 };
 
-const getData = async (ctx: GetServerSidePropsContext) => {
-  const ssr = await ssrInit(ctx);
-
-  const session = await getServerSession({ req: ctx.req });
-
-  let appStore;
-  if (session?.user?.id) {
-    appStore = await getAppRegistryWithCredentials(session.user.id);
-  } else {
-    appStore = await getAppRegistry();
-  }
-
-  const categories = appStore.reduce((c, app) => {
-    for (const category of app.categories) {
-      c[category] = c[category] ? c[category] + 1 : 1;
-    }
-    return c;
-  }, {} as Record<string, number>);
-
-  return {
-    categories: Object.entries(categories).map(([name, count]) => ({ name, count })),
-    dehydratedState: ssr.dehydrate(),
-  };
-};
-
-export default WithLayout({ getData, Page: LegacyPage, getLayout: null })<"P">;
+export default WithLayout({ getData: withAppDirSsr(getServerSideProps), Page, getLayout: null })<"P">;

--- a/apps/web/app/future/apps/installed/[category]/layout.tsx
+++ b/apps/web/app/future/apps/installed/[category]/layout.tsx
@@ -1,3 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-export default WithLayout({ getLayout: null })<"L">;

--- a/apps/web/app/future/apps/installed/[category]/page.tsx
+++ b/apps/web/app/future/apps/installed/[category]/page.tsx
@@ -1,14 +1,11 @@
-import LegacyPage from "@pages/apps/installed/[category]";
+import Page from "@pages/apps/installed/[category]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
-import { notFound } from "next/navigation";
-import { z } from "zod";
+import { WithLayout } from "app/layoutHOC";
 
 import { APP_NAME } from "@calcom/lib/constants";
-import { AppCategories } from "@calcom/prisma/enums";
 
-const querySchema = z.object({
-  category: z.nativeEnum(AppCategories),
-});
+import { getServerSideProps } from "@lib/apps/installed/[category]/getServerSideProps";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(
@@ -17,20 +14,6 @@ export const generateMetadata = async () => {
   );
 };
 
-const getPageProps = async ({ params }: { params: Record<string, string | string[]> }) => {
-  const p = querySchema.safeParse(params);
+const getData = withAppDirSsr(getServerSideProps);
 
-  if (!p.success) {
-    return notFound();
-  }
-
-  return {
-    category: p.data.category,
-  };
-};
-
-export default async function Page({ params }: { params: Record<string, string | string[]> }) {
-  await getPageProps({ params });
-
-  return <LegacyPage />;
-}
+export default WithLayout({ getLayout: null, getData, Page });

--- a/apps/web/app/future/apps/page.tsx
+++ b/apps/web/app/future/apps/page.tsx
@@ -1,17 +1,12 @@
 import AppsPage from "@pages/apps";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import type { GetServerSidePropsContext } from "next";
 
-import { getAppRegistry, getAppRegistryWithCredentials } from "@calcom/app-store/_appRegistry";
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import type { UserAdminTeams } from "@calcom/features/ee/teams/lib/getUserAdminTeams";
-import getUserAdminTeams from "@calcom/features/ee/teams/lib/getUserAdminTeams";
 import { APP_NAME } from "@calcom/lib/constants";
-import type { AppCategories } from "@calcom/prisma/enums";
 
-import { ssrInit } from "@server/lib/ssr";
+import { getServerSideProps } from "@lib/apps/getServerSideProps";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(
@@ -20,44 +15,4 @@ export const generateMetadata = async () => {
   );
 };
 
-const getData = async (ctx: GetServerSidePropsContext) => {
-  const ssr = await ssrInit(ctx);
-
-  const session = await getServerSession({ req: ctx.req });
-
-  let appStore, userAdminTeams: UserAdminTeams;
-  if (session?.user?.id) {
-    userAdminTeams = await getUserAdminTeams({ userId: session.user.id, getUserInfo: true });
-    appStore = await getAppRegistryWithCredentials(session.user.id, userAdminTeams);
-  } else {
-    appStore = await getAppRegistry();
-    userAdminTeams = [];
-  }
-
-  const categoryQuery = appStore.map(({ categories }) => ({
-    categories: categories || [],
-  }));
-
-  const categories = categoryQuery.reduce((c, app) => {
-    for (const category of app.categories) {
-      c[category] = c[category] ? c[category] + 1 : 1;
-    }
-    return c;
-  }, {} as Record<string, number>);
-
-  return {
-    categories: Object.entries(categories)
-      .map(([name, count]): { name: AppCategories; count: number } => ({
-        name: name as AppCategories,
-        count,
-      }))
-      .sort(function (a, b) {
-        return b.count - a.count;
-      }),
-    appStore,
-    userAdminTeams,
-    dehydratedState: ssr.dehydrate(),
-  };
-};
-
-export default WithLayout({ getLayout, getData, Page: AppsPage });
+export default WithLayout({ getLayout, getData: withAppDirSsr(getServerSideProps), Page: AppsPage });

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -1,27 +1,21 @@
-import LegacyPage, { type PageProps } from "@pages/d/[link]/[slug]";
-import { withAppDir } from "app/AppDirSSRHOC";
+import LegacyPage from "@pages/d/[link]/[slug]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
+import type { Params, SearchParams } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import type { GetServerSidePropsContext } from "next";
 import { cookies, headers } from "next/headers";
-import { notFound } from "next/navigation";
-import { z } from "zod";
-
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { getBookingForReschedule, getMultipleDurationValue } from "@calcom/features/bookings/lib/get-booking";
-import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
-import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import slugify from "@calcom/lib/slugify";
-import prisma from "@calcom/prisma";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { getServerSideProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 
-import { ssrInit } from "@server/lib/ssr";
-
-export const generateMetadata = async ({ params }: { params: Record<string, string | string[]> }) => {
-  const pageProps = await getPageProps(
-    buildLegacyCtx(headers(), cookies(), params) as unknown as GetServerSidePropsContext
-  );
+export const generateMetadata = async ({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: SearchParams;
+}) => {
+  const pageProps = await getData(buildLegacyCtx(headers(), cookies(), params, searchParams));
 
   const { entity, booking, user, slug, isTeamEvent } = pageProps;
   const rescheduleUid = booking?.uid;
@@ -38,95 +32,5 @@ export const generateMetadata = async ({ params }: { params: Record<string, stri
   );
 };
 
-async function getPageProps(context: GetServerSidePropsContext) {
-  const session = await getServerSession({ req: context.req });
-  const { link, slug } = paramsSchema.parse(context.params);
-  const { rescheduleUid, duration: queryDuration } = context.query;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
-
-  const hashedLink = await prisma.hashedLink.findUnique({
-    where: {
-      link,
-    },
-    select: {
-      eventTypeId: true,
-      eventType: {
-        select: {
-          users: {
-            select: {
-              username: true,
-            },
-          },
-          team: {
-            select: {
-              id: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  const username = hashedLink?.eventType.users[0]?.username;
-
-  if (!hashedLink || !username) {
-    return notFound();
-  }
-
-  const user = await prisma.user.findFirst({
-    where: {
-      username,
-      organization: isValidOrgDomain
-        ? {
-            slug: currentOrgDomain,
-          }
-        : null,
-    },
-    select: {
-      away: true,
-      hideBranding: true,
-    },
-  });
-
-  if (!user) {
-    return notFound();
-  }
-
-  let booking: GetBookingType | null = null;
-  if (rescheduleUid) {
-    booking = await getBookingForReschedule(`${rescheduleUid}`, session?.user?.id);
-  }
-
-  const isTeamEvent = !!hashedLink.eventType?.team?.id;
-  const ssr = await ssrInit(context);
-
-  // We use this to both prefetch the query on the server,
-  // as well as to check if the event exist, so we c an show a 404 otherwise.
-  const eventData = await ssr.viewer.public.event.fetch({ username, eventSlug: slug, isTeamEvent, org });
-
-  if (!eventData) {
-    return notFound();
-  }
-
-  return {
-    entity: eventData.entity,
-    duration: getMultipleDurationValue(eventData.metadata?.multipleDuration, queryDuration, eventData.length),
-    booking,
-    away: user?.away,
-    user: username,
-    slug,
-    dehydratedState: ssr.dehydrate(),
-    isBrandingHidden: user?.hideBranding,
-    // Sending the team event from the server, because this template file
-    // is reused for both team and user events.
-    isTeamEvent,
-    hashedLink: link,
-  };
-}
-
-const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
-
-// @ts-expect-error arg
-const getData = withAppDir<PageProps>(getPageProps);
+const getData = withAppDirSsr(getServerSideProps);
 export default WithLayout({ getLayout: null, Page: LegacyPage, getData })<"P">;

--- a/apps/web/app/future/getting-started/[[...step]]/page.tsx
+++ b/apps/web/app/future/getting-started/[[...step]]/page.tsx
@@ -1,57 +1,7 @@
-import LegacyPage from "@pages/getting-started/[[...step]]";
+import Page from "@pages/getting-started/[[...step]]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { redirect } from "next/navigation";
 
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import prisma from "@calcom/prisma";
+import { getServerSideProps } from "@lib/getting-started/[[...step]]/getServerSideProps";
 
-import { ssrInit } from "@server/lib/ssr";
-
-const getData = async (ctx: GetServerSidePropsContext) => {
-  const session = await getServerSession({ req: ctx.req });
-
-  if (!session?.user?.id) {
-    return redirect("/auth/login");
-  }
-  const ssr = await ssrInit(ctx);
-  await ssr.viewer.me.prefetch();
-
-  const user = await prisma.user.findUnique({
-    where: {
-      id: session.user.id,
-    },
-    select: {
-      completedOnboarding: true,
-      teams: {
-        select: {
-          accepted: true,
-          team: {
-            select: {
-              id: true,
-              name: true,
-              logo: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  if (!user) {
-    throw new Error("User from session not found");
-  }
-
-  if (user.completedOnboarding) {
-    redirect("/event-types");
-  }
-
-  return {
-    dehydratedState: ssr.dehydrate(),
-    hasPendingInvites: user.teams.find((team) => team.accepted === false) ?? false,
-    requiresLicense: false,
-    themeBasis: null,
-  };
-};
-
-export default WithLayout({ getLayout: null, getData, Page: LegacyPage });
+export default WithLayout({ getLayout: null, getData: withAppDirSsr(getServerSideProps), Page });

--- a/apps/web/app/future/org/[orgSlug]/[user]/[type]/embed/page.tsx
+++ b/apps/web/app/future/org/[orgSlug]/[user]/[type]/embed/page.tsx
@@ -1,13 +1,12 @@
 import { type PageProps } from "@pages/org/[orgSlug]/[user]/[type]";
 import Page from "@pages/org/[orgSlug]/[user]/[type]/embed";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import withEmbedSsrAppDir from "app/WithEmbedSSR";
 import { WithLayout } from "app/layoutHOC";
 
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/[type]/getServerSideProps";
 
-const getData = withAppDir<PageProps>(getServerSideProps);
-
+const getData = withAppDirSsr<PageProps>(getServerSideProps);
 const getEmbedData = withEmbedSsrAppDir(getData);
 
 export default WithLayout({ getLayout: null, getData: getEmbedData, isBookingPage: true, Page });

--- a/apps/web/app/future/org/[orgSlug]/[user]/[type]/page.tsx
+++ b/apps/web/app/future/org/[orgSlug]/[user]/[type]/page.tsx
@@ -1,9 +1,9 @@
 import Page, { type PageProps } from "@pages/org/[orgSlug]/[user]/[type]";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { WithLayout } from "app/layoutHOC";
 
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/[type]/getServerSideProps";
 
-const getData = withAppDir<PageProps>(getServerSideProps);
+const getData = withAppDirSsr<PageProps>(getServerSideProps);
 
 export default WithLayout({ getLayout: null, getData, isBookingPage: true, Page });

--- a/apps/web/app/future/org/[orgSlug]/[user]/embed/page.tsx
+++ b/apps/web/app/future/org/[orgSlug]/[user]/embed/page.tsx
@@ -1,10 +1,11 @@
 import { getServerSideProps, type PageProps } from "@pages/org/[orgSlug]/[user]";
 import Page from "@pages/org/[orgSlug]/[user]/embed";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import withEmbedSsrAppDir from "app/WithEmbedSSR";
 import { WithLayout } from "app/layoutHOC";
 
-const getData = withAppDir<PageProps>(getServerSideProps);
+const getData = withAppDirSsr<PageProps>(getServerSideProps);
+
 const getEmbedData = withEmbedSsrAppDir(getData);
 
 export default WithLayout({ getLayout: null, getData: getEmbedData, isBookingPage: true, Page });

--- a/apps/web/app/future/org/[orgSlug]/[user]/page.tsx
+++ b/apps/web/app/future/org/[orgSlug]/[user]/page.tsx
@@ -1,7 +1,7 @@
 import Page, { getServerSideProps, type PageProps } from "@pages/org/[orgSlug]/[user]";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { WithLayout } from "app/layoutHOC";
 
-const getData = withAppDir<PageProps>(getServerSideProps);
+const getData = withAppDirSsr<PageProps>(getServerSideProps);
 
 export default WithLayout({ getLayout: null, getData, isBookingPage: true, Page });

--- a/apps/web/app/future/reschedule/[uid]/embed/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/embed/page.tsx
@@ -1,5 +1,5 @@
 import { getServerSideProps } from "@pages/reschedule/[uid]";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { cookies, headers } from "next/headers";
 
@@ -12,8 +12,7 @@ type PageProps = Readonly<{
 
 const Page = async ({ params }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params);
-  // @ts-expect-error Argument of type '{ query: Params; params: Params; req: { headers: ReadonlyHeaders; cookies: ReadonlyRequestCookies; }; }'
-  await withAppDir(withEmbedSsr(getServerSideProps))(legacyCtx);
+  await withAppDirSsr(withEmbedSsr(getServerSideProps))(legacyCtx);
 
   return null;
 };

--- a/apps/web/app/future/reschedule/[uid]/embed/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/embed/page.tsx
@@ -1,5 +1,6 @@
 import { getServerSideProps } from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
+import type { SearchParams } from "app/_types";
 import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { cookies, headers } from "next/headers";
 
@@ -8,10 +9,11 @@ import withEmbedSsr from "@lib/withEmbedSsr";
 
 type PageProps = Readonly<{
   params: Params;
+  searchParams: SearchParams;
 }>;
 
-const Page = async ({ params }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(headers(), cookies(), params);
+const Page = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
   await withAppDirSsr(withEmbedSsr(getServerSideProps))(legacyCtx);
 
   return null;

--- a/apps/web/app/future/reschedule/[uid]/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/page.tsx
@@ -1,5 +1,6 @@
 import OldPage, { getServerSideProps as _getServerSideProps } from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
+import type { SearchParams } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { headers, cookies } from "next/headers";
@@ -14,12 +15,13 @@ export const generateMetadata = async () =>
 
 type PageProps = Readonly<{
   params: Params;
+  searchParams: SearchParams;
 }>;
 
 const getData = withAppDirSsr(_getServerSideProps);
 
-const Page = async ({ params }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(headers(), cookies(), params);
+const Page = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
 
   await getData(legacyCtx);
 

--- a/apps/web/app/future/reschedule/[uid]/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/page.tsx
@@ -1,5 +1,5 @@
 import OldPage, { getServerSideProps as _getServerSideProps } from "@pages/reschedule/[uid]";
-import { withAppDir } from "app/AppDirSSRHOC";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { headers, cookies } from "next/headers";
@@ -16,12 +16,11 @@ type PageProps = Readonly<{
   params: Params;
 }>;
 
-const getData = withAppDir(_getServerSideProps);
+const getData = withAppDirSsr(_getServerSideProps);
 
 const Page = async ({ params }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params);
 
-  // @ts-expect-error Argument of type '{ query: Params; params: Params; req: { headers: ReadonlyHeaders; cookies: ReadonlyRequestCookies; }; }'
   await getData(legacyCtx);
 
   return <OldPage />;

--- a/apps/web/app/future/teams/page.tsx
+++ b/apps/web/app/future/teams/page.tsx
@@ -1,13 +1,11 @@
-import OldPage from "@pages/teams/index";
+import Page from "@pages/teams/index";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import type { GetServerSidePropsContext } from "next";
-import { redirect } from "next/navigation";
 
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 
-import { ssrInit } from "@server/lib/ssr";
+import { getServerSideProps } from "@lib/teams/getServerSideProps";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -15,23 +13,4 @@ export const generateMetadata = async () =>
     (t) => t("create_manage_teams_collaborative")
   );
 
-async function getData(context: GetServerSidePropsContext) {
-  const ssr = await ssrInit(context);
-
-  await ssr.viewer.me.prefetch();
-
-  const session = await getServerSession({
-    req: context.req,
-  });
-
-  if (!session) {
-    const token = Array.isArray(context.query.token) ? context.query.token[0] : context.query.token;
-
-    const callbackUrl = token ? `/teams?token=${encodeURIComponent(token)}` : null;
-    return redirect(callbackUrl ? `/auth/login?callbackUrl=${callbackUrl}` : "/auth/login");
-  }
-
-  return { dehydratedState: ssr.dehydrate() };
-}
-
-export default WithLayout({ getData, getLayout, Page: OldPage })<"P">;
+export default WithLayout({ getData: withAppDirSsr(getServerSideProps), getLayout, Page })<"P">;

--- a/apps/web/app/future/video/[uid]/page.tsx
+++ b/apps/web/app/future/video/[uid]/page.tsx
@@ -1,15 +1,11 @@
-import OldPage from "@pages/video/[uid]";
+import Page from "@pages/video/[uid]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import MarkdownIt from "markdown-it";
-import type { GetServerSidePropsContext } from "next";
-import { redirect } from "next/navigation";
 
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { APP_NAME } from "@calcom/lib/constants";
-import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 
-import { ssrInit } from "@server/lib/ssr";
+import { getServerSideProps } from "@lib/video/[uid]/getServerSideProps";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -17,86 +13,6 @@ export const generateMetadata = async () =>
     (t) => t("quick_video_meeting")
   );
 
-const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+const getData = withAppDirSsr(getServerSideProps);
 
-async function getData(context: GetServerSidePropsContext) {
-  const ssr = await ssrInit(context);
-
-  const booking = await prisma.booking.findUnique({
-    where: {
-      uid: context.query.uid as string,
-    },
-    select: {
-      ...bookingMinimalSelect,
-      uid: true,
-      description: true,
-      isRecorded: true,
-      user: {
-        select: {
-          id: true,
-          timeZone: true,
-          name: true,
-          email: true,
-          organization: {
-            select: {
-              calVideoLogo: true,
-            },
-          },
-        },
-      },
-      references: {
-        select: {
-          uid: true,
-          type: true,
-          meetingUrl: true,
-          meetingPassword: true,
-        },
-        where: {
-          type: "daily_video",
-        },
-      },
-    },
-  });
-
-  if (!booking || booking.references.length === 0 || !booking.references[0].meetingUrl) {
-    return redirect("/video/no-meeting-found");
-  }
-
-  //daily.co calls have a 60 minute exit buffer when a user enters a call when it's not available it will trigger the modals
-  const now = new Date();
-  const exitDate = new Date(now.getTime() - 60 * 60 * 1000);
-
-  //find out if the meeting is in the past
-  const isPast = booking?.endTime <= exitDate;
-  if (isPast) {
-    return redirect(`/video/meeting-ended/${booking?.uid}`);
-  }
-
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
-
-  const session = await getServerSession({ req: context.req });
-
-  // set meetingPassword to null for guests
-  if (session?.user.id !== bookingObj.user?.id) {
-    bookingObj.references.forEach((bookRef) => {
-      bookRef.meetingPassword = null;
-    });
-  }
-
-  return {
-    meetingUrl: bookingObj.references[0].meetingUrl ?? "",
-    ...(typeof bookingObj.references[0].meetingPassword === "string" && {
-      meetingPassword: bookingObj.references[0].meetingPassword,
-    }),
-    booking: {
-      ...bookingObj,
-      ...(bookingObj.description && { description: md.render(bookingObj.description) }),
-    },
-    dehydratedState: ssr.dehydrate(),
-  };
-}
-
-export default WithLayout({ getData, Page: OldPage, getLayout: null })<"P">;
+export default WithLayout({ getData, Page, getLayout: null })<"P">;

--- a/apps/web/app/future/video/[uid]/page.tsx
+++ b/apps/web/app/future/video/[uid]/page.tsx
@@ -1,4 +1,4 @@
-import Page from "@pages/video/[uid]";
+import Page, { type JoinCallPageProps } from "@pages/video/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
@@ -13,6 +13,6 @@ export const generateMetadata = async () =>
     (t) => t("quick_video_meeting")
   );
 
-const getData = withAppDirSsr(getServerSideProps);
+const getData = withAppDirSsr<JoinCallPageProps>(getServerSideProps);
 
 export default WithLayout({ getData, Page, getLayout: null })<"P">;

--- a/apps/web/app/future/video/meeting-ended/[uid]/page.tsx
+++ b/apps/web/app/future/video/meeting-ended/[uid]/page.tsx
@@ -1,10 +1,9 @@
-import OldPage from "@pages/video/meeting-ended/[uid]";
+import Page from "@pages/video/meeting-ended/[uid]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { redirect } from "next/navigation";
 
-import prisma, { bookingMinimalSelect } from "@calcom/prisma";
+import { getServerSideProps } from "@lib/video/meeting-ended/[uid]/getServerSideProps";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -12,41 +11,6 @@ export const generateMetadata = async () =>
     () => "Meeting Unavailable"
   );
 
-async function getData(context: Omit<GetServerSidePropsContext, "res" | "resolvedUrl">) {
-  const booking = await prisma.booking.findUnique({
-    where: {
-      uid: typeof context?.params?.uid === "string" ? context.params.uid : "",
-    },
-    select: {
-      ...bookingMinimalSelect,
-      uid: true,
-      user: {
-        select: {
-          credentials: true,
-        },
-      },
-      references: {
-        select: {
-          uid: true,
-          type: true,
-          meetingUrl: true,
-        },
-      },
-    },
-  });
+const getData = withAppDirSsr(getServerSideProps);
 
-  if (!booking) {
-    return redirect("/video/no-meeting-found");
-  }
-
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
-
-  return {
-    booking: bookingObj,
-  };
-}
-
-export default WithLayout({ getData, Page: OldPage, getLayout: null })<"P">;
+export default WithLayout({ getData, Page, getLayout: null })<"P">;

--- a/apps/web/app/future/video/meeting-not-started/[uid]/page.tsx
+++ b/apps/web/app/future/video/meeting-not-started/[uid]/page.tsx
@@ -1,15 +1,12 @@
-import OldPage from "@pages/video/meeting-not-started/[uid]";
-import { type Params } from "app/_types";
+import Page from "@pages/video/meeting-not-started/[uid]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
+import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { redirect } from "next/navigation";
 
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 
-type PageProps = Readonly<{
-  params: Params;
-}>;
+import { getServerSideProps } from "@lib/video/meeting-not-started/[uid]/getServerSideProps";
 
 export const generateMetadata = async ({ params }: PageProps) => {
   const booking = await prisma.booking.findUnique({
@@ -25,26 +22,6 @@ export const generateMetadata = async ({ params }: PageProps) => {
   );
 };
 
-async function getData(context: Omit<GetServerSidePropsContext, "res" | "resolvedUrl">) {
-  const booking = await prisma.booking.findUnique({
-    where: {
-      uid: typeof context?.params?.uid === "string" ? context.params.uid : "",
-    },
-    select: bookingMinimalSelect,
-  });
+const getData = withAppDirSsr(getServerSideProps);
 
-  if (!booking) {
-    return redirect("/video/no-meeting-found");
-  }
-
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
-
-  return {
-    booking: bookingObj,
-  };
-}
-
-export default WithLayout({ getData, Page: OldPage, getLayout: null })<"P">;
+export default WithLayout({ getData, Page, getLayout: null })<"P">;

--- a/apps/web/app/future/video/no-meeting-found/page.tsx
+++ b/apps/web/app/future/video/no-meeting-found/page.tsx
@@ -1,7 +1,7 @@
 import LegacyPage from "@pages/video/no-meeting-found";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
+import type { GetServerSidePropsContext } from "next";
 
 import { ssrInit } from "@server/lib/ssr";
 
@@ -11,6 +11,7 @@ export const generateMetadata = async () =>
     (t) => t("no_meeting_found")
   );
 
+// ssr was added by Intuita, legacy page does not have it
 const getData = async (context: GetServerSidePropsContext) => {
   const ssr = await ssrInit(context);
 

--- a/apps/web/app/future/workflows/[workflow]/page.tsx
+++ b/apps/web/app/future/workflows/[workflow]/page.tsx
@@ -13,9 +13,15 @@ const querySchema = z.object({
   workflow: z.string(),
 });
 
-export const generateMetadata = async ({ params }: { params: Record<string, string | string[]> }) => {
+export const generateMetadata = async ({
+  params,
+  searchParams,
+}: {
+  params: Record<string, string | string[]>;
+  searchParams: { [key: string]: string | string[] | undefined };
+}) => {
   const { workflow } = await getProps(
-    buildLegacyCtx(headers(), cookies(), params) as unknown as GetServerSidePropsContext
+    buildLegacyCtx(headers(), cookies(), params, searchParams) as unknown as GetServerSidePropsContext
   );
   return await _generateMetadata(
     () => workflow ?? "Untitled",

--- a/apps/web/app/layoutHOC.tsx
+++ b/apps/web/app/layoutHOC.tsx
@@ -22,7 +22,11 @@ export function WithLayout<T extends Record<string, any>>({
   return async <P extends "P" | "L">(p: P extends "P" ? PageProps : LayoutProps) => {
     const h = headers();
     const nonce = h.get("x-nonce") ?? undefined;
-    const props = getData ? (await getData(buildLegacyCtx(h, cookies(), p.params))) ?? ({} as T) : ({} as T);
+    let props = {} as T;
+
+    if ("searchParams" in p && getData) {
+      props = (await getData(buildLegacyCtx(h, cookies(), p.params, p.searchParams))) ?? ({} as T);
+    }
 
     const children = "children" in p ? p.children : null;
 

--- a/apps/web/app/layoutHOC.tsx
+++ b/apps/web/app/layoutHOC.tsx
@@ -9,7 +9,7 @@ import PageWrapper from "@components/PageWrapperAppDir";
 type WithLayoutParams<T extends Record<string, any>> = {
   getLayout: ((page: React.ReactElement) => React.ReactNode) | null;
   Page?: (props: T) => React.ReactElement | null;
-  getData?: (arg: GetServerSidePropsContext) => Promise<T>;
+  getData?: (arg: GetServerSidePropsContext) => Promise<T | undefined>;
   isBookingPage?: boolean;
 };
 
@@ -22,9 +22,7 @@ export function WithLayout<T extends Record<string, any>>({
   return async <P extends "P" | "L">(p: P extends "P" ? PageProps : LayoutProps) => {
     const h = headers();
     const nonce = h.get("x-nonce") ?? undefined;
-    const props = getData
-      ? await getData(buildLegacyCtx(h, cookies(), p.params) as unknown as GetServerSidePropsContext)
-      : ({} as T);
+    const props = getData ? (await getData(buildLegacyCtx(h, cookies(), p.params))) ?? ({} as T) : ({} as T);
 
     const children = "children" in p ? p.children : null;
 

--- a/apps/web/lib/apps/[slug]/getStaticProps.tsx
+++ b/apps/web/lib/apps/[slug]/getStaticProps.tsx
@@ -1,0 +1,94 @@
+import fs from "fs";
+import matter from "gray-matter";
+import MarkdownIt from "markdown-it";
+import type { GetStaticPropsContext } from "next";
+import path from "path";
+import { z } from "zod";
+
+import { getAppWithMetadata } from "@calcom/app-store/_appRegistry";
+import { getAppAssetFullPath } from "@calcom/app-store/getAppAssetFullPath";
+import { IS_PRODUCTION } from "@calcom/lib/constants";
+import prisma from "@calcom/prisma";
+
+const md = new MarkdownIt("default", { html: true, breaks: true });
+
+export const sourceSchema = z.object({
+  content: z.string(),
+  data: z.object({
+    description: z.string().optional(),
+    items: z
+      .array(
+        z.union([
+          z.string(),
+          z.object({
+            iframe: z.object({ src: z.string() }),
+          }),
+        ])
+      )
+      .optional(),
+  }),
+});
+
+export const getStaticProps = async (ctx: GetStaticPropsContext) => {
+  if (typeof ctx.params?.slug !== "string") return { notFound: true } as const;
+
+  const appMeta = await getAppWithMetadata({
+    slug: ctx.params?.slug,
+  });
+
+  const appFromDb = await prisma.app.findUnique({
+    where: { slug: ctx.params.slug.toLowerCase() },
+  });
+
+  const isAppAvailableInFileSystem = appMeta;
+  const isAppDisabled = isAppAvailableInFileSystem && (!appFromDb || !appFromDb.enabled);
+
+  if (!IS_PRODUCTION && isAppDisabled) {
+    return {
+      props: {
+        isAppDisabled: true as const,
+        data: {
+          ...appMeta,
+        },
+      },
+    };
+  }
+
+  if (!appFromDb || !appMeta || isAppDisabled) return { notFound: true } as const;
+
+  const isTemplate = appMeta.isTemplate;
+  const appDirname = path.join(isTemplate ? "templates" : "", appFromDb.dirName);
+  const README_PATH = path.join(process.cwd(), "..", "..", `packages/app-store/${appDirname}/DESCRIPTION.md`);
+  const postFilePath = path.join(README_PATH);
+  let source = "";
+
+  try {
+    source = fs.readFileSync(postFilePath).toString();
+    source = source.replace(/{DESCRIPTION}/g, appMeta.description);
+  } catch (error) {
+    /* If the app doesn't have a README we fallback to the package description */
+    console.log(`No DESCRIPTION.md provided for: ${appDirname}`);
+    source = appMeta.description;
+  }
+
+  const result = matter(source);
+  const { content, data } = sourceSchema.parse({ content: result.content, data: result.data });
+  if (data.items) {
+    data.items = data.items.map((item) => {
+      if (typeof item === "string") {
+        return getAppAssetFullPath(item, {
+          dirName: appMeta.dirName,
+          isTemplate: appMeta.isTemplate,
+        });
+      }
+      return item;
+    });
+  }
+  return {
+    props: {
+      isAppDisabled: false as const,
+      source: { content, data },
+      data: appMeta,
+    },
+  };
+};

--- a/apps/web/lib/apps/categories/[category]/getStaticProps.tsx
+++ b/apps/web/lib/apps/categories/[category]/getStaticProps.tsx
@@ -1,0 +1,31 @@
+import type { GetStaticPropsContext } from "next";
+
+import { getAppRegistry } from "@calcom/app-store/_appRegistry";
+import prisma from "@calcom/prisma";
+import type { AppCategories } from "@calcom/prisma/enums";
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
+  const category = context.params?.category as AppCategories;
+
+  const appQuery = await prisma.app.findMany({
+    where: {
+      categories: {
+        has: category,
+      },
+    },
+    select: {
+      slug: true,
+    },
+  });
+
+  const dbAppsSlugs = appQuery.map((category) => category.slug);
+
+  const appStore = await getAppRegistry();
+
+  const apps = appStore.filter((app) => dbAppsSlugs.includes(app.slug));
+  return {
+    props: {
+      apps,
+    },
+  };
+};

--- a/apps/web/lib/apps/categories/getServerSideProps.tsx
+++ b/apps/web/lib/apps/categories/getServerSideProps.tsx
@@ -1,0 +1,35 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getAppRegistry, getAppRegistryWithCredentials } from "@calcom/app-store/_appRegistry";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+
+import { ssrInit } from "@server/lib/ssr";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const { req, res } = context;
+
+  const ssr = await ssrInit(context);
+
+  const session = await getServerSession({ req, res });
+
+  let appStore;
+  if (session?.user?.id) {
+    appStore = await getAppRegistryWithCredentials(session.user.id);
+  } else {
+    appStore = await getAppRegistry();
+  }
+
+  const categories = appStore.reduce((c, app) => {
+    for (const category of app.categories) {
+      c[category] = c[category] ? c[category] + 1 : 1;
+    }
+    return c;
+  }, {} as Record<string, number>);
+
+  return {
+    props: {
+      categories: Object.entries(categories).map(([name, count]) => ({ name, count })),
+      trpcState: ssr.dehydrate(),
+    },
+  };
+};

--- a/apps/web/lib/apps/getServerSideProps.tsx
+++ b/apps/web/lib/apps/getServerSideProps.tsx
@@ -1,0 +1,52 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getAppRegistry, getAppRegistryWithCredentials } from "@calcom/app-store/_appRegistry";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import getUserAdminTeams from "@calcom/features/ee/teams/lib/getUserAdminTeams";
+import type { UserAdminTeams } from "@calcom/features/ee/teams/lib/getUserAdminTeams";
+import type { AppCategories } from "@calcom/prisma/enums";
+
+import { ssrInit } from "@server/lib/ssr";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const { req, res } = context;
+
+  const ssr = await ssrInit(context);
+
+  const session = await getServerSession({ req, res });
+
+  let appStore, userAdminTeams: UserAdminTeams;
+  if (session?.user?.id) {
+    userAdminTeams = await getUserAdminTeams({ userId: session.user.id, getUserInfo: true });
+    appStore = await getAppRegistryWithCredentials(session.user.id, userAdminTeams);
+  } else {
+    appStore = await getAppRegistry();
+    userAdminTeams = [];
+  }
+
+  const categoryQuery = appStore.map(({ categories }) => ({
+    categories: categories || [],
+  }));
+  const categories = categoryQuery.reduce((c, app) => {
+    for (const category of app.categories) {
+      c[category] = c[category] ? c[category] + 1 : 1;
+    }
+    return c;
+  }, {} as Record<string, number>);
+
+  return {
+    props: {
+      categories: Object.entries(categories)
+        .map(([name, count]): { name: AppCategories; count: number } => ({
+          name: name as AppCategories,
+          count,
+        }))
+        .sort(function (a, b) {
+          return b.count - a.count;
+        }),
+      appStore,
+      userAdminTeams,
+      trpcState: ssr.dehydrate(),
+    },
+  };
+};

--- a/apps/web/lib/apps/installed/[category]/getServerSideProps.tsx
+++ b/apps/web/lib/apps/installed/[category]/getServerSideProps.tsx
@@ -1,0 +1,43 @@
+import type { GetServerSidePropsContext } from "next";
+import { z } from "zod";
+
+import { AppCategories } from "@calcom/prisma/enums";
+
+export type querySchemaType = z.infer<typeof querySchema>;
+
+export const querySchema = z.object({
+  category: z.nativeEnum(AppCategories),
+});
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  // get return-to cookie and redirect if needed
+  const { cookies } = ctx.req;
+
+  const returnTo = cookies["return-to"];
+
+  if (cookies && returnTo) {
+    ctx.res.setHeader("Set-Cookie", "return-to=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT");
+    const redirect = {
+      redirect: {
+        destination: `${returnTo}`,
+        permanent: false,
+      },
+    } as const;
+
+    return redirect;
+  }
+
+  const params = querySchema.safeParse(ctx.params);
+
+  if (!params.success) {
+    const notFound = { notFound: true } as const;
+
+    return notFound;
+  }
+
+  return {
+    props: {
+      category: params.data.category,
+    },
+  };
+}

--- a/apps/web/lib/apps/installed/getServerSideProps.tsx
+++ b/apps/web/lib/apps/installed/getServerSideProps.tsx
@@ -1,0 +1,3 @@
+export async function getServerSideProps() {
+  return { redirect: { permanent: false, destination: "/apps/installed/calendar" } };
+}

--- a/apps/web/lib/buildLegacyCtx.tsx
+++ b/apps/web/lib/buildLegacyCtx.tsx
@@ -1,23 +1,17 @@
+import type { SearchParams } from "app/_types";
 import { type Params } from "app/_types";
 import type { GetServerSidePropsContext } from "next";
 import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 
-// returns query object same as ctx.query but for app dir
-export const getQuery = (url: string, params: Params) => {
-  if (!url.length) {
-    return params;
-  }
-
-  const { searchParams } = new URL(url);
-  const searchParamsObj = Object.fromEntries(searchParams.entries());
-
-  return { ...searchParamsObj, ...params };
-};
-
-export const buildLegacyCtx = (headers: ReadonlyHeaders, cookies: ReadonlyRequestCookies, params: Params) => {
+export const buildLegacyCtx = (
+  headers: ReadonlyHeaders,
+  cookies: ReadonlyRequestCookies,
+  params: Params,
+  searchParams: SearchParams
+) => {
   return {
-    query: getQuery(headers.get("x-url") ?? "", params),
+    query: { ...searchParams, ...params },
     params,
     req: { headers, cookies },
   } as unknown as GetServerSidePropsContext;

--- a/apps/web/lib/buildLegacyCtx.tsx
+++ b/apps/web/lib/buildLegacyCtx.tsx
@@ -1,4 +1,5 @@
 import { type Params } from "app/_types";
+import type { GetServerSidePropsContext } from "next";
 import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 
@@ -19,5 +20,5 @@ export const buildLegacyCtx = (headers: ReadonlyHeaders, cookies: ReadonlyReques
     query: getQuery(headers.get("x-url") ?? "", params),
     params,
     req: { headers, cookies },
-  };
+  } as unknown as GetServerSidePropsContext;
 };

--- a/apps/web/lib/buildLegacyCtx.tsx
+++ b/apps/web/lib/buildLegacyCtx.tsx
@@ -4,15 +4,50 @@ import type { GetServerSidePropsContext } from "next";
 import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 
+const createProxifiedObject = (object: Record<string, string>) =>
+  new Proxy(object, {
+    set: () => {
+      throw new Error("You are trying to modify 'headers' or 'cookies', which is not supported in app dir");
+    },
+  });
+
+const buildLegacyHeaders = (headers: ReadonlyHeaders) => {
+  const headersObject = Object.fromEntries(headers.entries());
+
+  return createProxifiedObject(headersObject);
+};
+
+const buildLegacyCookies = (cookies: ReadonlyRequestCookies) => {
+  const cookiesObject = cookies.getAll().reduce<Record<string, string>>((acc, { name, value }) => {
+    acc[name] = value;
+    return acc;
+  }, {});
+
+  return createProxifiedObject(cookiesObject);
+};
+
 export const buildLegacyCtx = (
   headers: ReadonlyHeaders,
   cookies: ReadonlyRequestCookies,
   params: Params,
   searchParams: SearchParams
 ) => {
-  return {
-    query: { ...searchParams, ...params },
-    params,
-    req: { headers, cookies },
-  } as unknown as GetServerSidePropsContext;
+  return new Proxy<Record<string, any>>(
+    {
+      query: { ...searchParams, ...params },
+      params,
+      req: { headers: buildLegacyHeaders(headers), cookies: buildLegacyCookies(cookies) },
+    },
+    {
+      get(obj, prop) {
+        if (prop === "res") {
+          throw new Error(
+            "You are trying to access the 'res' property of the context, which is not supported in app dir"
+          );
+        }
+
+        return obj[prop as keyof typeof obj];
+      },
+    }
+  ) as unknown as GetServerSidePropsContext;
 };

--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -1,0 +1,123 @@
+import type { GetServerSidePropsContext } from "next";
+import { z } from "zod";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { getBookingForReschedule, getMultipleDurationValue } from "@calcom/features/bookings/lib/get-booking";
+import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
+import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
+import slugify from "@calcom/lib/slugify";
+import prisma from "@calcom/prisma";
+
+import type { inferSSRProps } from "@lib/types/inferSSRProps";
+import type { EmbedProps } from "@lib/withEmbedSsr";
+
+export type PageProps = inferSSRProps<typeof getServerSideProps> & EmbedProps;
+
+async function getUserPageProps(context: GetServerSidePropsContext) {
+  const session = await getServerSession(context);
+  const { link, slug } = paramsSchema.parse(context.params);
+  const { rescheduleUid, duration: queryDuration } = context.query;
+  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req);
+  const org = isValidOrgDomain ? currentOrgDomain : null;
+
+  const { ssrInit } = await import("@server/lib/ssr");
+  const ssr = await ssrInit(context);
+
+  const hashedLink = await prisma.hashedLink.findUnique({
+    where: {
+      link,
+    },
+    select: {
+      eventTypeId: true,
+      eventType: {
+        select: {
+          users: {
+            select: {
+              username: true,
+            },
+          },
+          team: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const username = hashedLink?.eventType.users[0]?.username;
+
+  if (!hashedLink || !username) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const user = await prisma.user.findFirst({
+    where: {
+      username,
+      organization: isValidOrgDomain
+        ? {
+            slug: currentOrgDomain,
+          }
+        : null,
+    },
+    select: {
+      away: true,
+      hideBranding: true,
+    },
+  });
+
+  if (!user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  let booking: GetBookingType | null = null;
+  if (rescheduleUid) {
+    booking = await getBookingForReschedule(`${rescheduleUid}`, session?.user?.id);
+  }
+
+  const isTeamEvent = !!hashedLink.eventType?.team?.id;
+
+  // We use this to both prefetch the query on the server,
+  // as well as to check if the event exist, so we c an show a 404 otherwise.
+  const eventData = await ssr.viewer.public.event.fetch({ username, eventSlug: slug, isTeamEvent, org });
+
+  if (!eventData) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      entity: eventData.entity,
+      duration: getMultipleDurationValue(
+        eventData.metadata?.multipleDuration,
+        queryDuration,
+        eventData.length
+      ),
+      booking,
+      away: user?.away,
+      user: username,
+      slug,
+      trpcState: ssr.dehydrate(),
+      isBrandingHidden: user?.hideBranding,
+      // Sending the team event from the server, because this template file
+      // is reused for both team and user events.
+      isTeamEvent,
+      hashedLink: link,
+    },
+  };
+}
+
+const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
+
+// Booker page fetches a tiny bit of data server side, to determine early
+// whether the page should show an away state or dynamic booking not allowed.
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  return await getUserPageProps(context);
+};

--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -48,10 +48,12 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
 
   const username = hashedLink?.eventType.users[0]?.username;
 
+  const notFound = {
+    notFound: true,
+  } as const;
+
   if (!hashedLink || !username) {
-    return {
-      notFound: true,
-    };
+    return notFound;
   }
 
   const user = await prisma.user.findFirst({
@@ -70,9 +72,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   });
 
   if (!user) {
-    return {
-      notFound: true,
-    };
+    return notFound;
   }
 
   let booking: GetBookingType | null = null;
@@ -87,9 +87,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   const eventData = await ssr.viewer.public.event.fetch({ username, eventSlug: slug, isTeamEvent, org });
 
   if (!eventData) {
-    return {
-      notFound: true,
-    };
+    return notFound;
   }
 
   return {

--- a/apps/web/lib/event-types/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/event-types/[type]/getServerSideProps.tsx
@@ -1,0 +1,42 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+
+import { asStringOrThrow } from "@lib/asStringOrNull";
+import type { inferSSRProps } from "@lib/types/inferSSRProps";
+
+import { ssrInit } from "@server/lib/ssr";
+
+export type PageProps = inferSSRProps<typeof getServerSideProps>;
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const { req, res, query } = context;
+
+  const session = await getServerSession({ req, res });
+
+  const typeParam = parseInt(asStringOrThrow(query.type));
+  const ssr = await ssrInit(context);
+
+  if (Number.isNaN(typeParam)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (!session?.user?.id) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/auth/login",
+      },
+    };
+  }
+
+  await ssr.viewer.eventTypes.get.prefetch({ id: typeParam });
+  return {
+    props: {
+      type: typeParam,
+      trpcState: ssr.dehydrate(),
+    },
+  };
+};

--- a/apps/web/lib/getting-started/[[...step]]/getServerSideProps.tsx
+++ b/apps/web/lib/getting-started/[[...step]]/getServerSideProps.tsx
@@ -1,0 +1,59 @@
+import type { GetServerSidePropsContext } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+import { getLocale } from "@calcom/features/auth/lib/getLocale";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import prisma from "@calcom/prisma";
+
+import { ssrInit } from "@server/lib/ssr";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const { req, res } = context;
+
+  const session = await getServerSession({ req, res });
+
+  if (!session?.user?.id) {
+    return { redirect: { permanent: false, destination: "/auth/login" } };
+  }
+
+  const ssr = await ssrInit(context);
+
+  await ssr.viewer.me.prefetch();
+
+  const user = await prisma.user.findUnique({
+    where: {
+      id: session.user.id,
+    },
+    select: {
+      completedOnboarding: true,
+      teams: {
+        select: {
+          accepted: true,
+          team: {
+            select: {
+              id: true,
+              name: true,
+              logo: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    throw new Error("User from session not found");
+  }
+
+  if (user.completedOnboarding) {
+    return { redirect: { permanent: false, destination: "/event-types" } };
+  }
+  const locale = await getLocale(context.req);
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"])),
+      trpcState: ssr.dehydrate(),
+      hasPendingInvites: user.teams.find((team) => team.accepted === false) ?? false,
+    },
+  };
+};

--- a/apps/web/lib/teams/getServerSideProps.tsx
+++ b/apps/web/lib/teams/getServerSideProps.tsx
@@ -1,0 +1,25 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+
+import { ssrInit } from "@server/lib/ssr";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const ssr = await ssrInit(context);
+  await ssr.viewer.me.prefetch();
+  const session = await getServerSession({ req: context.req, res: context.res });
+  const token = Array.isArray(context.query?.token) ? context.query.token[0] : context.query?.token;
+
+  const callbackUrl = token ? `/teams?token=${encodeURIComponent(token)}` : null;
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: callbackUrl ? `/auth/login?callbackUrl=${callbackUrl}` : "/auth/login",
+        permanent: false,
+      },
+    };
+  }
+
+  return { props: { trpcState: ssr.dehydrate() } };
+};

--- a/apps/web/lib/video/[uid]/getServerSideProps.tsx
+++ b/apps/web/lib/video/[uid]/getServerSideProps.tsx
@@ -1,0 +1,105 @@
+import MarkdownIt from "markdown-it";
+import type { GetServerSidePropsContext } from "next";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { getCalVideoReference } from "@calcom/features/get-cal-video-reference";
+import prisma, { bookingMinimalSelect } from "@calcom/prisma";
+
+import { ssrInit } from "@server/lib/ssr";
+
+const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const { req, res } = context;
+
+  const ssr = await ssrInit(context);
+
+  const booking = await prisma.booking.findUnique({
+    where: {
+      uid: context.query.uid as string,
+    },
+    select: {
+      ...bookingMinimalSelect,
+      uid: true,
+      description: true,
+      isRecorded: true,
+      user: {
+        select: {
+          id: true,
+          timeZone: true,
+          name: true,
+          email: true,
+          organization: {
+            select: {
+              calVideoLogo: true,
+            },
+          },
+        },
+      },
+      references: {
+        select: {
+          uid: true,
+          type: true,
+          meetingUrl: true,
+          meetingPassword: true,
+        },
+        where: {
+          type: "daily_video",
+        },
+      },
+    },
+  });
+
+  if (!booking || booking.references.length === 0 || !booking.references[0].meetingUrl) {
+    return {
+      redirect: {
+        destination: "/video/no-meeting-found",
+        permanent: false,
+      },
+    };
+  }
+
+  //daily.co calls have a 60 minute exit buffer when a user enters a call when it's not available it will trigger the modals
+  const now = new Date();
+  const exitDate = new Date(now.getTime() - 60 * 60 * 1000);
+
+  //find out if the meeting is in the past
+  const isPast = booking?.endTime <= exitDate;
+  if (isPast) {
+    return {
+      redirect: {
+        destination: `/video/meeting-ended/${booking?.uid}`,
+        permanent: false,
+      },
+    };
+  }
+
+  const bookingObj = Object.assign({}, booking, {
+    startTime: booking.startTime.toString(),
+    endTime: booking.endTime.toString(),
+  });
+
+  const session = await getServerSession({ req, res });
+
+  // set meetingPassword to null for guests
+  if (session?.user.id !== bookingObj.user?.id) {
+    bookingObj.references.forEach((bookRef) => {
+      bookRef.meetingPassword = null;
+    });
+  }
+  const videoReference = getCalVideoReference(bookingObj.references);
+
+  return {
+    props: {
+      meetingUrl: videoReference.meetingUrl ?? "",
+      ...(typeof videoReference.meetingPassword === "string" && {
+        meetingPassword: videoReference.meetingPassword,
+      }),
+      booking: {
+        ...bookingObj,
+        ...(bookingObj.description && { description: md.render(bookingObj.description) }),
+      },
+      trpcState: ssr.dehydrate(),
+    },
+  };
+}

--- a/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.tsx
+++ b/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.tsx
@@ -1,0 +1,49 @@
+import type { GetServerSidePropsContext } from "next";
+
+import prisma, { bookingMinimalSelect } from "@calcom/prisma";
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const booking = await prisma.booking.findUnique({
+    where: {
+      uid: context.query.uid as string,
+    },
+    select: {
+      ...bookingMinimalSelect,
+      uid: true,
+      user: {
+        select: {
+          credentials: true,
+        },
+      },
+      references: {
+        select: {
+          uid: true,
+          type: true,
+          meetingUrl: true,
+        },
+      },
+    },
+  });
+
+  if (!booking) {
+    const redirect = {
+      redirect: {
+        destination: "/video/no-meeting-found",
+        permanent: false,
+      },
+    } as const;
+
+    return redirect;
+  }
+
+  const bookingObj = Object.assign({}, booking, {
+    startTime: booking.startTime.toString(),
+    endTime: booking.endTime.toString(),
+  });
+
+  return {
+    props: {
+      booking: bookingObj,
+    },
+  };
+}

--- a/apps/web/lib/video/meeting-not-started/[uid]/getServerSideProps.tsx
+++ b/apps/web/lib/video/meeting-not-started/[uid]/getServerSideProps.tsx
@@ -1,0 +1,35 @@
+import type { GetServerSidePropsContext } from "next";
+
+import prisma, { bookingMinimalSelect } from "@calcom/prisma";
+
+// change the type
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const booking = await prisma.booking.findUnique({
+    where: {
+      uid: context.query.uid as string,
+    },
+    select: bookingMinimalSelect,
+  });
+
+  if (!booking) {
+    const redirect = {
+      redirect: {
+        destination: "/video/no-meeting-found",
+        permanent: false,
+      },
+    } as const;
+
+    return redirect;
+  }
+
+  const bookingObj = Object.assign({}, booking, {
+    startTime: booking.startTime.toString(),
+    endTime: booking.endTime.toString(),
+  });
+
+  return {
+    props: {
+      booking: bookingObj,
+    },
+  };
+}

--- a/apps/web/pages/apps/[slug]/index.tsx
+++ b/apps/web/pages/apps/[slug]/index.tsx
@@ -1,42 +1,20 @@
 "use client";
 
 import { Prisma } from "@prisma/client";
-import fs from "fs";
-import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
-import type { GetStaticPaths, GetStaticPropsContext } from "next";
+import type { GetStaticPaths } from "next";
 import Link from "next/link";
-import path from "path";
-import { z } from "zod";
 
-import { getAppWithMetadata } from "@calcom/app-store/_appRegistry";
-import { getAppAssetFullPath } from "@calcom/app-store/getAppAssetFullPath";
 import { IS_PRODUCTION } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 
+import { getStaticProps } from "@lib/apps/[slug]/getStaticProps";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 
 import PageWrapper from "@components/PageWrapper";
 import App from "@components/apps/App";
 
 const md = new MarkdownIt("default", { html: true, breaks: true });
-
-const sourceSchema = z.object({
-  content: z.string(),
-  data: z.object({
-    description: z.string().optional(),
-    items: z
-      .array(
-        z.union([
-          z.string(),
-          z.object({
-            iframe: z.object({ src: z.string() }),
-          }),
-        ])
-      )
-      .optional(),
-  }),
-});
 
 function SingleAppPage(props: inferSSRProps<typeof getStaticProps>) {
   // If it's not production environment, it would be a better idea to inform that the App is disabled.
@@ -113,69 +91,7 @@ export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
   };
 };
 
-export const getStaticProps = async (ctx: GetStaticPropsContext) => {
-  if (typeof ctx.params?.slug !== "string") return { notFound: true };
-
-  const appMeta = await getAppWithMetadata({
-    slug: ctx.params?.slug,
-  });
-
-  const appFromDb = await prisma.app.findUnique({
-    where: { slug: ctx.params.slug.toLowerCase() },
-  });
-
-  const isAppAvailableInFileSystem = appMeta;
-  const isAppDisabled = isAppAvailableInFileSystem && (!appFromDb || !appFromDb.enabled);
-
-  if (!IS_PRODUCTION && isAppDisabled) {
-    return {
-      props: {
-        isAppDisabled: true as const,
-        data: {
-          ...appMeta,
-        },
-      },
-    };
-  }
-
-  if (!appFromDb || !appMeta || isAppDisabled) return { notFound: true };
-
-  const isTemplate = appMeta.isTemplate;
-  const appDirname = path.join(isTemplate ? "templates" : "", appFromDb.dirName);
-  const README_PATH = path.join(process.cwd(), "..", "..", `packages/app-store/${appDirname}/DESCRIPTION.md`);
-  const postFilePath = path.join(README_PATH);
-  let source = "";
-
-  try {
-    source = fs.readFileSync(postFilePath).toString();
-    source = source.replace(/{DESCRIPTION}/g, appMeta.description);
-  } catch (error) {
-    /* If the app doesn't have a README we fallback to the package description */
-    console.log(`No DESCRIPTION.md provided for: ${appDirname}`);
-    source = appMeta.description;
-  }
-
-  const result = matter(source);
-  const { content, data } = sourceSchema.parse({ content: result.content, data: result.data });
-  if (data.items) {
-    data.items = data.items.map((item) => {
-      if (typeof item === "string") {
-        return getAppAssetFullPath(item, {
-          dirName: appMeta.dirName,
-          isTemplate: appMeta.isTemplate,
-        });
-      }
-      return item;
-    });
-  }
-  return {
-    props: {
-      isAppDisabled: false as const,
-      source: { content, data },
-      data: appMeta,
-    },
-  };
-};
+export { getStaticProps };
 
 SingleAppPage.PageWrapper = PageWrapper;
 

--- a/apps/web/pages/apps/categories/[category].tsx
+++ b/apps/web/pages/apps/categories/[category].tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { Prisma } from "@prisma/client";
-import type { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import type { InferGetStaticPropsType } from "next";
 import Link from "next/link";
 
-import { getAppRegistry } from "@calcom/app-store/_appRegistry";
 import Shell from "@calcom/features/shell/Shell";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import prisma from "@calcom/prisma";
 import { AppCategories } from "@calcom/prisma/enums";
 import { AppCard, SkeletonText } from "@calcom/ui";
+
+import { getStaticProps } from "@lib/apps/categories/[category]/getStaticProps";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -79,28 +80,4 @@ export const getStaticPaths = async () => {
   };
 };
 
-export const getStaticProps = async (context: GetStaticPropsContext) => {
-  const category = context.params?.category as AppCategories;
-
-  const appQuery = await prisma.app.findMany({
-    where: {
-      categories: {
-        has: category,
-      },
-    },
-    select: {
-      slug: true,
-    },
-  });
-
-  const dbAppsSlugs = appQuery.map((category) => category.slug);
-
-  const appStore = await getAppRegistry();
-
-  const apps = appStore.filter((app) => dbAppsSlugs.includes(app.slug));
-  return {
-    props: {
-      apps,
-    },
-  };
-};
+export { getStaticProps };

--- a/apps/web/pages/apps/index.tsx
+++ b/apps/web/pages/apps/index.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import type { GetServerSidePropsContext } from "next";
 import type { ChangeEventHandler } from "react";
 import { useState } from "react";
 
-import { getAppRegistry, getAppRegistryWithCredentials } from "@calcom/app-store/_appRegistry";
 import { getLayout } from "@calcom/features/MainLayout";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import getUserAdminTeams from "@calcom/features/ee/teams/lib/getUserAdminTeams";
-import type { UserAdminTeams } from "@calcom/features/ee/teams/lib/getUserAdminTeams";
 import { classNames } from "@calcom/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import type { AppCategories } from "@calcom/prisma/enums";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";
 import type { HorizontalTabItemProps } from "@calcom/ui";
 import {
@@ -24,10 +18,10 @@ import {
 } from "@calcom/ui";
 import { Search } from "@calcom/ui/components/icon";
 
+import { getServerSideProps } from "@lib/apps/getServerSideProps";
+
 import PageWrapper from "@components/PageWrapper";
 import AppsLayout from "@components/apps/layouts/AppsLayout";
-
-import { ssrInit } from "@server/lib/ssr";
 
 const tabs: HorizontalTabItemProps[] = [
   {
@@ -106,48 +100,7 @@ export default function Apps({
   );
 }
 
+export { getServerSideProps };
+
 Apps.PageWrapper = PageWrapper;
 Apps.getLayout = getLayout;
-
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const { req, res } = context;
-
-  const ssr = await ssrInit(context);
-
-  const session = await getServerSession({ req, res });
-
-  let appStore, userAdminTeams: UserAdminTeams;
-  if (session?.user?.id) {
-    userAdminTeams = await getUserAdminTeams({ userId: session.user.id, getUserInfo: true });
-    appStore = await getAppRegistryWithCredentials(session.user.id, userAdminTeams);
-  } else {
-    appStore = await getAppRegistry();
-    userAdminTeams = [];
-  }
-
-  const categoryQuery = appStore.map(({ categories }) => ({
-    categories: categories || [],
-  }));
-  const categories = categoryQuery.reduce((c, app) => {
-    for (const category of app.categories) {
-      c[category] = c[category] ? c[category] + 1 : 1;
-    }
-    return c;
-  }, {} as Record<string, number>);
-
-  return {
-    props: {
-      categories: Object.entries(categories)
-        .map(([name, count]): { name: AppCategories; count: number } => ({
-          name: name as AppCategories,
-          count,
-        }))
-        .sort(function (a, b) {
-          return b.count - a.count;
-        }),
-      appStore,
-      userAdminTeams,
-      trpcState: ssr.dehydrate(),
-    },
-  };
-};

--- a/apps/web/pages/apps/installed/[category].tsx
+++ b/apps/web/pages/apps/installed/[category].tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useReducer } from "react";
-import { z } from "zod";
 
 import DisconnectIntegrationModal from "@calcom/features/apps/components/DisconnectIntegrationModal";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { AppCategories } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
-import type { AppGetServerSidePropsContext } from "@calcom/types/AppGetServerSideProps";
 import { Button, EmptyScreen, AppSkeletonLoader as SkeletonLoader, ShellSubHeading } from "@calcom/ui";
 import type { LucideIcon } from "@calcom/ui/components/icon";
 import {
@@ -24,6 +22,8 @@ import {
 } from "@calcom/ui/components/icon";
 
 import { QueryCell } from "@lib/QueryCell";
+import type { querySchemaType } from "@lib/apps/installed/[category]/getServerSideProps";
+import { getServerSideProps } from "@lib/apps/installed/[category]/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
 import { AppList } from "@components/apps/AppList";
@@ -111,12 +111,6 @@ const IntegrationsContainer = ({
   );
 };
 
-const querySchema = z.object({
-  category: z.nativeEnum(AppCategories),
-});
-
-type querySchemaType = z.infer<typeof querySchema>;
-
 type ModalState = {
   isOpen: boolean;
   credentialId: null | number;
@@ -173,31 +167,6 @@ export default function InstalledApps() {
   );
 }
 
-// Server side rendering
-export async function getServerSideProps(ctx: AppGetServerSidePropsContext) {
-  // get return-to cookie and redirect if needed
-  const { cookies } = ctx.req;
-  if (cookies && cookies["return-to"]) {
-    const returnTo = cookies["return-to"];
-    if (returnTo) {
-      ctx.res.setHeader("Set-Cookie", "return-to=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT");
-      return {
-        redirect: {
-          destination: `${returnTo}`,
-          permanent: false,
-        },
-      };
-    }
-  }
-  const params = querySchema.safeParse(ctx.params);
-
-  if (!params.success) return { notFound: true };
-
-  return {
-    props: {
-      category: params.data.category,
-    },
-  };
-}
+export { getServerSideProps };
 
 InstalledApps.PageWrapper = PageWrapper;

--- a/apps/web/pages/apps/installed/index.tsx
+++ b/apps/web/pages/apps/installed/index.tsx
@@ -1,9 +1,7 @@
+export { getServerSideProps } from "@lib/apps/installed/getServerSideProps";
+
 function RedirectPage() {
   return;
-}
-
-export async function getServerSideProps() {
-  return { redirect: { permanent: false, destination: "/apps/installed/calendar" } };
 }
 
 export default RedirectPage;

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { Booker } from "@calcom/atoms";
 import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";

--- a/apps/web/pages/d/[link]/[slug].tsx
+++ b/apps/web/pages/d/[link]/[slug].tsx
@@ -1,24 +1,13 @@
-"use client";
 
-import type { GetServerSidePropsContext } from "next";
-import { z } from "zod";
+'use client'
 
 import { Booker } from "@calcom/atoms";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";
 import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
-import { getBookingForReschedule, getMultipleDurationValue } from "@calcom/features/bookings/lib/get-booking";
-import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
-import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import slugify from "@calcom/lib/slugify";
-import prisma from "@calcom/prisma";
 
-import type { inferSSRProps } from "@lib/types/inferSSRProps";
-import type { EmbedProps } from "@lib/withEmbedSsr";
+import { getServerSideProps, type PageProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
-
-export type PageProps = Omit<inferSSRProps<typeof getServerSideProps>, "trpcState"> & EmbedProps;
 
 export default function Type({
   slug,
@@ -56,114 +45,7 @@ export default function Type({
   );
 }
 
+export { getServerSideProps };
+
 Type.PageWrapper = PageWrapper;
 Type.isBookingPage = true;
-
-async function getUserPageProps(context: GetServerSidePropsContext) {
-  const session = await getServerSession(context);
-  const { link, slug } = paramsSchema.parse(context.params);
-  const { rescheduleUid, duration: queryDuration } = context.query;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
-
-  const { ssrInit } = await import("@server/lib/ssr");
-  const ssr = await ssrInit(context);
-
-  const hashedLink = await prisma.hashedLink.findUnique({
-    where: {
-      link,
-    },
-    select: {
-      eventTypeId: true,
-      eventType: {
-        select: {
-          users: {
-            select: {
-              username: true,
-            },
-          },
-          team: {
-            select: {
-              id: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  const username = hashedLink?.eventType.users[0]?.username;
-
-  if (!hashedLink || !username) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const user = await prisma.user.findFirst({
-    where: {
-      username,
-      organization: isValidOrgDomain
-        ? {
-            slug: currentOrgDomain,
-          }
-        : null,
-    },
-    select: {
-      away: true,
-      hideBranding: true,
-    },
-  });
-
-  if (!user) {
-    return {
-      notFound: true,
-    };
-  }
-
-  let booking: GetBookingType | null = null;
-  if (rescheduleUid) {
-    booking = await getBookingForReschedule(`${rescheduleUid}`, session?.user?.id);
-  }
-
-  const isTeamEvent = !!hashedLink.eventType?.team?.id;
-
-  // We use this to both prefetch the query on the server,
-  // as well as to check if the event exist, so we c an show a 404 otherwise.
-  const eventData = await ssr.viewer.public.event.fetch({ username, eventSlug: slug, isTeamEvent, org });
-
-  if (!eventData) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {
-      entity: eventData.entity,
-      duration: getMultipleDurationValue(
-        eventData.metadata?.multipleDuration,
-        queryDuration,
-        eventData.length
-      ),
-      booking,
-      away: user?.away,
-      user: username,
-      slug,
-      trpcState: ssr.dehydrate(),
-      isBrandingHidden: user?.hideBranding,
-      // Sending the team event from the server, because this template file
-      // is reused for both team and user events.
-      isTeamEvent,
-      hashedLink: link,
-    },
-  };
-}
-
-const paramsSchema = z.object({ link: z.string(), slug: z.string().transform((s) => slugify(s)) });
-
-// Booker page fetches a tiny bit of data server side, to determine early
-// whether the page should show an away state or dynamic booking not allowed.
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  return await getUserPageProps(context);
-};

--- a/apps/web/pages/org/[orgSlug]/[user]/[type]/embed.tsx
+++ b/apps/web/pages/org/[orgSlug]/[user]/[type]/embed.tsx
@@ -4,6 +4,6 @@ import withEmbedSsr from "@lib/withEmbedSsr";
 
 import { getServerSideProps as _getServerSideProps } from "../[type]";
 
-export { default } from "../[type]";
+export { default, type PageProps } from "../[type]";
 
 export const getServerSideProps = withEmbedSsr(_getServerSideProps);

--- a/apps/web/pages/teams/index.tsx
+++ b/apps/web/pages/teams/index.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import type { GetServerSidePropsContext } from "next";
-
 import { getLayout } from "@calcom/features/MainLayout";
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { TeamsListing } from "@calcom/features/ee/teams/components";
 import { ShellMain } from "@calcom/features/shell/Shell";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -14,7 +11,7 @@ import { Plus } from "@calcom/ui/components/icon";
 
 import PageWrapper from "@components/PageWrapper";
 
-import { ssrInit } from "@server/lib/ssr";
+export { getServerSideProps } from "@lib/teams/getServerSideProps";
 
 function Teams() {
   const { t } = useLocale();
@@ -41,27 +38,6 @@ function Teams() {
     </ShellMain>
   );
 }
-
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const ssr = await ssrInit(context);
-  await ssr.viewer.me.prefetch();
-  const session = await getServerSession({ req: context.req, res: context.res });
-  const token = Array.isArray(context.query?.token) ? context.query.token[0] : context.query?.token;
-
-  const callbackUrl = token ? `/teams?token=${encodeURIComponent(token)}` : null;
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: callbackUrl ? `/auth/login?callbackUrl=${callbackUrl}` : "/auth/login",
-        permanent: false,
-      },
-      props: {},
-    };
-  }
-
-  return { props: { trpcState: ssr.dehydrate() } };
-};
 
 Teams.requiresLicense = false;
 Teams.PageWrapper = PageWrapper;

--- a/apps/web/pages/video/meeting-ended/[uid].tsx
+++ b/apps/web/pages/video/meeting-ended/[uid].tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import type { NextPageContext } from "next";
-
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { detectBrowserTimeFormat } from "@calcom/lib/timeFormat";
-import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 import { Button, HeadSeo } from "@calcom/ui";
 import { ArrowRight, Calendar, X } from "@calcom/ui/components/icon";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
+import { getServerSideProps } from "@lib/video/meeting-ended/[uid]/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -66,48 +64,5 @@ export default function MeetingUnavailable(props: inferSSRProps<typeof getServer
   );
 }
 
+export { getServerSideProps };
 MeetingUnavailable.PageWrapper = PageWrapper;
-
-export async function getServerSideProps(context: NextPageContext) {
-  const booking = await prisma.booking.findUnique({
-    where: {
-      uid: context.query.uid as string,
-    },
-    select: {
-      ...bookingMinimalSelect,
-      uid: true,
-      user: {
-        select: {
-          credentials: true,
-        },
-      },
-      references: {
-        select: {
-          uid: true,
-          type: true,
-          meetingUrl: true,
-        },
-      },
-    },
-  });
-
-  if (!booking) {
-    return {
-      redirect: {
-        destination: "/video/no-meeting-found",
-        permanent: false,
-      },
-    };
-  }
-
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
-
-  return {
-    props: {
-      booking: bookingObj,
-    },
-  };
-}

--- a/apps/web/pages/video/meeting-not-started/[uid].tsx
+++ b/apps/web/pages/video/meeting-not-started/[uid].tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import type { NextPageContext } from "next";
-
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { detectBrowserTimeFormat } from "@calcom/lib/timeFormat";
-import prisma, { bookingMinimalSelect } from "@calcom/prisma";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";
 import { Button, HeadSeo, EmptyScreen } from "@calcom/ui";
 import { ArrowRight, Calendar, Clock } from "@calcom/ui/components/icon";
+
+import { getServerSideProps } from "@lib/video/meeting-not-started/[uid]/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -41,33 +40,6 @@ export default function MeetingNotStarted(props: inferSSRProps<typeof getServerS
   );
 }
 
+export { getServerSideProps };
+
 MeetingNotStarted.PageWrapper = PageWrapper;
-
-export async function getServerSideProps(context: NextPageContext) {
-  const booking = await prisma.booking.findUnique({
-    where: {
-      uid: context.query.uid as string,
-    },
-    select: bookingMinimalSelect,
-  });
-
-  if (!booking) {
-    return {
-      redirect: {
-        destination: "/video/no-meeting-found",
-        permanent: false,
-      },
-    };
-  }
-
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
-
-  return {
-    props: {
-      booking: bookingObj,
-    },
-  };
-}

--- a/apps/web/playwright/organization/organization-invitation.e2e.ts
+++ b/apps/web/playwright/organization/organization-invitation.e2e.ts
@@ -395,11 +395,11 @@ async function signupFromEmailInviteLink({
   signupPage.goto(inviteLink);
   await signupPage.locator(`[data-testid="signup-usernamefield"]`).waitFor({ state: "visible" });
   await expect(signupPage.locator(`[data-testid="signup-usernamefield"]`)).toBeDisabled();
-  expect(await signupPage.locator(`[data-testid="signup-usernamefield"]`).inputValue()).toBe(
-    expectedUsername
-  );
+  // await for value. initial value is ""
+  await expect(signupPage.locator(`[data-testid="signup-usernamefield"]`)).toHaveValue(expectedUsername);
+
   await expect(signupPage.locator(`[data-testid="signup-emailfield"]`)).toBeDisabled();
-  expect(await signupPage.locator(`[data-testid="signup-emailfield"]`).inputValue()).toBe(expectedEmail);
+  await expect(signupPage.locator(`[data-testid="signup-emailfield"]`)).toHaveValue(expectedEmail);
 
   await signupPage.waitForLoadState("networkidle");
   // Check required fields

--- a/packages/app-store/alby/pages/setup/_getServerSideProps.tsx
+++ b/packages/app-store/alby/pages/setup/_getServerSideProps.tsx
@@ -7,7 +7,9 @@ import { getAlbyKeys } from "../../lib/getAlbyKeys";
 import type { IAlbySetupProps } from "./index";
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  if (typeof ctx.params?.slug !== "string") return { notFound: true } as const;
+  const notFound = { notFound: true } as const;
+
+  if (typeof ctx.params?.slug !== "string") return notFound;
 
   const { req, res } = ctx;
   const session = await getServerSession({ req, res });

--- a/packages/app-store/alby/pages/setup/_getServerSideProps.tsx
+++ b/packages/app-store/alby/pages/setup/_getServerSideProps.tsx
@@ -13,13 +13,15 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const session = await getServerSession({ req, res });
 
   if (!session?.user?.id) {
-    return res.writeHead(401).end();
+    const redirect = { redirect: { permanent: false, destination: "/auth/login" } } as const;
+
+    return redirect;
   }
 
   const credentials = await prisma.credential.findFirst({
     where: {
       type: "alby_payment",
-      userId: session.user.id,
+      userId: session?.user.id,
     },
   });
 

--- a/packages/app-store/make/pages/setup/_getServerSideProps.tsx
+++ b/packages/app-store/make/pages/setup/_getServerSideProps.tsx
@@ -7,7 +7,9 @@ export interface IMakeSetupProps {
 }
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  if (typeof ctx.params?.slug !== "string") return { notFound: true } as const;
+  const notFound = { notFound: true } as const;
+
+  if (typeof ctx.params?.slug !== "string") return notFound;
   let inviteLink = "";
   const appKeys = await getAppKeysFromSlug("make");
   if (typeof appKeys.invite_link === "string") inviteLink = appKeys.invite_link;

--- a/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
+++ b/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
@@ -1,7 +1,8 @@
 import type { GetServerSidePropsContext } from "next";
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  if (typeof ctx.params?.slug !== "string") return { notFound: true } as const;
+  const notFound = { notFound: true } as const;
+  if (typeof ctx.params?.slug !== "string") return notFound;
   const targetUrl = "https://dashboard.stripe.com/settings/connect";
   return {
     redirect: {

--- a/packages/app-store/zapier/pages/setup/_getServerSideProps.tsx
+++ b/packages/app-store/zapier/pages/setup/_getServerSideProps.tsx
@@ -7,7 +7,9 @@ export interface IZapierSetupProps {
 }
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  if (typeof ctx.params?.slug !== "string") return { notFound: true } as const;
+  const notFound = { notFound: true } as const;
+
+  if (typeof ctx.params?.slug !== "string") return notFound;
   let inviteLink = "";
   const appKeys = await getAppKeysFromSlug("zapier");
   if (typeof appKeys.invite_link === "string") inviteLink = appKeys.invite_link;

--- a/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
+++ b/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
@@ -14,6 +14,9 @@ import {
   rescheduleEvent,
 } from "../lib/testUtils";
 
+// in parallel mode sometimes handleNewBooking endpoint throws "No available users found" error, this never happens in serial mode. 
+test.describe.configure({ mode: "serial" });
+
 async function bookFirstFreeUserEventThroughEmbed({
   addEmbedListeners,
   page,


### PR DESCRIPTION
## What does this PR do?

This PR add 2 High order functions: withAppDirSsr and withAppDirSsg that can be used to wrap legacy getServerSideProps and getStaticProps.  
This PR moves legacy getStaticProps and getServerSideProps function to separate file. This is needed because we cannot import anything from file that has module level "use client" to the future page that is React Server Component. 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

