### PR TITLE
fix: crash on signup page while inviting a new member to an org

### DIFF
--- a/apps/web/lib/signup/getServerSideProps.tsx
+++ b/apps/web/lib/signup/getServerSideProps.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     .optional()
     .safeParse(ctx.query.redirect);
 
-  const redirectUrl = redirectUrlData.success ? redirectUrlData.data : undefined;
+  const redirectUrl = redirectUrlData.success && redirectUrlData.data ? redirectUrlData.data : null;
 
   const props = {
     redirectUrl,


### PR DESCRIPTION
## What does this PR do?

Fixes - 
crash on signup page while inviting a new member to an organization
[LOOM](https://www.loom.com/share/c8d6dd3942fa46e8b1cba8e55e4d4aa6?sid=91a3681e-2f71-4d8f-982c-6fd866c16586)
