### PR TITLE
style: Update SettingsToggle.tsx

### DIFF
--- a/packages/ui/components/form/switch/SettingsToggle.tsx
+++ b/packages/ui/components/form/switch/SettingsToggle.tsx
@@ -55,7 +55,7 @@ function SettingsToggle({
                 switchContainerClassName
               )}>
               <div>
-                <div className="flex items-center" data-testid={`${rest["data-testid"]}-title`}>
+                <div className="flex items-center gap-x-2" data-testid={`${rest["data-testid"]}-title`}>
                   <Label
                     className={classNames("mt-0.5 text-base font-semibold leading-none", labelClassName)}>
                     {title}


### PR DESCRIPTION
## What does this PR do?

Makes SettingsToggle spacing between label and badges visually consistent with other components like AppListCard, AdditionalCalendarSelector, or HorizontalTabItem. 

Fixes # (issue)
What it looks like today:
<img width="954" alt="Screenshot 2024-02-13 at 11 18 54 AM" src="https://github.com/calcom/cal.com/assets/33043305/f7043893-636a-407c-aa9c-0f61ff42e46d">

What it looks like with this change:
<img width="930" alt="Screenshot 2024-02-13 at 11 19 29 AM" src="https://github.com/calcom/cal.com/assets/33043305/82f84cc9-a5d1-4590-824d-2559249a0fe1">

## Type of change
- "Bug" fix (non-breaking change which fixes an issue)

## How should this be tested?
- It's a single tailwind class addition, no testing necessary.
