### PR TITLE
fix: send completed_onboarding to intercom

### DIFF
--- a/packages/features/ee/support/lib/intercom/useIntercom.ts
+++ b/packages/features/ee/support/lib/intercom/useIntercom.ts
@@ -54,6 +54,7 @@ export const useIntercom = () => {
         has_paid_plan: hasPaidPlan,
         has_team_plan: hasTeamPlan,
         metadata: data?.metadata,
+        completed_onboarding: data.completedOnboarding,
         is_logged_in: !!data,
       },
     });
@@ -85,6 +86,7 @@ export const useIntercom = () => {
         has_paid_plan: hasPaidPlan,
         has_team_plan: hasTeamPlan,
         metadata: data?.metadata,
+        completed_onboarding: data?.completedOnboarding,
         is_logged_in: !!data,
       },
     });


### PR DESCRIPTION
## What does this PR do?


Fixes # (issue) Triggering emails to be sent upon completion of onboarding through Intercom. 