### PR TITLE
refactor: auto-accept membership for v2 org team creator

### DIFF
--- a/apps/api/v2/src/modules/memberships/memberships.repository.ts
+++ b/apps/api/v2/src/modules/memberships/memberships.repository.ts
@@ -50,12 +50,13 @@ export class MembershipsRepository {
     return !!adminMembership;
   }
 
-  async createMembership(teamId: number, userId: number, role: MembershipRole) {
+  async createMembership(teamId: number, userId: number, role: MembershipRole, accepted: boolean) {
     const membership = await this.dbRead.prisma.membership.create({
       data: {
         role,
         teamId,
         userId,
+        accepted,
       },
     });
 

--- a/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
+++ b/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
@@ -29,7 +29,7 @@ export class OrganizationsTeamsService {
   async createOrgTeam(organizationId: number, data: CreateOrgTeamDto, user: UserWithProfile) {
     const team = await this.organizationsTeamRepository.createOrgTeam(organizationId, data);
     if (user.role !== "ADMIN") {
-      await this.membershipsRepository.createMembership(team.id, user.id, "OWNER");
+      await this.membershipsRepository.createMembership(team.id, user.id, "OWNER", true);
     }
     return team;
   }


### PR DESCRIPTION
If a person creates a team in v2 orgs, then auto accept the membership, because otherwise the admin needs to accept it manually before being able to, for example, create v2 org event-types.

Tests pass:
```
npx jest src/modules/organizations/controllers/teams/organizations-teams.controller.e2e-spec.ts --config jest-e2e.json
```