### PR TITLE
revert: "fix: meeting link is not updated and broken ui in edit location dialog"

### DIFF
--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -261,7 +261,7 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
             {booking && (
               <>
                 <p className="text-emphasis mb-2 ml-1 mt-6 text-sm font-bold">{t("current_location")}:</p>
-                <p className="text-emphasis mb-2 ml-1 break-all text-sm">
+                <p className="text-emphasis mb-2 ml-1 text-sm">
                   {getHumanReadableLocationValue(booking.location, t)}
                 </p>
               </>

--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -832,6 +832,8 @@ test.describe("Text area min and max characters text", () => {
       // wait until the button with data-testid="time" is visible
       await page.locator('[data-testid="time"]').isVisible();
 
+      await page.getByTestId("incrementMonth").click();
+
       // Get first button with data-testid="time"
       const timeButton = page.locator('[data-testid="time"]').first();
       await timeButton.click();
@@ -845,6 +847,8 @@ test.describe("Text area min and max characters text", () => {
 
       // Get button with data-testid="confirm-book-button"
       const submitForm = async () => await page.locator('[data-testid="confirm-book-button"]').click();
+      await page.fill('[name="name"]', "Booker");
+      await page.fill('[name="email"]', "booker@example.com");
       await textAreaWithoutMinMax.fill("1234567890");
       await textAreaWithMin5.fill("1234");
       await textAreaWithMax10.fill("12345678901");

--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -832,8 +832,6 @@ test.describe("Text area min and max characters text", () => {
       // wait until the button with data-testid="time" is visible
       await page.locator('[data-testid="time"]').isVisible();
 
-      await page.getByTestId("incrementMonth").click();
-
       // Get first button with data-testid="time"
       const timeButton = page.locator('[data-testid="time"]').first();
       await timeButton.click();
@@ -847,8 +845,6 @@ test.describe("Text area min and max characters text", () => {
 
       // Get button with data-testid="confirm-book-button"
       const submitForm = async () => await page.locator('[data-testid="confirm-book-button"]').click();
-      await page.fill('[name="name"]', "Booker");
-      await page.fill('[name="email"]', "booker@example.com");
       await textAreaWithoutMinMax.fill("1234567890");
       await textAreaWithMin5.fill("1234");
       await textAreaWithMax10.fill("12345678901");

--- a/packages/trpc/server/routers/viewer/bookings/editLocation.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/editLocation.handler.ts
@@ -118,12 +118,6 @@ export const editLocationHandler = async ({ ctx, input }: EditLocationOptions) =
         },
         data: {
           location,
-          metadata: location.startsWith("http")
-            ? {
-                ...(typeof booking.metadata === "object" ? booking.metadata : {}),
-                videoCallUrl: location,
-              }
-            : {},
           references: {
             create: updatedResult.referencesToCreate,
           },


### PR DESCRIPTION
Reverts calcom/cal.com#15503

> this PR shouldn't have been merged yet. Will revert. Unless I'm missing more context if we have a location that doesn't start with "https" It will wipe out all existing booking metadata.
> 
> <img width="1007" alt="image" src="https://github.com/user-attachments/assets/ec1f939a-bd6c-45e6-8e8b-b71d82e82e5a">

_Originally posted by @zomars in https://github.com/calcom/cal.com/issues/15503#issuecomment-2261247253_
            