### PR TITLE
test: merge all e2e reports

### DIFF
--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -98,5 +98,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: app-store-results
-          path: test-results
+          name: blob-report-app-store
+          path: blob-report

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -85,5 +85,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: embed-react-results
-          path: test-results
+          name: blob-report-embed-react
+          path: blob-report

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -91,5 +91,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: embed-core-results
-          path: test-results
+          name: blob-report-embed-core
+          path: blob-report

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -189,19 +189,19 @@ jobs:
 
   merge-reports:
     name: Merge reports
-    if: ${{ !cancelled() }}
-    needs: [e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' }}
+    needs: [check-label, e2e]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
   publish-report:
     name: Publish HTML report
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [merge-reports]
+    needs: [check-label, merge-reports]
     uses: ./.github/workflows/publish-report.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -190,7 +190,7 @@ jobs:
   merge-reports:
     name: Merge reports
     if: ${{ !cancelled() }}
-    needs: [e2e]
+    needs: [e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 


### PR DESCRIPTION
## What does this PR do?

follow up to #16179 

Updated artifact naming and paths for E2E test results and adjusted workflow dependencies.

## What changed?

- Modified artifact names and paths in e2e-app-store.yml, e2e-embed-react.yml, and e2e-embed.yml workflows:
  - Changed artifact names to "blob-report-*" format
  - Updated artifact paths from "test-results" to "blob-report"
- Adjusted dependencies and conditions for merge-reports and publish-report jobs in pr.yml:
  - Added dependency on check-label job
  - Added condition to run only when run-e2e is true

## How to test?

1. Run the E2E workflows (app-store, embed-react, embed)
2. Verify that artifacts are correctly named and contain the expected blob reports
3. Trigger a PR workflow and ensure that merge-reports and publish-report jobs run only when E2E tests are executed

## Why make this change?

This change standardizes the naming convention for E2E test artifacts and ensures that report merging and publishing only occur when E2E tests are actually run. This improves consistency in artifact handling and optimizes workflow execution.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

- Done