### PR TITLE
refactor: getEventTypeById organizationId

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types.repository.ts
@@ -1,6 +1,7 @@
 import { CreateEventTypeInput } from "@/ee/event-types/inputs/create-event-type.input";
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { Injectable, NotFoundException } from "@nestjs/common";
+import { User } from "@prisma/client";
 
 import { getEventTypeById } from "@calcom/platform-libraries";
 
@@ -27,18 +28,19 @@ export class EventTypesRepository {
     });
   }
 
-  async getUserEventTypeForAtom(userId: number, isUserOrganizationAdmin: boolean, eventTypeId: number) {
+  async getUserEventTypeForAtom(user: User, isUserOrganizationAdmin: boolean, eventTypeId: number) {
     try {
       return getEventTypeById({
+        currentOrganizationId: user.organizationId,
         eventTypeId,
-        userId,
+        userId: user.id,
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         prisma: this.dbRead.prisma,
         isUserOrganizationAdmin,
       });
     } catch (error) {
-      throw new NotFoundException(`User with id ${userId} has no event type with id ${eventTypeId}`);
+      throw new NotFoundException(`User with id ${user.id} has no event type with id ${eventTypeId}`);
     }
   }
 }

--- a/apps/api/v2/src/ee/event-types/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/services/event-types.service.ts
@@ -25,7 +25,7 @@ export class EventTypesService {
       ? await this.membershipsRepository.isUserOrganizationAdmin(user.id, user.organizationId)
       : false;
 
-    return this.eventTypesRepository.getUserEventTypeForAtom(user.id, isUserOrganizationAdmin, eventTypeId);
+    return this.eventTypesRepository.getUserEventTypeForAtom(user, isUserOrganizationAdmin, eventTypeId);
   }
 
   async createUserDefaultEventTypes(userId: number) {

--- a/packages/lib/getEventTypeById.ts
+++ b/packages/lib/getEventTypeById.ts
@@ -29,6 +29,7 @@ interface getEventTypeByIdProps {
 export type EventType = Awaited<ReturnType<typeof getEventTypeById>>;
 
 export const getEventTypeById = async ({
+  currentOrganizationId,
   eventTypeId,
   userId,
   prisma,


### PR DESCRIPTION
There were changes in `getEventTypeById` - "currentOrganizationId" property was added and since platform calls `getEventTypeById` we need to add it.

I am setting it as "user.organizationId" just for the API to run (cant run it now), but we need to refactor all of our v2 where "user?.organizationId" or "user.organizationId" appear: created todo ticket https://linear.app/calcom/issue/PLA-43/refactor-userorganizationid-userorganizationid