### PR TITLE
fix: attempt to fix flaky e2e tests

### DIFF
--- a/apps/web/playwright/webhook.e2e.ts
+++ b/apps/web/playwright/webhook.e2e.ts
@@ -578,6 +578,8 @@ test.describe("FORM_SUBMITTED", async () => {
       ],
     });
 
+    await page.waitForLoadState("networkidle");
+
     await gotoRoutingLink({ page, formId: form.id });
     const fieldName = "name";
     await page.fill(`[data-testid="form-field-${fieldName}"]`, "John Doe");
@@ -636,6 +638,8 @@ test.describe("FORM_SUBMITTED", async () => {
         },
       ],
     });
+
+    await page.waitForLoadState("networkidle");
 
     await gotoRoutingLink({ page, formId: form.id });
     const fieldName = "name";


### PR DESCRIPTION
## What does this PR do?

FORM_SUBMITTED e2e tests in webhook.e2e.ts fail sometimes. Can also be reproduced locally. Here is an example where it fails: https://github.com/calcom/cal.com/actions/runs/9004397788/job/24738828638?pr=14922#step:10:367 

<img width="939" alt="Screenshot 2024-05-08 at 2 37 07 PM" src="https://github.com/calcom/cal.com/assets/30310907/40055e8f-1bad-4f3e-9bea-2b4e31edcaf4">
