### PR TITLE
fix: A bug fix Name Text Overflow in Dashboard Sidebar Menu (#13782)

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -463,7 +463,9 @@ function UserDropdown({ small }: UserDropdownProps) {
           {!small && (
             <span className="flex flex-grow items-center gap-2">
               <span className="line-clamp-1 flex-grow text-sm leading-none">
-                <span className="text-emphasis block font-medium">{user.name || "Nameless User"}</span>
+                <span className="text-emphasis block font-medium">
+                  {user.name?.length > 15 ? `${user.name.slice(0, 15)}...` : user.name || "Nameless User"}
+                </span>
               </span>
               <ChevronDown
                 className="group-hover:text-subtle text-muted h-4 w-4 flex-shrink-0 rtl:mr-4"


### PR DESCRIPTION
## What does this PR do?

This pull request addresses the issue related to the name text overflow in the sidebar menu dropdown when the name is 15 characters long. It fixes this issue by truncating the name text

Fixes #13782
![Screenshot from 2024-02-22 22-55-34](https://github.com/calcom/cal.com/assets/84541807/7a6b2f3e-665c-4503-83fa-ec9ffd3b0b4c)


## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
 - Increase the length of Full Name > 15 and check the main dashboard
 
- Are there environment variables that should be set?
- No
- What is expected (happy path) to have (input and output)?
-  Increase the length of Full Name greater than 15 and check the main dashboard it will .truncate the name and add elipsis
- Any other important info that could help to test that PR
- No

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
