### PR TITLE
feat: v2 API enable updating event-type bookingFields

### DIFF
--- a/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
+++ b/apps/api/v2/src/ee/event-types/inputs/update-event-type.input.ts
@@ -275,11 +275,11 @@ export class UpdateEventTypeInput {
   // @IsOptional()
   // parentId?: number;
 
-  // @IsOptional()
-  // @IsArray()
-  // @ValidateNested({ each: true })
-  // @Type(() => BookingField)
-  // bookingFields?: BookingField[];
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => BookingField)
+  bookingFields?: BookingField[];
 
   // @IsString()
   // @IsOptional()

--- a/packages/platform/libraries/index.ts
+++ b/packages/platform/libraries/index.ts
@@ -77,3 +77,5 @@ export { createNewUsersConnectToOrgIfExists };
 export { getAllUserBookings };
 export { getBookingInfo };
 export { handleCancelBooking };
+
+export { eventTypeBookingFields, eventTypeLocations } from "@calcom/prisma/zod-utils";


### PR DESCRIPTION
Fixes [CAL-3790](https://linear.app/calcom/issue/CAL-3790/customer-request-enable-event-type-booking-fields) by enabling `bookingFields` in the update event type input and adding tests to check if locations and bookingFields of an event type are updated.