### PR TITLE
fix: platform plan name is always uppercase

### DIFF
--- a/apps/api/v2/src/modules/billing/controllers/billing.controller.ts
+++ b/apps/api/v2/src/modules/billing/controllers/billing.controller.ts
@@ -122,7 +122,7 @@ export class BillingController {
       await this.billingService.setSubscriptionForTeam(
         teamId,
         subscription,
-        PlatformPlan[plan as keyof typeof PlatformPlan]
+        PlatformPlan[plan.toUpperCase() as keyof typeof PlatformPlan]
       );
 
       return {

--- a/apps/api/v2/src/modules/billing/services/billing.config.service.ts
+++ b/apps/api/v2/src/modules/billing/services/billing.config.service.ts
@@ -11,7 +11,7 @@ export class BillingConfigService {
     const planKeys = Object.keys(PlatformPlan).filter((key) => isNaN(Number(key)));
     for (const key of planKeys) {
       this.config.set(
-        PlatformPlan[key as keyof typeof PlatformPlan],
+        PlatformPlan[key.toUpperCase() as keyof typeof PlatformPlan],
         process.env[`STRIPE_PRICE_ID_${key}`] ?? ""
       );
     }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes an issue where we set the platform plan to "none" because if wasn't passed in uppercase and matching the value in constants 