### PR TITLE
chore: Add dynamic import and trigger captureException

### DIFF
--- a/packages/lib/server/defaultResponder.ts
+++ b/packages/lib/server/defaultResponder.ts
@@ -19,6 +19,10 @@ export function defaultResponder<T>(f: Handle<T>) {
     } catch (err) {
       console.error(err);
       const error = getServerErrorFromUnknown(err);
+      // dynamic import of Sentry so it's only loaded when something goes wrong.
+      const captureException = (await import("@sentry/nextjs")).captureException;
+      captureException(err);
+      // return API route response
       return res
         .status(error.statusCode)
         .json({ message: error.message, url: error.url, method: error.method });


### PR DESCRIPTION
## What does this PR do?

Adds a dynamic import (Sentry is huge) to be imported only when an error is caught; then trigger captureException.