### PR TITLE
fix: Hide org tab when you are team admin

### DIFF
--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -74,10 +74,19 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
   const { data: currentOrg } = trpc.viewer.organizations.listCurrent.useQuery(undefined, {
     enabled: !!session.data?.user?.org,
   });
-  const isOrgOwner = currentOrg && currentOrg.user.role === MembershipRole.OWNER;
+  const isOrgAdminOrOwner =
+    currentOrg &&
+    (currentOrg.user.role === MembershipRole.OWNER || currentOrg.user.role === MembershipRole.ADMIN);
+
+  const canSeeOrganization = !!(
+    props?.orgMembers &&
+    props.orgMembers?.length > 0 &&
+    currentOrg?.isPrivate &&
+    isOrgAdminOrOwner
+  );
 
   const [modalImportMode, setModalInputMode] = useState<ModalMode>(
-    props?.orgMembers && props.orgMembers?.length > 0 ? "ORGANIZATION" : "INDIVIDUAL"
+    canSeeOrganization ? "ORGANIZATION" : "INDIVIDUAL"
   );
 
   const createInviteMutation = trpc.viewer.teams.createInvite.useMutation({
@@ -98,12 +107,12 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
     ];
 
     // Adjust options for organizations where the user isn't the owner
-    if (isOrg && !isOrgOwner) {
+    if (isOrg && !isOrgAdminOrOwner) {
       return options.filter((option) => option.value !== MembershipRole.OWNER);
     }
 
     return options;
-  }, [t, isOrgOwner, isOrg]);
+  }, [t, isOrgAdminOrOwner, isOrg]);
 
   const toggleGroupOptions = useMemo(() => {
     const array = [
@@ -114,7 +123,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       },
       { value: "BULK", label: t("invite_team_bulk_segment"), iconLeft: <Icon name="users" /> },
     ];
-    if (props?.orgMembers && props.orgMembers?.length > 0) {
+    if (canSeeOrganization) {
       array.unshift({
         value: "ORGANIZATION",
         label: t("organization"),
@@ -122,7 +131,7 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
       });
     }
     return array;
-  }, [t, props.orgMembers]);
+  }, [t, canSeeOrganization]);
 
   const newMemberFormMethods = useForm<NewMemberForm>();
 

--- a/packages/features/ee/teams/components/MemberInvitationModal.tsx
+++ b/packages/features/ee/teams/components/MemberInvitationModal.tsx
@@ -74,6 +74,8 @@ export default function MemberInvitationModal(props: MemberInvitationModalProps)
   const { data: currentOrg } = trpc.viewer.organizations.listCurrent.useQuery(undefined, {
     enabled: !!session.data?.user?.org,
   });
+
+  // Check current org role and not team role
   const isOrgAdminOrOwner =
     currentOrg &&
     (currentOrg.user.role === MembershipRole.OWNER || currentOrg.user.role === MembershipRole.ADMIN);

--- a/packages/trpc/server/routers/viewer/organizations/getMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getMembers.handler.ts
@@ -15,6 +15,11 @@ export const getMembersHandler = async ({ input, ctx }: CreateOptions) => {
 
   if (!ctx.user.organizationId) return [];
 
+  const isOrgPrivate = ctx.user.organization.isPrivate;
+  const isOrgAdmin = ctx.user.organization.isOrgAdmin;
+
+  if (isOrgPrivate && !isOrgAdmin) return [];
+
   const teamQuery = await prisma.team.findUnique({
     where: {
       id: ctx.user.organizationId,


### PR DESCRIPTION
fixes: CAL-3473 CAL-3475

See [linear](https://linear.app/calcom/issue/CAL-3475/members-can-see-other-invited-team-members-to-a-team#comment-19635f2a) for loom

![CleanShot 2024-04-17 at 09 54 49@2x](https://github.com/calcom/cal.com/assets/55134778/7924a41e-8349-47b1-a324-04de0037e705)
