### PR TITLE
docs(contributing): change fork link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ branch are tagged into a release monthly.
 
 To develop locally:
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your
+1. [Fork](https://github.com/calcom/cal.com/fork/) this repository to your
    own GitHub account and then
    [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 2. Create a new branch:


### PR DESCRIPTION
## What does this PR do?

Was just getting started on another contributing and clicked the fork link, expecting it to take me to the fork page for the repository, but it instead took me to the docs on how to fork.

This change should reduce the friction for contributing.

I assume this wasn't initially done because someone didn't know the fork page existed? Not sure. If there's a different reason, feel free to close this pull request.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A (I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

All checked!