### PR TITLE
fix: Remove hardcoded stripe..

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/deleteCredential.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/deleteCredential.handler.ts
@@ -6,7 +6,6 @@ import { sendCancelledEmails } from "@calcom/emails";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { cancelScheduledJobs } from "@calcom/features/webhooks/lib/scheduleTrigger";
 import { isPrismaObjOrUndefined, parseRecurringEvent } from "@calcom/lib";
-import getPaymentAppData from "@calcom/lib/getPaymentAppData";
 import { deletePayment } from "@calcom/lib/payment/deletePayment";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import { bookingMinimalSelect, prisma } from "@calcom/prisma";
@@ -137,13 +136,11 @@ export const deleteCredentialHandler = async ({ ctx, input }: DeleteCredentialOp
       }
     }
 
-    const metadata = EventTypeMetaDataSchema.parse(eventType.metadata);
-
-    const stripeAppData = getPaymentAppData({ ...eventType, metadata });
-
     // If it's a payment, hide the event type and set the price to 0. Also cancel all pending bookings
     if (credential.app?.categories.includes(AppCategories.payment)) {
-      if (stripeAppData.price) {
+      const metadata = EventTypeMetaDataSchema.parse(eventType.metadata);
+      const appSlug = credential.app?.slug;
+      if (appSlug) {
         await prisma.$transaction(async () => {
           await prisma.eventType.update({
             where: {
@@ -155,11 +152,7 @@ export const deleteCredentialHandler = async ({ ctx, input }: DeleteCredentialOp
                 ...metadata,
                 apps: {
                   ...metadata?.apps,
-                  stripe: {
-                    ...metadata?.apps?.stripe,
-                    enabled: false,
-                    price: 0,
-                  },
+                  [appSlug]: null,
                 },
               },
             },


### PR DESCRIPTION
## What does this PR do?

Fixes whenever any payment app credential was deleted, if there was an installed payment app of any type on an event type, it would add stripe incorrectly to the event type and brick the user.

Fixes: #14482
Fixes CAL-3377

This created invalid data in our database, like:
<img width="263" alt="image" src="https://github.com/calcom/cal.com/assets/1046695/fb4e499e-ac91-491b-9669-fc8b49a05841">

Instead, the right behaviour should be to remove the deletedCredential from the eventType(s) in it's entirety, no reason to keep historical data. For now we keep the `hidden` behaviour; however this should be reevaluated @PeerRich  

Needs (but it's quite urgent):

* Tests for payment app disconnect / reconnecting / deletion
* Migrations to rectify broken apps (perhaps do it without migrations, instead fixing our data).
