### PR TITLE
refactor: delete OAuth managed users on OAuth client delete

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
@@ -4,6 +4,7 @@ import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { NextAuthGuard } from "@/modules/auth/guards/next-auth/next-auth.guard";
 import { OrganizationRolesGuard } from "@/modules/auth/guards/organization-roles/organization-roles.guard";
 import { CreateOAuthClientResponseDto } from "@/modules/oauth-clients/controllers/oauth-clients/responses/CreateOAuthClientResponse.dto";
+import { DeleteOAuthClientResponseDto } from "@/modules/oauth-clients/controllers/oauth-clients/responses/DeleteOAuthClientResponse.dto";
 import { GetOAuthClientResponseDto } from "@/modules/oauth-clients/controllers/oauth-clients/responses/GetOAuthClientResponse.dto";
 import { GetOAuthClientsResponseDto } from "@/modules/oauth-clients/controllers/oauth-clients/responses/GetOAuthClientsResponse.dto";
 import { UpdateOAuthClientInput } from "@/modules/oauth-clients/inputs/update-oauth-client.input";
@@ -113,9 +114,9 @@ export class OAuthClientsController {
   @HttpCode(HttpStatus.OK)
   @Roles([MembershipRole.ADMIN, MembershipRole.OWNER])
   @DocsOperation({ description: AUTH_DOCUMENTATION })
-  async deleteOAuthClient(@Param("clientId") clientId: string): Promise<GetOAuthClientResponseDto> {
+  async deleteOAuthClient(@Param("clientId") clientId: string): Promise<DeleteOAuthClientResponseDto> {
     this.logger.log(`Deleting OAuth Client with ID: ${clientId}`);
     const client = await this.oauthClientRepository.deleteOAuthClient(clientId);
-    return { status: SUCCESS_STATUS, data: client };
+    return { status: SUCCESS_STATUS, data: { id: client.id, name: client.name } };
   }
 }

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/responses/DeleteOAuthClientResponse.dto.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/responses/DeleteOAuthClientResponse.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { ValidateNested, IsEnum, IsString, IsNotEmptyObject } from "class-validator";
+
+import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
+
+export class DeletedOAuthClientDto {
+  @ApiProperty({ example: "clsx38nbl0001vkhlwin9fmt0" })
+  @IsString()
+  id!: string;
+
+  @ApiProperty({ example: "MyClient" })
+  @IsString()
+  name!: string;
+}
+
+export class DeleteOAuthClientResponseDto {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({
+    type: DeletedOAuthClientDto,
+  })
+  @IsNotEmptyObject()
+  @ValidateNested()
+  @Type(() => DeletedOAuthClientDto)
+  data!: DeletedOAuthClientDto;
+}

--- a/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
+++ b/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
@@ -95,8 +95,21 @@ export class OAuthClientRepository {
   }
 
   async deleteOAuthClient(clientId: string): Promise<PlatformOAuthClient> {
-    return this.dbWrite.prisma.platformOAuthClient.delete({
-      where: { id: clientId },
+    return await this.dbWrite.prisma.$transaction(async (prisma) => {
+      await prisma.user.deleteMany({
+        where: {
+          platformOAuthClients: {
+            some: {
+              id: clientId,
+            },
+          },
+          isPlatformManaged: true,
+        },
+      });
+
+      return await prisma.platformOAuthClient.delete({
+        where: { id: clientId },
+      });
     });
   }
 }


### PR DESCRIPTION
1. When deleting OAuth client also delete users connected to it in [refactor: delete OAuth managed users on OAuth client delete](https://github.com/calcom/cal.com/pull/14304/commits/d4e5d6c9602208dfc756390dc93ddb243faba0db)
2. When deleted return only deleted OAuth client id and name, do not return the secret - even if the OAuth client is deleted just in case something failed do not expose the secret in
[refactor: hide deleted oauth client secret](https://github.com/calcom/cal.com/pull/14304/commits/7d36403ce9accd4264ee86bc3abf6ccd7cf59c67)