### PR TITLE
build: adds action to manually remove faulty cache entries

### DIFF
--- a/.github/workflows/delete-buildjet-cache.yml
+++ b/.github/workflows/delete-buildjet-cache.yml
@@ -1,0 +1,17 @@
+name: Manually Delete BuildJet Cache
+on:
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: "BuildJet Cache Key to Delete"
+        required: true
+        type: string
+jobs:
+  manually-delete-buildjet-cache:
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: buildjet/cache-delete@v1
+        with:
+          cache_key: ${{ inputs.cache_key }}


### PR DESCRIPTION
## What does this PR do?



A per [bulildjet docs](https://buildjet.com/for-github-actions/docs/guides/migrating-to-buildjet-cache#manually-deleting-cache-entries), this PR adds a way to remove faulty cache entries that might be responsible for some PR checks to fail.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Chore (refactoring code, technical debt, workflow improvements)

