### PR TITLE
feat: Add profile table

### DIFF
--- a/apps/web/lib/orgMigration.test.ts
+++ b/apps/web/lib/orgMigration.test.ts
@@ -1589,10 +1589,13 @@ async function createTeamOutsideOrg(
   });
 }
 
-async function createUserOutsideOrg(data: Omit<Prisma.UserCreateArgs["data"], "organization">) {
+async function createUserOutsideOrg(
+  data: Omit<Prisma.UserCreateArgs["data"], "organization" | "movedToProfile">
+) {
   return await prismock.user.create({
     data: {
       ...data,
+      movedToProfileId: null,
       organizationId: null,
     },
   });
@@ -1625,6 +1628,7 @@ async function createUserInsideTheOrg(
           id: orgId,
         },
       },
+      movedToProfileId: null,
     },
   });
 }

--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -113,6 +113,7 @@ export const buildEventType = (eventType?: Partial<EventType>): EventType => {
     successRedirectUrl: null,
     bookingFields: [],
     parentId: null,
+    profileId: null,
     ...eventType,
   };
 };
@@ -236,6 +237,7 @@ export const buildUser = <T extends Partial<UserPayload>>(user?: T): UserPayload
     organizationId: null,
     allowSEOIndexing: null,
     receiveMonthlyDigestEmail: null,
+    movedToProfileId: null,
     ...user,
   };
 };

--- a/packages/prisma/migrations/20240126072041_add_profile_and_relations/migration.sql
+++ b/packages/prisma/migrations/20240126072041_add_profile_and_relations/migration.sql
@@ -1,0 +1,67 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[movedToProfileId]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "EventType" ADD COLUMN     "profileId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "movedToProfileId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+    "username" TEXT NOT NULL,
+    "movedFromUserId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Profile_uid_idx" ON "Profile"("uid");
+
+-- CreateIndex
+CREATE INDEX "Profile_userId_idx" ON "Profile"("userId");
+
+-- CreateIndex
+CREATE INDEX "Profile_organizationId_idx" ON "Profile"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_organizationId_key" ON "Profile"("userId", "organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_movedFromUserId_key" ON "Profile"("movedFromUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_movedToProfileId_key" ON "users"("movedToProfileId");
+
+-- AddForeignKey
+ALTER TABLE "EventType" ADD CONSTRAINT "EventType_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_movedToProfileId_fkey" FOREIGN KEY ("movedToProfileId") REFERENCES "Profile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+WITH new_profile AS (
+  INSERT INTO "Profile" ("uid", "organizationId", "userId", "username", "movedFromUserId", "updatedAt")
+  SELECT "id" as "uid", "organizationId", "id" AS "userId", "username", "id" as "movedFromUserId", NOW()
+  FROM "users"
+  WHERE "organizationId" IS NOT NULL
+  RETURNING "uid", "userId", "id"
+)
+UPDATE "users"
+SET "movedToProfileId" = "new_profile"."id"
+FROM "new_profile"
+WHERE "users"."id" = "new_profile"."userId";

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -47,23 +47,28 @@ model Host {
 }
 
 model EventType {
-  id                              Int                     @id @default(autoincrement())
+  id          Int     @id @default(autoincrement())
   /// @zod.min(1)
-  title                           String
+  title       String
   /// @zod.custom(imports.eventTypeSlug)
-  slug                            String
-  description                     String?
-  position                        Int                     @default(0)
+  slug        String
+  description String?
+  position    Int     @default(0)
   /// @zod.custom(imports.eventTypeLocations)
-  locations                       Json?
+  locations   Json?
   /// @zod.min(1)
-  length                          Int
-  offsetStart                     Int                     @default(0)
-  hidden                          Boolean                 @default(false)
-  hosts                           Host[]
-  users                           User[]                  @relation("user_eventtype")
-  owner                           User?                   @relation("owner", fields: [userId], references: [id], onDelete: Cascade)
-  userId                          Int?
+  length      Int
+  offsetStart Int     @default(0)
+  hidden      Boolean @default(false)
+  hosts       Host[]
+  users       User[]  @relation("user_eventtype")
+  owner       User?   @relation("owner", fields: [userId], references: [id], onDelete: Cascade)
+  userId      Int?
+
+  // TODO: Rename to ownerProfile
+  profileId Int?
+  profile   Profile? @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
   team                            Team?                   @relation(fields: [teamId], references: [id], onDelete: Cascade)
   teamId                          Int?
   hashedLink                      HashedLink?
@@ -130,11 +135,11 @@ model EventType {
 }
 
 model Credential {
-  id     Int     @id @default(autoincrement())
+  id     Int    @id @default(autoincrement())
   // @@type is deprecated
   type   String
   key    Json
-  user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user   User?  @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int?
   team   Team?   @relation(fields: [teamId], references: [id], onDelete: Cascade)
   teamId Int?
@@ -185,6 +190,7 @@ enum UserPermissionRole {
   ADMIN
 }
 
+// It holds Personal Profiles of a User plus it has email, password and other core things
 model User {
   id                  Int                  @id @default(autoincrement())
   username            String?
@@ -260,22 +266,46 @@ model User {
   accessCodes          AccessCode[]
   bookingRedirects     OutOfOfficeEntry[]
   bookingRedirectsTo   OutOfOfficeEntry[]      @relation(name: "toUser")
-  // Linking account code for orgs v2
-  //linkedByUserId       Int?
-  //linkedBy             User?                   @relation("linked_account", fields: [linkedByUserId], references: [id], onDelete: Cascade)
-  //linkedUsers          User[]                  @relation("linked_account")*/
 
   // Used to lock the user account
-  locked Boolean @default(false)
+  locked           Boolean   @default(false)
+  profiles         Profile[]
+  movedToProfileId Int?
+  movedToProfile   Profile?  @relation("moved_to_profile", fields: [movedToProfileId], references: [id], onDelete: SetNull)
 
   @@unique([email])
   @@unique([email, username])
   @@unique([username, organizationId])
+  @@unique([movedToProfileId])
   @@index([username])
   @@index([emailVerified])
   @@index([identityProvider])
   @@index([identityProviderId])
   @@map(name: "users")
+}
+
+// It holds Organization Profiles
+model Profile {
+  id                 Int                     @id @default(autoincrement())
+  // uid allows us to set an identifier chosen by us which is helpful in migration when we create the Profile from User directly.
+  uid                String
+  userId             Int
+  user               User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId     Int
+  organization       Team                    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  username           String
+  eventTypes         EventType[]
+
+  movedFromUserId Int?
+  movedFromUser   User?        @relation("moved_to_profile")
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
+
+  @@unique([userId, organizationId])
+  @@unique([movedFromUserId])
+  @@index([uid])
+  @@index([userId])
+  @@index([organizationId])
 }
 
 model Team {
@@ -317,6 +347,7 @@ model Team {
   credentials          Credential[]
   accessCodes          AccessCode[]
   instantMeetingTokens InstantMeetingToken[]
+  orgProfiles          Profile[]
   pendingPayment       Boolean                 @default(false)
 
   @@unique([slug, parentId])
@@ -805,18 +836,18 @@ model WorkflowStep {
 }
 
 model Workflow {
-  id       Int                     @id @default(autoincrement())
-  position Int                     @default(0)
-  name     String
-  userId   Int?
-  user     User?                   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  team     Team?                   @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  teamId   Int?
-  activeOn WorkflowsOnEventTypes[]
-  trigger  WorkflowTriggerEvents
-  time     Int?
-  timeUnit TimeUnit?
-  steps    WorkflowStep[]
+  id        Int                     @id @default(autoincrement())
+  position  Int                     @default(0)
+  name      String
+  userId    Int?
+  user      User?                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team      Team?                   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId    Int?
+  activeOn  WorkflowsOnEventTypes[]
+  trigger   WorkflowTriggerEvents
+  time      Int?
+  timeUnit  TimeUnit?
+  steps     WorkflowStep[]
 
   @@index([userId])
   @@index([teamId])
@@ -910,11 +941,11 @@ model BookingSeat {
 }
 
 model VerifiedNumber {
-  id          Int    @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   userId      Int?
-  user        User?  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user        User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
   teamId      Int?
-  team        Team?  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  team        Team?    @relation(fields: [teamId], references: [id], onDelete: Cascade)
   phoneNumber String
 
   @@index([userId])
@@ -1061,14 +1092,14 @@ model Avatar {
 }
 
 model OutOfOfficeEntry {
-  id       Int      @id @default(autoincrement())
-  uuid     String   @unique
-  start    DateTime
-  end      DateTime
-  userId   Int
-  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  toUserId Int?
-  toUser   User?    @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
+  id          Int      @id @default(autoincrement())
+  uuid        String   @unique
+  start       DateTime
+  end         DateTime
+  userId      Int
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  toUserId    Int?
+  toUser      User?    @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## What does this PR do?

- Adds Profile schema
- Copies organization users to Profile table.
- Adds profileId to event-type. Profile relations to other entities would be added later.


It is a pre-requisite for https://github.com/calcom/cal.com/pull/13002/files.

We should merge this first and deploy so that migrations can verified to be run successfully and be rolledback and fixed when needed.
