### PR TITLE
Ensure that dateRanges start and end have same timezone

### DIFF
--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -438,7 +438,7 @@ describe("getSchedule", () => {
       // `slotInterval` takes precedence over `length`
       // 4:30 is utc so it is 10:00 in IST
       expect(scheduleForEventWith30minsLengthAndSlotInterval2hrs).toHaveTimeSlots(
-        [`04:30:00.000Z`, `06:30:00.000Z`, `08:30:00.000Z`, `10:30:00.000Z`, `12:30:00.000Z`],
+        [`04:00:00.000Z`, `06:00:00.000Z`, `08:00:00.000Z`, `10:00:00.000Z`, `12:00:00.000Z`],
         {
           dateString: plus2DateString,
         }
@@ -535,142 +535,142 @@ describe("getSchedule", () => {
       vi.useRealTimers();
     });
 
-    test("afterBuffer and beforeBuffer tests - Non Cal Busy Time", async () => {
-      const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
-      const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
+    describe("Buffer", () => {
+      test("afterBuffer and beforeBuffer tests - Non Cal Busy Time", async () => {
+        const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
+        const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
 
-      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
-        {
-          start: `${plus3DateString}T04:00:00.000Z`,
-          end: `${plus3DateString}T05:59:59.000Z`,
-        },
-      ]);
-
-      const scenarioData = {
-        eventTypes: [
+        CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
           {
-            id: 1,
-            length: 120,
-            beforeEventBuffer: 120,
-            afterEventBuffer: 120,
-            users: [
-              {
-                id: 101,
-              },
-            ],
+            start: `${plus3DateString}T04:00:00.000Z`,
+            end: `${plus3DateString}T05:59:59.000Z`,
           },
-        ],
-        users: [
-          {
-            ...TestData.users.example,
-            id: 101,
-            schedules: [TestData.schedules.IstWorkHours],
-            credentials: [getGoogleCalendarCredential()],
-            selectedCalendars: [TestData.selectedCalendars.google],
-          },
-        ],
-        apps: [TestData.apps.googleCalendar],
-      };
+        ]);
 
-      await createBookingScenario(scenarioData);
+        const scenarioData = {
+          eventTypes: [
+            {
+              id: 1,
+              length: 120,
+              beforeEventBuffer: 120,
+              afterEventBuffer: 120,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          users: [
+            {
+              ...TestData.users.example,
+              id: 101,
+              schedules: [TestData.schedules.IstWorkHours],
+              credentials: [getGoogleCalendarCredential()],
+              selectedCalendars: [TestData.selectedCalendars.google],
+            },
+          ],
+          apps: [TestData.apps.googleCalendar],
+        };
 
-      const scheduleForEventOnADayWithNonCalBooking = await getSchedule({
-        input: {
-          eventTypeId: 1,
-          eventTypeSlug: "",
-          startTime: `${plus2DateString}T18:30:00.000Z`,
-          endTime: `${plus3DateString}T18:29:59.999Z`,
-          timeZone: Timezones["+5:30"],
-          isTeamEvent: false,
-        },
-      });
+        await createBookingScenario(scenarioData);
 
-      expect(scheduleForEventOnADayWithNonCalBooking).toHaveTimeSlots(
-        [
-          // `04:00:00.000Z`, // - 4 AM is booked
-          // `06:00:00.000Z`, // - 6 AM is not available because 08:00AM slot has a `beforeEventBuffer`
-          `08:00:00.000Z`, // - 8 AM is available because of availability of 06:00 - 07:59
-          `10:00:00.000Z`,
-          `12:00:00.000Z`,
-        ],
-        {
-          dateString: plus3DateString,
-        }
-      );
-    });
-
-    test("afterBuffer and beforeBuffer tests - Cal Busy Time", async () => {
-      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
-      const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
-      const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
-
-      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
-        {
-          start: `${plus3DateString}T04:00:00.000Z`,
-          end: `${plus3DateString}T05:59:59.000Z`,
-        },
-      ]);
-
-      const scenarioData = {
-        eventTypes: [
-          {
-            id: 1,
-            length: 120,
-            beforeEventBuffer: 120,
-            afterEventBuffer: 120,
-            users: [
-              {
-                id: 101,
-              },
-            ],
-          },
-        ],
-        users: [
-          {
-            ...TestData.users.example,
-            id: 101,
-            schedules: [TestData.schedules.IstWorkHours],
-            credentials: [getGoogleCalendarCredential()],
-            selectedCalendars: [TestData.selectedCalendars.google],
-          },
-        ],
-        bookings: [
-          {
-            userId: 101,
+        const scheduleForEventOnADayWithNonCalBooking = await getSchedule({
+          input: {
             eventTypeId: 1,
-            startTime: `${plus2DateString}T04:00:00.000Z`,
-            endTime: `${plus2DateString}T05:59:59.000Z`,
-            status: "ACCEPTED" as BookingStatus,
+            eventTypeSlug: "",
+            startTime: `${plus2DateString}T18:30:00.000Z`,
+            endTime: `${plus3DateString}T18:29:59.999Z`,
+            timeZone: Timezones["+5:30"],
+            isTeamEvent: false,
           },
-        ],
-        apps: [TestData.apps.googleCalendar],
-      };
+        });
 
-      await createBookingScenario(scenarioData);
-
-      const scheduleForEventOnADayWithCalBooking = await getSchedule({
-        input: {
-          eventTypeId: 1,
-          eventTypeSlug: "",
-          startTime: `${plus1DateString}T18:30:00.000Z`,
-          endTime: `${plus2DateString}T18:29:59.999Z`,
-          timeZone: Timezones["+5:30"],
-          isTeamEvent: false,
-        },
+        expect(scheduleForEventOnADayWithNonCalBooking).toHaveTimeSlots(
+          [
+            // `04:00:00.000Z`, // - 4 AM is booked
+            // `06:00:00.000Z`, // - 6 AM is not available because 08:00AM slot has a `beforeEventBuffer`
+            `08:30:00.000Z`, // - 8 AM is available because of availability of 06:00 - 07:59
+            `10:30:00.000Z`,
+          ],
+          {
+            dateString: plus3DateString,
+          }
+        );
       });
 
-      expect(scheduleForEventOnADayWithCalBooking).toHaveTimeSlots(
-        [
-          // `04:00:00.000Z`, // - 4 AM is booked
-          // `06:00:00.000Z`, // - 6 AM is not available because of afterBuffer(120 mins) of the existing booking(4-5:59AM slot)
-          // `08:00:00.000Z`, // - 8 AM is not available because of beforeBuffer(120mins) of possible booking at 08:00
-          `10:00:00.000Z`,
-          `12:00:00.000Z`,
-        ],
-        {
-          dateString: plus2DateString,
-        }
-      );
+      test("afterBuffer and beforeBuffer tests - Cal Busy Time", async () => {
+        const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+        const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
+        const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
+
+        CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
+          {
+            start: `${plus3DateString}T04:00:00.000Z`,
+            end: `${plus3DateString}T05:59:59.000Z`,
+          },
+        ]);
+
+        const scenarioData = {
+          eventTypes: [
+            {
+              id: 1,
+              length: 120,
+              beforeEventBuffer: 120,
+              afterEventBuffer: 120,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          users: [
+            {
+              ...TestData.users.example,
+              id: 101,
+              schedules: [TestData.schedules.IstWorkHours],
+              credentials: [getGoogleCalendarCredential()],
+              selectedCalendars: [TestData.selectedCalendars.google],
+            },
+          ],
+          bookings: [
+            {
+              userId: 101,
+              eventTypeId: 1,
+              startTime: `${plus2DateString}T04:00:00.000Z`,
+              endTime: `${plus2DateString}T05:59:59.000Z`,
+              status: "ACCEPTED" as BookingStatus,
+            },
+          ],
+          apps: [TestData.apps.googleCalendar],
+        };
+
+        await createBookingScenario(scenarioData);
+
+        const scheduleForEventOnADayWithCalBooking = await getSchedule({
+          input: {
+            eventTypeId: 1,
+            eventTypeSlug: "",
+            startTime: `${plus1DateString}T18:30:00.000Z`,
+            endTime: `${plus2DateString}T18:29:59.999Z`,
+            timeZone: Timezones["+5:30"],
+            isTeamEvent: false,
+          },
+        });
+
+        expect(scheduleForEventOnADayWithCalBooking).toHaveTimeSlots(
+          [
+            // `04:00:00.000Z`, // - 4 AM is booked
+            // `06:00:00.000Z`, // - 6 AM is not available because of afterBuffer(120 mins) of the existing booking(4-5:59AM slot)
+            // `08:00:00.000Z`, // - 8 AM is not available because of beforeBuffer(120mins) of possible booking at 08:00
+            `10:30:00.000Z`,
+          ],
+          {
+            dateString: plus2DateString,
+          }
+        );
+      });
     });
 
     test("Start times are offset (offsetStart)", async () => {
@@ -782,7 +782,7 @@ describe("getSchedule", () => {
       });
 
       expect(scheduleForEventOnADayWithDateOverride).toHaveTimeSlots(
-        ["08:30:00.000Z", "09:30:00.000Z", "10:30:00.000Z", "11:30:00.000Z"],
+        ["09:00:00.000Z", "10:00:00.000Z", "11:00:00.000Z"],
         {
           dateString: plus2DateString,
         }

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -365,7 +365,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
   }));
 
   const dateRangesInWhichUserIsAvailable = subtract(dateRanges, formattedBusyTimes);
-
   const dateRangesInWhichUserIsAvailableWithoutOOO = subtract(oooExcludedDateRanges, formattedBusyTimes);
 
   log.debug(
@@ -373,8 +372,14 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     JSON.stringify({
       workingHoursInUtc: workingHours,
       dateOverrides,
-      dateRangesAsPerAvailability: dateRanges,
-      dateRangesInWhichUserIsAvailable,
+      dateRangesAsPerAvailability: dateRanges.map((range) => ({
+        start: range.start.format(),
+        end: range.end.format(),
+      })),
+      dateRangesInWhichUserIsAvailable: dateRangesInWhichUserIsAvailable.map((range) => ({
+        start: range.start.format(),
+        end: range.end.format(),
+      })),
       detailedBusyTimes,
     })
   );

--- a/packages/lib/date-ranges.test.ts
+++ b/packages/lib/date-ranges.test.ts
@@ -645,4 +645,52 @@ describe("subtract", () => {
       ])
     );
   });
+
+  it("subtracts appropriately maintaining the timezone of sourceRanges", () => {
+    const data = {
+      sourceRanges: [
+        { start: dayjs.utc("2023-07-05T04:00:00.000Z"), end: dayjs.utc("2023-07-05T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-06T04:00:00.000Z"), end: dayjs.utc("2023-07-06T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-07T04:00:00.000Z"), end: dayjs.utc("2023-07-07T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-10T04:00:00.000Z"), end: dayjs.utc("2023-07-10T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-11T04:00:00.000Z"), end: dayjs.utc("2023-07-11T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-12T04:00:00.000Z"), end: dayjs.utc("2023-07-12T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-13T04:00:00.000Z"), end: dayjs.utc("2023-07-13T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-14T04:00:00.000Z"), end: dayjs.utc("2023-07-14T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-17T04:00:00.000Z"), end: dayjs.utc("2023-07-17T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-18T04:00:00.000Z"), end: dayjs.utc("2023-07-18T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-19T04:00:00.000Z"), end: dayjs.utc("2023-07-19T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-20T04:00:00.000Z"), end: dayjs.utc("2023-07-20T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-21T04:00:00.000Z"), end: dayjs.utc("2023-07-21T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-24T04:00:00.000Z"), end: dayjs.utc("2023-07-24T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-25T04:00:00.000Z"), end: dayjs.utc("2023-07-25T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-26T04:00:00.000Z"), end: dayjs.utc("2023-07-26T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-27T04:00:00.000Z"), end: dayjs.utc("2023-07-27T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-28T04:00:00.000Z"), end: dayjs.utc("2023-07-28T12:00:00.000Z") },
+        { start: dayjs.utc("2023-07-31T04:00:00.000Z"), end: dayjs.utc("2023-07-31T12:00:00.000Z") },
+      ],
+      excludedRanges: [
+        {
+          start: dayjs.utc("2023-07-05T04:00:00.000Z").utcOffset(330),
+          end: dayjs.utc("2023-07-05T04:15:00.000Z").utcOffset(330),
+        },
+        {
+          start: dayjs.utc("2023-07-05T04:45:00.000Z").utcOffset(330),
+          end: dayjs.utc("2023-07-05T05:00:00.000Z").utcOffset(330),
+        },
+      ],
+    };
+
+    const result = subtract(data["sourceRanges"], data["excludedRanges"]).map((range) => ({
+      start: range.start.format(),
+      end: range.end.format(),
+    }));
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { start: "2023-07-05T04:15:00Z", end: "2023-07-05T04:45:00Z" },
+        { start: "2023-07-05T05:00:00Z", end: "2023-07-05T12:00:00Z" },
+      ])
+    );
+  });
 });

--- a/packages/lib/date-ranges.ts
+++ b/packages/lib/date-ranges.ts
@@ -286,6 +286,10 @@ function getIntersection(range1: DateRange, range2: DateRange) {
   return null;
 }
 
+/**
+ * Make sure to pass all the ranges in the same timezone
+ * If not in passed in the same timezone, all timezones will be adjusted to the first sourceRange's timezone
+ */
 export function subtract(
   sourceRanges: (DateRange & { [x: string]: unknown })[],
   excludedRanges: DateRange[]
@@ -303,13 +307,18 @@ export function subtract(
 
     for (const { start: excludedStart, end: excludedEnd } of overlappingRanges) {
       if (excludedStart.isAfter(currentStart)) {
-        result.push({ start: currentStart, end: excludedStart });
+        result.push({
+          start: currentStart.utcOffset(sourceStart.utcOffset()),
+          end: excludedStart.utcOffset(sourceEnd.utcOffset()),
+          ...passThrough,
+        });
       }
       currentStart = excludedEnd.isAfter(currentStart) ? excludedEnd : currentStart;
     }
 
     if (sourceEnd.isAfter(currentStart)) {
-      result.push({ start: currentStart, end: sourceEnd, ...passThrough });
+      // Make sure that the dateRange still remain in the same utcOffset as the source
+      result.push({ start: currentStart.utcOffset(sourceStart.utcOffset()), end: sourceEnd, ...passThrough });
     }
   }
 

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -43,6 +43,16 @@ function buildSlots({
   organizerTimeZone: string;
   inviteeTimeZone: string;
 }) {
+  console.log("buildSlots", {
+    startOfInviteeDay,
+    computedLocalAvailability,
+    frequency,
+    eventLength,
+    offsetStart,
+    startDate,
+    organizerTimeZone,
+    inviteeTimeZone,
+  });
   // no slots today
   if (startOfInviteeDay.isBefore(startDate, "day")) {
     return [];
@@ -176,14 +186,12 @@ function buildSlotsWithDateRanges({
 
   let interval = Number(process.env.NEXT_PUBLIC_AVAILABILITY_SCHEDULE_INTERVAL) || 1;
   const intervalsWithDefinedStartTimes = [60, 30, 20, 15, 10, 5];
-
   for (let i = 0; i < intervalsWithDefinedStartTimes.length; i++) {
     if (frequency % intervalsWithDefinedStartTimes[i] === 0) {
       interval = intervalsWithDefinedStartTimes[i];
       break;
     }
   }
-
   dateRanges.forEach((range) => {
     const dateYYYYMMDD = range.start.format("YYYY-MM-DD");
     const startTimeWithMinNotice = dayjs.utc().add(minimumBookingNotice, "minute");
@@ -191,7 +199,6 @@ function buildSlotsWithDateRanges({
     let slotStartTime = range.start.utc().isAfter(startTimeWithMinNotice)
       ? range.start
       : startTimeWithMinNotice;
-
     slotStartTime =
       slotStartTime.minute() % interval !== 0
         ? slotStartTime.startOf("hour").add(Math.ceil(slotStartTime.minute() / interval) * interval, "minute")


### PR DESCRIPTION
## What does this PR do?

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Fixes the issue where the very first slot is not bookable https://www.loom.com/share/c2aa5e70d038432e951796325bc3fa32

The reason behind the issue was that range.start isn't in the correct timezone. It uses system timezone when infact we expect it to be in user's availability timezone for the event(I guess).
![image](https://github.com/calcom/cal.com/assets/1780212/40dbd0c8-6934-4ed5-9174-cfe7c382b1f3)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
