### PR TITLE
fix: Incorrect app store url in event type page

### DIFF
--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -246,7 +246,9 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                 <p className="text-default text-sm">
                   <Trans i18nKey="cant_find_the_right_video_app_visit_our_app_store">
                     Can&apos;t find the right video app? Visit our
-                    <Link className="cursor-pointer text-blue-500 underline" href="/apps/categories/video">
+                    <Link
+                      className="cursor-pointer text-blue-500 underline"
+                      href="/apps/categories/conferencing">
                       App Store
                     </Link>
                     .


### PR DESCRIPTION
## What does this PR do?
Changed the link to the app store in event type page point from /apps/categories/video to apps/categories/conferencing
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #15811 
- Fixes CAL-4063

/claim #15811

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Go to event page
- Scroll to the "Location" section
- The correct app store link will be apps/categories/conferencing.

## Checklist