### PR TITLE
fix: type issues in attributes-edit-view

### DIFF
--- a/packages/features/ee/organizations/pages/settings/attributes/attributes-edit-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/attributes/attributes-edit-view.tsx
@@ -27,15 +27,16 @@ function CreateAttributesPage() {
   const utils = trpc.useUtils();
   const { t } = useLocale();
   // Get the attribute id from the url
-  const { id } = useParams<{ id: string }>();
+  const params = useParams<{ id: string }>();
+  const id = params?.id || "";
   // ensure string with zod
-  const attribute = trpc.viewer.attributes.get.useQuery({ id: id as string });
+  const attribute = trpc.viewer.attributes.get.useQuery({ id });
 
   const mutation = trpc.viewer.attributes.edit.useMutation({
     onSuccess: () => {
       showToast(t("attribute_edited_successfully"), "success");
       utils.viewer.attributes.get.invalidate({
-        id: id as string,
+        id,
       });
       utils.viewer.attributes.list.invalidate();
       router.push("/settings/organizations/attributes");
@@ -59,7 +60,7 @@ function CreateAttributesPage() {
             header={<EditAttributeHeader isPending={mutation.isPending} />}
             onSubmit={(values) => {
               mutation.mutate({
-                attributeId: id as string,
+                attributeId: id,
                 name: values.attrName,
                 type: values.type,
                 options: values.options,


### PR DESCRIPTION
## What does this PR do?

Improved attribute editing functionality and error handling in the organizations settings page.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQbH4zeZd9J8lCntUKAP/53c08f49-59ce-49d8-9754-5cb5a29b1c50.png)

### What changed?

- Updated the way the attribute ID is extracted from URL parameters
- Ensured consistent usage of the `id` variable throughout the component
- Removed unnecessary type assertion for the `id` parameter

### How to test?

1. Navigate to the organization settings page
2. Attempt to edit an existing attribute
3. Verify that the attribute details are correctly loaded and can be edited
4. Submit the changes and confirm they are saved successfully
5. Check that the attribute list is updated after editing


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.