### PR TITLE
feat: return `isPlatform` boolean to detect if user is a platform user

### DIFF
--- a/packages/lib/server/repository/profile.ts
+++ b/packages/lib/server/repository/profile.ts
@@ -358,6 +358,7 @@ export class ProfileRepository {
             metadata: true,
             bannerUrl: true,
             isPrivate: true,
+            isPlatform: true,
             organizationSettings: {
               select: {
                 lockEventTypeCreationForUsers: true,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When returning a user org profile return the `isPlatform` boolean that can be used to detect if a user is a platform user or not 