### PR TITLE
fix: mobile-navbar 

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -765,7 +765,7 @@ const MobileNavigation = () => {
     <>
       <nav
         className={classNames(
-          "pwa:pb-[max(0.625rem,env(safe-area-inset-bottom))] pwa:-mx-2 bg-muted border-subtle fixed bottom-0 z-30 -mx-4 flex w-full border-t bg-opacity-40 px-1 shadow backdrop-blur-md md:hidden",
+          "pwa:pb-[max(0.625rem,env(safe-area-inset-bottom))] pwa:-mx-2 bg-muted border-subtle fixed bottom-0 left-0 z-30 flex w-full border-t bg-opacity-40 px-1 shadow backdrop-blur-md md:hidden",
           isEmbed && "hidden"
         )}>
         {mobileNavigationBottomItems.map((item) => (


### PR DESCRIPTION
## What does this PR do?

 nav  with ```-mx-4``` has been removes, and set the position to ```left-0```,  which is relative to viewport


Fixes #13264

Loom Video: https://www.loom.com/share/bf1dd41ee1e14123b588fc24c338d96e?sid=eab45668-b0ce-4950-954e-ca0249f51109

