### PR TITLE
chore: api-v2  slotInterval, afterEventBuffer, beforeEventBuffer min 0

### DIFF
--- a/apps/api/v2/src/ee/event-types/inputs/create-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/inputs/create-event-type.input.ts
@@ -55,6 +55,7 @@ export class CreateEventTypeInput {
   disableGuests?: boolean;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   slotInterval?: number;
 
@@ -64,10 +65,12 @@ export class CreateEventTypeInput {
   minimumBookingNotice?: number;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   beforeEventBuffer?: number;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   afterEventBuffer?: number;
 

--- a/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
@@ -336,10 +336,12 @@ export class UpdateEventTypeInput {
   minimumBookingNotice?: number;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   beforeEventBuffer?: number;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   afterEventBuffer?: number;
 
@@ -376,6 +378,7 @@ export class UpdateEventTypeInput {
   // currency?: string;
 
   @IsInt()
+  @Min(0)
   @IsOptional()
   slotInterval?: number;
 

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -15,10 +15,10 @@ export const createEventTypeInput = z.object({
   locations: imports.eventTypeLocations,
   metadata: imports.EventTypeMetaDataSchema.optional(),
   disableGuests: z.boolean().optional(),
-  slotInterval: z.number().nullish(),
+  slotInterval: z.number().min(0).nullish(),
   minimumBookingNotice: z.number().int().min(0).optional(),
-  beforeEventBuffer: z.number().int().optional(),
-  afterEventBuffer: z.number().int().optional(),
+  beforeEventBuffer: z.number().int().min(0).optional(),
+  afterEventBuffer: z.number().int().min(0).optional(),
 })
   .partial({ hidden: true, locations: true })
   .refine((data) => (data.teamId ? data.teamId && data.schedulingType : true), {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

event-types fields

- slotInterval
- afterEventBuffer
- beforeEventBuffer

minimum value is 0