### PR TITLE
fix: Sender ID info not being shown on 'info' hover in 'add action' flow

### DIFF
--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -216,10 +216,12 @@ export const AddActionDialog = (props: IAddActionDialog) => {
             {isSenderIdNeeded && (
               <>
                 <div className="mt-5">
-                  <div className="flex">
+                  <div className="flex items-center">
                     <Label>{t("sender_id")}</Label>
                     <Tooltip content={t("sender_id_info")}>
-                      <Icon name="info" className="ml-2 mr-1 mt-0.5 h-4 w-4 text-gray-500" />
+                      <span>
+                        <Icon name="info" className="mb-2 ml-2 mr-1 mt-0.5 h-4 w-4 text-gray-500" />
+                      </span>
                     </Tooltip>
                   </div>
                   <Input type="text" placeholder={SENDER_ID} maxLength={11} {...form.register(`senderId`)} />


### PR DESCRIPTION
## What does this PR do?

Fixes #14874 

Missed this in #14846 
Thanks @utkershrajvenshi

![Screenshot 2024-05-05 at 2 54 58 PM](https://github.com/calcom/cal.com/assets/74371312/54bc2133-a3f2-419e-b216-5a9381ce45f5)



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

