### PR TITLE
chore: Publish new versions of embeds

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @calcom/web
 
+## 3.9.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @calcom/embed-core@1.4.0
+  - @calcom/embed-react@1.4.0
+  - @calcom/embed-snippet@1.2.0
+
 ## 3.1.3
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/web",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "private": true,
   "scripts": {
     "analyze": "ANALYZE=true next build",

--- a/packages/embeds/embed-core/CHANGELOG.md
+++ b/packages/embeds/embed-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @calcom/embed-core
 
+## 1.4.0
+
+### Minor Changes
+
+- Added a few more events
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/embed-core",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "This is the vanilla JS core script that embeds Cal Link",
   "main": "./dist/embed/embed.js",
   "types": "./dist/index.d.ts",

--- a/packages/embeds/embed-react/CHANGELOG.md
+++ b/packages/embeds/embed-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @calcom/embed-react
 
+## 1.4.0
+
+### Minor Changes
+
+- Added a few more events
+
+### Patch Changes
+
+- Updated dependencies
+  - @calcom/embed-core@1.4.0
+  - @calcom/embed-snippet@1.2.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@calcom/embed-react",
   "sideEffects": false,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Embed Cal Link as a React Component",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/packages/embeds/embed-snippet/CHANGELOG.md
+++ b/packages/embeds/embed-snippet/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @calcom/embed-snippet
 
+## 1.2.0
+
+### Minor Changes
+
+- Added a few more events
+
+### Patch Changes
+
+- Updated dependencies
+  - @calcom/embed-core@1.4.0
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@calcom/embed-snippet",
   "sideEffects": false,
-  "version": "1.1.2",
+  "version": "1.2.0",
   "main": "./dist/snippet.umd.js",
   "module": "./dist/snippet.es.js",
   "description": "Vanilla JS embed snippet that is responsible to fetch @calcom/embed-core and thus show Cal Link as an embed on a page.",


### PR DESCRIPTION
Release new versions of embed. 

Versions are already published in npm repository. It just updates the versions in code to keep in sync