### PR TITLE
fix: improvements for variables in routing-from routes

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2258,6 +2258,8 @@
   "set_priority": "Set Priority",
   "priority_for_user": "Priority for {{userName}}",
   "change_priority": "change priority",
+  "field_identifiers_as_variables": "Use field identifiers as variables for your custom event redirect",
+  "field_identifiers_as_variables_with_example": "Use field identifiers as variables for your custom event redirect (e.g. {{variable}})",
   "account_already_linked": "Account is already linked",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
@@ -139,7 +139,7 @@ const Route = ({
       : "";
 
   const [customEventTypeSlug, setCustomEventTypeSlug] = useState<string>(
-    !isRouter(route) ? route.action.value.split("/").pop() : ""
+    !isRouter(route) ? route.action.value.split("/").pop() ?? "" : ""
   );
 
   const onChange = (route: Route, immutableTree: ImmutableTree, config: QueryBuilderUpdatedConfig) => {
@@ -612,6 +612,7 @@ const Routes = ({
             setRoute={setRoute}
             setRoutes={setRoutes}
             appUrl={appUrl}
+            fieldIdentifiers={fieldIdentifiers}
           />
         </div>
       </div>

--- a/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
@@ -88,11 +88,11 @@ const Route = ({
   setRoute: (id: string, route: Partial<Route>) => void;
   config: QueryBuilderUpdatedConfig;
   setRoutes: React.Dispatch<React.SetStateAction<Route[]>>;
+  fieldIdentifiers: string[];
   moveUp?: { fn: () => void; check: () => boolean } | null;
   moveDown?: { fn: () => void; check: () => boolean } | null;
   appUrl: string;
   disabled?: boolean;
-  fieldIdentifiers: string[];
 }) => {
   const { t } = useLocale();
 
@@ -138,7 +138,7 @@ const Route = ({
       ? eventOptions[0].value.substring(0, eventOptions[0].value.lastIndexOf("/") + 1)
       : "";
 
-  const [customEventTypeSlug, setCustomEventTypeSlug] = useState(
+  const [customEventTypeSlug, setCustomEventTypeSlug] = useState<string>(
     !isRouter(route) ? route.action.value.split("/").pop() : ""
   );
 
@@ -524,7 +524,9 @@ const Routes = ({
 
   hookForm.setValue("routes", routesToSave);
 
-  const fieldIdentifiers = hookForm.getValues("fields").map((field) => field.identifier ?? field.label);
+  const fields = hookForm.getValues("fields");
+
+  const fieldIdentifiers = fields ? fields.map((field) => field.identifier ?? field.label) : [];
 
   return (
     <div className="bg-default border-subtle flex flex-col-reverse rounded-md border p-8 md:flex-row">
@@ -537,7 +539,7 @@ const Routes = ({
               key={route.id}
               config={config}
               route={route}
-              fieldIdentifiers={fieldIdentifiers || []}
+              fieldIdentifiers={fieldIdentifiers}
               moveUp={{
                 check: () => key !== 0,
                 fn: () => {


### PR DESCRIPTION
## What does this PR do?

Move 'custom' to the top of select: 
![Screenshot 2024-02-09 at 5 31 45 PM](https://github.com/calcom/cal.com/assets/30310907/f0e222b1-9593-460d-8ed0-11a2bd5ff227)

Add info below on how to use field identifiers as variables (if no field exists, e.g. is not shown)
![Screenshot 2024-02-09 at 5 31 59 PM](https://github.com/calcom/cal.com/assets/30310907/51d3edb4-0164-454e-a5e7-af414a8d5189)

![Screenshot 2024-02-09 at 5 33 21 PM](https://github.com/calcom/cal.com/assets/30310907/3e2635a8-1468-4a23-b624-dd6b0da5517b)
