### PR TITLE
fix: UI breaking in AddActionDialog on reducing browser window height

### DIFF
--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -136,7 +136,7 @@ export const AddActionDialog = (props: IAddActionDialog) => {
 
   return (
     <Dialog open={isOpenDialog} onOpenChange={setIsOpenDialog}>
-      <DialogContent type="creation" title={t("add_action")}>
+      <DialogContent enableOverflow type="creation" title={t("add_action")}>
         <div className="-mt-3 space-x-3">
           <Form
             form={form}
@@ -166,6 +166,7 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                     <Select
                       isSearchable={false}
                       className="text-sm"
+                      menuPlacement="bottom"
                       defaultValue={actionOptions[0]}
                       onChange={handleSelectAction}
                       options={actionOptions.map((option) => ({
@@ -250,7 +251,7 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                 />
               </div>
             )}
-            <DialogFooter showDivider className="relative mt-12">
+            <DialogFooter showDivider className="mt-12">
               <DialogClose
                 onClick={() => {
                   setIsOpenDialog(false);


### PR DESCRIPTION
## What does this PR do?

Fixes #14875 

[Loom video](https://www.loom.com/share/f692c1693d104a68b6d603e502b17dfd?sid=a785c819-7562-42fe-b74f-9bea3935c3e6)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Render AddActionDialog by clicking on 'Add Action' in 'Workflows' section. Now reduce the window height manually or from Responsive View in Chrome DevTools. Observe that the content is now scrollable and the footer is fixed at the bottom, aligning with the design paradigms.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
