### PR TITLE
fix: remove away view

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -98,13 +98,13 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
               {!isOrg && user.verified && (
                 <Icon
                   name="badge-check"
-                  className=" mx-1 -mt-1 inline h-6 w-6 fill-blue-500 text-white dark:text-black"
+                  className="mx-1 -mt-1 inline h-6 w-6 fill-blue-500 text-white dark:text-black"
                 />
               )}
               {isOrg && (
                 <Icon
                   name="badge-check"
-                  className=" mx-1 -mt-1 inline h-6 w-6 fill-yellow-500 text-white dark:text-black"
+                  className="mx-1 -mt-1 inline h-6 w-6 fill-yellow-500 text-white dark:text-black"
                 />
               )}
             </h1>
@@ -121,47 +121,38 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
           <div
             className={classNames("rounded-md ", !isEventListEmpty && "border-subtle border")}
             data-testid="event-types">
-            {user.away ? (
-              <div className="overflow-hidden rounded-sm border ">
-                <div className="text-muted  p-8 text-center">
-                  <h2 className="font-cal text-default mb-2 text-3xl">😴{` ${t("user_away")}`}</h2>
-                  <p className="mx-auto max-w-md">{t("user_away_description") as string}</p>
+            {eventTypes.map((type) => (
+              <div
+                key={type.id}
+                style={{ display: "flex", ...eventTypeListItemEmbedStyles }}
+                className="bg-default border-subtle dark:bg-muted dark:hover:bg-emphasis hover:bg-muted group relative border-b first:rounded-t-md last:rounded-b-md last:border-b-0">
+                <Icon
+                  name="arrow-right"
+                  className="text-emphasis absolute right-4 top-4 h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"
+                />
+                {/* Don't prefetch till the time we drop the amount of javascript in [user][type] page which is impacting score for [user] page */}
+                <div className="block w-full p-5">
+                  <Link
+                    prefetch={false}
+                    href={{
+                      pathname: `/${user.profile.username}/${type.slug}`,
+                      query,
+                    }}
+                    passHref
+                    onClick={async () => {
+                      sdkActionManager?.fire("eventTypeSelected", {
+                        eventType: type,
+                      });
+                    }}
+                    data-testid="event-type-link">
+                    <div className="flex flex-wrap items-center">
+                      <h2 className="text-default pr-2 text-sm font-semibold">{type.title}</h2>
+                    </div>
+                    <EventTypeDescription eventType={type} isPublic={true} shortenDescription />
+                  </Link>
                 </div>
               </div>
-            ) : (
-              eventTypes.map((type) => (
-                <div
-                  key={type.id}
-                  style={{ display: "flex", ...eventTypeListItemEmbedStyles }}
-                  className="bg-default border-subtle dark:bg-muted dark:hover:bg-emphasis hover:bg-muted group relative border-b first:rounded-t-md last:rounded-b-md last:border-b-0">
-                  <Icon
-                    name="arrow-right"
-                    className="text-emphasis  absolute right-4 top-4 h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"
-                  />
-                  {/* Don't prefetch till the time we drop the amount of javascript in [user][type] page which is impacting score for [user] page */}
-                  <div className="block w-full p-5">
-                    <Link
-                      prefetch={false}
-                      href={{
-                        pathname: `/${user.profile.username}/${type.slug}`,
-                        query,
-                      }}
-                      passHref
-                      onClick={async () => {
-                        sdkActionManager?.fire("eventTypeSelected", {
-                          eventType: type,
-                        });
-                      }}
-                      data-testid="event-type-link">
-                      <div className="flex flex-wrap items-center">
-                        <h2 className=" text-default pr-2 text-sm font-semibold">{type.title}</h2>
-                      </div>
-                      <EventTypeDescription eventType={type} isPublic={true} shortenDescription />
-                    </Link>
-                  </div>
-                </div>
-              ))
-            )}
+            ))}
           </div>
 
           {isEventListEmpty && <EmptyPage name={profile.name || "User"} />}

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -24,7 +24,7 @@ import { LargeCalendar } from "./components/LargeCalendar";
 import { OverlayCalendar } from "./components/OverlayCalendar/OverlayCalendar";
 import { RedirectToInstantMeetingModal } from "./components/RedirectToInstantMeetingModal";
 import { BookerSection } from "./components/Section";
-import { Away, NotFound } from "./components/Unavailable";
+import { NotFound } from "./components/Unavailable";
 import { fadeInLeft, getBookerSizeClassNames, useBookerResizeAnimation } from "./config";
 import { useBookerStore } from "./store";
 import type { BookerProps, WrappedBookerProps } from "./types";
@@ -466,8 +466,6 @@ const BookerComponent = ({
 };
 
 export const Booker = (props: BookerProps & WrappedBookerProps) => {
-  if (props.isAway) return <Away />;
-
   return (
     <LazyMotion strict features={loadFramerFeatures}>
       <BookerComponent {...props} />

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -457,7 +457,6 @@ function UserDropdown({ small }: UserDropdownProps) {
             <span
               className={classNames(
                 "border-muted absolute -bottom-1 -right-1 rounded-full border bg-green-500",
-                user.away ? "bg-yellow-500" : "bg-green-500",
                 small ? "-bottom-0.5 -right-0.5 h-2.5 w-2.5" : "-bottom-0.5 -right-0 h-2 w-2"
               )}
             />


### PR DESCRIPTION
## What does this PR do?

With the new OOO feature we got rid of the away feature. Remove the following view form the profile page: 

<img width="889" alt="Screenshot 2024-04-19 at 11 45 53 AM" src="https://github.com/calcom/cal.com/assets/30310907/bae65202-96ef-445b-96a1-c9e8e1a10bf7">

Also, always show green dot here: 
<img width="205" alt="Screenshot 2024-04-19 at 11 49 59 AM" src="https://github.com/calcom/cal.com/assets/30310907/2f965d61-03d0-45c7-b38a-042455c7640a">
