### PR TITLE
fix: Production deploys

### DIFF
--- a/apps/web/scripts/vercel-production-deploy.sh
+++ b/apps/web/scripts/vercel-production-deploy.sh
@@ -40,6 +40,7 @@ rm -rf \
    app/future/payment\
    app/future/reschedule\
    app/future/routing-forms\
+   app/future/settings\
    app/future/signup\
    app/future/team
 


### PR DESCRIPTION
Goes back to removing the new admin settings routes because this triggers a conflict with our existing 404 and the new 404 provided in app router.