### PR TITLE
fix: incorrect encryption string instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,8 @@ CRON_API_KEY='0cc0e6c35519bba620c9360cfe3e68d0'
 CRON_ENABLE_APP_SYNC=false
 
 # Application Key for symmetric encryption and decryption
-# must be 32 bytes for AES256 encryption algorithm
-# You can use: `openssl rand -base64 32` to generate one
+# must be an alphanumeric 32 character string for AES256 encryption algorithm
+# You can use: `python -c "import random; import string; print(''.join(random.choices(string.ascii_letters + string.digits, k=32)))"` to generate one
 CALENDSO_ENCRYPTION_KEY=
 
 # Intercom Config


### PR DESCRIPTION
## What does this PR do?

As outlined in https://github.com/calcom/cal.com/issues/13290, any new calcom user following the .env example is unable to perform any administrative function as 2FA is required.

Because `"latin1"` is specified as the encryption/decryption method in `lib/crypto.ts`, using a base64 encoded string (as is currently suggested) results in a 44 length string, which breaks the 2FA process.

A cleaner solution would be to update `crypto.ts` directly, but this was already rejected in https://github.com/calcom/cal.com/pull/13484 in favour of the ongoing refactor in https://github.com/calcom/cal.com/pull/12698. This PR is a temporary fix until the larger refactor has been completed.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #13290
- Fixes CAL-3060

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)