### PR TITLE
chore: Add GH actions test branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
+            console.log('github.event.pull_request', ${{ github.event.pull_request }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
-      - chore/gh-actions-test-branch
+      - gh-actions-test-branch
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
+      - chore/gh-actions-test-branch
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request', ${{ github.event.pull_request }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);


### PR DESCRIPTION
This allows us to be able to more easily test changes to GitHub actions before they hit main.