### PR TITLE
fix: backward compatibility for old cal rooms

### DIFF
--- a/apps/web/modules/videos/views/videos-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.getServerSideProps.tsx
@@ -1,7 +1,10 @@
 import MarkdownIt from "markdown-it";
 import type { GetServerSidePropsContext } from "next";
 
-import { generateGuestMeetingTokenFromOwnerMeetingToken } from "@calcom/app-store/dailyvideo/lib/VideoApiAdapter";
+import {
+  generateGuestMeetingTokenFromOwnerMeetingToken,
+  hideRecordingButtonsForOrganizer,
+} from "@calcom/app-store/dailyvideo/lib/VideoApiAdapter";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getCalVideoReference } from "@calcom/features/get-cal-video-reference";
 import { UserRepository } from "@calcom/lib/server/repository/user";
@@ -40,6 +43,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       },
       references: {
         select: {
+          id: true,
           uid: true,
           type: true,
           meetingUrl: true,
@@ -104,16 +108,29 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   const session = await getServerSession({ req });
 
+  const oldVideoReference = getCalVideoReference(bookingObj.references);
+
   // set meetingPassword for guests
   if (session?.user.id !== bookingObj.user?.id) {
-    const videoReference = getCalVideoReference(bookingObj.references);
     const guestMeetingPassword = await generateGuestMeetingTokenFromOwnerMeetingToken(
-      videoReference.meetingPassword
+      oldVideoReference.meetingPassword
     );
 
     bookingObj.references.forEach((bookRef) => {
       bookRef.meetingPassword = guestMeetingPassword;
     });
+  }
+  // Only for backward compatibility for organizer
+  else {
+    const meetingPassword = await hideRecordingButtonsForOrganizer(
+      oldVideoReference.id,
+      oldVideoReference.meetingPassword
+    );
+    if (!!meetingPassword) {
+      bookingObj.references.forEach((bookRef) => {
+        bookRef.meetingPassword = meetingPassword;
+      });
+    }
   }
 
   const videoReference = getCalVideoReference(bookingObj.references);

--- a/apps/web/modules/videos/views/videos-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.getServerSideProps.tsx
@@ -3,7 +3,7 @@ import type { GetServerSidePropsContext } from "next";
 
 import {
   generateGuestMeetingTokenFromOwnerMeetingToken,
-  hideRecordingButtonsForOrganizer,
+  setEnableRecordingUIForOrganizer,
 } from "@calcom/app-store/dailyvideo/lib/VideoApiAdapter";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getCalVideoReference } from "@calcom/features/get-cal-video-reference";
@@ -122,7 +122,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   }
   // Only for backward compatibility for organizer
   else {
-    const meetingPassword = await hideRecordingButtonsForOrganizer(
+    const meetingPassword = await setEnableRecordingUIForOrganizer(
       oldVideoReference.id,
       oldVideoReference.meetingPassword
     );

--- a/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/dailyvideo/lib/VideoApiAdapter.ts
@@ -117,7 +117,7 @@ export const generateGuestMeetingTokenFromOwnerMeetingToken = async (meetingToke
 };
 
 // Only for backward compatibility
-export const hideRecordingButtonsForOrganizer = async (
+export const setEnableRecordingUIForOrganizer = async (
   bookingReferenceId: number,
   meetingToken: string | null
 ) => {

--- a/packages/app-store/dailyvideo/lib/types.ts
+++ b/packages/app-store/dailyvideo/lib/types.ts
@@ -62,5 +62,6 @@ export const ZGetMeetingTokenResponseSchema = z
   .object({
     room_name: z.string(),
     exp: z.number(),
+    enable_recording_ui: z.boolean().optional(),
   })
   .passthrough();

--- a/packages/features/get-cal-video-reference.ts
+++ b/packages/features/get-cal-video-reference.ts
@@ -1,4 +1,5 @@
 export type Reference = {
+  id: number;
   uid: string;
   type: string;
   meetingUrl: string | null;


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/calcom/cal.com/issues/15608
- Fixes CAL-3988 (Linear issue number - should be visible at the bottom of the GitHub issue description)

Backward compatibility

- As previously created meeting token for organizer doesn't have `enable_recording_ui: false` set https://github.com/calcom/cal.com/pull/15588/files#r1657094882 so it display recording ui button as well as custom tray recording button.


https://github.com/calcom/cal.com/assets/53316345/53a65838-99ee-492c-8b4e-b0c64a730f46



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x]  N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x]  N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

