### PR TITLE
fix: og image

### DIFF
--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -83,7 +83,7 @@ export const SEO_IMG_DEFAULT = `${CAL_URL}/og-image.png`;
 // parameters you pass to the /api/social/og/image endpoint, you wrap them in encodeURIComponent
 // as well, otherwise the URL won't be valid.
 export const SEO_IMG_OGIMG = `${CAL_URL}/_next/image?w=1200&q=100&url=${encodeURIComponent(
-  `${CAL_URL}/api/social/og/image`
+  `/api/social/og/image`
 )}`;
 export const SEO_IMG_OGIMG_VIDEO = `${CAL_URL}/video-og-image.png`;
 export const IS_STRIPE_ENABLED = !!(


### PR DESCRIPTION
## What does this PR do?

This url works (without CAL_URL in url param)

https://cal.com/_next/image?w=1200&q=100&url=%2Fapi%2Fsocial%2Fog%2Fimage%3Ftype%3Dmeeting%26title%3DMeeting%26meetingProfileName%3DPeer%2520Richelsen%26meetingImage%3Dhttps%253A%252F%252Fcal.com%252Fapi%252Favatar%252F6480c992-64c2-4ae4-8210-b3086d72439c.png%26names%3DPeer%2520Richelsen%26usernames%3Dpeer


but current one doesn't  (with CAL_URL in url param)

https://cal.com/_next/image?w=1200&q=100&url=https%3A%2F%2Fcal.com%2Fapi%2Fsocial%2Fog%2Fimage%3Ftype%3Dmeeting%26title%3DMeeting%26meetingProfileName%3DPeer%2520Richelsen%26meetingImage%3Dhttps%253A%252F%252Fcal.com%252Fapi%252Favatar%252F6480c992-64c2-4ae4-8210-b3086d72439c.png%26names%3DPeer%2520Richelsen%26usernames%3Dpeer



Fixes https://github.com/calcom/cal.com/issues/13777

<img width="521" alt="Screenshot 2024-02-22 at 8 00 49 PM" src="https://github.com/calcom/cal.com/assets/53316345/50851584-4000-4f67-ac5f-ee7544c37d71">



https://www.opengraph.xyz/url/https%3A%2F%2Fcal.com%2Fpeer

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
