### PR TITLE
fix: v2 event-types & MS outlook event description

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@calcom/platform-constants": "*",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
-    "@calcom/platform-libraries-0.0.23": "npm:@calcom/platform-libraries@0.0.23",
+    "@calcom/platform-libraries-0.0.25": "npm:@calcom/platform-libraries@0.0.25",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@calcom/platform-constants": "*",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
-    "@calcom/platform-libraries-0.0.25": "npm:@calcom/platform-libraries@0.0.25",
+    "@calcom/platform-libraries-0.0.26": "npm:@calcom/platform-libraries@0.0.26",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/src/ee/bookings/controllers/bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/controllers/bookings.controller.e2e-spec.ts
@@ -20,7 +20,7 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 import { withApiAuth } from "test/utils/withApiAuth";
 
 import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
-import { handleNewBooking } from "@calcom/platform-libraries-0.0.25";
+import { handleNewBooking } from "@calcom/platform-libraries-0.0.26";
 import { ApiSuccessResponse, ApiResponse } from "@calcom/platform-types";
 
 describe("Bookings Endpoints", () => {

--- a/apps/api/v2/src/ee/bookings/controllers/bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/controllers/bookings.controller.e2e-spec.ts
@@ -20,7 +20,7 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 import { withApiAuth } from "test/utils/withApiAuth";
 
 import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
-import { handleNewBooking } from "@calcom/platform-libraries-0.0.23";
+import { handleNewBooking } from "@calcom/platform-libraries-0.0.25";
 import { ApiSuccessResponse, ApiResponse } from "@calcom/platform-types";
 
 describe("Bookings Endpoints", () => {

--- a/apps/api/v2/src/ee/bookings/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/controllers/bookings.controller.ts
@@ -46,7 +46,7 @@ import {
   getBookingInfo,
   handleCancelBooking,
   getBookingForReschedule,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { GetBookingsInput, CancelBookingInput, Status } from "@calcom/platform-types";
 import { ApiResponse } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";

--- a/apps/api/v2/src/ee/bookings/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/controllers/bookings.controller.ts
@@ -46,7 +46,7 @@ import {
   getBookingInfo,
   handleCancelBooking,
   getBookingForReschedule,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { GetBookingsInput, CancelBookingInput, Status } from "@calcom/platform-types";
 import { ApiResponse } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";

--- a/apps/api/v2/src/ee/bookings/inputs/create-recurring-booking.input.ts
+++ b/apps/api/v2/src/ee/bookings/inputs/create-recurring-booking.input.ts
@@ -1,7 +1,7 @@
 import { CreateBookingInput } from "@/ee/bookings/inputs/create-booking.input";
 import { IsBoolean, IsNumber, IsOptional } from "class-validator";
 
-import type { AppsStatus } from "@calcom/platform-libraries-0.0.23";
+import type { AppsStatus } from "@calcom/platform-libraries-0.0.25";
 
 export class CreateRecurringBookingInput extends CreateBookingInput {
   @IsBoolean()

--- a/apps/api/v2/src/ee/bookings/inputs/create-recurring-booking.input.ts
+++ b/apps/api/v2/src/ee/bookings/inputs/create-recurring-booking.input.ts
@@ -1,7 +1,7 @@
 import { CreateBookingInput } from "@/ee/bookings/inputs/create-booking.input";
 import { IsBoolean, IsNumber, IsOptional } from "class-validator";
 
-import type { AppsStatus } from "@calcom/platform-libraries-0.0.25";
+import type { AppsStatus } from "@calcom/platform-libraries-0.0.26";
 
 export class CreateRecurringBookingInput extends CreateBookingInput {
   @IsBoolean()

--- a/apps/api/v2/src/ee/calendars/services/apple-calendar.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/apple-calendar.service.ts
@@ -5,7 +5,7 @@ import { BadRequestException, UnauthorizedException } from "@nestjs/common";
 import { Injectable } from "@nestjs/common";
 
 import { SUCCESS_STATUS, APPLE_CALENDAR_TYPE, APPLE_CALENDAR_ID } from "@calcom/platform-constants";
-import { symmetricEncrypt, CalendarService } from "@calcom/platform-libraries-0.0.25";
+import { symmetricEncrypt, CalendarService } from "@calcom/platform-libraries-0.0.26";
 
 @Injectable()
 export class AppleCalendarService implements CredentialSyncCalendarApp {

--- a/apps/api/v2/src/ee/calendars/services/apple-calendar.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/apple-calendar.service.ts
@@ -5,7 +5,7 @@ import { BadRequestException, UnauthorizedException } from "@nestjs/common";
 import { Injectable } from "@nestjs/common";
 
 import { SUCCESS_STATUS, APPLE_CALENDAR_TYPE, APPLE_CALENDAR_ID } from "@calcom/platform-constants";
-import { symmetricEncrypt, CalendarService } from "@calcom/platform-libraries-0.0.23";
+import { symmetricEncrypt, CalendarService } from "@calcom/platform-libraries-0.0.25";
 
 @Injectable()
 export class AppleCalendarService implements CredentialSyncCalendarApp {

--- a/apps/api/v2/src/ee/calendars/services/calendars.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/calendars.service.ts
@@ -18,7 +18,7 @@ import { User } from "@prisma/client";
 import { DateTime } from "luxon";
 import { z } from "zod";
 
-import { getConnectedDestinationCalendars, getBusyCalendarTimes } from "@calcom/platform-libraries-0.0.23";
+import { getConnectedDestinationCalendars, getBusyCalendarTimes } from "@calcom/platform-libraries-0.0.25";
 import { Calendar } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";
 

--- a/apps/api/v2/src/ee/calendars/services/calendars.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/calendars.service.ts
@@ -18,7 +18,7 @@ import { User } from "@prisma/client";
 import { DateTime } from "luxon";
 import { z } from "zod";
 
-import { getConnectedDestinationCalendars, getBusyCalendarTimes } from "@calcom/platform-libraries-0.0.25";
+import { getConnectedDestinationCalendars, getBusyCalendarTimes } from "@calcom/platform-libraries-0.0.26";
 import { Calendar } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
@@ -35,7 +35,7 @@ import {
   EventTypesPublic,
   eventTypeBookingFields,
   eventTypeLocations,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { ApiSuccessResponse } from "@calcom/platform-types";
 
 describe("Event types Endpoints", () => {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/controllers/event-types.controller.e2e-spec.ts
@@ -35,7 +35,7 @@ import {
   EventTypesPublic,
   eventTypeBookingFields,
   eventTypeLocations,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { ApiSuccessResponse } from "@calcom/platform-types";
 
 describe("Event types Endpoints", () => {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
@@ -4,7 +4,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
 
-import { getEventTypeById } from "@calcom/platform-libraries-0.0.25";
+import { getEventTypeById } from "@calcom/platform-libraries-0.0.26";
 import type { PrismaClient } from "@calcom/prisma";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
@@ -4,7 +4,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
 
-import { getEventTypeById } from "@calcom/platform-libraries-0.0.23";
+import { getEventTypeById } from "@calcom/platform-libraries-0.0.25";
 import type { PrismaClient } from "@calcom/prisma";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
@@ -14,7 +14,7 @@ import {
   updateEventType,
   EventTypesPublic,
   getEventTypesPublic,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { EventType } from "@calcom/prisma/client";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
@@ -14,7 +14,7 @@ import {
   updateEventType,
   EventTypesPublic,
   getEventTypesPublic,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { EventType } from "@calcom/prisma/client";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
@@ -7,7 +7,7 @@ import {
   getEventTypeById,
   transformApiEventTypeBookingFields,
   transformApiEventTypeLocations,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { CreateEventTypeInput_2024_06_14 } from "@calcom/platform-types";
 import type { PrismaClient } from "@calcom/prisma";
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/event-types.repository.ts
@@ -7,7 +7,7 @@ import {
   getEventTypeById,
   transformApiEventTypeBookingFields,
   transformApiEventTypeLocations,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { CreateEventTypeInput_2024_06_14 } from "@calcom/platform-types";
 import type { PrismaClient } from "@calcom/prisma";
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
@@ -10,9 +10,9 @@ import { UsersService } from "@/modules/users/services/users.service";
 import { UserWithProfile, UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 
-import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.23";
-import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries-0.0.23";
-import { dynamicEvent } from "@calcom/platform-libraries-0.0.23";
+import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.25";
+import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries-0.0.25";
+import { dynamicEvent } from "@calcom/platform-libraries-0.0.25";
 import {
   CreateEventTypeInput_2024_06_14,
   UpdateEventTypeInput_2024_06_14,

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
@@ -10,9 +10,9 @@ import { UsersService } from "@/modules/users/services/users.service";
 import { UserWithProfile, UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 
-import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.25";
-import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries-0.0.25";
-import { dynamicEvent } from "@calcom/platform-libraries-0.0.25";
+import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.26";
+import { getEventTypesPublic, EventTypesPublic } from "@calcom/platform-libraries-0.0.26";
+import { dynamicEvent } from "@calcom/platform-libraries-0.0.26";
 import {
   CreateEventTypeInput_2024_06_14,
   UpdateEventTypeInput_2024_06_14,

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import {
   transformApiEventTypeBookingFields,
   transformApiEventTypeLocations,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { CreateEventTypeInput_2024_06_14, UpdateEventTypeInput_2024_06_14 } from "@calcom/platform-types";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import {
   transformApiEventTypeBookingFields,
   transformApiEventTypeLocations,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { CreateEventTypeInput_2024_06_14, UpdateEventTypeInput_2024_06_14 } from "@calcom/platform-types";
 
 @Injectable()

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -9,7 +9,9 @@ import {
   parseRecurringEvent,
   TransformedLocationsSchema,
   BookingFieldsSchema,
-} from "@calcom/platform-libraries-0.0.23";
+  SystemField,
+  UserField,
+} from "@calcom/platform-libraries-0.0.25";
 
 type EventTypeRelations = { users: User[]; schedule: Schedule | null };
 type DatabaseEventType = EventType & EventTypeRelations;
@@ -72,7 +74,9 @@ export class OutputEventTypesService_2024_06_14 {
     } = databaseEventType;
 
     const locations = this.transformLocations(databaseEventType.locations);
-    const bookingFields = this.transformBookingFields(databaseEventType.bookingFields);
+    const bookingFields = databaseEventType.bookingFields
+      ? this.transformBookingFields(BookingFieldsSchema.parse(databaseEventType.bookingFields))
+      : [];
     const recurringEvent = this.transformRecurringEvent(databaseEventType.recurringEvent);
     const metadata = this.transformMetadata(databaseEventType.metadata) || {};
     const users = this.transformUsers(databaseEventType.users);
@@ -113,9 +117,10 @@ export class OutputEventTypesService_2024_06_14 {
     return getResponseEventTypeLocations(TransformedLocationsSchema.parse(locations));
   }
 
-  transformBookingFields(inputBookingFields: any) {
+  transformBookingFields(inputBookingFields: (SystemField | UserField)[] | null) {
     if (!inputBookingFields) return [];
-    return getResponseEventTypeBookingFields(BookingFieldsSchema.parse(inputBookingFields));
+    const userFields = inputBookingFields.filter((field) => field.editable === "user") as UserField[];
+    return getResponseEventTypeBookingFields(userFields);
   }
 
   transformRecurringEvent(recurringEvent: any) {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -11,7 +11,7 @@ import {
   BookingFieldsSchema,
   SystemField,
   UserField,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 
 type EventTypeRelations = { users: User[]; schedule: Schedule | null };
 type DatabaseEventType = EventType & EventTypeRelations;

--- a/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/input-schedules.service.ts
+++ b/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/input-schedules.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import {
   transformApiScheduleOverrides,
   transformApiScheduleAvailability,
-} from "@calcom/platform-libraries-0.0.23";
+} from "@calcom/platform-libraries-0.0.25";
 import { CreateScheduleInput_2024_06_11, ScheduleAvailabilityInput_2024_06_11 } from "@calcom/platform-types";
 import { ScheduleOverrideInput_2024_06_11 } from "@calcom/platform-types";
 

--- a/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/input-schedules.service.ts
+++ b/apps/api/v2/src/ee/schedules/schedules_2024_06_11/services/input-schedules.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import {
   transformApiScheduleOverrides,
   transformApiScheduleAvailability,
-} from "@calcom/platform-libraries-0.0.25";
+} from "@calcom/platform-libraries-0.0.26";
 import { CreateScheduleInput_2024_06_11, ScheduleAvailabilityInput_2024_06_11 } from "@calcom/platform-types";
 import { ScheduleOverrideInput_2024_06_11 } from "@calcom/platform-types";
 

--- a/apps/api/v2/src/filters/trpc-exception.filter.ts
+++ b/apps/api/v2/src/filters/trpc-exception.filter.ts
@@ -2,7 +2,7 @@ import { ArgumentsHost, Catch, ExceptionFilter, Logger } from "@nestjs/common";
 import { Request } from "express";
 
 import { ERROR_STATUS } from "@calcom/platform-constants";
-import { TRPCError } from "@calcom/platform-libraries-0.0.23";
+import { TRPCError } from "@calcom/platform-libraries-0.0.25";
 import { Response } from "@calcom/platform-types";
 
 @Catch(TRPCError)

--- a/apps/api/v2/src/filters/trpc-exception.filter.ts
+++ b/apps/api/v2/src/filters/trpc-exception.filter.ts
@@ -2,7 +2,7 @@ import { ArgumentsHost, Catch, ExceptionFilter, Logger } from "@nestjs/common";
 import { Request } from "express";
 
 import { ERROR_STATUS } from "@calcom/platform-constants";
-import { TRPCError } from "@calcom/platform-libraries-0.0.25";
+import { TRPCError } from "@calcom/platform-libraries-0.0.26";
 import { Response } from "@calcom/platform-types";
 
 @Catch(TRPCError)

--- a/apps/api/v2/src/modules/email/email.service.ts
+++ b/apps/api/v2/src/modules/email/email.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
-import { sendSignupToOrganizationEmail, getTranslation } from "@calcom/platform-libraries-0.0.23";
+import { sendSignupToOrganizationEmail, getTranslation } from "@calcom/platform-libraries-0.0.25";
 
 @Injectable()
 export class EmailService {

--- a/apps/api/v2/src/modules/email/email.service.ts
+++ b/apps/api/v2/src/modules/email/email.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
-import { sendSignupToOrganizationEmail, getTranslation } from "@calcom/platform-libraries-0.0.25";
+import { sendSignupToOrganizationEmail, getTranslation } from "@calcom/platform-libraries-0.0.26";
 
 @Injectable()
 export class EmailService {

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -8,7 +8,7 @@ import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { User } from "@prisma/client";
 
-import { createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries-0.0.23";
+import { createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries-0.0.25";
 
 @Injectable()
 export class OAuthClientUsersService {

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -8,7 +8,7 @@ import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { User } from "@prisma/client";
 
-import { createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries-0.0.25";
+import { createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries-0.0.26";
 
 @Injectable()
 export class OAuthClientUsersService {

--- a/apps/api/v2/src/modules/organizations/services/event-types/organizations-event-types.service.ts
+++ b/apps/api/v2/src/modules/organizations/services/event-types/organizations-event-types.service.ts
@@ -9,7 +9,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable, NotFoundException } from "@nestjs/common";
 
-import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.25";
+import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.26";
 import {
   CreateTeamEventTypeInput_2024_06_14,
   UpdateTeamEventTypeInput_2024_06_14,

--- a/apps/api/v2/src/modules/organizations/services/event-types/organizations-event-types.service.ts
+++ b/apps/api/v2/src/modules/organizations/services/event-types/organizations-event-types.service.ts
@@ -9,7 +9,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable, NotFoundException } from "@nestjs/common";
 
-import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.23";
+import { createEventType, updateEventType } from "@calcom/platform-libraries-0.0.25";
 import {
   CreateTeamEventTypeInput_2024_06_14,
   UpdateTeamEventTypeInput_2024_06_14,

--- a/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
+++ b/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
@@ -5,7 +5,7 @@ import { OrganizationsTeamsRepository } from "@/modules/organizations/repositori
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
 
-import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries-0.0.25";
+import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries-0.0.26";
 
 @Injectable()
 export class OrganizationsTeamsService {

--- a/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
+++ b/apps/api/v2/src/modules/organizations/services/organizations-teams.service.ts
@@ -5,7 +5,7 @@ import { OrganizationsTeamsRepository } from "@/modules/organizations/repositori
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
 
-import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries-0.0.23";
+import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries-0.0.25";
 
 @Injectable()
 export class OrganizationsTeamsService {

--- a/apps/api/v2/src/modules/organizations/services/organizations-users-service.ts
+++ b/apps/api/v2/src/modules/organizations/services/organizations-users-service.ts
@@ -7,7 +7,7 @@ import { CreateUserInput } from "@/modules/users/inputs/create-user.input";
 import { Injectable, ConflictException } from "@nestjs/common";
 import { plainToInstance } from "class-transformer";
 
-import { createNewUsersConnectToOrgIfExists } from "@calcom/platform-libraries-0.0.23";
+import { createNewUsersConnectToOrgIfExists } from "@calcom/platform-libraries-0.0.25";
 import { Team } from "@calcom/prisma/client";
 
 @Injectable()

--- a/apps/api/v2/src/modules/organizations/services/organizations-users-service.ts
+++ b/apps/api/v2/src/modules/organizations/services/organizations-users-service.ts
@@ -7,7 +7,7 @@ import { CreateUserInput } from "@/modules/users/inputs/create-user.input";
 import { Injectable, ConflictException } from "@nestjs/common";
 import { plainToInstance } from "class-transformer";
 
-import { createNewUsersConnectToOrgIfExists } from "@calcom/platform-libraries-0.0.25";
+import { createNewUsersConnectToOrgIfExists } from "@calcom/platform-libraries-0.0.26";
 import { Team } from "@calcom/prisma/client";
 
 @Injectable()

--- a/apps/api/v2/src/modules/slots/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/controllers/slots.controller.ts
@@ -5,8 +5,8 @@ import { ApiTags as DocsTags } from "@nestjs/swagger";
 import { Response as ExpressResponse, Request as ExpressRequest } from "express";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { getAvailableSlots } from "@calcom/platform-libraries-0.0.25";
-import type { AvailableSlotsType } from "@calcom/platform-libraries-0.0.25";
+import { getAvailableSlots } from "@calcom/platform-libraries-0.0.26";
+import type { AvailableSlotsType } from "@calcom/platform-libraries-0.0.26";
 import { RemoveSelectedSlotInput, ReserveSlotInput } from "@calcom/platform-types";
 import { ApiResponse, GetAvailableSlotsInput } from "@calcom/platform-types";
 

--- a/apps/api/v2/src/modules/slots/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/controllers/slots.controller.ts
@@ -5,8 +5,8 @@ import { ApiTags as DocsTags } from "@nestjs/swagger";
 import { Response as ExpressResponse, Request as ExpressRequest } from "express";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { getAvailableSlots } from "@calcom/platform-libraries-0.0.23";
-import type { AvailableSlotsType } from "@calcom/platform-libraries-0.0.23";
+import { getAvailableSlots } from "@calcom/platform-libraries-0.0.25";
+import type { AvailableSlotsType } from "@calcom/platform-libraries-0.0.25";
 import { RemoveSelectedSlotInput, ReserveSlotInput } from "@calcom/platform-types";
 import { ApiResponse, GetAvailableSlotsInput } from "@calcom/platform-types";
 

--- a/apps/api/v2/src/modules/slots/slots.repository.ts
+++ b/apps/api/v2/src/modules/slots/slots.repository.ts
@@ -3,7 +3,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { Injectable } from "@nestjs/common";
 import { DateTime } from "luxon";
 
-import { MINUTES_TO_BOOK } from "@calcom/platform-libraries-0.0.23";
+import { MINUTES_TO_BOOK } from "@calcom/platform-libraries-0.0.25";
 import { ReserveSlotInput } from "@calcom/platform-types";
 
 @Injectable()

--- a/apps/api/v2/src/modules/slots/slots.repository.ts
+++ b/apps/api/v2/src/modules/slots/slots.repository.ts
@@ -3,7 +3,7 @@ import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { Injectable } from "@nestjs/common";
 import { DateTime } from "luxon";
 
-import { MINUTES_TO_BOOK } from "@calcom/platform-libraries-0.0.25";
+import { MINUTES_TO_BOOK } from "@calcom/platform-libraries-0.0.26";
 import { ReserveSlotInput } from "@calcom/platform-types";
 
 @Injectable()

--- a/apps/api/v2/src/modules/timezones/controllers/timezones.controller.ts
+++ b/apps/api/v2/src/modules/timezones/controllers/timezones.controller.ts
@@ -4,7 +4,7 @@ import { Controller, Get } from "@nestjs/common";
 import { ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { CityTimezones } from "@calcom/platform-libraries-0.0.23";
+import type { CityTimezones } from "@calcom/platform-libraries-0.0.25";
 import { ApiResponse } from "@calcom/platform-types";
 
 @Controller({

--- a/apps/api/v2/src/modules/timezones/controllers/timezones.controller.ts
+++ b/apps/api/v2/src/modules/timezones/controllers/timezones.controller.ts
@@ -4,7 +4,7 @@ import { Controller, Get } from "@nestjs/common";
 import { ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { CityTimezones } from "@calcom/platform-libraries-0.0.25";
+import type { CityTimezones } from "@calcom/platform-libraries-0.0.26";
 import { ApiResponse } from "@calcom/platform-types";
 
 @Controller({

--- a/apps/api/v2/src/modules/timezones/services/timezones.service.ts
+++ b/apps/api/v2/src/modules/timezones/services/timezones.service.ts
@@ -1,8 +1,8 @@
 import { RedisService } from "@/modules/redis/redis.service";
 import { Injectable } from "@nestjs/common";
 
-import { cityTimezonesHandler } from "@calcom/platform-libraries-0.0.23";
-import type { CityTimezones } from "@calcom/platform-libraries-0.0.23";
+import { cityTimezonesHandler } from "@calcom/platform-libraries-0.0.25";
+import type { CityTimezones } from "@calcom/platform-libraries-0.0.25";
 
 @Injectable()
 export class TimezonesService {

--- a/apps/api/v2/src/modules/timezones/services/timezones.service.ts
+++ b/apps/api/v2/src/modules/timezones/services/timezones.service.ts
@@ -1,8 +1,8 @@
 import { RedisService } from "@/modules/redis/redis.service";
 import { Injectable } from "@nestjs/common";
 
-import { cityTimezonesHandler } from "@calcom/platform-libraries-0.0.25";
-import type { CityTimezones } from "@calcom/platform-libraries-0.0.25";
+import { cityTimezonesHandler } from "@calcom/platform-libraries-0.0.26";
+import type { CityTimezones } from "@calcom/platform-libraries-0.0.26";
 
 @Injectable()
 export class TimezonesService {

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -1219,6 +1219,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScheduleInput_2024_06_11"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "",
@@ -1321,6 +1331,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleInput_2024_06_11"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -2360,6 +2380,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleInput_2024_04_15"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -5841,6 +5871,57 @@
           "data"
         ]
       },
+      "CreateScheduleInput_2024_06_11": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "One-on-one coaching"
+          },
+          "timeZone": {
+            "type": "string",
+            "example": "Europe/Rome"
+          },
+          "availability": {
+            "example": [
+              {
+                "days": [
+                  "Monday",
+                  "Tuesday"
+                ],
+                "startTime": "09:00",
+                "endTime": "10:00"
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleAvailabilityInput_2024_06_11"
+            }
+          },
+          "isDefault": {
+            "type": "boolean",
+            "example": true
+          },
+          "overrides": {
+            "example": [
+              {
+                "date": "2024-05-20",
+                "startTime": "12:00",
+                "endTime": "14:00"
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleOverrideInput_2024_06_11"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "timeZone",
+          "isDefault"
+        ]
+      },
       "CreateScheduleOutput_2024_06_11": {
         "type": "object",
         "properties": {
@@ -5888,6 +5969,52 @@
           "status",
           "data"
         ]
+      },
+      "UpdateScheduleInput_2024_06_11": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "One-on-one coaching"
+          },
+          "timeZone": {
+            "type": "string",
+            "example": "Europe/Rome"
+          },
+          "availability": {
+            "example": [
+              {
+                "days": [
+                  "Monday",
+                  "Tuesday"
+                ],
+                "startTime": "09:00",
+                "endTime": "10:00"
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleAvailabilityInput_2024_06_11"
+            }
+          },
+          "isDefault": {
+            "type": "boolean",
+            "example": true
+          },
+          "overrides": {
+            "example": [
+              {
+                "date": "2024-05-20",
+                "startTime": "12:00",
+                "endTime": "14:00"
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleOverrideInput_2024_06_11"
+            }
+          }
+        }
       },
       "UpdateScheduleOutput_2024_06_11": {
         "type": "object",
@@ -6983,6 +7110,26 @@
           "userId"
         ]
       },
+      "GetDefaultScheduleOutput_2024_06_11": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success",
+            "enum": [
+              "success",
+              "error"
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/ScheduleOutput_2024_06_11"
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
       "CreateAvailabilityInput_2024_04_15": {
         "type": "object",
         "properties": {
@@ -7278,6 +7425,66 @@
         "required": [
           "status",
           "data"
+        ]
+      },
+      "UpdateScheduleInput_2024_04_15": {
+        "type": "object",
+        "properties": {
+          "timeZone": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "schedule": {
+            "example": [
+              [],
+              [
+                {
+                  "start": "2022-01-01T00:00:00.000Z",
+                  "end": "2022-01-02T00:00:00.000Z"
+                }
+              ],
+              [],
+              [],
+              [],
+              [],
+              []
+            ],
+            "items": {
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "dateOverrides": {
+            "example": [
+              [],
+              [
+                {
+                  "start": "2022-01-01T00:00:00.000Z",
+                  "end": "2022-01-02T00:00:00.000Z"
+                }
+              ],
+              [],
+              [],
+              [],
+              [],
+              []
+            ],
+            "items": {
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "timeZone",
+          "name",
+          "isDefault",
+          "schedule"
         ]
       },
       "EventTypeModel_2024_04_15": {
@@ -8543,9 +8750,6 @@
           },
           "noShowHost": {
             "type": "boolean"
-          },
-          "messageKey": {
-            "type": "string"
           },
           "attendees": {
             "type": "array",

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -267,7 +267,7 @@ export default class Office365CalendarService implements Calendar {
       subject: event.title,
       body: {
         contentType: "HTML",
-        content: getRichDescription(event),
+        content: getRichDescription(event).replace(/\n/g, "<br>"),
       },
       start: {
         dateTime: dayjs(event.startTime).tz(event.organizer.timeZone).format("YYYY-MM-DDTHH:mm:ss"),

--- a/packages/lib/event-types/transformers/api-request.spec.ts
+++ b/packages/lib/event-types/transformers/api-request.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BookingField_2024_06_14, Location_2024_06_14 } from "@calcom/platform-types";
 
-import type { CommonField, OptionsField } from "./api-request";
+import type { UserField, OptionsField } from "./api-request";
 import {
   transformApiEventTypeLocations,
   transformApiEventTypeBookingFields,
@@ -90,7 +90,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -125,7 +125,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -160,7 +160,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -195,7 +195,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -230,7 +230,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -265,7 +265,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -300,7 +300,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -408,7 +408,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,
@@ -514,7 +514,7 @@ describe("transformApiEventTypeBookingFields", () => {
 
     const input: BookingField_2024_06_14[] = [bookingField];
 
-    const expectedOutput: CommonField[] = [
+    const expectedOutput: UserField[] = [
       {
         name: bookingField.slug,
         type: bookingField.type,

--- a/packages/lib/event-types/transformers/api-request.ts
+++ b/packages/lib/event-types/transformers/api-request.ts
@@ -70,7 +70,7 @@ function transformApiEventTypeBookingFields(
   }
 
   const customBookingFields = inputBookingFields.map((field) => {
-    const commonFields: CommonField = {
+    const commonFields: UserField = {
       name: field.slug,
       type: field.type,
       label: field.label,
@@ -126,7 +126,7 @@ const FieldTypeEnum = z.enum([
   "radioInput",
 ]);
 
-const CommonFieldsSchema = z.object({
+const UserFieldsSchema = z.object({
   name: z.string(),
   type: FieldTypeEnum,
   label: z.string(),
@@ -141,13 +141,21 @@ const CommonFieldsSchema = z.object({
   editable: z.literal("user"),
   required: z.boolean(),
   placeholder: z.string().optional(),
+  options: z
+    .array(
+      z.object({
+        label: z.string(),
+        value: z.string(),
+      })
+    )
+    .optional(),
 });
 
 const SystemFieldsSchema = z.object({
   name: z.string(),
   type: FieldTypeEnum,
   defaultLabel: z.string(),
-  labe: z.string().optional(),
+  label: z.string().optional(),
   editable: z.enum(["system-but-optional", "system"]),
   sources: z.array(
     z.object({
@@ -187,18 +195,8 @@ const SystemFieldsSchema = z.object({
 
 export type SystemField = z.infer<typeof SystemFieldsSchema>;
 
-export type CommonField = z.infer<typeof CommonFieldsSchema>;
+export type UserField = z.infer<typeof UserFieldsSchema>;
 
-const OptionSchema = z.object({
-  label: z.string(),
-  value: z.string(),
-});
-
-const BookingFieldSchema = CommonFieldsSchema.extend({
-  options: z.array(OptionSchema).optional(),
-});
-export type OptionsField = z.infer<typeof BookingFieldSchema>;
-
-export const BookingFieldsSchema = z.array(BookingFieldSchema);
+export const BookingFieldsSchema = z.array(z.union([UserFieldsSchema, SystemFieldsSchema]));
 
 export { transformApiEventTypeLocations, transformApiEventTypeBookingFields };

--- a/packages/lib/event-types/transformers/api-response.spec.ts
+++ b/packages/lib/event-types/transformers/api-response.spec.ts
@@ -7,7 +7,7 @@ import type {
   IntegrationLocation_2024_06_14,
 } from "@calcom/platform-types";
 
-import type { CommonField, OptionsField } from "./api-request";
+import type { UserField, OptionsField } from "./api-request";
 import { getResponseEventTypeLocations, getResponseEventTypeBookingFields } from "./api-response";
 
 describe("getResponseEventTypeLocations", () => {
@@ -99,7 +99,7 @@ describe("getResponseEventTypeLocations", () => {
 
 describe("getResponseEventTypeBookingFields", () => {
   it("should reverse transform name field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-name",
         type: "name",
@@ -134,7 +134,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform email field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-email",
         type: "email",
@@ -169,7 +169,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform phone field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-phone",
         type: "phone",
@@ -204,7 +204,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform address field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-address",
         type: "address",
@@ -239,7 +239,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform text field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-text",
         type: "text",
@@ -274,7 +274,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform number field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-number",
         type: "number",
@@ -309,7 +309,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform textarea field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-textarea",
         type: "textarea",
@@ -422,7 +422,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform multiemail field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "your-multiemail",
         type: "multiemail",
@@ -533,7 +533,7 @@ describe("getResponseEventTypeBookingFields", () => {
   });
 
   it("should reverse transform boolean field", () => {
-    const transformedField: CommonField[] = [
+    const transformedField: UserField[] = [
       {
         name: "agree-to-terms",
         type: "boolean",

--- a/packages/lib/event-types/transformers/api-response.ts
+++ b/packages/lib/event-types/transformers/api-response.ts
@@ -4,6 +4,7 @@ import type {
   LinkLocation_2024_06_14,
   PhoneLocation_2024_06_14,
   Integration_2024_06_14,
+  BookingField_2024_06_14,
 } from "@calcom/platform-types";
 
 import type { transformApiEventTypeBookingFields, transformApiEventTypeLocations } from "./api-request";
@@ -71,7 +72,7 @@ function getResponseEventTypeLocations(
 
 function getResponseEventTypeBookingFields(
   transformedBookingFields: ReturnType<typeof transformApiEventTypeBookingFields>
-) {
+): BookingField_2024_06_14[] {
   if (!transformedBookingFields) {
     return [];
   }
@@ -156,7 +157,7 @@ function getResponseEventTypeBookingFields(
           label: field.label,
           required: field.required,
           placeholder: field.placeholder,
-          options: "options" in field ? field.options?.map((option) => option.value) : [],
+          options: field.options ? field.options.map((option) => option.value) : [],
         };
       case "multiselect":
         return {
@@ -164,7 +165,7 @@ function getResponseEventTypeBookingFields(
           slug: field.name,
           label: field.label,
           required: field.required,
-          options: "options" in field ? field.options?.map((option) => option.value) : [],
+          options: field.options ? field.options?.map((option) => option.value) : [],
         };
       case "checkbox":
         return {
@@ -172,7 +173,7 @@ function getResponseEventTypeBookingFields(
           slug: field.name,
           label: field.label,
           required: field.required,
-          options: "options" in field ? field.options?.map((option) => option.value) : [],
+          options: field.options ? field.options?.map((option) => option.value) : [],
         };
       case "radio":
         return {
@@ -180,7 +181,7 @@ function getResponseEventTypeBookingFields(
           slug: field.name,
           label: field.label,
           required: field.required,
-          options: "options" in field ? field.options?.map((option) => option.value) : [],
+          options: field.options ? field.options?.map((option) => option.value) : [],
         };
       default:
         throw new Error(`Unsupported booking field type '${field.type}'.`);

--- a/packages/platform/libraries/CHANGELOG.md
+++ b/packages/platform/libraries/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.26
+Update `packages/app-store/office365calendar/lib/CalendarService.ts` "translateEvent" content so that in microsoft outlook calendar event the description
+has newlines instead of being all in 1 line.
+
 ## 0.0.25
 Refactor "packages/lib/event-types/transformers/api-request.ts" getResponseEventTypeBookingFields - make sure that booking fields with options don't have
 undefines options.

--- a/packages/platform/libraries/CHANGELOG.md
+++ b/packages/platform/libraries/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.0.25
+Refactor "packages/lib/event-types/transformers/api-request.ts" getResponseEventTypeBookingFields - make sure that booking fields with options don't have
+undefines options.
+
+
+## 0.0.24
+Refactor "packages/lib/event-types/transformers/api-request.ts" - we access event-type booking fields in database and then distinguish them as either
+created by the user or system. Then in v2 api "event-types_2024_06_14/services/output-event-types.service.ts" we first parse them and then filter
+out only user fields. This is done because when creating an event-type we only store user passed booking fields, but if someone already had created
+booking-fields using event-types version 2024_04_15, then they contained system fields which is why event-types 2024_06_14 controller was failing.
+
 ## 0.0.23
 Update "createBooking" (packages/features/bookings/lib/handleNewBooking/createBooking.ts) that is used by handleNewBooking (packages/features/bookings/lib/handleNewBooking.ts) to correctly handle metadata of a re-scheduled booking. Previously,
 metadata of original booking was overwriting metadata in the request body of the new booking (rescheduled), but now

--- a/packages/platform/libraries/index.ts
+++ b/packages/platform/libraries/index.ts
@@ -100,6 +100,8 @@ export {
   BookingFieldsSchema,
 } from "@calcom/lib/event-types/transformers";
 
+export type { SystemField, UserField } from "@calcom/lib/event-types/transformers";
+
 export { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 export { dynamicEvent } from "@calcom/lib/defaultEvents";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,23 +172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "@anthropic-ai/sdk@npm:0.9.1"
-  dependencies:
-    "@types/node": ^18.11.18
-    "@types/node-fetch": ^2.6.4
-    abort-controller: ^3.0.0
-    agentkeepalive: ^4.2.1
-    digest-fetch: ^1.3.0
-    form-data-encoder: 1.7.2
-    formdata-node: ^4.3.2
-    node-fetch: ^2.6.7
-    web-streams-polyfill: ^3.2.1
-  checksum: 0ec50abc0ffc694d903d516f4ac110aafa3a588438791851dd2c3d220da49ceaf2723e218b7f1bc13e737fee1561b18ad8c3b4cc4347e8212131f69637216413
-  languageName: node
-  linkType: hard
-
 "@apidevtools/json-schema-ref-parser@npm:9.0.9":
   version: 9.0.9
   resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
@@ -4112,23 +4095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@calcom/ai@workspace:apps/ai":
-  version: 0.0.0-use.local
-  resolution: "@calcom/ai@workspace:apps/ai"
-  dependencies:
-    "@calcom/prisma": "*"
-    "@langchain/core": ^0.1.26
-    "@langchain/openai": ^0.0.14
-    "@t3-oss/env-nextjs": ^0.6.1
-    "@types/mailparser": ^3.4.0
-    langchain: ^0.1.17
-    mailparser: ^3.6.5
-    next: ^13.5.4
-    supports-color: 8.1.1
-    zod: ^3.22.4
-  languageName: unknown
-  linkType: soft
-
 "@calcom/alby@workspace:packages/app-store/alby":
   version: 0.0.0-use.local
   resolution: "@calcom/alby@workspace:packages/app-store/alby"
@@ -4168,7 +4134,7 @@ __metadata:
   dependencies:
     "@calcom/platform-constants": "*"
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2"
-    "@calcom/platform-libraries-0.0.23": "npm:@calcom/platform-libraries@0.0.23"
+    "@calcom/platform-libraries-0.0.25": "npm:@calcom/platform-libraries@0.0.25"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -4402,15 +4368,6 @@ __metadata:
 "@calcom/basecamp3@workspace:packages/app-store/basecamp3":
   version: 0.0.0-use.local
   resolution: "@calcom/basecamp3@workspace:packages/app-store/basecamp3"
-  dependencies:
-    "@calcom/lib": "*"
-    "@calcom/types": "*"
-  languageName: unknown
-  linkType: soft
-
-"@calcom/cal-ai@workspace:packages/app-store/cal-ai":
-  version: 0.0.0-use.local
-  resolution: "@calcom/cal-ai@workspace:packages/app-store/cal-ai"
   dependencies:
     "@calcom/lib": "*"
     "@calcom/types": "*"
@@ -5130,14 +5087,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries-0.0.23@npm:@calcom/platform-libraries@0.0.23":
-  version: 0.0.23
-  resolution: "@calcom/platform-libraries@npm:0.0.23"
+"@calcom/platform-libraries-0.0.25@npm:@calcom/platform-libraries@0.0.25":
+  version: 0.0.25
+  resolution: "@calcom/platform-libraries@npm:0.0.25"
   dependencies:
     "@calcom/core": "*"
     "@calcom/features": "*"
     "@calcom/lib": "*"
-  checksum: f3261fac9c2255fe50abd56729dd34811776c8006c1761fca630534198ae4dd3021944e9b0f77619f37cd5481e9aa9f8ac62bff891d73930f0e58e2f6127dd44
+  checksum: ec81bb7dd6db345e25a725f5cd451d5f17ae32401206c80a1dab673419c3e7a41d502b76aa4f48a37016835dd8652a65cd9a3d4aae09a25b8e875d8335a8189e
   languageName: node
   linkType: hard
 
@@ -8824,379 +8781,6 @@ __metadata:
   version: 1.1.4
   resolution: "@kamilkisiela/fast-url-parser@npm:1.1.4"
   checksum: 921d305eff1fce5c7c669aee5cfe39e50109968addb496c23f0a42253d030e3cd5865eb01b13245915923bee452db75ba8a8254e69b0d0575d3c168efce7091e
-  languageName: node
-  linkType: hard
-
-"@langchain/community@npm:~0.0.47":
-  version: 0.0.57
-  resolution: "@langchain/community@npm:0.0.57"
-  dependencies:
-    "@langchain/core": ~0.1.60
-    "@langchain/openai": ~0.0.28
-    expr-eval: ^2.0.2
-    flat: ^5.0.2
-    langsmith: ~0.1.1
-    uuid: ^9.0.0
-    zod: ^3.22.3
-    zod-to-json-schema: ^3.22.5
-  peerDependencies:
-    "@aws-crypto/sha256-js": ^5.0.0
-    "@aws-sdk/client-bedrock-agent-runtime": ^3.485.0
-    "@aws-sdk/client-bedrock-runtime": ^3.422.0
-    "@aws-sdk/client-dynamodb": ^3.310.0
-    "@aws-sdk/client-kendra": ^3.352.0
-    "@aws-sdk/client-lambda": ^3.310.0
-    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
-    "@aws-sdk/client-sfn": ^3.310.0
-    "@aws-sdk/credential-provider-node": ^3.388.0
-    "@azure/search-documents": ^12.0.0
-    "@clickhouse/client": ^0.2.5
-    "@cloudflare/ai": "*"
-    "@datastax/astra-db-ts": ^1.0.0
-    "@elastic/elasticsearch": ^8.4.0
-    "@getmetal/metal-sdk": "*"
-    "@getzep/zep-js": ^0.9.0
-    "@gomomento/sdk": ^1.51.1
-    "@gomomento/sdk-core": ^1.51.1
-    "@google-ai/generativelanguage": ^0.2.1
-    "@gradientai/nodejs-sdk": ^1.2.0
-    "@huggingface/inference": ^2.6.4
-    "@mlc-ai/web-llm": ^0.2.35
-    "@mozilla/readability": "*"
-    "@neondatabase/serverless": "*"
-    "@opensearch-project/opensearch": "*"
-    "@pinecone-database/pinecone": "*"
-    "@planetscale/database": ^1.8.0
-    "@premai/prem-sdk": ^0.3.25
-    "@qdrant/js-client-rest": ^1.8.2
-    "@raycast/api": ^1.55.2
-    "@rockset/client": ^0.9.1
-    "@smithy/eventstream-codec": ^2.0.5
-    "@smithy/protocol-http": ^3.0.6
-    "@smithy/signature-v4": ^2.0.10
-    "@smithy/util-utf8": ^2.0.0
-    "@supabase/postgrest-js": ^1.1.1
-    "@supabase/supabase-js": ^2.10.0
-    "@tensorflow-models/universal-sentence-encoder": "*"
-    "@tensorflow/tfjs-converter": "*"
-    "@tensorflow/tfjs-core": "*"
-    "@upstash/redis": ^1.20.6
-    "@upstash/vector": ^1.0.7
-    "@vercel/kv": ^0.2.3
-    "@vercel/postgres": ^0.5.0
-    "@writerai/writer-sdk": ^0.40.2
-    "@xata.io/client": ^0.28.0
-    "@xenova/transformers": ^2.5.4
-    "@zilliz/milvus2-sdk-node": ">=2.2.7"
-    better-sqlite3: ^9.4.0
-    cassandra-driver: ^4.7.2
-    cborg: ^4.1.1
-    chromadb: "*"
-    closevector-common: 0.1.3
-    closevector-node: 0.1.6
-    closevector-web: 0.1.6
-    cohere-ai: "*"
-    convex: ^1.3.1
-    couchbase: ^4.3.0
-    discord.js: ^14.14.1
-    dria: ^0.0.3
-    duck-duck-scrape: ^2.2.5
-    faiss-node: ^0.5.1
-    firebase-admin: ^11.9.0 || ^12.0.0
-    google-auth-library: ^8.9.0
-    googleapis: ^126.0.1
-    hnswlib-node: ^3.0.0
-    html-to-text: ^9.0.5
-    interface-datastore: ^8.2.11
-    ioredis: ^5.3.2
-    it-all: ^3.0.4
-    jsdom: "*"
-    jsonwebtoken: ^9.0.2
-    llmonitor: ^0.5.9
-    lodash: ^4.17.21
-    lunary: ^0.6.11
-    mongodb: ">=5.2.0"
-    mysql2: ^3.3.3
-    neo4j-driver: "*"
-    node-llama-cpp: "*"
-    pg: ^8.11.0
-    pg-copy-streams: ^6.0.5
-    pickleparser: ^0.2.1
-    portkey-ai: ^0.1.11
-    redis: "*"
-    replicate: ^0.18.0
-    typeorm: ^0.3.12
-    typesense: ^1.5.3
-    usearch: ^1.1.1
-    vectordb: ^0.1.4
-    voy-search: 0.6.2
-    weaviate-ts-client: "*"
-    web-auth-library: ^1.0.3
-    ws: ^8.14.2
-  peerDependenciesMeta:
-    "@aws-crypto/sha256-js":
-      optional: true
-    "@aws-sdk/client-bedrock-agent-runtime":
-      optional: true
-    "@aws-sdk/client-bedrock-runtime":
-      optional: true
-    "@aws-sdk/client-dynamodb":
-      optional: true
-    "@aws-sdk/client-kendra":
-      optional: true
-    "@aws-sdk/client-lambda":
-      optional: true
-    "@aws-sdk/client-sagemaker-runtime":
-      optional: true
-    "@aws-sdk/client-sfn":
-      optional: true
-    "@aws-sdk/credential-provider-node":
-      optional: true
-    "@azure/search-documents":
-      optional: true
-    "@clickhouse/client":
-      optional: true
-    "@cloudflare/ai":
-      optional: true
-    "@datastax/astra-db-ts":
-      optional: true
-    "@elastic/elasticsearch":
-      optional: true
-    "@getmetal/metal-sdk":
-      optional: true
-    "@getzep/zep-js":
-      optional: true
-    "@gomomento/sdk":
-      optional: true
-    "@gomomento/sdk-core":
-      optional: true
-    "@google-ai/generativelanguage":
-      optional: true
-    "@gradientai/nodejs-sdk":
-      optional: true
-    "@huggingface/inference":
-      optional: true
-    "@mlc-ai/web-llm":
-      optional: true
-    "@mozilla/readability":
-      optional: true
-    "@neondatabase/serverless":
-      optional: true
-    "@opensearch-project/opensearch":
-      optional: true
-    "@pinecone-database/pinecone":
-      optional: true
-    "@planetscale/database":
-      optional: true
-    "@premai/prem-sdk":
-      optional: true
-    "@qdrant/js-client-rest":
-      optional: true
-    "@raycast/api":
-      optional: true
-    "@rockset/client":
-      optional: true
-    "@smithy/eventstream-codec":
-      optional: true
-    "@smithy/protocol-http":
-      optional: true
-    "@smithy/signature-v4":
-      optional: true
-    "@smithy/util-utf8":
-      optional: true
-    "@supabase/postgrest-js":
-      optional: true
-    "@supabase/supabase-js":
-      optional: true
-    "@tensorflow-models/universal-sentence-encoder":
-      optional: true
-    "@tensorflow/tfjs-converter":
-      optional: true
-    "@tensorflow/tfjs-core":
-      optional: true
-    "@upstash/redis":
-      optional: true
-    "@upstash/vector":
-      optional: true
-    "@vercel/kv":
-      optional: true
-    "@vercel/postgres":
-      optional: true
-    "@writerai/writer-sdk":
-      optional: true
-    "@xata.io/client":
-      optional: true
-    "@xenova/transformers":
-      optional: true
-    "@zilliz/milvus2-sdk-node":
-      optional: true
-    better-sqlite3:
-      optional: true
-    cassandra-driver:
-      optional: true
-    cborg:
-      optional: true
-    chromadb:
-      optional: true
-    closevector-common:
-      optional: true
-    closevector-node:
-      optional: true
-    closevector-web:
-      optional: true
-    cohere-ai:
-      optional: true
-    convex:
-      optional: true
-    couchbase:
-      optional: true
-    discord.js:
-      optional: true
-    dria:
-      optional: true
-    duck-duck-scrape:
-      optional: true
-    faiss-node:
-      optional: true
-    firebase-admin:
-      optional: true
-    google-auth-library:
-      optional: true
-    googleapis:
-      optional: true
-    hnswlib-node:
-      optional: true
-    html-to-text:
-      optional: true
-    interface-datastore:
-      optional: true
-    ioredis:
-      optional: true
-    it-all:
-      optional: true
-    jsdom:
-      optional: true
-    jsonwebtoken:
-      optional: true
-    llmonitor:
-      optional: true
-    lodash:
-      optional: true
-    lunary:
-      optional: true
-    mongodb:
-      optional: true
-    mysql2:
-      optional: true
-    neo4j-driver:
-      optional: true
-    node-llama-cpp:
-      optional: true
-    pg:
-      optional: true
-    pg-copy-streams:
-      optional: true
-    pickleparser:
-      optional: true
-    portkey-ai:
-      optional: true
-    redis:
-      optional: true
-    replicate:
-      optional: true
-    typeorm:
-      optional: true
-    typesense:
-      optional: true
-    usearch:
-      optional: true
-    vectordb:
-      optional: true
-    voy-search:
-      optional: true
-    weaviate-ts-client:
-      optional: true
-    web-auth-library:
-      optional: true
-    ws:
-      optional: true
-  checksum: 9a9f8396af0571bad920c0871329953f74a2907c5cdbab544f94269db2eff3de475c07e25c69dcf1e3b014f21ab9fc9f3cf79717ed44a7878bf780e58f11da87
-  languageName: node
-  linkType: hard
-
-"@langchain/core@npm:>0.1.56 <0.3.0, @langchain/core@npm:>0.2.0 <0.3.0":
-  version: 0.2.18
-  resolution: "@langchain/core@npm:0.2.18"
-  dependencies:
-    ansi-styles: ^5.0.0
-    camelcase: 6
-    decamelize: 1.2.0
-    js-tiktoken: ^1.0.12
-    langsmith: ~0.1.39
-    ml-distance: ^4.0.0
-    mustache: ^4.2.0
-    p-queue: ^6.6.2
-    p-retry: 4
-    uuid: ^10.0.0
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.22.3
-  checksum: f1090a300825a8cefdf873a38926f5a3a8f1208ebcdd9f65c4858e851082b8f89b7b7d7dba50c3907de997b0f2fad2856d611adf61096dffcf240e959809e4fc
-  languageName: node
-  linkType: hard
-
-"@langchain/core@npm:^0.1.26, @langchain/core@npm:~0.1.13, @langchain/core@npm:~0.1.60":
-  version: 0.1.63
-  resolution: "@langchain/core@npm:0.1.63"
-  dependencies:
-    ansi-styles: ^5.0.0
-    camelcase: 6
-    decamelize: 1.2.0
-    js-tiktoken: ^1.0.12
-    langsmith: ~0.1.7
-    ml-distance: ^4.0.0
-    mustache: ^4.2.0
-    p-queue: ^6.6.2
-    p-retry: 4
-    uuid: ^9.0.0
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.22.3
-  checksum: 0aa18f55e5e5cab2c609a6c0d37bcfe9a36b574658acaeb7857f6a0e23dd9ad5617d40988a48f6f00c461a33a5abee983d2ed8b311b92c60b641002b42f0ab26
-  languageName: node
-  linkType: hard
-
-"@langchain/openai@npm:^0.0.14":
-  version: 0.0.14
-  resolution: "@langchain/openai@npm:0.0.14"
-  dependencies:
-    "@langchain/core": ~0.1.13
-    js-tiktoken: ^1.0.7
-    openai: ^4.26.0
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.22.3
-  checksum: bfaf344580d493e8296344da63d9227bf896d3755d36cb8c29ac6c9ac087f1de83e2520078d32f24f7a95bf78ff64c338e411423c734382106d90676ae035b7f
-  languageName: node
-  linkType: hard
-
-"@langchain/openai@npm:~0.0.28":
-  version: 0.0.34
-  resolution: "@langchain/openai@npm:0.0.34"
-  dependencies:
-    "@langchain/core": ">0.1.56 <0.3.0"
-    js-tiktoken: ^1.0.12
-    openai: ^4.41.1
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.22.3
-  checksum: d2a5568b7fd0507af2510d68cf568945d5c7f6e45f57ac1178f65d0092e0437e7c908e2af3e20b829ce4507f63e71ddc38df7dc35b7e3d21394daa380243e297
-  languageName: node
-  linkType: hard
-
-"@langchain/textsplitters@npm:~0.0.0":
-  version: 0.0.3
-  resolution: "@langchain/textsplitters@npm:0.0.3"
-  dependencies:
-    "@langchain/core": ">0.2.0 <0.3.0"
-    js-tiktoken: ^1.0.12
-  checksum: f0b32d65c863a280ce7104bff4d367734b8f76f2ec42b741fb690fbc20737bb4a3a412b82d8ba308a524441b6084ecd59cf61c3ce13cbb9639fbd02241c341d1
   languageName: node
   linkType: hard
 
@@ -14237,16 +13821,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@selderee/plugin-htmlparser2@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@selderee/plugin-htmlparser2@npm:0.11.0"
-  dependencies:
-    domhandler: ^5.0.3
-    selderee: ^0.11.0
-  checksum: 6deafedd153e492359f8f0407d20903d82f2ef4950e420f4b2ee6ffbb955753524631aac7d6a5fe61dc7c7893e6928b4d8409e886157ad64a60ab37bc08b17c4
-  languageName: node
-  linkType: hard
-
 "@sendgrid/client@npm:^7.7.0":
   version: 7.7.0
   resolution: "@sendgrid/client@npm:7.7.0"
@@ -16480,28 +16054,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@t3-oss/env-core@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@t3-oss/env-core@npm:0.6.1"
-  peerDependencies:
-    typescript: ">=4.7.2"
-    zod: ^3.0.0
-  checksum: 6a1dd9d2f88643f6315a3add7eb6053a436a953a3c2b59b9743a2d8f28dbafcdaf4f6bccf0e7dfe424189834f75fbb53b9ac3891076a19b289468e4b406a340b
-  languageName: node
-  linkType: hard
-
-"@t3-oss/env-nextjs@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@t3-oss/env-nextjs@npm:0.6.1"
-  dependencies:
-    "@t3-oss/env-core": 0.6.1
-  peerDependencies:
-    typescript: ">=4.7.2"
-    zod: ^3.0.0
-  checksum: c103a501b186c2a1633ead602fbd4e2d3096f736dceecba2f88a8c7b016c6f982a42bb8eb948e8069df93bf8d51a8a973e49a0a497d3da9282933683ced665e5
-  languageName: node
-  linkType: hard
-
 "@tailwindcss/forms@npm:^0.5.2":
   version: 0.5.2
   resolution: "@tailwindcss/forms@npm:0.5.2"
@@ -17787,16 +17339,6 @@ __metadata:
   version: 3.4.2
   resolution: "@types/luxon@npm:3.4.2"
   checksum: 6f92d5bd02e89f310395753506bcd9cef3a56f5940f7a50db2a2b9822bce753553ac767d143cb5b4f9ed5ddd4a84e64f89ff538082ceb4d18739af7781b56925
-  languageName: node
-  linkType: hard
-
-"@types/mailparser@npm:^3.4.0":
-  version: 3.4.4
-  resolution: "@types/mailparser@npm:3.4.4"
-  dependencies:
-    "@types/node": "*"
-    iconv-lite: ^0.6.3
-  checksum: c8bdb579d66756042b75c3763dd8b7b2fab6657d7e7d33504bb65bbbe6fa220b8da2ae67918dd821716c3229d8803bedffb00f2314a8946da1856396187c646a
   languageName: node
   linkType: hard
 
@@ -20984,13 +20526,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-64@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "base-64@npm:0.1.0"
-  checksum: 5a42938f82372ab5392cbacc85a5a78115cbbd9dbef9f7540fa47d78763a3a8bd7d598475f0d92341f66285afd377509851a9bb5c67bbecb89686e9255d5b3eb
-  languageName: node
-  linkType: hard
-
 "base64-js@npm:0.0.8":
   version: 0.0.8
   resolution: "base64-js@npm:0.0.8"
@@ -21092,20 +20627,6 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
-  languageName: node
-  linkType: hard
-
-"binary-extensions@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "binary-extensions@npm:2.3.0"
-  checksum: bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
-  languageName: node
-  linkType: hard
-
-"binary-search@npm:^1.3.5":
-  version: 1.3.6
-  resolution: "binary-search@npm:1.3.6"
-  checksum: 2e6b3459a9c1ba1bd674a6a855a5ef7505f70707422244430e3510e989c0df6074a49fe60784a98b93b51545c9bcace1db1defee06ff861b124c036a2f2836bf
   languageName: node
   linkType: hard
 
@@ -21904,13 +21425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:6, camelcase@npm:^6.2.0":
-  version: 6.3.0
-  resolution: "camelcase@npm:6.3.0"
-  checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
-  languageName: node
-  linkType: hard
-
 "camelcase@npm:^3.0.0":
   version: 3.0.0
   resolution: "camelcase@npm:3.0.0"
@@ -21922,6 +21436,13 @@ __metadata:
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
+  languageName: node
+  linkType: hard
+
+"camelcase@npm:^6.2.0":
+  version: 6.3.0
+  resolution: "camelcase@npm:6.3.0"
+  checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
   languageName: node
   linkType: hard
 
@@ -23026,13 +22547,6 @@ __metadata:
   version: 9.1.0
   resolution: "commander@npm:9.1.0"
   checksum: 1428319b6b90600a813c28fe1e413996d1be99bf01afe9ebc4a9fc6f8077ff3e75f11809b2d2f85bd9b13d7cb592154278e9bbfdb16dc5843cef97bcba6a9cfd
-  languageName: node
-  linkType: hard
-
-"commander@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "commander@npm:10.0.1"
-  checksum: 436901d64a818295803c1996cd856621a74f30b9f9e28a588e726b2b1670665bccd7c1a77007ebf328729f0139838a88a19265858a0fa7a8728c4656796db948
   languageName: node
   linkType: hard
 
@@ -24405,7 +23919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:1.2.0, decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.2.0":
+"decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
@@ -24523,13 +24037,6 @@ __metadata:
   version: 4.2.2
   resolution: "deepmerge@npm:4.2.2"
   checksum: a8c43a1ed8d6d1ed2b5bf569fa4c8eb9f0924034baf75d5d406e47e157a451075c4db353efea7b6bcc56ec48116a8ce72fccf867b6e078e7c561904b5897530b
-  languageName: node
-  linkType: hard
-
-"deepmerge@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "deepmerge@npm:4.3.1"
-  checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
   languageName: node
   linkType: hard
 
@@ -24891,16 +24398,6 @@ __metadata:
     miller-rabin: ^4.0.0
     randombytes: ^2.0.0
   checksum: 0e620f322170c41076e70181dd1c24e23b08b47dbb92a22a644f3b89b6d3834b0f8ee19e37916164e5eb1ee26d2aa836d6129f92723995267250a0b541811065
-  languageName: node
-  linkType: hard
-
-"digest-fetch@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "digest-fetch@npm:1.3.0"
-  dependencies:
-    base-64: ^0.1.0
-    md5: ^2.3.0
-  checksum: 8ebdb4b9ef02b1ac0da532d25c7d08388f2552813dfadabfe7c4630e944bb4a48093b997fc926440a10e1ccf4912f2ce9adcf2d6687b0518dab8480e08f22f9d
   languageName: node
   linkType: hard
 
@@ -25423,20 +24920,6 @@ __metadata:
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
-  languageName: node
-  linkType: hard
-
-"encoding-japanese@npm:2.0.0":
-  version: 2.0.0
-  resolution: "encoding-japanese@npm:2.0.0"
-  checksum: 6b1ee85e81d16bfbeb96b887239cef888859b071164c916088078f4db4c10f7b83e4042dfd804c68063ce50c129abd02c42ac1753e60ccd2705f4c103ec798f1
-  languageName: node
-  linkType: hard
-
-"encoding-japanese@npm:2.1.0":
-  version: 2.1.0
-  resolution: "encoding-japanese@npm:2.1.0"
-  checksum: ea1944539046fa9ae8ac38324e5349ebaecc1f972906ad855cc8400e6cac9d47eef16265440d2b8d72165123b94c953374549a85745863bd7d61fac84c2d258a
   languageName: node
   linkType: hard
 
@@ -27109,13 +26592,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expr-eval@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expr-eval@npm:2.0.2"
-  checksum: 01862f09b50b17b45a6268b1153280afede99e1b51752a323661f7f4010eaed34cd6c682bf439b7f8a92df6aa82f326f0ce0aa20964d175feee97377fe53921d
-  languageName: node
-  linkType: hard
-
 "express@npm:4.18.2, express@npm:^4.17.3":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
@@ -27795,15 +27271,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "flat@npm:5.0.2"
-  bin:
-    flat: cli.js
-  checksum: 12a1536ac746db74881316a181499a78ef953632ddd28050b7a3a43c62ef5462e3357c8c29d76072bb635f147f7a9a1f0c02efef6b4be28f8db62ceb3d5c7f5d
-  languageName: node
-  linkType: hard
-
 "flatted@npm:^3.1.0":
   version: 3.2.5
   resolution: "flatted@npm:3.2.5"
@@ -27968,7 +27435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:1.7.2, form-data-encoder@npm:^1.4.3":
+"form-data-encoder@npm:^1.4.3":
   version: 1.7.2
   resolution: "form-data-encoder@npm:1.7.2"
   checksum: aeebd87a1cb009e13cbb5e4e4008e6202ed5f6551eb6d9582ba8a062005178907b90f4887899d3c993de879159b6c0c940af8196725b428b4248cec5af3acf5f
@@ -28061,7 +27528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formdata-node@npm:^4.3.1, formdata-node@npm:^4.3.2":
+"formdata-node@npm:^4.3.1":
   version: 4.4.1
   resolution: "formdata-node@npm:4.4.1"
   dependencies:
@@ -29919,19 +29386,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-to-text@npm:9.0.5":
-  version: 9.0.5
-  resolution: "html-to-text@npm:9.0.5"
-  dependencies:
-    "@selderee/plugin-htmlparser2": ^0.11.0
-    deepmerge: ^4.3.1
-    dom-serializer: ^2.0.0
-    htmlparser2: ^8.0.2
-    selderee: ^0.11.0
-  checksum: 205e0faa9b9aa281b369122acdffc5f348848e400f4037fde1fb12d68a6baa11644d2b64c3cc6821a79d3bc7316d89e85cc733d86f7f709858cb5c5b72faac65
-  languageName: node
-  linkType: hard
-
 "html-url-attributes@npm:^3.0.0":
   version: 3.0.0
   resolution: "html-url-attributes@npm:3.0.0"
@@ -29973,7 +29427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^8.0.0, htmlparser2@npm:^8.0.2":
+"htmlparser2@npm:^8.0.0":
   version: 8.0.2
   resolution: "htmlparser2@npm:8.0.2"
   dependencies:
@@ -30976,13 +30430,6 @@ __metadata:
     is-alphabetical: ^2.0.0
     is-decimal: ^2.0.0
   checksum: 87acc068008d4c9c4e9f5bd5e251041d42e7a50995c77b1499cf6ed248f971aadeddb11f239cabf09f7975ee58cac7a48ffc170b7890076d8d227b24a68663c9
-  languageName: node
-  linkType: hard
-
-"is-any-array@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "is-any-array@npm:2.0.1"
-  checksum: 472ed80e17d32951435087951af30c29498b163c31bf723dd5af76545b100bcfac6fad2df3f1a648b45e3b027de8f5dc2389935267ba5258eae85762804b4982
   languageName: node
   linkType: hard
 
@@ -32781,15 +32228,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tiktoken@npm:^1.0.12, js-tiktoken@npm:^1.0.7":
-  version: 1.0.12
-  resolution: "js-tiktoken@npm:1.0.12"
-  dependencies:
-    base64-js: ^1.5.1
-  checksum: 07a0e9cd5cb05f304696ac74e76d48f960d62b0443b65f0d09adf79dc903d2fba82d2cff2907491259bbf8b59842c20f89fd1879d2c0249706e7c84507c687fd
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -33134,13 +32572,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpointer@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "jsonpointer@npm:5.0.1"
-  checksum: 0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
-  languageName: node
-  linkType: hard
-
 "jsonwebtoken@npm:9.0.2, jsonwebtoken@npm:^9.0.0":
   version: 9.0.2
   resolution: "jsonwebtoken@npm:9.0.2"
@@ -33373,223 +32804,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"langchain@npm:^0.1.17":
-  version: 0.1.37
-  resolution: "langchain@npm:0.1.37"
-  dependencies:
-    "@anthropic-ai/sdk": ^0.9.1
-    "@langchain/community": ~0.0.47
-    "@langchain/core": ~0.1.60
-    "@langchain/openai": ~0.0.28
-    "@langchain/textsplitters": ~0.0.0
-    binary-extensions: ^2.2.0
-    js-tiktoken: ^1.0.7
-    js-yaml: ^4.1.0
-    jsonpointer: ^5.0.1
-    langchainhub: ~0.0.8
-    langsmith: ~0.1.7
-    ml-distance: ^4.0.0
-    openapi-types: ^12.1.3
-    p-retry: 4
-    uuid: ^9.0.0
-    yaml: ^2.2.1
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.22.3
-  peerDependencies:
-    "@aws-sdk/client-s3": ^3.310.0
-    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
-    "@aws-sdk/client-sfn": ^3.310.0
-    "@aws-sdk/credential-provider-node": ^3.388.0
-    "@azure/storage-blob": ^12.15.0
-    "@browserbasehq/sdk": "*"
-    "@gomomento/sdk": ^1.51.1
-    "@gomomento/sdk-core": ^1.51.1
-    "@gomomento/sdk-web": ^1.51.1
-    "@google-ai/generativelanguage": ^0.2.1
-    "@google-cloud/storage": ^6.10.1 || ^7.7.0
-    "@mendable/firecrawl-js": ^0.0.13
-    "@notionhq/client": ^2.2.10
-    "@pinecone-database/pinecone": "*"
-    "@supabase/supabase-js": ^2.10.0
-    "@vercel/kv": ^0.2.3
-    "@xata.io/client": ^0.28.0
-    apify-client: ^2.7.1
-    assemblyai: ^4.0.0
-    axios: "*"
-    cheerio: ^1.0.0-rc.12
-    chromadb: "*"
-    convex: ^1.3.1
-    couchbase: ^4.3.0
-    d3-dsv: ^2.0.0
-    epub2: ^3.0.1
-    fast-xml-parser: "*"
-    google-auth-library: ^8.9.0
-    handlebars: ^4.7.8
-    html-to-text: ^9.0.5
-    ignore: ^5.2.0
-    ioredis: ^5.3.2
-    jsdom: "*"
-    mammoth: ^1.6.0
-    mongodb: ">=5.2.0"
-    node-llama-cpp: "*"
-    notion-to-md: ^3.1.0
-    officeparser: ^4.0.4
-    pdf-parse: 1.1.1
-    peggy: ^3.0.2
-    playwright: ^1.32.1
-    puppeteer: ^19.7.2
-    pyodide: ^0.24.1
-    redis: ^4.6.4
-    sonix-speech-recognition: ^2.1.1
-    srt-parser-2: ^1.2.3
-    typeorm: ^0.3.12
-    weaviate-ts-client: "*"
-    web-auth-library: ^1.0.3
-    ws: ^8.14.2
-    youtube-transcript: ^1.0.6
-    youtubei.js: ^9.1.0
-  peerDependenciesMeta:
-    "@aws-sdk/client-s3":
-      optional: true
-    "@aws-sdk/client-sagemaker-runtime":
-      optional: true
-    "@aws-sdk/client-sfn":
-      optional: true
-    "@aws-sdk/credential-provider-node":
-      optional: true
-    "@azure/storage-blob":
-      optional: true
-    "@browserbasehq/sdk":
-      optional: true
-    "@gomomento/sdk":
-      optional: true
-    "@gomomento/sdk-core":
-      optional: true
-    "@gomomento/sdk-web":
-      optional: true
-    "@google-ai/generativelanguage":
-      optional: true
-    "@google-cloud/storage":
-      optional: true
-    "@mendable/firecrawl-js":
-      optional: true
-    "@notionhq/client":
-      optional: true
-    "@pinecone-database/pinecone":
-      optional: true
-    "@supabase/supabase-js":
-      optional: true
-    "@vercel/kv":
-      optional: true
-    "@xata.io/client":
-      optional: true
-    apify-client:
-      optional: true
-    assemblyai:
-      optional: true
-    axios:
-      optional: true
-    cheerio:
-      optional: true
-    chromadb:
-      optional: true
-    convex:
-      optional: true
-    couchbase:
-      optional: true
-    d3-dsv:
-      optional: true
-    epub2:
-      optional: true
-    faiss-node:
-      optional: true
-    fast-xml-parser:
-      optional: true
-    google-auth-library:
-      optional: true
-    handlebars:
-      optional: true
-    html-to-text:
-      optional: true
-    ignore:
-      optional: true
-    ioredis:
-      optional: true
-    jsdom:
-      optional: true
-    mammoth:
-      optional: true
-    mongodb:
-      optional: true
-    node-llama-cpp:
-      optional: true
-    notion-to-md:
-      optional: true
-    officeparser:
-      optional: true
-    pdf-parse:
-      optional: true
-    peggy:
-      optional: true
-    playwright:
-      optional: true
-    puppeteer:
-      optional: true
-    pyodide:
-      optional: true
-    redis:
-      optional: true
-    sonix-speech-recognition:
-      optional: true
-    srt-parser-2:
-      optional: true
-    typeorm:
-      optional: true
-    weaviate-ts-client:
-      optional: true
-    web-auth-library:
-      optional: true
-    ws:
-      optional: true
-    youtube-transcript:
-      optional: true
-    youtubei.js:
-      optional: true
-  checksum: 6c1106d02c7198db973f0714cd71fb4c11a28a6630818f39ec07c2e0af573af64118bef49d7eb4cea3e2b2b701a2644fb95021377f75b8a9862e6faf9fa8a93a
-  languageName: node
-  linkType: hard
-
-"langchainhub@npm:~0.0.8":
-  version: 0.0.11
-  resolution: "langchainhub@npm:0.0.11"
-  checksum: 511371a6d9f277ddb0425b830afe41b029cf101becfa8ac55c3e7bf3dba2191d13772130b3c3d99f39d25f3bb22345808e0e8ce956296f49c728f8713072ce0b
-  languageName: node
-  linkType: hard
-
-"langsmith@npm:~0.1.1, langsmith@npm:~0.1.39, langsmith@npm:~0.1.7":
-  version: 0.1.39
-  resolution: "langsmith@npm:0.1.39"
-  dependencies:
-    "@types/uuid": ^9.0.1
-    commander: ^10.0.1
-    p-queue: ^6.6.2
-    p-retry: 4
-    uuid: ^9.0.0
-  peerDependencies:
-    "@langchain/core": "*"
-    langchain: "*"
-    openai: "*"
-  peerDependenciesMeta:
-    "@langchain/core":
-      optional: true
-    langchain:
-      optional: true
-    openai:
-      optional: true
-  checksum: df21332662ec3a2d2d5cf915acede52b96aedf2a286259435d683f230af5926500b129cab1f0275450e0d3de6d9d8476e410ac46f5e994beb43f2e2df8a1965f
-  languageName: node
-  linkType: hard
-
 "language-subtag-registry@npm:^0.3.20":
   version: 0.3.22
   resolution: "language-subtag-registry@npm:0.3.22"
@@ -33657,13 +32871,6 @@ __metadata:
   dependencies:
     invert-kv: ^1.0.0
   checksum: e8c7a4db07663068c5c44b650938a2bc41aa992037eebb69376214320f202c1250e70b50c32f939e28345fd30c2d35b8e8cd9a19d5932c398246a864ce54843d
-  languageName: node
-  linkType: hard
-
-"leac@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "leac@npm:0.6.0"
-  checksum: a7a722cfc2ddfd6fb2620e5dee3ac8e9b0af4eb04325f3c8286a820de78becba3010a4d7026ff5189bb159eb7a851c3a1ac73e076eb0d54fcee0adaf695291ba
   languageName: node
   linkType: hard
 
@@ -33801,44 +33008,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libbase64@npm:1.2.1":
-  version: 1.2.1
-  resolution: "libbase64@npm:1.2.1"
-  checksum: 891ed18fa0f0cd51a7a50d305dad03c3c35a077d46d23bd0a642a9710273294e331269ccf469a60e2191919f87fdf57c333d36bf4d33f176077c7cb3baf5c07c
-  languageName: node
-  linkType: hard
-
-"libbase64@npm:1.3.0":
-  version: 1.3.0
-  resolution: "libbase64@npm:1.3.0"
-  checksum: 14adc74fab5635f7e57b4e49b3bfb13b1e3f3abc2615e56c9c96571b994125ceed12de2c36c0a1d7a3a4d5bb34b82d18cf7fe354382c946929dc42397baf4d1e
-  languageName: node
-  linkType: hard
-
-"libmime@npm:5.2.0":
-  version: 5.2.0
-  resolution: "libmime@npm:5.2.0"
-  dependencies:
-    encoding-japanese: 2.0.0
-    iconv-lite: 0.6.3
-    libbase64: 1.2.1
-    libqp: 2.0.1
-  checksum: 266cdd678be0fe07048016246185eee9b77660ed824d8dd78e514f7efdebfcf8b7a73869c6151f2ccee6ba60df8c95ab3541a805a5606f375843edafd66e09b1
-  languageName: node
-  linkType: hard
-
-"libmime@npm:5.3.5":
-  version: 5.3.5
-  resolution: "libmime@npm:5.3.5"
-  dependencies:
-    encoding-japanese: 2.1.0
-    iconv-lite: 0.6.3
-    libbase64: 1.3.0
-    libqp: 2.1.0
-  checksum: bf541c3968ddebf639be742745d8953f9a0d38f1341cb77c84dc87e537de46f41af7907f3bb32c5da62bb11c4e99579a7bc36211b3f24899e5c37643a4d912e7
-  languageName: node
-  linkType: hard
-
 "libphonenumber-js@npm:1.10.51":
   version: 1.10.51
   resolution: "libphonenumber-js@npm:1.10.51"
@@ -33857,20 +33026,6 @@ __metadata:
   version: 1.10.51
   resolution: "libphonenumber-js@patch:libphonenumber-js@npm%3A1.10.51#./.yarn/patches/libphonenumber-js-npm-1.10.51-4ff79b15f8.patch::version=1.10.51&hash=1455d3&locator=calcom-monorepo%40workspace%3A."
   checksum: 6730b41757b106a2cbd298bb51e2a794e80c37c08942530f65e5e3c54aabf2b673c551a3dc17ccfe983dd948764fd7665048584b862b439a213f5ccb2fc3355b
-  languageName: node
-  linkType: hard
-
-"libqp@npm:2.0.1":
-  version: 2.0.1
-  resolution: "libqp@npm:2.0.1"
-  checksum: 04e3d32a1b89588ea50f73da39366b64dd9183d5b1fad3ac65e69abfac1f99693325da8cf6368b37836102dc13a67a1b9b5eab768c3e99246defaf460db96d94
-  languageName: node
-  linkType: hard
-
-"libqp@npm:2.1.0":
-  version: 2.1.0
-  resolution: "libqp@npm:2.1.0"
-  checksum: 6fbc0e23cc84e1f9d5061db4fc0363a4fe42fdc008ece956bc525336efa75e297a45f23ed11df15e7fc07419ff11630ac9e310ad5f25347fc26cb673dd578b86
   languageName: node
   linkType: hard
 
@@ -33918,15 +33073,6 @@ __metadata:
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
   checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
-  languageName: node
-  linkType: hard
-
-"linkify-it@npm:5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
-  dependencies:
-    uc.micro: ^2.0.0
-  checksum: b0b86cadaf816b64c947a83994ceaad1c15f9fe7e079776ab88699fb71afd7b8fc3fd3d0ae5ebec8c92c1d347be9ba257b8aef338c0ebf81b0d27dcf429a765a
   languageName: node
   linkType: hard
 
@@ -34789,35 +33935,6 @@ __metadata:
     iconv-lite:
       optional: true
   checksum: 3fe666bd0cb4cd6998da77e4b362ad1f34e4b8e8fc06724dba72712fe8f091dbc4e6d15e315c88d83bff6b9d3e682536cab51f376752ae340504265bf0bb3dd8
-  languageName: node
-  linkType: hard
-
-"mailparser@npm:^3.6.5":
-  version: 3.7.1
-  resolution: "mailparser@npm:3.7.1"
-  dependencies:
-    encoding-japanese: 2.1.0
-    he: 1.2.0
-    html-to-text: 9.0.5
-    iconv-lite: 0.6.3
-    libmime: 5.3.5
-    linkify-it: 5.0.0
-    mailsplit: 5.4.0
-    nodemailer: 6.9.13
-    punycode.js: 2.3.1
-    tlds: 1.252.0
-  checksum: 509c7177b0e1bae5f29eb2e10606562cae8a83785f09ed1e9adb62b317bbc99dfdb594dd08acb3dc6c81065a427da2f73d2db06e503c74f2b903e75dc2977321
-  languageName: node
-  linkType: hard
-
-"mailsplit@npm:5.4.0":
-  version: 5.4.0
-  resolution: "mailsplit@npm:5.4.0"
-  dependencies:
-    libbase64: 1.2.1
-    libmime: 5.2.0
-    libqp: 2.0.1
-  checksum: 2362d034558ea0ddc00a85e4229ce04b28a457f39d8014a5362fe8734051eae4de01110cb32efabec9abee1491dadcf47c7c7fa2ad2c60c18d23aad07634feda
   languageName: node
   linkType: hard
 
@@ -36253,52 +35370,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ml-array-mean@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "ml-array-mean@npm:1.1.6"
-  dependencies:
-    ml-array-sum: ^1.1.6
-  checksum: 81999dac8bad3bf2dafb23a9bc71883879b9d55889e48d00b91dd4a2568957a6f5373632ae57324760d1e1d7d29ad45ab4ea7ae32de67ce144d57a21e36dd9c2
-  languageName: node
-  linkType: hard
-
-"ml-array-sum@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "ml-array-sum@npm:1.1.6"
-  dependencies:
-    is-any-array: ^2.0.0
-  checksum: 369dbb3681e3f8b0d0facba9fcfc981656dac49a80924859c3ed8f0a5880fb6db2d6e534f8b7b9c3cda59248152e61b27d6419d19c69539de7c3aa6aea3094eb
-  languageName: node
-  linkType: hard
-
-"ml-distance-euclidean@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ml-distance-euclidean@npm:2.0.0"
-  checksum: e31f98a947ce6971c35d74e6d2521800f0d219efb34c78b20b5f52debd206008d52e677685c09839e6bab5d2ed233aa009314236e4e548d5fafb60f2f71e2b3e
-  languageName: node
-  linkType: hard
-
-"ml-distance@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "ml-distance@npm:4.0.1"
-  dependencies:
-    ml-array-mean: ^1.1.6
-    ml-distance-euclidean: ^2.0.0
-    ml-tree-similarity: ^1.0.0
-  checksum: 21ea014064eb7795c6c8c16e76bb834cba73f9f1ee2f761a3c3c34536f70bd6299b044dd05c495c533f5bdfea7401011dd4bdd159545ef69f5a021f5be4c77a2
-  languageName: node
-  linkType: hard
-
-"ml-tree-similarity@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "ml-tree-similarity@npm:1.0.0"
-  dependencies:
-    binary-search: ^1.3.5
-    num-sort: ^2.0.0
-  checksum: f99e217dc94acf75c089469dc3c278f388146e43c82212160b6b75daa14309902f84eb0a00c67d502fc79dc171cf15a33d392326e024b2e89881adc585d15513
-  languageName: node
-  linkType: hard
-
 "mlly@npm:^1.2.0":
   version: 1.2.1
   resolution: "mlly@npm:1.2.1"
@@ -36627,15 +35698,6 @@ __metadata:
     inherits: ^2.0.1
     readable-stream: ^2.0.5
   checksum: 4c5c8e7c8591048d74e6f6a6c9f914782d65109d152f78216faedf49c29f3223221049e8993f419a6bb94b4a9a7bfd676a2a98a0e110c77787909df2c715e0d0
-  languageName: node
-  linkType: hard
-
-"mustache@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "mustache@npm:4.2.0"
-  bin:
-    mustache: bin/mustache
-  checksum: 928fcb63e3aa44a562bfe9b59ba202cccbe40a46da50be6f0dd831b495be1dd7e38ca4657f0ecab2c1a89dc7bccba0885eab7ee7c1b215830da765758c7e0506
   languageName: node
   linkType: hard
 
@@ -37502,13 +36564,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:6.9.13":
-  version: 6.9.13
-  resolution: "nodemailer@npm:6.9.13"
-  checksum: 1b591ef480be2ff69480127cbff819e6593b1ef263b6f920e1a4e83e40280582daf7a14a809ef92f9828e2a70bdb3ce22b11924e209f2afe4975f9ff37e08e9d
-  languageName: node
-  linkType: hard
-
 "nodemailer@npm:^6.7.8":
   version: 6.7.8
   resolution: "nodemailer@npm:6.7.8"
@@ -37702,13 +36757,6 @@ __metadata:
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
   checksum: 10806b92121253eb1b08ecf707d92480f5331ba8ae5b23fa3eb0548ad24196eb797ed47606153006568a5733ea9e528a3579f21421f7828e09e7756f4bdd386f
-  languageName: node
-  linkType: hard
-
-"num-sort@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "num-sort@npm:2.1.0"
-  checksum: 5a80cd0456c8847f71fb80ad3c3596714cebede76de585aa4fed2b9a4fb0907631edca1f7bb31c24dbb9928b66db3d03059994cc365d2ae011b80ddddac28f6e
   languageName: node
   linkType: hard
 
@@ -38192,24 +37240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^4.26.0, openai@npm:^4.41.1":
-  version: 4.52.7
-  resolution: "openai@npm:4.52.7"
-  dependencies:
-    "@types/node": ^18.11.18
-    "@types/node-fetch": ^2.6.4
-    abort-controller: ^3.0.0
-    agentkeepalive: ^4.2.1
-    form-data-encoder: 1.7.2
-    formdata-node: ^4.3.2
-    node-fetch: ^2.6.7
-    web-streams-polyfill: ^3.2.1
-  bin:
-    openai: bin/cli
-  checksum: dcf5adc107366c91276a93ec338bb50e82f98048d18ac9bc330e05327fea854404f6ee40b1012c0f99e290afc174d9b886b8fe37f864c22ece30c53c666ed2e1
-  languageName: node
-  linkType: hard
-
 "openapi-sampler@npm:^1.0.0-beta.14":
   version: 1.2.1
   resolution: "openapi-sampler@npm:1.2.1"
@@ -38227,13 +37257,6 @@ __metadata:
     httpsnippet: ^2.0.0
     openapi-sampler: ^1.0.0-beta.14
   checksum: b5ba6ba799c95501cfa518fbee970c4fded4eadf6b56ca232f9b4e3e1e08eb8fda9df8e63914797281ea524dc648a377186966a5bdfc36fd7cff5acb899e5d5d
-  languageName: node
-  linkType: hard
-
-"openapi-types@npm:^12.1.3":
-  version: 12.1.3
-  resolution: "openapi-types@npm:12.1.3"
-  checksum: 7fa5547f87a58d2aa0eba6e91d396f42d7d31bc3ae140e61b5d60b47d2fd068b48776f42407d5a8da7280cf31195aa128c2fc285e8bb871d1105edee5647a0bb
   languageName: node
   linkType: hard
 
@@ -38560,7 +37583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-queue@npm:6.6.2, p-queue@npm:^6.6.2":
+"p-queue@npm:6.6.2":
   version: 6.6.2
   resolution: "p-queue@npm:6.6.2"
   dependencies:
@@ -38570,7 +37593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-retry@npm:4, p-retry@npm:4.6.2":
+"p-retry@npm:4.6.2":
   version: 4.6.2
   resolution: "p-retry@npm:4.6.2"
   dependencies:
@@ -38876,16 +37899,6 @@ __metadata:
   dependencies:
     entities: ^4.4.0
   checksum: 59465dd05eb4c5ec87b76173d1c596e152a10e290b7abcda1aecf0f33be49646ea74840c69af975d7887543ea45564801736356c568d6b5e71792fd0f4055713
-  languageName: node
-  linkType: hard
-
-"parseley@npm:^0.12.0":
-  version: 0.12.1
-  resolution: "parseley@npm:0.12.1"
-  dependencies:
-    leac: ^0.6.0
-    peberminta: ^0.9.0
-  checksum: 147760bce6c4a4f8c62af021a84ced262f078f60a1119e6891eba69567a953e06295ad2c70e5e89892ad1d4af0126f0856742d657a19a29ebf58422cf3bfd4f3
   languageName: node
   linkType: hard
 
@@ -39199,13 +38212,6 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: 2c950a100b1da72123449208e231afc188d980177d021d7121e96a2de7f2abbc96ead2b87d03d8fe5c318face097f203270d7e27908af9f471c165a4e8e69c92
-  languageName: node
-  linkType: hard
-
-"peberminta@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "peberminta@npm:0.9.0"
-  checksum: b983b68077269ca8a3327520a0a3f027fa930faa9fb3cb53bed1cb3847ebc0ed55db936d70b1745a756149911f5f450e898e87e25ab207f1b8b892bed48fb540
   languageName: node
   linkType: hard
 
@@ -40543,13 +39549,6 @@ __metadata:
     inherits: ^2.0.3
     pump: ^2.0.0
   checksum: 26ca412ec8d665bd0d5e185c1b8f627728eff603440d75d22a58e421e3c66eaf86ec6fc6a6efc54808ecef65979279fa8e99b109a23ec1fa8d79f37e6978c9bd
-  languageName: node
-  linkType: hard
-
-"punycode.js@npm:2.3.1":
-  version: 2.3.1
-  resolution: "punycode.js@npm:2.3.1"
-  checksum: 13466d7ed5e8dacdab8c4cc03837e7dd14218a59a40eb14a837f1f53ca396e18ef2c4ee6d7766b8ed2fc391d6a3ac489eebf2de83b3596f5a54e86df4a251b72
   languageName: node
   linkType: hard
 
@@ -43652,15 +42651,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selderee@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "selderee@npm:0.11.0"
-  dependencies:
-    parseley: ^0.12.0
-  checksum: af8a68c1f4cde858152943b6fc9f2b7164c8fb1a1c9f01b44350dffd1f79783930d77a0ae33548a036816d17c8130eeb9d15f1db65c9262ca368ad3a0d750f66
-  languageName: node
-  linkType: hard
-
 "semver-diff@npm:^4.0.0":
   version: 4.0.0
   resolution: "semver-diff@npm:4.0.0"
@@ -45455,15 +44445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: ^4.0.0
-  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -45486,6 +44467,15 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: 3dda818de06ebbe5b9653e07842d9479f3555ebc77e9a0280caf5a14fb877ffee9ed57007c3b78f5a6324b8dbeec648d9e97a24e2ed9fdb81ddc69ea07100f4a
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: ^4.0.0
+  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
   languageName: node
   linkType: hard
 
@@ -46290,15 +45280,6 @@ __metadata:
   dependencies:
     tslib: ^2.0.3
   checksum: e8b7ea006b53cf3208d278455d9f1e22c409459d7f9878da324fa3b18cc0aef8560924c19c744e870394a5d9cddfdbe029ebae9875909ee7f4fc562e7cbfc53e
-  languageName: node
-  linkType: hard
-
-"tlds@npm:1.252.0":
-  version: 1.252.0
-  resolution: "tlds@npm:1.252.0"
-  bin:
-    tlds: bin.js
-  checksum: cc25439b380f879d8ebd23c294e4f9a14e81332ff134122e4dae136fed579b835e6272d39b3e52aeb084f2cb9748f7616dcebf83a0b3e5af312a8e54b712ecbe
   languageName: node
   linkType: hard
 
@@ -47444,13 +46425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uc.micro@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "uc.micro@npm:2.1.0"
-  checksum: 37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2
-  languageName: node
-  linkType: hard
-
 "ufo@npm:^1.1.2":
   version: 1.1.2
   resolution: "ufo@npm:1.1.2"
@@ -48231,15 +47205,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
   languageName: node
   linkType: hard
 
@@ -49689,15 +48654,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.2.1":
-  version: 2.4.5
-  resolution: "yaml@npm:2.4.5"
-  bin:
-    yaml: bin.mjs
-  checksum: f8efd407c07e095f00f3031108c9960b2b12971d10162b1ec19007200f6c987d2e28f73283f4731119aa610f177a3ea03d4a8fcf640600a25de1b74d00c69b3d
-  languageName: node
-  linkType: hard
-
 "yaml@npm:^2.3.1":
   version: 2.5.0
   resolution: "yaml@npm:2.5.0"
@@ -49965,26 +48921,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.22.3, zod-to-json-schema@npm:^3.22.5":
-  version: 3.23.1
-  resolution: "zod-to-json-schema@npm:3.23.1"
-  peerDependencies:
-    zod: ^3.23.3
-  checksum: bbb0fdd8d28179c912d2d1c93051e418fc933288b8ac3704e7a514498fadf7781a8417aa9d52129a6a89ed5bc5a59793d3739c4869aa38600743cb009b52856d
-  languageName: node
-  linkType: hard
-
 "zod@npm:^3.20.2, zod@npm:^3.22.2, zod@npm:^3.22.4":
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.3":
-  version: 3.23.8
-  resolution: "zod@npm:3.23.8"
-  checksum: 15949ff82118f59c893dacd9d3c766d02b6fa2e71cf474d5aa888570c469dbf5446ac5ad562bb035bf7ac9650da94f290655c194f4a6de3e766f43febd432c5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4134,7 +4134,7 @@ __metadata:
   dependencies:
     "@calcom/platform-constants": "*"
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2"
-    "@calcom/platform-libraries-0.0.25": "npm:@calcom/platform-libraries@0.0.25"
+    "@calcom/platform-libraries-0.0.26": "npm:@calcom/platform-libraries@0.0.26"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -5087,14 +5087,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries-0.0.25@npm:@calcom/platform-libraries@0.0.25":
-  version: 0.0.25
-  resolution: "@calcom/platform-libraries@npm:0.0.25"
+"@calcom/platform-libraries-0.0.26@npm:@calcom/platform-libraries@0.0.26":
+  version: 0.0.26
+  resolution: "@calcom/platform-libraries@npm:0.0.26"
   dependencies:
     "@calcom/core": "*"
     "@calcom/features": "*"
     "@calcom/lib": "*"
-  checksum: ec81bb7dd6db345e25a725f5cd451d5f17ae32401206c80a1dab673419c3e7a41d502b76aa4f48a37016835dd8652a65cd9a3d4aae09a25b8e875d8335a8189e
+  checksum: 95b60b6bccfecf1d75f5b37b6e2b48811d6cbdd6ccb8157fa700558f2947adefd1fa26e7ed123f72960ddbf44ead26cce6e6fbd62505d73f5490abcf7c95563d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Releasing this 2 fixes in same PR because needed to update platform libraries for both and otherwise would have to wait for fix 1 merge.

# Problem 1 - event-types
If an event-type was created using version 2024_04_15  (prior to refactor #15457  / version 2024_06_14), then `bookingFields` were populated with system fields.

The new version 2024_06_14 only adds booking fields passed by the user to give full control. However, if user then uses version 2024_06_14 to fetch event-types created using version 2024_04_15, then error ocurred.

## Reason
2024_04_15 even-type booking fields includes user and system event-types, but 2024_06_14 used zod schema to parse and return only user event-types, so if system was encountered the zod schema failed and error occurred:
```
{
    "status": "error",
    "timestamp": "2024-08-04T19:53:41.713Z",
    "path": "/v2/organizations/15359/teams/17166/event-types",
    "error": {
        "code": "BAD_REQUEST",
        "message": "6.editable - Invalid literal value, expected \"user\", 6.sources.0.fieldRequired - Invalid literal value, expected true, 6.sources.0.label - Invalid literal value, expected \"User\", 6.sources.0.type - Invalid literal value, expected \"user\", 6.sources.0.id - Invalid literal value, expected \"user\", 6.label - Required, 5.editable - Invalid literal value, expected \"user\", 5.sources.0.fieldRequired - Invalid literal value, expected true, 5.sources.0.label - Invalid literal value, expected \"User\"
    }
}
```

Why did we change this logic? Because if user does not provide any booking fields when creating an event-type, then in database there should not be bunch of default system fields that would be also returned when fetching the event-type. Furthermore, booking atom then transforms api response by adding name and e-mail booking fields by default, so `bookingFields` acts as custom booking fields user needs.

## Solution

Shortly - make event-types with booking fields containing system booking fields backwards compatible with the new event-types 2024_06_14 version.

1. In commit [refactor: have system and user booking fields schemas and united schema](https://github.com/calcom/cal.com/commit/0e6fd0e3b8789dfa8d888b5337092b416bba4218) simplify code to clearly distinguish between system and user booking fields.
2. In commit [fix: event-types output service filter out system booking fields](https://github.com/calcom/cal.com/commit/92676ea18e79c0eade6b28769a68b6665756dd25) when constructing event-type response filter out system fields.

Chore: update platform libraries to support it and publish to version `0.0.25`

## Test
This issue was reported by our customer in [Slack](https://calcominc.slack.com/archives/C06QJ0P3EKH/p1722801313901169) and we checked the faulty event-type that has the booking fields below:
```
[{"name": "name", "type": "name", "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system", "required": true, "defaultLabel": "your_name"}, {"name": "email", "type": "email", "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system", "required": true, "defaultLabel": "email_address"}, {"name": "location", "type": "radioInput", "label": "", "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system", "required": false, "placeholder": "", "defaultLabel": "location", "getOptionsAt": "locations", "optionsInputs": {"phone": {"type": "phone", "required": true, "placeholder": ""}, "attendeeInPerson": {"type": "address", "required": true, "placeholder": ""}}, "hideWhenJustOneOption": true}, {"name": "title", "type": "text", "hidden": true, "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system-but-optional", "required": true, "defaultLabel": "what_is_this_meeting_about", "defaultPlaceholder": ""}, {"name": "notes", "type": "textarea", "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system-but-optional", "required": false, "defaultLabel": "additional_notes", "defaultPlaceholder": "share_additional_notes"}, {"name": "guests", "type": "multiemail", "hidden": false, "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system-but-optional", "required": false, "defaultLabel": "additional_guests", "defaultPlaceholder": "email"}, {"name": "rescheduleReason", "type": "textarea", "views": [{"id": "reschedule", "label": "Reschedule View"}], "sources": [{"id": "default", "type": "default", "label": "Default"}], "editable": "system-but-optional", "required": false, "defaultLabel": "reason_for_reschedule", "defaultPlaceholder": "reschedule_placeholder"}]
```

1. Create platform team event-type and pass these as `bookingFields`
2. Make a request to `api/v2/organizations/:orgId/teams/:teamId/event-types` and see that `bookingFields` are returned as `[]` aka with system fields filtered out.

# Problem 2 - outlook event description formatting

Events scheduled in outlook do not have newlines:
<img width="1177" alt="Screenshot 2024-08-08 at 15 39 58" src="https://github.com/user-attachments/assets/94986a30-b2a0-4aba-82d2-2131d594e6b4">

Solution: In [office365calendar/lib/CalendarService.ts](https://github.com/calcom/cal.com/pull/16132/files#diff-4f075841987a4d1474327cb5c6097757822d5df69616798d8014ff3207a3034b) replace newline characters with `<br>` since the content is sent as HTML. The description now is displayed just like in google calendar events:
<img width="1158" alt="Screenshot 2024-08-08 at 15 51 34" src="https://github.com/user-attachments/assets/d2855e71-0635-41ed-b72e-413b82e48010">

