### PR TITLE
feat: check v2 request origin

### DIFF
--- a/apps/api/v2/src/ee/schedules/controllers/schedules.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/schedules/controllers/schedules.controller.e2e-spec.ts
@@ -327,7 +327,6 @@ describe("Schedules Endpoints", () => {
         .expect(200)
         .then((response: any) => {
           const responseBody: ApiSuccessResponse<UpdateScheduleOutputType> = response.body;
-          console.log("asap responseBody.data 1", JSON.stringify(responseBody.data, null, 2));
           expect(responseBody.status).toEqual(SUCCESS_STATUS);
           expect(responseBody.data).toBeDefined();
           expect(responseBody.data.schedule.id).toBeDefined();

--- a/apps/api/v2/src/modules/auth/strategies/access-token/access-token.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/access-token/access-token.strategy.ts
@@ -21,12 +21,25 @@ export class AccessTokenStrategy extends PassportStrategy(BaseStrategy, "access-
   async authenticate(request: Request) {
     try {
       const accessToken = request.get("Authorization")?.replace("Bearer ", "");
+      const requestOrigin = request.get("Origin");
 
       if (!accessToken) {
         throw new UnauthorizedException(INVALID_ACCESS_TOKEN);
       }
+      if (!requestOrigin) {
+        throw new UnauthorizedException("Missing request origin");
+      }
 
       await this.oauthFlowService.validateAccessToken(accessToken);
+
+      const client = await this.tokensRepository.getAccessTokenClient(accessToken);
+      if (!client) {
+        throw new UnauthorizedException("OAuth client not found given the access token");
+      }
+
+      if (!client.redirectUris.some((uri) => uri.startsWith(requestOrigin))) {
+        throw new UnauthorizedException("Invalid request origin");
+      }
 
       const ownerId = await this.tokensRepository.getAccessTokenOwnerId(accessToken);
 


### PR DESCRIPTION
401 unauthorized when missing Origin header
<img width="1191" alt="Screenshot 2024-03-14 at 11 02 03" src="https://github.com/calcom/cal.com/assets/42170848/0f31bde7-9b23-4156-b4e0-9d850b713f77">

Given that http://localhost:4321 is REDIRECT_URI of the oauth client and is passed as Origin
<img width="1190" alt="Screenshot 2024-03-14 at 11 02 34" src="https://github.com/calcom/cal.com/assets/42170848/7876a1b6-5c34-4f57-92b3-3eefeab0e8fe">

Origin needs to resolve to domain without paths, if Origin is {{REDIRECT_URI}}/some/path then its 401 again. We are asking if one of the oauth client's redirectUris starts with origin url.
<img width="1191" alt="Screenshot 2024-03-14 at 11 02 42" src="https://github.com/calcom/cal.com/assets/42170848/83c79ae2-9cf6-401f-9fe9-bdc2d268034c">

This logic is used only for the AccessTokenGuard