### PR TITLE
fix(@cal.com/web): [CAL-3992] allow users to update required name fie…

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
@@ -79,9 +79,7 @@ export const BookingFields = ({
           field.variantsConfig?.variants[field.variant].fields[1].required
         ) {
           const nameField = bookingData?.responses.name || {};
-          // @ts-expect-error the nameField is an object and it has lastName
-          // it appears that the type definition is incorrect. TODO: Fix the type definition
-          if (nameField && Object.keys(nameField).length === 2 && !nameField.lastName) {
+          if (typeof nameField === "object" && "lastName" in nameField && !nameField.lastName) {
             readOnly = false;
           }
         }


### PR DESCRIPTION
update BookingFields.tsx to allow user making the booking to update their first & last names if both were marked as "required" after the original booking

Fixes #15640

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://github.com/calcom/cal.com/issues/15640
- Fixes CAL-3992

Here's how to replicate the issue:

- Visit http://cal.com/event-types/1135?tabName=advanced
- Edit the name field to split into "First Name" and "Last Name"
- Set the "First Name" as required and "Last Name" as not required
- Go to the booking link in an incoginto tab
- Fill in the First Name, leave out the last name and make the booking
- Once the booking is done, update the setting for "Last Name" to required
- Go back to the booking page and try to reschedule
- Since the name fields are un-editable, it shows a validation error

Before Fix (Video):

https://github.com/calcom/cal.com/assets/19223383/7b07c7c6-5d5a-40a5-be3e-165422787042

To fix this,
- We check if this is a "reschedule" and not a new booking.
- If the user is rescheduling, we check if the variant is "firstAndLastName".
- If it is, we verify if the last name is required. If the last name is required and is empty:
- We set both the first and last names to empty, so the user can add them both during the booking.
- The reason we need to set both to empty is due to the onChange handler being passed into react-hook-form. If we don't set both to empty, it replaces the value with an object like { lastName: "name" }, causing the Zod validations to fail.

After Fix (Video):

https://github.com/calcom/cal.com/assets/19223383/96d18249-de5b-4e29-8fb9-07c2048b807b

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No
- What are the minimal test data to have? default data
- What is expected (happy path) to have (input and output)? The user should be able to update missing required name field
- Any other important info that could help to test that PR - NA