### PR TITLE
chore: Moved legacy rewrites from afterFiles to beforeFiles

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -265,6 +265,29 @@ const nextConfig = {
   async rewrites() {
     const beforeFiles = [
       {
+        source: "/forms/:formQuery*",
+        destination: "/apps/routing-forms/routing-link/:formQuery*",
+      },
+      {
+        source: "/router",
+        destination: "/apps/routing-forms/router",
+      },
+      {
+        source: "/success/:path*",
+        has: [
+          {
+            type: "query",
+            key: "uid",
+            value: "(?<uid>.*)",
+          },
+        ],
+        destination: "/booking/:uid/:path*",
+      },
+      {
+        source: "/cancel/:path*",
+        destination: "/booking/:path*",
+      },
+      {
         /**
          * Needed due to the introduction of dotted usernames
          * @see https://github.com/calcom/cal.com/pull/11706
@@ -326,29 +349,6 @@ const nextConfig = {
         {
           source: "/:user/avatar.png",
           destination: "/api/user/avatar?username=:user",
-        },
-        {
-          source: "/forms/:formQuery*",
-          destination: "/apps/routing-forms/routing-link/:formQuery*",
-        },
-        {
-          source: "/router",
-          destination: "/apps/routing-forms/router",
-        },
-        {
-          source: "/success/:path*",
-          has: [
-            {
-              type: "query",
-              key: "uid",
-              value: "(?<uid>.*)",
-            },
-          ],
-          destination: "/booking/:uid/:path*",
-        },
-        {
-          source: "/cancel/:path*",
-          destination: "/booking/:path*",
         },
       ],
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Neede to unblock #9923

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

- Without removing any of the app directory files
- Test a valid success page like this example: `http://localhost:3000/success?uid=34PXyRU1pJVPx3fM86CtH7`. It should display the same page as `http://localhost:3000/booking/34PXyRU1pJVPx3fM86CtH7`

I couldn't find a way to add tests for this since we rely on the `x-matched-path` header that Vercel adds. It doesn't exists locally so we cannot use expects like the ones on checkly:

```
expect(response?.headers()["x-matched-path"], "/success?uid Rewrite").toBe("/en/booking/[uid]");
```

