### PR TITLE
chore: Increase API rate limit

### DIFF
--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -46,7 +46,7 @@ function logOnce(message: string) {
   warningDisplayed = true;
 }
 
-export const API_KEY_RATE_LIMIT = 10;
+export const API_KEY_RATE_LIMIT = 30;
 
 export function rateLimiter() {
   const UPSATCH_ENV_FOUND = process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN;


### PR DESCRIPTION
## What does this PR do?

Increase the API rate limit to 30 / minute (1800 / hour). Our limit before was knowingly quite restrictive. Until we have configurable rate limiting per user/partner, increasing the default so we are not hindering people's ability to use the API for their needs.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
