### PR TITLE
fix: Resource owner id check only in case credentialSync is enabled which absolutely need it.

### DIFF
--- a/packages/app-store/_utils/oauth/OAuthManager.ts
+++ b/packages/app-store/_utils/oauth/OAuthManager.ts
@@ -174,7 +174,6 @@ export class OAuthManager {
      */
     isTokenExpired?: IsTokenExpired;
   }) {
-    ensureValidResourceOwner(resourceOwner);
     this.resourceOwner = resourceOwner;
     this.currentTokenObject = currentTokenObject;
     this.appSlug = appSlug;
@@ -191,6 +190,13 @@ export class OAuthManager {
       credentialSyncVariables.CREDENTIAL_SYNC_SECRET_HEADER_NAME &&
       credentialSyncVariables.CREDENTIAL_SYNC_SECRET
     );
+
+    if (this.useCredentialSync) {
+      // Though it should be validated without credential sync as well but it seems like we have some credentials without userId in production
+      // So, we are not validating it for now
+      ensureValidResourceOwner(resourceOwner);
+    }
+
     this.autoCheckTokenExpiryOnRequest = autoCheckTokenExpiryOnRequest;
     this.updateTokenObject = updateTokenObject;
   }


### PR DESCRIPTION
## What does this PR do?

Fixes weird crash during booking in some cases where credential doesn't have `userId.`

## Type of change
- Bug fix (non-breaking change which fixes an issue)

