### PR TITLE
fix: pipeline permissions for label action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   label-pr:
     runs-on: ubuntu-latest
-
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Label PR as ready for E2E
         if: github.event.review.state == 'approved'


### PR DESCRIPTION
## What does this PR do?

Added permissions to the PR review workflow.

### What changed?

Added explicit permissions for actions, issues, and pull requests to the `label-pr` job in the PR review workflow.

### How to test?

1. Create a new pull request
2. Have someone review and approve the PR
3. Verify that the workflow runs successfully and applies the appropriate label

### Why make this change?

This change ensures that the workflow has the necessary permissions to read actions, write to issues, and modify pull requests. It follows GitHub's best practices for security by explicitly defining the required permissions, rather than relying on default settings.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
