### PR TITLE
chore: Including original start and end dates from request in log

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -379,7 +379,7 @@ export async function ensureAvailableUsers(
         safeStringify({
           startDateTimeUtc,
           endDateTimeUtc,
-          timeZone: input.timeZone,
+          input,
         })
       );
       continue;
@@ -406,7 +406,7 @@ export async function ensureAvailableUsers(
         safeStringify({
           startDateTimeUtc,
           endDateTimeUtc,
-          timeZone: input.timeZone,
+          input,
         })
       );
       continue;
@@ -428,7 +428,7 @@ export async function ensureAvailableUsers(
       safeStringify({
         startDateTimeUtc,
         endDateTimeUtc,
-        timeZone: input.timeZone,
+        input,
       })
     );
     throw new Error(ErrorCode.NoAvailableUsersFound);


### PR DESCRIPTION
## What does this PR do?

We log the dateTimes in UTC after transformation but want to see the original values passed into `handleNewBooking`.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)
