### PR TITLE
fix: ssr translation on no-meeting, signup pages [CAL-3880]

### DIFF
--- a/apps/web/pages/video/no-meeting-found.tsx
+++ b/apps/web/pages/video/no-meeting-found.tsx
@@ -1,6 +1,19 @@
+import type { GetServerSidePropsContext } from "next";
+
 import PageWrapper, { type CalPageWrapper } from "@components/PageWrapper";
 
+import { ssrInit } from "@server/lib/ssr";
+
 import NoMeetingFound from "~/videos/views/videos-no-meeting-found-single-view";
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const ssr = await ssrInit(context);
+  return {
+    props: {
+      trpcState: ssr.dehydrate(),
+    },
+  };
+};
 
 const NoMeetingFoundPage = NoMeetingFound as unknown as CalPageWrapper;
 


### PR DESCRIPTION
## What does this PR do?
Adds missing `ssrInit()` functions to load server side translations
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #15354 (GitHub issue number)
- Fixes CAL-3880 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Visit /video/no-meeting-found or /signup, the pages will serve translated responses

/claim #15354