### PR TITLE
fix: Limit future bookings - Default is 1 day even though on UI it is 30 days

### DIFF
--- a/apps/web/components/eventtype/EventLimitsTab.tsx
+++ b/apps/web/components/eventtype/EventLimitsTab.tsx
@@ -360,10 +360,12 @@ export const EventLimitsTab = () => {
               title={t("limit_future_bookings")}
               description={t("limit_future_bookings_description")}
               checked={isChecked}
-              onCheckedChange={(bool) =>
-                // formMethods.setValue("periodType", bool ? "ROLLING" : "UNLIMITED", { shouldDirty: true })
-                onChange(bool ? "ROLLING" : "UNLIMITED")
-              }>
+              onCheckedChange={(bool) => {
+                if (bool && !formMethods.getValues("periodDays")) {
+                  formMethods.setValue("periodDays", 30, { shouldDirty: true });
+                }
+                return onChange(bool ? "ROLLING" : "UNLIMITED");
+              }}>
               <div className="border-subtle rounded-b-lg border border-t-0 p-6">
                 <RadioGroup.Root
                   value={watchPeriodType}

--- a/apps/web/modules/event-types/views/event-types-single-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.tsx
@@ -266,7 +266,7 @@ const EventTypePage = (props: EventTypeSetupProps) => {
       beforeEventBuffer: eventType.beforeEventBuffer,
       eventName: eventType.eventName || "",
       scheduleName: eventType.scheduleName,
-      periodDays: eventType.periodDays || 30,
+      periodDays: eventType.periodDays,
       requiresBookerEmailVerification: eventType.requiresBookerEmailVerification,
       seatsPerTimeSlot: eventType.seatsPerTimeSlot,
       seatsShowAttendees: eventType.seatsShowAttendees,


### PR DESCRIPTION
## What does this PR do?

Fixes #13848 

<!-- Please provide a loom video for visual changes to speed up reviews

Before:
https://www.loom.com/share/226e033874d343f08925ca0a08d64345?sid=67ddd09b-f12f-4c89-a0f7-9a4bc00796bc


After: 
 https://www.loom.com/share/226e033874d343f08925ca0a08d64345
-->
## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
to test changes of this PR set limit on future books with value 30. and then check booking page whether bookings are available or not.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if  existing unit tests pass locally with my changes
