### PR TITLE
fix: tooltip text on Create event type dialog

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -222,7 +222,7 @@ export default function CreateEventTypeDialog({
                   required
                   addOnLeading={
                     <Tooltip
-                      content={`${urlPrefix}/{!isManagedEventType ? pageSlug : t("username_placeholder")}/`}>
+                      content={`${urlPrefix}/${!isManagedEventType ? pageSlug : t("username_placeholder")}/`}>
                       <span className="max-w-24 md:max-w-56">
                         {urlPrefix}/{!isManagedEventType ? pageSlug : t("username_placeholder")}/
                       </span>


### PR DESCRIPTION
## What does this PR do?

In the Create event type dialog, a tooltip had an incorrect value:
![20240420_21h04m26s_grim](https://github.com/calcom/cal.com/assets/42411122/ce5a4d41-dd15-42ee-8ca8-289754d4faa3)

The template literal had a missing dollar sign, which I added now.



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?


- What are the minimal test data to have?
A user account which can create event types.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
