### PR TITLE
fix: Ensure the session is invalidated during booking-seats test

### DIFF
--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -308,6 +308,8 @@ test.describe("Reschedule for booking with seats", () => {
     await expect(foundSecondAttendeeAsOwner).toHaveCount(1);
 
     await page.goto("auth/logout");
+    await page.getByTestId("logout-btn").click();
+    await expect(page).toHaveURL(/login/);
 
     // Now we cancel the booking as the first attendee
     // booking/${bookingUid}?cancel=true&allRemainingBookings=false&seatReferenceUid={bookingSeat.referenceUid}


### PR DESCRIPTION
## What does this PR do?

Fixes test fail on localhost due to the session user not being immediately invalidated, therefore still seeing isHost = true and seeing all attendee information.