### PR TITLE
refactor: prisma platform tables use pascal case

### DIFF
--- a/packages/prisma/migrations/20240329084749_platform_snake_case_to_pascal_case/migration.sql
+++ b/packages/prisma/migrations/20240329084749_platform_snake_case_to_pascal_case/migration.sql
@@ -1,0 +1,125 @@
+/*
+  Warnings:
+
+  - You are about to drop the `platform_access_tokens` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `platform_authorization_token` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `platform_oauth_clients` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `platform_refresh_token` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_PlatformOAuthClientToUser" DROP CONSTRAINT "_PlatformOAuthClientToUser_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_access_tokens" DROP CONSTRAINT "platform_access_tokens_platform_oauth_client_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_access_tokens" DROP CONSTRAINT "platform_access_tokens_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_authorization_token" DROP CONSTRAINT "platform_authorization_token_platform_oauth_client_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_authorization_token" DROP CONSTRAINT "platform_authorization_token_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_oauth_clients" DROP CONSTRAINT "platform_oauth_clients_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_refresh_token" DROP CONSTRAINT "platform_refresh_token_platform_oauth_client_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "platform_refresh_token" DROP CONSTRAINT "platform_refresh_token_user_id_fkey";
+
+-- DropTable
+DROP TABLE "platform_access_tokens";
+
+-- DropTable
+DROP TABLE "platform_authorization_token";
+
+-- DropTable
+DROP TABLE "platform_oauth_clients";
+
+-- DropTable
+DROP TABLE "platform_refresh_token";
+
+-- CreateTable
+CREATE TABLE "PlatformOAuthClient" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "permissions" INTEGER NOT NULL,
+    "logo" TEXT,
+    "redirectUris" TEXT[],
+    "organizationId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PlatformOAuthClient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PlatformAuthorizationToken" (
+    "id" TEXT NOT NULL,
+    "platformOAuthClientId" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PlatformAuthorizationToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AccessToken" (
+    "id" SERIAL NOT NULL,
+    "secret" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "platformOAuthClientId" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "AccessToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" SERIAL NOT NULL,
+    "secret" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "platformOAuthClientId" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlatformAuthorizationToken_userId_platformOAuthClientId_key" ON "PlatformAuthorizationToken"("userId", "platformOAuthClientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccessToken_secret_key" ON "AccessToken"("secret");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_secret_key" ON "RefreshToken"("secret");
+
+-- AddForeignKey
+ALTER TABLE "PlatformOAuthClient" ADD CONSTRAINT "PlatformOAuthClient_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PlatformAuthorizationToken" ADD CONSTRAINT "PlatformAuthorizationToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PlatformAuthorizationToken" ADD CONSTRAINT "PlatformAuthorizationToken_platformOAuthClientId_fkey" FOREIGN KEY ("platformOAuthClientId") REFERENCES "PlatformOAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AccessToken" ADD CONSTRAINT "AccessToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AccessToken" ADD CONSTRAINT "AccessToken_platformOAuthClientId_fkey" FOREIGN KEY ("platformOAuthClientId") REFERENCES "PlatformOAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_platformOAuthClientId_fkey" FOREIGN KEY ("platformOAuthClientId") REFERENCES "PlatformOAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PlatformOAuthClientToUser" ADD CONSTRAINT "_PlatformOAuthClientToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "PlatformOAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1186,21 +1186,19 @@ model OutOfOfficeEntry {
 model PlatformOAuthClient {
   id             String   @id @default(cuid())
   name           String
-  secret         String // auth secret?
+  secret         String
   permissions    Int
   users          User[]
   logo           String?
-  redirectUris   String[] @map("redirect_uris")
-  organizationId Int      @map("organization_id")
+  redirectUris   String[]
+  organizationId Int
   organization   Team     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   accessTokens        AccessToken[]
   refreshToken        RefreshToken[]
   authorizationTokens PlatformAuthorizationToken[]
 
-  createdAt DateTime @default(now()) @map("created_at")
-
-  @@map(name: "platform_oauth_clients")
+  createdAt DateTime @default(now())
 }
 
 model PlatformAuthorizationToken {
@@ -1209,45 +1207,40 @@ model PlatformAuthorizationToken {
   owner  User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   client PlatformOAuthClient @relation(fields: [platformOAuthClientId], references: [id], onDelete: Cascade)
 
-  platformOAuthClientId String @map("platform_oauth_client_id")
-  userId                Int    @map("user_id")
+  platformOAuthClientId String
+  userId                Int
 
-  createdAt DateTime @default(now()) @map("created_at")
+  createdAt DateTime @default(now())
 
   @@unique([userId, platformOAuthClientId])
-  @@map("platform_authorization_token")
 }
 
 model AccessToken {
   id Int @id @default(autoincrement())
 
   secret    String   @unique
-  createdAt DateTime @default(now()) @map("created_at")
-  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now())
+  expiresAt DateTime
 
   owner  User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   client PlatformOAuthClient @relation(fields: [platformOAuthClientId], references: [id], onDelete: Cascade)
 
-  platformOAuthClientId String @map("platform_oauth_client_id")
-  userId                Int    @map("user_id")
-
-  @@map("platform_access_tokens")
+  platformOAuthClientId String
+  userId                Int
 }
 
 model RefreshToken {
   id Int @id @default(autoincrement())
 
   secret    String   @unique
-  createdAt DateTime @default(now()) @map("created_at")
-  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now())
+  expiresAt DateTime
 
   owner  User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   client PlatformOAuthClient @relation(fields: [platformOAuthClientId], references: [id], onDelete: Cascade)
 
-  platformOAuthClientId String @map("platform_oauth_client_id")
-  userId                Int    @map("user_id")
-
-  @@map("platform_refresh_token")
+  platformOAuthClientId String
+  userId                Int
 }
 
 model DSyncData {


### PR DESCRIPTION
Platform tables and their properties were mapped to snake_case in database, however, the standard is PascalCase.

This migration removes @@map from tables and @map from properties.
