### PR TITLE
fix: Kbar component styles and improve transitions

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -126,7 +126,7 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
               <div
                 key={type.id}
                 style={{ display: "flex", ...eventTypeListItemEmbedStyles }}
-                className="bg-default border-subtle dark:bg-muted dark:hover:bg-emphasis hover:bg-muted group relative border-b first:rounded-t-md last:rounded-b-md last:border-b-0">
+                className="bg-default border-subtle dark:bg-muted dark:hover:bg-emphasis hover:bg-muted group relative border-b transition first:rounded-t-md last:rounded-b-md last:border-b-0">
                 <Icon
                   name="arrow-right"
                   className="text-emphasis absolute right-4 top-4 h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"

--- a/packages/features/kbar/Kbar.tsx
+++ b/packages/features/kbar/Kbar.tsx
@@ -313,10 +313,10 @@ function RenderResults() {
             // For seeing keyboard up & down navigation in action, we need visual feedback based on "active" prop
             style={{
               background: active ? "var(--cal-bg-subtle)" : `var(--cal-bg-default)`,
-              borderLeft: active ? "2px solid var(--cal-border-default)" : "2px solid transparent",
+              borderLeft: active ? "2px solid var(--cal-border)" : "2px solid transparent",
               color: "var(--cal-text)",
             }}
-            className="flex items-center justify-between px-4 py-2.5 text-sm hover:cursor-pointer">
+            className="flex items-center justify-between px-4 py-2.5 text-sm transition hover:cursor-pointer">
             <span>{t(item.name)}</span>
             <DisplayShortcuts shortcuts={item.shortcut} />
           </div>


### PR DESCRIPTION
Fix Kbar styles on active state


## What does this PR do?

- Fixes #15282

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [x] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

1. `⌘ + K` to launch the command bar
2. hover over search elements
3. left gray bar doesn't show up and content is pushed to the left

prefix:
![image](https://github.com/calcom/cal.com/assets/34947993/1e3f8d72-2e24-422e-9739-354956ccc03a)

postfix:
![image](https://github.com/calcom/cal.com/assets/34947993/be564378-acbc-4abc-ab6b-1825137e06a2)

add transition to public page cards:

https://github.com/calcom/cal.com/assets/34947993/add678a8-5864-46cb-b0e2-012754b5826e

