### PR TITLE
chore: when creating platform instruct creating separate account

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2042,6 +2042,7 @@
   "organization_banner_title": "Manage organizations with multiple teams",
   "set_up_your_organization": "Set up your organization",
   "set_up_your_platform_organization": "Set up your platform",
+  "platform_account_warning": "Do not use your personal Cal.com account or account used to manage teams and organizations. Create a new Cal.com account specifically for setting up the Platform and only then continue on this page.",
   "organizations_description": "Organizations are shared environments where teams can create shared event types, apps, workflows and more.",
   "platform_organization_description": "Cal.com Platform lets you integrate scheduling effortlessly into your app using platform apis and atoms.",
   "must_enter_organization_name": "Must enter an organization name",

--- a/packages/features/ee/platform/components/CreateANewPlatformForm.tsx
+++ b/packages/features/ee/platform/components/CreateANewPlatformForm.tsx
@@ -90,6 +90,9 @@ const CreateANewPlatformFormChild = ({ session }: { session: Ensure<SessionConte
           }
         }}>
         <div>
+          <Alert severity="warning" title={t("platform_account_warning")} />
+        </div>
+        <div>
           {serverErrorMessage && (
             <div className="mb-4">
               <Alert severity="error" message={serverErrorMessage} />


### PR DESCRIPTION
## Problem

As seen in [campsite thread](https://app.campsite.co/cal/inbox/updates/0f48ae8bf1ab), platform customers should use account specifically dedicated for platform creation.

## Solution
As recommended by @Ryukemeister , at least display a warning message during platform creation:

<img width="1702" alt="Screenshot 2024-06-05 at 10 22 09" src="https://github.com/calcom/cal.com/assets/42170848/958510d3-1231-43b8-be30-7fc202af91bb">
