### PR TITLE
fix: skip e2e tests that are memory crashing

### DIFF
--- a/apps/web/playwright/ab-tests-redirect.e2e.ts
+++ b/apps/web/playwright/ab-tests-redirect.e2e.ts
@@ -86,7 +86,8 @@ test.describe("apps/ A/B tests", () => {
     await expect(locator).toBeVisible();
   });
 
-  test("should point to the /future/apps/categories", async ({ page, users, context }) => {
+  // TODO: Revert until OOM issue is resolved
+  test.skip("should point to the /future/apps/categories", async ({ page, users, context }) => {
     await context.addCookies([
       {
         name: "x-calcom-future-routes-override",
@@ -167,7 +168,8 @@ test.describe("apps/ A/B tests", () => {
     await expect(locator).toHaveClass(/bg-emphasis/);
   });
 
-  test("should point to the /future/getting-started", async ({ page, users, context }) => {
+  // TODO: Revert until OOM issue is resolved
+  test.skip("should point to the /future/getting-started", async ({ page, users, context }) => {
     await context.addCookies([
       {
         name: "x-calcom-future-routes-override",

--- a/apps/web/playwright/ab-tests-redirect.e2e.ts
+++ b/apps/web/playwright/ab-tests-redirect.e2e.ts
@@ -9,20 +9,11 @@ test.describe.configure({ mode: "parallel" });
 // TODO Fix /apps/categories and /getting-started first
 test./* testBothFutureAndLegacyRoutes. */ describe("apps/ A/B tests", () => {
   test("should render the /apps/installed/[category]", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/apps/installed/messaging");
-
-    await page.waitForLoadState();
 
     const locator = page.getByRole("heading", { name: "Messaging" });
 

--- a/apps/web/playwright/ab-tests-redirect.e2e.ts
+++ b/apps/web/playwright/ab-tests-redirect.e2e.ts
@@ -2,10 +2,13 @@ import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
 
+// import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
+
 test.describe.configure({ mode: "parallel" });
 
-test.describe("apps/ A/B tests", () => {
-  test("should point to the /future/apps/installed/[category]", async ({ page, users, context }) => {
+// TODO Fix /apps/categories and /getting-started first
+test./* testBothFutureAndLegacyRoutes. */ describe("apps/ A/B tests", () => {
+  test("should render the /apps/installed/[category]", async ({ page, users, context }) => {
     await context.addCookies([
       {
         name: "x-calcom-future-routes-override",
@@ -21,175 +24,77 @@ test.describe("apps/ A/B tests", () => {
 
     await page.waitForLoadState();
 
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByRole("heading", { name: "Messaging" });
 
     await expect(locator).toBeVisible();
   });
 
-  test("should point to the /future/apps/[slug]", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /apps/[slug]", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/apps/telegram");
 
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByRole("heading", { name: "Telegram" });
 
     await expect(locator).toBeVisible();
   });
 
-  test("should point to the /future/apps/[slug]/setup", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /apps/[slug]/setup", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/apps/apple-calendar/setup");
 
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByRole("heading", { name: "Connect to Apple Server" });
 
     await expect(locator).toBeVisible();
   });
 
-  // TODO: Revert until OOM issue is resolved
-  test.skip("should point to the /future/apps/categories", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /apps/categories", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/apps/categories");
 
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByTestId("app-store-category-messaging");
 
     await expect(locator).toBeVisible();
   });
 
-  test("should point to the /future/apps/categories/[category]", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /apps/categories/[category]", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/apps/categories/messaging");
 
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByText(/messaging apps/i);
 
     await expect(locator).toBeVisible();
   });
 
-  test("should point to the /future/bookings/[status]", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /bookings/[status]", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/bookings/upcoming/");
 
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByTestId("horizontal-tab-upcoming");
 
     await expect(locator).toHaveClass(/bg-emphasis/);
   });
 
-  // TODO: Revert until OOM issue is resolved
-  test.skip("should point to the /future/getting-started", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /getting-started", async ({ page, users, context }) => {
     const user = await users.create({ completedOnboarding: false, name: null });
 
     await user.apiLogin();
 
     await page.goto("/getting-started/connected-calendar");
-
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
 
     const locator = page.getByText("Apple Calendar");
 

--- a/apps/web/playwright/ab-tests-redirect.e2e.ts
+++ b/apps/web/playwright/ab-tests-redirect.e2e.ts
@@ -1,13 +1,11 @@
 import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
-
-// import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
+import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 
 test.describe.configure({ mode: "parallel" });
 
-// TODO Fix /apps/categories and /getting-started first
-test./* testBothFutureAndLegacyRoutes. */ describe("apps/ A/B tests", () => {
+testBothFutureAndLegacyRoutes.describe("apps/ A/B tests", (routeVariant) => {
   test("should render the /apps/installed/[category]", async ({ page, users, context }) => {
     const user = await users.create();
 
@@ -45,6 +43,7 @@ test./* testBothFutureAndLegacyRoutes. */ describe("apps/ A/B tests", () => {
   });
 
   test("should render the /apps/categories", async ({ page, users, context }) => {
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const user = await users.create();
 
     await user.apiLogin();
@@ -81,6 +80,7 @@ test./* testBothFutureAndLegacyRoutes. */ describe("apps/ A/B tests", () => {
   });
 
   test("should render the /getting-started", async ({ page, users, context }) => {
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const user = await users.create({ completedOnboarding: false, name: null });
 
     await user.apiLogin();

--- a/apps/web/playwright/app-store.e2e.ts
+++ b/apps/web/playwright/app-store.e2e.ts
@@ -1,22 +1,15 @@
 import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
+import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 import { installAppleCalendar } from "./lib/testUtils";
 
 test.describe.configure({ mode: "parallel" });
 
 test.afterEach(({ users }) => users.deleteAll());
 
-test.describe("App Store - Authed", () => {
-  // TODO: Revert until OOM issue is resolved
-  test.skip("should point to the /future/apps/", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+testBothFutureAndLegacyRoutes.describe("App Store - Authed", () => {
+  test("should render /apps page", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
@@ -24,12 +17,6 @@ test.describe("App Store - Authed", () => {
     await page.goto("/apps/");
 
     await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
 
     const locator = page.getByRole("heading", { name: "App Store" });
 

--- a/apps/web/playwright/app-store.e2e.ts
+++ b/apps/web/playwright/app-store.e2e.ts
@@ -8,7 +8,8 @@ test.describe.configure({ mode: "parallel" });
 test.afterEach(({ users }) => users.deleteAll());
 
 test.describe("App Store - Authed", () => {
-  test("should point to the /future/apps/", async ({ page, users, context }) => {
+  // TODO: Revert until OOM issue is resolved
+  test.skip("should point to the /future/apps/", async ({ page, users, context }) => {
     await context.addCookies([
       {
         name: "x-calcom-future-routes-override",

--- a/apps/web/playwright/app-store.e2e.ts
+++ b/apps/web/playwright/app-store.e2e.ts
@@ -8,8 +8,9 @@ test.describe.configure({ mode: "parallel" });
 
 test.afterEach(({ users }) => users.deleteAll());
 
-testBothFutureAndLegacyRoutes.describe("App Store - Authed", () => {
+testBothFutureAndLegacyRoutes.describe("App Store - Authed", (routeVariant) => {
   test("should render /apps page", async ({ page, users, context }) => {
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const user = await users.create();
 
     await user.apiLogin();

--- a/apps/web/playwright/event-types.e2e.ts
+++ b/apps/web/playwright/event-types.e2e.ts
@@ -10,28 +10,13 @@ import { bookTimeSlot, createNewEventType, selectFirstAvailableTimeSlotNextMonth
 
 test.describe.configure({ mode: "parallel" });
 
-test.describe("Event Types A/B tests", () => {
-  test("should point to the /future/event-types page", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+testBothFutureAndLegacyRoutes.describe("Event Types A/B tests", () => {
+  test("should render the /future/event-types page", async ({ page, users }) => {
     const user = await users.create();
 
     await user.apiLogin();
 
     await page.goto("/event-types");
-
-    await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
 
     const locator = page.getByRole("heading", { name: "Event Types" });
 
@@ -39,8 +24,8 @@ test.describe("Event Types A/B tests", () => {
   });
 });
 
-test.describe("Event Types tests", () => {
-  testBothFutureAndLegacyRoutes.describe("user", () => {
+testBothFutureAndLegacyRoutes.describe("Event Types tests", () => {
+  test.describe("user", () => {
     test.beforeEach(async ({ page, users }) => {
       const user = await users.create();
       await user.apiLogin();

--- a/apps/web/playwright/payment.e2e.ts
+++ b/apps/web/playwright/payment.e2e.ts
@@ -3,19 +3,18 @@ import { expect } from "@playwright/test";
 import { bookTimeSlot, selectFirstAvailableTimeSlotNextMonth } from "@calcom/web/playwright/lib/testUtils";
 
 import { test } from "./lib/fixtures";
-
-// import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
+import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 
 test.describe.configure({ mode: "parallel" });
 
-// TODO: Future route not ready yet
-test./* testBothFutureAndLegacyRoutes. */ describe("Payment", () => {
+testBothFutureAndLegacyRoutes.describe("Payment", (routeVariant) => {
   test.describe("user", () => {
     test.afterEach(async ({ users }) => {
       await users.deleteAll();
     });
 
     test("should create a mock payment for a user", async ({ context, users, page }) => {
+      test.skip(routeVariant === "future", "Future route not ready yet");
       test.skip(process.env.MOCK_PAYMENT_APP_ENABLED === undefined, "Skipped as Stripe is not installed");
 
       const user = await users.create();

--- a/apps/web/playwright/payment.e2e.ts
+++ b/apps/web/playwright/payment.e2e.ts
@@ -4,9 +4,12 @@ import { bookTimeSlot, selectFirstAvailableTimeSlotNextMonth } from "@calcom/web
 
 import { test } from "./lib/fixtures";
 
+// import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
+
 test.describe.configure({ mode: "parallel" });
 
-test.describe("Payment", () => {
+// TODO: Future route not ready yet
+test./* testBothFutureAndLegacyRoutes. */ describe("Payment", () => {
   test.describe("user", () => {
     test.afterEach(async ({ users }) => {
       await users.deleteAll();
@@ -17,15 +20,6 @@ test.describe("Payment", () => {
 
       const user = await users.create();
       await user.apiLogin();
-
-      await context.addCookies([
-        {
-          name: "x-calcom-future-routes-override",
-          value: "1",
-          url: "http://localhost:3000",
-        },
-      ]);
-
       await page.goto("/apps");
 
       await page.getByPlaceholder("Search").click();

--- a/apps/web/playwright/settings-admin.e2e.ts
+++ b/apps/web/playwright/settings-admin.e2e.ts
@@ -1,18 +1,12 @@
 import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
+import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 
 test.describe.configure({ mode: "parallel" });
 
-test.describe("Settings/admin A/B tests", () => {
-  test("should point to the /future/settings/admin page", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+testBothFutureAndLegacyRoutes.describe("Settings/admin tests", () => {
+  test("should render /settings/admin page", async ({ page, users, context }) => {
     const user = await users.create({
       role: "ADMIN",
     });
@@ -21,12 +15,6 @@ test.describe("Settings/admin A/B tests", () => {
     await page.goto("/settings/admin");
 
     await page.waitForLoadState();
-
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
 
     const locator = page.getByRole("heading", { name: "Feature Flags" });
 

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -5,6 +5,7 @@ import { prisma } from "@calcom/prisma";
 import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 
 import { test } from "./lib/fixtures";
+import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 import {
   NotFoundPageTextAppDir,
   bookTimeSlot,
@@ -17,16 +18,10 @@ import {
 
 test.describe.configure({ mode: "parallel" });
 
-test.describe("Teams A/B tests", () => {
+// TODO: Future route not ready yet
+test./* testBothFutureAndLegacyRoutes. */ describe("Teams A/B tests", () => {
   // TODO: Revert until OOM issue is resolved
-  test.skip("should point to the /future/teams page", async ({ page, users, context }) => {
-    await context.addCookies([
-      {
-        name: "x-calcom-future-routes-override",
-        value: "1",
-        url: "http://localhost:3000",
-      },
-    ]);
+  test("should render the /teams page", async ({ page, users, context }) => {
     const user = await users.create();
 
     await user.apiLogin();
@@ -35,19 +30,13 @@ test.describe("Teams A/B tests", () => {
 
     await page.waitForLoadState();
 
-    const dataNextJsRouter = await page.evaluate(() =>
-      window.document.documentElement.getAttribute("data-nextjs-router")
-    );
-
-    expect(dataNextJsRouter).toEqual("app");
-
     const locator = page.getByRole("heading", { name: "Teams", exact: true });
 
     await expect(locator).toBeVisible();
   });
 });
 
-test.describe("Teams - NonOrg", () => {
+testBothFutureAndLegacyRoutes.describe("Teams - NonOrg", () => {
   test.afterEach(({ users }) => users.deleteAll());
 
   test("Team Onboarding Invite Members", async ({ page, users }) => {

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -18,7 +18,7 @@ import {
 
 test.describe.configure({ mode: "parallel" });
 
-testBothFutureAndLegacyRoutes.describe("Teams A/B tests", () => {
+testBothFutureAndLegacyRoutes.describe("Teams A/B tests", (routeVariant) => {
   test("should render the /teams page", async ({ page, users, context }) => {
     // TODO: Revert until OOM issue is resolved
     test.skip(routeVariant === "future", "Future route not ready yet");

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -7,10 +7,10 @@ import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "./lib/fixtures";
 import { testBothFutureAndLegacyRoutes } from "./lib/future-legacy-routes";
 import {
-  NotFoundPageTextAppDir,
   bookTimeSlot,
   doOnOrgDomain,
   fillStripeTestCheckout,
+  NotFoundPageTextAppDir,
   selectFirstAvailableTimeSlotNextMonth,
   testName,
   todo,
@@ -18,10 +18,10 @@ import {
 
 test.describe.configure({ mode: "parallel" });
 
-// TODO: Future route not ready yet
-test./* testBothFutureAndLegacyRoutes. */ describe("Teams A/B tests", () => {
-  // TODO: Revert until OOM issue is resolved
+testBothFutureAndLegacyRoutes.describe("Teams A/B tests", () => {
   test("should render the /teams page", async ({ page, users, context }) => {
+    // TODO: Revert until OOM issue is resolved
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const user = await users.create();
 
     await user.apiLogin();

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -36,7 +36,7 @@ test./* testBothFutureAndLegacyRoutes. */ describe("Teams A/B tests", () => {
   });
 });
 
-testBothFutureAndLegacyRoutes.describe("Teams - NonOrg", () => {
+testBothFutureAndLegacyRoutes.describe("Teams - NonOrg", (routeVariant) => {
   test.afterEach(({ users }) => users.deleteAll());
 
   test("Team Onboarding Invite Members", async ({ page, users }) => {
@@ -161,6 +161,7 @@ testBothFutureAndLegacyRoutes.describe("Teams - NonOrg", () => {
   });
 
   test("Non admin team members cannot create team in org", async ({ page, users }) => {
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const teamMateName = "teammate-1";
 
     const owner = await users.create(undefined, {
@@ -195,6 +196,7 @@ testBothFutureAndLegacyRoutes.describe("Teams - NonOrg", () => {
   });
 
   test("Can create team with same name as user", async ({ page, users }) => {
+    test.skip(routeVariant === "future", "Future route not ready yet");
     const user = await users.create();
     // Name to be used for both user and team
     const uniqueName = user.username!;

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -18,7 +18,8 @@ import {
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Teams A/B tests", () => {
-  test("should point to the /future/teams page", async ({ page, users, context }) => {
+  // TODO: Revert until OOM issue is resolved
+  test.skip("should point to the /future/teams page", async ({ page, users, context }) => {
     await context.addCookies([
       {
         name: "x-calcom-future-routes-override",


### PR DESCRIPTION
## What does this PR do?

Skips E2E tests that are currently failing on future app dir routes.