### PR TITLE
fix: Old username link on org user's profile.

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -155,7 +155,7 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
                     <Link
                       prefetch={false}
                       href={{
-                        pathname: `/${user.username}/${type.slug}`,
+                        pathname: `/${user.profile.username}/${type.slug}`,
                         query,
                       }}
                       passHref


### PR DESCRIPTION
## What does this PR do?

Before:
![image](https://github.com/calcom/cal.com/assets/1780212/da964435-9719-4071-a66d-3a42557b1438)

After:
![image](https://github.com/calcom/cal.com/assets/1780212/1814070b-2765-4ac0-b655-072aa333fe0e)

Fixes https://calcominc.slack.com/archives/C05V243E153/p1708111917971829.

**Note:** this bug occurs only for the existing users that are invited to an organization and doesn't occur for migrated users that are migrated through migration script. This is because migration script changes user.username but invitation logic only sets the correct username in profile.username

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
1. Invite an existing user teampro to Acme. 
2. Accept the invite.
3. The username changes to teampro-example
4. Access at acme.cal.local:3000/teampro-example
5. Make sure that there are atleast 2 events added to teampro user so that the page doesn't redirect to the only event-type
6. Accessing any event-type from the profile page takes to 404 page as we are trying to access old username on organization domain. It should be fixed now.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works 


Test followup in #13754
