### PR TITLE
fix: broken password inputs

### DIFF
--- a/packages/ui/components/form/inputs/Input.tsx
+++ b/packages/ui/components/form/inputs/Input.tsx
@@ -48,9 +48,9 @@ export const PasswordField = forwardRef<HTMLInputElement, InputFieldProps>(funct
             type="button"
             onClick={() => toggleIsPasswordVisible()}>
             {isPasswordVisible ? (
-              <Icon name="eye-off" className="h-4 stroke-[2.5px]" />
+              <Icon name="eye-off" className="h-4 w-4 stroke-[2.5px]" />
             ) : (
-              <Icon name="eye" className="h-4 stroke-[2.5px]" />
+              <Icon name="eye" className="h-4 w-4 stroke-[2.5px]" />
             )}
             <span className="sr-only">{textLabel}</span>
           </button>


### PR DESCRIPTION
## What does this PR do?

Fixes password input icons not being the correct size caused by: https://github.com/calcom/cal.com/pull/16135

Before: 
![CleanShot 2024-08-09 at 11 22 23](https://github.com/user-attachments/assets/caffd311-23cc-4ed2-b133-b22208a0d092)
 
After:
![CleanShot 2024-08-09 at 11 51 24](https://github.com/user-attachments/assets/d59d3ecb-16a8-4301-9ffb-7a5ace37ccb6)
