### PR TITLE
chore: open intercom in settings

### DIFF
--- a/packages/features/ee/support/lib/intercom/IntercomMenuItem.tsx
+++ b/packages/features/ee/support/lib/intercom/IntercomMenuItem.tsx
@@ -24,3 +24,14 @@ export default function IntercomMenuItem(props: IntercomMenuItemProps) {
     </button>
   );
 }
+
+export function InitIntercom() {
+  const { open } = useIntercom();
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  if (!process.env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    return null;
+  } else {
+    open();
+  }
+  return <></>;
+}

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps } from "react";
 import React, { Suspense, useEffect, useState } from "react";
 
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
+import { InitIntercom } from "@calcom/features/ee/support/lib/intercom/IntercomMenuItem";
 import Shell from "@calcom/features/shell/Shell";
 import { classNames } from "@calcom/lib";
 import { HOSTED_CAL_FEATURES, WEBAPP_URL } from "@calcom/lib/constants";
@@ -278,6 +279,7 @@ const SettingsSidebarContainer = ({
       )}
       aria-label="Tabs">
       <>
+        <InitIntercom />
         <BackButtonInSidebar name={t("back")} />
         {tabsWithPermissions.map((tab) => {
           return (


### PR DESCRIPTION
we need to figure out how to init intercom without asking the user to click "Help" to sync user data.

alternatively, we could sync user data on the database level

discussing with @ThyMinimalDev on Tuesday 20th Feb