### PR TITLE
fix: findOrgUser use profiles instead of organizationId apiv2

### DIFF
--- a/apps/api/v2/src/modules/organizations/organizations.repository.ts
+++ b/apps/api/v2/src/modules/organizations/organizations.repository.ts
@@ -74,7 +74,11 @@ export class OrganizationsRepository {
     return this.dbRead.prisma.user.findUnique({
       where: {
         id: userId,
-        organizationId,
+        profiles: {
+          some: {
+            organizationId,
+          },
+        },
       },
     });
   }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

findOrgUser in organizationRepository was using depecated field User.organizationId, now using org profile

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
yarn test:e2e