### PR TITLE
fix: Duplicating org team event types not working #16199

### DIFF
--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -33,7 +33,7 @@ export const createEventTypeInput = z.object({
     title: z.string().min(1),
     description: z.string(),
     length: z.number(),
-    teamId: z.number().optional(),
+    teamId: z.number().optional().nullable(),
   }).strict();
 
 export type EventTypeLocation = (z.infer<typeof imports.eventTypeLocations>)[number];

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -33,7 +33,7 @@ export const createEventTypeInput = z.object({
     title: z.string().min(1),
     description: z.string(),
     length: z.number(),
-    teamId: z.number().optional().nullable(),
+    teamId: z.number().nullish(),
   }).strict();
 
 export type EventTypeLocation = (z.infer<typeof imports.eventTypeLocations>)[number];

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -33,6 +33,7 @@ export const createEventTypeInput = z.object({
     title: z.string().min(1),
     description: z.string(),
     length: z.number(),
+    teamId: z.number().optional(),
   }).strict();
 
 export type EventTypeLocation = (z.infer<typeof imports.eventTypeLocations>)[number];


### PR DESCRIPTION
## What does this PR do?


- Fixes #16199 (GitHub issue number)
- Fixes [CAL-4144] (Linear issue number - should be visible at the bottom of the GitHub issue description)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

https://www.loom.com/share/f9056cbd9b5246288910ab84ecc3b96a?sid=e6d72d83-e699-4307-8f90-4970458e1921


## Bug 

The bug was that the zodresolver was having  validation failure with duplicate event type for team as there is an additional field (`teamId`) in the form's defalutValues. Hence the "continue" button didn't do anything on click. 

`const form = useForm({
    defaultValues: {
      slug: t("event_type_duplicate_copy_text", { slug }),
      ...defaultValues,
    },
    resolver: zodResolver(EventTypeDuplicateInput),
  });`


`{title: '15 Min Meeting', description: '', id: 1133, length: 15}` -> Individual  EventType

`{title: 'Feedback', description: '', id: 1136, length: 15, teamId: 29}` -> Team EventType

