### PR TITLE
fix: show toast in center of screen

### DIFF
--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -88,6 +88,7 @@ export function showToast(
   //
   const _options: ToastOptions = typeof options === "number" ? { duration: options } : options;
   if (!_options.duration) _options.duration = TOAST_VISIBLE_DURATION;
+  if (!_options.position) _options.position = "bottom-center";
 
   const onClose = (toastId: string) => {
     toast.remove(toastId);


### PR DESCRIPTION
## What does this PR do?
adds default position for a toast message that displays it in center of screen.

Fixes #14686 