### PR TITLE
fix: cancel sub when movingTeamToOrg

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
@@ -248,7 +248,7 @@ async function moveTeam({
   }
 }
 
-function tryToCancelSubscription(subscriptionId: string) {
+async function tryToCancelSubscription(subscriptionId: string) {
   try {
     log.debug("Canceling stripe subscription", safeStringify({ subscriptionId }));
     return stripe.subscriptions.cancel(subscriptionId);

--- a/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
@@ -251,7 +251,7 @@ async function moveTeam({
 async function tryToCancelSubscription(subscriptionId: string) {
   try {
     log.debug("Canceling stripe subscription", safeStringify({ subscriptionId }));
-    return stripe.subscriptions.cancel(subscriptionId);
+    return await stripe.subscriptions.cancel(subscriptionId);
   } catch (error) {
     log.error("Error while cancelling stripe subscription", error);
   }


### PR DESCRIPTION
## What does this PR do?

Fixes: [CAL-3393](https://linear.app/calcom/issue/CAL-3393/looks-like-we-are-not-cancelling-existing-teams-subscriptions-for)
Loom: https://www.tella.tv/video/seans-video-8ent

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

* Setup a team 
* invite members
* Visit org self serve flow 
* Complete flow - check stripe 
* notice old sub isnt active

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
