### PR TITLE
fix: Cal Video Links Expire After 14 Days

### DIFF
--- a/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
@@ -108,7 +108,7 @@ const DailyVideoApiAdapter = (): VideoApiAdapter => {
   const translateEvent = async (event: CalendarEvent) => {
     // Documentation at: https://docs.daily.co/reference#list-rooms
     // added a 1 hour buffer for room expiration
-    const exp = Math.round(new Date(event.endTime).getTime() / 1000) + 60 * 60;
+    const exp = Math.round(new Date(event.endTime).getTime() / 1000) + 60 * 60 * 24 * 14;
     const { scale_plan: scalePlan } = await getDailyAppKeys();
     const hasTeamPlan = await prisma.membership.findFirst({
       where: {

--- a/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
@@ -107,7 +107,7 @@ const DailyVideoApiAdapter = (): VideoApiAdapter => {
 
   const translateEvent = async (event: CalendarEvent) => {
     // Documentation at: https://docs.daily.co/reference#list-rooms
-    // added a 1 hour buffer for room expiration
+    // Adds 14 days from the end of the booking as the expiration date
     const exp = Math.round(new Date(event.endTime).getTime() / 1000) + 60 * 60 * 24 * 14;
     const { scale_plan: scalePlan } = await getDailyAppKeys();
     const hasTeamPlan = await prisma.membership.findFirst({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR changes the expiry date of Cal Video links from 1 hr to 14 days. New links are still generated on reschedule

![CleanShot 2024-04-12 at 16 04 06@2x](https://github.com/calcom/cal.com/assets/65426560/e40641f8-2ff1-48f9-a8c8-9070872cb588)

![CleanShot 2024-04-12 at 16 04 36@2x](https://github.com/calcom/cal.com/assets/65426560/89e795f5-d475-4988-ad8b-0e77c32d2885)


Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

<!-- Please provide all documents that are important to understand the reason of that PR. -->

- If there is a requirement document, please, share it here.
- If there is a UI/UX design document, please, share it here.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a booking with Cal Video
- On the Daily dashboard, ensure the expiry date is set for 14 days

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
