### PR TITLE
fix: create event type refresh bug

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -170,7 +170,8 @@ const InfiniteMobileTeamsTab: FC<InfiniteMobileTeamsTabProps> = (props) => {
     },
     {
       refetchOnWindowFocus: true,
-      staleTime: 1 * 60 * 60 * 1000,
+      refetchOnMount: true,
+      staleTime: 0,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     }
   );
@@ -1619,6 +1620,7 @@ const EventTypesPage: React.FC<{ isInfiniteScrollEnabled?: boolean }> & {
   PageWrapper?: AppProps["Component"]["PageWrapper"];
   getLayout?: AppProps["Component"]["getLayout"];
 } = ({ isInfiniteScrollEnabled = false }) => {
+  isInfiniteScrollEnabled = true;
   const { t } = useLocale();
   const searchParams = useCompatSearchParams();
   const { open } = useIntercom();

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -1620,7 +1620,6 @@ const EventTypesPage: React.FC<{ isInfiniteScrollEnabled?: boolean }> & {
   PageWrapper?: AppProps["Component"]["PageWrapper"];
   getLayout?: AppProps["Component"]["getLayout"];
 } = ({ isInfiniteScrollEnabled = false }) => {
-  isInfiniteScrollEnabled = true;
   const { t } = useLocale();
   const searchParams = useCompatSearchParams();
   const { open } = useIntercom();

--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -121,11 +121,13 @@ export default function CreateEventTypeDialog({
       await router.replace(`/event-types/${eventType.id}${teamId ? "?tabName=team" : ""}`);
 
       if (isInfiniteScrollEnabled) {
-        await utils.viewer.eventTypes.getUserEventGroups.invalidate();
-        await utils.viewer.eventTypes.getEventTypesFromGroup.invalidate({
-          limit: 10,
-          group: { teamId: eventType?.teamId, parentId: eventType?.parentId },
-        });
+        await utils.viewer.eventTypes.getEventTypesFromGroup.fetchInfinite(
+          {
+            group: { teamId: eventType.teamId, parentId: eventType.parentId },
+            limit: 10,
+          },
+          { refetchPage: (_, index) => index === 0 }
+        );
       } else {
         await utils.viewer.eventTypes.getByViewer.invalidate();
       }

--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -121,13 +121,10 @@ export default function CreateEventTypeDialog({
       await router.replace(`/event-types/${eventType.id}${teamId ? "?tabName=team" : ""}`);
 
       if (isInfiniteScrollEnabled) {
-        await utils.viewer.eventTypes.getEventTypesFromGroup.fetchInfinite(
-          {
-            group: { teamId: eventType.teamId, parentId: eventType.parentId },
-            limit: 10,
-          },
-          { refetchPage: (_, index) => index === 0 }
-        );
+        await utils.viewer.eventTypes.getEventTypesFromGroup.fetchInfinite({
+          group: { teamId: eventType.teamId, parentId: eventType.parentId },
+          limit: 10,
+        });
       } else {
         await utils.viewer.eventTypes.getByViewer.invalidate();
       }


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/calcom/cal.com/issues/16070
- Fixes CAL-4105 (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

1) 

https://github.com/user-attachments/assets/b8d60bd5-9281-4cb9-bd32-1c0e2f2ccf5d


2)

https://github.com/user-attachments/assets/4f0c0136-61f5-48fc-a527-6d7e393a526a


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) set isInfiniteScrollEnabled = true in L1623 in apps/web/modules/event-types/views/event-types-listing-view.tsx
2) Create a new event type
