### PR TITLE
fix: remove row on click for data-table

### DIFF
--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -327,13 +327,13 @@ export function UserListTable() {
           const user = row.original;
           const canEdit = adminOrOwner;
           if (canEdit) {
-            dispatch({
-              type: "EDIT_USER_SHEET",
-              payload: {
-                showModal: true,
-                user,
-              },
-            });
+            // dispatch({
+            //   type: "EDIT_USER_SHEET",
+            //   payload: {
+            //     showModal: true,
+            //     user,
+            //   },
+            // });
           }
         }}
         data-testid="user-list-data-table"


### PR DESCRIPTION
Removes opening the sheet for now as the event propigates and prevents any other event from happening. 

Invite members or impersonation.

