### PR TITLE
chore: Update PR template to include more mandatory tasks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 <!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
-Fixes # (GitHub issue number)
-Fixes CAL-XXX (Linear issue number)
+Fixes #XXXX (GitHub issue number)
+Fixes CAL-XXXX (Linear issue number)
 
 <!-- Please provide a loom video for visual changes to speed up reviews
  Loom Video: https://www.loom.com/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,29 +2,18 @@
 
 <!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
-Fixes # (issue)
+Fixes # (GitHub issue number)
+Fixes CAL-XXX (Linear issue number)
 
 <!-- Please provide a loom video for visual changes to speed up reviews
  Loom Video: https://www.loom.com/
 -->
 
-## Requirement/Documentation
+## Mandatory Tasks (DO NOT REMOVE)
 
-<!-- Please provide all documents that are important to understand the reason of that PR. -->
-
-- If there is a requirement document, please, share it here.
-- If there is a UI/UX design document, please, share it here.
-
-## Type of change
-
-<!-- Please delete bullets that are not relevant. -->
-
-- Bug fix (non-breaking change which fixes an issue)
-- Chore (refactoring code, technical debt, workflow improvements)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- Tests (Unit/Integration/E2E or any other test)
-- This change requires a documentation update
+- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
+- [ ] I have added the "docs" label if this PR makes changes that would require a [documentation change](https://docs.cal.com)
+- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)
 
 ## How should this be tested?
 
@@ -35,10 +24,6 @@ Fixes # (issue)
 - What is expected (happy path) to have (input and output)?
 - Any other important info that could help to test that PR
 
-## Mandatory Tasks
-
-- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
-
 ## Checklist
 
 <!-- Remove bullet points below that don't apply to you -->
@@ -46,7 +31,4 @@ Fixes # (issue)
 - I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
 - My code doesn't follow the style guidelines of this project
 - I haven't commented my code, particularly in hard-to-understand areas
-- I haven't checked if my PR needs changes to the documentation
 - I haven't checked if my changes generate no new warnings
-- I haven't added tests that prove my fix is effective or that my feature works
-- I haven't checked if new and existing unit tests pass locally with my changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 <!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
-Fixes #XXXX (GitHub issue number)
-Fixes CAL-XXXX (Linear issue number)
+- Fixes #XXXX (GitHub issue number)
+- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)
 
 <!-- Please provide a loom video for visual changes to speed up reviews
  Loom Video: https://www.loom.com/
@@ -12,7 +12,7 @@ Fixes CAL-XXXX (Linear issue number)
 ## Mandatory Tasks (DO NOT REMOVE)
 
 - [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
-- [ ] I have added the "docs" label if this PR makes changes that would require a [documentation change](https://docs.cal.com)
+- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
 - [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)
 
 ## How should this be tested?


### PR DESCRIPTION
## What does this PR do?

- Updates our PR template so that mandatory tasks we expect to be completed for PRs are properly noted.
- Removed extra parts that are redundant, like the type of change. Since we require the PR title to have a prefix which is the type of change, this section is obsolete.
- Requirement/Documentation section was rarely ever used and often we have these details in the GitHub issue instead. 

