### PR TITLE
fix: Profile page crash due to invalid topLevelElement

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -371,7 +371,15 @@ export default function ToolbarPlugin(props: TextEditorProps) {
         const nodes = $generateNodesFromDOM(editor, dom);
 
         $getRoot().select();
-        $insertNodes(nodes);
+        try {
+          $insertNodes(nodes);
+        } catch (e: unknown) {
+          // resolves: "topLevelElement is root node at RangeSelection.insertNodes"
+          // @see https://stackoverflow.com/questions/73094258/setting-editor-from-html
+          const paragraphNode = $createParagraphNode();
+          nodes.forEach((n) => paragraphNode.append(n));
+          $getRoot().append(paragraphNode);
+        }
 
         editor.registerUpdateListener(({ editorState, prevEditorState }) => {
           editorState.read(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes that adding unterminated nodes like <br> can crash the profile page.

- Fixes #15197
- Fixes CAL-3804

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

@CarinaWolli are there tests to cover the Editor?
