### PR TITLE
fix: Missing date ranges when specifying a specific slot time

### DIFF
--- a/packages/lib/date-ranges.test.ts
+++ b/packages/lib/date-ranges.test.ts
@@ -317,6 +317,26 @@ describe("buildDateRanges", () => {
       end: dayjs("2023-06-14T16:00:00Z").tz(timeZone),
     });
   });
+  it("should return correct date ranges for specific time slot in date override", () => {
+    const items = [
+      {
+        date: new Date(Date.UTC(2023, 5, 13)),
+        startTime: new Date(Date.UTC(0, 0, 0, 9, 0)),
+        endTime: new Date(Date.UTC(0, 0, 0, 14, 0)),
+      },
+    ];
+    const timeZone = "Europe/London";
+
+    const dateFrom = dayjs("2023-06-13T10:00:00Z");
+    const dateTo = dayjs("2023-06-13T10:30:00Z");
+
+    const results = buildDateRanges({ availability: items, timeZone, dateFrom, dateTo });
+
+    expect(results[0]).toEqual({
+      start: dayjs("2023-06-13T08:00:00Z").tz(timeZone),
+      end: dayjs("2023-06-13T13:00:00Z").tz(timeZone),
+    });
+  });
   it("should return correct date ranges if date override would already already be the next day in utc timezone", () => {
     const items = [
       {

--- a/packages/lib/date-ranges.ts
+++ b/packages/lib/date-ranges.ts
@@ -116,7 +116,7 @@ export function buildDateRanges({
     availability.reduce((processed: DateRange[], item) => {
       if ("date" in item && !!item.date) {
         const itemDateAsUtc = dayjs.utc(item.date);
-        if (itemDateAsUtc.isBetween(dateFrom, dateTo, null, "[]")) {
+        if (itemDateAsUtc.isBetween(dateFrom.startOf("day"), dateTo.endOf("day"), null, "[]")) {
           processed.push(processDateOverride({ item, itemDateAsUtc, timeZone }));
         }
       }


### PR DESCRIPTION
## What does this PR do?

Fixes bug introduced in https://github.com/calcom/cal.com/pull/13495 as there was an uncovered scenario. Date ranges that fall on the same day as a given slot are now properly added.

This bug was only visible on the booking page as "No available users found".