### PR TITLE
chore: more fields event-types api v2

### DIFF
--- a/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/controllers/event-types.controller.e2e-spec.ts
@@ -132,6 +132,10 @@ describe("Event types Endpoints", () => {
         length: 60,
         hidden: false,
         disableGuests: true,
+        slotInterval: 15,
+        afterEventBuffer: 5,
+        beforeEventBuffer: 10,
+        minimumBookingNotice: 120,
         locations: [
           {
             type: "Online",
@@ -150,6 +154,11 @@ describe("Event types Endpoints", () => {
           expect(responseBody.data).toHaveProperty("id");
           expect(responseBody.data.title).toEqual(body.title);
           expect(responseBody.data.disableGuests).toEqual(body.disableGuests);
+          expect(responseBody.data.slotInterval).toEqual(body.slotInterval);
+          expect(responseBody.data.minimumBookingNotice).toEqual(body.minimumBookingNotice);
+          expect(responseBody.data.beforeEventBuffer).toEqual(body.beforeEventBuffer);
+          expect(responseBody.data.afterEventBuffer).toEqual(body.afterEventBuffer);
+
           eventType = responseBody.data;
         });
     });
@@ -160,6 +169,10 @@ describe("Event types Endpoints", () => {
       const body: UpdateEventTypeInput = {
         title: newTitle,
         disableGuests: false,
+        slotInterval: 30,
+        afterEventBuffer: 10,
+        beforeEventBuffer: 15,
+        minimumBookingNotice: 240,
       };
 
       return request(app.getHttpServer())
@@ -170,8 +183,17 @@ describe("Event types Endpoints", () => {
           const responseBody: ApiSuccessResponse<EventType> = response.body;
           expect(responseBody.data.title).toEqual(newTitle);
           expect(responseBody.data.disableGuests).toEqual(body.disableGuests);
+          expect(responseBody.data.slotInterval).toEqual(body.slotInterval);
+          expect(responseBody.data.minimumBookingNotice).toEqual(body.minimumBookingNotice);
+          expect(responseBody.data.beforeEventBuffer).toEqual(body.beforeEventBuffer);
+          expect(responseBody.data.afterEventBuffer).toEqual(body.afterEventBuffer);
+
           eventType.title = newTitle;
           eventType.disableGuests = responseBody.data.disableGuests ?? false;
+          eventType.slotInterval = body.slotInterval ?? null;
+          eventType.minimumBookingNotice = body.minimumBookingNotice ?? 10;
+          eventType.beforeEventBuffer = body.beforeEventBuffer ?? 10;
+          eventType.afterEventBuffer = body.afterEventBuffer ?? 10;
         });
     });
 

--- a/apps/api/v2/src/ee/event-types/inputs/create-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/inputs/create-event-type.input.ts
@@ -1,7 +1,16 @@
 import { EventTypeLocation } from "@/ee/event-types/inputs/event-type-location.input";
 import { ApiProperty as DocsProperty, ApiHideProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsString, IsNumber, IsBoolean, IsOptional, ValidateNested, Min, IsArray } from "class-validator";
+import {
+  IsString,
+  IsNumber,
+  IsBoolean,
+  IsOptional,
+  ValidateNested,
+  Min,
+  IsArray,
+  IsInt,
+} from "class-validator";
 
 export const CREATE_EVENT_LENGTH_EXAMPLE = 60;
 export const CREATE_EVENT_SLUG_EXAMPLE = "cooking-class";
@@ -44,6 +53,23 @@ export class CreateEventTypeInput {
   @IsBoolean()
   @IsOptional()
   disableGuests?: boolean;
+
+  @IsInt()
+  @IsOptional()
+  slotInterval?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  minimumBookingNotice?: number;
+
+  @IsInt()
+  @IsOptional()
+  beforeEventBuffer?: number;
+
+  @IsInt()
+  @IsOptional()
+  afterEventBuffer?: number;
 
   // @ApiHideProperty()
   // @IsOptional()

--- a/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
@@ -330,18 +330,18 @@ export class UpdateEventTypeInput {
   // @IsOptional()
   // hideCalendarNotes?: boolean;
 
-  // @IsInt()
-  // @Min(0)
-  // @IsOptional()
-  // minimumBookingNotice?: number;
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  minimumBookingNotice?: number;
 
-  // @IsInt()
-  // @IsOptional()
-  // beforeEventBuffer?: number;
+  @IsInt()
+  @IsOptional()
+  beforeEventBuffer?: number;
 
-  // @IsInt()
-  // @IsOptional()
-  // afterEventBuffer?: number;
+  @IsInt()
+  @IsOptional()
+  afterEventBuffer?: number;
 
   // @IsInt()
   // @IsOptional()
@@ -375,9 +375,9 @@ export class UpdateEventTypeInput {
   // @IsOptional()
   // currency?: string;
 
-  // @IsInt()
-  // @IsOptional()
-  // slotInterval?: number;
+  @IsInt()
+  @IsOptional()
+  slotInterval?: number;
 
   // @IsString()
   // @IsOptional()

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -2102,6 +2102,19 @@
           },
           "disableGuests": {
             "type": "boolean"
+          },
+          "slotInterval": {
+            "type": "number"
+          },
+          "minimumBookingNotice": {
+            "type": "number",
+            "minimum": 0
+          },
+          "beforeEventBuffer": {
+            "type": "number"
+          },
+          "afterEventBuffer": {
+            "type": "number"
           }
         },
         "required": [
@@ -2787,6 +2800,19 @@
           },
           "disableGuests": {
             "type": "boolean"
+          },
+          "minimumBookingNotice": {
+            "type": "number",
+            "minimum": 0
+          },
+          "beforeEventBuffer": {
+            "type": "number"
+          },
+          "afterEventBuffer": {
+            "type": "number"
+          },
+          "slotInterval": {
+            "type": "number"
           }
         }
       },

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -15,6 +15,10 @@ export const createEventTypeInput = z.object({
   locations: imports.eventTypeLocations,
   metadata: imports.EventTypeMetaDataSchema.optional(),
   disableGuests: z.boolean().optional(),
+  slotInterval: z.number().nullish(),
+  minimumBookingNotice: z.number().int().min(0).optional(),
+  beforeEventBuffer: z.number().int().optional(),
+  afterEventBuffer: z.number().int().optional(),
 })
   .partial({ hidden: true, locations: true })
   .refine((data) => (data.teamId ? data.teamId && data.schedulingType : true), {


### PR DESCRIPTION
## What does this PR do?

Chore: api v2 allows settings more fields when creating / updating event-types

- slotInterval
- afterEventBuffer
- beforeEventBugger
- minimumBookingNotice