### PR TITLE
refactor: Invert ternary operator in buildWhereClause function to remove negation for better readability

### DIFF
--- a/apps/api/v1/pages/api/bookings/_get.ts
+++ b/apps/api/v1/pages/api/bookings/_get.ts
@@ -126,7 +126,7 @@ function buildWhereClause(
   userEmails: string[] = []
 ) {
   const filterByAttendeeEmails = attendeeEmails.length > 0;
-  const userFilter = userIds.length > 0 ? { userId: { in: userIds } } : !!userId ? { userId } : {};
+  const userFilter = userIds.length > 0 ? { userId: { in: userIds } } : userId ? { userId } : {};
   let whereClause = {};
   if (filterByAttendeeEmails) {
     whereClause = {


### PR DESCRIPTION
Invert ternary operator in buildWhereClause function to remove negation for better readability