### PR TITLE
chore: Use 4vCPU BuildJet hardware for type checks

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -5,7 +5,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 jobs:
   check-types:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/dangerous-git-checkout


### PR DESCRIPTION
In #14835, I backed down the vCPUs for type-checks since that job runs in parallel to everything. This is apparently not compatible with our type checks. Putting back for now to fix.