### PR TITLE
fix: Make the full calendar link clickable

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -132,8 +132,9 @@ export function UserPage(props: InferGetServerSidePropsType<typeof getServerSide
                   className="text-emphasis absolute right-4 top-4 h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"
                 />
                 {/* Don't prefetch till the time we drop the amount of javascript in [user][type] page which is impacting score for [user] page */}
-                <div className="block w-full p-5">
+                <div className="block w-full">
                   <Link
+                    className="block p-5"
                     prefetch={false}
                     href={{
                       pathname: `/${user.profile.username}/${type.slug}`,


### PR DESCRIPTION
## What does this PR do?

It adds padding to the link tag instead of the surrounding div in event listing so that the whole area is clickable

- Fixes #15445

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code 
- [ ] I have added a Docs issue
- [ ] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

1. Run the branch locally (or use the preview URL if it is available)
2. Create multiple events
3. Visit the public profile page
4. Now the whole tile should be clickable not just the contents in the center

## Checklist

- ~I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)~
- ~My code doesn't follow the style guidelines of this project~
- ~I haven't commented my code, particularly in hard-to-understand areas~
- ~I haven't checked if my changes generate no new warnings~
