### PR TITLE
fix: add prisma client generated types to atoms package

### DIFF
--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.40",
   "scripts": {
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
-    "build": "yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify",
+    "build": "yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
     "publish": "rm -rf dist && yarn build && npm publish --access public"
   },
   "devDependencies": {

--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -43,7 +43,8 @@ export default defineConfig({
       path: resolve("../../../node_modules/rollup-plugin-node-builtins"),
       os: resolve("../../../node_modules/rollup-plugin-node-builtins"),
       "@": path.resolve(__dirname, "./src"),
-
+      ".prisma/client": path.resolve(__dirname, "../../prisma-client"),
+      "@prisma/client": path.resolve(__dirname, "../../prisma-client"),
       "@calcom/prisma": path.resolve(__dirname, "../../prisma"),
       "@calcom/dayjs": path.resolve(__dirname, "../../dayjs"),
       "@calcom/platform-constants": path.resolve(__dirname, "../constants/index.ts"),


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Atoms npm package was missing prisma generated types 