### PR TITLE
fix: `Booker` atom modal not rendering for mobile devices

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -447,15 +447,11 @@ const BookerComponent = ({
         )}
       </div>
 
-      {!isPlatform ? (
-        <BookFormAsModal
-          onCancel={() => setSelectedTimeslot(null)}
-          visible={bookerState === "booking" && shouldShowFormInDialog}>
-          {EventBooker}
-        </BookFormAsModal>
-      ) : (
-        <></>
-      )}
+      <BookFormAsModal
+        onCancel={() => setSelectedTimeslot(null)}
+        visible={bookerState === "booking" && shouldShowFormInDialog}>
+        {EventBooker}
+      </BookFormAsModal>
     </>
   );
 };

--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -1,6 +1,7 @@
 import { Calendar, Clock } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { useIsPlatform } from "@calcom/atoms/monorepo";
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge, Dialog, DialogContent } from "@calcom/ui";
@@ -9,11 +10,33 @@ import { useTimePreferences } from "../../../lib";
 import { useBookerStore } from "../../store";
 import { useEvent } from "../../utils/event";
 
-const BookEventFormWrapper = ({ children }: { onCancel: () => void; children: ReactNode }) => {
+const BookEventFormWrapper = ({ children, onCancel }: { onCancel: () => void; children: ReactNode }) => {
+  const { data } = useEvent();
+
+  return <BookEventFormWrapperComponent child={children} eventLength={data?.length} onCancel={onCancel} />;
+};
+
+const PlatformBookEventFormWrapper = ({
+  children,
+  onCancel,
+}: {
+  onCancel: () => void;
+  children: ReactNode;
+}) => {
+  return <BookEventFormWrapperComponent child={children} onCancel={onCancel} />;
+};
+
+export const BookEventFormWrapperComponent = ({
+  child,
+  eventLength,
+}: {
+  onCancel: () => void;
+  child: ReactNode;
+  eventLength?: number;
+}) => {
   const { t } = useLocale();
   const selectedTimeslot = useBookerStore((state) => state.selectedTimeslot);
   const selectedDuration = useBookerStore((state) => state.selectedDuration);
-  const { data } = useEvent();
   const parsedSelectedTimeslot = dayjs(selectedTimeslot);
   const { timeFormat, timezone } = useTimePreferences();
   if (!selectedTimeslot) {
@@ -28,13 +51,13 @@ const BookEventFormWrapper = ({ children }: { onCancel: () => void; children: Re
             {parsedSelectedTimeslot.format("LL")} {parsedSelectedTimeslot.tz(timezone).format(timeFormat)}
           </span>
         </Badge>
-        {(selectedDuration || data?.length) && (
+        {(selectedDuration || eventLength) && (
           <Badge variant="grayWithoutHover" startIcon={Clock} size="lg">
-            <span>{selectedDuration || data?.length}</span>
+            <span>{selectedDuration || eventLength}</span>
           </Badge>
         )}
       </div>
-      {children}
+      {child}
     </>
   );
 };
@@ -48,13 +71,19 @@ export const BookFormAsModal = ({
   onCancel: () => void;
   children: ReactNode;
 }) => {
+  const isPlatform = useIsPlatform();
+
   return (
     <Dialog open={visible} onOpenChange={onCancel}>
       <DialogContent
         type={undefined}
         enableOverflow
         className="[&_.modalsticky]:border-t-subtle [&_.modalsticky]:bg-default max-h-[80vh] pb-0 [&_.modalsticky]:sticky [&_.modalsticky]:bottom-0 [&_.modalsticky]:left-0 [&_.modalsticky]:right-0 [&_.modalsticky]:-mx-8 [&_.modalsticky]:border-t [&_.modalsticky]:px-8 [&_.modalsticky]:py-4">
-        <BookEventFormWrapper onCancel={onCancel}>{children}</BookEventFormWrapper>
+        {!isPlatform ? (
+          <BookEventFormWrapper onCancel={onCancel}>{children}</BookEventFormWrapper>
+        ) : (
+          <PlatformBookEventFormWrapper onCancel={onCancel}>{children}</PlatformBookEventFormWrapper>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -1,6 +1,7 @@
 import { Calendar, Clock } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { useGetEventTypeById } from "@calcom/atoms";
 import { useIsPlatform } from "@calcom/atoms/monorepo";
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -23,6 +24,11 @@ const PlatformBookEventFormWrapper = ({
   onCancel: () => void;
   children: ReactNode;
 }) => {
+  const eventId = useBookerStore((state) => state.eventId);
+  const eventType = useGetEventTypeById(eventId);
+
+  console.log("this is the event type", eventType);
+
   return <BookEventFormWrapperComponent child={children} onCancel={onCancel} />;
 };
 

--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -1,8 +1,7 @@
 import { Calendar, Clock } from "lucide-react";
 import type { ReactNode } from "react";
 
-import { useGetEventTypeById } from "@calcom/atoms";
-import { useIsPlatform } from "@calcom/atoms/monorepo";
+import { useIsPlatform, useGetEventTypeById } from "@calcom/atoms/monorepo";
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge, Dialog, DialogContent } from "@calcom/ui";
@@ -25,11 +24,15 @@ const PlatformBookEventFormWrapper = ({
   children: ReactNode;
 }) => {
   const eventId = useBookerStore((state) => state.eventId);
-  const eventType = useGetEventTypeById(eventId);
+  const { data } = useGetEventTypeById(eventId);
 
-  console.log("this is the event type", eventType);
-
-  return <BookEventFormWrapperComponent child={children} onCancel={onCancel} />;
+  return (
+    <BookEventFormWrapperComponent
+      child={children}
+      eventLength={data?.eventType.length}
+      onCancel={onCancel}
+    />
+  );
 };
 
 export const BookEventFormWrapperComponent = ({

--- a/packages/platform/atoms/hooks/event-types/useGetEventTypeById.ts
+++ b/packages/platform/atoms/hooks/event-types/useGetEventTypeById.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { BASE_URL, API_VERSION, V2_ENDPOINTS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import type { EventType as AtomEventType } from "@calcom/platform-libraries";
+import type { ApiResponse, ApiSuccessResponse } from "@calcom/platform-types";
+
+import http from "../../lib/http";
+
+export const QUERY_KEY = "get-event-by-id";
+export const useGetEventTypeById = (id: number | null) => {
+  const endpoint = new URL(BASE_URL);
+
+  endpoint.pathname = `api/${API_VERSION}/${V2_ENDPOINTS.eventTypes}/${id}`;
+  endpoint.searchParams.set("for", "atom");
+
+  return useQuery({
+    queryKey: [QUERY_KEY, id],
+    queryFn: () => {
+      return http?.get<ApiResponse<AtomEventType>>(endpoint.toString()).then((res) => {
+        if (res.data.status === SUCCESS_STATUS) {
+          return (res.data as ApiSuccessResponse<AtomEventType>).data;
+        }
+        throw new Error(res.data.error.message);
+      });
+    },
+  });
+};

--- a/packages/platform/atoms/index.ts
+++ b/packages/platform/atoms/index.ts
@@ -6,6 +6,7 @@ export { useIsPlatform } from "./hooks/useIsPlatform";
 export { useAtomsContext } from "./hooks/useAtomsContext";
 export { useConnectedCalendars } from "./hooks/useConnectedCalendars";
 export { useEventTypesPublic } from "./hooks/event-types/useEventTypesPublic";
+export { useGetEventTypeById } from "./hooks/event-types/useGetEventTypeById";
 export { useCancelBooking } from "./hooks/useCancelBooking";
 export { useGetBooking } from "./hooks/useGetBooking";
 export { useGetBookings } from "./hooks/useGetBookings";

--- a/packages/platform/atoms/monorepo.ts
+++ b/packages/platform/atoms/monorepo.ts
@@ -3,6 +3,7 @@ export { WebAvailabilitySettingsWrapper as AvailabilitySettings } from "./availa
 export { CalProvider } from "./cal-provider/CalProvider";
 export { useIsPlatform } from "./hooks/useIsPlatform";
 export { useAtomsContext } from "./hooks/useAtomsContext";
+export { useGetEventTypeById } from "./hooks/event-types/useGetEventTypeById";
 export { useHandleBookEvent } from "./hooks/useHandleBookEvent";
 export * as Dialog from "./src/components/ui/dialog";
 export { Timezone } from "./timezone";


### PR DESCRIPTION
## What does this PR do?

The `Booker` atom displays a modal for small screen devices like the one we have below.

<img width="362" alt="Screenshot 2024-04-01 at 3 59 25 PM" src="https://github.com/calcom/cal.com/assets/86043008/400c6f84-a912-4930-8161-ef66d70a3b07">

Previously we were only displaying this modal based on the logic that if the component is not in platform i.e. `!isPlatform` only then the modal is displayed. Because of this the booker atom never displays the modal meant for mobile devices and so a user using a small screen device wouldnt be able to make a booking through our atom. This PR aims to display the booking modal for platform as well as the web app. I modified the wrapper being used in the modal such that only if we're in the web app then it makes trpc calls otherwise we don't use trpc if we're in platform