### PR TITLE
docs: update documentation references to include `/docs` base path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 ## Mandatory Tasks (DO NOT REMOVE)
 
 - [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
-- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
+- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
 - [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
 
 ## How should this be tested?

--- a/apps/api/v1/pages/api/availabilities/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_delete.ts
@@ -27,7 +27,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/availability
+ *        url: https://docs.cal.com/docs/availability
  *     responses:
  *       201:
  *         description: OK, availability removed successfully

--- a/apps/api/v1/pages/api/availabilities/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_delete.ts
@@ -27,7 +27,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/docs/availability
+ *        url: https://docs.cal.com/docs/core-features/availability
  *     responses:
  *       201:
  *         description: OK, availability removed successfully

--- a/apps/api/v1/pages/api/availabilities/[id]/_get.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_get.ts
@@ -28,7 +28,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/availability
+ *        url: https://docs.cal.com/docs/availability
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/availabilities/[id]/_get.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_get.ts
@@ -28,7 +28,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/docs/availability
+ *        url: https://docs.cal.com/docs/core-features/availability
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/availabilities/[id]/_patch.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_patch.ts
@@ -63,7 +63,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/availability
+ *        url: https://docs.cal.com/docs/availability
  *     responses:
  *       201:
  *         description: OK, availability edited successfully

--- a/apps/api/v1/pages/api/availabilities/[id]/_patch.ts
+++ b/apps/api/v1/pages/api/availabilities/[id]/_patch.ts
@@ -63,7 +63,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/docs/availability
+ *        url: https://docs.cal.com/docs/core-features/availability
  *     responses:
  *       201:
  *         description: OK, availability edited successfully

--- a/apps/api/v1/pages/api/availabilities/_post.ts
+++ b/apps/api/v1/pages/api/availabilities/_post.ts
@@ -62,7 +62,7 @@ import {
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/availability
+ *        url: https://docs.cal.com/docs/availability
  *     responses:
  *       201:
  *         description: OK, availability created

--- a/apps/api/v1/pages/api/availabilities/_post.ts
+++ b/apps/api/v1/pages/api/availabilities/_post.ts
@@ -62,7 +62,7 @@ import {
  *     tags:
  *     - availabilities
  *     externalDocs:
- *        url: https://docs.cal.com/docs/availability
+ *        url: https://docs.cal.com/docs/core-features/availability
  *     responses:
  *       201:
  *         description: OK, availability created

--- a/apps/api/v1/pages/api/docs.ts
+++ b/apps/api/v1/pages/api/docs.ts
@@ -11,8 +11,8 @@ const swaggerHandler = withSwagger({
       { url: "https://api.cal.com/v1" },
     ],
     externalDocs: {
-      url: "https://docs.cal.com",
-      description: "Find more info at our main docs: https://docs.cal.com/",
+      url: "https://docs.cal.com/docs",
+      description: "Find more info at our main docs: https://docs.cal.com/docs/",
     },
     info: {
       title: `${pjson.name}: ${pjson.description}`,

--- a/apps/api/v1/pages/api/event-types/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_delete.ts
@@ -28,7 +28,7 @@ import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransform
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       201:
  *         description: OK, eventType removed successfully

--- a/apps/api/v1/pages/api/event-types/[id]/_get.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_get.ts
@@ -34,7 +34,7 @@ import getCalLink from "../_utils/getCalLink";
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/event-types/[id]/_patch.ts
+++ b/apps/api/v1/pages/api/event-types/[id]/_patch.ts
@@ -194,7 +194,7 @@ import checkTeamEventEditPermission from "../_utils/checkTeamEventEditPermission
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       201:
  *         description: OK, eventType edited successfully

--- a/apps/api/v1/pages/api/event-types/_get.ts
+++ b/apps/api/v1/pages/api/event-types/_get.ts
@@ -33,7 +33,7 @@ import getCalLink from "./_utils/getCalLink";
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/event-types/_post.ts
+++ b/apps/api/v1/pages/api/event-types/_post.ts
@@ -255,7 +255,7 @@ import ensureOnlyMembersAsHosts from "./_utils/ensureOnlyMembersAsHosts";
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       201:
  *         description: OK, event type created

--- a/apps/api/v1/pages/api/teams/[teamId]/event-types/_get.ts
+++ b/apps/api/v1/pages/api/teams/[teamId]/event-types/_get.ts
@@ -32,7 +32,7 @@ const querySchema = z.object({
  *     tags:
  *     - event-types
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/event-types
+ *        url: https://docs.cal.com/docs/core-features/event-types
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/webhooks/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/webhooks/[id]/_delete.ts
@@ -27,7 +27,7 @@ import { schemaQueryIdAsString } from "~/lib/validations/shared/queryIdString";
  *     tags:
  *     - webhooks
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/webhooks
+ *        url: https://docs.cal.com/docs/core-features/webhooks
  *     responses:
  *       201:
  *         description: OK, hook removed successfully

--- a/apps/api/v1/pages/api/webhooks/[id]/_get.ts
+++ b/apps/api/v1/pages/api/webhooks/[id]/_get.ts
@@ -28,7 +28,7 @@ import { schemaWebhookReadPublic } from "~/lib/validations/webhook";
  *     tags:
  *     - webhooks
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/webhooks
+ *        url: https://docs.cal.com/docs/core-features/webhooks
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/webhooks/[id]/_patch.ts
+++ b/apps/api/v1/pages/api/webhooks/[id]/_patch.ts
@@ -58,7 +58,7 @@ import { schemaWebhookEditBodyParams, schemaWebhookReadPublic } from "~/lib/vali
  *     tags:
  *     - webhooks
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/webhooks
+ *        url: https://docs.cal.com/docs/core-features/webhooks
  *     responses:
  *       201:
  *         description: OK, webhook edited successfully

--- a/apps/api/v1/pages/api/webhooks/_get.ts
+++ b/apps/api/v1/pages/api/webhooks/_get.ts
@@ -24,7 +24,7 @@ import { schemaWebhookReadPublic } from "~/lib/validations/webhook";
  *     tags:
  *     - webhooks
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/webhooks
+ *        url: https://docs.cal.com/docs/core-features/webhooks
  *     responses:
  *       200:
  *         description: OK

--- a/apps/api/v1/pages/api/webhooks/_post.ts
+++ b/apps/api/v1/pages/api/webhooks/_post.ts
@@ -56,7 +56,7 @@ import { schemaWebhookCreateBodyParams, schemaWebhookReadPublic } from "~/lib/va
  *     tags:
  *     - webhooks
  *     externalDocs:
- *        url: https://docs.cal.com/core-features/webhooks
+ *        url: https://docs.cal.com/docs/core-features/webhooks
  *     responses:
  *       201:
  *         description: OK, webhook created


### PR DESCRIPTION
## What does this PR do?

- Updates documentation references, uncovered by searching w/ `https:\/\/docs\.cal\.com(?!\/docs)`

https://github.com/calcom/docs/commit/e25efd96a1bc454a2286546b760b084f834b4714

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
