### PR TITLE
refactor: only check platform billing for platforms

### DIFF
--- a/apps/web/components/settings/platform/hooks/useGetUserAttributes.ts
+++ b/apps/web/components/settings/platform/hooks/useGetUserAttributes.ts
@@ -4,7 +4,8 @@ import { useCheckTeamBilling } from "@calcom/web/lib/hooks/settings/platform/oau
 export const useGetUserAttributes = () => {
   const { data: user, isLoading: isUserLoading } = useMeQuery();
   const { data: userBillingData, isFetching: isUserBillingDataLoading } = useCheckTeamBilling(
-    user?.organizationId
+    user?.organizationId,
+    user?.organization.isPlatform
   );
   const isPlatformUser = user?.organization.isPlatform;
   const isPaidUser = userBillingData?.valid;

--- a/apps/web/lib/hooks/settings/platform/oauth-clients/usePersistOAuthClient.ts
+++ b/apps/web/lib/hooks/settings/platform/oauth-clients/usePersistOAuthClient.ts
@@ -119,7 +119,7 @@ export const useDeleteOAuthClient = (
   return mutation;
 };
 
-export const useCheckTeamBilling = (teamId?: number | null) => {
+export const useCheckTeamBilling = (teamId?: number | null, isPlatformTeam?: boolean | null) => {
   const QUERY_KEY = "check-team-billing";
   const isTeamBilledAlready = useQuery({
     queryKey: [QUERY_KEY, teamId],
@@ -132,7 +132,7 @@ export const useCheckTeamBilling = (teamId?: number | null) => {
 
       return data.data;
     },
-    enabled: !!teamId,
+    enabled: !!teamId && !!isPlatformTeam,
   });
 
   return isTeamBilledAlready;


### PR DESCRIPTION
## Problem

If user belongs to a non platform org we are sending requests to `v2/billing/:teamId/check` which results in 403:
![image](https://github.com/calcom/cal.com/assets/42170848/fe91b5ea-6087-4c17-baf8-827e0113f61f)

## Solution
Disable `useCheckTeamBilling` query calling `v2/billing/:teamId/check` if user's organization is not platform.