### PR TITLE
fix: scroll to time after clicking a date on mobile

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -113,6 +113,9 @@ const BookerComponent = ({
 
   const timeslotsRef = useRef<HTMLDivElement>(null);
   const StickyOnDesktop = isMobile ? "div" : StickyBox;
+  const scrollToTimeSlots = () => {
+    timeslotsRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
 
   const { bookerFormErrorRef, key, formEmail, bookingForm, errors: formErrors } = bookerForm;
 
@@ -346,7 +349,7 @@ const BookerComponent = ({
                 {layout !== BookerLayouts.MONTH_VIEW &&
                   !(layout === "mobile" && bookerState === "booking") && (
                     <div className="mt-auto px-5 py-3 ">
-                      <DatePicker event={event} schedule={schedule} />
+                      <DatePicker event={event} schedule={schedule} scrollToTimeSlots={scrollToTimeSlots} />
                     </div>
                   )}
               </BookerSection>

--- a/packages/features/bookings/Booker/components/DatePicker.tsx
+++ b/packages/features/bookings/Booker/components/DatePicker.tsx
@@ -14,6 +14,7 @@ export const DatePicker = ({
   event,
   schedule,
   classNames,
+  scrollToTimeSlots,
 }: {
   event: useEventReturnType;
   schedule: useScheduleForEventReturnType;
@@ -25,6 +26,7 @@ export const DatePicker = ({
     datePickerDatesActive?: string;
     datePickerToggle?: string;
   };
+  scrollToTimeSlots?: () => void;
 }) => {
   const { i18n } = useLocale();
   const [month, selectedDate] = useBookerStore((state) => [state.month, state.selectedDate], shallow);
@@ -47,6 +49,7 @@ export const DatePicker = ({
       isPending={schedule.isPending}
       onChange={(date: Dayjs | null) => {
         setSelectedDate(date === null ? date : date.format("YYYY-MM-DD"));
+        if (scrollToTimeSlots) scrollToTimeSlots();
       }}
       onMonthChange={(date: Dayjs) => {
         setMonth(date.format("YYYY-MM"));


### PR DESCRIPTION
## What does this PR do?

- Fixes #15122

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?
1. Open an event in mobile view.
2. Select a date.
3. You should be automatically scrolled to the timeslots section.

## Checklist
- I haven't checked if my changes generate no new warnings
