### PR TITLE
fix: password reset when provider is changed

### DIFF
--- a/apps/web/pages/api/auth/reset-password.ts
+++ b/apps/web/pages/api/auth/reset-password.ts
@@ -51,7 +51,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
     });
   } catch (e) {
-    console.error("Error updating password", e);
     return res.status(404).end();
   }
 

--- a/apps/web/pages/api/auth/reset-password.ts
+++ b/apps/web/pages/api/auth/reset-password.ts
@@ -42,14 +42,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
       data: {
         password: {
-          update: {
-            hash: hashedPassword,
+          upsert: {
+            create: { hash: hashedPassword },
+            update: { hash: hashedPassword },
           },
         },
         emailVerified: new Date(),
       },
     });
   } catch (e) {
+    console.error("Error updating password", e);
     return res.status(404).end();
   }
 


### PR DESCRIPTION
## What does this PR do?


Fixes 

![image](https://github.com/calcom/cal.com/assets/53316345/bf2e296f-53ea-41c3-a281-28aa2a021496)

How to reproduce the bug?

1) Login in with google

2) Change your email which would send password reset email and change your provider from google to CAL

