### PR TITLE
fix: Remove exports in barrel file which are causing prisma import on client side

### DIFF
--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -5,6 +5,3 @@ export * from "./isBookingLimits";
 export * from "./isDurationLimits";
 export * from "./validateIntervalLimitOrder";
 export * from "./schedules";
-export * from "./event-types/getEventTypesByViewer";
-export * from "./event-types/getEventTypesPublic";
-export * from "./bookings/getAllUserBookings";


### PR DESCRIPTION
There are `className` imports on client side which is imported from @calcom/lib/index file which was importing `getEventTypesByViewer` file which imports repository which then imports prisma.

className -> @calcom/lib/index -> getEventTypesByViewer -> repository/event-type -> prisma


