### PR TITLE
feat: Disallowing use of Prisma includes using only "true" and not a field selector

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -5,6 +5,7 @@ const recommended = {
     "@calcom/eslint/deprecated-imports": "error",
     "@calcom/eslint/avoid-web-storage": "error",
     "@calcom/eslint/avoid-prisma-client-import-for-enums": "error",
+    "@calcom/eslint/disallow-prisma-include-only-true-not-field-selector": "error",
   },
 };
 

--- a/packages/eslint-plugin/src/rules/disallow-prisma-include-only-true-not-field-selector.ts
+++ b/packages/eslint-plugin/src/rules/disallow-prisma-include-only-true-not-field-selector.ts
@@ -1,0 +1,44 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator((name) => `https://developer.cal.com/eslint/rule/${name}`);
+
+const rule = createRule({
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier" &&
+          node.callee.object.name === "include" &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === "ObjectExpression" &&
+          node.arguments[0].properties.length === 1 &&
+          node.arguments[0].properties[0].type === "Property" &&
+          node.arguments[0].properties[0].value.type === "Literal" &&
+          node.arguments[0].properties[0].value.value === true
+        ) {
+          context.report({
+            node: node,
+            messageId: "disallow-prisma-include-only-true",
+          });
+        }
+      },
+    };
+  },
+  name: "disallow-prisma-include-only-true-not-field-selector",
+  meta: {
+    docs: {
+      description: "Disallow Prisma includes using only true, without a field selector",
+      recommended: "error",
+    },
+    messages: {
+      "disallow-prisma-include-only-true":
+        "Avoid using Prisma includes with only 'true', specify fields explicitly",
+    },
+    type: "suggestion",
+    schema: [],
+  },
+  defaultOptions: [],
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -5,4 +5,6 @@ export default {
   "deprecated-imports": require("./deprecated-imports").default,
   "avoid-web-storage": require("./avoid-web-storage").default,
   "avoid-prisma-client-import-for-enums": require("./avoid-prisma-client-import-for-enums").default,
+  "disallow-prisma-include-only-true-not-field-selector":
+    require("./disallow-prisma-include-only-true-not-field-selector").default,
 } as ESLint.Plugin["rules"];


### PR DESCRIPTION
## What does this PR do?
Created a linting rule for Prisma that disallow's use of Prisma, including only true not a field selector
Fixes #13577 

## Type of change
- New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my PR needs changes to the documentation
- I haven't added tests that prove my fix is effective or that my feature works
