### PR TITLE
fix: Redirect only those apps that extend 'EventType' to the new apps install flow

### DIFF
--- a/packages/lib/apps/shouldRedirectToAppOnboarding.ts
+++ b/packages/lib/apps/shouldRedirectToAppOnboarding.ts
@@ -1,9 +1,6 @@
 import type { AppMeta } from "@calcom/types/App";
 
 export const shouldRedirectToAppOnboarding = (appMetadata: AppMeta) => {
-  // const appMetadata = appStoreMetadata[dirName as keyof typeof appStoreMetadata];
   const hasEventTypes = appMetadata?.extendsFeature == "EventType";
-  const isOAuth = appMetadata?.isOAuth;
-  const isCalendar = appMetadata?.category === "calendar";
-  return !isCalendar && (hasEventTypes || isOAuth);
+  return hasEventTypes;
 };


### PR DESCRIPTION

## What does this PR do?
