### PR TITLE
fix: v2 e2e tests

### DIFF
--- a/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { bootstrap } from "@/app";
 import { AppModule } from "@/app.module";
 import { CalendarsService } from "@/ee/calendars/services/calendars.service";
-import { GcalModule } from "@/ee/gcal/gcal.module";
 import { HttpExceptionFilter } from "@/filters/http-exception.filter";
 import { PrismaExceptionFilter } from "@/filters/prisma-exception.filter";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
@@ -76,7 +75,7 @@ describe("Platform Gcal Endpoints", () => {
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [PrismaExceptionFilter, HttpExceptionFilter],
-      imports: [AppModule, UsersModule, TokensModule, GcalModule],
+      imports: [AppModule, UsersModule, TokensModule],
     })
       .overrideGuard(PermissionsGuard)
       .useValue({

--- a/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/gcal/gcal.controller.e2e-spec.ts
@@ -19,38 +19,14 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 
 const CLIENT_REDIRECT_URI = "http://localhost:5555";
 
-class CalendarsServiceMock extends CalendarsService {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getCalendars(userId: number) {
+class CalendarsServiceMock {
+  async getCalendars() {
     return {
       connectedCalendars: [
         {
-          name: "Google Calendar",
-          appId: "google-calendar",
-          userId: 10,
           integration: {
             type: "google_calendar",
           },
-          calendars: [
-            {
-              externalId: "alice@gmail.com",
-              name: "alice@gmail.com",
-              primary: true,
-              readOnly: false,
-            },
-            {
-              externalId: "addressbook#contacts@group.v.calendar.google.com",
-              name: "Dzimšanas dienas",
-              primary: false,
-              readOnly: true,
-            },
-            {
-              externalId: "en.latvian#holiday@group.v.calendar.google.com",
-              name: "Holidays in Latvia",
-              primary: false,
-              readOnly: true,
-            },
-          ],
         },
       ],
     };

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -199,7 +199,7 @@ describe("OAuth Client Users Endpoints", () => {
     it(`/GET/:id`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
-        .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("x-cal-secret-key", oAuthClient.secret)
         .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .expect(200);
 
@@ -216,7 +216,7 @@ describe("OAuth Client Users Endpoints", () => {
 
       const response = await request(app.getHttpServer())
         .patch(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
-        .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("x-cal-secret-key", oAuthClient.secret)
         .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .send(body)
         .expect(200);
@@ -231,7 +231,7 @@ describe("OAuth Client Users Endpoints", () => {
     it(`/DELETE/:id`, () => {
       return request(app.getHttpServer())
         .delete(`/api/v2/oauth-clients/${oAuthClient.id}/users/${postResponseData.user.id}`)
-        .set("Authorization", `Bearer ${postResponseData.accessToken}`)
+        .set("x-cal-secret-key", oAuthClient.secret)
         .set("Origin", `${CLIENT_REDIRECT_URI}`)
         .expect(200);
     });


### PR DESCRIPTION
## What does this PR do?

Fixes oauth-clients-users (we switched from access token guard to secret header), gcal one we need to mock response when fetching connected calendars because in prod that results in a call to google.

bookings tests will fixed in #14604 