### PR TITLE
chore: add platform-libraries change log

### DIFF
--- a/packages/platform/libraries/CHANGELOG.md
+++ b/packages/platform/libraries/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.19
+Added - create event type handler was [updated](https://github.com/calcom/cal.com/pull/15774) for system admins not to be required
+to be part of org team when creating event type for team. Update libraries to include these changes.


### PR DESCRIPTION
Document why do we re-publish platform libraries - was one of the libraries functions updated, changed or something new was added?