### PR TITLE
chore: [app-router-migration 38]: Refactor migrated pages and fix generateMetadata functions

### DIFF
--- a/apps/web/app/future/apps/categories/[category]/page.tsx
+++ b/apps/web/app/future/apps/categories/[category]/page.tsx
@@ -1,12 +1,9 @@
-import CategoryPage from "@pages/apps/categories/[category]";
+import CategoryPage, { getStaticProps, type PageProps } from "@pages/apps/categories/[category]";
 import { Prisma } from "@prisma/client";
+import { withAppDirSsg } from "app/WithAppDirSsg";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { notFound } from "next/navigation";
-import z from "zod";
 
-import { getAppRegistry } from "@calcom/app-store/_appRegistry";
 import { APP_NAME } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 import { AppCategories } from "@calcom/prisma/enums";
@@ -35,37 +32,7 @@ export const generateStaticParams = async () => {
   return paths.map((category) => ({ category }));
 };
 
-const querySchema = z.object({
-  category: z.nativeEnum(AppCategories),
-});
+const getData = withAppDirSsg<PageProps>(getStaticProps);
 
-const getPageProps = async (context: GetServerSidePropsContext) => {
-  const p = querySchema.safeParse(context.params);
-
-  if (!p.success) {
-    return notFound();
-  }
-
-  const appQuery = await prisma.app.findMany({
-    where: {
-      categories: {
-        has: p.data.category,
-      },
-    },
-    select: {
-      slug: true,
-    },
-  });
-
-  const dbAppsSlugs = appQuery.map((category) => category.slug);
-
-  const appStore = await getAppRegistry();
-
-  const apps = appStore.filter((app) => dbAppsSlugs.includes(app.slug));
-  return {
-    apps,
-  };
-};
-
-export default WithLayout({ getData: getPageProps, Page: CategoryPage, getLayout: null })<"P">;
+export default WithLayout({ getData, Page: CategoryPage, getLayout: null })<"P">;
 export const dynamic = "force-static";

--- a/apps/web/app/future/apps/categories/[category]/page.tsx
+++ b/apps/web/app/future/apps/categories/[category]/page.tsx
@@ -1,4 +1,4 @@
-import CategoryPage, { getStaticProps, type PageProps } from "@pages/apps/categories/[category]";
+import CategoryPage, { type PageProps } from "@pages/apps/categories/[category]";
 import { Prisma } from "@prisma/client";
 import { withAppDirSsg } from "app/WithAppDirSsg";
 import { _generateMetadata } from "app/_utils";
@@ -7,6 +7,8 @@ import { WithLayout } from "app/layoutHOC";
 import { APP_NAME } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
 import { AppCategories } from "@calcom/prisma/enums";
+
+import { getStaticProps } from "@lib/apps/categories/[category]/getStaticProps";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/future/enterprise/layout.tsx
+++ b/apps/web/app/future/enterprise/layout.tsx
@@ -1,5 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-import { getLayout } from "@calcom/features/MainLayoutAppDir";
-
-export default WithLayout({ getLayout })<"L">;

--- a/apps/web/app/future/enterprise/page.tsx
+++ b/apps/web/app/future/enterprise/page.tsx
@@ -1,4 +1,7 @@
 import { _generateMetadata } from "app/_utils";
+import { WithLayout } from "app/layoutHOC";
+
+import { getLayout } from "@calcom/features/MainLayoutAppDir";
 
 import EnterprisePage from "@components/EnterprisePage";
 
@@ -8,4 +11,4 @@ export const generateMetadata = async () =>
     (t) => t("create_your_org_description")
   );
 
-export default EnterprisePage;
+export default WithLayout({ getLayout, Page: EnterprisePage })<"P">;

--- a/apps/web/app/future/event-types/layout.tsx
+++ b/apps/web/app/future/event-types/layout.tsx
@@ -1,5 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-import { getLayout } from "@calcom/features/MainLayoutAppDir";
-
-export default WithLayout({ getLayout })<"L">;

--- a/apps/web/app/future/event-types/page.tsx
+++ b/apps/web/app/future/event-types/page.tsx
@@ -1,5 +1,8 @@
 import EventTypes from "@pages/event-types";
 import { _generateMetadata } from "app/_utils";
+import { WithLayout } from "app/layoutHOC";
+
+import { getLayout } from "@calcom/features/MainLayoutAppDir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -7,4 +10,4 @@ export const generateMetadata = async () =>
     (t) => t("event_types_page_subtitle")
   );
 
-export default EventTypes;
+export default WithLayout({ getLayout, Page: EventTypes })<"P">;

--- a/apps/web/app/future/insights/page.tsx
+++ b/apps/web/app/future/insights/page.tsx
@@ -1,11 +1,10 @@
-import LegacyPage from "@pages/insights/index";
+import LegacyPage, { getServerSideProps } from "@pages/insights/index";
 import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
 
-import { getServerSideProps } from "@lib/insights/getServerSideProps";
 import { type inferSSRProps } from "@lib/types/inferSSRProps";
 
 export const generateMetadata = async () =>
@@ -14,7 +13,6 @@ export const generateMetadata = async () =>
     (t) => t("insights_subtitle")
   );
 
-// @ts-expect-error TODO: fix this
 const getData = withAppDirSsr<inferSSRProps<typeof getServerSideProps>>(getServerSideProps);
 
 export default WithLayout({ getLayout, getData, Page: LegacyPage });

--- a/apps/web/app/future/insights/page.tsx
+++ b/apps/web/app/future/insights/page.tsx
@@ -1,10 +1,12 @@
 import LegacyPage from "@pages/insights/index";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { notFound } from "next/navigation";
 
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
-import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
+
+import { getServerSideProps } from "@lib/insights/getServerSideProps";
+import { type inferSSRProps } from "@lib/types/inferSSRProps";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -12,15 +14,7 @@ export const generateMetadata = async () =>
     (t) => t("insights_subtitle")
   );
 
-async function getData() {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-
-  if (flags.insights === false) {
-    return notFound();
-  }
-
-  return {};
-}
+// @ts-expect-error TODO: fix this
+const getData = withAppDirSsr<inferSSRProps<typeof getServerSideProps>>(getServerSideProps);
 
 export default WithLayout({ getLayout, getData, Page: LegacyPage });

--- a/apps/web/app/future/payment/[uid]/page.tsx
+++ b/apps/web/app/future/payment/[uid]/page.tsx
@@ -1,18 +1,10 @@
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { redirect, notFound } from "next/navigation";
-import { z } from "zod";
 
-import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import PaymentPage from "@calcom/features/ee/payments/components/PaymentPage";
-import { getClientSecretFromPayment } from "@calcom/features/ee/payments/pages/getClientSecretFromPayment";
+import { getServerSideProps, type PaymentPageProps } from "@calcom/features/ee/payments/pages/payment";
 import { APP_NAME } from "@calcom/lib/constants";
-import prisma from "@calcom/prisma";
-import { BookingStatus } from "@calcom/prisma/enums";
-import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
-
-import { ssrInit } from "@server/lib/ssr";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -21,147 +13,7 @@ export const generateMetadata = async () =>
     () => ""
   );
 
-const querySchema = z.object({
-  uid: z.string(),
-});
-
-async function getData(context: GetServerSidePropsContext) {
-  const session = await getServerSession({ req: context.req });
-
-  if (!session?.user?.id) {
-    return redirect("/auth/login");
-  }
-
-  const ssr = await ssrInit(context);
-  await ssr.viewer.me.prefetch();
-
-  const { uid } = querySchema.parse(context.params);
-  const rawPayment = await prisma.payment.findFirst({
-    where: {
-      uid,
-    },
-    select: {
-      data: true,
-      success: true,
-      uid: true,
-      refunded: true,
-      bookingId: true,
-      appId: true,
-      amount: true,
-      currency: true,
-      paymentOption: true,
-      booking: {
-        select: {
-          id: true,
-          uid: true,
-          description: true,
-          title: true,
-          startTime: true,
-          endTime: true,
-          attendees: {
-            select: {
-              email: true,
-              name: true,
-            },
-          },
-          eventTypeId: true,
-          location: true,
-          status: true,
-          rejectionReason: true,
-          cancellationReason: true,
-          eventType: {
-            select: {
-              id: true,
-              title: true,
-              description: true,
-              length: true,
-              eventName: true,
-              requiresConfirmation: true,
-              userId: true,
-              metadata: true,
-              users: {
-                select: {
-                  name: true,
-                  username: true,
-                  hideBranding: true,
-                  theme: true,
-                },
-              },
-              team: {
-                select: {
-                  name: true,
-                  hideBranding: true,
-                },
-              },
-              price: true,
-              currency: true,
-              successRedirectUrl: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  if (!rawPayment) {
-    return notFound();
-  }
-
-  const { data, booking: _booking, ...restPayment } = rawPayment;
-
-  const payment = {
-    ...restPayment,
-    data: data as Record<string, unknown>,
-  };
-
-  if (!_booking) {
-    return notFound();
-  }
-
-  const { startTime, endTime, eventType, ...restBooking } = _booking;
-  const booking = {
-    ...restBooking,
-    startTime: startTime.toString(),
-    endTime: endTime.toString(),
-  };
-
-  if (!eventType) {
-    return notFound();
-  }
-
-  if (eventType.users.length === 0 && !!!eventType.team) {
-    return notFound();
-  }
-
-  const [user] = eventType?.users.length
-    ? eventType.users
-    : [{ name: null, theme: null, hideBranding: null, username: null }];
-  const profile = {
-    name: eventType.team?.name || user?.name || null,
-    theme: (!eventType.team?.name && user?.theme) || null,
-    hideBranding: eventType.team?.hideBranding || user?.hideBranding || null,
-  };
-
-  if (
-    ([BookingStatus.CANCELLED, BookingStatus.REJECTED] as BookingStatus[]).includes(
-      booking.status as BookingStatus
-    )
-  ) {
-    return redirect(`/booking/${booking.uid}`);
-  }
-
-  return {
-    user,
-    eventType: {
-      ...eventType,
-      metadata: EventTypeMetaDataSchema.parse(eventType.metadata),
-    },
-    booking,
-    dehydratedState: ssr.dehydrate(),
-    payment,
-    clientSecret: getClientSecretFromPayment(payment),
-    profile,
-  };
-}
+// @ts-expect-error TODO: fix this
+const getData = withAppDirSsr<PaymentPageProps>(getServerSideProps);
 
 export default WithLayout({ getLayout: null, getData, Page: PaymentPage });

--- a/apps/web/app/future/payment/[uid]/page.tsx
+++ b/apps/web/app/future/payment/[uid]/page.tsx
@@ -13,7 +13,6 @@ export const generateMetadata = async () =>
     () => ""
   );
 
-// @ts-expect-error TODO: fix this
 const getData = withAppDirSsr<PaymentPageProps>(getServerSideProps);
 
 export default WithLayout({ getLayout: null, getData, Page: PaymentPage });

--- a/apps/web/app/future/reschedule/[uid]/embed/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/embed/page.tsx
@@ -1,11 +1,22 @@
 import { getServerSideProps } from "@pages/reschedule/[uid]";
-import OldPage from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
-import withEmbedSsrAppDir from "app/WithEmbedSSR";
-import { WithLayout } from "app/layoutHOC";
+import type { SearchParams } from "app/_types";
+import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import { cookies, headers } from "next/headers";
 
-const getData = withAppDirSsr(getServerSideProps);
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import withEmbedSsr from "@lib/withEmbedSsr";
 
-const getEmbedData = withEmbedSsrAppDir(getData);
+type PageProps = Readonly<{
+  params: Params;
+  searchParams: SearchParams;
+}>;
 
-export default WithLayout({ getLayout: null, getData: getEmbedData, Page: OldPage });
+const Page = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
+  await withAppDirSsr(withEmbedSsr(getServerSideProps))(legacyCtx);
+
+  return null;
+};
+
+export default Page;

--- a/apps/web/app/future/reschedule/[uid]/embed/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/embed/page.tsx
@@ -1,22 +1,11 @@
 import { getServerSideProps } from "@pages/reschedule/[uid]";
+import OldPage from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
-import type { SearchParams } from "app/_types";
-import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
-import { cookies, headers } from "next/headers";
+import withEmbedSsrAppDir from "app/WithEmbedSSR";
+import { WithLayout } from "app/layoutHOC";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
-import withEmbedSsr from "@lib/withEmbedSsr";
+const getData = withAppDirSsr(getServerSideProps);
 
-type PageProps = Readonly<{
-  params: Params;
-  searchParams: SearchParams;
-}>;
+const getEmbedData = withEmbedSsrAppDir(getData);
 
-const Page = async ({ params, searchParams }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
-  await withAppDirSsr(withEmbedSsr(getServerSideProps))(legacyCtx);
-
-  return null;
-};
-
-export default Page;
+export default WithLayout({ getLayout: null, getData: getEmbedData, Page: OldPage });

--- a/apps/web/app/future/reschedule/[uid]/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/page.tsx
@@ -1,7 +1,11 @@
-import OldPage, { getServerSideProps } from "@pages/reschedule/[uid]";
+import { getServerSideProps } from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
+import type { SearchParams } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { WithLayout } from "app/layoutHOC";
+import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import { headers, cookies } from "next/headers";
+
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -9,6 +13,19 @@ export const generateMetadata = async () =>
     () => ""
   );
 
+type PageProps = Readonly<{
+  params: Params;
+  searchParams: SearchParams;
+}>;
+
 const getData = withAppDirSsr(getServerSideProps);
 
-export default WithLayout({ getLayout: null, getData, Page: OldPage });
+const Page = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
+
+  await getData(legacyCtx);
+
+  return null;
+};
+
+export default Page;

--- a/apps/web/app/future/reschedule/[uid]/page.tsx
+++ b/apps/web/app/future/reschedule/[uid]/page.tsx
@@ -1,11 +1,7 @@
-import OldPage, { getServerSideProps as _getServerSideProps } from "@pages/reschedule/[uid]";
+import OldPage, { getServerSideProps } from "@pages/reschedule/[uid]";
 import { withAppDirSsr } from "app/WithAppDirSsr";
-import type { SearchParams } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
-import { headers, cookies } from "next/headers";
-
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { WithLayout } from "app/layoutHOC";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -13,19 +9,6 @@ export const generateMetadata = async () =>
     () => ""
   );
 
-type PageProps = Readonly<{
-  params: Params;
-  searchParams: SearchParams;
-}>;
+const getData = withAppDirSsr(getServerSideProps);
 
-const getData = withAppDirSsr(_getServerSideProps);
-
-const Page = async ({ params, searchParams }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
-
-  await getData(legacyCtx);
-
-  return <OldPage />;
-};
-
-export default Page;
+export default WithLayout({ getLayout: null, getData, Page: OldPage });

--- a/apps/web/app/future/settings/admin/users/add/page.tsx
+++ b/apps/web/app/future/settings/admin/users/add/page.tsx
@@ -1,6 +1,8 @@
 import { _generateMetadata } from "app/_utils";
+import { WithLayout } from "app/layoutHOC";
 
 import Page from "@calcom/features/ee/users/pages/users-add-view";
+import { getLayout } from "@calcom/features/settings/layouts/SettingsLayoutAppDir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -8,4 +10,4 @@ export const generateMetadata = async () =>
     () => "Here you can add a new user."
   );
 
-export default Page;
+export default WithLayout({ getLayout, Page })<"P">;

--- a/apps/web/app/future/settings/admin/users/layout.tsx
+++ b/apps/web/app/future/settings/admin/users/layout.tsx
@@ -1,5 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-import { getLayout } from "@calcom/features/settings/layouts/SettingsLayoutAppDir";
-
-export default WithLayout({ getLayout })<"L">;

--- a/apps/web/app/future/settings/admin/users/page.tsx
+++ b/apps/web/app/future/settings/admin/users/page.tsx
@@ -1,6 +1,8 @@
 import { _generateMetadata } from "app/_utils";
+import { WithLayout } from "app/layoutHOC";
 
 import Page from "@calcom/features/ee/users/pages/users-listing-view";
+import { getLayout } from "@calcom/features/settings/layouts/SettingsLayoutAppDir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -8,4 +10,4 @@ export const generateMetadata = async () =>
     () => "A list of all the users in your account including their name, title, email and role."
   );
 
-export default Page;
+export default WithLayout({ getLayout, Page })<"P">;

--- a/apps/web/app/future/settings/organizations/new/page.tsx
+++ b/apps/web/app/future/settings/organizations/new/page.tsx
@@ -1,10 +1,9 @@
-import LegacyPage, { WrappedCreateNewOrganizationPage } from "@pages/settings/organizations/new/index";
+import LegacyPage, { getServerSideProps, LayoutWrapperAppDir } from "@pages/settings/organizations/new/index";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { type GetServerSidePropsContext } from "next";
-import { notFound } from "next/navigation";
 
-import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
+import { type inferSSRProps } from "@lib/types/inferSSRProps";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -12,23 +11,9 @@ export const generateMetadata = async () =>
     (t) => t("organizations_description")
   );
 
-const getPageProps = async (context: GetServerSidePropsContext) => {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-  // Check if organizations are enabled
-  if (flags["organizations"] !== true) {
-    return notFound();
-  }
-
-  const querySlug = context.query.slug as string;
-
-  return {
-    querySlug: querySlug ?? null,
-  };
-};
-
 export default WithLayout({
-  getLayout: WrappedCreateNewOrganizationPage,
+  getLayout: LayoutWrapperAppDir,
   Page: LegacyPage,
-  getData: getPageProps,
+  // @ts-expect-error TODO: fix this
+  getData: withAppDirSsr<inferSSRProps<typeof getServerSideProps>>(getServerSideProps),
 });

--- a/apps/web/app/future/settings/organizations/new/page.tsx
+++ b/apps/web/app/future/settings/organizations/new/page.tsx
@@ -14,6 +14,5 @@ export const generateMetadata = async () =>
 export default WithLayout({
   getLayout: LayoutWrapperAppDir,
   Page: LegacyPage,
-  // @ts-expect-error TODO: fix this
   getData: withAppDirSsr<inferSSRProps<typeof getServerSideProps>>(getServerSideProps),
 });

--- a/apps/web/app/future/workflows/[workflow]/page.tsx
+++ b/apps/web/app/future/workflows/[workflow]/page.tsx
@@ -1,11 +1,9 @@
-import { getStaticProps } from "@pages/workflows/[workflow]";
+import LegacyPage, { getStaticProps } from "@pages/workflows/[workflow]";
 import { withAppDirSsg } from "app/WithAppDirSsg";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 import { type GetServerSidePropsContext } from "next";
 import { headers, cookies } from "next/headers";
-
-import LegacyPage from "@calcom/features/ee/workflows/pages/workflow";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
@@ -29,6 +27,7 @@ const getData = withAppDirSsg(getStaticProps);
 
 export const generateStaticParams = () => [];
 
+// @ts-expect-error TODO: fix this
 export default WithLayout({ getLayout: null, getData, Page: LegacyPage })<"P">;
 export const dynamic = "force-static";
 // generate segments on demand

--- a/apps/web/app/future/workflows/[workflow]/page.tsx
+++ b/apps/web/app/future/workflows/[workflow]/page.tsx
@@ -1,17 +1,13 @@
+import { getStaticProps } from "@pages/workflows/[workflow]";
+import { withAppDirSsg } from "app/WithAppDirSsg";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 import { type GetServerSidePropsContext } from "next";
 import { headers, cookies } from "next/headers";
-import { notFound } from "next/navigation";
-import { z } from "zod";
 
 import LegacyPage from "@calcom/features/ee/workflows/pages/workflow";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
-
-const querySchema = z.object({
-  workflow: z.string(),
-});
 
 export const generateMetadata = async ({
   params,
@@ -20,7 +16,7 @@ export const generateMetadata = async ({
   params: Record<string, string | string[]>;
   searchParams: { [key: string]: string | string[] | undefined };
 }) => {
-  const { workflow } = await getProps(
+  const { workflow } = await getData(
     buildLegacyCtx(headers(), cookies(), params, searchParams) as unknown as GetServerSidePropsContext
   );
   return await _generateMetadata(
@@ -29,19 +25,11 @@ export const generateMetadata = async ({
   );
 };
 
-async function getProps(context: GetServerSidePropsContext) {
-  const safeParams = querySchema.safeParse(context.params);
-
-  console.log("Built workflow page:", safeParams);
-  if (!safeParams.success) {
-    return notFound();
-  }
-  return { workflow: safeParams.data.workflow };
-}
+const getData = withAppDirSsg(getStaticProps);
 
 export const generateStaticParams = () => [];
 
-export default WithLayout({ getLayout: null, getData: getProps, Page: LegacyPage })<"P">;
+export default WithLayout({ getLayout: null, getData, Page: LegacyPage })<"P">;
 export const dynamic = "force-static";
 // generate segments on demand
 export const dynamicParams = true;

--- a/apps/web/lib/insights/getServerSideProps.tsx
+++ b/apps/web/lib/insights/getServerSideProps.tsx
@@ -8,10 +8,8 @@ export const getServerSideProps = async () => {
   if (flags.insights === false) {
     return {
       notFound: true,
-    };
+    } as const;
   }
 
-  return {
-    props: {},
-  };
+  return { props: {} };
 };

--- a/apps/web/lib/insights/getServerSideProps.tsx
+++ b/apps/web/lib/insights/getServerSideProps.tsx
@@ -1,0 +1,17 @@
+import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
+
+// If feature flag is disabled, return not found on getServerSideProps
+export const getServerSideProps = async () => {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
+
+  if (flags.insights === false) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {},
+  };
+};

--- a/apps/web/lib/settings/organizations/new/getServerSideProps.tsx
+++ b/apps/web/lib/settings/organizations/new/getServerSideProps.tsx
@@ -1,0 +1,22 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
+  // Check if organizations are enabled
+  if (flags["organizations"] !== true) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const querySlug = context.query.slug as string;
+
+  return {
+    props: {
+      querySlug: querySlug ?? null,
+    },
+  };
+};

--- a/apps/web/lib/settings/organizations/new/getServerSideProps.tsx
+++ b/apps/web/lib/settings/organizations/new/getServerSideProps.tsx
@@ -9,7 +9,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   if (flags["organizations"] !== true) {
     return {
       notFound: true,
-    };
+    } as const;
   }
 
   const querySlug = context.query.slug as string;

--- a/apps/web/lib/workflows/[workflow]/getStaticProps.tsx
+++ b/apps/web/lib/workflows/[workflow]/getStaticProps.tsx
@@ -1,0 +1,19 @@
+import type { GetStaticProps } from "next";
+import { z } from "zod";
+
+const querySchema = z.object({
+  workflow: z.string(),
+});
+
+export const getStaticProps: GetStaticProps = (ctx) => {
+  const params = querySchema.safeParse(ctx.params);
+  console.log("Built workflow page:", params);
+  if (!params.success) return { notFound: true };
+
+  return {
+    props: {
+      workflow: params.data.workflow,
+    },
+    revalidate: 10, // seconds
+  };
+};

--- a/apps/web/pages/apps/categories/[category].tsx
+++ b/apps/web/pages/apps/categories/[category].tsx
@@ -15,7 +15,8 @@ import { getStaticProps } from "@lib/apps/categories/[category]/getStaticProps";
 
 import PageWrapper from "@components/PageWrapper";
 
-export default function Apps({ apps }: InferGetStaticPropsType<typeof getStaticProps>) {
+export type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
+export default function Apps({ apps }: PageProps) {
   const searchParams = useCompatSearchParams();
   const { t, isLocaleReady } = useLocale();
   const category = searchParams?.get("category");

--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { getLayout } from "@calcom/features/MainLayout";
-import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
 import {
   AverageEventDurationChart,
   BookingKPICards,
@@ -19,6 +18,8 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc";
 import { Button, ButtonGroup } from "@calcom/ui";
 import { RefreshCcw, UserPlus, Users } from "@calcom/ui/components/icon";
+
+import { getServerSideProps } from "@lib/insights/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -106,18 +107,4 @@ export default function InsightsPage() {
 InsightsPage.PageWrapper = PageWrapper;
 InsightsPage.getLayout = getLayout;
 
-// If feature flag is disabled, return not found on getServerSideProps
-export const getServerSideProps = async () => {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-
-  if (flags.insights === false) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {},
-  };
-};
+export { getServerSideProps };

--- a/apps/web/pages/settings/organizations/new/index.tsx
+++ b/apps/web/pages/settings/organizations/new/index.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import type { GetServerSidePropsContext } from "next";
-
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { CreateANewOrganizationForm } from "@calcom/features/ee/organizations/components";
-import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { WizardLayout, Meta, WizardLayoutAppDir } from "@calcom/ui";
 
+import { getServerSideProps } from "@lib/settings/organizations/new/getServerSideProps";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 
 import PageWrapper from "@components/PageWrapper";
@@ -29,7 +27,7 @@ const LayoutWrapper = (page: React.ReactElement) => {
   );
 };
 
-export const WrappedCreateNewOrganizationPage = (page: React.ReactElement) => {
+export const LayoutWrapperAppDir = (page: React.ReactElement) => {
   return (
     <WizardLayoutAppDir currentStep={1} maxSteps={5}>
       {page}
@@ -37,26 +35,9 @@ export const WrappedCreateNewOrganizationPage = (page: React.ReactElement) => {
   );
 };
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-  // Check if organizations are enabled
-  if (flags["organizations"] !== true) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const querySlug = context.query.slug as string;
-
-  return {
-    props: {
-      querySlug: querySlug ?? null,
-    },
-  };
-};
-
 CreateNewOrganizationPage.getLayout = LayoutWrapper;
 CreateNewOrganizationPage.PageWrapper = PageWrapper;
 
 export default CreateNewOrganizationPage;
+
+export { getServerSideProps };

--- a/apps/web/pages/workflows/[workflow].tsx
+++ b/apps/web/pages/workflows/[workflow].tsx
@@ -1,27 +1,11 @@
-import type { GetStaticPaths, GetStaticProps } from "next";
-import { z } from "zod";
+import type { GetStaticPaths } from "next";
 
 import Workflow from "@calcom/features/ee/workflows/pages/workflow";
 
+import { getStaticProps } from "@lib/workflows/[workflow]/getStaticProps";
+
 import PageWrapper from "@components/PageWrapper";
 import type { CalPageWrapper } from "@components/PageWrapper";
-
-const querySchema = z.object({
-  workflow: z.string(),
-});
-
-export const getStaticProps: GetStaticProps = (ctx) => {
-  const params = querySchema.safeParse(ctx.params);
-  console.log("Built workflow page:", params);
-  if (!params.success) return { notFound: true };
-
-  return {
-    props: {
-      workflow: params.data.workflow,
-    },
-    revalidate: 10, // seconds
-  };
-};
 
 export const getStaticPaths: GetStaticPaths = () => {
   return {
@@ -34,3 +18,4 @@ const WorkflowsPage = Workflow as CalPageWrapper;
 WorkflowsPage.PageWrapper = PageWrapper;
 
 export default WorkflowsPage;
+export { getStaticProps };

--- a/apps/web/pages/workflows/[workflow].tsx
+++ b/apps/web/pages/workflows/[workflow].tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { GetStaticPaths } from "next";
 
 import Workflow from "@calcom/features/ee/workflows/pages/workflow";

--- a/packages/features/ee/payments/pages/payment.tsx
+++ b/packages/features/ee/payments/pages/payment.tsx
@@ -86,7 +86,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     },
   });
 
-  if (!rawPayment) return { notFound: true };
+  if (!rawPayment) return { notFound: true } as const;
 
   const { data, booking: _booking, ...restPayment } = rawPayment;
 
@@ -95,7 +95,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     data: data as Record<string, unknown>,
   };
 
-  if (!_booking) return { notFound: true };
+  if (!_booking) return { notFound: true } as const;
 
   const { startTime, endTime, eventType, ...restBooking } = _booking;
   const booking = {
@@ -104,9 +104,9 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     endTime: endTime.toString(),
   };
 
-  if (!eventType) return { notFound: true };
+  if (!eventType) return { notFound: true } as const;
 
-  if (eventType.users.length === 0 && !!!eventType.team) return { notFound: true };
+  if (eventType.users.length === 0 && !!!eventType.team) return { notFound: true } as const;
 
   const [user] = eventType?.users.length
     ? eventType.users

--- a/packages/features/ee/payments/pages/payment.tsx
+++ b/packages/features/ee/payments/pages/payment.tsx
@@ -9,7 +9,7 @@ import type { inferSSRProps } from "@calcom/types/inferSSRProps";
 
 import { ssrInit } from "../../../../../apps/web/server/lib/ssr";
 
-export type PaymentPageProps = Omit<inferSSRProps<typeof getServerSideProps>, "trpcState">;
+export type PaymentPageProps = inferSSRProps<typeof getServerSideProps>;
 
 const querySchema = z.object({
   uid: z.string(),

--- a/packages/features/ee/workflows/pages/workflow.tsx
+++ b/packages/features/ee/workflows/pages/workflow.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { WorkflowStep } from "@prisma/client";
 import { isValidPhoneNumber } from "libphonenumber-js";


### PR DESCRIPTION
For some already migrated pages, we have the following problems:
- `generateMetadata` is incorrect
- we are not extracting `getStaticProps` / `getServerSideProps` into `@lib` and using it but rather duplicating the entire function in App Router pages