### PR TITLE
fix: video call url in event location for recurring events

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -264,6 +264,7 @@ export default class GoogleCalendarService implements Calendar {
             calendarId: selectedCalendar,
             eventId: event.id || "",
             requestBody: {
+              location: getLocation(calEventRaw),
               description: getRichDescription({
                 ...calEventRaw,
               }),


### PR DESCRIPTION
## What does this PR do?

Fixes the video call URL in the location of the calendar event for recurring events. The event description had the correct URL but the event location showed the URL of the last recurring event. 

Now each recurring event is showing a different video call URL in the location that matches the one in the event description. 

![Screenshot 2024-02-23 at 4 52 03 PM](https://github.com/calcom/cal.com/assets/30310907/70aac360-71ba-4ab2-a0af-fcef13f48dcd)

