### PR TITLE
fix: disable emails for platform

### DIFF
--- a/packages/features/auth/lib/verifyEmail.ts
+++ b/packages/features/auth/lib/verifyEmail.ts
@@ -20,6 +20,7 @@ interface VerifyEmailType {
   email: string;
   language?: string;
   secondaryEmailId?: number;
+  isPlatform?: boolean;
 }
 
 export const sendEmailVerification = async ({
@@ -27,6 +28,7 @@ export const sendEmailVerification = async ({
   language,
   username,
   secondaryEmailId,
+  isPlatform = false,
 }: VerifyEmailType) => {
   const token = randomBytes(32).toString("hex");
   const translation = await getTranslation(language ?? "en", "common");
@@ -34,6 +36,11 @@ export const sendEmailVerification = async ({
 
   if (!emailVerification) {
     log.warn("Email verification is disabled - Skipping");
+    return { ok: true, skipped: true };
+  }
+
+  if (isPlatform) {
+    log.warn("Skipping Email verification");
     return { ok: true, skipped: true };
   }
 

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -164,8 +164,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
       isPlatform: isPlatform,
     });
 
-    !isPlatform &&
-      (await sendOrganizationCreationEmail({
+    if (!isPlatform) {
+      await sendOrganizationCreationEmail({
         language: translation,
         from: ctx.user.name ?? `${organization.name}'s admin`,
         to: orgOwnerEmail,
@@ -175,7 +175,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
         orgName: organization.name,
         prevLink: null,
         newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
-      }));
+      });
+    }
 
     const user = await UserRepository.enrichUserWithItsProfile({
       user: { ...orgOwner, organizationId: organization.id },
@@ -204,8 +205,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
       },
     });
 
-    !isPlatform &&
-      (await sendOrganizationCreationEmail({
+    if (!isPlatform) {
+      await sendOrganizationCreationEmail({
         language: inputLanguageTranslation,
         from: ctx.user.name ?? `${organization.name}'s admin`,
         to: orgOwnerEmail,
@@ -215,7 +216,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
         orgName: organization.name,
         prevLink: `${getOrgFullOrigin("", { protocol: true })}/${nonOrgUsernameForOwner}`,
         newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
-      }));
+      });
+    }
 
     if (!organization.id) throw Error("User not created");
     const user = await UserRepository.enrichUserWithItsProfile({

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -157,12 +157,12 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
 
     const translation = await getTranslation(input.language ?? "en", "common");
 
-    !isPlatform &&
-      (await sendEmailVerification({
-        email: orgOwnerEmail,
-        language: ctx.user.locale,
-        username: ownerProfile.username || "",
-      }));
+    await sendEmailVerification({
+      email: orgOwnerEmail,
+      language: ctx.user.locale,
+      username: ownerProfile.username || "",
+      isPlatform: isPlatform,
+    });
 
     !isPlatform &&
       (await sendOrganizationCreationEmail({

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -157,23 +157,25 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
 
     const translation = await getTranslation(input.language ?? "en", "common");
 
-    await sendEmailVerification({
-      email: orgOwnerEmail,
-      language: ctx.user.locale,
-      username: ownerProfile.username || "",
-    });
+    !isPlatform &&
+      (await sendEmailVerification({
+        email: orgOwnerEmail,
+        language: ctx.user.locale,
+        username: ownerProfile.username || "",
+      }));
 
-    await sendOrganizationCreationEmail({
-      language: translation,
-      from: ctx.user.name ?? `${organization.name}'s admin`,
-      to: orgOwnerEmail,
-      ownerNewUsername: ownerProfile.username,
-      ownerOldUsername: null,
-      orgDomain: getOrgFullOrigin(slug, { protocol: false }),
-      orgName: organization.name,
-      prevLink: null,
-      newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
-    });
+    !isPlatform &&
+      (await sendOrganizationCreationEmail({
+        language: translation,
+        from: ctx.user.name ?? `${organization.name}'s admin`,
+        to: orgOwnerEmail,
+        ownerNewUsername: ownerProfile.username,
+        ownerOldUsername: null,
+        orgDomain: getOrgFullOrigin(slug, { protocol: false }),
+        orgName: organization.name,
+        prevLink: null,
+        newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
+      }));
 
     const user = await UserRepository.enrichUserWithItsProfile({
       user: { ...orgOwner, organizationId: organization.id },
@@ -202,17 +204,18 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
       },
     });
 
-    await sendOrganizationCreationEmail({
-      language: inputLanguageTranslation,
-      from: ctx.user.name ?? `${organization.name}'s admin`,
-      to: orgOwnerEmail,
-      ownerNewUsername: ownerProfile.username,
-      ownerOldUsername: nonOrgUsernameForOwner,
-      orgDomain: getOrgFullOrigin(slug, { protocol: false }),
-      orgName: organization.name,
-      prevLink: `${getOrgFullOrigin("", { protocol: true })}/${nonOrgUsernameForOwner}`,
-      newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
-    });
+    !isPlatform &&
+      (await sendOrganizationCreationEmail({
+        language: inputLanguageTranslation,
+        from: ctx.user.name ?? `${organization.name}'s admin`,
+        to: orgOwnerEmail,
+        ownerNewUsername: ownerProfile.username,
+        ownerOldUsername: nonOrgUsernameForOwner,
+        orgDomain: getOrgFullOrigin(slug, { protocol: false }),
+        orgName: organization.name,
+        prevLink: `${getOrgFullOrigin("", { protocol: true })}/${nonOrgUsernameForOwner}`,
+        newLink: `${getOrgFullOrigin(slug, { protocol: true })}/${ownerProfile.username}`,
+      }));
 
     if (!organization.id) throw Error("User not created");
     const user = await UserRepository.enrichUserWithItsProfile({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a check to disable sending org creation and verification emails for a platform user. 

NOTE: This is a temporary fix for the time being and won't be needed after #14911 is merged 