### PR TITLE
fix: event name in attendee cancellation email

### DIFF
--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -378,7 +378,7 @@ export const sendCancelledEmails = async (
                   t: attendee.language.translate,
                   attendeeName: attendee.name,
                   host: calendarEvent.organizer.name,
-                  eventType: calendarEvent.type,
+                  eventType: calendarEvent.title,
                   eventDuration,
                   ...(calendarEvent.responses && { bookingFields: calendarEvent.responses }),
                   ...(calendarEvent.location && { location: calendarEvent.location }),


### PR DESCRIPTION
## What does this PR do?

Event type slug was used instead of the event type title for the event name in the attendee cancellation email (What section). 

Before: 
<img width="676" alt="Screenshot 2024-08-16 at 2 26 22 PM" src="https://github.com/user-attachments/assets/9262f6ac-e788-48d8-bfa3-0ea15cfbd7eb">

After
<img width="709" alt="Screenshot 2024-08-16 at 2 26 38 PM" src="https://github.com/user-attachments/assets/02c21568-3bd0-4787-804d-646c07faaef1">
