### PR TITLE
fix: type in webhook payload

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -270,7 +270,7 @@ async function handler(req: CustomRequest) {
 
   const evt: CalendarEvent = {
     title: bookingToDelete?.title,
-    type: bookingToDelete?.eventType?.title as string,
+    type: bookingToDelete?.eventType?.slug as string,
     description: bookingToDelete?.description || "",
     customInputs: isPrismaObjOrUndefined(bookingToDelete.customInputs),
     eventTypeId: bookingToDelete.eventTypeId as number,

--- a/packages/trpc/server/routers/viewer/payments.tsx
+++ b/packages/trpc/server/routers/viewer/payments.tsx
@@ -77,7 +77,7 @@ export const paymentsRouter = router({
       const attendeesList = await Promise.all(attendeesListPromises);
 
       const evt: CalendarEvent = {
-        type: (booking?.eventType?.title as string) || booking?.title,
+        type: booking?.eventType?.slug as string,
         title: booking.title,
         startTime: dayjs(booking.startTime).format(),
         endTime: dayjs(booking.endTime).format(),


### PR DESCRIPTION
## What does this PR do?

`type` in the webhook payload should be the event type slug not title. 