### PR TITLE
fix: v2 e2e tests

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -18,7 +18,7 @@
     "test:watch": "yarn dev:build && jest --watch",
     "test:cov": "yarn dev:build && jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "yarn dev:build && jest --config ./jest-e2e.json",
+    "test:e2e": "yarn dev:build && jest --runInBand --config ./jest-e2e.json",
     "prisma": "yarn workspace @calcom/prisma prisma",
     "generate-schemas": "yarn prisma generate && yarn prisma format",
     "copy-swagger-module": "ts-node -r tsconfig-paths/register swagger/copy-swagger-module.ts"

--- a/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
@@ -127,7 +127,7 @@ describe("Platform Gcal Endpoints", () => {
     await request(app.getHttpServer())
       .get(`/api/v2/platform/gcal/check`)
       .set("Authorization", `Bearer ${accessTokenSecret}`)
-      .expect(401);
+      .expect(400);
   });
 
   it(`/GET/platform/gcal/check without access token`, async () => {

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -23,6 +23,8 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { ApiSuccessResponse } from "@calcom/platform-types";
 
+const CLIENT_REDIRECT_URI = "http://localhost:4321";
+
 describe("OAuth Client Users Endpoints", () => {
   describe("Not authenticated", () => {
     let app: INestApplication;
@@ -99,7 +101,7 @@ describe("OAuth Client Users Endpoints", () => {
       const data = {
         logo: "logo-url",
         name: "name",
-        redirectUris: ["redirect-uri"],
+        redirectUris: [CLIENT_REDIRECT_URI],
         permissions: 32,
       };
       const secret = "secret";
@@ -180,6 +182,7 @@ describe("OAuth Client Users Endpoints", () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
         .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .expect(200);
 
       const responseBody: ApiSuccessResponse<UserReturned> = response.body;
@@ -196,6 +199,7 @@ describe("OAuth Client Users Endpoints", () => {
       const response = await request(app.getHttpServer())
         .patch(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
         .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .send(body)
         .expect(200);
 
@@ -210,6 +214,7 @@ describe("OAuth Client Users Endpoints", () => {
       return request(app.getHttpServer())
         .delete(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
         .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .expect(200);
     });
 


### PR DESCRIPTION
Make "yarn test:e2e" in v2 api run green:
<img width="495" alt="Screenshot 2024-03-14 at 16 01 52" src="https://github.com/calcom/cal.com/assets/42170848/c12c15a6-f845-4417-9686-ac12320d5407">


Fixed individual tests [gcal.controller.e2e-spec.ts](https://github.com/calcom/cal.com/pull/14088/files#diff-683f9b88ecd7ca785e8714d4e60485a7cabf3c6eafafd6b36f9fbbbd9e6efa00) and [oauth-client-users.controller.e2e-spec.ts](https://github.com/calcom/cal.com/pull/14088/files#diff-ef70ba4530dadca8396cec66a0d6b872cbf43dae90a7024a77524092fc626725).

Fixed e2e tests timing out: in "test:e2e" command of [api/v2/package.json](https://github.com/calcom/cal.com/pull/14088/files#diff-7d2b1a32a187da390f2023118a13d1dd4de67cbdc064b868fc4d2fccc2e3fa35) added "--runInBand" flag that means "Run all tests serially in the current process, rather than creating a worker pool of child processes that run tests." - the tests run in 35 seconds with it but without it were around 150 seconds and many of them timed out, essentially we run tests 1 after another now.