### PR TITLE
fix: CAL-3959 Disable Duplicate button in Readonly event type

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -520,7 +520,8 @@ export const EventTypeList = ({
                                       type="button"
                                       data-testid={`event-type-duplicate-${type.id}`}
                                       StartIcon="copy"
-                                      onClick={() => openDuplicateModal(type, group)}>
+                                      onClick={() => openDuplicateModal(type, group)}
+                                      disabled={readOnly}>
                                       {t("duplicate")}
                                     </DropdownItem>
                                   </DropdownMenuItem>

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -513,15 +513,14 @@ export const EventTypeList = ({
                                   </DropdownItem>
                                 </DropdownMenuItem>
                               )}
-                              {!isManagedEventType && !isChildrenManagedEventType && (
+                              {!isManagedEventType && !isChildrenManagedEventType && !readOnly && (
                                 <>
                                   <DropdownMenuItem className="outline-none">
                                     <DropdownItem
                                       type="button"
                                       data-testid={`event-type-duplicate-${type.id}`}
                                       StartIcon="copy"
-                                      onClick={() => openDuplicateModal(type, group)}
-                                      disabled={readOnly}>
+                                      onClick={() => openDuplicateModal(type, group)}>
                                       {t("duplicate")}
                                     </DropdownItem>
                                   </DropdownMenuItem>
@@ -630,7 +629,7 @@ export const EventTypeList = ({
                             </DropdownItem>
                           </DropdownMenuItem>
                         )}
-                        {!isManagedEventType && !isChildrenManagedEventType && (
+                        {!isManagedEventType && !isChildrenManagedEventType && !readOnly && (
                           <DropdownMenuItem className="outline-none">
                             <DropdownItem
                               onClick={() => openDuplicateModal(type, group)}


### PR DESCRIPTION
## What does this PR do?

Summary of Changes: Added condition to disable the duplicate button based on the readOnly value

- Fixes #15509 
- Fixes CAL-3959

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A-I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

