### PR TITLE
feat: atoms date overrides modal custom classes

### DIFF
--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 
 import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
+import { classNames as cs } from "@calcom/lib";
 import { yyyymmdd } from "@calcom/lib/date-fns";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { WorkingHours } from "@calcom/types/schedule";
@@ -205,6 +206,7 @@ const DateOverrideInputDialog = ({
   excludedDates = [],
   userTimeFormat,
   weekStart = 0,
+  className,
   ...passThroughProps
 }: {
   workingHours: WorkingHours[];
@@ -214,13 +216,14 @@ const DateOverrideInputDialog = ({
   value?: TimeRange[];
   userTimeFormat: number | null;
   weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  className?: string;
 }) => {
   const [open, setOpen] = useState(false);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{Trigger}</DialogTrigger>
 
-      <DialogContent enableOverflow={true} size="md" className="p-0">
+      <DialogContent enableOverflow={true} size="md" className={cs("p-0", className)}>
         <DateOverrideForm
           excludedDates={excludedDates}
           weekStart={weekStart}

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -61,7 +61,7 @@ export type CustomClassNames = {
     timeRanges?: string;
     labelAndSwitchContainer?: string;
   };
-  overridesModalClassName?: string;
+  overridesModalClassNames?: string;
 };
 
 export type Availability = Pick<Schedule, "days" | "startTime" | "endTime">;
@@ -153,13 +153,13 @@ const DateOverride = ({
   userTimeFormat,
   travelSchedules,
   weekStart,
-  overridesModalClassName,
+  overridesModalClassNames,
 }: {
   workingHours: WorkingHours[];
   userTimeFormat: number | null;
   travelSchedules?: RouterOutputs["viewer"]["getTravelSchedules"];
   weekStart: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  overridesModalClassName?: string;
+  overridesModalClassNames?: string;
 }) => {
   const { append, replace, fields } = useFieldArray<AvailabilityFormValues, "dateOverrides">({
     name: "dateOverrides",
@@ -189,7 +189,7 @@ const DateOverride = ({
           travelSchedules={travelSchedules}
         />
         <DateOverrideInputDialog
-          className={overridesModalClassName}
+          className={overridesModalClassNames}
           workingHours={workingHours}
           excludedDates={excludedDates}
           onChange={(ranges) => ranges.forEach((range) => append({ ranges: [range] }))}
@@ -529,7 +529,7 @@ export function AvailabilitySettings({
                     weekStart
                   ) as 0 | 1 | 2 | 3 | 4 | 5 | 6
                 }
-                overridesModalClassName={customClassNames?.overridesModalClassName}
+                overridesModalClassNames={customClassNames?.overridesModalClassNames}
               />
             )}
           </div>

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -61,6 +61,7 @@ export type CustomClassNames = {
     timeRanges?: string;
     labelAndSwitchContainer?: string;
   };
+  overridesModalClassName?: string;
 };
 
 export type Availability = Pick<Schedule, "days" | "startTime" | "endTime">;
@@ -152,11 +153,13 @@ const DateOverride = ({
   userTimeFormat,
   travelSchedules,
   weekStart,
+  overridesModalClassName,
 }: {
   workingHours: WorkingHours[];
   userTimeFormat: number | null;
   travelSchedules?: RouterOutputs["viewer"]["getTravelSchedules"];
   weekStart: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  overridesModalClassName?: string;
 }) => {
   const { append, replace, fields } = useFieldArray<AvailabilityFormValues, "dateOverrides">({
     name: "dateOverrides",
@@ -186,6 +189,7 @@ const DateOverride = ({
           travelSchedules={travelSchedules}
         />
         <DateOverrideInputDialog
+          className={overridesModalClassName}
           workingHours={workingHours}
           excludedDates={excludedDates}
           onChange={(ranges) => ranges.forEach((range) => append({ ranges: [range] }))}
@@ -525,6 +529,7 @@ export function AvailabilitySettings({
                     weekStart
                   ) as 0 | 1 | 2 | 3 | 4 | 5 | 6
                 }
+                overridesModalClassName={customClassNames?.overridesModalClassName}
               />
             )}
           </div>


### PR DESCRIPTION
Allow passing new prop `overridesModalClassNames` to `AvailabilitySettings.customClassNames`:

```
<AvailabilitySettings
    enableOverrides={true}
    customClassNames={{
        overridesModalClassNames: "font-mono",
}}
```

<img width="874" alt="Screenshot 2024-08-09 at 12 03 04" src="https://github.com/user-attachments/assets/f8a2a60f-6cd5-4f94-8ba2-9e29b4bb0554">

and with overridesModalClassNames: "font-serif"
<img width="837" alt="Screenshot 2024-08-09 at 12 04 18" src="https://github.com/user-attachments/assets/a307b872-c01b-4e3b-9cf7-c903afa30bff">
