### PR TITLE
chore: Remove check for labeled action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,28 +88,28 @@ jobs:
   type-check:
     name: Type check
     needs: [changes, check-label]
-    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   lint:
     name: Linters
     needs: [changes, check-label]
-    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   unit-test:
     name: Tests
     needs: [changes, check-label]
-    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   integration-test:
     name: Tests
     needs: [changes, check-label]
-    if: ${{ github.event.action != 'labeled' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 


### PR DESCRIPTION
Removes the check for labeled action for non-e2e jobs since when adding the `ready-for-e2e`, we don't want those jobs skipped