### PR TITLE
fix: copy private link tooltip

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -470,7 +470,7 @@ export const EventTypeList = ({
                               </Tooltip>
 
                               {isPrivateURLEnabled && (
-                                <Tooltip content={t("copy_link")}>
+                                <Tooltip content={t("copy_private_link_to_event")}>
                                   <Button
                                     color="secondary"
                                     variant="icon"

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -819,6 +819,7 @@
   "private_link_label": "Private link",
   "private_link_hint": "Your private link will regenerate after each use",
   "copy_private_link": "Copy private link",
+  "copy_private_link_to_event": "Copy private link to event",
   "private_link_description": "Generate a private URL to share without exposing your {{appName}} username",
   "invitees_can_schedule": "Invitees can schedule",
   "date_range": "Date Range",


### PR DESCRIPTION
## What does this PR do?

Fixes a small tooltip issue when private URL's are enabled

## before

https://github.com/calcom/cal.com/assets/32706411/2f529f41-432b-4683-8293-bdef08df90c8

## after

https://github.com/calcom/cal.com/assets/32706411/85550748-94c8-4fbb-9f01-9003dc721749

