### PR TITLE
fix: conditionally remove fixed prop if we're in embed

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -247,18 +247,6 @@ const BookerComponent = ({
     <>
       {event.data && !isPlatform ? <BookingPageTagManager eventType={event.data} /> : <></>}
 
-      {bookerState !== "booking" && event.data?.isInstantEvent && (
-        <div
-          className="animate-fade-in-up fixed bottom-2 z-40 my-2 opacity-0"
-          style={{ animationDelay: "1s" }}>
-          <InstantBooking
-            event={event.data}
-            onConnectNow={() => {
-              onConnectNowInstantMeeting();
-            }}
-          />
-        </div>
-      )}
       <div
         className={classNames(
           // In a popup embed, if someone clicks outside the main(having main class or main tag), it closes the embed
@@ -439,6 +427,22 @@ const BookerComponent = ({
             setDayCount(null);
           }}
         />
+
+        {bookerState !== "booking" && event.data?.isInstantEvent && (
+          <div
+            className={classNames(
+              "animate-fade-in-up  z-40 my-2 opacity-0",
+              layout === BookerLayouts.MONTH_VIEW && isEmbed ? "" : "fixed bottom-2"
+            )}
+            style={{ animationDelay: "1s" }}>
+            <InstantBooking
+              event={event.data}
+              onConnectNow={() => {
+                onConnectNowInstantMeeting();
+              }}
+            />
+          </div>
+        )}
         {!hideBranding && !isPlatform && (
           <m.span
             key="logo"

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -247,18 +247,6 @@ const BookerComponent = ({
     <>
       {event.data && !isPlatform ? <BookingPageTagManager eventType={event.data} /> : <></>}
 
-      {bookerState !== "booking" && event.data?.isInstantEvent && (
-        <div
-          className="animate-fade-in-up fixed bottom-2 z-40 my-2 opacity-0"
-          style={{ animationDelay: "1s" }}>
-          <InstantBooking
-            event={event.data}
-            onConnectNow={() => {
-              onConnectNowInstantMeeting();
-            }}
-          />
-        </div>
-      )}
       <div
         className={classNames(
           // In a popup embed, if someone clicks outside the main(having main class or main tag), it closes the embed
@@ -439,6 +427,22 @@ const BookerComponent = ({
             setDayCount(null);
           }}
         />
+
+        {bookerState !== "booking" && true && (
+          <div
+            className={classNames(
+              "animate-fade-in-up  z-40 my-2 opacity-0",
+              layout === BookerLayouts.MONTH_VIEW && isEmbed ? "" : "fixed bottom-2"
+            )}
+            style={{ animationDelay: "1s" }}>
+            <InstantBooking
+              event={event.data}
+              onConnectNow={() => {
+                onConnectNowInstantMeeting();
+              }}
+            />
+          </div>
+        )}
         {!hideBranding && !isPlatform && (
           <m.span
             key="logo"


### PR DESCRIPTION
fixes: #13456 
fixes: CAL-3049

Currently in embed monthly view - this instant meeting element doesnt increase the size of the booker and can block the events for a user to select

Embed: 
Monthly View
![CleanShot 2024-04-15 at 12 28 07@2x](https://github.com/calcom/cal.com/assets/55134778/b5a63cc4-1713-41a0-a139-7189ab369f4d)
Weekly View
![CleanShot 2024-04-15 at 12 28 39@2x](https://github.com/calcom/cal.com/assets/55134778/e5d31063-b248-42ba-9af3-d7a0998bc72d)

Normal Monthly View
![CleanShot 2024-04-15 at 12 28 56@2x](https://github.com/calcom/cal.com/assets/55134778/40e1e7eb-bf46-4a48-b540-6321e619fddb)

