### PR TITLE
fix: Failing futureLimit handleNewBooking test

### DIFF
--- a/apps/web/test/utils/bookingScenario/bookingScenario.ts
+++ b/apps/web/test/utils/bookingScenario/bookingScenario.ts
@@ -653,6 +653,8 @@ export async function createOrganization(orgData: {
  * - `monthIncrement` adds the increment to current month
  * - `yearIncrement` adds the increment to current year
  * - `fromDate` starts incrementing from this date (default: today)
+ *  @deprecated Stop using this function as it is not timezone aware and can return wrong date depending on the time of the day and timezone. Instead
+ *  use vi.setSystemTime to fix the date and time and then use hardcoded days instead of dynamic date calculation.
  */
 export const getDate = (
   param: {

--- a/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
@@ -687,11 +687,12 @@ describe("handleNewBooking", () => {
     timeout
   );
 
-  // FIXME: Test is flaky, sometimes it fails on CI. It resolves instead of rejecting.
-  describe.skipIf(true)("Future Limits", () => {
+  describe("Future Limits", () => {
     test(
       `should fail booking if periodType=ROLLING check fails`,
       async () => {
+        // In IST it is 2024-05-22 12:39am
+        vi.setSystemTime("2024-05-21T19:09:13Z");
         const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
         const booker = getBooker({
           email: "booker@example.com",
@@ -721,7 +722,7 @@ describe("handleNewBooking", () => {
                 id: 1,
                 slotInterval: 30,
                 periodType: PeriodType.ROLLING,
-                // Today, plus1 and plus2
+                // 22st, 23nd and 24th in IST availability(Schedule being used is ISTWorkHours)
                 periodDays: 2,
                 periodCountCalendarDays: true,
                 length: 30,
@@ -738,7 +739,7 @@ describe("handleNewBooking", () => {
           })
         );
 
-        const plus3DateString = getDate({ dateIncrement: 3 }).dateString;
+        const plus3DateString = `2024-05-25`;
         const mockBookingData = getMockRequestDataForBooking({
           data: {
             user: organizer.username,


### PR DESCRIPTION
## What does this PR do?
- Re-enables skipped booking-limit test for Future Limit
- Fixes the test.
- Mark getDate deprecated and suggest a better way.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)


