### PR TITLE
fix: Org Seeder - to better represent production scenario and fix admin org delete cleanup

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2263,7 +2263,7 @@
   "create_your_org_description": "Upgrade to Organizations and receive a subdomain, unified billing, Insights, extensive whitelabeling and more",
   "create_your_enterprise_description": "Upgrade to Enterprise and get access to Active Directory Sync, SCIM Automatic User provisioning, Cal.ai Voice Agents, Admin APIs and more!",
   "other_payment_app_enabled": "You can only enable one payment app per event type",
-  "admin_delete_organization_description": "<ul><li>Teams that are member of this organization will also be deleted along with their event-types</li><li>Users that were part of the organization will not be deleted and their event-types will also remain intact.</li><li>Usernames would be changed to allow them to exist outside the organization</li></ul>",
+  "admin_delete_organization_description": "<ul><li>Teams that are member of this organization will also be deleted along with their event-types</li><li>Users that were part of the organization will not be deleted but their usernames would be changed to allow them to exist outside the organization</li><li>User event-types created after the user was in the organization will be deleted</li><li>Migrated user event-types will not be deleted</li></ul>",
   "admin_delete_organization_title": "Delete {{organizationName}}?",
   "published": "Published",
   "unpublished": "Unpublished",

--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -7,8 +7,9 @@ import dailyMeta from "@calcom/app-store/dailyvideo/_metadata";
 import googleMeetMeta from "@calcom/app-store/googlevideo/_metadata";
 import zoomMeta from "@calcom/app-store/zoomvideo/_metadata";
 import dayjs from "@calcom/dayjs";
+import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { hashPassword } from "@calcom/features/auth/lib/hashPassword";
-import { BookingStatus, MembershipRole, SchedulingType } from "@calcom/prisma/enums";
+import { BookingStatus, MembershipRole, RedirectType, SchedulingType } from "@calcom/prisma/enums";
 import type { Ensure } from "@calcom/types/utils";
 
 import prisma from ".";
@@ -146,6 +147,15 @@ async function createOrganizationAndAddMembersAndTeams({
         orgMembership: member.orgMembership,
         orgProfile: member.orgProfile,
       };
+
+      await prisma.tempOrgRedirect.create({
+        data: {
+          fromOrgId: 0,
+          type: RedirectType.User,
+          from: member.memberData.username,
+          toUrl: `${getOrgFullOrigin(orgData.slug)}/${member.orgProfile.username}`,
+        },
+      });
 
       orgMembersInDb.push(orgMemberInDb);
     }

--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -191,6 +191,11 @@ async function createOrganizationAndAddMembersAndTeams({
         create: orgMembersInDb.map((member) => ({
           uid: uuid(),
           username: member.orgProfile.username,
+          movedFromUser: {
+            connect: {
+              id: member.id,
+            },
+          },
           user: {
             connect: {
               id: member.id,


### PR DESCRIPTION
## What does this PR do?
Fixes CAL-3788
On org delete
- Do better messaging
- cleanup redirects

Fix seeder 
- Create redirects
- Set `movedFromUser`


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested) - **It is a straightforward change testing a flow that is seldom used and only by admins.**

## How should this be tested?
- Delete seeded Acme org and test that app.cal.local:3000/owner1-acme doesn't redirect any more

