### PR TITLE
fix(@cal.com/web): update debounce logic to work correctly and not show non-premium usernames as premium

### DIFF
--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -4,7 +4,7 @@ import { debounce, noop } from "lodash";
 import { useSession } from "next-auth/react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { RefCallback } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getPremiumPlanPriceValue } from "@calcom/app-store/stripepayment/lib/utils";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -71,17 +71,13 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
   const isCurrentUsernamePremium =
     user && user.metadata && hasKeyInMetadata(user, "isPremium") ? !!user.metadata.isPremium : false;
   const [isInputUsernamePremium, setIsInputUsernamePremium] = useState(false);
-  const debouncedApiCall = useMemo(
-    () =>
-      debounce(async (username: string) => {
-        // TODO: Support orgSlug
-        const { data } = await fetchUsername(username, null);
-        setMarkAsError(!data.available && !!currentUsername && username !== currentUsername);
-        setIsInputUsernamePremium(data.premium);
-        setUsernameIsAvailable(data.available);
-      }, 150),
-    [currentUsername]
-  );
+  const debouncedApiCall = debounce(async (username: string) => {
+    // TODO: Support orgSlug
+    const { data } = await fetchUsername(username, null);
+    setMarkAsError(!data.available && !!currentUsername && username !== currentUsername);
+    setIsInputUsernamePremium(data.premium);
+    setUsernameIsAvailable(data.available);
+  }, 150);
 
   useEffect(() => {
     // Use the current username or if it's not set, use the one available from stripe
@@ -94,6 +90,9 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
       return;
     }
     debouncedApiCall(inputUsernameValue);
+
+    // cancle the debouncedApiCall when the component unmounts
+    return () => debouncedApiCall.cancel();
   }, [debouncedApiCall, inputUsernameValue]);
 
   const updateUsername = trpc.viewer.updateProfile.useMutation({

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -1,11 +1,12 @@
 import classNames from "classnames";
 // eslint-disable-next-line no-restricted-imports
-import { debounce, noop } from "lodash";
+import { noop } from "lodash";
 import { useSession } from "next-auth/react";
 import type { RefCallback } from "react";
 import { useEffect, useState } from "react";
 
 import { fetchUsername } from "@calcom/lib/fetchUsername";
+import { useDebounce } from "@calcom/lib/hooks/useDebounce";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { TRPCClientErrorLike } from "@calcom/trpc/client";
 import { trpc } from "@calcom/trpc/react";
@@ -41,29 +42,28 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
   const [markAsError, setMarkAsError] = useState(false);
   const [openDialogSaveUsername, setOpenDialogSaveUsername] = useState(false);
 
-  const debouncedApiCall = debounce(async (username) => {
-    // TODO: Support orgSlug
-    const { data } = await fetchUsername(username, null);
-    setMarkAsError(!data.available);
-    setUsernameIsAvailable(data.available);
-  }, 150);
+  // debounce the username input, set the delay to 600ms to be consistent with signup form
+  const debouncedUsername = useDebounce(inputUsernameValue, 600);
 
   useEffect(() => {
-    if (!inputUsernameValue) {
-      debouncedApiCall.cancel();
-      setUsernameIsAvailable(false);
-      setMarkAsError(false);
-      return;
+    async function checkUsername(username: string | undefined) {
+      if (!username) {
+        setUsernameIsAvailable(false);
+        setMarkAsError(false);
+        return;
+      }
+
+      if (currentUsername !== username) {
+        const { data } = await fetchUsername(username, null);
+        setMarkAsError(!data.available);
+        setUsernameIsAvailable(data.available);
+      } else {
+        setUsernameIsAvailable(false);
+      }
     }
 
-    if (currentUsername !== inputUsernameValue) {
-      debouncedApiCall(inputUsernameValue);
-    } else {
-      setUsernameIsAvailable(false);
-    }
-    // cancle the debouncedApiCall when the component unmounts
-    () => debouncedApiCall.cancel();
-  }, [inputUsernameValue, debouncedApiCall, currentUsername]);
+    checkUsername(debouncedUsername);
+  }, [debouncedUsername, currentUsername]);
 
   const updateUsernameMutation = trpc.viewer.updateProfile.useMutation({
     onSuccess: async () => {

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { debounce, noop } from "lodash";
 import { useSession } from "next-auth/react";
 import type { RefCallback } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { fetchUsername } from "@calcom/lib/fetchUsername";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -41,16 +41,12 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
   const [markAsError, setMarkAsError] = useState(false);
   const [openDialogSaveUsername, setOpenDialogSaveUsername] = useState(false);
 
-  const debouncedApiCall = useMemo(
-    () =>
-      debounce(async (username) => {
-        // TODO: Support orgSlug
-        const { data } = await fetchUsername(username, null);
-        setMarkAsError(!data.available);
-        setUsernameIsAvailable(data.available);
-      }, 150),
-    []
-  );
+  const debouncedApiCall = debounce(async (username) => {
+    // TODO: Support orgSlug
+    const { data } = await fetchUsername(username, null);
+    setMarkAsError(!data.available);
+    setUsernameIsAvailable(data.available);
+  }, 150);
 
   useEffect(() => {
     if (!inputUsernameValue) {
@@ -65,6 +61,8 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
     } else {
       setUsernameIsAvailable(false);
     }
+    // cancle the debouncedApiCall when the component unmounts
+    () => debouncedApiCall.cancel();
   }, [inputUsernameValue, debouncedApiCall, currentUsername]);
 
   const updateUsernameMutation = trpc.viewer.updateProfile.useMutation({

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -123,15 +123,8 @@ function UsernameField({
       });
     }
     checkUsername();
-  }, [
-    debouncedUsername,
-    setPremium,
-    disabled,
-    orgSlug,
-    setUsernameTaken,
-    formState.isSubmitting,
-    formState.isSubmitSuccessful,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedUsername, disabled, orgSlug, formState.isSubmitting, formState.isSubmitSuccessful]);
 
   return (
     <div>


### PR DESCRIPTION
fix(@cal.com/web): update debounce logic to work correctly and not show non-premium usernames as premium

- removes redundant useMemo hook from UsernameTextfield.tsx & PremiumTextField.tsx
- cancles the debounceAPICall on every unmount of UsernameTextfield.tsx & PremiumTextfield.tsx via useEffect cleanup function

Fixes #15628

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #15628 
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

### Video
In the video below you can see the debounce logic now works as expected and API requests to `POST /api/username` only happen when user is done typing. Towards the end of the video, I also show a comparison with cal.com/getting-started production site.

https://github.com/calcom/cal.com/assets/19223383/41e10ad4-3caa-4aff-9da9-4aeca96cb506



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No
- What are the minimal test data to have? Just the basic seed data
- What is expected (happy path) to have (input and output)? When you enter `liukang` or some non-premium username in localhost:3000/getting-started it shouldn't show an incorrect Premium state
- Any other important info that could help to test that PR - I've added the details in the Issue description of #15628 