### PR TITLE
fix: Return team event type

### DIFF
--- a/apps/api/v1/pages/api/event-types/[id]/_get.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_get.ts
@@ -93,6 +93,7 @@ async function checkPermissions<T extends BaseEventTypeCheckPermissions>(
     await canAccessTeamEventOrThrow(req, {
       in: [MembershipRole.OWNER, MembershipRole.ADMIN, MembershipRole.MEMBER],
     });
+    return true;
   }
   if (eventType?.userId === req.userId) return true; // is owner.
   throw new HttpError({ statusCode: 403, message: "Forbidden" });


### PR DESCRIPTION
## What does this PR do?

Fixes issues where trying to return details about an event type would return a 403 Forbidden when it should return the proper details

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a team event type
- Call the API using an API key of a user within the team using the event type
- Ensure you get the event type details
