### PR TITLE
fix: Broken SSR for event booking pages

### DIFF
--- a/apps/web/app/future/[user]/[type]/page.tsx
+++ b/apps/web/app/future/[user]/[type]/page.tsx
@@ -24,7 +24,13 @@ export const generateMetadata = async ({
   const rescheduleUid = booking?.uid;
   const { trpc } = await import("@calcom/trpc");
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username: user, eventSlug: slug, isTeamEvent: false, org: eventData.entity.orgSlug ?? null },
+    {
+      username: user,
+      eventSlug: slug,
+      isTeamEvent: false,
+      org: eventData.entity.orgSlug ?? null,
+      fromRedirectOfNonOrgLink: eventData.entity.fromRedirectOfNonOrgLink,
+    },
     { refetchOnWindowFocus: false }
   );
 

--- a/apps/web/app/future/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/future/d/[link]/[slug]/page.tsx
@@ -21,7 +21,13 @@ export const generateMetadata = async ({
   const rescheduleUid = booking?.uid;
   const { trpc } = await import("@calcom/trpc");
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username: user ?? "", eventSlug: slug ?? "", isTeamEvent, org: entity.orgSlug ?? null },
+    {
+      username: user ?? "",
+      eventSlug: slug ?? "",
+      isTeamEvent,
+      org: entity.orgSlug ?? null,
+      fromRedirectOfNonOrgLink: entity.fromRedirectOfNonOrgLink,
+    },
     { refetchOnWindowFocus: false }
   );
   const profileName = event?.profile?.name ?? "";

--- a/apps/web/app/future/org/[orgSlug]/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/future/org/[orgSlug]/team/[slug]/[type]/page.tsx
@@ -22,7 +22,13 @@ export const generateMetadata = async ({
   const entity = eventData.entity;
   const { trpc } = await import("@calcom/trpc");
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username: user, eventSlug: slug, isTeamEvent: false, org: entity.orgSlug ?? null },
+    {
+      username: user,
+      eventSlug: slug,
+      isTeamEvent: false,
+      org: entity.orgSlug ?? null,
+      fromRedirectOfNonOrgLink: entity.fromRedirectOfNonOrgLink,
+    },
     { refetchOnWindowFocus: false }
   );
 

--- a/apps/web/app/future/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/future/team/[slug]/[type]/page.tsx
@@ -20,7 +20,13 @@ export const generateMetadata = async ({
   const entity = eventData.entity;
   const { trpc } = await import("@calcom/trpc");
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username: user, eventSlug: slug, isTeamEvent: false, org: entity.orgSlug ?? null },
+    {
+      username: user,
+      eventSlug: slug,
+      isTeamEvent: false,
+      org: entity.orgSlug ?? null,
+      fromRedirectOfNonOrgLink: entity.fromRedirectOfNonOrgLink,
+    },
     { refetchOnWindowFocus: false }
   );
 

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import { JSDOM } from "jsdom";
 
 import { randomString } from "@calcom/lib/random";
 import { SchedulingType } from "@calcom/prisma/client";
@@ -20,6 +21,34 @@ const freeUserObj = { name: `Free-user-${randomString(3)}` };
 test.describe.configure({ mode: "parallel" });
 test.afterEach(async ({ users }) => {
   await users.deleteAll();
+});
+
+test("check SSR and OG", async ({ page, users }) => {
+  const name = "Test User";
+  const user = await users.create({
+    name,
+  });
+  const [response] = await Promise.all([
+    // This promise resolves to the main resource response
+    page.waitForResponse(
+      (response) => response.url().includes(`/${user.username}/30-min`) && response.status() === 200
+    ),
+
+    // Trigger the page navigation
+    page.goto(`/${user.username}/30-min`),
+  ]);
+  const ssrResponse = await response.text();
+  const document = new JSDOM(ssrResponse).window.document;
+
+  const titleText = document.querySelector("title")?.textContent;
+  const ogImage = document.querySelector('meta[property="og:image"]')?.getAttribute("content");
+  expect(titleText).toContain(name);
+  // Verify that there is correct URL that would generate the awesome OG image
+  expect(ogImage).toContain(
+    "/_next/image?w=1200&q=100&url=%2Fapi%2Fsocial%2Fog%2Fimage%3Ftype%3Dmeeting%26title%3D"
+  );
+  // Verify Organizer Name in the URL
+  expect(ogImage).toContain("meetingProfileName%3DTest%2520User%26");
 });
 
 testBothFutureAndLegacyRoutes.describe("free user", () => {

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -15,6 +15,7 @@ import {
   selectFirstAvailableTimeSlotNextMonth,
   testEmail,
   testName,
+  todo,
 } from "./lib/testUtils";
 
 const freeUserObj = { name: `Free-user-${randomString(3)}` };
@@ -23,7 +24,7 @@ test.afterEach(async ({ users }) => {
   await users.deleteAll();
 });
 
-test("check SSR and OG", async ({ page, users }) => {
+test("check SSR and OG - User Event Type", async ({ page, users }) => {
   const name = "Test User";
   const user = await users.create({
     name,
@@ -50,6 +51,8 @@ test("check SSR and OG", async ({ page, users }) => {
   // Verify Organizer Name in the URL
   expect(ogImage).toContain("meetingProfileName%3DTest%2520User%26");
 });
+
+todo("check SSR and OG - Team Event Type");
 
 testBothFutureAndLegacyRoutes.describe("free user", () => {
   test.beforeEach(async ({ page, users }) => {

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -25,7 +25,12 @@ export const useEvent = () => {
   const org = useBookerStore((state) => state.org);
 
   const event = trpc.viewer.public.event.useQuery(
-    { username: username ?? "", eventSlug: eventSlug ?? "", isTeamEvent, org: org ?? null },
+    {
+      username: username ?? "",
+      eventSlug: eventSlug ?? "",
+      isTeamEvent,
+      org: org ?? null,
+    },
     { refetchOnWindowFocus: false, enabled: Boolean(username) && Boolean(eventSlug) }
   );
 

--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -11,6 +11,7 @@ interface BookerSeoProps {
   isSEOIndexable?: boolean;
   isTeamEvent?: boolean;
   entity: {
+    fromRedirectOfNonOrgLink: boolean;
     orgSlug?: string | null;
     teamSlug?: string | null;
     name?: string | null;
@@ -30,8 +31,15 @@ export const BookerSeo = (props: BookerSeoProps) => {
     bookingData,
   } = props;
   const { t } = useLocale();
+  console.log("BookerSeo Event Params", { username, eventSlug, isTeamEvent, org: entity.orgSlug ?? null });
   const { data: event } = trpc.viewer.public.event.useQuery(
-    { username, eventSlug, isTeamEvent, org: entity.orgSlug ?? null },
+    {
+      username,
+      eventSlug,
+      isTeamEvent,
+      org: entity.orgSlug ?? null,
+      fromRedirectOfNonOrgLink: entity.fromRedirectOfNonOrgLink,
+    },
     { refetchOnWindowFocus: false }
   );
 

--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -31,7 +31,6 @@ export const BookerSeo = (props: BookerSeoProps) => {
     bookingData,
   } = props;
   const { t } = useLocale();
-  console.log("BookerSeo Event Params", { username, eventSlug, isTeamEvent, org: entity.orgSlug ?? null });
   const { data: event } = trpc.viewer.public.event.useQuery(
     {
       username,

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -189,6 +189,7 @@ export const getPublicEvent = async (
       },
       entity: {
         considerUnpublished: !fromRedirectOfNonOrgLink && unPublishedOrgUser !== undefined,
+        fromRedirectOfNonOrgLink,
         orgSlug: org,
         name: unPublishedOrgUser?.profile?.organization?.name ?? null,
       },
@@ -291,6 +292,7 @@ export const getPublicEvent = async (
     profile: getProfileFromEvent(eventWithUserProfiles),
     users,
     entity: {
+      fromRedirectOfNonOrgLink,
       considerUnpublished:
         !fromRedirectOfNonOrgLink &&
         (eventWithUserProfiles.team?.slug === null ||


### PR DESCRIPTION
## What does this PR do?

Fixes broken OG images.

Happened because React Query is unable to reuse already sent `/event` request's response and because SSR doesn’t wait for re-renders, it gets `event` as `undefined` causing the issue of OG image generation(which is completely SSR)

It happened because of newly introduced param `orgRedirection` which is by default assumed `false` but for React Query `orgRedirection=undefined `and `orgRedirection=false` are two different queries.

Wrote a failing test now that’s passing in the PR

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- Simply see the source code for pro/30min and notice that title is wrong in it.
- It has og:image URL also wrong

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

