### PR TITLE
chore: add i18n to atoms

### DIFF
--- a/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
@@ -18,7 +18,7 @@ import { Toaster } from "../src/components/ui/toaster";
 import { EN } from "./CalProvider";
 import type {
   CalProviderProps,
-  CalProverLanguagesType,
+  CalProviderLanguagesType,
   translationKeys,
   enTranslationKeys,
   frTranslationKeys,
@@ -154,7 +154,7 @@ function replaceOccurrences(input: string, replacementMap: { [key: string]: stri
   });
 }
 
-function getTranslation(key: string, language: CalProverLanguagesType) {
+function getTranslation(key: string, language: CalProviderLanguagesType) {
   switch (language) {
     case "en":
       return enTranslations[key as enTranslationKeys];

--- a/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
@@ -15,19 +15,17 @@ import { useTimezone } from "../hooks/useTimezone";
 import { useUpdateUserTimezone } from "../hooks/useUpdateUserTimezone";
 import http from "../lib/http";
 import { Toaster } from "../src/components/ui/toaster";
-import type { CalProviderProps } from "./CalProvider";
-
-type enTranslationKeys = keyof typeof enTranslations;
-type frTranslationKeys = keyof typeof frTranslations;
-type deTranslationKeys = keyof typeof deTranslations;
-type esTranslationKeys = keyof typeof esTranslations;
-type ptBrTranslationKeys = keyof typeof ptBrTranslations;
-type translationKeys =
-  | enTranslationKeys
-  | frTranslationKeys
-  | deTranslationKeys
-  | esTranslationKeys
-  | ptBrTranslationKeys;
+import { EN } from "./CalProvider";
+import type {
+  CalProviderProps,
+  CalProverLanguagesType,
+  translationKeys,
+  enTranslationKeys,
+  frTranslationKeys,
+  ptBrTranslationKeys,
+  deTranslationKeys,
+  esTranslationKeys,
+} from "./CalProvider";
 
 export function BaseCalProvider({
   clientId,
@@ -36,7 +34,7 @@ export function BaseCalProvider({
   children,
   labels,
   autoUpdateTimezone,
-  language = "en",
+  language = EN,
   onTimezoneChange,
 }: CalProviderProps) {
   const [error, setError] = useState<string>("");
@@ -80,7 +78,7 @@ export function BaseCalProvider({
 
   const translations = {
     t: (key: string, values: Record<string, string | number | null | undefined>) => {
-      let translation = labels?.[key as translationKeys] ?? String(getTranslation(key, language) ?? "");
+      let translation = labels?.[key as keyof typeof labels] ?? String(getTranslation(key, language) ?? "");
       if (!translation) {
         return "";
       }
@@ -156,12 +154,12 @@ function replaceOccurrences(input: string, replacementMap: { [key: string]: stri
   });
 }
 
-function getTranslation(key: string, language: "en" | "fr" | "pt-BR" | "de" | "es") {
+function getTranslation(key: string, language: CalProverLanguagesType) {
   switch (language) {
     case "en":
       return enTranslations[key as enTranslationKeys];
     case "fr":
-      return frTranslations;
+      return frTranslations[key as frTranslationKeys];
     case "pt-BR":
       return ptBrTranslations[key as ptBrTranslationKeys];
     case "de":

--- a/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
@@ -2,7 +2,11 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { useState } from "react";
 import { useCallback } from "react";
 
+import deTranslations from "@calcom/web/public/static/locales/de/common.json";
 import enTranslations from "@calcom/web/public/static/locales/en/common.json";
+import esTranslations from "@calcom/web/public/static/locales/es/common.json";
+import frTranslations from "@calcom/web/public/static/locales/fr/common.json";
+import ptBrTranslations from "@calcom/web/public/static/locales/pt-BR/common.json";
 
 import { AtomsContext } from "../hooks/useAtomsContext";
 import { useOAuthClient } from "../hooks/useOAuthClient";
@@ -13,14 +17,26 @@ import http from "../lib/http";
 import { Toaster } from "../src/components/ui/toaster";
 import type { CalProviderProps } from "./CalProvider";
 
-type translationKeys = keyof typeof enTranslations;
+type enTranslationKeys = keyof typeof enTranslations;
+type frTranslationKeys = keyof typeof frTranslations;
+type deTranslationKeys = keyof typeof deTranslations;
+type esTranslationKeys = keyof typeof esTranslations;
+type ptBrTranslationKeys = keyof typeof ptBrTranslations;
+type translationKeys =
+  | enTranslationKeys
+  | frTranslationKeys
+  | deTranslationKeys
+  | esTranslationKeys
+  | ptBrTranslationKeys;
 
 export function BaseCalProvider({
   clientId,
   accessToken,
   options,
   children,
+  labels,
   autoUpdateTimezone,
+  language = "en",
   onTimezoneChange,
 }: CalProviderProps) {
   const [error, setError] = useState<string>("");
@@ -64,7 +80,7 @@ export function BaseCalProvider({
 
   const translations = {
     t: (key: string, values: Record<string, string | number | null | undefined>) => {
-      let translation = String(enTranslations[key as translationKeys] ?? "");
+      let translation = labels?.[key as translationKeys] ?? String(getTranslation(key, language) ?? "");
       if (!translation) {
         return "";
       }
@@ -84,9 +100,9 @@ export function BaseCalProvider({
       return replaceOccurrences(translation, enTranslations) ?? "";
     },
     i18n: {
-      language: "en",
-      defaultLocale: "en",
-      locales: ["en"],
+      language: language,
+      defaultLocale: language,
+      locales: [language],
       exists: (key: translationKeys | string) => Boolean(enTranslations[key as translationKeys]),
     },
   };
@@ -138,4 +154,21 @@ function replaceOccurrences(input: string, replacementMap: { [key: string]: stri
     // If the key is not found in the replacement map, you may choose to return the original match
     return match;
   });
+}
+
+function getTranslation(key: string, language: "en" | "fr" | "pt-BR" | "de" | "es") {
+  switch (language) {
+    case "en":
+      return enTranslations[key as enTranslationKeys];
+    case "fr":
+      return frTranslations;
+    case "pt-BR":
+      return ptBrTranslations[key as ptBrTranslationKeys];
+    case "de":
+      return deTranslations[key as deTranslationKeys];
+    case "es":
+      return esTranslations[key as esTranslationKeys];
+    default:
+      return enTranslations[key as enTranslationKeys];
+  }
 }

--- a/packages/platform/atoms/cal-provider/CalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/CalProvider.tsx
@@ -30,7 +30,7 @@ const PT_BR = "pt-BR";
 const DE = "de";
 const ES = "es";
 export const CAL_PROVIDER_LANGUAUES = [FR, EN, PT_BR, DE, ES] as const;
-export type CalProverLanguagesType = (typeof CAL_PROVIDER_LANGUAUES)[number];
+export type CalProviderLanguagesType = (typeof CAL_PROVIDER_LANGUAUES)[number];
 
 const queryClient = new QueryClient();
 

--- a/packages/platform/atoms/cal-provider/CalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/CalProvider.tsx
@@ -3,9 +3,12 @@ import { useEffect, type ReactNode } from "react";
 
 import type { API_VERSIONS_ENUM } from "@calcom/platform-constants";
 import { VERSION_2024_06_14 } from "@calcom/platform-constants";
+import type enTranslations from "@calcom/web/public/static/locales/en/common.json";
 
 import http from "../lib/http";
 import { BaseCalProvider } from "./BaseCalProvider";
+
+type translationKeys = keyof typeof enTranslations;
 
 const queryClient = new QueryClient();
 
@@ -17,6 +20,8 @@ export type CalProviderProps = {
   autoUpdateTimezone?: boolean;
   onTimezoneChange?: () => void;
   version?: API_VERSIONS_ENUM;
+  labels?: Record<translationKeys, string>;
+  language?: "en" | "fr" | "pt-BR" | "de" | "es";
 };
 
 /**
@@ -39,6 +44,8 @@ export function CalProvider({
   options,
   children,
   autoUpdateTimezone = true,
+  labels,
+  language = "en",
   onTimezoneChange,
   version = VERSION_2024_06_14,
 }: CalProviderProps) {
@@ -60,7 +67,9 @@ export function CalProvider({
         clientId={clientId}
         accessToken={accessToken}
         options={options}
-        version={version}>
+        version={version}
+        labels={labels}
+        language={language}>
         {children}
       </BaseCalProvider>
     </QueryClientProvider>

--- a/packages/platform/atoms/cal-provider/CalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/CalProvider.tsx
@@ -3,14 +3,63 @@ import { useEffect, type ReactNode } from "react";
 
 import type { API_VERSIONS_ENUM } from "@calcom/platform-constants";
 import { VERSION_2024_06_14 } from "@calcom/platform-constants";
+import type deTranslations from "@calcom/web/public/static/locales/de/common.json";
 import type enTranslations from "@calcom/web/public/static/locales/en/common.json";
+import type esTranslations from "@calcom/web/public/static/locales/es/common.json";
+import type frTranslations from "@calcom/web/public/static/locales/fr/common.json";
+import type ptBrTranslations from "@calcom/web/public/static/locales/pt-BR/common.json";
 
 import http from "../lib/http";
 import { BaseCalProvider } from "./BaseCalProvider";
 
-type translationKeys = keyof typeof enTranslations;
+export type enTranslationKeys = keyof typeof enTranslations;
+export type frTranslationKeys = keyof typeof frTranslations;
+export type deTranslationKeys = keyof typeof deTranslations;
+export type esTranslationKeys = keyof typeof esTranslations;
+export type ptBrTranslationKeys = keyof typeof ptBrTranslations;
+export type translationKeys =
+  | enTranslationKeys
+  | frTranslationKeys
+  | deTranslationKeys
+  | esTranslationKeys
+  | ptBrTranslationKeys;
+
+const FR = "fr";
+export const EN = "en";
+const PT_BR = "pt-BR";
+const DE = "de";
+const ES = "es";
+export const CAL_PROVIDER_LANGUAUES = [FR, EN, PT_BR, DE, ES] as const;
+export type CalProverLanguagesType = (typeof CAL_PROVIDER_LANGUAUES)[number];
 
 const queryClient = new QueryClient();
+
+type i18nFrProps = {
+  labels?: Partial<Record<frTranslationKeys, string>>;
+  language?: "fr";
+};
+
+type i18nEnProps = {
+  labels?: Partial<Record<enTranslationKeys, string>>;
+  language?: "en";
+};
+
+type i18nPtBrProps = {
+  labels?: Partial<Record<ptBrTranslationKeys, string>>;
+  language?: "pt-BR";
+};
+
+type i18nDeProps = {
+  labels?: Partial<Record<deTranslationKeys, string>>;
+  language?: "de";
+};
+
+type i18nEsProps = {
+  labels?: Partial<Record<esTranslationKeys, string>>;
+  language?: "es";
+};
+
+export type i18nProps = i18nFrProps | i18nEnProps | i18nPtBrProps | i18nDeProps | i18nEsProps;
 
 export type CalProviderProps = {
   children?: ReactNode;
@@ -20,9 +69,7 @@ export type CalProviderProps = {
   autoUpdateTimezone?: boolean;
   onTimezoneChange?: () => void;
   version?: API_VERSIONS_ENUM;
-  labels?: Record<translationKeys, string>;
-  language?: "en" | "fr" | "pt-BR" | "de" | "es";
-};
+} & i18nProps;
 
 /**
  * Renders a CalProvider component.
@@ -68,7 +115,7 @@ export function CalProvider({
         accessToken={accessToken}
         options={options}
         version={version}
-        labels={labels}
+        labels={labels as Record<translationKeys, string>}
         language={language}>
         {children}
       </BaseCalProvider>

--- a/packages/platform/atoms/hooks/useAtomsContext.ts
+++ b/packages/platform/atoms/hooks/useAtomsContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { translationKeys, CalProverLanguagesType } from "../cal-provider/CalProvider.tsx";
+import type { translationKeys, CalProverLanguagesType } from "../cal-provider/CalProvider";
 import type http from "../lib/http";
 
 export interface IAtomsContextOptions {

--- a/packages/platform/atoms/hooks/useAtomsContext.ts
+++ b/packages/platform/atoms/hooks/useAtomsContext.ts
@@ -1,10 +1,8 @@
+import type { translationKeys, CalProverLanguagesType } from "cal-provider/CalProvider";
 import { createContext, useContext } from "react";
-
-import type enTranslations from "@calcom/web/public/static/locales/en/common.json";
 
 import type http from "../lib/http";
 
-type translationKeys = keyof typeof enTranslations;
 export interface IAtomsContextOptions {
   refreshUrl?: string;
   apiUrl: string;
@@ -23,9 +21,9 @@ export interface IAtomsContext {
   isInit: boolean;
   t: (key: string, values: Record<string, string | number | undefined | null>) => string;
   i18n: {
-    language: string;
-    defaultLocale: string;
-    locales: string[];
+    language: CalProverLanguagesType;
+    defaultLocale: CalProverLanguagesType;
+    locales: CalProverLanguagesType[];
     exists: (key: translationKeys | string) => boolean;
   };
 }

--- a/packages/platform/atoms/hooks/useAtomsContext.ts
+++ b/packages/platform/atoms/hooks/useAtomsContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { translationKeys, CalProverLanguagesType } from "../cal-provider/CalProvider";
+import type { translationKeys, CalProviderLanguagesType } from "../cal-provider/CalProvider";
 import type http from "../lib/http";
 
 export interface IAtomsContextOptions {
@@ -21,9 +21,9 @@ export interface IAtomsContext {
   isInit: boolean;
   t: (key: string, values: Record<string, string | number | undefined | null>) => string;
   i18n: {
-    language: CalProverLanguagesType;
-    defaultLocale: CalProverLanguagesType;
-    locales: CalProverLanguagesType[];
+    language: CalProviderLanguagesType;
+    defaultLocale: CalProviderLanguagesType;
+    locales: CalProviderLanguagesType[];
     exists: (key: translationKeys | string) => boolean;
   };
 }

--- a/packages/platform/atoms/hooks/useAtomsContext.ts
+++ b/packages/platform/atoms/hooks/useAtomsContext.ts
@@ -1,6 +1,6 @@
-import type { translationKeys, CalProverLanguagesType } from "cal-provider/CalProvider";
 import { createContext, useContext } from "react";
 
+import type { translationKeys, CalProverLanguagesType } from "../cal-provider/CalProvider.tsx";
 import type http from "../lib/http";
 
 export interface IAtomsContextOptions {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adding i18n to platform atoms (es, fr, de, en, pt-BR)


<img width="483" alt="Screenshot 2024-07-09 at 11 08 05" src="https://github.com/calcom/cal.com/assets/33722304/371c7310-51d4-4640-9060-4024e15fcb6d">

<img width="669" alt="Screenshot 2024-07-09 at 11 08 20" src="https://github.com/calcom/cal.com/assets/33722304/1cabb8bf-c354-42d7-8ad4-a59e576089bc">

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
