### PR TITLE
fix: don't show 'send event details to' for team events

### DIFF
--- a/apps/web/components/eventtype/EventAdvancedTab.tsx
+++ b/apps/web/components/eventtype/EventAdvancedTab.tsx
@@ -216,7 +216,7 @@ export const EventAdvancedTab = ({ eventType, team }: Pick<EventTypeSetupProps, 
             />
           </div>
         )}
-        {!useEventTypeDestinationCalendarEmail && verifiedSecondaryEmails.length > 0 && (
+        {!useEventTypeDestinationCalendarEmail && verifiedSecondaryEmails.length > 1 && !team && (
           <div className="w-full">
             <SelectField
               label={t("send_event_details_to")}


### PR DESCRIPTION
## What does this PR do?

Don't show 'send event details to' for team events. Also, only show if user has a secondary email to choose from 