### PR TITLE
fix: resolve TS errors to build v2 for prod

### DIFF
--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -101,7 +101,7 @@ const emptyResponseEventsByStatus = {
   },
 };
 
-interface IResultTeamList {
+export interface IResultTeamList {
   id: number;
   slug: string | null;
   name: string | null;

--- a/packages/trpc/react/trpc.ts
+++ b/packages/trpc/react/trpc.ts
@@ -5,6 +5,7 @@ import { httpBatchLink } from "../client";
 import { httpLink } from "../client";
 import { loggerLink } from "../client";
 import { splitLink } from "../client";
+import type { CreateTRPCNext } from "../next";
 import { createTRPCNext } from "../next";
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
@@ -49,7 +50,10 @@ const resolveEndpoint = (links: any) => {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createTRPCReact`.
  * @link https://trpc.io/docs/v10/react#2-create-trpc-hooks
  */
-export const trpc = createTRPCNext<AppRouter, NextPageContext>({
+export const trpc: CreateTRPCNext<AppRouter, NextPageContext, null> = createTRPCNext<
+  AppRouter,
+  NextPageContext
+>({
   config() {
     const url =
       typeof window !== "undefined"

--- a/packages/trpc/server/routers/viewer/sso/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/sso/get.handler.ts
@@ -1,4 +1,5 @@
 import jackson from "@calcom/features/ee/sso/lib/jackson";
+import type { SSOConnection } from "@calcom/features/ee/sso/lib/saml";
 import {
   canAccess,
   oidcPath,
@@ -19,7 +20,7 @@ type GetOptions = {
   input: TGetInputSchema;
 };
 
-export const getHandler = async ({ ctx, input }: GetOptions) => {
+export const getHandler = async ({ ctx, input }: GetOptions): Promise<SSOConnection | null> => {
   const { teamId } = input;
 
   const { message, access } = await canAccess(ctx.user, teamId);


### PR DESCRIPTION
Fix Typescript errors when running "yarn build" for v2 API for preparing app for production. The API imports from trpc package which had type errors that needed to be fixed.