### PR TITLE
perf: Improve event-types query

### DIFF
--- a/packages/lib/event-types/getEventTypesPublic.ts
+++ b/packages/lib/event-types/getEventTypesPublic.ts
@@ -1,6 +1,5 @@
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
-import { baseEventTypeSelect } from "@calcom/prisma/selects";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 
 import { markdownToSafeHTML } from "../markdownToSafeHTML";
@@ -22,41 +21,21 @@ export async function getEventTypesPublic(userId: number) {
 }
 
 const getEventTypesWithHiddenFromDB = async (userId: number) => {
-  const eventTypes = await prisma.eventType.findMany({
-    where: {
-      AND: [
-        {
-          teamId: null,
-        },
-        {
-          OR: [
-            {
-              userId,
-            },
-            {
-              users: {
-                some: {
-                  id: userId,
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    orderBy: [
-      {
-        position: "desc",
-      },
-      {
-        id: "asc",
-      },
-    ],
-    select: {
-      ...baseEventTypeSelect,
-      metadata: true,
-    },
-  });
+  const eventTypes = await prisma.$queryRaw`
+    SELECT "t"."id", "t"."title", "t"."description", "t"."length", "t"."schedulingType"::text, "t"."recurringEvent", "t"."slug", "t"."hidden", "t"."price", "t"."currency", "t"."lockTimeZoneToggleOnBookingPage", "t"."requiresConfirmation", "t"."requiresBookerEmailVerification", "t"."metadata", "t"."position"
+    FROM (
+      SELECT "public"."EventType"."id", "public"."EventType"."title", "public"."EventType"."description", "public"."EventType"."length", "public"."EventType"."schedulingType"::text, "public"."EventType"."recurringEvent", "public"."EventType"."slug", "public"."EventType"."hidden", "public"."EventType"."price", "public"."EventType"."currency", "public"."EventType"."lockTimeZoneToggleOnBookingPage", "public"."EventType"."requiresConfirmation", "public"."EventType"."requiresBookerEmailVerification", "public"."EventType"."metadata", "public"."EventType"."position"
+      FROM "public"."EventType"
+      WHERE "public"."EventType"."teamId" IS NULL AND "public"."EventType"."userId" = ${userId}
+      UNION
+      SELECT "public"."EventType"."id", "public"."EventType"."title", "public"."EventType"."description", "public"."EventType"."length", "public"."EventType"."schedulingType"::text, "public"."EventType"."recurringEvent", "public"."EventType"."slug", "public"."EventType"."hidden", "public"."EventType"."price", "public"."EventType"."currency", "public"."EventType"."lockTimeZoneToggleOnBookingPage", "public"."EventType"."requiresConfirmation", "public"."EventType"."requiresBookerEmailVerification", "public"."EventType"."metadata", "public"."EventType"."position"
+      FROM "public"."EventType"
+      INNER JOIN "public"."_user_eventtype" "uet" on "uet"."A" = "public"."EventType"."id"
+      WHERE "uet"."B" = ${userId} AND "public"."EventType"."teamId" IS NULL
+    ) t
+    ORDER BY "t"."position" DESC, "t"."id" ASC
+  `;
+
   // map and filter metadata, exclude eventType entirely when faulty metadata is found.
   // report error to exception so we don't lose the error.
   return eventTypes.reduce<typeof eventTypes>((eventTypes, eventType) => {

--- a/packages/lib/event-types/getEventTypesPublic.ts
+++ b/packages/lib/event-types/getEventTypesPublic.ts
@@ -1,5 +1,6 @@
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
+import type { EventType } from "@calcom/prisma/client";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 
 import { markdownToSafeHTML } from "../markdownToSafeHTML";
@@ -21,7 +22,7 @@ export async function getEventTypesPublic(userId: number) {
 }
 
 const getEventTypesWithHiddenFromDB = async (userId: number) => {
-  const eventTypes = await prisma.$queryRaw`
+  const eventTypes = await prisma.$queryRaw<EventType[]>`
     SELECT "t"."id", "t"."title", "t"."description", "t"."length", "t"."schedulingType"::text, "t"."recurringEvent", "t"."slug", "t"."hidden", "t"."price", "t"."currency", "t"."lockTimeZoneToggleOnBookingPage", "t"."requiresConfirmation", "t"."requiresBookerEmailVerification", "t"."metadata", "t"."position"
     FROM (
       SELECT "et1"."id", "et1"."title", "et1"."description", "et1"."length", "et1"."schedulingType"::text, "et1"."recurringEvent", "et1"."slug", "et1"."hidden", "et1"."price", "et1"."currency", "et1"."lockTimeZoneToggleOnBookingPage", "et1"."requiresConfirmation", "et1"."requiresBookerEmailVerification", "et1"."metadata", "et1"."position"

--- a/packages/lib/event-types/getEventTypesPublic.ts
+++ b/packages/lib/event-types/getEventTypesPublic.ts
@@ -24,14 +24,14 @@ const getEventTypesWithHiddenFromDB = async (userId: number) => {
   const eventTypes = await prisma.$queryRaw`
     SELECT "t"."id", "t"."title", "t"."description", "t"."length", "t"."schedulingType"::text, "t"."recurringEvent", "t"."slug", "t"."hidden", "t"."price", "t"."currency", "t"."lockTimeZoneToggleOnBookingPage", "t"."requiresConfirmation", "t"."requiresBookerEmailVerification", "t"."metadata", "t"."position"
     FROM (
-      SELECT "public"."EventType"."id", "public"."EventType"."title", "public"."EventType"."description", "public"."EventType"."length", "public"."EventType"."schedulingType"::text, "public"."EventType"."recurringEvent", "public"."EventType"."slug", "public"."EventType"."hidden", "public"."EventType"."price", "public"."EventType"."currency", "public"."EventType"."lockTimeZoneToggleOnBookingPage", "public"."EventType"."requiresConfirmation", "public"."EventType"."requiresBookerEmailVerification", "public"."EventType"."metadata", "public"."EventType"."position"
-      FROM "public"."EventType"
-      WHERE "public"."EventType"."teamId" IS NULL AND "public"."EventType"."userId" = ${userId}
+      SELECT "et1"."id", "et1"."title", "et1"."description", "et1"."length", "et1"."schedulingType"::text, "et1"."recurringEvent", "et1"."slug", "et1"."hidden", "et1"."price", "et1"."currency", "et1"."lockTimeZoneToggleOnBookingPage", "et1"."requiresConfirmation", "et1"."requiresBookerEmailVerification", "et1"."metadata", "et1"."position"
+      FROM "public"."EventType" "et1"
+      WHERE "et1"."teamId" IS NULL AND "et1"."userId" = ${userId}
       UNION
-      SELECT "public"."EventType"."id", "public"."EventType"."title", "public"."EventType"."description", "public"."EventType"."length", "public"."EventType"."schedulingType"::text, "public"."EventType"."recurringEvent", "public"."EventType"."slug", "public"."EventType"."hidden", "public"."EventType"."price", "public"."EventType"."currency", "public"."EventType"."lockTimeZoneToggleOnBookingPage", "public"."EventType"."requiresConfirmation", "public"."EventType"."requiresBookerEmailVerification", "public"."EventType"."metadata", "public"."EventType"."position"
-      FROM "public"."EventType"
-      INNER JOIN "public"."_user_eventtype" "uet" on "uet"."A" = "public"."EventType"."id"
-      WHERE "uet"."B" = ${userId} AND "public"."EventType"."teamId" IS NULL
+      SELECT "et2"."id", "et2"."title", "et2"."description", "et2"."length", "et2"."schedulingType"::text, "et2"."recurringEvent", "et2"."slug", "et2"."hidden", "et2"."price", "et2"."currency", "et2"."lockTimeZoneToggleOnBookingPage", "et2"."requiresConfirmation", "et2"."requiresBookerEmailVerification", "et2"."metadata", "et2"."position"
+      FROM "public"."EventType" "et2"
+      INNER JOIN "public"."_user_eventtype" "uet" on "uet"."A" = "et2"."id"
+      WHERE "uet"."B" = ${userId} AND "et2"."teamId" IS NULL
     ) t
     ORDER BY "t"."position" DESC, "t"."id" ASC
   `;


### PR DESCRIPTION
This query runs on average in 376.81ms very frequently, consuming a lot of the DB resources. Rewriting it this way with the union brings it down to 190ms on average.