### PR TITLE
refactor: booker atom unmount reset duration query param

### DIFF
--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -57,6 +57,7 @@ type BookerPlatformWrapperAtomProps = Omit<BookerProps, "entity"> & {
 export const BookerPlatformWrapper = (props: BookerPlatformWrapperAtomProps) => {
   const [bookerState, setBookerState] = useBookerStore((state) => [state.state, state.setState], shallow);
   const setSelectedDate = useBookerStore((state) => state.setSelectedDate);
+  const setSelectedDuration = useBookerStore((state) => state.setSelectedDuration);
   const setBookingData = useBookerStore((state) => state.setBookingData);
   const bookingData = useBookerStore((state) => state.bookingData);
 
@@ -76,6 +77,7 @@ export const BookerPlatformWrapper = (props: BookerPlatformWrapperAtomProps) => 
       setSelectedDate(null);
       setSelectedTimeslot(null);
       setSelectedMonth(null);
+      setSelectedDuration(null);
     };
   }, []);
 


### PR DESCRIPTION
Reset "duration" query param when booker atom is unmounted to address customer issue on slack: https://calcominc.slack.com/archives/C06PW113ZME/p1714034004544489?thread_ts=1713616599.968079&cid=C06PW113ZME

Same strategy worked with the "month" query param.

Tested locally and booking and rescheduling works.