### PR TITLE
fix: custom attributes not being synced in intercom

### DIFF
--- a/apps/web/server/lib/ssr.ts
+++ b/apps/web/server/lib/ssr.ts
@@ -81,6 +81,7 @@ export async function ssrInit(context: GetServerSidePropsContext, options?: { no
     // Provides a better UX to the users who have already upgraded.
     ssr.viewer.teams.hasTeamPlan.prefetch(),
     ssr.viewer.public.session.prefetch(),
+    ssr.viewer.loggedInRouter.me.prefetch(),
   ]);
 
   return ssr;

--- a/apps/web/server/lib/ssr.ts
+++ b/apps/web/server/lib/ssr.ts
@@ -81,7 +81,7 @@ export async function ssrInit(context: GetServerSidePropsContext, options?: { no
     // Provides a better UX to the users who have already upgraded.
     ssr.viewer.teams.hasTeamPlan.prefetch(),
     ssr.viewer.public.session.prefetch(),
-    ssr.viewer.loggedInRouter.me.prefetch(),
+    ssr.viewer.me.prefetch(),
   ]);
 
   return ssr;

--- a/packages/features/ee/support/lib/intercom/useIntercom.ts
+++ b/packages/features/ee/support/lib/intercom/useIntercom.ts
@@ -28,6 +28,7 @@ export const useIntercom = () => {
   const { hasTeamPlan } = useHasTeamPlan();
 
   const boot = async () => {
+    if (!data) return;
     let userHash;
 
     const req = await fetch(`/api/intercom-hash`);

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -215,15 +215,17 @@ const useBanners = () => {
 const Layout = (props: LayoutProps) => {
   const banners = useBanners();
 
-  const showIntercom = localStorage.getItem("showIntercom");
+  const { data: user } = trpc.viewer.me.useQuery();
   const { boot } = useIntercom();
   const pageTitle = typeof props.heading === "string" && !props.title ? props.heading : props.title;
 
   useEffect(() => {
     // not using useMediaQuery as it toggles between true and false
-    if (showIntercom === "false" || window.innerWidth <= 768) return;
+    const showIntercom = localStorage.getItem("showIntercom");
+    if (showIntercom === "false" || window.innerWidth <= 768 || !user) return;
     boot();
-  }, [showIntercom]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
 
   const bannersHeight = useMemo(() => {
     const activeBanners =


### PR DESCRIPTION
Fixes: 


a lot of users have undefined data in their custom data in intercom
they basically contact us, but our custom data is not being shared so there is no way to identify users

![CleanShot 2024-04-15 at 20 59 50@2x](https://github.com/calcom/cal.com/assets/32706411/acc4caf9-a746-4d7c-bf10-3cbfedc10330)

