### PR TITLE
fix: hide org upgrade banner for platform orgs

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/checkIfOrgNeedsUpgrade.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/checkIfOrgNeedsUpgrade.handler.ts
@@ -22,6 +22,7 @@ export async function checkIfOrgNeedsUpgradeHandler({ ctx }: GetUpgradeableOptio
       },
       role: MembershipRole.OWNER,
       team: {
+        isPlatform: false,
         parentId: null, // Since ORGS relay on their parent's subscription, we don't need to return them
       },
     },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Org Upgrade banner being displayed for platform orgs when it should never 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Create platform org and go on main dashboard
