### PR TITLE
fix: text overflowing in username change popup

### DIFF
--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -160,7 +160,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
               <div className="bg-subtle flex w-full flex-wrap gap-6 rounded-sm px-2 py-3 text-sm">
                 <div>
                   <p className="text-subtle">{t("current_username")}</p>
-                  <p className="text-emphasis mt-1" data-testid="current-username">
+                  <p className="text-emphasis mt-1 break-all" data-testid="current-username">
                     {currentUsername}
                   </p>
                 </div>
@@ -168,7 +168,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>
-                  <p className="text-emphasis mt-1">{inputUsernameValue}</p>
+                  <p className="text-emphasis mt-1 break-all">{inputUsernameValue}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What does this PR do?
Fixed text overflowing in the username change modal. 

Fixes #13786

**Before**
![before](https://github.com/calcom/cal.com/assets/24193157/9903446c-ba1c-4b96-af87-78e264c0bf44)

**After**
<img width="1512" alt="Screenshot 2024-02-24 at 4 40 13 PM" src="https://github.com/calcom/cal.com/assets/24193157/5564cf7b-c3f5-44fa-ba2a-d624a32bfa96">


## Type of change
- Bug fix 

## How should this be tested?
* Go to My setting
* Clicked on Profile
* Update the input field of URL

## Mandatory Tasks
- [✅ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
