### PR TITLE
fix: availability.e2e.ts - Date Overrides

### DIFF
--- a/apps/web/playwright/availability.e2e.ts
+++ b/apps/web/playwright/availability.e2e.ts
@@ -22,6 +22,9 @@ test.describe("Availablity", () => {
 
   test("Date Overrides", async ({ page }) => {
     await page.getByTestId("schedules").first().click();
+    await page.locator('[data-testid="Sunday-switch"]').first().click();
+    await page.locator('[data-testid="Saturday-switch"]').first().click();
+
     await page.getByTestId("add-override").click();
     await page.locator('[id="modal-title"]').waitFor();
     await page.getByTestId("incrementMonth").click();

--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -91,6 +91,7 @@ export const ScheduleDay = <TFieldValues extends FieldValues>({
                 disabled={!watchDayRange || disabled}
                 defaultChecked={watchDayRange && watchDayRange.length > 0}
                 checked={watchDayRange && !!watchDayRange.length}
+                data-testid={`${weekday}-switch`}
                 onCheckedChange={(isChecked) => {
                   setValue(name, (isChecked ? [DEFAULT_DAY_RANGE] : []) as TFieldValues[typeof name]);
                 }}


### PR DESCRIPTION
## What does this PR do?

Fix failing e2e test: availability.e2e.ts - Date Overrides

Run: 
`yarn e2e availability.e2e.ts`