### PR TITLE
chore: Add default to match migration for Platform Billing

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1364,7 +1364,7 @@ model PlatformBilling {
 
   customerId     String  @unique
   subscriptionId String?
-  plan           String
+  plan           String  @default("none")
 
   billingCycleStart Int?
   billingCycleEnd   Int?


### PR DESCRIPTION
## What does this PR do?

Migration for Platform Billing included a default which was not defined in the schema.