### PR TITLE
chore: missing ff attributes migration

### DIFF
--- a/packages/prisma/migrations/20240816083533_attribute_feature_flag/migration.sql
+++ b/packages/prisma/migrations/20240816083533_attribute_feature_flag/migration.sql
@@ -1,0 +1,9 @@
+INSERT INTO
+  "Feature" (slug, enabled, description, "type")
+VALUES
+  (
+    'attributes',
+    false,
+    'Enable attributes - Custom fields for users and teams.',
+    'OPERATIONAL'
+  ) ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
Adds the missing migration file that should have been included in #15964 