### PR TITLE
chore: Add index to Team.parentId

### DIFF
--- a/packages/prisma/migrations/20240229154858_add_insights_db_indexes/migration.sql
+++ b/packages/prisma/migrations/20240229154858_add_insights_db_indexes/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Team_parentId_idx" ON "Team"("parentId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -361,6 +361,7 @@ model Team {
   pendingPayment       Boolean                 @default(false)
 
   @@unique([slug, parentId])
+  @@index([parentId])
 }
 
 enum MembershipRole {


### PR DESCRIPTION
## What does this PR do?

Adds an index to Team.parentId which is queried heavily for insights. A start to https://github.com/calcom/cal.com/issues/13731

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Ensure insights reports are generated properly