### PR TITLE
fix: booker atom month reset

### DIFF
--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -209,6 +209,10 @@ export const useBookerStore = create<BookerStore>((set, get) => ({
   },
   month: getQueryParam("month") || getQueryParam("date") || dayjs().format("YYYY-MM"),
   setMonth: (month: string | null) => {
+    if (!month) {
+      removeQueryParam("month");
+      return;
+    }
     set({ month, selectedTimeslot: null });
     updateQueryParam("month", month ?? "");
     get().setSelectedDate(null);


### PR DESCRIPTION
In pr #14715 we reset month when booker is unmounted, but it breaks the booker - it loads infinetely. This PR fixes that by replicating how "setSelectedDate" which manages "date" url param operates.