### PR TITLE
fix: Fixed email embed for team when specific times are chosen embeds the wrong URL

### DIFF
--- a/packages/features/embed/Embed.tsx
+++ b/packages/features/embed/Embed.tsx
@@ -418,7 +418,11 @@ const EmailEmbedPreview = ({
                                   <tr style={{ height: "25px" }}>
                                     {selectedDateAndTime[key]?.length > 0 &&
                                       selectedDateAndTime[key].map((time) => {
-                                        const bookingURL = `${WEBSITE_URL}/${username}/${eventType.slug}?duration=${eventType.length}&date=${key}&month=${month}&slot=${time}`;
+                                        const bookingURL = `${WEBSITE_URL}/${
+                                          eventType.teamId !== null ? "team/" : ""
+                                        }${username}/${eventType.slug}?duration=${
+                                          eventType.length
+                                        }&date=${key}&month=${month}&slot=${time}`;
                                         return (
                                           <td
                                             key={time}

--- a/packages/features/embed/Embed.tsx
+++ b/packages/features/embed/Embed.tsx
@@ -418,6 +418,8 @@ const EmailEmbedPreview = ({
                                   <tr style={{ height: "25px" }}>
                                     {selectedDateAndTime[key]?.length > 0 &&
                                       selectedDateAndTime[key].map((time) => {
+                                        // If teamId is present on eventType and is not null, it means it is a team event.
+                                        // So we add 'team/' to the url.
                                         const bookingURL = `${WEBSITE_URL}/${
                                           eventType.teamId !== null ? "team/" : ""
                                         }${username}/${eventType.slug}?duration=${


### PR DESCRIPTION
## What does this PR do?
- Fixes #14259

## Mandatory Tasks (DO NOT REMOVE)

- [*] I have self-reviewed the code (A decent size PR without self-review might be rejected)

## How should this be tested?
1. Set up a Team and add availability
2. Go to team event and click the Embed button
3. Click on Email embed
4. Choose specific times to embed
5. Paste into the email
6. When clicking on each of the selected times, they go to the correct page.

## Checklist
- I haven't checked if my changes generate no new warnings
