### PR TITLE
fix: wrong availability calculation

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -179,10 +179,9 @@ function buildSlotsWithDateRanges({
       ? range.start
       : startTimeWithMinNotice;
 
-    slotStartTime =
-      slotStartTime.minute() % interval !== 0
-        ? slotStartTime.startOf("hour").add(Math.ceil(slotStartTime.minute() / interval) * interval, "minute")
-        : slotStartTime;
+    slotStartTime = ![0, 15, 30, 45, 60].includes(slotStartTime.minute())
+      ? slotStartTime.startOf("hour").add(Math.ceil(slotStartTime.minute() / interval) * interval, "minute")
+      : slotStartTime;
 
     // Adding 1 minute to date ranges that end at midnight to ensure that the last slot is included
     const rangeEnd = range.end


### PR DESCRIPTION
## What does this PR do?

This PR fixes the wrong slotTime calculation in displaying the available slots for booking a meeting.

Fixes #14134

<img width="1041" alt="Screenshot 2024-03-21 at 2 58 39 PM" src="https://github.com/calcom/cal.com/assets/28892893/e028f76c-166b-4a46-ae7c-2343e806366e">
<img width="1041" alt="Screenshot 2024-03-21 at 2 58 51 PM" src="https://github.com/calcom/cal.com/assets/28892893/d7b59483-3ee9-4ff1-bbde-02cca4fb5a45">

### Availability

<img width="797" alt="Screenshot 2024-03-21 at 2 59 20 PM" src="https://github.com/calcom/cal.com/assets/28892893/c69e21bc-1151-48a2-85c7-9a596b5c41f6">

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't checked if my PR needs changes to unit tests

