### PR TITLE
fix: Minor UI fix to team profile / fallback to parent org logo

### DIFF
--- a/packages/features/ee/teams/components/TeamList.tsx
+++ b/packages/features/ee/teams/components/TeamList.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function TeamList(props: Props) {
-  const utils = trpc.useContext();
+  const utils = trpc.useUtils();
 
   const { t } = useLocale();
 
@@ -56,7 +56,6 @@ export default function TeamList(props: Props) {
           setHideDropdown={setHideDropdown}
         />
       ))}
-
       {/* only show recommended steps when there is only one team */}
       {!props.pending && props.teams.length === 1 && (
         <>

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -107,8 +107,8 @@ export default function TeamListItem(props: Props) {
     <div className="item-center flex px-5 py-5">
       <Avatar
         size="md"
-        imageSrc={getPlaceholderAvatar(team?.logo, team?.name as string)}
-        alt="Team Logo"
+        imageSrc={getPlaceholderAvatar(team?.logo || team?.parent?.logo, team?.name as string)}
+        alt="Team logo"
         className="inline-flex justify-center"
       />
       <div className="ms-3 inline-block truncate">

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -364,17 +364,13 @@ const TeamProfileForm = ({ team }: TeamProfileFormProps) => {
         <Controller
           control={form.control}
           name="name"
-          render={({ field: { value } }) => (
-            <div className="mt-8">
-              <TextField
-                name="name"
-                label={t("team_name")}
-                value={value}
-                onChange={(e) => {
-                  form.setValue("name", e?.target.value, { shouldDirty: true });
-                }}
-              />
-            </div>
+          render={({ field: { name, value, onChange } }) => (
+            <TextField
+              name={name}
+              label={t("team_name")}
+              value={value}
+              onChange={(e) => onChange(e?.target.value)}
+            />
           )}
         />
         <Controller


### PR DESCRIPTION
## What does this PR do?

* Show the organisation avatar for subteams (if not has logo, show parent logo, if no parent logo - default)
* Fix too much margin UI issue in sub team profiles.
