### PR TITLE
chore: specify platform-libraries version for event-types

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
@@ -9,8 +9,8 @@ import { UsersService } from "@/modules/users/services/users.service";
 import { UserWithProfile, UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 
-import { createEventType, updateEventType } from "@calcom/platform-libraries";
-import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries";
+import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.18";
+import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries-0.0.18";
 import { dynamicEvent } from "@calcom/platform-libraries-0.0.18";
 import {
   CreateEventTypeInput_2024_06_14,


### PR DESCRIPTION
Specify specific platform-libraries version in the latest event-types module.

e2e tests for the modified module pass:

```
npx jest apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts --config jest-e2e.json
```