### PR TITLE
fix: v2 create schedule with availabilities

### DIFF
--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.ts
@@ -91,7 +91,6 @@ export class EventTypesController {
   }
 
   @Get("/:username/public")
-  @Permissions([EVENT_TYPE_READ])
   async getPublicEventTypes(@Param("username") username: string): Promise<GetEventTypesPublicOutput> {
     const eventTypes = await this.eventTypesService.getEventTypesPublicByUsername(username);
 

--- a/apps/api/v2/src/modules/availabilities/inputs/create-availability.input.ts
+++ b/apps/api/v2/src/modules/availabilities/inputs/create-availability.input.ts
@@ -19,12 +19,17 @@ export class CreateAvailabilityInput {
 }
 
 function transformStringToDate(value: string, key: string): Date {
-  const parts = value.split(":");
+  // note(Lauris): incoming value is ISO8061 e.g. 2025-0412T13:17:56.324Z
+  const dateTimeParts = value.split("T");
+
+  const timePart = dateTimeParts[1].split(".")[0]; // Removes milliseconds
+  const parts = timePart.split(":");
 
   if (parts.length !== 3) {
-    throw new BadRequestException(`Invalid ${key} format. Expected format: HH:MM:SS. Received ${value}`);
+    throw new BadRequestException(
+      `Invalid time format. Expected format(ISO8061): 2025-0412T13:17:56.324Z. Received: ${value}`
+    );
   }
-
   const [hours, minutes, seconds] = parts.map(Number);
 
   if (hours < 0 || hours > 23) {


### PR DESCRIPTION
There was a refactor so validation for schedule availabilities changed. Previously [create-availability.input.ts](https://github.com/calcom/cal.com/compare/v2-fix-create-schedule?expand=1#diff-11fdeed6bf8243c3e4ee96956947584e0eb30a02470d380a8bb1189eb81f3ca2) expected for startTime and endTime time in format "HH:mm:ss" but now we are submitting ISO8061 time format e.g. 2025-0412T13:17:56.324Z from the atom.

Driveby: [remove permissions from public event-types endpoint](https://github.com/calcom/cal.com/commit/b1294798c6798e5709fe4ad42754837b201d0e9d)

To test i submitted to "http://localhost:5555/api/v2/schedules"

```
{
  "name": "aasd",
  "timeZone": "Europe/Rome",
  "availabilities": [
    {
      "days": [
        1,
        2
      ],
      "startTime": "2025-0312T13:17:56.324Z",
      "endTime": "2025-04-12T16:17:56.324Z"
    }
  ],
  "isDefault": true
}
```

and got response:
```
{
  "status": "success",
  "data": {
    "id": 137,
    "name": "aasd",
    "isManaged": false,
    "workingHours": [
      {
        "days": [
          1,
          2
        ],
        "startTime": 797,
        "endTime": 977,
        "userId": 252
      }
    ],
    "schedule": [
      {
        "id": 176,
        "userId": 252,
        "eventTypeId": null,
        "days": [
          1,
          2
        ],
        "startTime": "1970-01-01T13:17:56.000Z",
        "endTime": "1970-01-01T16:17:56.000Z",
        "date": null,
        "scheduleId": 137
      }
    ],
    "availability": [
      [],
      [
        {
          "start": "2024-04-12T13:17:00.000Z",
          "end": "2024-04-12T16:17:00.000Z"
        }
      ],
      [
        {
          "start": "2024-04-12T13:17:00.000Z",
          "end": "2024-04-12T16:17:00.000Z"
        }
      ],
      [],
      [],
      [],
      []
    ],
    "timeZone": "Europe/Rome",
    "dateOverrides": [],
    "isDefault": true,
    "isLastSchedule": false,
    "readOnly": false
  }
}
```