### PR TITLE
fix: filter and listMember handler

### DIFF
--- a/packages/features/bookings/components/PeopleFilter.tsx
+++ b/packages/features/bookings/components/PeopleFilter.tsx
@@ -17,7 +17,7 @@ export const PeopleFilter = () => {
 
   const { data: currentOrg } = trpc.viewer.organizations.listCurrent.useQuery();
   const isAdmin = currentOrg?.user.role === "ADMIN" || currentOrg?.user.role === "OWNER";
-  const hasPermToView = currentOrg?.isPrivate ? isAdmin : true;
+  const hasPermToView = !currentOrg?.isPrivate || isAdmin;
 
   const { data: query, pushItemToKey, removeItemByKeyAndValue, removeAllQueryParams } = useFilterQuery();
   const [searchText, setSearchText] = useState("");

--- a/packages/features/bookings/components/PeopleFilter.tsx
+++ b/packages/features/bookings/components/PeopleFilter.tsx
@@ -15,6 +15,10 @@ export const PeopleFilter = () => {
   const { t } = useLocale();
   const orgBranding = useOrgBranding();
 
+  const { data: currentOrg } = trpc.viewer.organizations.listCurrent.useQuery();
+  const isAdmin = currentOrg?.user.role === "ADMIN" || currentOrg?.user.role === "OWNER";
+  const hasPermToView = currentOrg?.isPrivate ? isAdmin : true;
+
   const { data: query, pushItemToKey, removeItemByKeyAndValue, removeAllQueryParams } = useFilterQuery();
   const [searchText, setSearchText] = useState("");
 
@@ -36,6 +40,10 @@ export const PeopleFilter = () => {
     }
     return `${t("all")}`;
   };
+
+  if (!hasPermToView) {
+    return null;
+  }
 
   return (
     <AnimatedPopover text={getTextForPopover()} prefix={`${t("people")}: `}>

--- a/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
@@ -15,7 +15,7 @@ type ListMembersOptions = {
 export const listMembersHandler = async ({ ctx, input }: ListMembersOptions) => {
   const { prisma } = ctx;
   const { isOrgAdmin } = ctx.user.organization;
-  const hasPermsToView = ctx.user.organization.isPrivate ? isOrgAdmin : true;
+  const hasPermsToView = !ctx.user.organization.isPrivate || isOrgAdmin;
 
   if (!hasPermsToView) {
     return [];

--- a/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
@@ -14,6 +14,13 @@ type ListMembersOptions = {
 
 export const listMembersHandler = async ({ ctx, input }: ListMembersOptions) => {
   const { prisma } = ctx;
+  const { isOrgAdmin } = ctx.user.organization;
+  const hasPermsToView = ctx.user.organization.isPrivate ? isOrgAdmin : true;
+
+  if (!hasPermsToView) {
+    return [];
+  }
+
   const teams = await prisma.team.findMany({
     where: {
       id: {


### PR DESCRIPTION
fixes: #14427 

Hide people filter 
![CleanShot 2024-04-05 at 14 05 14](https://github.com/calcom/cal.com/assets/55134778/a05f5242-cc3f-44c6-8b42-e76e0f928fbf)

Also remove members being returned form the org listMember page if its private and youre not an admin. 
This fixes the other place this could leak into the UI in the app OOO page. 
![CleanShot 2024-04-05 at 14 06 29](https://github.com/calcom/cal.com/assets/55134778/41832552-0059-4f33-b993-90934578424d)
