### PR TITLE
fix: DELETE /event-types/:id returning unexpected 403 #16189

### DIFF
--- a/apps/api/v1/pages/api/event-types/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_delete.ts
@@ -51,7 +51,7 @@ async function checkPermissions(req: NextApiRequest) {
   if (isSystemWideAdmin) return;
   /** Only event type owners can delete it */
   const eventType = await prisma.eventType.findFirst({ where: { id, userId } });
-  if (!eventType) throw new HttpError({ statusCode: 403, message: "Forbidden" });
+  if (!eventType) throw new HttpError({ statusCode: 404, message: "Event type with ID ${id} not found" });
 }
 
 export default defaultResponder(deleteHandler);

--- a/apps/api/v1/pages/api/event-types/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_delete.ts
@@ -51,7 +51,7 @@ async function checkPermissions(req: NextApiRequest) {
   if (isSystemWideAdmin) return;
   /** Only event type owners can delete it */
   const eventType = await prisma.eventType.findFirst({ where: { id, userId } });
-  if (!eventType) throw new HttpError({ statusCode: 404, message: "Event type with ID ${id} not found" });
+  if (!eventType) throw new HttpError({ statusCode: 404, message: `Event type with ID ${id} not found` });
 }
 
 export default defaultResponder(deleteHandler);


### PR DESCRIPTION
## What does this PR do?


- Fixes #16189 (GitHub issue number)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Bug 

The issue why we are getting 403 as API Response code because whenever we provide a non existent event Type id it can't find the eventType and hence throws 403. I have changed it to throw 404. I have seen this is the case in 2-3 more instances such as post and patch APIs for event-types.

