### PR TITLE
fix: Show error log in case of /event-types redirect

### DIFF
--- a/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.getServerSideProps.tsx
@@ -1,6 +1,8 @@
 import type { GetServerSidePropsContext } from "next";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import logger from "@calcom/lib/logger";
+import { safeStringify } from "@calcom/lib/safeStringify";
 
 import { asStringOrThrow } from "@lib/asStringOrNull";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -40,6 +42,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       const { eventType } = await ssr.viewer.eventTypes.get.fetch({ id: eventTypeId });
       return eventType;
     } catch (e: unknown) {
+      logger.error(safeStringify(e));
       // reject, user has no access to this event type.
       return null;
     }

--- a/packages/lib/safeStringify.ts
+++ b/packages/lib/safeStringify.ts
@@ -5,7 +5,8 @@ export function safeStringify(obj: unknown) {
   try {
     if (obj instanceof Error) {
       // Errors don't serialize well, so we extract what we want
-      return obj.stack ?? obj.message;
+      // We stringify so that we can log the error message and stack trace in a single log event
+      return JSON.stringify(obj.stack ?? obj.message);
     }
     // Avoid crashing on circular references
     return JSON.stringify(obj);


### PR DESCRIPTION
## What does this PR do?
Any error(including an error due to migration wasn't logged). I spent some time figuring out why browsing to an event-type wasn't working as it was silently redirecting.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)