### PR TITLE
fix: booker readded border

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -279,7 +279,7 @@ const BookerComponent = ({
             (layout === BookerLayouts.MONTH_VIEW || isEmbed) && "border-subtle rounded-md",
             !isEmbed && "sm:transition-[width] sm:duration-300",
             isEmbed && layout === BookerLayouts.MONTH_VIEW && "border-booker sm:border-booker-width",
-            !isEmbed && layout === BookerLayouts.MONTH_VIEW && `border-subtle`,
+            !isEmbed && layout === BookerLayouts.MONTH_VIEW && `border-subtle border`,
             `${customClassNames?.bookerContainer}`
           )}>
           <AnimatePresence>


### PR DESCRIPTION
before

<img width="1125" alt="CleanShot 2024-07-16 at 14 47 04@2x" src="https://github.com/user-attachments/assets/6ee20029-66ed-4c19-8a04-3eebe074b152">


after 

<img width="1105" alt="CleanShot 2024-07-16 at 14 47 20@2x" src="https://github.com/user-attachments/assets/96dbfb18-c62f-4b91-abc5-31e2fa52a77f">


<sub>[CAL-4046](https://linear.app/calcom/issue/CAL-4046/border-missing)</sub>