### PR TITLE
chore: Make ready-for-e2e label check more robust

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           commit_sha=$(git rev-parse HEAD)
           echo "Commit SHA: $commit_sha"
-          echo "::set-output name=commit_sha::$commit-sha"
+          echo "::set-output name=commit-sha::$commit_sha"
 
 
   check-label:
@@ -96,6 +96,7 @@ jobs:
             if (!pr) {
               core.setOutput('run-e2e', false);
               console.log('Could not find the PR for this commit');
+              return;
             }
 
             console.log(`PR number: ${pr.number}`);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: read
     outputs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
-      commit-sha: ${{ steps.filter.outputs.commit-sha }}
+      commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
             let pr;
             console.log('github.event.action', '${{ github.event.action }}');
             try {
-              sha = '${{ needs.changes.outputs.commit-sha }}';
+              sha = '${{ github.event.pull_request.head.sha }}';
               console.log('sha', sha);
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
             let pr;
             try {
               sha = '${{ needs.changes.outputs.commit-sha }}';
+              console.log(sha);
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
           script: |
             let sha = '';
             let pr;
+            console.log('github.event.action', '${{ github.event.action }}');
             try {
               sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);
@@ -60,33 +61,26 @@ jobs:
 
               if (prs.length === 0) {
                 core.setOutput('run-e2e', false);
-                core.setFailed(`No pull requests found for commit SHA ${sha}`);
+                console.log(`No pull requests found for commit SHA ${sha}`);
                 return;
               }
 
               pr = prs[0];
+              console.log(`PR number: ${pr.number}`);
+              console.log(`PR title: ${pr.title}`);
+              console.log(`PR state: ${pr.state}`);
+              console.log(`PR URL: ${pr.html_url}`);
+
+              const labels = pr.labels.map(label => label.name);
+              const labelFound = labels.includes('ready-for-e2e');
+              console.log('PR #', pr.number);
+              console.log('Found the label?', labelFound);
+              core.setOutput('run-e2e', labelFound);
             }
             catch (e) {
+              core.setOutput('run-e2e', false);
               console.log(e);
             }
-
-            if (!pr) {
-              core.setOutput('run-e2e', false);
-              console.log('Could not find the PR for this commit');
-              return;
-            }
-
-            console.log(`PR number: ${pr.number}`);
-            console.log(`PR title: ${pr.title}`);
-            console.log(`PR state: ${pr.state}`);
-            console.log(`PR URL: ${pr.html_url}`);
-            console.log('github.event.action', '${{ github.event.action }}');
-
-            const labels = pr.labels.map(label => label.name);
-            const labelFound = labels.includes('ready-for-e2e');
-            console.log('PR #', pr.number);
-            console.log('Found the label?', labelFound);
-            core.setOutput('run-e2e', labelFound);
 
   type-check:
     name: Type check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,39 +41,25 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            let pr;
-            console.log('github.event_name', '${{ github.event_name }}');
-            const parsedEvent = ${{ github.event }};
-            if (parsedEvent && parsedEvent.pull_request) {
-              const response = await github.rest.pulls.get({
-                owner: github.context.repo.owner,
-                repo: github.context.repo.repo,
-                pull_number: parsedEvent.pull_request.number
-              });
+            const sha = '${{ github.event.pull_request.head.sha }}';
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: sha
+            });
 
-              pr = response.data;
-            } else {
-              const ref = '${{ github.ref }}';
-              const branch = ref.replace('refs/heads/', '');
-              console.log('ref', ref);
-              console.log('branch', branch);
-              const response = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                head: `${context.repo.owner}:${branch}`
-              });
-
-              if (response.data.length > 0) {
-                pr = response.data[0];
-              }
-            }
-
-            if (!pr) {
+            if (prs.length === 0) {
               core.setOutput('run-e2e', false);
-              console.log('No PR found');
+              core.setFailed(`No pull requests found for commit SHA ${sha}`);
               return;
             }
+
+            const pr = prs[0];
+            console.log(`PR number: ${pr.number}`);
+            console.log(`PR title: ${pr.title}`);
+            console.log(`PR state: ${pr.state}`);
+            console.log(`PR URL: ${pr.html_url}`);
+            console.log('github.event_name', '${{ github.event_name }}');
 
             const labels = pr.labels.map(label => label.name);
             const labelFound = labels.includes('ready-for-e2e');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,9 @@ jobs:
                   pr = response.data[0];
                 }
               }
+              catch (e) {
+                console.log(e);
+              }
             }
 
             if (!pr) {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,18 +32,15 @@ jobs:
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
-          commit_sha=$(git rev-parse HEAD)
-          echo "Commit SHA: $commit_sha"
-          echo "::set-output name=commit-sha::$commit_sha"
-
+          echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   check-label:
     needs: [changes]
     runs-on: buildjet-2vcpu-ubuntu-2204
     name: Check for E2E label
     outputs:
-      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event_name != 'labeled' || (github.event_name == 'labeled' && github.event.label.name == 'ready-for-e2e')) }}
-      run-jobs: ${{ github.event_name != 'labeled' }}
+      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'ready-for-e2e')) }}
+      run-jobs: ${{ github.event.action != 'labeled' }}
     steps:
       - name: Get PR from branch name
         id: check-if-pr-has-label
@@ -54,7 +51,7 @@ jobs:
             let pr;
             try {
               sha = '${{ needs.changes.outputs.commit-sha }}';
-              console.log(sha);
+              console.log('sha', sha);
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -74,27 +71,6 @@ jobs:
             }
 
             if (!pr) {
-              try {
-                const ref = '${{ github.ref }}';
-                const branch = ref.replace('refs/heads/', '');
-                console.log('ref', ref);
-                console.log('branch', branch);
-                const response = await github.rest.pulls.list({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: 'open',
-                  head: `${context.repo.owner}:${branch}`
-                });
-                if (response.data.length > 0) {
-                  pr = response.data[0];
-                }
-              }
-              catch (e) {
-                console.log(e);
-              }
-            }
-
-            if (!pr) {
               core.setOutput('run-e2e', false);
               console.log('Could not find the PR for this commit');
               return;
@@ -104,7 +80,7 @@ jobs:
             console.log(`PR title: ${pr.title}`);
             console.log(`PR state: ${pr.state}`);
             console.log(`PR URL: ${pr.html_url}`);
-            console.log('github.event_name', '${{ github.event_name }}');
+            console.log('github.event.action', '${{ github.event.action }}');
 
             const labels = pr.labels.map(label => label.name);
             const labelFound = labels.includes('ready-for-e2e');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'The branch to check'
-        required: true
-        default: 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -43,6 +38,7 @@ jobs:
 
 
   check-label:
+    needs: [changes]
     runs-on: buildjet-2vcpu-ubuntu-2204
     name: Check for E2E label
     outputs:
@@ -57,7 +53,7 @@ jobs:
             let sha = '';
             let pr;
             try {
-              sha = '${{ github.event.pull_request.head.sha }}';
+              sha = '${{ needs.changes.outputs.commit-sha }}';
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
             let pr;
             console.log('github.event.action', '${{ github.event.action }}');
             try {
-              sha = '${{ github.event.pull_request.head.sha }}';
+              sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,16 +42,14 @@ jobs:
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'ready-for-e2e')) }}
       run-jobs: ${{ github.event.action != 'labeled' }}
     steps:
-      - name: Get PR from branch name
+      - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
         with:
           script: |
-            let sha = '';
-            let pr;
             console.log('github.event.action', '${{ github.event.action }}');
             try {
-              sha = '${{ needs.changes.outputs.commit-sha }}';
+              const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
@@ -65,7 +63,7 @@ jobs:
                 return;
               }
 
-              pr = prs[0];
+              const pr = prs[0];
               console.log(`PR number: ${pr.number}`);
               console.log(`PR title: ${pr.title}`);
               console.log(`PR state: ${pr.state}`);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,8 +43,8 @@ jobs:
           script: |
             const sha = '${{ github.event.pull_request.head.sha }}';
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
+              owner: github.context.repo.owner,
+              repo: github.context.repo.repo,
               commit_sha: sha
             });
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to check'
+        required: true
+        default: 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +24,7 @@ jobs:
       pull-requests: read
     outputs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
+      commit-sha: ${{ steps.filter.outputs.commit-sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -28,6 +34,13 @@ jobs:
           filters: |
             has-files-requiring-all-checks:
               - "!(**.md|.github/CODEOWNERS)"
+      - name: Get Latest Commit SHA
+        id: get_sha
+        run: |
+          commit_sha=$(git rev-parse HEAD)
+          echo "Commit SHA: $commit_sha"
+          echo "::set-output name=commit_sha::$commit-sha"
+
 
   check-label:
     runs-on: buildjet-2vcpu-ubuntu-2204
@@ -41,20 +54,51 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = '${{ github.event.pull_request.head.sha }}';
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: sha
-            });
+            let sha = '';
+            let pr;
+            try {
+              sha = '${{ github.event.pull_request.head.sha }}';
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha
+              });
 
-            if (prs.length === 0) {
-              core.setOutput('run-e2e', false);
-              core.setFailed(`No pull requests found for commit SHA ${sha}`);
-              return;
+              if (prs.length === 0) {
+                core.setOutput('run-e2e', false);
+                core.setFailed(`No pull requests found for commit SHA ${sha}`);
+                return;
+              }
+
+              pr = prs[0];
+            }
+            catch (e) {
+              console.log(e);
             }
 
-            const pr = prs[0];
+            if (!pr) {
+              try {
+                const ref = '${{ github.ref }}';
+                const branch = ref.replace('refs/heads/', '');
+                console.log('ref', ref);
+                console.log('branch', branch);
+                const response = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head: `${context.repo.owner}:${branch}`
+                });
+                if (response.data.length > 0) {
+                  pr = response.data[0];
+                }
+              }
+            }
+
+            if (!pr) {
+              core.setOutput('run-e2e', false);
+              console.log('Could not find the PR for this commit');
+            }
+
             console.log(`PR number: ${pr.number}`);
             console.log(`PR title: ${pr.title}`);
             console.log(`PR state: ${pr.state}`);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,8 +43,8 @@ jobs:
           script: |
             const sha = '${{ github.event.pull_request.head.sha }}';
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               commit_sha: sha
             });
 


### PR DESCRIPTION
Making the check more robust so it can be run on PR events and workflow_dispatch events for testing.