### PR TITLE
fix: missing date overrides in negative tz

### DIFF
--- a/apps/web/playwright/availability.e2e.ts
+++ b/apps/web/playwright/availability.e2e.ts
@@ -88,6 +88,29 @@ test.describe("Availablity", () => {
     await expect(await page.getByTitle(deleteButtonTitle).isVisible()).toBe(false);
   });
 
+  test("Can create date override on current day in a negative timezone", async ({ page }) => {
+    await page.getByTestId("schedules").first().click();
+    // set time zone to New York
+    await page
+      .locator("#availability-form div")
+      .filter({ hasText: "TimezoneEurope/London" })
+      .locator("svg")
+      .click();
+    await page.locator("[id=timeZone-lg-viewport]").fill("New");
+    await page.getByTestId("select-option-America/New_York").click();
+
+    // Add override for today
+    await page.getByTestId("add-override").click();
+    await page.locator('[id="modal-title"]').waitFor();
+    await page.locator('[data-testid="day"][data-disabled="false"]').first().click();
+    await page.getByTestId("add-override-submit-btn").click();
+    await page.getByTestId("dialog-rejection").click();
+
+    await page.locator('[form="availability-form"][type="submit"]').click();
+    await page.reload();
+    await expect(page.locator('[data-testid="date-overrides-list"] > li')).toHaveCount(1);
+  });
+
   test("Schedule listing", async ({ page }) => {
     await test.step("Can add a new schedule", async () => {
       await page.getByTestId("new-schedule").click();

--- a/packages/features/timezone-buddy/components/AvailabilityEditSheet.tsx
+++ b/packages/features/timezone-buddy/components/AvailabilityEditSheet.tsx
@@ -194,6 +194,7 @@ export function AvailabilityEditSheetForm(props: Props & { data: Data; isPending
                 id="timezone"
                 isDisabled={!hasEditPermission || !data.hasDefaultSchedule}
                 value={watchTimezone ?? "Europe/London"}
+                data-testid="timezone-select"
                 onChange={(event) => {
                   if (event) form.setValue("timeZone", event.value, { shouldDirty: true });
                 }}

--- a/packages/lib/schedules/client/transformers.ts
+++ b/packages/lib/schedules/client/transformers.ts
@@ -37,8 +37,11 @@ export function transformAvailabilityForClient(schedule: ScheduleWithAvailabilit
 
 export function transformDateOverridesForClient(schedule: ScheduleWithAvailabilities, timeZone: string) {
   return schedule.availability.reduce((acc, override) => {
-    // only iff future date override
-    if (!override.date || dayjs.tz(override.date, timeZone).isBefore(dayjs(), "day")) {
+    // only if future date override
+    const currentUtcOffset = dayjs().tz(timeZone).utcOffset();
+    const currentTimeInTz = dayjs().utc().add(currentUtcOffset, "minute");
+
+    if (!override.date || dayjs(override.date).isBefore(currentTimeInTz, "day")) {
       return acc;
     }
     const newValue = {


### PR DESCRIPTION
## What does this PR do?

Fixes that some date overrides disappeared when schedule was in a negative timezone. 

How to reproduce the bug: 
- set system time to UTC
- create schedule in NY timezone, click save 
- add date override on the current day
- save availability and reload 
- new date override is gone (it's still in db)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

- Follow steps for how to reproduce bug 
- Run `yarn e2e availability.e2e.ts`
   -   This test fails without the fix


