### PR TITLE
fix: Changing the zoom type meeting in recurring events

### DIFF
--- a/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
@@ -76,7 +76,7 @@ const ZoomVideoApiAdapter = (credential: CredentialPayload): VideoApiAdapter => 
       recurringEvent,
       startTime,
       attendees,
-    }: CalendarEvent): { recurrence: ZoomRecurrence; type: 8 } | undefined => {
+    }: CalendarEvent): { recurrence: ZoomRecurrence; type: 2 } | undefined => {
       if (!recurringEvent) {
         return;
       }


### PR DESCRIPTION
## What does this PR do?

Using type 8 creates multiple recurring zoom meetings effectively creating a new meeting for each occurrence. Changing the type to 2 will create a single meeting the right amount of occurrences. docs: https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetingCreate

- Fixes #14171
## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A-I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [X] N/A-I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
