### PR TITLE
fix: Dynamic group booking  org-migration redirect

### DIFF
--- a/apps/web/pages/[user].tsx
+++ b/apps/web/pages/[user].tsx
@@ -318,7 +318,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
   const isOrgContext = isValidOrgDomain && currentOrgDomain;
   const dataFetchStart = Date.now();
   let outOfOffice = false;
-
+  const isDynamicGroup = usernameList.length > 1;
   if (usernameList.length === 1) {
     const result = await handleUserRedirection({ username: usernameList[0] });
     if (result && result.outOfOffice) {
@@ -326,6 +326,19 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     }
     if (result && result.redirect?.destination) {
       return result;
+    }
+  }
+
+  if (!isOrgContext) {
+    const redirect = await getTemporaryOrgRedirect({
+      slugs: usernameList,
+      redirectType: RedirectType.User,
+      eventTypeSlug: null,
+      currentQuery: context.query,
+    });
+
+    if (redirect) {
+      return redirect;
     }
   }
 
@@ -362,21 +375,6 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     },
   });
 
-  const isDynamicGroup = usersWithoutAvatar.length > 1;
-  if (isDynamicGroup) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: `/${usernameList.join("+")}/dynamic`,
-      },
-    } as {
-      redirect: {
-        permanent: false;
-        destination: string;
-      };
-    };
-  }
-
   const users = usersWithoutAvatar.map((user) => ({
     ...user,
     organization: {
@@ -386,17 +384,20 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     avatar: `/${user.username}/avatar.png`,
   }));
 
-  if (!isOrgContext) {
-    const redirect = await getTemporaryOrgRedirect({
-      slug: usernameList[0],
-      redirectType: RedirectType.User,
-      eventTypeSlug: null,
-      currentQuery: context.query,
-    });
-
-    if (redirect) {
-      return redirect;
-    }
+  if (isDynamicGroup) {
+    const destinationUrl = `/${usernameList.join("+")}/dynamic`;
+    logger.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);
+    return {
+      redirect: {
+        permanent: false,
+        destination: destinationUrl,
+      },
+    } as {
+      redirect: {
+        permanent: false;
+        destination: string;
+      };
+    };
   }
 
   if (!users.length || (!isValidOrgDomain && !users.some((user) => user.organizationId === null))) {

--- a/apps/web/pages/team/[slug].tsx
+++ b/apps/web/pages/team/[slug].tsx
@@ -294,7 +294,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   if (!isOrgContext && slug) {
     const redirect = await getTemporaryOrgRedirect({
-      slug: slug,
+      slugs: slug,
       redirectType: RedirectType.Team,
       eventTypeSlug: null,
       currentQuery: context.query,

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -81,7 +81,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   if (!isOrgContext) {
     const redirect = await getTemporaryOrgRedirect({
-      slug: teamSlug,
+      slugs: teamSlug,
       redirectType: RedirectType.Team,
       eventTypeSlug: meetingSlug,
       currentQuery: context.query,

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -268,11 +268,13 @@ test.describe("Teams - NonOrg", () => {
 
     // Mark team as private
     await page.goto(`/settings/teams/${team.id}/members`);
-    await page.click("[data-testid=make-team-private-check]");
-    await expect(page.locator(`[data-testid=make-team-private-check][data-state="checked"]`)).toBeVisible();
-    // according to switch implementation, checked state can be set before mutation is resolved
-    // so we need to await for req to resolve
-    await page.waitForResponse((res) => res.url().includes("/api/trpc/teams/update"));
+    await Promise.all([
+      page.click("[data-testid=make-team-private-check]"),
+      expect(page.locator(`[data-testid=make-team-private-check][data-state="checked"]`)).toBeVisible(),
+      // according to switch implementation, checked state can be set before mutation is resolved
+      // so we need to await for req to resolve
+      page.waitForResponse((res) => res.url().includes("/api/trpc/teams/update")),
+    ]);
 
     // Go to Team's page
     await page.goto(`/team/${team.slug}`);


### PR DESCRIPTION
## What does this PR do?

Fixes #13224

- Fixes the issue where two users who are moved to an org has broken dynamic group booking links with old slugs.
So, for  teampro -> tpro-org1 and teamfree -> tfree-org1,  the old link app.cal.local:3000/teamfree+teampro would correctly redirect to org1.cal.local:3000/tfree-org1+tpro-org1

- Updated existing unit tests and added more.


## Demo
https://www.loom.com/share/55d2e364d8be448bb5115c6f8e54237b

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Create org1
2. Migrate teampro -> tpro-org1 and teamfree -> tfree-org1
3. Access the old group booking link at app.cal.local:3000/teampro+teamfree and see that it correctly redirects to new usernames in org1.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

