### PR TITLE
fix: v2 throttling setup

### DIFF
--- a/apps/api/v2/docker-compose.yaml
+++ b/apps/api/v2/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:latest
+    container_name: redis_container
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "dev": "yarn workspace @calcom/platform-constants build:watch & yarn workspace @calcom/platform-utils build:watch & yarn workspace @calcom/platform-types build:watch & nest start --watch",
+    "dev": "docker-compose up -d && yarn workspace @calcom/platform-constants build:watch & yarn workspace @calcom/platform-utils build:watch & yarn workspace @calcom/platform-types build:watch & nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "test": "yarn workspace @calcom/platform-constants build && yarn workspace @calcom/platform-utils build && yarn workspace @calcom/platform-types build && jest",

--- a/apps/api/v2/src/app.module.ts
+++ b/apps/api/v2/src/app.module.ts
@@ -21,7 +21,7 @@ import { AppController } from "./app.controller";
     }),
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
-      inject: [ConfigModule],
+      inject: [ConfigService],
       useFactory: (config: ConfigService<AppConfig>) => ({
         throttlers: [
           {


### PR DESCRIPTION
1. v2 api could not start, because ThrottlerModule was injecting ConfigModule instead of ConfigService. See file [src/app.module.ts](https://github.com/calcom/cal.com/compare/platform...fix-throttling?expand=1#diff-6f93d441f8f5905cb1e818900f7187165d155b96efa879fd1acbc434f669035d).

2. I setup redis using docker compose so that there are no info warnings "[ioredis] Unhandled error event: Error: connect ENOTSOCK /  at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1555:16)". Docker compose is ran as part of "yarn dev". See commit [fix: setup redis locally](https://github.com/calcom/cal.com/commit/1515dec8d5a542cfd503c1f2f5d97d2db10fc386).

---

PS. add `REDIS_URL="redis://localhost:6379"` environment variable to your `apps/api/v2/.env` for v2 API to run.