### PR TITLE
fix: add sensible default size for svg icons

### DIFF
--- a/packages/ui/components/icon/Icon.tsx
+++ b/packages/ui/components/icon/Icon.tsx
@@ -4,7 +4,7 @@ import type { IconName } from "./icon-names";
 
 function Icon({
   name,
-  size,
+  size = 16,
   ...props
 }: SVGProps<SVGSVGElement> & {
   name: IconName;


### PR DESCRIPTION
## What does this PR do?
Follow up to #16135 Updated the default size of the Icon component to 16.

### What changed?
The default size argument in the Icon component was set to 16 px. This change ensures that the Icon component will have a default size of 16 px if no size is provided.

### How to test?
- Include the Icon component in a UI without specifying the size.
- Verify that the icon displayed is of 16 px.

### Why make this change?
This change sets a standard default size for icons which can help in maintaining consistency in the UI elements of the application.

---

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
