### PR TITLE
chore: v2 managed user inform when access token expires

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
@@ -91,6 +91,7 @@ export class OAuthClientUsersController {
       data: {
         user: this.getResponseUser(user),
         accessToken: tokens.accessToken,
+        accessTokenExpiresAt: tokens.accessTokenExpiresAt.valueOf(),
         refreshToken: tokens.refreshToken,
       },
     };

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/outputs/create-managed-user.output.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/outputs/create-managed-user.output.ts
@@ -1,7 +1,7 @@
 import { ManagedUserOutput } from "@/modules/oauth-clients/controllers/oauth-client-users/outputs/managed-user.output";
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsEnum, IsString, ValidateNested } from "class-validator";
+import { IsEnum, IsNumber, IsString, ValidateNested } from "class-validator";
 
 import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
 
@@ -18,6 +18,9 @@ class CreateManagedUserData {
 
   @IsString()
   refreshToken!: string;
+
+  @IsNumber()
+  accessTokenExpiresAt!: number;
 }
 
 export class CreateManagedUserOutput {

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -62,7 +62,7 @@ export class OAuthClientUsersService {
       await this.userRepository.update(user.id, { name: body.name ?? user.username ?? undefined });
     }
 
-    const { accessToken, refreshToken } = await this.tokensRepository.createOAuthTokens(
+    const { accessToken, refreshToken, accessTokenExpiresAt } = await this.tokensRepository.createOAuthTokens(
       oAuthClientId,
       user.id
     );
@@ -78,6 +78,7 @@ export class OAuthClientUsersService {
       user,
       tokens: {
         accessToken,
+        accessTokenExpiresAt,
         refreshToken,
       },
     };

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -89,6 +89,7 @@ export class TokensRepository {
 
     return {
       accessToken: accessToken.secret,
+      accessTokenExpiresAt: accessToken.expiresAt,
       refreshToken: refreshToken.secret,
     };
   }

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -1833,12 +1833,16 @@
           },
           "refreshToken": {
             "type": "string"
+          },
+          "accessTokenExpiresAt": {
+            "type": "number"
           }
         },
         "required": [
           "user",
           "accessToken",
-          "refreshToken"
+          "refreshToken",
+          "accessTokenExpiresAt"
         ]
       },
       "CreateManagedUserOutput": {


### PR DESCRIPTION
## What

Add `accessTokenExpiresAt` timestamp when creating managed user.

<img width="1284" alt="Screenshot 2024-06-12 at 09 11 06" src="https://github.com/calcom/cal.com/assets/42170848/3d2f43a1-70d9-4746-81ed-d6fb9f1f0e3b">


## Why

If refreshing tokens automatically fails, then it's possible to refresh them manually but with timestamp above to know when that should be done.