### PR TITLE
feat: Read event duration from URLs

### DIFF
--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -1,4 +1,5 @@
 import type { TFunction } from "next-i18next";
+import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { useBookerStore } from "@calcom/features/bookings/Booker/store";
@@ -34,6 +35,8 @@ const getDurationFormatted = (mins: number, t: TFunction) => {
 };
 
 export const EventDuration = ({ event }: { event: PublicEvent }) => {
+  const router = useRouter();
+
   const { t } = useLocale();
   const [selectedDuration, setSelectedDuration, state] = useBookerStore((state) => [
     state.selectedDuration,

--- a/packages/features/bookings/components/event-meta/Duration.tsx
+++ b/packages/features/bookings/components/event-meta/Duration.tsx
@@ -43,22 +43,33 @@ export const EventDuration = ({ event }: { event: PublicEvent }) => {
 
   const isDynamicEvent = "isDynamic" in event && event.isDynamic;
 
+  // Function to extract duration from URL
+  const getDurationFromURL = () => {
+    const pathParts = router.asPath.split("/");
+    const lastPart = pathParts[pathParts.length - 1];
+    return isNaN(parseInt(lastPart)) ? null : parseInt(lastPart);
+  };
+
   // Sets initial value of selected duration to the default duration.
   useEffect(() => {
-    // Only store event duration in url if event has multiple durations.
-    if (!selectedDuration && (event.metadata?.multipleDuration || isDynamicEvent))
-      setSelectedDuration(event.length);
+    const urlDuration = getDurationFromURL();
+    const defaultDurations = event?.metadata?.multipleDuration || [15, 30, 60];
+    const durationToSet = urlDuration && defaultDurations.includes(urlDuration) ? urlDuration : event.length;
+    if (!selectedDuration) setSelectedDuration(durationToSet);
   }, [selectedDuration, setSelectedDuration, event.metadata?.multipleDuration, event.length, isDynamicEvent]);
 
   if (!event?.metadata?.multipleDuration && !isDynamicEvent)
     return <>{getDurationFormatted(event.length, t)}</>;
 
   const durations = event?.metadata?.multipleDuration || [15, 30, 60];
+  const urlDuration = getDurationFromURL();
 
   return (
     <div className="flex flex-wrap gap-2">
       {durations
-        .filter((dur) => state !== "booking" || dur === selectedDuration)
+        .filter((dur) =>
+          urlDuration ? dur === urlDuration : state !== "booking" || dur === selectedDuration
+        )
         .map((duration) => (
           <Badge
             variant="gray"


### PR DESCRIPTION
## What does this PR do?
A quick summary of changes made: 
- The getDurationFromURL function extracts the duration from the URL.
- The useEffect sets the selectedDuration based on the URL parameter if it's valid and exists in the default options; otherwise, it sets the event's default length.
- The rendering logic now checks if a duration is specified in the URL. If so, it only displays that duration if it's one of the default options.

Please review the changes and let me know if there are any errors. 

Fixes #13233 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes