### PR TITLE
revert: "fix: Redirect only those apps that extend 'EventType' to the new apps install flow"

### DIFF
--- a/packages/lib/apps/shouldRedirectToAppOnboarding.ts
+++ b/packages/lib/apps/shouldRedirectToAppOnboarding.ts
@@ -1,6 +1,9 @@
 import type { AppMeta } from "@calcom/types/App";
 
 export const shouldRedirectToAppOnboarding = (appMetadata: AppMeta) => {
+  // const appMetadata = appStoreMetadata[dirName as keyof typeof appStoreMetadata];
   const hasEventTypes = appMetadata?.extendsFeature == "EventType";
-  return hasEventTypes;
+  const isOAuth = appMetadata?.isOAuth;
+  const isCalendar = appMetadata?.category === "calendar";
+  return !isCalendar && (hasEventTypes || isOAuth);
 };


### PR DESCRIPTION
Reverts calcom/cal.com#14527