### PR TITLE
fix: Prevent 500 error when fetching more than 3000 bookings from an user

### DIFF
--- a/apps/api/v1/pages/api/bookings/_get.ts
+++ b/apps/api/v1/pages/api/bookings/_get.ts
@@ -5,6 +5,7 @@ import { HttpError } from "@calcom/lib/http-error";
 import { defaultResponder } from "@calcom/lib/server";
 import prisma from "@calcom/prisma";
 
+import { withMiddleware } from "~/lib/helpers/withMiddleware";
 import { schemaBookingGetParams, schemaBookingReadPublic } from "~/lib/validations/booking";
 import { schemaQuerySingleOrMultipleAttendeeEmails } from "~/lib/validations/shared/queryAttendeeEmail";
 import { schemaQuerySingleOrMultipleUserIds } from "~/lib/validations/shared/queryUserId";
@@ -225,4 +226,4 @@ async function handler(req: NextApiRequest) {
   return { bookings: data.map((booking) => schemaBookingReadPublic.parse(booking)) };
 }
 
-export default defaultResponder(handler);
+export default withMiddleware("pagination")(defaultResponder(handler));


### PR DESCRIPTION
## What does this PR do?

We had some Checkly errors when trying to fetch from the rick demo account which has more that 3k bookings.

<img width="583" alt="image" src="https://github.com/calcom/cal.com/assets/3504472/ab4b9f54-65f8-4ed6-9fd2-1dadb6256cb0">


<img width="949" alt="image" src="https://github.com/calcom/cal.com/assets/3504472/1e0339b2-e51d-42c9-aaa0-15be2c67e0c9">


This adds pagination to the endpoint which should alleviate the query.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

- Try to fetch more than 3k bookings from an user in a deployment

