### PR TITLE
fix: unable to setup localy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ CALCOM_LICENSE_KEY=
 DATABASE_URL="postgresql://postgres:@localhost:5450/calendso"
 # Needed to run migrations while using a connection pooler like PgBouncer
 # Use the same one as DATABASE_URL if you're not using a connection pooler
-DATABASE_DIRECT_URL=
+DATABASE_DIRECT_URL="postgresql://postgres:@localhost:5450/calendso"
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 INSIGHTS_DATABASE_URL=


### PR DESCRIPTION
## What does this PR do?

I'm encountering this error every time I try to set up locally. It appears to be because the Database Direct URL is set to empty. It's not optimal, especially for quick setups like Gitpod, where users shouldn't need to run or set up anything externally.

![Screenshot 2024-02-11 014415](https://github.com/calcom/cal.com/assets/81948346/be8a670d-37ac-45fb-808e-fd82dce7c63a)
