### PR TITLE
refactor: standardize v2 api returned data

### DIFF
--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
@@ -118,14 +118,14 @@ describe("Event types Endpoints", () => {
         .set("Authorization", `Bearer whatever`)
         .expect(200);
 
-      const responseBody: ApiSuccessResponse<{ eventType: EventType }> = response.body;
+      const responseBody: ApiSuccessResponse<EventType> = response.body;
 
       expect(responseBody.status).toEqual(SUCCESS_STATUS);
       expect(responseBody.data).toBeDefined();
-      expect(responseBody.data.eventType.id).toEqual(eventType.id);
-      expect(responseBody.data.eventType.title).toEqual(eventType.title);
-      expect(responseBody.data.eventType.slug).toEqual(eventType.slug);
-      expect(responseBody.data.eventType.userId).toEqual(user.id);
+      expect(responseBody.data.id).toEqual(eventType.id);
+      expect(responseBody.data.title).toEqual(eventType.title);
+      expect(responseBody.data.slug).toEqual(eventType.slug);
+      expect(responseBody.data.userId).toEqual(user.id);
     });
 
     it(`/GET/:id not existing`, async () => {

--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
@@ -22,14 +22,12 @@ export class EventTypesController {
   async createEventType(
     @Body() body: CreateEventTypeInput,
     @GetUser() user: User
-  ): Promise<ApiResponse<{ eventType: EventType }>> {
+  ): Promise<ApiResponse<EventType>> {
     const eventType = await this.eventTypesService.createUserEventType(user.id, body);
 
     return {
       status: SUCCESS_STATUS,
-      data: {
-        eventType,
-      },
+      data: eventType,
     };
   }
 
@@ -38,7 +36,7 @@ export class EventTypesController {
     @Param("eventTypeId") eventTypeId: string,
     @ForAtom() forAtom: boolean,
     @GetUser() user: User
-  ): Promise<ApiResponse<{ eventType: EventType | AtomEventType }>> {
+  ): Promise<ApiResponse<EventType | AtomEventType>> {
     const eventType = forAtom
       ? await this.eventTypesService.getUserEventTypeForAtom(user, Number(eventTypeId))
       : await this.eventTypesService.getUserEventType(user.id, Number(eventTypeId));
@@ -49,9 +47,7 @@ export class EventTypesController {
 
     return {
       status: SUCCESS_STATUS,
-      data: {
-        eventType,
-      },
+      data: eventType,
     };
   }
 }

--- a/apps/api/v2/src/ee/me/me.controller.ts
+++ b/apps/api/v2/src/ee/me/me.controller.ts
@@ -22,14 +22,12 @@ export class MeController {
   ) {}
 
   @Get("/")
-  async getMe(@GetUser() user: User): Promise<ApiResponse<{ user: UserResponse }>> {
+  async getMe(@GetUser() user: User): Promise<ApiResponse<UserResponse>> {
     const me = userSchemaResponse.parse(user);
 
     return {
       status: SUCCESS_STATUS,
-      data: {
-        user: me,
-      },
+      data: me,
     };
   }
 
@@ -37,7 +35,7 @@ export class MeController {
   async updateMe(
     @GetUser() user: User,
     @Body() bodySchedule: UpdateUserInput
-  ): Promise<ApiResponse<{ user: UserResponse }>> {
+  ): Promise<ApiResponse<UserResponse>> {
     const updatedUser = await this.usersRepository.update(user.id, bodySchedule);
     if (bodySchedule.timeZone && user.defaultScheduleId) {
       await this.schedulesRepository.updateUserSchedule(user.id, user.defaultScheduleId, {
@@ -49,9 +47,7 @@ export class MeController {
 
     return {
       status: SUCCESS_STATUS,
-      data: {
-        user: me,
-      },
+      data: me,
     };
   }
 }

--- a/packages/platform/atoms/availability/wrappers/PlatformAvailabilitySettingsWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/PlatformAvailabilitySettingsWrapper.tsx
@@ -56,7 +56,7 @@ export const PlatformAvailabilitySettingsWrapper = ({
   const mySchedule = schedule as ApiSuccessResponse<ScheduleWithAvailabilitiesForWeb>;
   const { data: me } = useMe();
   const userSchedule = mySchedule?.data;
-  const { timeFormat } = me?.data.user || { timeFormat: null };
+  const { timeFormat } = me?.data || { timeFormat: null };
   const { toast } = useToast();
 
   const { mutate: deleteSchedule, isPending: isDeletionInProgress } = useDeleteSchedule({

--- a/packages/platform/atoms/hooks/useMe.ts
+++ b/packages/platform/atoms/hooks/useMe.ts
@@ -14,7 +14,7 @@ export const useMe = () => {
   const me = useQuery({
     queryKey: [QUERY_KEY],
     queryFn: () => {
-      return http?.get<ApiResponse<{ user: UserResponse }>>(endpoint.toString()).then((res) => {
+      return http?.get<ApiResponse<UserResponse>>(endpoint.toString()).then((res) => {
         if (res.data.status === SUCCESS_STATUS) {
           return res.data;
         }

--- a/packages/platform/atoms/hooks/useTimezone.ts
+++ b/packages/platform/atoms/hooks/useTimezone.ts
@@ -7,7 +7,7 @@ export const useTimezone = (
   currentTimezone: string = new Intl.DateTimeFormat().resolvedOptions().timeZone
 ) => {
   const { data: me, isLoading } = useMe();
-  const preferredTimezone = me?.data?.user?.timeZone ?? currentTimezone;
+  const preferredTimezone = me?.data?.timeZone ?? currentTimezone;
 
   useEffect(() => {
     if (!isLoading && preferredTimezone && preferredTimezone !== currentTimezone) {

--- a/packages/platform/atoms/hooks/useUpdateUserTimezone.ts
+++ b/packages/platform/atoms/hooks/useUpdateUserTimezone.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { BASE_URL, API_VERSION, V2_ENDPOINTS } from "@calcom/platform-constants";
-import type { ApiResponse } from "@calcom/platform-types";
+import type { ApiResponse, UserResponse } from "@calcom/platform-types";
 
 import http from "../lib/http";
 
@@ -14,7 +14,7 @@ export const useUpdateUserTimezone = () => {
 
   endpoint.pathname = `api/${API_VERSION}/${V2_ENDPOINTS.me}`;
 
-  const mutation = useMutation<ApiResponse<undefined>, unknown, updateTimezoneInput>({
+  const mutation = useMutation<ApiResponse<UserResponse>, unknown, updateTimezoneInput>({
     mutationFn: (data) => {
       const { timeZone } = data;
 


### PR DESCRIPTION
Some controllers return `Promise<ApiResponse<{ eventType: EventType }>` instead of `Promise<ApiResponse<EventType>`.

Refactor controllers to have return format `Promise<ApiResponse<ReturnedType>`