### PR TITLE
fix: v2 event-types versioning

### DIFF
--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -20,13 +20,14 @@ runs:
         key-2: ${{ hashFiles('apps/**/**.[jt]s', 'apps/**/**.[jt]sx', 'packages/**/**.[jt]s', 'packages/**/**.[jt]sx', '!**/node_modules') }}
         key-3: ${{ github.event.pull_request.number || github.ref }}
         key-4: ${{ github.sha }}
+        key-5: ${{ github.event.pull_request.head.sha }}
       with:
         path: |
           ${{ github.workspace }}/apps/web/.next
           ${{ github.workspace }}/apps/web/public/embed
           **/.turbo/**
           **/dist/**
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}-${{ env.key-5 }}
     - run: |
         export NODE_OPTIONS="--max_old_space_size=8192"
         yarn build

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const labelName = github.context.payload.label.name;
-            const prNumber = github.context.payload.pull_request.number;
-            const owner = github.context.repo.owner;
-            const repo = github.context.repo.repo;
+            const labelName = context.payload.label.name;
+            const prNumber = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
             if (labelName === 'ready-for-e2e') {
               console.log(`Running E2E jobs for PR #${prNumber}...`);
@@ -33,7 +33,7 @@ jobs:
               const checkRuns = await github.rest.checks.listForRef({
                 owner,
                 repo,
-                ref: github.context.payload.pull_request.head.sha,
+                ref: context.payload.pull_request.head.sha,
               });
 
               for (const check of checkRuns.data.check_runs) {

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -37,7 +37,7 @@ jobs:
               });
 
               for (const check of checkRuns.data.check_runs) {
-                console.log('check', check);
+                console.log('check.name', check.name);
                 if (check.name.includes('e2e')) {
                   await github.rest.actions.reRunJob({
                     owner,

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -37,6 +37,7 @@ jobs:
               });
 
               for (const check of checkRuns.data.check_runs) {
+                console.log('check.name', check.name);
                 if (check.name.includes('e2e')) {
                   await github.rest.actions.reRunJob({
                     owner,

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -1,0 +1,52 @@
+name: PR Labeled with ready-for-e2e
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
+      - gh-actions-test-branch
+  workflow_dispatch:
+jobs:
+  run-e2e-jobs:
+    name: Run E2E Jobs
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/dangerous-git-checkout
+
+      - name: Check Label and Retrigger Checks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labelName = github.context.payload.label.name;
+            const prNumber = github.context.payload.pull_request.number;
+            const owner = github.context.repo.owner;
+            const repo = github.context.repo.repo;
+
+            if (labelName === 'ready-for-e2e') {
+              console.log(`Running E2E jobs for PR #${prNumber}...`);
+
+              const checkRuns = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: github.context.payload.pull_request.head.sha,
+              });
+
+              for (const check of checkRuns.data.check_runs) {
+                if (check.name.includes('e2e') {
+                  await github.rest.actions.reRunJob({
+                    owner,
+                    repo,
+                    job_id: check.id,
+                  });
+                }
+              }
+
+              console.log(`Triggered E2E checks for PR #${prNumber}`);
+            } else {
+              console.log(`Label ${labelName} does not trigger re-running checks.`);
+            }

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -37,7 +37,7 @@ jobs:
               });
 
               for (const check of checkRuns.data.check_runs) {
-                console.log('check.name', check.name);
+                console.log('check', check);
                 if (check.name.includes('e2e')) {
                   await github.rest.actions.reRunJob({
                     owner,

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -37,7 +37,7 @@ jobs:
               });
 
               for (const check of checkRuns.data.check_runs) {
-                if (check.name.includes('e2e') {
+                if (check.name.includes('e2e')) {
                   await github.rest.actions.reRunJob({
                     owner,
                     repo,

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -44,6 +44,7 @@ jobs:
                     repo,
                     job_id: check.id,
                   });
+                  console.log(`Triggering job #${check.id}`);
                 }
               }
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', ${{ toJson(github.event.pull_request.labels) }});
+            console.log('github.event.pull_request.labels', context.payload.pull_request.labels);
 
             let labels = [];
 
-            if (${{ toJson(github.event) }} && ${{ toJson(github.event.pull_request) }}) {
-              labels = ${{ toJson(github.event.pull_request.labels) }};
+            if (context.payload.pull_request) {
+              labels = context.payload.pull_request.labels;
             } else {
               try {
                 const sha = '${{ needs.changes.outputs.commit-sha }}';

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
+            console.log('github.event.pull_request', ${{ github.event.pull_request }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,28 +135,28 @@ jobs:
     secrets: inherit
 
   e2e:
-    name: Tests
+    name: e2e
     needs: [changes, check-label, build]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
   e2e-app-store:
-    name: Tests
+    name: e2e-app-store
     needs: [changes, check-label, build]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
-    name: Tests
+    name: e2e-embed
     needs: [changes, check-label, build]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
-    name: Tests
+    name: e2e-embed-react
     needs: [changes, check-label, build]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,10 +49,12 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
+            console.log('github.event.pull_request.labels', ${{ toJson(github.event.pull_request.labels) }});
 
-            if (${{ github.event }} && ${{ github.event.pull_request }}) {
-              labels = ${{ github.event.pull_request.labels }};
+            let labels = [];
+
+            if (${{ toJson(github.event) }} && ${{ toJson(github.event.pull_request) }}) {
+              labels = ${{ toJson(github.event.pull_request.labels) }};
             } else {
               try {
                 const sha = '${{ needs.changes.outputs.commit-sha }}';

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: PR Update
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - gh-actions-test-branch

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,37 +50,43 @@ jobs:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
             console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
-            try {
-              const sha = '${{ needs.changes.outputs.commit-sha }}';
-              console.log('sha', sha);
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: sha
-              });
 
-              if (prs.length === 0) {
-                core.setOutput('run-e2e', false);
-                console.log(`No pull requests found for commit SHA ${sha}`);
-                return;
+            if (${{ github.event }} && ${{ github.event.pull_request }}) {
+              labels = ${{ github.event.pull_request.labels }};
+            } else {
+              try {
+                const sha = '${{ needs.changes.outputs.commit-sha }}';
+                console.log('sha', sha);
+                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: sha
+                });
+
+                if (prs.length === 0) {
+                  core.setOutput('run-e2e', false);
+                  console.log(`No pull requests found for commit SHA ${sha}`);
+                  return;
+                }
+
+                const pr = prs[0];
+                console.log(`PR number: ${pr.number}`);
+                console.log(`PR title: ${pr.title}`);
+                console.log(`PR state: ${pr.state}`);
+                console.log(`PR URL: ${pr.html_url}`);
+
+                labels = pr.labels.map(label => label.name);
               }
-
-              const pr = prs[0];
-              console.log(`PR number: ${pr.number}`);
-              console.log(`PR title: ${pr.title}`);
-              console.log(`PR state: ${pr.state}`);
-              console.log(`PR URL: ${pr.html_url}`);
-
-              const labels = pr.labels.map(label => label.name);
-              const labelFound = labels.includes('ready-for-e2e');
-              console.log('PR #', pr.number);
-              console.log('Found the label?', labelFound);
-              core.setOutput('run-e2e', labelFound);
+              catch (e) {
+                core.setOutput('run-e2e', false);
+                console.log(e);
+              }
             }
-            catch (e) {
-              core.setOutput('run-e2e', false);
-              console.log(e);
-            }
+
+            const labelFound = labels.includes('ready-for-e2e');
+            console.log('PR #', pr.number);
+            console.log('Found the label?', labelFound);
+            core.setOutput('run-e2e', labelFound);
 
   type-check:
     name: Type check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           script: |
             console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request', ${{ github.event.pull_request }});
+            console.log('github.event.pull_request.labels', ${{ github.event.pull_request.labels }});
             try {
               const sha = '${{ needs.changes.outputs.commit-sha }}';
               console.log('sha', sha);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,6 @@ jobs:
             }
 
             const labelFound = labels.includes('ready-for-e2e');
-            console.log('PR #', pr.number);
             console.log('Found the label?', labelFound);
             core.setOutput('run-e2e', labelFound);
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,9 +48,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log('github.event.action', '${{ github.event.action }}');
-            console.log('github.event.pull_request.labels', context.payload.pull_request.labels);
-
             let labels = [];
 
             if (context.payload.pull_request) {
@@ -77,7 +74,7 @@ jobs:
                 console.log(`PR state: ${pr.state}`);
                 console.log(`PR URL: ${pr.html_url}`);
 
-                labels = pr.labels.map(label => label.name);
+                labels = pr.labels;
               }
               catch (e) {
                 core.setOutput('run-e2e', false);
@@ -85,7 +82,7 @@ jobs:
               }
             }
 
-            const labelFound = labels.includes('ready-for-e2e');
+            const labelFound = labels.map(l => l.name).includes('ready-for-e2e');
             console.log('Found the label?', labelFound);
             core.setOutput('run-e2e', labelFound);
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
@@ -24,7 +24,12 @@ import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.
 import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
 import { withApiAuth } from "test/utils/withApiAuth";
 
-import { SUCCESS_STATUS, VERSION_2024_06_11, CAL_API_VERSION_HEADER } from "@calcom/platform-constants";
+import {
+  SUCCESS_STATUS,
+  VERSION_2024_06_11,
+  VERSION_2024_04_15,
+  CAL_API_VERSION_HEADER,
+} from "@calcom/platform-constants";
 import {
   EventTypesByViewer,
   EventTypesPublic,
@@ -154,6 +159,7 @@ describe("Event types Endpoints", () => {
 
       return request(app.getHttpServer())
         .post("/api/v2/event-types")
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         .send(body)
         .expect(201)
         .then(async (response) => {
@@ -184,6 +190,7 @@ describe("Event types Endpoints", () => {
 
       return request(app.getHttpServer())
         .patch(`/api/v2/event-types/${eventType.id}`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         .send(body)
         .expect(200)
         .then(async (response) => {
@@ -288,6 +295,7 @@ describe("Event types Endpoints", () => {
     it(`/GET/:id`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types/${eventType.id}`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);
@@ -323,6 +331,7 @@ describe("Event types Endpoints", () => {
     it(`/GET/:username/public`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types/${username}/public`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);
@@ -341,6 +350,7 @@ describe("Event types Endpoints", () => {
     it(`/GET/:username/:eventSlug/public`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types/${username}/${eventType.slug}/public`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);
@@ -358,6 +368,7 @@ describe("Event types Endpoints", () => {
     it(`/GET/`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);
@@ -377,6 +388,7 @@ describe("Event types Endpoints", () => {
     it(`/GET/public/:username/`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types/${username}/public`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);
@@ -393,13 +405,17 @@ describe("Event types Endpoints", () => {
     it(`/GET/:id not existing`, async () => {
       await request(app.getHttpServer())
         .get(`/api/v2/event-types/1000`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(404);
     });
 
     it("should delete schedule", async () => {
-      return request(app.getHttpServer()).delete(`/api/v2/event-types/${eventType.id}`).expect(200);
+      return request(app.getHttpServer())
+        .delete(`/api/v2/event-types/${eventType.id}`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_04_15)
+        .expect(200);
     });
 
     afterAll(async () => {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
@@ -24,7 +24,7 @@ import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.
 import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
 import { withApiAuth } from "test/utils/withApiAuth";
 
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { SUCCESS_STATUS, VERSION_2024_06_11, CAL_API_VERSION_HEADER } from "@calcom/platform-constants";
 import {
   EventTypesByViewer,
   EventTypesPublic,
@@ -288,6 +288,24 @@ describe("Event types Endpoints", () => {
     it(`/GET/:id`, async () => {
       const response = await request(app.getHttpServer())
         .get(`/api/v2/event-types/${eventType.id}`)
+        // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
+        .set("Authorization", `Bearer whatever`)
+        .expect(200);
+
+      const responseBody: GetEventTypeOutput = response.body;
+
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data).toBeDefined();
+      expect(responseBody.data.eventType.id).toEqual(eventType.id);
+      expect(responseBody.data.eventType.title).toEqual(eventType.title);
+      expect(responseBody.data.eventType.slug).toEqual(eventType.slug);
+      expect(responseBody.data.eventType.userId).toEqual(user.id);
+    });
+
+    it(`/GET/:id with version VERSION_2024_06_11`, async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/api/v2/event-types/${eventType.id}`)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_06_11)
         // note: bearer token value mocked using "withApiAuth" for user which id is used when creating event type above
         .set("Authorization", `Bearer whatever`)
         .expect(200);

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.ts
@@ -13,7 +13,7 @@ import {
 } from "@/ee/event-types/event-types_2024_04_15/outputs/get-event-types.output";
 import { UpdateEventTypeOutput } from "@/ee/event-types/event-types_2024_04_15/outputs/update-event-type.output";
 import { EventTypesService_2024_04_15 } from "@/ee/event-types/event-types_2024_04_15/services/event-types.service";
-import { VERSION_2024_04_15_VALUE } from "@/lib/api-versions";
+import { VERSION_2024_04_15, VERSION_2024_06_11 } from "@/lib/api-versions";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
@@ -45,7 +45,7 @@ import { PrismaClient } from "@calcom/prisma";
 
 @Controller({
   path: "/v2/event-types",
-  version: VERSION_2024_04_15_VALUE,
+  version: [VERSION_2024_04_15, VERSION_2024_06_11],
 })
 @UseGuards(PermissionsGuard)
 @DocsTags("Event types")

--- a/apps/api/v2/src/lib/api-versions.ts
+++ b/apps/api/v2/src/lib/api-versions.ts
@@ -12,6 +12,6 @@ export const VERSION_2024_06_14_VALUE: VersionValue = VERSION_2024_06_14 as unkn
 export const VERSION_2024_06_11_VALUE: VersionValue = VERSION_2024_06_11 as unknown as VersionValue;
 export const VERSION_2024_04_15_VALUE: VersionValue = VERSION_2024_04_15 as unknown as VersionValue;
 
+export { VERSION_2024_04_15 };
 export { VERSION_2024_06_11 };
 export { VERSION_2024_06_14 };
-export { VERSION_2024_04_15 };

--- a/apps/api/v2/src/lib/api-versions.ts
+++ b/apps/api/v2/src/lib/api-versions.ts
@@ -14,3 +14,4 @@ export const VERSION_2024_04_15_VALUE: VersionValue = VERSION_2024_04_15 as unkn
 
 export { VERSION_2024_06_11 };
 export { VERSION_2024_06_14 };
+export { VERSION_2024_04_15 };


### PR DESCRIPTION
## Problem
Was testing platform starter kit and noticed that event-types can't be fetched:

<img width="804" alt="Screenshot 2024-06-24 at 11 21 11" src="https://github.com/calcom/cal.com/assets/42170848/e3af9f01-ff05-4e95-ac0b-6f532965dfc8">

## Reason
I refactored event-types in PR #15457 and versioned old event-types endpoints at version `VERSION_2024_04_15` while the new event-types at `VERSION_2024_06_14`, but forgot that there are people using version `VERSION_2024_06_11` that is between, which is version that platform starter kit is using.

## Solution
Add version `VERSION_2024_06_11`  to the old event-types controller aka make it process all event-types before latest `VERSION_2024_06_14` in [event-types.controller.ts](https://github.com/calcom/cal.com/pull/15549/files#diff-9f84947c30e3cbcd5d5eaf35cd3f77510d2db1c09a76f67a00833a354f3590d2).

Then, change old event-types tests to add `VERSION_2024_04_15` headers to requests, and then a [new test](https://github.com/calcom/cal.com/pull/15549/files#diff-331e58d1e4431607603a634f28fb1aa760fc117c37c4fa4fa45774d0c5320aabR313) with api version header at `VERSION_2024_06_11`. To run event-types tests run:
```
npx jest apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts --config jest-e2e.json
``` 

```
npx jest apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts --config jest-e2e.json
```
