### PR TITLE
fix: display skeleton loader

### DIFF
--- a/apps/web/components/eventtype/SkeletonLoader.tsx
+++ b/apps/web/components/eventtype/SkeletonLoader.tsx
@@ -22,6 +22,18 @@ function SkeletonLoader() {
 
 export default SkeletonLoader;
 
+export function InfiniteSkeletonLoader() {
+  return (
+    <SkeletonContainer>
+      <ul className="border-subtle bg-default divide-subtle divide-y rounded-md border sm:mx-0 sm:overflow-hidden">
+        <SkeletonItem />
+        <SkeletonItem />
+        <SkeletonItem />
+      </ul>
+    </SkeletonContainer>
+  );
+}
+
 function SkeletonItem() {
   return (
     <li className="group flex w-full items-center justify-between px-4 py-4 sm:px-6">

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -64,7 +64,7 @@ import type { AppProps } from "@lib/app-providers";
 import { useInViewObserver } from "@lib/hooks/useInViewObserver";
 import useMeQuery from "@lib/hooks/useMeQuery";
 
-import SkeletonLoader from "@components/eventtype/SkeletonLoader";
+import SkeletonLoader, { InfiniteSkeletonLoader } from "@components/eventtype/SkeletonLoader";
 
 type GetUserEventGroupsResponse = RouterOutputs["viewer"]["eventTypes"]["getUserEventGroups"];
 type GetEventTypesFromGroupsResponse = RouterOutputs["viewer"]["eventTypes"]["getEventTypesFromGroup"];
@@ -968,7 +968,7 @@ export const InfiniteEventTypeList = ({
   }, []);
 
   if (!pages?.[0]?.eventTypes?.length) {
-    if (isPending) return <SkeletonLoader />;
+    if (isPending) return <InfiniteSkeletonLoader />;
 
     return group.teamId ? (
       <EmptyEventTypeList group={group} />
@@ -1575,7 +1575,7 @@ const InfiniteScrollMain = ({
   }
 
   if (!eventTypeGroups || !profiles || status === "pending") {
-    return <SkeletonLoader />;
+    return <InfiniteSkeletonLoader />;
   }
 
   const tabs = eventTypeGroups.map((item) => ({

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -105,6 +105,7 @@ interface InfiniteEventTypeListProps {
   bookerUrl: string | null;
   pages: { nextCursor: number | undefined; eventTypes: InfiniteEventType[] }[] | undefined;
   lockedByOrg?: boolean;
+  isPending?: boolean;
 }
 
 interface EventTypeListProps {
@@ -186,6 +187,7 @@ const InfiniteMobileTeamsTab: FC<InfiniteMobileTeamsTabProps> = (props) => {
           group={activeEventTypeGroup}
           bookerUrl={activeEventTypeGroup.bookerUrl}
           readOnly={activeEventTypeGroup.metadata.readOnly}
+          isPending={query.isPending}
         />
       )}
       <div className="text-default p-4 text-center" ref={buttonInView.ref}>
@@ -785,6 +787,7 @@ export const InfiniteEventTypeList = ({
   pages,
   bookerUrl,
   lockedByOrg,
+  isPending,
 }: InfiniteEventTypeListProps): JSX.Element => {
   const { t } = useLocale();
   const router = useRouter();
@@ -965,6 +968,8 @@ export const InfiniteEventTypeList = ({
   }, []);
 
   if (!pages?.[0]?.eventTypes?.length) {
+    if (isPending) return <SkeletonLoader />;
+
     return group.teamId ? (
       <EmptyEventTypeList group={group} />
     ) : !group.profile.eventTypesLockedByOrg ? (


### PR DESCRIPTION
## What does this PR do?


- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

When infinite scrolling enabled instead of displaying skeleton loader when event types query was loading we were displaying "team or user has no event types"

AFTER:-

https://github.com/user-attachments/assets/b1e5b1b9-22d6-4604-bf1e-c773f66bb302



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


## Checklist

