### PR TITLE
fix: platform orgs shouldn't have org redirect

### DIFF
--- a/packages/lib/createAProfileForAnExistingUser.ts
+++ b/packages/lib/createAProfileForAnExistingUser.ts
@@ -57,7 +57,12 @@ export const createAProfileForAnExistingUser = async ({
 
   const orgUrl = getOrgFullOrigin(orgSlug);
 
-  if (!org.isPlatform && user.currentUsername) {
+  if (org.isPlatform) {
+    // We don't want redirects for Platform Organizations
+    return;
+  }
+
+  if (user.currentUsername) {
     log.debug(`Creating redirect for user ${user.currentUsername} to ${orgUrl}/${usernameInOrg}`);
     await prisma.tempOrgRedirect.upsert({
       where: {

--- a/packages/lib/createAProfileForAnExistingUser.ts
+++ b/packages/lib/createAProfileForAnExistingUser.ts
@@ -57,7 +57,7 @@ export const createAProfileForAnExistingUser = async ({
 
   const orgUrl = getOrgFullOrigin(orgSlug);
 
-  if (user.currentUsername) {
+  if (!org.isPlatform && user.currentUsername) {
     log.debug(`Creating redirect for user ${user.currentUsername} to ${orgUrl}/${usernameInOrg}`);
     await prisma.tempOrgRedirect.upsert({
       where: {

--- a/packages/lib/createAProfileForAnExistingUser.ts
+++ b/packages/lib/createAProfileForAnExistingUser.ts
@@ -59,7 +59,7 @@ export const createAProfileForAnExistingUser = async ({
 
   if (org.isPlatform) {
     // We don't want redirects for Platform Organizations
-    return;
+    return profile;
   }
 
   if (user.currentUsername) {

--- a/packages/lib/server/repository/team.ts
+++ b/packages/lib/server/repository/team.ts
@@ -162,6 +162,7 @@ const teamSelect = Prisma.validator<Prisma.TeamSelect>()({
   metadata: true,
   isOrganization: true,
   organizationSettings: true,
+  isPlatform: true,
 });
 
 export class TeamRepository {


### PR DESCRIPTION
## What does this PR do?

creating a platform org blocking access to user public page

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

create a platform org and try to access public page using org slug
