### PR TITLE
fix: date overrides typing issue in `AvailabilitySettings` atom

### DIFF
--- a/packages/platform/atoms/availability/wrappers/PlatformAvailabilitySettingsWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/PlatformAvailabilitySettingsWrapper.tsx
@@ -94,7 +94,14 @@ export const PlatformAvailabilitySettingsWrapper = ({
   };
 
   const handleUpdate = async (id: number, body: AvailabilityFormValues) => {
-    await updateSchedule({ scheduleId: id, ...body });
+    const transformedDateOverrides = body.dateOverrides[0].ranges.map((range) => {
+      return {
+        start: range.start,
+        end: range.end,
+      };
+    });
+
+    await updateSchedule({ ...body, scheduleId: id, dateOverrides: transformedDateOverrides });
   };
 
   if (isLoading) return <div className="px-10 py-4 text-xl">Loading...</div>;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The update handler for the `Availability Settings` atom has type issues with the expected date overrides data and the one being given, so at the time of updating let's just transform the data overrides to the format that v2 api expects it to be
