### PR TITLE
fix: ics-feedcalendar logo not showing

### DIFF
--- a/packages/app-store/ics-feedcalendar/config.json
+++ b/packages/app-store/ics-feedcalendar/config.json
@@ -2,6 +2,7 @@
   "name": "ICS Feed",
   "title": "ICS Feed",
   "slug": "ics-feed",
+  "dirName":"ics-feedcalendar",
   "type": "ics-feed_calendar",
   "logo": "icon.svg",
   "variant": "calendar",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the logo of ics-feed calendar, when user makes a new account and in connect app the ics-feed calender logo not showing

**before**

![Screenshot 2024-02-26 145058](https://github.com/calcom/cal.com/assets/94217498/c796546e-8dda-4bf7-a4d6-48a3a6a82b4c)

**after**

![Screenshot 2024-02-27 163646](https://github.com/calcom/cal.com/assets/94217498/d037c052-34ad-46c1-8102-de06386695e0)
