### PR TITLE
fix: permissions issue in pr labeler

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,7 +14,15 @@ jobs:
     steps:
       - name: Label PR as ready for E2E
         if: github.event.review.state == 'approved'
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v4
         with:
+          script: |
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: process.env.labels.split(', '),
+            })
+        env:
           github_token: ${{ secrets.READY_FOR_E2E_PAT }}
           labels: 'ready-for-e2e'


### PR DESCRIPTION
## What does this PR do?

Updated PR review workflow to use GitHub Script for adding labels. Seems like the previous action is not compatible with the updated permissions API yet: https://github.com/actions-ecosystem/action-add-labels/issues/444

### What changed?

Replaced the `actions-ecosystem/action-add-labels@v1` action with `actions/github-script@v4` in the PR review workflow. The new implementation uses a custom script to add the 'ready-for-e2e' label when a PR is approved.

### How to test?

1. Create a new pull request
2. Have a reviewer approve the PR
3. Verify that the 'ready-for-e2e' label is automatically added to the PR

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
