### PR TITLE
fix: text overflowing in username change popup

### DIFF
--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -160,7 +160,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
               <div className="bg-subtle flex w-full flex-wrap gap-6 rounded-sm px-2 py-3 text-sm">
                 <div>
                   <p className="text-subtle">{t("current_username")}</p>
-                  <p className="text-emphasis mt-1" data-testid="current-username">
+                  <p className="text-emphasis mt-1 break-all" data-testid="current-username">
                     {currentUsername}
                   </p>
                 </div>
@@ -168,7 +168,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>
-                  <p className="text-emphasis mt-1">{inputUsernameValue}</p>
+                  <p className="text-emphasis mt-1 break-all">{inputUsernameValue}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
fixes: #13846
**Before** 
![WhatsApp Image 2024-02-28 at 13 20 58_5fcb92c6](https://github.com/calcom/cal.com/assets/137920494/811d8f9e-9c9f-48ff-b139-7457eb6938b7)
After
![WhatsApp Image 2024-02-28 at 13 21 48_b743c8c3](https://github.com/calcom/cal.com/assets/137920494/5b3f5dc5-28f0-4ad1-8295-4fd089522759)


