### PR TITLE
fix: 404s becoming 500s

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,17 +1,12 @@
-import NotFoundPage from "@pages/404";
-import { WithLayout } from "app/layoutHOC";
-import type { GetStaticPropsContext } from "next";
+import React from "react";
 
-import { getTranslations } from "@server/lib/getTranslations";
-
-const getData = async (context: GetStaticPropsContext) => {
-  const i18n = await getTranslations(context);
-
-  return {
-    i18n,
-  };
+const NotFound = () => {
+  return (
+    <div>
+      <h1>404 - Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
+    </div>
+  );
 };
 
-export const dynamic = "force-static";
-
-export default WithLayout({ getLayout: null, getData, Page: NotFoundPage });
+export default NotFound;

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const NotFound = () => {
   return (
-    <div>
+    <div data-testid="404-page">
       <h1>404 - Page Not Found</h1>
       <p>Sorry, the page you are looking for does not exist.</p>
     </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the blocker for the app router migration where 404s were turning into 500s. The error we see without this code change is `[Error]: Failed to load static file for page: /404 `

We decided to keep this for now so we can move forward and will improve the 404 experience in app router as we move forward.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Go to page that should show the 404 page (e.g. https://dev-git-fix-404-becoming-500-cal-staging.vercel.app/askdfjaksdjf) and ensure it shows the 404 page and not a 500.
