### PR TITLE
fix: Enable embed namespacing again

### DIFF
--- a/apps/web/components/eventtype/EventTypeSingleLayout.tsx
+++ b/apps/web/components/eventtype/EventTypeSingleLayout.tsx
@@ -390,7 +390,7 @@ function EventTypeSingleLayout({
                   StartIcon="code"
                   color="secondary"
                   variant="icon"
-                  namespace=""
+                  namespace={eventType.slug}
                   tooltip={t("embed")}
                   tooltipSide="bottom"
                   tooltipOffset={4}

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -530,7 +530,7 @@ export const EventTypeList = ({
                               {!isManagedEventType && (
                                 <DropdownMenuItem className="outline-none">
                                   <EventTypeEmbedButton
-                                    namespace=""
+                                    namespace={type.slug}
                                     as={DropdownItem}
                                     type="button"
                                     StartIcon="code"


### PR DESCRIPTION
Re-enables embed namespacing that was [disabled here](https://github.com/calcom/cal.com/pull/13637) due to some bugs.
[Those bugs are now fixed](https://github.com/calcom/cal.com/pull/13386)

Embed namespacing is required so that users can install multiple embeds on same page 