### PR TITLE
Issue Fix  #14963

### DIFF
--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -403,9 +403,10 @@ export default function Signup({
                     isSubmitting ||
                     usernameTaken
                   }>
-                  {premiumUsername && !usernameTaken
-                    ? `Create Account for ${getPremiumPlanPriceValue()}`
-                    : t("create_account")}
+                  {!loadingSubmitState &&
+                    (premiumUsername && !usernameTaken
+                      ? `Create Account for ${getPremiumPlanPriceValue()}`
+                      : t("create_account"))}
                 </Button>
               </Form>
               {/* Continue with Social Logins - Only for non-invite links */}


### PR DESCRIPTION
## What does this PR do?

As per the issue , there would be spinner and text , both shown while submitting.
My Fix : Show the text `Create Account ` only when NOT loading (!loadingSubmitState)

- Fixes #14963 



## Mandatory Tasks 

- [✅  ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [✅  ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ✅ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)




