### PR TITLE
fix: missing pipeline dependecies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -189,19 +189,19 @@ jobs:
 
   merge-reports:
     name: Merge reports
-    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' }}
-    needs: [check-label, e2e]
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
   publish-report:
     name: Publish HTML report
-    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' }}
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [check-label, merge-reports]
+    needs: [changes, check-label, merge-reports]
     uses: ./.github/workflows/publish-report.yml
     secrets: inherit
 


### PR DESCRIPTION
## What does this PR do?

Updated conditions and dependencies for merge-reports and publish-report jobs in PR workflow.

## What changed?

- Added a new condition `needs.changes.outputs.has-files-requiring-all-checks == 'true'` to both merge-reports and publish-report jobs.
- Expanded the needs array for merge-reports job to include changes, e2e-embed, e2e-embed-react, and e2e-app-store.
- Added 'changes' to the needs array for the publish-report job.

## How to test?

1. Create a pull request that triggers the PR workflow.
2. Verify that the merge-reports and publish-report jobs only run when all conditions are met, including the new condition for files requiring all checks.
3. Ensure that the merge-reports job waits for the completion of all e2e-related jobs before running.

## Why make this change?

This change improves the efficiency and accuracy of the PR workflow by:
1. Ensuring that report merging and publishing only occur when necessary (i.e., when files requiring all checks have been modified).
2. Guaranteeing that all relevant e2e test results are included in the merged reports.
3. Reducing unnecessary workflow runs, potentially saving time and computational resources.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
