### PR TITLE
fix: add missing multiple_duration_timeUnit translation in zh-CN

### DIFF
--- a/apps/web/public/static/locales/zh-CN/common.json
+++ b/apps/web/public/static/locales/zh-CN/common.json
@@ -679,6 +679,7 @@
   "default_duration": "默认时长",
   "default_duration_no_options": "请先选择可用时长",
   "multiple_duration_mins": "{{count}} $t(minute_timeUnit)",
+  "multiple_duration_timeUnit": "{{count}} $t({{unit}}_timeUnit)",
   "minutes": "分钟",
   "round_robin": "轮流模式",
   "round_robin_description": "和多个团队成员之间轮流举行会议。",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes missing `multiple_duration_timeUnit` translation in zh-CN


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- The following display problem in locale zh-CN should be fixed.
![image](https://github.com/calcom/cal.com/assets/7402471/257e6176-693a-4e55-a4b5-f33ecf8e4305)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follow the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have checked if new and existing unit tests pass locally with my changes
