### PR TITLE
fix: Errors due to namespacing of embed

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -352,7 +352,7 @@ function EventTypeSingleLayout({
                   StartIcon={Code}
                   color="secondary"
                   variant="icon"
-                  namespace={eventType.slug}
+                  namespace=""
                   tooltip={t("embed")}
                   tooltipSide="bottom"
                   tooltipOffset={4}

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -517,7 +517,7 @@ export const EventTypeList = ({
                               {!isManagedEventType && (
                                 <DropdownMenuItem className="outline-none">
                                   <EventTypeEmbedButton
-                                    namespace={type.slug}
+                                    namespace=""
                                     as={DropdownItem}
                                     type="button"
                                     StartIcon={Code}

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -439,10 +439,6 @@ class CalApi {
     elementOrSelector: string | HTMLElement;
     config?: PrefillAndIframeAttrsConfig;
   }) {
-    if (this.cal.inlineEl) {
-      console.warn("Inline embed already exists. Ignoring this call");
-      return;
-    }
     // eslint-disable-next-line prefer-rest-params
     validate(arguments[0], {
       required: true,


### PR DESCRIPTION
## What does this PR do?


Fixes #13501 
- Avoid distributing namespaced embed snippet as there are some bugs in it
- Also, remove faulty check of inline embed existence. DOM can be out of sync with in memory tracking of existence.

It effectively reopens #10031. But namespacing, by default, will make a comeback in #13386 after making sure all scenarios are tested.

## Important
Users need to re-copy the snippets from the app to get it working. This is applicable to react as well as vanilla JS snippets.


Before (React)
![image](https://github.com/calcom/cal.com/assets/1780212/4b0690c6-2fc6-4173-9367-e65eed8de35a)

After(React)
![image](https://github.com/calcom/cal.com/assets/1780212/9b7bba5a-0f7c-42d3-9026-954f2ed87df1)


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
