### PR TITLE
fix: Make usernameList optional and make consistent return obj structure

### DIFF
--- a/apps/api/pages/api/slots/_get.ts
+++ b/apps/api/pages/api/slots/_get.ts
@@ -22,7 +22,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const { usernameList, ...rest } = req.query;
     let slugs = usernameList;
     if (!Array.isArray(usernameList)) {
-      slugs = usernameList ? [usernameList] : [];
+      slugs = usernameList ? [usernameList] : undefined;
     }
     const input = getScheduleSchema.parse({ usernameList: slugs, ...rest });
     const timeZoneSupported = input.timeZone ? isSupportedTimeZone(input.timeZone) : false;
@@ -40,7 +40,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         )
       : availableSlots;
 
-    return slotsInProvidedTimeZone;
+    return { slots: slotsInProvidedTimeZone };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (cause) {
     if (cause instanceof TRPCError) {


### PR DESCRIPTION
## What does this PR do?

This PR sorts 2 things:
1. Makes usernameList optional so that it works like before for event-type slots (non dynamic), as is expected
2. When someone passes in a timezone, it now wraps the return in top-level `slots` key which is how we return it when there is no timezone passed.

Fixes #13322 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
NA
- If there is ab UI/UX design document, please, share it here.
NA

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Query the Slots endpoint with and without usernameList parameter passed in. It should work fine.
- Query the Slots endpoint with and without timezone parameter passed in, the response in both situations should be consistent in terms of object structure..

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


