### PR TITLE
fix: typo in `Gcal` atom prop and outlook service 

### DIFF
--- a/apps/api/v2/src/ee/calendars/services/outlook.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/outlook.service.ts
@@ -156,7 +156,7 @@ export class OutlookService implements OAuthCalendarApp {
 
     const office365OAuthCredentials = await this.getOAuthCredentials(parsedCode);
 
-    const defaultCalendar = await this.getDefaultCalendar(accessToken);
+    const defaultCalendar = await this.getDefaultCalendar(office365OAuthCredentials.access_token);
 
     if (defaultCalendar?.id) {
       const credential = await this.credentialRepository.createAppCredential(

--- a/packages/platform/atoms/gcal-connect/GcalConnect.tsx
+++ b/packages/platform/atoms/gcal-connect/GcalConnect.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { Button } from "@calcom/ui";
 
 import { useAtomsContext } from "../hooks/useAtomsContext";
-import type { OnCheckErroType } from "../hooks/useGcal";
+import type { OnCheckErrorType } from "../hooks/useGcal";
 import { useGcal } from "../hooks/useGcal";
 import { AtomsWrapper } from "../src/components/atoms-wrapper";
 import { cn } from "../src/lib/utils";
@@ -12,7 +12,7 @@ interface GcalConnectProps {
   className?: string;
   label?: string;
   alreadyConnectedLabel?: string;
-  onCheckError?: OnCheckErroType;
+  onCheckError?: OnCheckErrorType;
 }
 
 /**
@@ -32,7 +32,7 @@ interface GcalConnectProps {
  * @param {string} [label="Connect Google Calendar"] - The label for the connect button. Optional.
  * @param {string} [alreadyConnectedLabel="Connected Google Calendar"] - The label for the already connected button. Optional.
  * @param {string} [className] - Additional CSS class name for the button. Optional.
- * @param {OnCheckErroType} [onCheckError] - A callback function to handle errors when checking the connection status. Optional.
+ * @param {OnCheckErrorType} [onCheckError] - A callback function to handle errors when checking the connection status. Optional.
  * @returns {JSX.Element} The rendered component.
  */
 export const GcalConnect: FC<GcalConnectProps> = ({

--- a/packages/platform/atoms/hooks/useGcal.ts
+++ b/packages/platform/atoms/hooks/useGcal.ts
@@ -4,10 +4,10 @@ import type { ApiErrorResponse } from "@calcom/platform-types";
 
 import http from "../lib/http";
 
-export type OnCheckErroType = (err: ApiErrorResponse) => void;
+export type OnCheckErrorType = (err: ApiErrorResponse) => void;
 export interface useGcalProps {
   isAuth: boolean;
-  onCheckError?: OnCheckErroType;
+  onCheckError?: OnCheckErrorType;
 }
 
 export const useGcal = ({ isAuth, onCheckError }: useGcalProps) => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR fixed two things in particular 1. There was a typo in one of types in the useGal hook, so renamed that from `OnCheckErroType` to `OnCheckErrorType` 2. And inside of the calendars service while trying to get the default calendar of a user we were passing the access token of our v2 api instead of passing the access token that we get from a users outlook credentials. This was resulting in an invalid and as a result user credentials were not being saved in the db.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?
This can be tested under the examples app in `packages/platform/examples/base` 
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
