### PR TITLE
fix: remove permission blocking public apiv2 event-types endpoint

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -77,7 +77,6 @@ export class EventTypesController_2024_06_14 {
   }
 
   @Get("/")
-  @Permissions([EVENT_TYPE_READ])
   async getEventTypes(
     @Query() queryParams: GetEventTypesQuery_2024_06_14
   ): Promise<GetEventTypesOutput_2024_06_14> {


### PR DESCRIPTION
## What does this PR do?

Fix: Permission guard blocking fetching public event-types data on api v2 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

yarn test:e2e event-types.controller.e2e-spec.ts

