### PR TITLE
fix: org user event types with same event slug

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -196,6 +196,7 @@ export const getPublicEvent = async (
                   profiles: {
                     some: {
                       organization: orgQuery,
+                      username: username,
                     },
                   },
                 }


### PR DESCRIPTION
## What does this PR do?

When org members had the same event slugs wrong event types were shown on org event type links (`acme.cal.local:3000/user/slug`)