### PR TITLE
fix: acme.cal.local crashes due to missing requestedSlug in seed

### DIFF
--- a/apps/web/lib/team/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/getServerSideProps.tsx
@@ -213,6 +213,9 @@ function getTeamWithoutMetadata<T extends Pick<Team, "metadata">>(team: T) {
   const teamMetadata = teamMetadataSchema.parse(metadata);
   return {
     ...rest,
-    requestedSlug: teamMetadata?.requestedSlug,
+    // add requestedSlug if available.
+    ...(typeof teamMetadata?.requestedSlug !== "undefined"
+      ? { requestedSlug: teamMetadata?.requestedSlug }
+      : {}),
   };
 }


### PR DESCRIPTION
## What does this PR do?

requestedSlug should never be undefined as this value is passed back in the getServerSideProps (undefined is an invalid value and causes a crash; if undefined; it shouldn't be added).