### PR TITLE
fix: New CI workflow flaws in detecting the ready-for-e2e label on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           script: |
             let pr;
-            console.log('github.event_name', github.event_name);
-            console.log('github.event', github.event);
+            console.log('github.event_name', ${{ github.event_name }});
+            console.log('github.event', ${{ github.event }});
             if (github.event && github.event.pull_request) {
               const response = await github.rest.pulls.get({
                 owner: github.context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           script: |
             let pr;
-            console.log('github.event_name', ${{ github.event_name }});
+            console.log('github.event_name', '${{ github.event_name }}');
             console.log('github.event', ${{ github.event }});
             if (github.event && github.event.pull_request) {
               const response = await github.rest.pulls.get({

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,20 +43,20 @@ jobs:
           script: |
             let pr;
             console.log('github.event_name', '${{ github.event_name }}');
-            console.log('github.event', ${{ github.event }});
-            if (github.event && github.event.pull_request) {
+            const parsedEvent = ${{ github.event }};
+            if (parsedEvent && parsedEvent.pull_request) {
               const response = await github.rest.pulls.get({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                pull_number: github.event.pull_request.number
+                pull_number: parsedEvent.pull_request.number
               });
 
               pr = response.data;
             } else {
               const ref = '${{ github.ref }}';
               const branch = ref.replace('refs/heads/', '');
-              console.log(ref);
-              console.log(branch);
+              console.log('ref', ref);
+              console.log('branch', branch);
               const response = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -66,26 +66,20 @@ jobs:
 
               if (response.data.length > 0) {
                 pr = response.data[0];
-              } else {
-                core.setOutput('run-e2e', false);
-                console.log('No PR found matching the branch');
               }
             }
 
             if (!pr) {
+              core.setOutput('run-e2e', false);
               console.log('No PR found');
               return;
             }
 
             const labels = pr.labels.map(label => label.name);
+            const labelFound = labels.includes('ready-for-e2e');
             console.log('PR #', pr.number);
-            if (labels.includes('ready-for-e2e')) {
-              core.setOutput('run-e2e', true);
-              console.log('Found the label');
-            } else {
-              core.setOutput('run-e2e', false);
-              console.log('Did not find the label');
-            }
+            console.log('Found the label?', labelFound);
+            core.setOutput('run-e2e', labelFound);
 
   type-check:
     name: Type check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,8 @@ jobs:
         with:
           script: |
             let pr;
-            console.log(github.event);
+            console.log('github.event_name', github.event_name);
+            console.log('github.event', github.event);
             if (github.event && github.event.pull_request) {
               const response = await github.rest.pulls.get({
                 owner: github.context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           script: |
             let pr;
+            console.log(github.event);
             if (github.event && github.event.pull_request) {
               const response = await github.rest.pulls.get({
                 owner: github.context.repo.owner,


### PR DESCRIPTION
## What does this PR do?

Fixes some issues with the script to detect the `ready-for-e2e` label. We need to use the ${{ }} syntax to retrieve the objects from the event.