### PR TITLE
chore: Remove dublicate object key "signing_up_terms"

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2471,7 +2471,6 @@
   "no_availability_shown_to_bookers": "If you don't assign anyone for this event, there will be no availability shown to bookers.",
   "go_back_and_assign": "Go back and Assign",
   "leave_without_assigning": "Leave without Assigning",
-  "signing_up_terms": "By proceeding, you agree to our <0>Terms</0> and <1>Privacy Policy</1>.",
   "always_show_x_days": "Always {{x}} days available",
   "unable_to_subscribe_to_the_platform": "An error occurred while trying to subscribe to the platform plan, please try again later",
   "updating_oauth_client_error": "An error occurred while updating the OAuth client, please try again later",


### PR DESCRIPTION
There is a dublicate entry for "signing_up_terms" on line 2474, and so I removed it.

## What does this PR do?

It simply removes a dublicate entry from en/common.json

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

I locally ran the code, and it works fine, I believe its a human error, and added accidentally.

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code does follow the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
