### PR TITLE
fix: avatar upload flakyness

### DIFF
--- a/apps/web/playwright/settings/upload-avatar.e2e.ts
+++ b/apps/web/playwright/settings/upload-avatar.e2e.ts
@@ -40,10 +40,8 @@ test.describe("UploadAvatar", async () => {
         },
       });
 
-      // todo: remove this; ideally the organization-avatar is updated the moment
-      //       'Settings updated succesfully' is saved.
-      await page.waitForLoadState("networkidle");
-      const avatar = page.getByTestId("profile-upload-avatar").locator("img");
+      // Wait for the avatar image with the http src to appear instead of the data uri
+      const avatar = page.getByTestId("profile-upload-avatar").locator("img[src^=http]");
 
       const src = await avatar.getAttribute("src");
 


### PR DESCRIPTION
## What does this PR do?

Fixes flakiness with avatar uploads. The "expect" was running so fast that the img src was not updated yet with the new generated URL. This adds a selector that ensure that we wait for the src change.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Tests (Unit/Integration/E2E or any other test)

## How should this be tested?
 
- Run `PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/settings/upload-avatar.e2e.ts`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

