### PR TITLE
chore: Bring back merge queues

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -1,0 +1,84 @@
+name: All checks
+
+on:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check:
+    name: Type check
+    uses: ./.github/workflows/check-types.yml
+    secrets: inherit
+
+  lint:
+    name: Linters
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+
+  unit-test:
+    name: Tests
+    uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
+
+  build-api-v1:
+    name: Production builds
+    uses: ./.github/workflows/api-v1-production-build.yml
+    secrets: inherit
+
+  build-api-v2:
+    name: Production builds
+    uses: ./.github/workflows/api-v2-production-build.yml
+    secrets: inherit
+
+  build:
+    name: Production builds
+    uses: ./.github/workflows/production-build-without-database.yml
+    secrets: inherit
+
+  integration-test:
+    name: Tests
+    needs: [lint, build, build-api-v1, build-api-v2]
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+
+  e2e:
+    name: Tests
+    needs: [lint, build, build-api-v1, build-api-v2]
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
+
+  e2e-app-store:
+    name: Tests
+    needs: [lint, build, build-api-v1, build-api-v2]
+    uses: ./.github/workflows/e2e-app-store.yml
+    secrets: inherit
+
+  e2e-embed:
+    name: Tests
+    needs: [lint, build, build-api-v1, build-api-v2]
+    uses: ./.github/workflows/e2e-embed.yml
+    secrets: inherit
+
+  e2e-embed-react:
+    name: Tests
+    needs: [lint, build, build-api-v1, build-api-v2]
+    uses: ./.github/workflows/e2e-embed-react.yml
+    secrets: inherit
+
+  analyze:
+    name: Analyze Build
+    needs: [build]
+    uses: ./.github/workflows/nextjs-bundle-analysis.yml
+    secrets: inherit
+
+  required:
+    needs: [lint, type-check, unit-test, integration-test, build, build-api-v1, build-api-v2, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    if: always()
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - name: fail if conditional jobs failed
+        run: exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,15 +75,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
       - name: Run Tests
         run: yarn test -- --integrationTestsOnly
-      - name: Upload Test Results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: test-results
+      # TODO: Generate test results so we can upload them
+      # - name: Upload Test Results
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: test-results
+      #     path: test-results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
 
   integration-test:
     name: Tests
-    needs: [changes, lint]
+    needs: [changes]
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     branches:
       - main
-  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -35,13 +34,6 @@ jobs:
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
-  unit-test:
-    name: Tests
-    needs: [changes]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/unit-tests.yml
-    secrets: inherit
-
   lint:
     name: Linters
     needs: [changes]
@@ -49,71 +41,22 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
-  build-api-v1:
-    name: Production builds
+  unit-test:
+    name: Tests
     needs: [changes]
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/api-v1-production-build.yml
-    secrets: inherit
-
-  build-api-v2:
-    name: Production builds
-    needs: [changes]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/api-v2-production-build.yml
-    secrets: inherit
-
-  build:
-    name: Production builds
-    needs: [changes]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/production-build-without-database.yml
+    uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   integration-test:
     name: Tests
-    needs: [changes, lint, build, build-api-v1, build-api-v2]
+    needs: [changes, lint]
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
-  e2e:
-    name: Tests
-    needs: [changes, lint, build, build-api-v1, build-api-v2]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/e2e.yml
-    secrets: inherit
-
-  e2e-app-store:
-    name: Tests
-    needs: [changes, lint, build, build-api-v1, build-api-v2]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/e2e-app-store.yml
-    secrets: inherit
-
-  e2e-embed:
-    name: Tests
-    needs: [changes, lint, build, build-api-v1, build-api-v2]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/e2e-embed.yml
-    secrets: inherit
-
-  e2e-embed-react:
-    name: Tests
-    needs: [changes, lint, build, build-api-v1, build-api-v2]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/e2e-embed-react.yml
-    secrets: inherit
-
-  analyze:
-    name: Analyze Build
-    needs: [changes, build]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/nextjs-bundle-analysis.yml
-    secrets: inherit
-
   required:
-    needs: [changes, lint, type-check, unit-test, integration-test, build, build-api-v1, build-api-v2, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    needs: [changes, lint, type-check, unit-test, integration-test]
     if: always()
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
## What does this PR do?

Reduces our CI pipeline on every PR commit to only linting, type checking, unit tests and integration tests. The web app, v1 API and v2 API builds + E2E test suite will be run when the PR hits the merge queue.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] N/A - I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

Once merged, ensure the entire pipeline is run when a PR is put into the merge queue.
