### PR TITLE
fix: disable useGetOAuthClientManagedUsers if clientId not defined

### DIFF
--- a/apps/web/lib/hooks/settings/platform/oauth-clients/useOAuthClients.ts
+++ b/apps/web/lib/hooks/settings/platform/oauth-clients/useOAuthClients.ts
@@ -77,6 +77,7 @@ export const useGetOAuthClientManagedUsers = (clientId: string) => {
         headers: { "Content-type": "application/json" },
       }).then((res) => res.json());
     },
+    enabled: Boolean(clientId),
   });
 
   return { isLoading, error, data: response?.data, refetch };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In platform dashboard, disable useGetOAuthClientManagedUsers if clientId not defined