### PR TITLE
chore: Reduce insights range to 7 days

### DIFF
--- a/packages/features/insights/context/FiltersProvider.tsx
+++ b/packages/features/insights/context/FiltersProvider.tsx
@@ -58,9 +58,9 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
 
   const [configFilters, setConfigFilters] = useState<FilterContextType["filter"]>({
     dateRange: [
-      startTimeParsed ? dayjs(startTimeParsed) : dayjs().subtract(1, "month"),
+      startTimeParsed ? dayjs(startTimeParsed) : dayjs().subtract(1, "week"),
       endTimeParsed ? dayjs(endTimeParsed) : dayjs(),
-      "t",
+      "w",
     ],
     selectedTimeView: "week",
     selectedUserId: userIdParsed || null,
@@ -150,7 +150,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
             selectedTimeView: "week",
             selectedUserId: userId,
             isAll: !!initialConfig?.isAll,
-            dateRange: [dayjs().subtract(1, "month"), dayjs(), "t"],
+            dateRange: [dayjs().subtract(1, "week"), dayjs(), "w"],
             initialConfig,
           });
 


### PR DESCRIPTION
## What does this PR do?

Chatted with @ciaranha and we decided that `Last 7 Days` makes more sense for the default view.

## Type of change

- Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Load insights and ensure it defaults to Last 7 Days.
- Ensure the timeline view is only calculating and displaying data for the last 7 days.
- Ensure that clearing filters resets the date range back to last 7 days

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
