### PR TITLE
fix: body payload of MEETING_STARTED & MEETING_ENDED webhook

### DIFF
--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -314,11 +314,31 @@ export async function handleConfirmation(args: {
 
     const scheduleTriggerPromises: Promise<unknown>[] = [];
 
+    const eventTypeInfo: EventTypeInfo = {
+      eventTitle: booking.eventType?.title,
+      eventDescription: booking.eventType?.description,
+      requiresConfirmation: booking.eventType?.requiresConfirmation || null,
+      price: booking.eventType?.price,
+      currency: booking.eventType?.currency,
+      length: booking.eventType?.length,
+    };
+
+    const webhookData = {
+      ...evt,
+      ...eventTypeInfo,
+      bookingId,
+      eventTypeId: booking.eventType?.id,
+      status: "ACCEPTED",
+      smsReminderNumber: booking.smsReminderNumber || undefined,
+      metadata: meetingUrl ? { videoCallUrl: meetingUrl } : undefined,
+    };
+
     subscribersMeetingStarted.forEach((subscriber) => {
       updatedBookings.forEach((booking) => {
         scheduleTriggerPromises.push(
           scheduleTrigger({
             booking,
+            webhookData,
             subscriberUrl: subscriber.subscriberUrl,
             subscriber,
             triggerEvent: WebhookTriggerEvents.MEETING_STARTED,
@@ -331,6 +351,7 @@ export async function handleConfirmation(args: {
         scheduleTriggerPromises.push(
           scheduleTrigger({
             booking,
+            webhookData,
             subscriberUrl: subscriber.subscriberUrl,
             subscriber,
             triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
@@ -341,25 +362,14 @@ export async function handleConfirmation(args: {
 
     await Promise.all(scheduleTriggerPromises);
 
-    const eventTypeInfo: EventTypeInfo = {
-      eventTitle: eventType?.title,
-      eventDescription: eventType?.description,
-      requiresConfirmation: eventType?.requiresConfirmation || null,
-      price: eventType?.price,
-      currency: eventType?.currency,
-      length: eventType?.length,
-    };
-
     const promises = subscribersBookingCreated.map((sub) =>
-      sendPayload(sub.secret, WebhookTriggerEvents.BOOKING_CREATED, new Date().toISOString(), sub, {
-        ...evt,
-        ...eventTypeInfo,
-        bookingId,
-        eventTypeId: eventType?.id,
-        status: "ACCEPTED",
-        smsReminderNumber: booking.smsReminderNumber || undefined,
-        metadata: meetingUrl ? { videoCallUrl: meetingUrl } : undefined,
-      }).catch((e) => {
+      sendPayload(
+        sub.secret,
+        WebhookTriggerEvents.BOOKING_CREATED,
+        new Date().toISOString(),
+        sub,
+        webhookData
+      ).catch((e) => {
         log.error(
           `Error executing webhook for event: ${WebhookTriggerEvents.BOOKING_CREATED}, URL: ${sub.subscriberUrl}, bookingId: ${evt.bookingId}, bookingUid: ${evt.uid}`,
           safeStringify(e)

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1656,6 +1656,7 @@ async function handler(
         scheduleTriggerPromises.push(
           scheduleTrigger({
             booking,
+            webhookData,
             subscriberUrl: subscriber.subscriberUrl,
             subscriber,
             triggerEvent: WebhookTriggerEvents.MEETING_ENDED,
@@ -1667,6 +1668,7 @@ async function handler(
         scheduleTriggerPromises.push(
           scheduleTrigger({
             booking,
+            webhookData,
             subscriberUrl: subscriber.subscriberUrl,
             subscriber,
             triggerEvent: WebhookTriggerEvents.MEETING_STARTED,

--- a/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
+++ b/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
@@ -52,12 +52,14 @@ export async function handleWebhookScheduledTriggers(prisma: PrismaClient) {
     }
 
     const headers: Record<string, string> = {
-      "Content-Type": "application/json",
+      "Content-Type":
+        !job.payload || jsonParse(job.payload) ? "application/json" : "application/x-www-form-urlencoded",
     };
 
     const parsedPayload = jsonParse(job.payload);
 
     const body = JSON.stringify({
+      ...(job.payload && parsedPayload),
       triggerEvent: parsedPayload.triggerEvent,
       payload: parsedPayload,
       createdAt: new Date().toISOString(),

--- a/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
+++ b/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
@@ -61,9 +61,11 @@ export async function handleWebhookScheduledTriggers(prisma: PrismaClient) {
     const parsedPayload = jsonParse(job.payload);
 
     const body = JSON.stringify({
-      ...parsedLegacyPayload, // for ensures backward compatibility. Note: It also populate the triggerEvent which is part of the actual payload
-      payload: parsedPayload,
-      createdAt: new Date().toISOString(),
+      ...parsedLegacyPayload, // for ensures backward compatibility. Note: It also populate the triggerEvent which is part of the both actual and legacy payload
+      ...(job.payload && {
+        payload: parsedPayload,
+        createdAt: new Date().toISOString(),
+      }),
     });
 
     if (webhook) {

--- a/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
+++ b/packages/features/webhooks/lib/handleWebhookScheduledTriggers.ts
@@ -61,7 +61,7 @@ export async function handleWebhookScheduledTriggers(prisma: PrismaClient) {
     const parsedPayload = jsonParse(job.payload);
 
     const body = JSON.stringify({
-      ...parsedLegacyPayload, // for ensures backward compatibility. Note: It also populate the triggerEvent which is part of the both actual and legacy payload
+      ...parsedLegacyPayload, // ensures backward compatibility. Note: It also populates the triggerEvent which is part of the both the actual and legacy payload
       ...(job.payload && {
         payload: parsedPayload,
         createdAt: new Date().toISOString(),

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -452,9 +452,9 @@ export async function updateTriggerForExistingBookings(
   if (bookings.length === 0) return;
 
   if (addedEventTriggers.length > 0) {
-    const promise = bookings.map((booking) => {
-      return addedEventTriggers.map(async (triggerEvent) => {
-        const { booking: bookingWithWebhookPayload, evt } = await getBooking(booking.id);
+    const promise = bookings.map(async (booking) => {
+      const { booking: bookingWithWebhookPayload, evt } = await getBooking(booking.id);
+      return addedEventTriggers.map((triggerEvent) => {
         const webhookData = getWebhookPayloadForBooking({
           booking: bookingWithWebhookPayload,
           evt,

--- a/packages/features/webhooks/lib/test/webhooks.test.ts
+++ b/packages/features/webhooks/lib/test/webhooks.test.ts
@@ -46,20 +46,20 @@ describe("Cron job handler", () => {
   });
   test(`should trigger if current date is after startAfter`, async () => {
     const now = dayjs();
-    const payload = `{"triggerEvent":"MEETING_ENDED"}`;
+    const payload = { triggerEvent: "MEETING_ENDED" };
     await prismock.webhookScheduledTriggers.createMany({
       data: [
         {
           id: 1,
           subscriberUrl: "https://example.com",
           startAfter: now.add(5, "minute").toDate(),
-          payload,
+          payload: JSON.stringify(payload),
         },
         {
           id: 2,
           subscriberUrl: "https://example.com/test",
           startAfter: now.subtract(5, "minute").toDate(),
-          payload,
+          payload: JSON.stringify(payload),
         },
       ],
     });

--- a/packages/prisma/migrations/20240609185254_add_legacypayload_to_webhookscheduledtriggers/migration.sql
+++ b/packages/prisma/migrations/20240609185254_add_legacypayload_to_webhookscheduledtriggers/migration.sql
@@ -1,0 +1,14 @@
+
+-- AlterTable
+ALTER TABLE "WebhookScheduledTriggers" ADD COLUMN     "legacyPayload" TEXT;
+
+-- Update the legacyPayload column with the payload column's value
+UPDATE "WebhookScheduledTriggers" SET "legacyPayload" = "payload";
+
+-- make payload column values to {}
+UPDATE "WebhookScheduledTriggers" SET "payload" = '';
+
+
+-- Make the legacyPayload column not nullable
+ALTER TABLE "WebhookScheduledTriggers" ALTER COLUMN "legacyPayload" SET NOT NULL;
+

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1043,6 +1043,7 @@ model WebhookScheduledTriggers {
   id            Int       @id @default(autoincrement())
   jobName       String? // jobName is deprecated, not needed when webhook and booking is set
   subscriberUrl String
+  legacyPayload String
   payload       String
   startAfter    DateTime
   retryCount    Int       @default(0)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The PR now provides the proper body in the webhook payload for scheduled Triggers (MEETING_STARTED & MEETING_ENDED)
- Fixes #15033 
- Fixed #15078

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

- Follow steps to setup webhooks in your applciation from the [docs](https://cal.com/docs/core-features/webhooks)
- Adding logs to print (`req.body.payload, req.body`)
- Trigger the MEETING_START or MEETING_ENDED event
- You should find `req.body.payload` will be `undefined` and `req.body`  having the contents of payload which isn't the format mentioned in the docs, neither do other events have.


- What are the minimal test data to have?
Booking a event creates the necessary records in the database, for ease of testing set buffer time to book to 0 and booking interval to 1 min, so that MEETING_STARTED & MEETING_ENDED will be trigerred faster.


## Checklist

- I haven't checked if my changes generate no new warnings
