### PR TITLE
fix: doesn't fall back to calvideo if wrong destination is used for google meet

### DIFF
--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -170,6 +170,7 @@ export default class EventManager {
     if (evt.location === MeetLocationType && mainHostDestinationCalendar?.integration !== "google_calendar") {
       log.warn("Falling back to Cal Video integration as Google Calendar not installed");
       evt["location"] = "integrations:daily";
+      evt["conferenceCredentialId"] = undefined;
     }
     const isDedicated = evt.location ? isDedicatedIntegration(evt.location) : null;
 


### PR DESCRIPTION




## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #16149 (GitHub issue number)
- Fixes CAL-4129 (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Loom Video: https://www.loom.com/share/5755e62f0b3b4dd89e7ace6588552f01?sid=5a613d57-5166-412f-b48a-378b7fa48a9c

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). N/A.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Set a non google calendar as the destination calendar for an event.
- Set google meet as location value for the event.
- Now try to make a booking for that event.
- Notice that cal video is used as a fallback.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
