### PR TITLE
fix: prefill avatar when signing up

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -788,6 +788,7 @@ export const AUTH_OPTIONS: AuthOptions = {
             username: orgId ? slugify(orgUsername) : usernameSlug(user.name),
             emailVerified: new Date(Date.now()),
             name: user.name,
+            ...(user.image && { avatarUrl: user.image }),
             email: user.email,
             identityProvider: idP,
             identityProviderId: account.providerAccountId,


### PR DESCRIPTION
## What does this PR do?
prefills avatar when signing up if it exists

Fixes #13426

## Type of change

- Bug fix (non-breaking change which fixes an issue)

/claim #13426