### PR TITLE
chore: Allow disabling email sending without errors

### DIFF
--- a/apps/web/playwright/fixtures/emails.ts
+++ b/apps/web/playwright/fixtures/emails.ts
@@ -3,7 +3,7 @@ import mailhog from "mailhog";
 import { IS_MAILHOG_ENABLED } from "@calcom/lib/constants";
 
 const unimplemented = () => {
-  throw new Error("Mailhog is not enabled");
+  // throw new Error("Mailhog is not enabled");
 };
 
 const hasUUID = (query: string) => {

--- a/apps/web/playwright/fixtures/emails.ts
+++ b/apps/web/playwright/fixtures/emails.ts
@@ -4,6 +4,7 @@ import { IS_MAILHOG_ENABLED } from "@calcom/lib/constants";
 
 const unimplemented = () => {
   // throw new Error("Mailhog is not enabled");
+  return null;
 };
 
 const hasUUID = (query: string) => {


### PR DESCRIPTION
## What does this PR do?

Email sending is notoriously unreliable, so I'm working on creating a better system to test our emails that work unrelated from our general E2E suite. Our vitest tests should test that the email functions are actually called. For now however the best way forward is disabling Mailhog; but in order to disable mailhog we should prevent errors when the env var is missing. Hense this PR.

* Follow up, create separate suite of tests to test email sending.