### PR TITLE
fix: use org logo for sub teams

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -87,7 +87,6 @@ interface EventTypeListHeadingProps {
   membershipCount: number;
   teamId?: number | null;
   bookerUrl: string;
-  isOrganization?: boolean;
 }
 
 type EventTypeGroup = EventTypeGroups[number];
@@ -731,7 +730,6 @@ const EventTypeListHeading = ({
   membershipCount,
   teamId,
   bookerUrl,
-  isOrganization,
 }: EventTypeListHeadingProps): JSX.Element => {
   const { t } = useLocale();
   const router = useRouter();

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -87,6 +87,7 @@ interface EventTypeListHeadingProps {
   membershipCount: number;
   teamId?: number | null;
   bookerUrl: string;
+  isOrganization?: boolean;
 }
 
 type EventTypeGroup = EventTypeGroups[number];
@@ -730,6 +731,7 @@ const EventTypeListHeading = ({
   membershipCount,
   teamId,
   bookerUrl,
+  isOrganization,
 }: EventTypeListHeadingProps): JSX.Element => {
   const { t } = useLocale();
   const router = useRouter();

--- a/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getByViewer.handler.ts
@@ -4,7 +4,7 @@ import { orderBy } from "lodash";
 import { hasFilter } from "@calcom/features/filters/lib/hasFilter";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { isOrganization } from "@calcom/lib/entityPermissionUtils";
-import { getTeamAvatarUrl, getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import { getOrgAvatarUrl, getTeamAvatarUrl, getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { getBookerBaseUrlSync } from "@calcom/lib/getBookerUrl/client";
 import { getBookerBaseUrl } from "@calcom/lib/getBookerUrl/server";
 import logger from "@calcom/lib/logger";
@@ -245,11 +245,17 @@ export const getByViewerHandler = async ({ ctx, input }: GetByViewerOptions) => 
                 ? orgMembership
                 : membership.role,
             profile: {
-              image: getTeamAvatarUrl({
-                slug: team.slug,
-                requestedSlug: team.metadata?.requestedSlug ?? null,
-                organizationId: team.parentId,
-              }),
+              image: team.parentId
+                ? getOrgAvatarUrl({
+                    slug: team.parent?.slug || null,
+                    logoUrl: team.parent?.logoUrl,
+                    requestedSlug: team.slug,
+                  })
+                : getTeamAvatarUrl({
+                    slug: team.slug,
+                    requestedSlug: team.metadata?.requestedSlug ?? null,
+                    organizationId: team.parentId,
+                  }),
               name: team.name,
               slug,
             },


### PR DESCRIPTION
Fixes: #12956 

Use org logo for any org sub teams.

![CleanShot 2024-02-10 at 16 17 45@2x](https://github.com/calcom/cal.com/assets/55134778/b0c43ade-bae0-46e2-a13e-17f7ad03603b)
