### PR TITLE
fix: booker atom types

### DIFF
--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -380,6 +380,7 @@ export const BookerPlatformWrapper = (props: BookerPlatformWrapperAtomProps) => 
             return;
           },
           renderConfirmNotVerifyEmailButtonCond: true,
+          isVerificationCodeSending: false,
         }}
         bookerForm={bookerForm}
         event={event}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- There was a prop added to the `useVerifyEmail.ts` util file [here](https://github.com/calcom/cal.com/pull/15649/files#diff-d8cdd443610a4483db45dcc4da6a02bcff302ad6c591aea6fa1ee8646a52aedbR127) whose return type we use for the booker atom, this caused the `verifyEmail` prop in the BookerComponent to miss one that prop. For the time being I've added the prop with a default value of false.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

use the Platform Booker Atom