### PR TITLE
feat: upgrade react query 5

### DIFF
--- a/apps/web/app/_trpc/trpc-provider.tsx
+++ b/apps/web/app/_trpc/trpc-provider.tsx
@@ -1,7 +1,8 @@
-import { type DehydratedState, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type DehydratedState, QueryClient, QueryClientProvider, QueryCache } from "@tanstack/react-query";
 import { HydrateClient } from "app/_trpc/HydrateClient";
 import { trpc } from "app/_trpc/client";
 import { useState } from "react";
+import toast from "react-hot-toast";
 import superjson from "superjson";
 
 import { httpBatchLink } from "@calcom/trpc/client/links/httpBatchLink";
@@ -43,6 +44,13 @@ export const TrpcProvider: React.FC<{ children: React.ReactNode; dehydratedState
     () =>
       new QueryClient({
         defaultOptions: { queries: { staleTime: 5000 } },
+        queryCache: new QueryCache({
+          onError: (_error, query: { meta?: { errorMessage?: string } }) => {
+            if (query.meta?.errorMessage) {
+              toast.error(query.meta.errorMessage);
+            }
+          },
+        }),
       })
   );
   const url =

--- a/apps/web/components/eventtype/EventAvailabilityTab.tsx
+++ b/apps/web/components/eventtype/EventAvailabilityTab.tsx
@@ -241,8 +241,9 @@ const EventTypeSchedule = ({ eventType }: { eventType: EventTypeSetup }) => {
           {t("availability")}
           {shouldLockIndicator("availability")}
         </label>
-        {isLoading && <SelectSkeletonLoader />}
-        {!isLoading && (
+        {isLoading ? (
+          <SelectSkeletonLoader />
+        ) : (
           <Controller
             name="schedule"
             render={({ field }) => {

--- a/apps/web/components/eventtype/EventAvailabilityTab.tsx
+++ b/apps/web/components/eventtype/EventAvailabilityTab.tsx
@@ -192,7 +192,11 @@ const useListScheduleOptions = ({
     });
   }
 
-  if (isChildrenManagedEventType && watchSchedule && !options.find((option) => option.id === watchSchedule)) {
+  if (
+    isChildrenManagedEventType &&
+    watchSchedule &&
+    !options.find((option) => option.value === watchSchedule)
+  ) {
     options.push({
       value: watchSchedule,
       label: eventType.scheduleName ?? t("default_schedule_name"),


### PR DESCRIPTION
## What does this PR do?

* Allow toast errors through custom meta in the useQuery hook.
* Remove the onSuccess callback from the useQuery listSchedules.
* BUGFIX: When selecting the default option, it will now unset the schedule; so it will change upon changing the default. (Before this fix the schedule would not be changed after toggling the select options, as the schedule id would be set in the DB)