### PR TITLE
refactor: Replace function declaration with function expression and inline immediately returned variable in createOAuthClient function for improved readability

### DIFF
--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
@@ -101,7 +101,7 @@ describe("Event types Endpoints", () => {
       await app.init();
     });
 
-    async function createOAuthClient(organizationId: number) {
+    const createOAuthClient = async (organizationId: number) => {
       const data = {
         logo: "logo-url",
         name: "name",
@@ -110,9 +110,8 @@ describe("Event types Endpoints", () => {
       };
       const secret = "secret";
 
-      const client = await oauthClientRepositoryFixture.create(organizationId, data, secret);
-      return client;
-    }
+      return await oauthClientRepositoryFixture.create(organizationId, data, secret);
+    };
 
     it("should be defined", () => {
       expect(oauthClientRepositoryFixture).toBeDefined();


### PR DESCRIPTION
Replace function declaration with function expression and inline immediately returned variable in createOAuthClient function for improved readability