### PR TITLE
fix: email not sending with : in from name

### DIFF
--- a/packages/emails/lib/sanitizeDisplayName.ts
+++ b/packages/emails/lib/sanitizeDisplayName.ts
@@ -10,7 +10,7 @@ export const sanitizeDisplayName = (nameAndEmail: string) => {
 };
 
 const sanitize = (name: string) => {
-  const charsToReplace = /[;,"<>()]/g;
+  const charsToReplace = /[;,"<>():]/g;
 
-  return name.replace(charsToReplace, " ");
+  return name.replace(charsToReplace, " ").replace(/\s+/g, " ");
 };


### PR DESCRIPTION
## What does this PR do?

When Full Name has several : sending the the booking confirmation (and any other bookings emails) to the attendee failed. It was throwing: `The from address does not match a verified Sender Identity`

Fixes https://linear.app/calcom/issue/CAL-3339/booker-doesnt-get-confirmation-email
