### PR TITLE
feat: Create default team events on a new team creation

### DIFF
--- a/packages/lib/createEventType.ts
+++ b/packages/lib/createEventType.ts
@@ -1,0 +1,108 @@
+import type { Prisma } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import type { z } from "zod";
+
+import getAppKeysFromSlug from "@calcom/app-store/_utils/getAppKeysFromSlug";
+import { DailyLocationType } from "@calcom/app-store/locations";
+import getApps from "@calcom/app-store/utils";
+import { getUsersCredentials } from "@calcom/lib/server/getUsersCredentials";
+import type { PrismaClient } from "@calcom/prisma";
+import { SchedulingType } from "@calcom/prisma/enums";
+import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
+import type { createEventTypeInput } from "@calcom/prisma/zod/custom/eventtype";
+
+import { TRPCError } from "@trpc/server";
+
+import type { TrpcSessionUser } from "./../trpc/server/trpc";
+
+interface createEventTypeProps extends z.infer<typeof createEventTypeInput> {
+  prisma: PrismaClient;
+  user: NonNullable<TrpcSessionUser>;
+}
+
+export default async function createEventType({
+  prisma,
+  user,
+  title,
+  slug,
+  description,
+  length,
+  hidden,
+  locations,
+  schedulingType,
+  teamId,
+  metadata,
+}: createEventTypeProps) {
+  const userId = user.id;
+  const isManagedEventType = schedulingType === SchedulingType.MANAGED;
+  // Get Users default conferencing app
+
+  const defaultConferencingData = userMetadataSchema.parse(user.metadata)?.defaultConferencingApp;
+  const appKeys = await getAppKeysFromSlug("daily-video");
+
+  let locationsArray: { type: string; link?: string }[] = [];
+
+  // If no locations are passed in and the user has a daily api key then default to daily
+  if ((typeof locations === "undefined" || locations?.length === 0) && typeof appKeys.api_key === "string") {
+    locationsArray = [{ type: DailyLocationType }];
+  }
+
+  if (defaultConferencingData && defaultConferencingData.appSlug !== "daily-video") {
+    const credentials = await getUsersCredentials(user.id);
+    const foundApp = getApps(credentials, true).filter(
+      (app) => app.slug === defaultConferencingData.appSlug
+    )[0]; // There is only one possible install here so index [0] is the one we are looking for ;
+    const locationType = foundApp?.locationOption?.value ?? DailyLocationType; // Default to Daily if no location type is found
+    locationsArray = [{ type: locationType, link: defaultConferencingData.appLink }];
+  }
+
+  const data: Prisma.EventTypeCreateInput = {
+    title,
+    slug,
+    description,
+    length,
+    hidden,
+    owner: teamId ? undefined : { connect: { id: userId } },
+    // metadata: metadata as unknown as Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue | undefined,
+    metadata: (metadata as Prisma.InputJsonObject) ?? undefined,
+    // Only connecting the current user for non-managed event type
+    users: isManagedEventType ? undefined : { connect: { id: userId } },
+    locations: locationsArray,
+  };
+
+  if (teamId && schedulingType) {
+    const hasMembership = await prisma.membership.findFirst({
+      where: {
+        userId,
+        teamId: teamId,
+        accepted: true,
+      },
+    });
+
+    const isOrgAdmin = !!user?.organization?.isOrgAdmin;
+
+    if (!hasMembership?.role || !(["ADMIN", "OWNER"].includes(hasMembership.role) || isOrgAdmin)) {
+      console.warn(`User ${userId} does not have permission to create this new event type`);
+      throw new TRPCError({ code: "UNAUTHORIZED" });
+    }
+
+    data.team = {
+      connect: {
+        id: teamId,
+      },
+    };
+    data.schedulingType = schedulingType;
+  }
+
+  try {
+    const eventType = await prisma.eventType.create({ data });
+    return { eventType };
+  } catch (e) {
+    if (e instanceof PrismaClientKnownRequestError) {
+      if (e.code === "P2002" && Array.isArray(e.meta?.target) && e.meta?.target.includes("slug")) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "URL Slug already exists for given user." });
+      }
+    }
+    throw new TRPCError({ code: "BAD_REQUEST" });
+  }
+}

--- a/packages/lib/defaultTeamEvents.ts
+++ b/packages/lib/defaultTeamEvents.ts
@@ -39,7 +39,7 @@ export default async function createDefaultTeamEvents({ teamId, user }: CreateDe
     },
   ];
 
-  await defaultTeamEvents.forEach(async (teamEvent) => {
+  defaultTeamEvents.forEach(async (teamEvent) => {
     await createEventType({
       prisma,
       user,

--- a/packages/lib/defaultTeamEvents.ts
+++ b/packages/lib/defaultTeamEvents.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@calcom/prisma";
+import { unlockedManagedEventTypeProps } from "@calcom/prisma/zod-utils";
+
+import type { TrpcSessionUser } from "./../trpc/server/trpc";
+import createEventType from "./createEventType";
+
+interface CreateDefaultTeamEventsProps {
+  teamId: number;
+  user: NonNullable<TrpcSessionUser>;
+}
+
+export default async function createDefaultTeamEvents({ teamId, user }: CreateDefaultTeamEventsProps) {
+  const defaultTeamEvents = [
+    {
+      title: "Collective Team Event",
+      slug: "collective-team-event",
+      length: 15,
+      teamId,
+      schedulingType: "COLLECTIVE" as const,
+    },
+    {
+      title: "Round Robin Team Event",
+      slug: "round-robin-team-event",
+      length: 15,
+      teamId,
+      schedulingType: "ROUND_ROBIN" as const,
+    },
+    {
+      title: "Managed Event",
+      slug: "managed-event",
+      length: 30,
+      teamId,
+      schedulingType: "MANAGED" as const,
+      metadata: {
+        managedEventConfig: {
+          unlockedFields: unlockedManagedEventTypeProps,
+        },
+      },
+    },
+  ];
+
+  await defaultTeamEvents.forEach(async (teamEvent) => {
+    await createEventType({
+      prisma,
+      user,
+      ...teamEvent,
+    });
+  });
+}

--- a/packages/trpc/server/routers/viewer/eventTypes/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/create.handler.ts
@@ -1,15 +1,5 @@
-import type { Prisma } from "@prisma/client";
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-
-import getAppKeysFromSlug from "@calcom/app-store/_utils/getAppKeysFromSlug";
-import { DailyLocationType } from "@calcom/app-store/locations";
-import getApps from "@calcom/app-store/utils";
-import { getUsersCredentials } from "@calcom/lib/server/getUsersCredentials";
+import createEventType from "@calcom/lib/createEventType";
 import type { PrismaClient } from "@calcom/prisma";
-import { SchedulingType } from "@calcom/prisma/enums";
-import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
-
-import { TRPCError } from "@trpc/server";
 
 import type { TrpcSessionUser } from "../../../trpc";
 import type { TCreateInputSchema } from "./create.schema";
@@ -23,76 +13,8 @@ type CreateOptions = {
 };
 
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
-  const { schedulingType, teamId, metadata, ...rest } = input;
-
-  const userId = ctx.user.id;
-  const isManagedEventType = schedulingType === SchedulingType.MANAGED;
-  // Get Users default conferencing app
-
-  const defaultConferencingData = userMetadataSchema.parse(ctx.user.metadata)?.defaultConferencingApp;
-  const appKeys = await getAppKeysFromSlug("daily-video");
-
-  let locations: { type: string; link?: string }[] = [];
-
-  // If no locations are passed in and the user has a daily api key then default to daily
-  if (
-    (typeof rest?.locations === "undefined" || rest.locations?.length === 0) &&
-    typeof appKeys.api_key === "string"
-  ) {
-    locations = [{ type: DailyLocationType }];
-  }
-
-  if (defaultConferencingData && defaultConferencingData.appSlug !== "daily-video") {
-    const credentials = await getUsersCredentials(ctx.user.id);
-    const foundApp = getApps(credentials, true).filter(
-      (app) => app.slug === defaultConferencingData.appSlug
-    )[0]; // There is only one possible install here so index [0] is the one we are looking for ;
-    const locationType = foundApp?.locationOption?.value ?? DailyLocationType; // Default to Daily if no location type is found
-    locations = [{ type: locationType, link: defaultConferencingData.appLink }];
-  }
-
-  const data: Prisma.EventTypeCreateInput = {
-    ...rest,
-    owner: teamId ? undefined : { connect: { id: userId } },
-    metadata: (metadata as Prisma.InputJsonObject) ?? undefined,
-    // Only connecting the current user for non-managed event type
-    users: isManagedEventType ? undefined : { connect: { id: userId } },
-    locations,
-  };
-
-  if (teamId && schedulingType) {
-    const hasMembership = await ctx.prisma.membership.findFirst({
-      where: {
-        userId,
-        teamId: teamId,
-        accepted: true,
-      },
-    });
-
-    const isOrgAdmin = !!ctx.user?.organization?.isOrgAdmin;
-
-    if (!hasMembership?.role || !(["ADMIN", "OWNER"].includes(hasMembership.role) || isOrgAdmin)) {
-      console.warn(`User ${userId} does not have permission to create this new event type`);
-      throw new TRPCError({ code: "UNAUTHORIZED" });
-    }
-
-    data.team = {
-      connect: {
-        id: teamId,
-      },
-    };
-    data.schedulingType = schedulingType;
-  }
-
-  try {
-    const eventType = await ctx.prisma.eventType.create({ data });
-    return { eventType };
-  } catch (e) {
-    if (e instanceof PrismaClientKnownRequestError) {
-      if (e.code === "P2002" && Array.isArray(e.meta?.target) && e.meta?.target.includes("slug")) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "URL Slug already exists for given user." });
-      }
-    }
-    throw new TRPCError({ code: "BAD_REQUEST" });
-  }
+  return await createEventType({
+    ...ctx,
+    ...input,
+  });
 };

--- a/packages/trpc/server/routers/viewer/teams/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/create.handler.ts
@@ -1,5 +1,6 @@
 import { generateTeamCheckoutSession } from "@calcom/features/ee/teams/lib/payments";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
+import createDefaultTeamEvents from "@calcom/lib/defaultTeamEvents";
 import { closeComUpsertTeamUser } from "@calcom/lib/sync/SyncServiceManager";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
@@ -110,6 +111,7 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
 
   // Sync Services: Close.com
   closeComUpsertTeamUser(createdTeam, ctx.user, MembershipRole.OWNER);
+  await createDefaultTeamEvents({ teamId: createdTeam.id, user });
 
   return {
     url: `${WEBAPP_URL}/settings/teams/${createdTeam.id}/onboard-members`,


### PR DESCRIPTION
## What does this PR do?

Creates Collective, Round Robin and Managed Team Event on new team creation.

Fixes #13300 

## Type of change

- New feature (non-breaking change which adds functionality)

## How should this be tested?

Create a new team and observe that default team event types (Collective, Round Robin, Managed Event) are also created as a template along with it.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
