### PR TITLE
fix: [CAL-3141] (+1) badge not aligned

### DIFF
--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -29,7 +29,7 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
   return (
     <ul className={classNames("flex items-center", props.className)}>
       {displayedAvatars.map((item, idx) => (
-        <li key={idx} className="-mr-[4px] inline-block">
+        <li key={idx} className="-mr-1 inline-block">
           <Avatar
             data-testid="avatar"
             className="border-subtle"
@@ -44,13 +44,13 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
       {numTruncatedAvatars > 0 && (
         <li
           className={classNames(
-            "bg-inverted relative -mr-[4px] inline-flex justify-center overflow-hidden rounded-full",
+            "bg-inverted relative -mr-1 inline-flex justify-center  overflow-hidden rounded-full",
             props.size === "sm" ? "min-w-6 h-6" : "min-w-16 h-16"
           )}>
           <span
             className={classNames(
-              "text-inverted m-auto px-1 py-0.5 text-center",
-              props.size === "sm" ? "min-w-6 h-6 text-[12px]" : "min-w-16 h-16 text-2xl"
+              " text-inverted m-auto flex h-full w-full items-center justify-center text-center",
+              props.size === "sm" ? "text-[12px]" : "text-2xl"
             )}>
             +{numTruncatedAvatars}
           </span>

--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -44,13 +44,13 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
       {numTruncatedAvatars > 0 && (
         <li
           className={classNames(
-            "bg-inverted relative -mr-[4px] mb-1 inline-flex justify-center overflow-hidden rounded-full",
+            "bg-inverted relative -mr-[4px] inline-flex justify-center overflow-hidden rounded-full",
             props.size === "sm" ? "min-w-6 h-6" : "min-w-16 h-16"
           )}>
           <span
             className={classNames(
-              "text-inverted m-auto px-1 text-center",
-              props.size === "sm" ? "text-[12px]" : "text-2xl"
+              "text-inverted m-auto px-1 py-0.5 text-center",
+              props.size === "sm" ? "min-w-6 h-6 text-[12px]" : "min-w-16 h-16 text-2xl"
             )}>
             +{numTruncatedAvatars}
           </span>


### PR DESCRIPTION
## What does this PR do?
Updated the class names for AvatarGroup elements to align the +n badge 


Fixes #13688



## Requirement/Documentation



## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
For a group of users when Avatar's are rendered on screen they should be aligned


- What are the minimal test data to have?
  - to have at least more than 4 users for this scenario
- What is expected (happy path) to have (input and output)?
  - all badge elements to be aligned

## Checklist



- I haven't checked if new and existing unit tests pass locally with my changes
