### PR TITLE
chore: streamline ready-for-e2e label check for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', ${{ toJson(github.event.pull_request.labels) }});
+            console.log('github.event.pull_request.labels', context.payload.pull_request.labels);
 
             let labels = [];
 
-            if (${{ toJson(github.event) }} && ${{ toJson(github.event.pull_request) }}) {
-              labels = ${{ toJson(github.event.pull_request.labels) }};
+            if (context.payload.pull_request) {
+              labels = context.payload.pull_request.labels;
             } else {
               try {
                 const sha = '${{ needs.changes.outputs.commit-sha }}';

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
+            console.log('github.event.pull_request', ${{ github.event.pull_request }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,10 +49,12 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
+            console.log('github.event.pull_request.labels', ${{ toJson(github.event.pull_request.labels) }});
 
-            if (${{ github.event }} && ${{ github.event.pull_request }}) {
-              labels = ${{ github.event.pull_request.labels }};
+            let labels = [];
+
+            if (${{ toJson(github.event) }} && ${{ toJson(github.event.pull_request) }}) {
+              labels = ${{ toJson(github.event.pull_request.labels) }};
             } else {
               try {
                 const sha = '${{ needs.changes.outputs.commit-sha }}';

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: PR Update
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - gh-actions-test-branch

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,37 +50,43 @@ jobs:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
             console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
-            try {
-              const sha = '${{ needs.changes.outputs.commit-sha }}';
-              console.log('sha', sha);
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: sha
-              });
 
-              if (prs.length === 0) {
-                core.setOutput('run-e2e', false);
-                console.log(`No pull requests found for commit SHA ${sha}`);
-                return;
+            if (${{ github.event }} && ${{ github.event.pull_request }}) {
+              labels = ${{ github.event.pull_request.labels }};
+            } else {
+              try {
+                const sha = '${{ needs.changes.outputs.commit-sha }}';
+                console.log('sha', sha);
+                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: sha
+                });
+
+                if (prs.length === 0) {
+                  core.setOutput('run-e2e', false);
+                  console.log(`No pull requests found for commit SHA ${sha}`);
+                  return;
+                }
+
+                const pr = prs[0];
+                console.log(`PR number: ${pr.number}`);
+                console.log(`PR title: ${pr.title}`);
+                console.log(`PR state: ${pr.state}`);
+                console.log(`PR URL: ${pr.html_url}`);
+
+                labels = pr.labels.map(label => label.name);
               }
-
-              const pr = prs[0];
-              console.log(`PR number: ${pr.number}`);
-              console.log(`PR title: ${pr.title}`);
-              console.log(`PR state: ${pr.state}`);
-              console.log(`PR URL: ${pr.html_url}`);
-
-              const labels = pr.labels.map(label => label.name);
-              const labelFound = labels.includes('ready-for-e2e');
-              console.log('PR #', pr.number);
-              console.log('Found the label?', labelFound);
-              core.setOutput('run-e2e', labelFound);
+              catch (e) {
+                core.setOutput('run-e2e', false);
+                console.log(e);
+              }
             }
-            catch (e) {
-              core.setOutput('run-e2e', false);
-              console.log(e);
-            }
+
+            const labelFound = labels.includes('ready-for-e2e');
+            console.log('PR #', pr.number);
+            console.log('Found the label?', labelFound);
+            core.setOutput('run-e2e', labelFound);
 
   type-check:
     name: Type check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request', ${{ github.event.pull_request }});
+            console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,6 @@ jobs:
             }
 
             const labelFound = labels.includes('ready-for-e2e');
-            console.log('PR #', pr.number);
             console.log('Found the label?', labelFound);
             core.setOutput('run-e2e', labelFound);
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: PR Update
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - gh-actions-test-branch

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,9 +48,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', context.payload.pull_request.labels);
-
             let labels = [];
 
             if (context.payload.pull_request) {
@@ -77,7 +74,7 @@ jobs:
                 console.log(`PR state: ${pr.state}`);
                 console.log(`PR URL: ${pr.html_url}`);
 
-                labels = pr.labels.map(label => label.name);
+                labels = pr.labels;
               }
               catch (e) {
                 core.setOutput('run-e2e', false);
@@ -85,7 +82,7 @@ jobs:
               }
             }
 
-            const labelFound = labels.includes('ready-for-e2e');
+            const labelFound = labels.map(l => l.name).includes('ready-for-e2e');
             console.log('Found the label?', labelFound);
             core.setOutput('run-e2e', labelFound);
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,6 @@ jobs:
     name: Check for E2E label
     outputs:
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'ready-for-e2e')) }}
-      run-jobs: ${{ github.event.action != 'labeled' }}
     steps:
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
@@ -88,28 +87,28 @@ jobs:
   type-check:
     name: Type check
     needs: [changes, check-label]
-    if: ${{ needs.check-label.outputs.run-jobs == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes, check-label]
-    if: ${{ needs.check-label.outputs.run-jobs == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   unit-test:
     name: Tests
     needs: [changes, check-label]
-    if: ${{ needs.check-label.outputs.run-jobs == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   integration-test:
     name: Tests
     needs: [changes, check-label]
-    if: ${{ needs.check-label.outputs.run-jobs == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
@@ -170,7 +169,6 @@ jobs:
 
   required:
     needs: [changes, lint, type-check, unit-test, integration-test, check-label, build, build-api-v1, build-api-v2, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' }}
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed


### PR DESCRIPTION
Using the `pull_request` object to get the labels when available instead of always calling the GitHub API.