### PR TITLE
fix: passing booking id in the payload

### DIFF
--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -109,6 +109,7 @@ test.describe("Bookings", () => {
           message: "first@cal.com marked as no-show",
           attendees: [{ email: "first@cal.com", noShow: true, utcOffset: null }],
           bookingUid: bookingWhereFirstUserIsOrganizer?.uid,
+          bookingId: bookingWhereFirstUserIsOrganizer?.id,
         },
       });
       webhookReceiver.close();

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -32,6 +32,7 @@ export type WithUTCOffsetType<T> = T & {
 export type BookingNoShowUpdatedPayload = {
   message: string;
   bookingUid: string;
+  bookingId: number;
   attendees: { email: string; noShow: boolean }[];
 };
 

--- a/packages/trpc/server/routers/publicViewer/noShow.handler.ts
+++ b/packages/trpc/server/routers/publicViewer/noShow.handler.ts
@@ -104,7 +104,7 @@ export const noShowHandler = async ({ input }: NoShowOptions) => {
         // @ts-expect-error payload is too booking specific, we need to refactor this
         message: t(payload.message, { x: payload.attendees[0]?.email || "User" }),
         bookingUid,
-        bookingId: booking.id,
+        bookingId: booking?.id,
       });
       return payload;
     }

--- a/packages/trpc/server/routers/publicViewer/noShow.handler.ts
+++ b/packages/trpc/server/routers/publicViewer/noShow.handler.ts
@@ -75,6 +75,7 @@ export const noShowHandler = async ({ input }: NoShowOptions) => {
       const booking = await prisma.booking.findUnique({
         where: { uid: bookingUid },
         select: {
+          id: true,
           eventType: {
             select: {
               id: true,
@@ -103,6 +104,7 @@ export const noShowHandler = async ({ input }: NoShowOptions) => {
         // @ts-expect-error payload is too booking specific, we need to refactor this
         message: t(payload.message, { x: payload.attendees[0]?.email || "User" }),
         bookingUid,
+        bookingId: booking.id,
       });
       return payload;
     }


### PR DESCRIPTION
## What does this PR do?


- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Related to https://calcominc.slack.com/archives/C06UTF7QLU9/p1719907151496169
as we cannot fetch booking details from bookingUid

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Create an event type with "Booking No-Show Updated" webhook trigger
2) Create a booking and then mark attendee as no show.

You would get this payload

![Screenshot 2024-07-02 at 7 56 41 PM](https://github.com/calcom/cal.com/assets/53316345/4d87530a-6853-44b9-8191-5839d5bf0119)

