### PR TITLE
perf: Reduce .tz() usage when building slots

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -161,6 +161,7 @@ function buildSlotsWithDateRanges({
   eventLength = minimumOfOne(eventLength);
   offsetStart = offsetStart ? minimumOfOne(offsetStart) : 0;
   const slots: { time: Dayjs; userIds?: number[] }[] = [];
+  const organizerTimeZoneUtcOffset = dayjs().tz(organizerTimeZone).utcOffset();
 
   dateRanges.forEach((range) => {
     const startTimeWithMinNotice = dayjs.utc().add(minimumBookingNotice, "minute");
@@ -187,8 +188,8 @@ function buildSlotsWithDateRanges({
 
     // Adding 1 minute to date ranges that end at midnight to ensure that the last slot is included
     const rangeEnd = range.end
-      .add(dayjs().tz(organizerTimeZone).utcOffset(), "minutes")
-      .isSame(range.end.endOf("day").add(dayjs().tz(organizerTimeZone).utcOffset(), "minutes"), "minute")
+      .add(organizerTimeZoneUtcOffset, "minutes")
+      .isSame(range.end.endOf("day").add(organizerTimeZoneUtcOffset, "minutes"), "minute")
       ? range.end.add(1, "minute")
       : range.end;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #13358.

reduces the usage of .tz(), which we know to be incredibly slow, out of the loop of date ranges.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure all test suites pass and slots are calculated properly per user's time zones

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

