### PR TITLE
refactor: v2 user timezones

### DIFF
--- a/apps/api/v2/src/modules/users/inputs/create-user.input.ts
+++ b/apps/api/v2/src/modules/users/inputs/create-user.input.ts
@@ -1,5 +1,4 @@
 import { IsTimeFormat } from "@/modules/users/inputs/validators/is-time-format";
-import { IsTimeZone } from "@/modules/users/inputs/validators/is-time-zone";
 import { IsWeekStart } from "@/modules/users/inputs/validators/is-week-start";
 import { IsNumber, IsOptional, IsString, Validate } from "class-validator";
 
@@ -23,6 +22,5 @@ export class CreateUserInput {
 
   @IsString()
   @IsOptional()
-  @Validate(IsTimeZone)
   timeZone?: string;
 }

--- a/apps/api/v2/src/modules/users/inputs/update-user.input.ts
+++ b/apps/api/v2/src/modules/users/inputs/update-user.input.ts
@@ -1,5 +1,4 @@
 import { IsTimeFormat } from "@/modules/users/inputs/validators/is-time-format";
-import { IsTimeZone } from "@/modules/users/inputs/validators/is-time-zone";
 import { IsWeekStart } from "@/modules/users/inputs/validators/is-week-start";
 import { IsNumber, IsOptional, IsString, Validate } from "class-validator";
 
@@ -24,6 +23,5 @@ export class UpdateUserInput {
 
   @IsString()
   @IsOptional()
-  @Validate(IsTimeZone)
   timeZone?: string;
 }


### PR DESCRIPTION
Dayjs on frontend detect timezones in a different format than IsTimezone validator accepts, which initially was created to be used with schedules, so the validator is removed to enable updating managed users.