### PR TITLE
fix: padding around adding fixed host

### DIFF
--- a/apps/web/components/eventtype/EventTeamTab.tsx
+++ b/apps/web/components/eventtype/EventTeamTab.tsx
@@ -119,7 +119,7 @@ const FixedHosts = ({
             <Label className="mb-1 text-sm font-semibold">{t("fixed_hosts")}</Label>
             <p className="text-subtle max-w-full break-words text-sm leading-tight">{FixedHostHelper}</p>
           </div>
-          <div className="border-subtle rounded-b-md border border-t-0">
+          <div className="border-subtle rounded-b-md border border-t-0 px-6">
             <AddMembersWithSwitch
               teamMembers={teamMembers}
               value={value}
@@ -162,7 +162,7 @@ const FixedHosts = ({
             setIsDisabled(checked);
           }}
           childrenClassName="lg:ml-0">
-          <div className="border-subtle flex flex-col gap-6 rounded-bl-md rounded-br-md border border-t-0">
+          <div className="border-subtle flex flex-col gap-6 rounded-bl-md rounded-br-md border border-t-0 px-6">
             <AddMembersWithSwitch
               teamMembers={teamMembers}
               value={value}


### PR DESCRIPTION
## What does this PR do?

Before: 
![Screenshot 2024-08-16 at 8 59 25 AM](https://github.com/user-attachments/assets/e31a5ca4-c10c-4884-bdde-ba53b18af40d)

![Screenshot 2024-08-16 at 8 59 38 AM](https://github.com/user-attachments/assets/d8c118c0-a136-46bd-9351-c7eabecc542f)


After: 
![Screenshot 2024-08-16 at 8 58 45 AM](https://github.com/user-attachments/assets/71d4324e-12ce-4745-973f-fa4e657d991a)

![Screenshot 2024-08-16 at 8 58 59 AM](https://github.com/user-attachments/assets/b12db8c2-4274-4ac0-a059-202240b302fe)
