### PR TITLE
fix: add redirectUrl to /eventTypes page as well

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -955,6 +955,7 @@ const EventTypesPage: React.FC & {
   const orgBranding = useOrgBranding();
   const routerQuery = useRouterQuery();
   const filters = getTeamsFiltersFromQuery(routerQuery);
+  const router = useRouter();
 
   // TODO: Maybe useSuspenseQuery to focus on success case only? Remember that it would crash the page when there is an error in query. Also, it won't support skeleton
   const { data, status, error } = trpc.viewer.eventTypes.getByViewer.useQuery(filters && { filters }, {
@@ -967,6 +968,13 @@ const EventTypesPage: React.FC & {
     if (searchParams?.get("openIntercom") === "true") {
       open();
     }
+    /**
+     * During signup, if the account already exists, we redirect the user to /event-types instead of onboarding.
+     * Adding this redirection logic here as well to ensure the user is redirected to the correct redirectUrl.
+     */
+    const redirectUrl = localStorage.getItem("onBoardingRedirect");
+    localStorage.removeItem("onBoardingRedirect");
+    redirectUrl && router.push(redirectUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## What does this PR do?

During signup, if the account already exists, we redirect the user to /event-types instead of onboarding. Adding the redirection logic to /event-types page as well to ensure the user is redirected to the correct redirectUrl.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Before
https://www.loom.com/share/5d357a3097bb40358f8a4683421348aa?sid=e8cadc61-7d16-44ed-ae66-45a0504537a5

After
https://www.loom.com/share/2061bef8c86944bb948976d4cc41dd9e?sid=6e2498c7-03a0-446c-9510-1af10529d865

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] (N/A) I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] (N/A) I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- go to http://localhost:3000/signup?redirect=http://localhost:3000/apps/jelly?defaultInstall=true

