### PR TITLE
fix: typo in license service + move to a noop

### DIFF
--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -30,7 +30,8 @@ class LicenseKeyService implements ILicenseKeyService {
   // Static async factory method
   public static async create(): Promise<ILicenseKeyService> {
     const licenseKey = await getDeploymentKey(prisma);
-    return licenseKey ? new LicenseKeyService(licenseKey) : new NoopLicenseKeyService();
+    const useNoop = !licenseKey || process.env.NEXT_PUBLIC_IS_E2E;
+    return !useNoop ? new LicenseKeyService(licenseKey) : new NoopLicenseKeyService();
   }
 
   private async fetcher({

--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -107,7 +107,7 @@ export class NoopLicenseKeyService implements ILicenseKeyService {
   }
 
   async checkLicense(): Promise<boolean> {
-    return Promise.resolve(false);
+    return Promise.resolve(process.env.NEXT_PUBLIC_IS_E2E === "1");
   }
 }
 

--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -85,7 +85,7 @@ class LicenseKeyService {
     try {
       const response = await this.fetcher({ url, options: { mode: "cors" } });
       const data = await response.json();
-      cache.put(url, data.stauts, this.CACHING_TIME);
+      cache.put(url, data.status, this.CACHING_TIME);
       return data.status;
     } catch (error) {
       console.error("Check license failed:", error);

--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -106,7 +106,6 @@ export class NoopLicenseKeyService implements ILicenseKeyService {
   }
 
   async checkLicense(): Promise<boolean> {
-    // Always return true for NOOP
     return Promise.resolve(false);
   }
 }

--- a/packages/features/ee/common/server/LicenseKeyService.ts
+++ b/packages/features/ee/common/server/LicenseKeyService.ts
@@ -30,7 +30,7 @@ class LicenseKeyService implements ILicenseKeyService {
   // Static async factory method
   public static async create(): Promise<ILicenseKeyService> {
     const licenseKey = await getDeploymentKey(prisma);
-    const useNoop = !licenseKey || process.env.NEXT_PUBLIC_IS_E2E;
+    const useNoop = !licenseKey || process.env.NEXT_PUBLIC_IS_E2E === "1";
     return !useNoop ? new LicenseKeyService(licenseKey) : new NoopLicenseKeyService();
   }
 


### PR DESCRIPTION
We were having an issue in CI where if a license key wasnt set it'd always throw an error about calcom signature. 

Now we use an NOOP to skip these license checks as we already know the value is false without a license key present