### PR TITLE
fix: dark mode for OAuth /authorize page

### DIFF
--- a/apps/web/pages/auth/oauth2/authorize.tsx
+++ b/apps/web/pages/auth/oauth2/authorize.tsx
@@ -81,7 +81,7 @@ export default function Authorize() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="mt-2 max-w-xl rounded-md bg-white px-9 pb-3 pt-2">
+      <div className="bg-default border-subtle mt-2 max-w-xl rounded-md border px-9 pb-3 pt-2">
         <div className="flex items-center justify-center">
           <Avatar
             alt=""
@@ -92,7 +92,7 @@ export default function Authorize() {
           />
           <div className="relative -ml-6 h-24 w-24">
             <div className="absolute inset-0 flex items-center justify-center">
-              <div className="flex h-[70px] w-[70px] items-center justify-center  rounded-full bg-white">
+              <div className="bg-default flex h-[70px] w-[70px] items-center  justify-center rounded-full">
                 <img src="/cal-com-icon.svg" alt="Logo" className="h-16 w-16 rounded-full" />
               </div>
             </div>


### PR DESCRIPTION
## What does this PR do?

Fix dark mode for OAuth authorization page. 

Before: 
<img width="648" alt="Screenshot 2024-01-22 at 3 49 48 PM" src="https://github.com/calcom/cal.com/assets/30310907/3c1b2c37-c405-4bc2-9c9a-31583068bb6f">

After:
<img width="660" alt="Screenshot 2024-01-22 at 3 48 32 PM" src="https://github.com/calcom/cal.com/assets/30310907/b4810872-b0ac-494a-a0db-2b7c92b5d044">
<img width="629" alt="Screenshot 2024-01-22 at 3 48 41 PM" src="https://github.com/calcom/cal.com/assets/30310907/34acd9b1-750c-4998-85a9-ac972ea0a2fa">
