### PR TITLE
refactor: v2 API remove defaultScheduleId when creating a managed user

### DIFF
--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
@@ -59,7 +59,7 @@ describe("Event types Endpoints", () => {
     let teamRepositoryFixture: TeamRepositoryFixture;
     let eventTypesRepositoryFixture: EventTypesRepositoryFixture;
 
-    const userEmail = "test-e2e@api.com";
+    const userEmail = "event-types-test-e2e@api.com";
     let eventType: EventType;
     let user: User;
 
@@ -153,7 +153,11 @@ describe("Event types Endpoints", () => {
       await oauthClientRepositoryFixture.delete(oAuthClient.id);
       await teamRepositoryFixture.delete(organization.id);
       await eventTypesRepositoryFixture.delete(eventType.id);
-
+      try {
+        await userRepositoryFixture.delete(user.id);
+      } catch (e) {
+        // User might have been deleted by the test
+      }
       await app.close();
     });
   });

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -221,7 +221,11 @@ describe("OAuth Client Users Endpoints", () => {
     afterAll(async () => {
       await oauthClientRepositoryFixture.delete(oAuthClient.id);
       await teamRepositoryFixture.delete(organization.id);
-
+      try {
+        await userRepositoryFixture.delete(postResponseData.user.id);
+      } catch (e) {
+        // User might have been deleted by the test
+      }
       await app.close();
     });
   });

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -169,7 +169,8 @@ describe("OAuth Client Users Endpoints", () => {
     async function userHasDefaultEventTypes(userId: number) {
       const defaultEventTypes = await eventTypesRepositoryFixture.getAllUserEventTypes(userId);
 
-      expect(defaultEventTypes?.length).toEqual(2);
+      // note(Lauris): to determine count see default event types created in EventTypesService.createUserDefaultEventTypes
+      expect(defaultEventTypes?.length).toEqual(4);
       expect(
         defaultEventTypes?.find((eventType) => eventType.length === DEFAULT_EVENT_TYPES.thirtyMinutes.length)
       ).toBeTruthy();

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
@@ -155,10 +155,6 @@ export class OAuthClientUsersController {
       throw new NotFoundException(`User with ${userId} does not exist`);
     }
 
-    if (existingUser.username) {
-      throw new BadRequestException("Cannot delete a non manually-managed user");
-    }
-
     const user = await this.userRepository.delete(userId);
 
     return {

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.e2e-spec.ts
@@ -65,7 +65,7 @@ describe("OAuth Clients Endpoints", () => {
     let user: User;
     let org: Team;
     let app: INestApplication;
-    const userEmail = "test-e2e@api.com";
+    const userEmail = "oauth-clients-test-e2e@api.com";
 
     beforeAll(async () => {
       const moduleRef = await withNextAuth(

--- a/apps/api/v2/src/modules/users/inputs/create-user.input.ts
+++ b/apps/api/v2/src/modules/users/inputs/create-user.input.ts
@@ -15,10 +15,6 @@ export class CreateUserInput {
   @Validate(IsTimeFormat)
   timeFormat?: number;
 
-  @IsNumber()
-  @IsOptional()
-  defaultScheduleId?: number;
-
   @IsString()
   @IsOptional()
   @Validate(IsWeekStart)


### PR DESCRIPTION
## What does this PR do?

1. It was possible to pass "defaultScheduleId" when creating a managed user which is useless, because "SchedulesController.createSchedule" is behind an access token, which can only be obtained after creating a managed user. So [refactor: v2 api remove defaultScheduleId from create user input](https://github.com/calcom/cal.com/commit/679695f119eb35601ba18c6f22adc8e2ca0f291e) removes the property from input data.
2. I saw in my database that some tests hadn't cleaned up test user and that some tests had same user e-mail. I changed user e-mails in tests for them to be distinct and also in "afterAll" added deletion of users just in case DELETE call fails in [refactor: ensure user from test is deleted](https://github.com/calcom/cal.com/commit/261fceb4affa972c35240b1254fb9e8c6b719fc6)
3. In [fix: oauth-client-users test and allow deleting oauth users](https://github.com/calcom/cal.com/commit/f184062fa6132cc25b9966c57bb7ef38f78e7420) i updated oauth-client-users test because by default we now create 4 event types and also removed check when deleting managed user that permitted deleting one with username, but we by default create username when creating a managed user.