### PR TITLE
feat: isPlatform toggle during org creation

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2037,6 +2037,7 @@
   "organization_url": "Organization URL",
   "organization_verify_header": "Verify your organization email",
   "organization_verify_email_body": "Please use the code below to verify your email address to continue setting up your organization.",
+  "organization_is_platform": "Organization is platform",
   "additional_url_parameters": "Additional URL parameters",
   "about_your_organization": "About your organization",
   "about_your_organization_description": "Organizations are shared environments where you can create multiple teams with shared members, event types, apps, workflows and more.",

--- a/packages/features/ee/organizations/components/CreateANewOrganizationForm.tsx
+++ b/packages/features/ee/organizations/components/CreateANewOrganizationForm.tsx
@@ -10,7 +10,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import slugify from "@calcom/lib/slugify";
 import { telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import { trpc } from "@calcom/trpc/react";
-import { Button, Form, TextField, Alert } from "@calcom/ui";
+import { Button, Form, TextField, Alert, SettingsToggle } from "@calcom/ui";
 import { ArrowRight } from "@calcom/ui/components/icon";
 
 function extractDomainFromEmail(email: string) {
@@ -34,9 +34,11 @@ export const CreateANewOrganizationForm = ({ slug }: { slug?: string }) => {
     slug: string;
     adminEmail: string;
     adminUsername: string;
+    isPlatform: boolean;
   }>({
     defaultValues: {
       slug: `${slug ?? ""}`,
+      isPlatform: false,
     },
   });
   const watchAdminEmail = newOrganizationFormMethods.watch("adminEmail");
@@ -192,6 +194,25 @@ export const CreateANewOrganizationForm = ({ slug }: { slug?: string }) => {
                   newOrganizationFormMethods.clearErrors("slug");
                 }}
               />
+            )}
+          />
+        </div>
+
+        <div className="mb-5">
+          <Controller
+            name="isPlatform"
+            control={newOrganizationFormMethods.control}
+            defaultValue={false}
+            render={({ field: { value } }) => (
+              <div className="[&_label]:mt-1">
+                <SettingsToggle
+                  title={t("organization_is_platform")}
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    newOrganizationFormMethods.setValue("isPlatform", checked);
+                  }}
+                />
+              </div>
             )}
           />
         </div>

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -104,6 +104,7 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
       data: {
         name,
         isOrganization: true,
+        isPlatform,
         ...(!IS_TEAM_BILLING_ENABLED ? { slug } : {}),
         organizationSettings: {
           create: {


### PR DESCRIPTION
Platform orgs are setup manually, so add a toggle that sets "Team.isPlatform" when creating the org. By default it is false:

<img width="1707" alt="Screenshot 2024-04-02 at 10 44 40" src="https://github.com/calcom/cal.com/assets/42170848/951e62ca-74f2-43cd-9fb4-95dd9fd8e873">

Platform org in database has "isPlatform" true:
<img width="1378" alt="Screenshot 2024-04-02 at 10 45 04" src="https://github.com/calcom/cal.com/assets/42170848/5e68fe1e-3fae-4d49-957f-69104f6e808e">

After this "settings/organizations/platform/oauth-clients" can be browsed to create client and because org has "isPlatform" client creation is successful. Non platform orgs can't create OAuth clients.
