### PR TITLE
feat: add row click to open slideover

### DIFF
--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -323,6 +323,19 @@ export function UserListTable() {
   return (
     <>
       <DataTable
+        onRowMouseclick={(row) => {
+          const user = row.original;
+          const canEdit = adminOrOwner;
+          if (canEdit) {
+            dispatch({
+              type: "EDIT_USER_SHEET",
+              payload: {
+                showModal: true,
+                user,
+              },
+            });
+          }
+        }}
         data-testId="user-list-data-table"
         onSearch={(value) => setDebouncedSearchTerm(value)}
         selectionOptions={[


### PR DESCRIPTION
## What does this PR do?

Adds a onclick handler to row in organizations so we can show off the slider over easier without it being nested.

![CleanShot 2024-07-31 at 10 31 29](https://github.com/user-attachments/assets/c0061b7e-7ff5-4da6-95c8-8e7aadca1cc6)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Click a row in organizations/members 
