### PR TITLE
refactor: removed isNotAnApiCall

### DIFF
--- a/apps/api/pages/api/bookings/_post.ts
+++ b/apps/api/pages/api/bookings/_post.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest } from "next";
 
+import getBookingDataSchemaForApi from "@calcom/features/bookings/lib/getBookingDataSchemaForApi";
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
 import { defaultResponder } from "@calcom/lib/server";
 
@@ -206,7 +207,7 @@ async function handler(req: NextApiRequest) {
   const { userId, isAdmin } = req;
   if (isAdmin) req.userId = req.body.userId || userId;
 
-  return await handleNewBooking(req);
+  return await handleNewBooking(req, getBookingDataSchemaForApi);
 }
 
 export default defaultResponder(handler);

--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -17,9 +17,7 @@ async function handler(req: NextApiRequest & { userId?: number }, res: NextApiRe
   const session = await getServerSession({ req, res });
   /* To mimic API behavior and comply with types */
   req.userId = session?.user?.id || -1;
-  const booking = await handleNewBooking(req, {
-    isNotAnApiCall: true,
-  });
+  const booking = await handleNewBooking(req);
   return booking;
 }
 

--- a/apps/web/pages/api/book/recurring-event.ts
+++ b/apps/web/pages/api/book/recurring-event.ts
@@ -52,9 +52,7 @@ async function handler(req: NextApiRequest & { userId?: number }, res: NextApiRe
       noEmail: false,
     };
 
-    const firstBookingResult = await handleNewBooking(recurringEventReq, {
-      isNotAnApiCall: true,
-    });
+    const firstBookingResult = await handleNewBooking(recurringEventReq);
     luckyUsers = firstBookingResult.luckyUsers?.map((user) => user.id);
   }
 
@@ -92,12 +90,8 @@ async function handler(req: NextApiRequest & { userId?: number }, res: NextApiRe
       luckyUsers,
     };
 
-    const promiseEachRecurringBooking: ReturnType<typeof handleNewBooking> = handleNewBooking(
-      recurringEventReq,
-      {
-        isNotAnApiCall: true,
-      }
-    );
+    const promiseEachRecurringBooking: ReturnType<typeof handleNewBooking> =
+      handleNewBooking(recurringEventReq);
 
     const eachRecurringBooking = await promiseEachRecurringBooking;
 

--- a/packages/features/bookings/Booker/components/hooks/useBookingForm.ts
+++ b/packages/features/bookings/Booker/components/hooks/useBookingForm.ts
@@ -27,7 +27,7 @@ export const useBookingForm = ({ event }: IUseBookingForm) => {
     .object({
       responses: event?.data
         ? getBookingResponsesSchema({
-            eventType: event?.data,
+            bookingFields: event.data.bookingFields,
             view: rescheduleUid ? "reschedule" : "booking",
           })
         : // Fallback until event is loaded.

--- a/packages/features/bookings/Booker/components/hooks/useInitialFormValues.ts
+++ b/packages/features/bookings/Booker/components/hooks/useInitialFormValues.ts
@@ -37,9 +37,7 @@ export function useInitialFormValues({
         return {};
       }
       const querySchema = getBookingResponsesPartialSchema({
-        eventType: {
-          bookingFields: eventType.bookingFields,
-        },
+        bookingFields: eventType.bookingFields,
         view: rescheduleUid ? "reschedule" : "booking",
       });
 

--- a/packages/features/bookings/lib/getBookingDataSchema.ts
+++ b/packages/features/bookings/lib/getBookingDataSchema.ts
@@ -1,80 +1,20 @@
 import { z } from "zod";
 
-import {
-  bookingCreateSchemaLegacyPropsForApi,
-  bookingCreateBodySchemaForApi,
-  extendedBookingCreateBody,
-} from "@calcom/prisma/zod-utils";
+import { extendedBookingCreateBody } from "@calcom/prisma/zod-utils";
 
+import type { getBookingFieldsWithSystemFields } from "./getBookingFields";
 import getBookingResponsesSchema from "./getBookingResponsesSchema";
-import type { getEventTypesFromDB } from "./handleNewBooking";
 
-const getBookingDataSchema = (
-  rescheduleUid: string | undefined,
-  isNotAnApiCall: boolean,
-  eventType: Awaited<ReturnType<typeof getEventTypesFromDB>>
-) => {
-  const responsesSchema = getBookingResponsesSchema({
-    eventType: {
-      bookingFields: eventType.bookingFields,
-    },
-    view: rescheduleUid ? "reschedule" : "booking",
-  });
-  const bookingDataSchema = isNotAnApiCall
-    ? extendedBookingCreateBody.merge(
-        z.object({
-          responses: responsesSchema,
-        })
-      )
-    : bookingCreateBodySchemaForApi
-        .merge(
-          z.object({
-            responses: responsesSchema.optional(),
-          })
-        )
-        .superRefine((val, ctx) => {
-          if (val.responses && val.customInputs) {
-            ctx.addIssue({
-              code: "custom",
-              message:
-                "Don't use both customInputs and responses. `customInputs` is only there for legacy support.",
-            });
-            return;
-          }
-          const legacyProps = Object.keys(bookingCreateSchemaLegacyPropsForApi.shape);
-
-          if (val.responses) {
-            const unwantedProps: string[] = [];
-            legacyProps.forEach((legacyProp) => {
-              if (typeof val[legacyProp as keyof typeof val] !== "undefined") {
-                console.error(
-                  `Deprecated: Unexpected falsy value for: ${unwantedProps.join(
-                    ","
-                  )}. They can't be used with \`responses\`. This will become a 400 error in the future.`
-                );
-              }
-              if (val[legacyProp as keyof typeof val]) {
-                unwantedProps.push(legacyProp);
-              }
-            });
-            if (unwantedProps.length) {
-              ctx.addIssue({
-                code: "custom",
-                message: `Legacy Props: ${unwantedProps.join(",")}. They can't be used with \`responses\``,
-              });
-              return;
-            }
-          } else if (val.customInputs) {
-            const { success } = bookingCreateSchemaLegacyPropsForApi.safeParse(val);
-            if (!success) {
-              ctx.addIssue({
-                code: "custom",
-                message: `With \`customInputs\` you must specify legacy props ${legacyProps.join(",")}`,
-              });
-            }
-          }
-        });
-  return bookingDataSchema;
+const getBookingDataSchema = ({
+  view = "booking",
+  bookingFields,
+}: {
+  view: "booking" | "reschedule";
+  bookingFields: Awaited<ReturnType<typeof getBookingFieldsWithSystemFields>>;
+}) => {
+  return extendedBookingCreateBody.merge(
+    z.object({ responses: getBookingResponsesSchema({ bookingFields, view }) })
+  );
 };
 
 export default getBookingDataSchema;

--- a/packages/features/bookings/lib/getBookingDataSchemaForApi.ts
+++ b/packages/features/bookings/lib/getBookingDataSchemaForApi.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+import {
+  bookingCreateBodySchemaForApi,
+  bookingCreateSchemaLegacyPropsForApi,
+} from "@calcom/prisma/zod-utils";
+
+import type { getBookingFieldsWithSystemFields } from "./getBookingFields";
+import getBookingResponsesSchema from "./getBookingResponsesSchema";
+
+const getBookingDataSchemaForApi = ({
+  view = "booking",
+  bookingFields,
+}: {
+  view: "booking" | "reschedule";
+  bookingFields: Awaited<ReturnType<typeof getBookingFieldsWithSystemFields>>;
+}) => {
+  const responsesSchema = getBookingResponsesSchema({ bookingFields, view });
+  return bookingCreateBodySchemaForApi
+    .merge(
+      z.object({
+        responses: responsesSchema.optional(),
+      })
+    )
+    .superRefine((val, ctx) => {
+      if (val.responses && val.customInputs) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "Don't use both customInputs and responses. `customInputs` is only there for legacy support.",
+        });
+        return;
+      }
+      const legacyProps = Object.keys(bookingCreateSchemaLegacyPropsForApi.shape);
+
+      if (val.responses) {
+        const unwantedProps: string[] = [];
+        legacyProps.forEach((legacyProp) => {
+          if (typeof val[legacyProp as keyof typeof val] !== "undefined") {
+            console.error(
+              `Deprecated: Unexpected falsy value for: ${unwantedProps.join(
+                ","
+              )}. They can't be used with \`responses\`. This will become a 400 error in the future.`
+            );
+          }
+          if (val[legacyProp as keyof typeof val]) {
+            unwantedProps.push(legacyProp);
+          }
+        });
+        if (unwantedProps.length) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Legacy Props: ${unwantedProps.join(",")}. They can't be used with \`responses\``,
+          });
+          return;
+        }
+      } else if (val.customInputs) {
+        const { success } = bookingCreateSchemaLegacyPropsForApi.safeParse(val);
+        if (!success) {
+          ctx.addIssue({
+            code: "custom",
+            message: `With \`customInputs\` you must specify legacy props ${legacyProps.join(",")}`,
+          });
+        }
+      }
+    });
+};
+
+export default getBookingDataSchemaForApi;

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -990,25 +990,23 @@ describe("getBookingResponsesSchema", () => {
 describe("getBookingResponsesPartialSchema - Prefill validation", () => {
   test(`should be able to get fields prefilled even when name is empty string`, async ({}) => {
     const schema = getBookingResponsesPartialSchema({
-      eventType: {
-        bookingFields: [
-          {
-            name: "name",
-            type: "name",
-            required: true,
-          },
-          {
-            name: "email",
-            type: "email",
-            required: true,
-          },
-          {
-            name: "testField",
-            type: "text",
-            required: true,
-          },
-        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-      },
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+        },
+        {
+          name: "testField",
+          type: "text",
+          required: true,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
       view: "ALL_VIEWS",
     });
     const parsedResponses = await schema.parseAsync({

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -15,25 +15,23 @@ const ZOD_REQUIRED_FIELD_ERROR_MSG = "Required";
 describe("getBookingResponsesSchema", () => {
   test(`should parse booking responses`, async ({}) => {
     const schema = getBookingResponsesSchema({
-      eventType: {
-        bookingFields: [
-          {
-            name: "name",
-            type: "name",
-            required: true,
-          },
-          {
-            name: "email",
-            type: "email",
-            required: true,
-          },
-          {
-            name: "testField",
-            type: "text",
-            required: true,
-          },
-        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-      },
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+        },
+        {
+          name: "testField",
+          type: "text",
+          required: true,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
       view: "ALL_VIEWS",
     });
     const parsedResponses = await schema.parseAsync({
@@ -52,25 +50,23 @@ describe("getBookingResponsesSchema", () => {
 
   test(`should error if required fields are missing`, async ({}) => {
     const schema = getBookingResponsesSchema({
-      eventType: {
-        bookingFields: [
-          {
-            name: "name",
-            type: "name",
-            required: true,
-          },
-          {
-            name: "email",
-            type: "email",
-            required: true,
-          },
-          {
-            name: "testField",
-            type: "text",
-            required: true,
-          },
-        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-      },
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+        },
+        {
+          name: "testField",
+          type: "text",
+          required: true,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
       view: "ALL_VIEWS",
     });
     const parsedResponses = await schema.safeParseAsync({
@@ -92,25 +88,23 @@ describe("getBookingResponsesSchema", () => {
     describe(`'name' and 'email' must be considered as required fields`, () => {
       test(`'name' and 'email' must be considered as required fields `, async ({}) => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: false,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: false,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponsesWithJustName = await schema.safeParseAsync({
@@ -143,25 +137,23 @@ describe("getBookingResponsesSchema", () => {
 
       test(`'email' must be validated `, async () => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: false,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: false,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponses = await schema.safeParseAsync({
@@ -183,26 +175,24 @@ describe("getBookingResponsesSchema", () => {
 
       test(`firstName is required and lastName is optional by default`, async () => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-                variant: "firstAndLastName",
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: false,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+              variant: "firstAndLastName",
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: false,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponses = await schema.safeParseAsync({
@@ -226,25 +216,23 @@ describe("getBookingResponsesSchema", () => {
 
       test(`should reject empty fullname`, async ({}) => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: true,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: true,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponses = await schema.safeParseAsync({
@@ -268,26 +256,24 @@ describe("getBookingResponsesSchema", () => {
 
       test(`should reject empty firstName`, async ({}) => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-                variant: "firstAndLastName",
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: true,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+              variant: "firstAndLastName",
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: true,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponses = await schema.safeParseAsync({
@@ -312,26 +298,24 @@ describe("getBookingResponsesSchema", () => {
 
       test(`should accept empty lastname`, async ({}) => {
         const schema = getBookingResponsesSchema({
-          eventType: {
-            bookingFields: [
-              {
-                name: "name",
-                type: "name",
-                required: true,
-                variant: "firstAndLastName",
-              },
-              {
-                name: "email",
-                type: "email",
-                required: true,
-              },
-              {
-                name: "testField",
-                type: "text",
-                required: true,
-              },
-            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-          },
+          bookingFields: [
+            {
+              name: "name",
+              type: "name",
+              required: true,
+              variant: "firstAndLastName",
+            },
+            {
+              name: "email",
+              type: "email",
+              required: true,
+            },
+            {
+              name: "testField",
+              type: "text",
+              required: true,
+            },
+          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
           view: "ALL_VIEWS",
         });
         const parsedResponses = await schema.parseAsync({
@@ -356,25 +340,23 @@ describe("getBookingResponsesSchema", () => {
       describe(`'name' can be transformed from one variant to other `, () => {
         test("`firstAndLastName` variant to `fullName`", async () => {
           const schema = getBookingResponsesSchema({
-            eventType: {
-              bookingFields: [
-                {
-                  name: "name",
-                  type: "name",
-                  required: true,
-                },
-                {
-                  name: "email",
-                  type: "email",
-                  required: true,
-                },
-                {
-                  name: "testField",
-                  type: "text",
-                  required: false,
-                },
-              ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-            },
+            bookingFields: [
+              {
+                name: "name",
+                type: "name",
+                required: true,
+              },
+              {
+                name: "email",
+                type: "email",
+                required: true,
+              },
+              {
+                name: "testField",
+                type: "text",
+                required: false,
+              },
+            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
             view: "ALL_VIEWS",
           });
           const parsedResponses = await schema.safeParseAsync({
@@ -400,26 +382,24 @@ describe("getBookingResponsesSchema", () => {
 
         test("`fullName` to `firstAndLastName` when there is a lastName(separated by space)", async () => {
           const schema = getBookingResponsesSchema({
-            eventType: {
-              bookingFields: [
-                {
-                  name: "name",
-                  type: "name",
-                  required: true,
-                  variant: "firstAndLastName",
-                },
-                {
-                  name: "email",
-                  type: "email",
-                  required: true,
-                },
-                {
-                  name: "testField",
-                  type: "text",
-                  required: false,
-                },
-              ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-            },
+            bookingFields: [
+              {
+                name: "name",
+                type: "name",
+                required: true,
+                variant: "firstAndLastName",
+              },
+              {
+                name: "email",
+                type: "email",
+                required: true,
+              },
+              {
+                name: "testField",
+                type: "text",
+                required: false,
+              },
+            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
             view: "ALL_VIEWS",
           });
           const parsedResponses = await schema.safeParseAsync({
@@ -444,26 +424,24 @@ describe("getBookingResponsesSchema", () => {
         });
         test("`fullName` to `firstAndLastName` when there is no lastName(separated by space)", async () => {
           const schema = getBookingResponsesSchema({
-            eventType: {
-              bookingFields: [
-                {
-                  name: "name",
-                  type: "name",
-                  required: true,
-                  variant: "firstAndLastName",
-                },
-                {
-                  name: "email",
-                  type: "email",
-                  required: true,
-                },
-                {
-                  name: "testField",
-                  type: "text",
-                  required: false,
-                },
-              ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-            },
+            bookingFields: [
+              {
+                name: "name",
+                type: "name",
+                required: true,
+                variant: "firstAndLastName",
+              },
+              {
+                name: "email",
+                type: "email",
+                required: true,
+              },
+              {
+                name: "testField",
+                type: "text",
+                required: false,
+              },
+            ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
             view: "ALL_VIEWS",
           });
           const parsedResponses = await schema.safeParseAsync({
@@ -493,25 +471,23 @@ describe("getBookingResponsesSchema", () => {
   describe("validate phone type field", () => {
     test(`should fail parsing if invalid phone provided`, async ({}) => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testPhone",
-              type: "phone",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testPhone",
+            type: "phone",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -532,25 +508,23 @@ describe("getBookingResponsesSchema", () => {
     });
     test(`should succesfull give responses if phone type field value is valid`, async ({}) => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testPhone",
-              type: "phone",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testPhone",
+            type: "phone",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -571,25 +545,23 @@ describe("getBookingResponsesSchema", () => {
 
     test("should fail parsing if phone field value is empty", async ({}) => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testPhone",
-              type: "phone",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testPhone",
+            type: "phone",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -612,25 +584,23 @@ describe("getBookingResponsesSchema", () => {
 
     test("should fail parsing if phone field value isn't provided", async ({}) => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testPhone",
-              type: "phone",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testPhone",
+            type: "phone",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -653,25 +623,23 @@ describe("getBookingResponsesSchema", () => {
 
   test("should fail parsing when invalid field type is provided", async () => {
     const schema = getBookingResponsesSchema({
-      eventType: {
-        bookingFields: [
-          {
-            name: "name",
-            type: "name",
-            required: true,
-          },
-          {
-            name: "email",
-            type: "email",
-            required: true,
-          },
-          {
-            name: "invalidField",
-            type: "unknown-field-type",
-            required: true,
-          },
-        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-      },
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+        },
+        {
+          name: "invalidField",
+          type: "unknown-field-type",
+          required: true,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
       view: "ALL_VIEWS",
     });
     const parsedResponses = await schema.safeParseAsync({
@@ -694,25 +662,23 @@ describe("getBookingResponsesSchema", () => {
   describe("multiemail field type", () => {
     test("should succesfully parse a multiemail type field", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testEmailsList",
-              type: "multiemail",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testEmailsList",
+            type: "multiemail",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -734,25 +700,23 @@ describe("getBookingResponsesSchema", () => {
 
     test("should fail parsing when one of the emails is invalid", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testEmailsList",
-              type: "multiemail",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testEmailsList",
+            type: "multiemail",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -775,25 +739,23 @@ describe("getBookingResponsesSchema", () => {
 
     test("should succesfully parse a multiemail type field response, even when the value is just a string[Prefill needs it]", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testEmailsList",
-              type: "multiemail",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testEmailsList",
+            type: "multiemail",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -816,25 +778,23 @@ describe("getBookingResponsesSchema", () => {
   describe("multiselect field type", () => {
     test("should succesfully parse a multiselect type field", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testMultiselect",
-              type: "multiselect",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testMultiselect",
+            type: "multiselect",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -855,25 +815,23 @@ describe("getBookingResponsesSchema", () => {
     });
     test("should succesfully parse a multiselect type field", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testMultiselect",
-              type: "multiselect",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testMultiselect",
+            type: "multiselect",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -894,25 +852,23 @@ describe("getBookingResponsesSchema", () => {
     });
     test("should fail parsing if selected options aren't strings", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testMultiselect",
-              type: "multiselect",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testMultiselect",
+            type: "multiselect",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({
@@ -939,25 +895,23 @@ describe("getBookingResponsesSchema", () => {
   describe("multiselect field type", () => {
     test("should succesfully parse a multiselect type field", async () => {
       const schema = getBookingResponsesSchema({
-        eventType: {
-          bookingFields: [
-            {
-              name: "name",
-              type: "name",
-              required: true,
-            },
-            {
-              name: "email",
-              type: "email",
-              required: true,
-            },
-            {
-              name: "testMultiselect",
-              type: "multiselect",
-              required: true,
-            },
-          ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
-        },
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "testMultiselect",
+            type: "multiselect",
+            required: true,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
         view: "ALL_VIEWS",
       });
       const parsedResponses = await schema.safeParseAsync({

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -43,7 +43,7 @@ export const getCalEventResponses = ({
       const label = field.label || field.defaultLabel;
       if (!label) {
         //TODO: This error must be thrown while saving event-type as well so that such an event-type can't be saved
-        throw new Error('Missing label for booking field "' + field.name + '"');
+        throw new Error(`Missing label for booking field "${field.name}"`);
       }
 
       // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -607,31 +607,36 @@ export async function getBookingData<T extends z.ZodType>({
       smsReminderNumber: reqBodyWithLegacyProps.smsReminderNumber,
       notes: reqBodyWithLegacyProps.notes,
       rescheduleReason: reqBodyWithLegacyProps.rescheduleReason,
-    };
-  } else {
-    if (!reqBody.responses) {
-      throw new Error("`responses` must not be nullish");
-    }
-    const responses = reqBody.responses;
-
-    const { userFieldsResponses: calEventUserFieldsResponses, responses: calEventResponses } =
-      getCalEventResponses({
-        bookingFields: eventType.bookingFields,
-        responses,
-      });
-    return {
-      ...reqBody,
-      name: responses.name,
-      email: responses.email,
-      guests: responses.guests ? responses.guests : [],
-      location: responses.location?.optionValue || responses.location?.value || "",
-      smsReminderNumber: responses.smsReminderNumber,
-      notes: responses.notes || "",
-      calEventUserFieldsResponses,
-      rescheduleReason: responses.rescheduleReason,
-      calEventResponses,
+      // So TS doesn't complain about unknown properties
+      calEventUserFieldsResponses: undefined,
+      calEventResponses: undefined,
+      customInputs: undefined,
     };
   }
+  if (!reqBody.responses) {
+    throw new Error("`responses` must not be nullish");
+  }
+  const responses = reqBody.responses;
+
+  const { userFieldsResponses: calEventUserFieldsResponses, responses: calEventResponses } =
+    getCalEventResponses({
+      bookingFields: eventType.bookingFields,
+      responses,
+    });
+  return {
+    ...reqBody,
+    name: responses.name,
+    email: responses.email,
+    guests: responses.guests ? responses.guests : [],
+    location: responses.location?.optionValue || responses.location?.value || "",
+    smsReminderNumber: responses.smsReminderNumber,
+    notes: responses.notes || "",
+    calEventUserFieldsResponses,
+    rescheduleReason: responses.rescheduleReason,
+    calEventResponses,
+    // So TS doesn't complain about unknown properties
+    customInputs: undefined,
+  };
 }
 
 async function createBooking({

--- a/packages/features/instant-meeting/handleInstantMeeting.ts
+++ b/packages/features/instant-meeting/handleInstantMeeting.ts
@@ -6,11 +6,12 @@ import { v5 as uuidv5 } from "uuid";
 
 import { createInstantMeetingWithCalVideo } from "@calcom/core/videoClient";
 import dayjs from "@calcom/dayjs";
+import getBookingDataSchema from "@calcom/features/bookings/lib/getBookingDataSchema";
 import { getBookingFieldsWithSystemFields } from "@calcom/features/bookings/lib/getBookingFields";
 import {
-  getEventTypesFromDB,
   getBookingData,
   getCustomInputsResponses,
+  getEventTypesFromDB,
 } from "@calcom/features/bookings/lib/handleNewBooking";
 import { getFullName } from "@calcom/features/form-builder/utils";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
@@ -83,10 +84,14 @@ async function handler(req: NextApiRequest) {
     throw new Error("Only Team Event Types are supported for Instant Meeting");
   }
 
+  const schema = getBookingDataSchema({
+    view: req.body?.rescheduleUid ? "reschedule" : "booking",
+    bookingFields: eventType.bookingFields,
+  });
   const reqBody = await getBookingData({
     req,
-    isNotAnApiCall: true,
     eventType,
+    schema,
   });
   const { email: bookerEmail, name: bookerName } = reqBody;
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -2,8 +2,6 @@ import type { Prisma } from "@prisma/client";
 import type { UnitTypeLongPlural } from "dayjs";
 import type { TFunction } from "next-i18next";
 import z, { ZodNullable, ZodObject, ZodOptional } from "zod";
-
-/* eslint-disable no-underscore-dangle */
 import type {
   AnyZodObject,
   objectInputType,
@@ -272,6 +270,7 @@ export const extendedBookingCreateBody = bookingCreateBodySchema.merge(
       )
       .optional(),
     luckyUsers: z.array(z.number()).optional(),
+    customInputs: z.undefined().optional(),
   })
 );
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -35,8 +35,12 @@ const workspaces = packagedEmbedTestsOnly
       {
         test: {
           include: ["packages/**/*.{test,spec}.{ts,js}", "apps/**/*.{test,spec}.{ts,js}"],
-          // TODO: Ignore the api until tests are fixed
-          exclude: ["**/node_modules/**/*", "packages/embeds/**/*", "packages/lib/hooks/**/*"],
+          exclude: [
+            "**/node_modules/**/*",
+            "**/.next/**/*",
+            "packages/embeds/**/*",
+            "packages/lib/hooks/**/*",
+          ],
           setupFiles: ["setupVitest.ts"],
         },
       },


### PR DESCRIPTION
## What does this PR do?

- Since the API handler is the odd one out. It should only pass the desired schema instead of doing `isNotAnApiCall: true` in all other calls.
- Removes the need for `isNotAnApiCall` in code it makes the logic unnecessarily harder to read.
- Allows `handleNewBooking` to receive an optional schema for the request body. Fallbacks to the default one if none is passed.
- Split api specific logic to it's own file

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- yarn build
- yarn e2e

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
