### PR TITLE
fix: Org branding isnt centered in shell

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -892,7 +892,7 @@ function SideBar({ bannersHeight, user }: SideBarProps) {
         <div className="flex h-full flex-col justify-between py-3 lg:pt-4">
           <header className="todesktop:-mt-3 todesktop:flex-col-reverse todesktop:[-webkit-app-region:drag] items-center justify-between md:hidden lg:flex">
             {orgBranding ? (
-              <Link href="/settings/organizations/profile" className="mt-3 w-full px-1.5">
+              <Link href="/settings/organizations/profile" className="w-full px-1.5">
                 <div className="flex items-center gap-2 font-medium">
                   <Avatar
                     alt={`${orgBranding.name} logo`}


### PR DESCRIPTION
## What does this PR do?
Centered organization branding in shell 

Fixes #13225 

## Type of change
- Bug fix Centered organization branding in shell

![CAL-2930](https://github.com/calcom/cal.com/assets/72154969/263d1b66-1e9f-4919-a3d0-f0b0aa44cb51)
