### PR TITLE
fix: uncaught errors in sendPayload

### DIFF
--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -1,4 +1,4 @@
-import type { Webhook } from "@prisma/client";
+import type { Payment, Webhook } from "@prisma/client";
 import { createHmac } from "crypto";
 import { compile } from "handlebars";
 
@@ -60,6 +60,7 @@ export type WebhookDataType = CalendarEvent &
     createdAt: string;
     downloadLink?: string;
     paymentId?: number;
+    paymentData?: Payment;
   };
 
 function addUTCOffset(


### PR DESCRIPTION
## What does this PR do?

Follow up to #15929

This pull request adds missing payment typings data in the webhook payload.

### What changed?

- Modified `sendPayload.ts` to import the `Payment` type from `@prisma/client`.
- Updated the `WebhookDataType` to include an optional `paymentData` field.

### How to test?

1. Trigger a webhook event that includes payment data.
2. Verify that the payload includes the new `paymentData` field with the correct information.

---

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
