### PR TITLE
test: test cases for POST selected-calendars

### DIFF
--- a/apps/api/v1/test/lib/selected-calendars/_post.test.ts
+++ b/apps/api/v1/test/lib/selected-calendars/_post.test.ts
@@ -1,0 +1,122 @@
+import prismaMock from "../../../../../../tests/libs/__mocks__/prismaMock";
+
+import type { Request, Response } from "express";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { describe, expect, test } from "vitest";
+
+import { HttpError } from "@calcom/lib/http-error";
+
+import handler from "../../../pages/api/selected-calendars/_post";
+
+type CustomNextApiRequest = NextApiRequest & Request;
+type CustomNextApiResponse = NextApiResponse & Response;
+
+describe("POST /api/selected-calendars", () => {
+  describe("Errors", () => {
+    test("Returns 403 if non-admin user tries to set userId in body", async () => {
+      const { req, res } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
+        method: "POST",
+        body: {
+          integration: "google",
+          externalId: "ext123",
+          userId: 444444,
+        },
+      });
+
+      req.userId = 333333;
+      req.isSystemWideAdmin = false;
+      try {
+        await handler(req, res);
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpError);
+        expect((e as HttpError).statusCode).toBe(403);
+        expect((e as HttpError).message).toBe("ADMIN required for userId");
+      }
+    });
+
+    test("Returns 400 if request body is invalid", async () => {
+      const { req, res } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
+        method: "POST",
+        body: {
+          integration: "google",
+        },
+      });
+
+      req.userId = 333333;
+      req.isSystemWideAdmin = true;
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData()).message).toBe("invalid_type in 'externalId': Required");
+    });
+  });
+
+  describe("Success", () => {
+    test("Creates selected calendar if user is admin and sets bodyUserId", async () => {
+      const { req, res } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
+        method: "POST",
+        query: {
+          apiKey: "validApiKey",
+        },
+        body: {
+          integration: "google",
+          externalId: "ext123",
+          userId: 444444,
+        },
+      });
+
+      req.userId = 333333;
+      req.isSystemWideAdmin = true;
+
+      prismaMock.user.findFirstOrThrow.mockResolvedValue({
+        id: 444444,
+      } as any);
+
+      prismaMock.selectedCalendar.create.mockResolvedValue({
+        credentialId: 1,
+        integration: "google",
+        externalId: "ext123",
+        userId: 444444,
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.selected_calendar.credentialId).toBe(1);
+      expect(responseData.message).toBe("Selected Calendar created successfully");
+    });
+
+    test("Creates selected calendar if user is non-admin and does not set bodyUserId", async () => {
+      const { req, res } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
+        method: "POST",
+        query: {
+          apiKey: "validApiKey",
+        },
+        body: {
+          integration: "google",
+          externalId: "ext123",
+        },
+      });
+
+      req.userId = 333333;
+      req.isSystemWideAdmin = false;
+
+      prismaMock.selectedCalendar.create.mockResolvedValue({
+        credentialId: 1,
+        integration: "google",
+        externalId: "ext123",
+        userId: 333333,
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.selected_calendar.credentialId).toBe(1);
+      expect(responseData.message).toBe("Selected Calendar created successfully");
+    });
+  });
+});

--- a/apps/api/v1/test/lib/selected-calendars/_post.test.ts
+++ b/apps/api/v1/test/lib/selected-calendars/_post.test.ts
@@ -25,7 +25,7 @@ describe("POST /api/selected-calendars", () => {
       });
 
       req.userId = 333333;
-      req.isSystemWideAdmin = false;
+
       try {
         await handler(req, res);
       } catch (e) {
@@ -102,7 +102,6 @@ describe("POST /api/selected-calendars", () => {
       });
 
       req.userId = 333333;
-      req.isSystemWideAdmin = false;
 
       prismaMock.selectedCalendar.create.mockResolvedValue({
         credentialId: 1,


### PR DESCRIPTION
## What does this PR do?


This PR adds unit tests for the POST /api/selected-calendars endpoint. It tests various scenarios including:

- Non-admin users trying to set `userId` in the body.
- Invalid request body scenarios.
- Successful creation of selected calendars for both admin and non-admin users.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


1. Run the unit tests added in this PR to verify different scenarios for the POST /api/selected-calendars endpoint.
2. Ensure that the Prisma mock functions correctly simulate database interactions.
3. Check for proper error handling when a non-admin user attempts to set `userId` in the request body.
4. Validate that a 400 status code is returned for invalid request bodies.
5. Confirm that the selected calendar is created successfully for both admin and non-admin users under the correct conditions.

- Are there environment variables that should be set?
  No additional environment variables are required for these tests.
- What are the minimal test data to have?
  Ensure that mock data is in place for user and selected calendar entities.
- What is expected (happy path) to have (input and output)?
  For valid requests, the endpoint should create a selected calendar and return a 200 status code with the expected response data.
- Any other important info that could help to test that PR
  Make sure to run the tests in an environment where the Prisma client is properly mocked.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
