### PR TITLE
fix: navbar bottom width mobile fix

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -765,7 +765,7 @@ const MobileNavigation = () => {
     <>
       <nav
         className={classNames(
-          "pwa:pb-[max(0.625rem,env(safe-area-inset-bottom))] pwa:-mx-2 bg-muted border-subtle fixed bottom-0 z-30 -mx-4 flex w-full border-t bg-opacity-40 px-1 shadow backdrop-blur-md md:hidden",
+          "pwa:pb-[max(0.625rem,env(safe-area-inset-bottom))] pwa:-mx-2 bg-muted border-subtle fixed bottom-0 z-30 flex w-full border-t bg-opacity-40 px-1 shadow backdrop-blur-md md:hidden",
           isEmbed && "hidden"
         )}>
         {mobileNavigationBottomItems.map((item) => (
@@ -995,11 +995,11 @@ export function ShellMain(props: LayoutProps) {
     <>
       {(props.heading || !!props.backPath) && (
         <div
-          className={classNames(
+          className={`${classNames(
             "flex items-center md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
             props.hideHeadingOnMobile ? "mb-0" : "mb-6"
-          )}>
+          )} px-2`}>
           {!!props.backPath && (
             <Button
               variant="icon"
@@ -1053,7 +1053,7 @@ export function ShellMain(props: LayoutProps) {
         </div>
       )}
       {props.afterHeading && <>{props.afterHeading}</>}
-      <div className={classNames(props.flexChildrenContainer && "flex flex-1 flex-col")}>
+      <div className={`${classNames(props.flexChildrenContainer && "flex flex-1 flex-col")} px-2`}>
         {props.children}
       </div>
     </>
@@ -1069,7 +1069,7 @@ function MainContainer({
     <main className="bg-default relative z-0 flex-1 focus:outline-none">
       {/* show top navigation for md and smaller (tablet and phones) */}
       {TopNavContainerProp}
-      <div className="max-w-full px-2 py-4 lg:px-6">
+      <div className="max-w-full py-4 lg:px-6">
         <ErrorBoundary>
           {!props.withoutMain ? <ShellMain {...props}>{props.children}</ShellMain> : props.children}
         </ErrorBoundary>

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -995,11 +995,11 @@ export function ShellMain(props: LayoutProps) {
     <>
       {(props.heading || !!props.backPath) && (
         <div
-          className={`${classNames(
-            "flex items-center md:mb-6 md:mt-0",
+          className={classNames(
+            "flex items-center px-2 md:mb-6 md:mt-0",
             props.smallHeading ? "lg:mb-7" : "lg:mb-8",
             props.hideHeadingOnMobile ? "mb-0" : "mb-6"
-          )} px-2`}>
+          )}>
           {!!props.backPath && (
             <Button
               variant="icon"
@@ -1053,7 +1053,7 @@ export function ShellMain(props: LayoutProps) {
         </div>
       )}
       {props.afterHeading && <>{props.afterHeading}</>}
-      <div className={`${classNames(props.flexChildrenContainer && "flex flex-1 flex-col")} px-2`}>
+      <div className={classNames(props.flexChildrenContainer && "flex flex-1 flex-col px-2")}>
         {props.children}
       </div>
     </>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- The parent having `px-2` is breaking the navbar bottom in mobile dues to it having `position:fixed`, the change is to remove `px-2` from the parent and add it to all its children except the navbar.

Fixes #13264 

Loom Video: https://www.loom.com/share/eb16ba8ceb9b46ba9ad5a4736c3d04c9?sid=edb1efdb-329b-4e8b-b72a-7d9b306c46b1

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Just open cal.com on prod or on local and navigate to `/` with an authenticated user.

## Mandatory Tasks

- [ x ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
