### PR TITLE
fix: AvailabilitySettings atom closing override window button

### DIFF
--- a/packages/ui/components/dialog/Dialog.tsx
+++ b/packages/ui/components/dialog/Dialog.tsx
@@ -244,7 +244,7 @@ export function DialogClose(
         data-testid={props["data-testid"] || "dialog-rejection"}
         color={props.color || "minimal"}
         {...props}>
-        {props.children ? props.children : t("Close")}
+        {props.children ? props.children : t("close")}
       </Button>
     </Close>
   );

--- a/packages/ui/components/dialog/dialog.test.tsx
+++ b/packages/ui/components/dialog/dialog.test.tsx
@@ -128,7 +128,7 @@ describe("Tests for Dialog component", () => {
 
   test("Should use color from props in CloseDialog", async () => {
     render(<DialogComponent open color="destructive" />);
-    const closeBtn = screen.getByText("Close");
+    const closeBtn = screen.getByText("close");
     expect(closeBtn.classList.toString()).toContain("hover:text-red-700");
   });
 


### PR DESCRIPTION
## Problem

When adding date override in availability atom there is no "Close" button like in web app.

<img width="743" alt="Screenshot 2024-06-21 at 10 24 21" src="https://github.com/calcom/cal.com/assets/42170848/4c9a3b6d-0d19-41b6-9265-1b4c4f0dd931">

## Reason
If you see file changed, then before we displayed "Close" text as `t("Close")}`, but no such entry exists in our i18n files only "close":
<img width="634" alt="Screenshot 2024-06-21 at 10 22 54" src="https://github.com/calcom/cal.com/assets/42170848/32457122-565d-41d7-abaa-62aa01922fdb">

## Solution
Change `t("Close")}` to `t("close")}` and override close button is showing:
<img width="819" alt="Screenshot 2024-06-21 at 10 26 07" src="https://github.com/calcom/cal.com/assets/42170848/09141787-ad88-43e1-a442-0a38e1ca4f42">
