### PR TITLE
fix: managed type url in orgs

### DIFF
--- a/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
+++ b/packages/features/eventtypes/components/ChildrenEventTypeSelect.tsx
@@ -1,6 +1,7 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import type { Props } from "react-select";
 
+import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { classNames } from "@calcom/lib";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -34,7 +35,10 @@ export const ChildrenEventTypeSelect = ({
   onChange: (value: readonly ChildrenEventType[]) => void;
 }) => {
   const { t } = useLocale();
+  const orgBranding = useOrgBranding();
+
   const [animationRef] = useAutoAnimate<HTMLUListElement>();
+  const domain = orgBranding?.fullDomain ?? WEBSITE_URL;
 
   return (
     <>
@@ -105,7 +109,7 @@ export const ChildrenEventTypeSelect = ({
                           color="secondary"
                           target="_blank"
                           variant="icon"
-                          href={`${WEBSITE_URL}/${children.owner?.username}/${children.slug}`}
+                          href={`${domain}/${children.owner?.username}/${children.slug}`}
                           StartIcon="external-link"
                         />
                       </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue)
Fixes https://linear.app/calcom/issue/CAL-3507/orgs-managed-links-preview-doesnt-include-subdomain

how to test?
1) Create a managed event type in an org
2) Assign some members and click save
3) Check if you can preview the url 

<img width="1280" alt="Screenshot 2024-04-22 at 1 40 25 PM" src="https://github.com/calcom/cal.com/assets/53316345/4f520f7b-707c-4cca-a6b7-38936165e6ad">

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)