### PR TITLE
fix: Broken reschedule page for migrated user's booking through request-reschedule

### DIFF
--- a/apps/web/pages/reschedule/[uid].tsx
+++ b/apps/web/pages/reschedule/[uid].tsx
@@ -16,6 +16,16 @@ export default function Type() {
   return null;
 }
 
+const querySchema = z.object({
+  uid: z.string(),
+  seatReferenceUid: z.string().optional(),
+  rescheduledBy: z.string().optional(),
+  allowRescheduleForCancelledBooking: z
+    .string()
+    .transform((value) => value === "true")
+    .optional(),
+});
+
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const session = await getServerSession(context);
 
@@ -27,17 +37,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
      * This is for the case of request-reschedule where the booking is cancelled
      */
     allowRescheduleForCancelledBooking,
-  } = z
-    .object({
-      uid: z.string(),
-      seatReferenceUid: z.string().optional(),
-      rescheduledBy: z.string().optional(),
-      allowRescheduleForCancelledBooking: z
-        .string()
-        .transform((value) => value === "true")
-        .optional(),
-    })
-    .parse(context.query);
+  } = querySchema.parse(context.query);
+
   const coepFlag = context.query["flag.coep"];
   const { uid, seatReferenceUid: maybeSeatReferenceUid } = await maybeGetBookingUidFromSeat(
     prisma,

--- a/apps/web/test/utils/bookingScenario/bookingScenario.ts
+++ b/apps/web/test/utils/bookingScenario/bookingScenario.ts
@@ -34,7 +34,7 @@ import type { EventBusyDate, IntervalLimit } from "@calcom/types/Calendar";
 import { getMockPaymentService } from "./MockPaymentService";
 import type { getMockRequestDataForBooking } from "./getMockRequestDataForBooking";
 
-logger.settings.minLevel = 0;
+logger.settings.minLevel = 1;
 const log = logger.getSubLogger({ prefix: ["[bookingScenario]"] });
 
 type InputWebhook = {

--- a/apps/web/test/utils/bookingScenario/expects.ts
+++ b/apps/web/test/utils/bookingScenario/expects.ts
@@ -143,10 +143,9 @@ expect.extend({
 
     if (!isEmailContentMatched) {
       logger.silly("All Emails", JSON.stringify({ numEmails: emailsToLog.length, emailsToLog }));
-
       return {
         pass: false,
-        message: () => `Email content ${isNot ? "is" : "is not"} matching. ${JSON.stringify(emailsToLog)}`,
+        message: () => `Email content ${isNot ? "is" : "is not"} matching.`,
         actual: actualEmailContent,
         expected: expectedEmailContent,
       };
@@ -818,8 +817,6 @@ export function expectBookingRequestRescheduledEmails({
   loggedInUser,
   booker,
   booking,
-  bookNewTimePath,
-  organizer,
 }: {
   emails: Fixtures["emails"];
   organizer: ReturnType<typeof getOrganizer>;
@@ -840,7 +837,7 @@ export function expectBookingRequestRescheduledEmails({
       subHeading: "request_reschedule_subtitle",
       links: [
         {
-          href: `${bookingUrlOrigin}${bookNewTimePath}?rescheduleUid=${booking.uid}`,
+          href: `${bookingUrlOrigin}/reschedule/${booking.uid}?allowRescheduleForCancelledBooking=true`,
           text: "Book a new time",
         },
       ],

--- a/packages/core/builders/CalendarEvent/builder.ts
+++ b/packages/core/builders/CalendarEvent/builder.ts
@@ -1,10 +1,9 @@
-import type { Booking } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 
 import dayjs from "@calcom/dayjs";
-import { WEBAPP_URL } from "@calcom/lib/constants";
+import { getRescheduleLink } from "@calcom/lib/CalEventParser";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { getTranslation } from "@calcom/lib/server/i18n";
@@ -238,32 +237,16 @@ export class CalendarEventBuilder implements ICalendarEventBuilder {
     }
   }
 
-  public buildRescheduleLink(booking: Partial<Booking>, eventType?: CalendarEventBuilder["eventType"]) {
+  public buildRescheduleLink({
+    allowRescheduleForCancelledBooking = false,
+  }: {
+    allowRescheduleForCancelledBooking?: boolean;
+  }) {
     try {
-      if (!booking) {
-        throw new Error("Parameter booking is required to build reschedule link");
-      }
-      const isTeam = !!eventType && !!eventType.teamId;
-      const isDynamic = booking?.dynamicEventSlugRef && booking?.dynamicGroupSlugRef;
-
-      let slug = "";
-      if (isTeam && eventType?.team?.slug) {
-        slug = `team/${eventType.team?.slug}/${eventType.slug}`;
-      } else if (isDynamic) {
-        const dynamicSlug = isDynamic ? `${booking.dynamicGroupSlugRef}/${booking.dynamicEventSlugRef}` : "";
-        slug = dynamicSlug;
-      } else if (eventType?.slug) {
-        slug = `${this.users[0].username}/${eventType.slug}`;
-      }
-
-      const queryParams = new URLSearchParams();
-      queryParams.set("rescheduleUid", `${booking.uid}`);
-      slug = `${slug}`;
-
-      const rescheduleLink = `${
-        this.calendarEvent.bookerUrl ?? WEBAPP_URL
-      }/${slug}?${queryParams.toString()}`;
-      this.rescheduleLink = rescheduleLink;
+      this.rescheduleLink = getRescheduleLink({
+        calEvent: this.calendarEvent,
+        allowRescheduleForCancelledBooking,
+      });
     } catch (error) {
       if (error instanceof Error) {
         throw new Error(`buildRescheduleLink.error: ${error.message}`);

--- a/packages/core/builders/CalendarEvent/builder.ts
+++ b/packages/core/builders/CalendarEvent/builder.ts
@@ -241,7 +241,7 @@ export class CalendarEventBuilder implements ICalendarEventBuilder {
     allowRescheduleForCancelledBooking = false,
   }: {
     allowRescheduleForCancelledBooking?: boolean;
-  }) {
+  } = {}) {
     try {
       this.rescheduleLink = getRescheduleLink({
         calEvent: this.calendarEvent,

--- a/packages/core/builders/CalendarEvent/director.ts
+++ b/packages/core/builders/CalendarEvent/director.ts
@@ -72,7 +72,7 @@ export class CalendarEventDirector {
       this.builder.setUId(this.existingBooking.uid);
       this.builder.setCancellationReason(this.cancellationReason);
       this.builder.setDescription(this.existingBooking.description);
-      await this.builder.buildRescheduleLink(this.existingBooking);
+      await this.builder.buildRescheduleLink({ calEvent: this.existingBooking });
     } else {
       throw new Error("buildWithoutEventTypeForRescheduleEmail.missing.params.required");
     }

--- a/packages/core/builders/CalendarEvent/director.ts
+++ b/packages/core/builders/CalendarEvent/director.ts
@@ -44,7 +44,7 @@ export class CalendarEventDirector {
      * By default we don't want to allow reschedule for cancelled bookings.
      */
     allowRescheduleForCancelledBooking?: boolean;
-  }): Promise<void> {
+  } = {}): Promise<void> {
     if (this.existingBooking && this.existingBooking.eventTypeId && this.existingBooking.uid) {
       await this.builder.buildEventObjectFromInnerClass(this.existingBooking.eventTypeId);
       await this.builder.buildUsersFromInnerClass();

--- a/packages/core/builders/CalendarEvent/director.ts
+++ b/packages/core/builders/CalendarEvent/director.ts
@@ -72,7 +72,7 @@ export class CalendarEventDirector {
       this.builder.setUId(this.existingBooking.uid);
       this.builder.setCancellationReason(this.cancellationReason);
       this.builder.setDescription(this.existingBooking.description);
-      await this.builder.buildRescheduleLink({ calEvent: this.existingBooking });
+      await this.builder.buildRescheduleLink();
     } else {
       throw new Error("buildWithoutEventTypeForRescheduleEmail.missing.params.required");
     }

--- a/packages/core/builders/CalendarEvent/director.ts
+++ b/packages/core/builders/CalendarEvent/director.ts
@@ -37,7 +37,14 @@ export class CalendarEventDirector {
     this.cancellationReason = reason;
   }
 
-  public async buildForRescheduleEmail(): Promise<void> {
+  public async buildForRescheduleEmail({
+    allowRescheduleForCancelledBooking = false,
+  }: {
+    /**
+     * By default we don't want to allow reschedule for cancelled bookings.
+     */
+    allowRescheduleForCancelledBooking?: boolean;
+  }): Promise<void> {
     if (this.existingBooking && this.existingBooking.eventTypeId && this.existingBooking.uid) {
       await this.builder.buildEventObjectFromInnerClass(this.existingBooking.eventTypeId);
       await this.builder.buildUsersFromInnerClass();
@@ -47,7 +54,7 @@ export class CalendarEventDirector {
       this.builder.setCancellationReason(this.cancellationReason);
       this.builder.setDescription(this.builder.eventType.description);
       this.builder.setNotes(this.existingBooking.description);
-      this.builder.buildRescheduleLink(this.existingBooking, this.builder.eventType);
+      this.builder.buildRescheduleLink({ allowRescheduleForCancelledBooking });
       log.debug(
         "buildForRescheduleEmail",
         safeStringify({ existingBooking: this.existingBooking, builder: this.builder })

--- a/packages/emails/src/components/ManageLink.tsx
+++ b/packages/emails/src/components/ManageLink.tsx
@@ -6,7 +6,7 @@ export function ManageLink(props: { calEvent: CalendarEvent; attendee: Person })
   // Guests cannot
   const t = props.attendee.language.translate;
   const cancelLink = getCancelLink(props.calEvent, props.attendee);
-  const rescheduleLink = getRescheduleLink(props.calEvent, props.attendee);
+  const rescheduleLink = getRescheduleLink({ calEvent: props.calEvent, attendee: props.attendee });
   const bookingLink = getBookingUrl(props.calEvent);
 
   const isOriginalAttendee = props.attendee.email === props.calEvent.attendees[0]?.email;

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -183,7 +183,7 @@ export const getPlatformManageLink = (calEvent: CalendarEvent, t: TFunction) => 
   if (!calEvent.recurringEvent && calEvent.platformRescheduleUrl) {
     res += `${calEvent.platformCancelUrl ? ` ${t("or_lowercase")} ` : ""}${t(
       "reschedule"
-    )}: ${getRescheduleLink(calEvent)}`;
+    )}: ${getRescheduleLink({ calEvent })}`;
   }
 
   return res;
@@ -252,7 +252,15 @@ export const getPlatformRescheduleLink = (
   return "";
 };
 
-export const getRescheduleLink = (calEvent: CalendarEvent, attendee?: Person): string => {
+export const getRescheduleLink = ({
+  calEvent,
+  allowRescheduleForCancelledBooking = false,
+  attendee,
+}: {
+  calEvent: CalendarEvent;
+  allowRescheduleForCancelledBooking?: boolean;
+  attendee?: Person;
+}): string => {
   const Uid = getUid(calEvent);
   const seatUid = getSeatReferenceId(calEvent);
 
@@ -260,13 +268,15 @@ export const getRescheduleLink = (calEvent: CalendarEvent, attendee?: Person): s
     return getPlatformRescheduleLink(calEvent, Uid, seatUid);
   }
 
-  const rescheduleLink = new URL(`${calEvent.bookerUrl ?? WEBAPP_URL}/reschedule/${seatUid ? seatUid : Uid}`);
-
+  const url = new URL(`${calEvent.bookerUrl ?? WEBAPP_URL}/reschedule/${seatUid ? seatUid : Uid}`);
+  if (allowRescheduleForCancelledBooking) {
+    url.searchParams.append("allowRescheduleForCancelledBooking", "true");
+  }
   if (attendee?.email) {
-    rescheduleLink.searchParams.append("rescheduledBy", attendee.email);
+    url.searchParams.append("rescheduledBy", attendee.email);
   }
 
-  return rescheduleLink.toString();
+  return url.toString();
 };
 
 export const getRichDescription = (

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -58,8 +58,6 @@ model Host {
   @@index([eventTypeId])
 }
 
-
-
 model EventType {
   id          Int     @id @default(autoincrement())
   /// @zod.min(1)

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -58,6 +58,8 @@ model Host {
   @@index([eventTypeId])
 }
 
+
+
 model EventType {
   id          Int     @id @default(autoincrement())
   /// @zod.min(1)

--- a/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/requestReschedule.handler.ts
@@ -205,7 +205,8 @@ export const requestRescheduleHandler = async ({ ctx, input }: RequestReschedule
   director.setExistingBooking(bookingToReschedule);
   cancellationReason && director.setCancellationReason(cancellationReason);
   if (Object.keys(event).length) {
-    await director.buildForRescheduleEmail();
+    // Request Reschedule flow first cancels the booking and then reschedule email is sent. So, we need to allow reschedule for cancelled booking
+    await director.buildForRescheduleEmail({ allowRescheduleForCancelledBooking: true });
   } else {
     await director.buildWithoutEventTypeForRescheduleEmail();
   }


### PR DESCRIPTION
## What does this PR do?

Fixes one more case for the problem handled by #15736.
Request Reschedule email wasn't even using /reschedule/[uid] endpoint causing the fix to not work there.

This PR now ensures that request-reschedule email has /reschedule/[uid] link for reschedule instead of generating the entire bookingLink with rescheduleUid

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

