### PR TITLE
fix: cross domain SVG sprites 

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { headers, cookies } from "next/headers";
 import React from "react";
 
 import { getLocale } from "@calcom/features/auth/lib/getLocale";
+import { IconSprites } from "@calcom/ui";
 
 import { prepareRootMetadata } from "@lib/metadata";
 
@@ -83,6 +84,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             --font-cal: ${calFont.style.fontFamily.replace(/\'/g, "")};
           }
         `}</style>
+        <IconSprites />
       </head>
       <body
         className="dark:bg-darkgray-50 bg-subtle antialiased"

--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -8,6 +8,7 @@ import "@calcom/embed-core/src/embed-iframe";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { IS_CALCOM, WEBAPP_URL } from "@calcom/lib/constants";
 import { buildCanonical } from "@calcom/lib/next-seo.config";
+import { IconSprites } from "@calcom/ui";
 
 import type { AppProps } from "@lib/app-providers";
 import AppProviders from "@lib/app-providers";
@@ -85,6 +86,7 @@ function PageWrapper(props: AppProps) {
           --font-cal: ${calFont.style.fontFamily};
         }
       `}</style>
+      <IconSprites />
 
       {getLayout(
         Component.requiresLicense ? (

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -10,6 +10,7 @@ import type { AppProps as NextAppProps } from "next/app";
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { useSearchParams } from "next/navigation";
 import { useEffect, type ReactNode } from "react";
+import CacheProvider from "react-inlinesvg/provider";
 
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
 import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/providerDynamic";
@@ -273,7 +274,10 @@ const AppProviders = (props: PageWrapperProps) => {
                 isBookingPage={props.isBookingPage || isBookingPage}>
                 <FeatureFlagsProvider>
                   <OrgBrandProvider>
-                    <MetaProvider>{props.children}</MetaProvider>
+                    {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
+                    <CacheProvider>
+                      <MetaProvider>{props.children}</MetaProvider>
+                    </CacheProvider>
                   </OrgBrandProvider>
                 </FeatureFlagsProvider>
               </CalcomThemeProvider>

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -10,6 +10,7 @@ import type { AppProps as NextAppProps, AppProps as NextJsAppProps } from "next/
 import type { ParsedUrlQuery } from "querystring";
 import type { PropsWithChildren, ReactNode } from "react";
 import { useEffect } from "react";
+import CacheProvider from "react-inlinesvg/provider";
 
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
 import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/providerDynamic";
@@ -299,7 +300,10 @@ const AppProviders = (props: AppPropsWithChildren) => {
               router={props.router}>
               <FeatureFlagsProvider>
                 <OrgBrandProvider>
-                  <MetaProvider>{props.children}</MetaProvider>
+                  {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
+                  <CacheProvider>
+                    <MetaProvider>{props.children}</MetaProvider>
+                  </CacheProvider>
                 </OrgBrandProvider>
               </FeatureFlagsProvider>
             </CalcomThemeProvider>

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -369,6 +369,10 @@ const nextConfig = {
         source: "/icons/sprite.svg",
         destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg`,
       },
+      {
+        source: "/icons/sprite.svg#:icon*",
+        destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg:icon*`,
+      },
 
       // When updating this also update pagesAndRewritePaths.js
       ...[

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -369,11 +369,6 @@ const nextConfig = {
         source: "/icons/sprite.svg",
         destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg`,
       },
-      // test
-      {
-        source: "/icons/sprite.svg#:icon*",
-        destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg:icon*`,
-      },
 
       // When updating this also update pagesAndRewritePaths.js
       ...[

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -369,6 +369,7 @@ const nextConfig = {
         source: "/icons/sprite.svg",
         destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg`,
       },
+      // test
       {
         source: "/icons/sprite.svg#:icon*",
         destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg:icon*`,

--- a/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
+++ b/packages/platform/atoms/cal-provider/BaseCalProvider.tsx
@@ -2,6 +2,7 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { useState } from "react";
 import { useCallback } from "react";
 
+import { IconSprites } from "@calcom/ui";
 import deTranslations from "@calcom/web/public/static/locales/de/common.json";
 import enTranslations from "@calcom/web/public/static/locales/en/common.json";
 import esTranslations from "@calcom/web/public/static/locales/es/common.json";
@@ -124,6 +125,7 @@ export function BaseCalProvider({
       }}>
       <TooltipProvider>{children}</TooltipProvider>
       <Toaster />
+      <IconSprites />
     </AtomsContext.Provider>
   ) : (
     <AtomsContext.Provider
@@ -142,6 +144,7 @@ export function BaseCalProvider({
       <>
         <TooltipProvider>{children}</TooltipProvider>
         <Toaster />
+        <IconSprites />
       </>
     </AtomsContext.Provider>
   );

--- a/packages/ui/components/icon/Icon.tsx
+++ b/packages/ui/components/icon/Icon.tsx
@@ -12,7 +12,7 @@ function Icon({
 }) {
   return (
     <svg height={size} width={size} {...props} aria-hidden>
-      <use href={`/icons/sprite.svg#${name}`} />
+      <use href={`#${name}`} />
     </svg>
   );
 }

--- a/packages/ui/components/icon/IconSprites.tsx
+++ b/packages/ui/components/icon/IconSprites.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import SVG from "react-inlinesvg";
+
+export function IconSprites() {
+  const ref = React.useRef<SVGElement>(null);
+  return <SVG innerRef={ref} src={`${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg`} />;
+}
+
+export default IconSprites;

--- a/packages/ui/components/icon/IconSprites.tsx
+++ b/packages/ui/components/icon/IconSprites.tsx
@@ -2,8 +2,11 @@ import * as React from "react";
 import SVG from "react-inlinesvg";
 
 export function IconSprites() {
-  const ref = React.useRef<SVGElement>(null);
-  return <SVG innerRef={ref} src={`${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg`} />;
+  return (
+    <SVG
+      src={`${process.env.NEXT_PUBLIC_WEBAPP_URL}/icons/sprite.svg?v=${process.env.NEXT_PUBLIC_CALCOM_VERSION}`}
+    />
+  );
 }
 
 export default IconSprites;

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -203,3 +203,4 @@ export type { OrgBannerProps } from "./components/organization-banner";
 export { StorybookTrpcProvider } from "./components/mocks/trpc";
 export { default as Icon } from "./components/icon/Icon";
 export type { IconName } from "./components/icon/icon-names";
+export { IconSprites } from "./components/icon/IconSprites";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,6 +48,7 @@
     "react-colorful": "^5.6.0",
     "react-day-picker": "^8.10.1",
     "react-hook-form": "^7.43.3",
+    "react-inlinesvg": "^4.1.3",
     "react-select": "^5.7.0",
     "react-virtual": "^2.10.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4867,6 +4867,7 @@ __metadata:
     react-colorful: ^5.6.0
     react-day-picker: ^8.10.1
     react-hook-form: ^7.43.3
+    react-inlinesvg: ^4.1.3
     react-select: ^5.7.0
     react-virtual: ^2.10.4
     typescript: ^4.9.4
@@ -35715,6 +35716,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-from-dom@npm:^0.7.2":
+  version: 0.7.3
+  resolution: "react-from-dom@npm:0.7.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: c2dd74dbdae570ce3ce2f7466643ac8e27de2511cb73cb3027fdfc572bed7bb058e1c459ffb32d02e2c41e4c21b0ca490d0dc861f30452fe3689d2e938ad7277
+  languageName: node
+  linkType: hard
+
 "react-hook-form@npm:^7.43.3":
   version: 7.43.3
   resolution: "react-hook-form@npm:7.43.3"
@@ -35773,6 +35783,17 @@ __metadata:
     react: ">= 16.6"
     react-dom: ">= 16.6"
   checksum: 73254040cb25b93343c03fb694c5eebbe558d486068ad9766d87ecb2661c38a2c2edf75e683da269f01a138f1aad1cd23cc456a857c5931af4ca54bf941bf12a
+  languageName: node
+  linkType: hard
+
+"react-inlinesvg@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "react-inlinesvg@npm:4.1.3"
+  dependencies:
+    react-from-dom: ^0.7.2
+  peerDependencies:
+    react: 16.8 - 18
+  checksum: c8b3f670188b645f03172ca89c653435cf41d99123791694e7525a5a2531a0bde4451735afe4e82a7188d8f90a362cb55f49bf8160cd77cd4fd5b1c78aa0f324
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Follow up to #16135 

Implemented icon sprite fetching to avoid CORS issues in Atoms, Embeds and Orgs subdomains.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQbH4zeZd9J8lCntUKAP/f793ee9f-ddcb-4ee6-b873-52339a265228.png)

### What changed?

- Added `IconSprites` component to render SVG sprites inline
- Updated `Icon` component to use local references instead of external SVG files
- Integrated `react-inlinesvg` library for efficient SVG handling
- Modified app layouts and providers to include `IconSprites` and `CacheProvider`

### How to test?

1. Run the application and navigate through different pages
2. Verify that icons are displayed correctly across the site
3. Inspect the page source to confirm the presence of inline SVG sprites
4. Check network requests to ensure SVG icons are not being loaded individually

### Why make this change?

This change optimizes icon loading by using SVG sprites, which reduces the number of HTTP requests and improves overall page load performance. By rendering icons inline and utilizing a cache provider, we enhance the efficiency of SVG handling across the application.

More info on the SVG CORS subject:

https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

