### PR TITLE
fix: email embed displaying wrong date

### DIFF
--- a/packages/features/embed/Embed.tsx
+++ b/packages/features/embed/Embed.tsx
@@ -385,7 +385,7 @@ const EmailEmbedPreview = ({
                 Object.keys(selectedDateAndTime)
                   .sort()
                   .map((key) => {
-                    const date = new Date(key);
+                    const selectedDate = dayjs(key).tz(timezone).format("dddd, MMMM D, YYYY");
                     return (
                       <table
                         key={key}
@@ -406,12 +406,7 @@ const EmailEmbedPreview = ({
                                   color: "rgb(26, 26, 26)",
                                   fontWeight: "bold",
                                 }}>
-                                {date.toLocaleDateString("en-US", {
-                                  weekday: "long",
-                                  month: "long",
-                                  day: "numeric",
-                                  year: "numeric",
-                                })}
+                                {selectedDate}
                                 &nbsp;
                               </span>
                             </td>


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/calcom/cal.com/issues/13776

<img width="1287" alt="Screenshot 2024-03-18 at 6 18 38 AM" src="https://github.com/calcom/cal.com/assets/53316345/14322f5e-b6dd-4d65-a3aa-7c8d5114c486">


How to reproduce the bug?
1) Change you system's timezone and cal.com timezone to America/Chicago

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)