### PR TITLE
refactor: v2 organizations event-types e2e tests

### DIFF
--- a/apps/api/v2/src/modules/organizations/controllers/event-types/organizations-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/controllers/event-types/organizations-event-types.e2e-spec.ts
@@ -489,21 +489,26 @@ describe("Organizations Event Types Endpoints", () => {
           );
 
           expect(teammate1EventTypes.length).toEqual(1);
+          expect(teammate1EventTypes[0].title).toEqual(newTitle);
           expect(teammate2EventTypes.length).toEqual(0);
           expect(managedTeamEventTypes.length).toEqual(1);
           expect(managedTeamEventTypes[0].assignAllTeamMembers).toEqual(false);
-
-          const responseTeamEvent = responseBody.data[0];
-          expect(responseTeamEvent.title).toEqual(newTitle);
-          expect(responseTeamEvent.assignAllTeamMembers).toEqual(false);
-
-          const responseTeammate1Event = responseBody.data[1];
-          expect(responseTeammate1Event.title).toEqual(newTitle);
-
-          expect(teammate1EventTypes[0].title).toEqual(newTitle);
           expect(
             teamEventTypes.filter((eventType) => eventType.schedulingType === "MANAGED")?.[0]?.title
           ).toEqual(newTitle);
+
+          const responseTeamEvent = responseBody.data.find(
+            (eventType) => eventType.schedulingType === "MANAGED"
+          );
+          expect(responseTeamEvent).toBeDefined();
+          expect(responseTeamEvent?.title).toEqual(newTitle);
+          expect(responseTeamEvent?.assignAllTeamMembers).toEqual(false);
+
+          const responseTeammate1Event = responseBody.data.find(
+            (eventType) => eventType.ownerId === teammate1.id
+          );
+          expect(responseTeammate1Event).toBeDefined();
+          expect(responseTeammate1Event?.title).toEqual(newTitle);
 
           managedEventType = responseBody.data[0];
         });
@@ -537,19 +542,28 @@ describe("Organizations Event Types Endpoints", () => {
           expect(managedTeamEventTypes.length).toEqual(1);
           expect(managedTeamEventTypes[0].assignAllTeamMembers).toEqual(true);
 
-          const responseTeamEvent = responseBody.data[0];
+          const responseTeamEvent = responseBody.data.find(
+            (eventType) => eventType.schedulingType === "MANAGED"
+          );
+          expect(responseTeamEvent).toBeDefined();
           expect(responseTeamEvent?.teamId).toEqual(team.id);
-          expect(responseTeamEvent.assignAllTeamMembers).toEqual(true);
+          expect(responseTeamEvent?.assignAllTeamMembers).toEqual(true);
 
-          const responseTeammate1Event = responseBody.data[1];
-          expect(responseTeammate1Event?.ownerId).toEqual(teammate1.id);
+          const responseTeammate1Event = responseBody.data.find(
+            (eventType) => eventType.ownerId === teammate1.id
+          );
+          expect(responseTeammate1Event).toBeDefined();
           expect(responseTeammate1Event?.parentEventTypeId).toEqual(responseTeamEvent?.id);
 
-          const responseTeammate2Event = responseBody.data[2];
-          expect(responseTeammate2Event?.ownerId).toEqual(teammate2.id);
+          const responseTeammate2Event = responseBody.data.find(
+            (eventType) => eventType.ownerId === teammate2.id
+          );
+          expect(responseTeammate1Event).toBeDefined();
           expect(responseTeammate2Event?.parentEventTypeId).toEqual(responseTeamEvent?.id);
 
-          managedEventType = responseTeamEvent;
+          if (responseTeamEvent) {
+            managedEventType = responseTeamEvent;
+          }
         });
     });
 


### PR DESCRIPTION
Instead of relying on acessing an array of response event-types using index, use `.find`