### PR TITLE
fix: add the X-Cal-Signature-256 header to MEETING_ENDED webhook requests

### DIFF
--- a/packages/features/webhooks/lib/cron.ts
+++ b/packages/features/webhooks/lib/cron.ts
@@ -28,7 +28,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // Fetch the webhook configuration so that we can get the secret.
     const [appId, subscriberId] = job.jobName.split("_");
     const webhook = await prisma.webhook.findUniqueOrThrow({
-      where: { id: subscriberId, appId },
+      where: { id: subscriberId, appId: appId !== "null" ? appId : null },
     });
     try {
       await fetch(job.subscriberUrl, {

--- a/packages/features/webhooks/lib/cron.ts
+++ b/packages/features/webhooks/lib/cron.ts
@@ -5,7 +5,7 @@ import dayjs from "@calcom/dayjs";
 import { defaultHandler } from "@calcom/lib/server";
 import prisma from "@calcom/prisma";
 
-import { jsonParse } from "./sendPayload";
+import { createWebhookSignature, jsonParse } from "./sendPayload";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const apiKey = req.headers.authorization || req.query.apiKey;
@@ -25,6 +25,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   // run jobs
   for (const job of jobsToRun) {
+    // Fetch the webhook configuration so that we can get the secret.
+    const [appId, subscriberId] = job.jobName.split("_");
+    const webhook = await prisma.webhook.findUniqueOrThrow({
+      where: { id: subscriberId, appId },
+    });
     try {
       await fetch(job.subscriberUrl, {
         method: "POST",
@@ -32,6 +37,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         headers: {
           "Content-Type":
             !job.payload || jsonParse(job.payload) ? "application/json" : "application/x-www-form-urlencoded",
+          "X-Cal-Signature-256": createWebhookSignature({ secret: webhook.secret, body: job.payload }),
         },
       });
     } catch (error) {

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -189,6 +189,11 @@ export const sendGenericWebhookPayload = async ({
   return _sendPayload(secretKey, webhook, body, "application/json");
 };
 
+export const createWebhookSignature = (params: { secret?: string | null; body: string }) =>
+  params.secret
+    ? createHmac("sha256", params.secret).update(`${params.body}`).digest("hex")
+    : "no-secret-provided";
+
 const _sendPayload = async (
   secretKey: string | null,
   webhook: Pick<Webhook, "subscriberUrl" | "appId" | "payloadTemplate">,
@@ -200,15 +205,11 @@ const _sendPayload = async (
     throw new Error("Missing required elements to send webhook payload.");
   }
 
-  const secretSignature = secretKey
-    ? createHmac("sha256", secretKey).update(`${body}`).digest("hex")
-    : "no-secret-provided";
-
   const response = await fetch(subscriberUrl, {
     method: "POST",
     headers: {
       "Content-Type": contentType,
-      "X-Cal-Signature-256": secretSignature,
+      "X-Cal-Signature-256": createWebhookSignature({ secret: secretKey, body }),
     },
     redirect: "manual",
     body,


### PR DESCRIPTION
## What does this PR do?
Fixes #13985

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is ab UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Tests (Unit/Integration/E2E or any other test)
- This change requires a documentation update

## How should this be tested?
I tested this change by running locally to validate that the header is sent correctly.

As far as I can tell, there are no existing test cases that validate this functionality (unit or end-to-end). I'm afraid I'm not familiar enough with how this project works to be able to bootstrap a new test suite for this logic.

If a reviewer wants to offer guidance to that end, I'd be happy to put something together.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have checked if new and existing unit tests pass locally with my changes
