### PR TITLE
chore: Downgrade 8 vCPU actions to 4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
   e2e:
     timeout-minutes: 20
     name: E2E tests (${{ matrix.shard }}/${{ strategy.job-total }})
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     services:
       postgres:
         image: postgres:13


### PR DESCRIPTION
## What does this PR do?

Downgrades the 8 vCPU action for running E2E tests back to 4 vCPUs like it was before. We did this as a test to see if E2E timeouts would improve and become more stable but it seems to have had little to no effect and the cost of these actions is now doubled.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] N/A - I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure the CI pipeline succeeds
