### PR TITLE
fix: isTeamEvent would eval to null when undefined

### DIFF
--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -24,7 +24,7 @@ export const BookerSeo = (props: BookerSeoProps) => {
     username,
     rescheduleUid,
     hideBranding,
-    isTeamEvent,
+    isTeamEvent = false,
     entity,
     isSEOIndexable,
     bookingData,


### PR DESCRIPTION
## What does this PR do?

getPublicEvent would be called twice for each user-type-public booking view, this was due to "undefined" evaluating to 'null' in the URL formatting call of tRPC. By defaulting to boolean we ensure that the same tRPC call is made (therefore tRPC realises it is the same call, and merges).
