### PR TITLE
fix: duplicate username when inviting to team

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -238,7 +238,7 @@ export async function createNewUsersConnectToOrgIfExists({
         const username =
           emailDomain === autoAcceptEmailDomain
             ? slugify(emailUser)
-            : slugify(`${emailUser}-${emailDomain.split(".")[0]}`);
+            : `${slugify(emailUser)}@${emailDomain.split(".")[0]}`;
 
         const createdUser = await tx.user.create({
           data: {


### PR DESCRIPTION
## What does this PR do?

Fixes 500 case when duplicate username when inviting to team

Approach: Uses '@' instead of '-' to separate name and domain name for non auto accepted email domains.

Bug was caused by cases: 
Email 1, Email 2
adam-gmail@autoAcceptedEmailDomain.com,  adam@gmail.com
Generated usernames: adam-gmail, adam-gmail

Email 1, Email 2
joe-flowers@autoAcceptedEmailDomain.com,  joe@flowers.com
Generated usernames: joe-flowers, joe-flowers

Since '-' is a valid character in an email address.
Consider using '@' as a delimiter when identifying non auto accepted email domains.

Limited fix to only when inserting to database. 
Might cause mismatch when comparing _username queried from database_ and slugify(username)


Fixes #13464 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

