### PR TITLE
fix: ensures tRPC definitions are built before starting dev scripts

### DIFF
--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "build": "yarn trpc:generate || true",
+    "dev": "yarn build",
+    "dx": "yarn build",
     "trpc:generate": "yarn tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -128,11 +128,11 @@
       "outputs": ["dist/**", "build/**"]
     },
     "dev": {
-      "dependsOn": ["//#env-check:common", "//#env-check:app-store"],
+      "dependsOn": ["//#env-check:common", "//#env-check:app-store", "^dev"],
       "cache": false
     },
     "dx": {
-      "dependsOn": ["//#env-check:common", "//#env-check:app-store"],
+      "dependsOn": ["//#env-check:common", "//#env-check:app-store", "^dx"],
       "cache": false
     },
     "lint": {


### PR DESCRIPTION
## What does this PR do?

Follow up to #15929

Added `dev` and `dx` commands to `package.json` for the `trpc` package and updated dependencies in `turbo.json`.

### What changed?

- Added `dev` and `dx` commands in `packages/trpc/package.json` for better development and DX workflows.
- Updated `turbo.json` to include new `dev` and `dx` commands in the dependencies.

### How to test?

1. Run `yarn dev` and `yarn dx` in the `packages/trpc` directory to ensure they execute correctly.
2. Verify that `turbo` tasks run as expected with the new dependencies.

### Why make this change?

To streamline the development workflow and improve developer experience by adding commonly used `dev` and `dx` commands.

---

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
