### PR TITLE
refactor: check organizationId primarily on user profile

### DIFF
--- a/apps/api/v2/src/ee/calendars/controllers/calendars.controller.ts
+++ b/apps/api/v2/src/ee/calendars/controllers/calendars.controller.ts
@@ -1,8 +1,8 @@
 import { CalendarsService } from "@/ee/calendars/services/calendars.service";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { AccessTokenGuard } from "@/modules/auth/guards/access-token/access-token.guard";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import { Controller, Get, Logger, UseGuards, Query } from "@nestjs/common";
-import { User } from "@prisma/client";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { ConnectedDestinationCalendars } from "@calcom/platform-libraries";
@@ -23,7 +23,7 @@ export class CalendarsController {
   @Get("/busy-times")
   async getBusyTimes(
     @Query() queryParams: CalendarBusyTimesInput,
-    @GetUser() user: User
+    @GetUser() user: UserWithProfile
   ): Promise<ApiResponse<EventBusyDate[]>> {
     const { loggedInUsersTz, dateFrom, dateTo, calendarsToLoad } = queryParams;
     if (!dateFrom || !dateTo) {

--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
@@ -3,8 +3,9 @@ import { EventTypesService } from "@/ee/event-types/services/event-types.service
 import { ForAtom } from "@/lib/atoms/decorators/for-atom.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { AccessTokenGuard } from "@/modules/auth/guards/access-token/access-token.guard";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import { Controller, UseGuards, Get, Param, Post, Body, NotFoundException } from "@nestjs/common";
-import { EventType, User } from "@prisma/client";
+import { EventType } from "@prisma/client";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import type { EventType as AtomEventType } from "@calcom/platform-libraries";
@@ -21,7 +22,7 @@ export class EventTypesController {
   @Post("/")
   async createEventType(
     @Body() body: CreateEventTypeInput,
-    @GetUser() user: User
+    @GetUser() user: UserWithProfile
   ): Promise<ApiResponse<{ eventType: EventType }>> {
     const eventType = await this.eventTypesService.createUserEventType(user.id, body);
 
@@ -37,7 +38,7 @@ export class EventTypesController {
   async getEventType(
     @Param("eventTypeId") eventTypeId: string,
     @ForAtom() forAtom: boolean,
-    @GetUser() user: User
+    @GetUser() user: UserWithProfile
   ): Promise<ApiResponse<{ eventType: EventType | AtomEventType }>> {
     const eventType = forAtom
       ? await this.eventTypesService.getUserEventTypeForAtom(user, Number(eventTypeId))

--- a/apps/api/v2/src/ee/event-types/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types.repository.ts
@@ -1,8 +1,8 @@
 import { CreateEventTypeInput } from "@/ee/event-types/inputs/create-event-type.input";
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable, NotFoundException } from "@nestjs/common";
-import { User } from "@prisma/client";
 
 import { getEventTypeById } from "@calcom/platform-libraries";
 
@@ -36,10 +36,14 @@ export class EventTypesRepository {
     });
   }
 
-  async getUserEventTypeForAtom(user: User, isUserOrganizationAdmin: boolean, eventTypeId: number) {
+  async getUserEventTypeForAtom(
+    user: UserWithProfile,
+    isUserOrganizationAdmin: boolean,
+    eventTypeId: number
+  ) {
     try {
       return getEventTypeById({
-        currentOrganizationId: user.organizationId,
+        currentOrganizationId: user.movedToProfile?.organizationId || user.organizationId,
         eventTypeId,
         userId: user.id,
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/apps/api/v2/src/ee/event-types/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/services/event-types.service.ts
@@ -2,8 +2,8 @@ import { DEFAULT_EVENT_TYPES } from "@/ee/event-types/constants/constants";
 import { EventTypesRepository } from "@/ee/event-types/event-types.repository";
 import { CreateEventTypeInput } from "@/ee/event-types/inputs/create-event-type.input";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
-import { User } from "@prisma/client";
 
 @Injectable()
 export class EventTypesService {
@@ -20,9 +20,11 @@ export class EventTypesService {
     return this.eventTypesRepository.getUserEventType(userId, eventTypeId);
   }
 
-  async getUserEventTypeForAtom(user: User, eventTypeId: number) {
-    const isUserOrganizationAdmin = user?.organizationId
-      ? await this.membershipsRepository.isUserOrganizationAdmin(user.id, user.organizationId)
+  async getUserEventTypeForAtom(user: UserWithProfile, eventTypeId: number) {
+    const organizationId = user.movedToProfile?.organizationId || user.organizationId;
+
+    const isUserOrganizationAdmin = organizationId
+      ? await this.membershipsRepository.isUserOrganizationAdmin(user.id, organizationId)
       : false;
 
     return this.eventTypesRepository.getUserEventTypeForAtom(user, isUserOrganizationAdmin, eventTypeId);

--- a/apps/api/v2/src/ee/me/me.controller.ts
+++ b/apps/api/v2/src/ee/me/me.controller.ts
@@ -1,9 +1,8 @@
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { AccessTokenGuard } from "@/modules/auth/guards/access-token/access-token.guard";
 import { UpdateUserInput } from "@/modules/users/inputs/update-user.input";
-import { UsersRepository } from "@/modules/users/users.repository";
+import { UserWithProfile, UsersRepository } from "@/modules/users/users.repository";
 import { Controller, UseGuards, Get, Patch, Body } from "@nestjs/common";
-import { User } from "@prisma/client";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { UserResponse, userSchemaResponse } from "@calcom/platform-types";
@@ -18,7 +17,7 @@ export class MeController {
   constructor(private readonly usersRepository: UsersRepository) {}
 
   @Get("/")
-  async getMe(@GetUser() user: User): Promise<ApiResponse<{ user: UserResponse }>> {
+  async getMe(@GetUser() user: UserWithProfile): Promise<ApiResponse<{ user: UserResponse }>> {
     const me = userSchemaResponse.parse(user);
 
     return {
@@ -31,7 +30,7 @@ export class MeController {
 
   @Patch("/")
   async updateMe(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @Body() bodySchedule: UpdateUserInput
   ): Promise<ApiResponse<{ user: UserResponse }>> {
     const updatedUser = await this.usersRepository.update(user.id, bodySchedule);

--- a/apps/api/v2/src/ee/provider/provider.controller.ts
+++ b/apps/api/v2/src/ee/provider/provider.controller.ts
@@ -1,8 +1,8 @@
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { AccessTokenGuard } from "@/modules/auth/guards/access-token/access-token.guard";
-import { UserReturned } from "@/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller";
 import { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import {
   BadRequestException,
   Controller,
@@ -51,7 +51,7 @@ export class CalProviderController {
   @UseGuards(AccessTokenGuard)
   async verifyAccessToken(
     @Param("clientId") clientId: string,
-    @GetUser() user: UserReturned
+    @GetUser() user: UserWithProfile
   ): Promise<ApiResponse> {
     if (!clientId) {
       throw new BadRequestException();

--- a/apps/api/v2/src/ee/schedules/controllers/schedules.controller.ts
+++ b/apps/api/v2/src/ee/schedules/controllers/schedules.controller.ts
@@ -3,6 +3,7 @@ import { SchedulesService } from "@/ee/schedules/services/schedules.service";
 import { ForAtom } from "@/lib/atoms/decorators/for-atom.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { AccessTokenGuard } from "@/modules/auth/guards/access-token/access-token.guard";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import {
   Body,
   Controller,
@@ -15,7 +16,6 @@ import {
   Patch,
   UseGuards,
 } from "@nestjs/common";
-import { User } from "@prisma/client";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import type { ScheduleWithAvailabilitiesForWeb } from "@calcom/platform-libraries";
@@ -40,7 +40,7 @@ export class SchedulesController {
 
   @Post("/")
   async createSchedule(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @Body() bodySchedule: CreateScheduleInput,
     @ForAtom() forAtom: boolean
   ): Promise<ApiResponse<{ schedule: ScheduleResponse | ScheduleWithAvailabilitiesForWeb }>> {
@@ -57,7 +57,7 @@ export class SchedulesController {
 
   @Get("/default")
   async getDefaultSchedule(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @ForAtom() forAtom: boolean
   ): Promise<ApiResponse<ScheduleResponse | ScheduleWithAvailabilitiesForWeb | null>> {
     const schedule = await this.schedulesService.getUserScheduleDefault(user.id);
@@ -85,7 +85,7 @@ export class SchedulesController {
 
   @Get("/:scheduleId")
   async getSchedule(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @Param("scheduleId") scheduleId: number,
     @ForAtom() forAtom: boolean
   ): Promise<ApiResponse<ScheduleResponse | ScheduleWithAvailabilitiesForWeb>> {
@@ -102,7 +102,7 @@ export class SchedulesController {
 
   @Get("/")
   async getSchedules(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @ForAtom() forAtom: boolean
   ): Promise<ApiResponse<{ schedules: ScheduleResponse[] | ScheduleWithAvailabilitiesForWeb[] }>> {
     const schedules = await this.schedulesService.getUserSchedules(user.id);
@@ -117,7 +117,7 @@ export class SchedulesController {
   }
   @Patch("/:scheduleId")
   async updateSchedule(
-    @GetUser() user: User,
+    @GetUser() user: UserWithProfile,
     @Body() bodySchedule: UpdateScheduleInput
   ): Promise<ApiResponse<unknown>> {
     const updatedSchedule: UpdateScheduleOutputType = await updateScheduleHandler({

--- a/apps/api/v2/src/modules/auth/guards/organization-roles/organization-roles.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/organization-roles/organization-roles.guard.ts
@@ -1,5 +1,6 @@
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
+import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 
@@ -15,14 +16,14 @@ export class OrganizationRolesGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest();
-    const user = request.user;
-    const partOfOrganization = Boolean(user?.organizationId);
+    const user: UserWithProfile = request.user;
+    const organizationId = user?.movedToProfile?.organizationId || user?.organizationId;
 
-    if (!user || !partOfOrganization) {
+    if (!user || !organizationId) {
       return false;
     }
 
-    const membership = await this.membershipRepository.findOrgUserMembership(user.organizationId, user.id);
+    const membership = await this.membershipRepository.findOrgUserMembership(organizationId, user.id);
     const isAccepted = membership.accepted;
     const hasRequiredRole = requiredRoles.includes(membership.role);
 

--- a/apps/api/v2/src/modules/auth/strategies/access-token/access-token.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/access-token/access-token.strategy.ts
@@ -1,7 +1,7 @@
 import { BaseStrategy } from "@/lib/passport/strategies/types";
 import { OAuthFlowService } from "@/modules/oauth-clients/services/oauth-flow.service";
 import { TokensRepository } from "@/modules/tokens/tokens.repository";
-import { UsersRepository } from "@/modules/users/users.repository";
+import { UserWithProfile, UsersRepository } from "@/modules/users/users.repository";
 import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import type { Request } from "express";
@@ -34,7 +34,7 @@ export class AccessTokenStrategy extends PassportStrategy(BaseStrategy, "access-
         throw new UnauthorizedException(INVALID_ACCESS_TOKEN);
       }
 
-      const user = await this.userRepository.findById(ownerId);
+      const user: UserWithProfile | null = await this.userRepository.findByIdWithProfile(ownerId);
 
       if (!user) {
         throw new UnauthorizedException(INVALID_ACCESS_TOKEN);

--- a/apps/api/v2/src/modules/users/users.repository.ts
+++ b/apps/api/v2/src/modules/users/users.repository.ts
@@ -3,7 +3,11 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { CreateUserInput } from "@/modules/users/inputs/create-user.input";
 import { UpdateUserInput } from "@/modules/users/inputs/update-user.input";
 import { Injectable } from "@nestjs/common";
-import type { User } from "@prisma/client";
+import type { Profile, User } from "@prisma/client";
+
+export type UserWithProfile = User & {
+  movedToProfile?: Profile | null;
+};
 
 @Injectable()
 export class UsersRepository {
@@ -26,6 +30,17 @@ export class UsersRepository {
     return this.dbRead.prisma.user.findUnique({
       where: {
         id: userId,
+      },
+    });
+  }
+
+  async findByIdWithProfile(userId: number): Promise<UserWithProfile | null> {
+    return this.dbRead.prisma.user.findUnique({
+      where: {
+        id: userId,
+      },
+      include: {
+        movedToProfile: true,
       },
     });
   }


### PR DESCRIPTION
Before:
Rely on "user.organizationId"

After:
First, check "user.movedToProfile.organizationId", and then "user.organizationId" as a fallback, because "user.movedToProfile" can be null.