### PR TITLE
fix: 500 on forbidden showing up in logs

### DIFF
--- a/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
@@ -34,11 +34,24 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     } as const;
     return redirect;
   }
-
-  await ssr.viewer.eventTypes.get.prefetch({ id: typeParam });
-
-  const { eventType } = await ssr.viewer.eventTypes.get.fetch({ id: typeParam });
-
+  const getEventTypeById = async (eventTypeId: number) => {
+    await ssr.viewer.eventTypes.get.prefetch({ id: eventTypeId });
+    try {
+      return await ssr.viewer.eventTypes.get.fetch({ id: eventTypeId });
+    } catch (e: unknown) {
+      // reject, user has no access to this event type.
+      return null;
+    }
+  };
+  const eventType = await getEventTypeById(typeParam);
+  if (!eventType) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/event-types",
+      },
+    } as const;
+  }
   return {
     props: {
       eventType,

--- a/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
@@ -46,12 +46,13 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   };
   const eventType = await getEventTypeById(typeParam);
   if (!eventType) {
-    return {
+    const redirect = {
       redirect: {
         permanent: false,
         destination: "/event-types",
       },
     } as const;
+    return redirect;
   }
   return {
     props: {

--- a/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
@@ -37,7 +37,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const getEventTypeById = async (eventTypeId: number) => {
     await ssr.viewer.eventTypes.get.prefetch({ id: eventTypeId });
     try {
-      return await ssr.viewer.eventTypes.get.fetch({ id: eventTypeId });
+      const { eventType } = await ssr.viewer.eventTypes.get.fetch({ id: eventTypeId });
+      return eventType;
     } catch (e: unknown) {
       // reject, user has no access to this event type.
       return null;

--- a/packages/trpc/server/routers/viewer/eventTypes/util.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/util.ts
@@ -56,8 +56,7 @@ export const eventOwnerProcedure = authedProcedure
     })();
 
     if (!isAuthorized) {
-      console.warn(`User ${ctx.user.id} attempted to an access an event ${event.id} they do not own.`);
-      throw new TRPCError({ code: "UNAUTHORIZED" });
+      throw new TRPCError({ code: "FORBIDDEN" });
     }
 
     const isAllowed = (function () {


### PR DESCRIPTION
## What does this PR do?

When accessing an event type that doesn't exist or doesn't belong to you, redirect back to the /event-types page instead of throwing a 500 error.

Future improvement, show toast or error, but practically this should happen only when intentional.