### PR TITLE
fix: v2 app.rewrites.middleware.ts

### DIFF
--- a/apps/api/v2/src/app.rewrites.middleware.ts
+++ b/apps/api/v2/src/app.rewrites.middleware.ts
@@ -10,7 +10,7 @@ export class RewriterMiddleware implements NestMiddleware {
     if (req.url.startsWith("/v2/ee")) {
       req.url = req.url.replace("/v2/ee", "/v2");
     }
-    if (req.url.contains("reccuring")) {
+    if (req.url.includes("reccuring")) {
       req.url = req.url.replace("reccuring", "recurring");
     }
     next();


### PR DESCRIPTION
There is no such a thing as ".contains" in javascript for a string:

<img width="779" alt="Screenshot 2024-04-17 at 10 45 25" src="https://github.com/calcom/cal.com/assets/42170848/f7591dab-889f-4c83-a6cc-5e25ef773293">

there is ".includes" tho

<img width="693" alt="Screenshot 2024-04-17 at 10 47 34" src="https://github.com/calcom/cal.com/assets/42170848/24f1a655-5301-4a7d-8649-b58df76d4d96">
