### PR TITLE
fix: booking limits for team event types

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -371,7 +371,7 @@ export async function ensureAvailableUsers(
         user,
         eventType,
         rescheduleUid: input.originalRescheduledBooking?.uid ?? null,
-        busyTimesFromLimitsBookings: busyTimesFromLimitsBookingsAllUsers.filter((b) => b.userId === user.id),
+        busyTimesFromLimitsBookings: busyTimesFromLimitsBookingsAllUsers,
       }
     );
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -472,9 +472,7 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions) {
               const { attendees: _attendees, ...bookingWithoutAttendees } = bookings;
               return bookingWithoutAttendees;
             }),
-          busyTimesFromLimitsBookings: busyTimesFromLimitsBookingsAllUsers.filter(
-            (b) => b.userId === currentUser.id
-          ),
+          busyTimesFromLimitsBookings: busyTimesFromLimitsBookingsAllUsers,
         }
       );
       if (!currentSeats && _currentSeats) currentSeats = _currentSeats;


### PR DESCRIPTION
## What does this PR do?

This fixes a bug for team event types with booking limits enabled. Slots were shown as available even though the limit was already reached. When trying to book the slot it was throwing "Booking Limit for this event type has been reached"

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- create round robin event type and assign hosts 
- add a limit of 1 booking per day 
- book one slot 
- go back to availabilities and see that the day is now blocked 
  - before the day was still open, but when trying to book a slot it was throwing the error
