### PR TITLE
fix: UI Breaks When Entering a Long Username in Profile Settings

### DIFF
--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -278,17 +278,17 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
           <div className="flex flex-row">
             <div className="mb-4 w-full px-4 pt-1">
               <div className="bg-subtle flex w-full flex-wrap rounded-sm py-3 text-sm">
-                <div className="max-w-96 w-fit flex-1 px-2">
+                <div className="flex-1 px-2">
                   <p className="text-subtle">{t("current_username")}</p>
-                  <p className="text-emphasis mt-1" data-testid="current-username">
+                  <p className="text-emphasis mt-1 break-all" data-testid="current-username">
                     {currentUsername}
                   </p>
                 </div>
-                <div className="max-w-96 ml-6 w-fit flex-1">
+                <div className="ml-6 flex-1">
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>
-                  <p className="text-emphasis">{inputUsernameValue}</p>
+                  <p className="text-emphasis break-all">{inputUsernameValue}</p>
                 </div>
               </div>
             </div>

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -278,13 +278,13 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
           <div className="flex flex-row">
             <div className="mb-4 w-full px-4 pt-1">
               <div className="bg-subtle flex w-full flex-wrap rounded-sm py-3 text-sm">
-                <div className="flex-1 px-2">
+                <div className="max-w-96 w-fit flex-1 px-2">
                   <p className="text-subtle">{t("current_username")}</p>
                   <p className="text-emphasis mt-1" data-testid="current-username">
                     {currentUsername}
                   </p>
                 </div>
-                <div className="ml-6 flex-1">
+                <div className="max-w-96 ml-6 w-fit flex-1">
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -159,7 +159,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
         <DialogContent type="confirmation" Icon="pencil" title={t("confirm_username_change_dialog_title")}>
           <div className="flex flex-row">
             <div className="mb-4 w-full pt-1">
-              <div className="bg-subtle flex w-full flex-wrap justify-between gap-6 rounded-sm  px-4 py-3 text-sm">
+              <div className="bg-subtle flex w-full flex-wrap justify-between gap-6 rounded-sm px-4 py-3 text-sm">
                 <div>
                   <p className="text-subtle">{t("current_username")}</p>
                   <Tooltip content={currentUsername}>
@@ -175,7 +175,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
                     {t("new_username")}
                   </p>
                   <Tooltip content={inputUsernameValue}>
-                    <p className="text-emphasis mt-1 max-w-md overflow-hidden text-ellipsis">
+                    <p className="text-emphasis mt-1 w-96 overflow-hidden text-ellipsis">
                       {inputUsernameValue}
                     </p>
                   </Tooltip>

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -159,23 +159,23 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
         <DialogContent type="confirmation" Icon="pencil" title={t("confirm_username_change_dialog_title")}>
           <div className="flex flex-row">
             <div className="mb-4 w-full pt-1">
-              <div className="bg-subtle flex w-full flex-wrap justify-between gap-6 rounded-sm px-4 py-3 text-sm">
-                <div className="max-w-96 w-fit">
+              <div className="bg-subtle flex w-full flex-wrap justify-between gap-6 rounded-sm  px-4 py-3 text-sm">
+                <div>
                   <p className="text-subtle">{t("current_username")}</p>
                   <Tooltip content={currentUsername}>
                     <p
-                      className="text-emphasis mt-1 w-full max-w-md overflow-hidden text-ellipsis"
+                      className="text-emphasis mt-1 max-w-md overflow-hidden text-ellipsis break-all"
                       data-testid="current-username">
                       {currentUsername}
                     </p>
                   </Tooltip>
                 </div>
-                <div className="max-w-96 w-fit">
+                <div>
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>
                   <Tooltip content={inputUsernameValue}>
-                    <p className="text-emphasis mt-1 w-full overflow-hidden text-ellipsis">
+                    <p className="text-emphasis mt-1 max-w-md overflow-hidden text-ellipsis break-all">
                       {inputUsernameValue}
                     </p>
                   </Tooltip>

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -160,22 +160,22 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
           <div className="flex flex-row">
             <div className="mb-4 w-full pt-1">
               <div className="bg-subtle flex w-full flex-wrap justify-between gap-6 rounded-sm px-4 py-3 text-sm">
-                <div>
+                <div className="max-w-96 w-fit">
                   <p className="text-subtle">{t("current_username")}</p>
                   <Tooltip content={currentUsername}>
                     <p
-                      className="text-emphasis mt-1 max-w-md overflow-hidden text-ellipsis"
+                      className="text-emphasis mt-1 w-full max-w-md overflow-hidden text-ellipsis"
                       data-testid="current-username">
                       {currentUsername}
                     </p>
                   </Tooltip>
                 </div>
-                <div>
+                <div className="max-w-96 w-fit">
                   <p className="text-subtle" data-testid="new-username">
                     {t("new_username")}
                   </p>
                   <Tooltip content={inputUsernameValue}>
-                    <p className="text-emphasis mt-1 w-96 overflow-hidden text-ellipsis">
+                    <p className="text-emphasis mt-1 w-full overflow-hidden text-ellipsis">
                       {inputUsernameValue}
                     </p>
                   </Tooltip>


### PR DESCRIPTION
## What does this PR do?
This PR addresses a UI bug on the update username modal at [https://app.cal.com/settings/my-account/profile](https://app.cal.com/settings/my-account/profile), where entering a very long username would break the layout. The fix includes applying a character limit on the username input field and ensuring long usernames are truncated with an ellipsis to prevent UI issues.

- Fixes #16297
- Fixes CAL-4162

Loom Video: [https://www.loom.com/share/5112a72ae42d4aae9bf42bf2aa4d20c3?sid=09aa27f8-b4f9-46b7-92be-e3a87aff80fe](https://www.loom.com/share/5112a72ae42d4aae9bf42bf2aa4d20c3?sid=09aa27f8-b4f9-46b7-92be-e3a87aff80fe)

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent-sized PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to [https://app.cal.com/settings/my-account/profile](https://app.cal.com/settings/my-account/profile).
2. Try to update the username with a long string and verify that the UI no longer breaks.
3. Check that a character limit is enforced on the username input field.
4. Verify that long usernames are correctly displayed with truncation (e.g., ellipsis) if they exceed the allowed space.

- No additional environment variables are required.
- Minimal test data: Any valid username.
- Expected result: The username should update without breaking the UI, and long usernames should be truncated with ellipses when displayed.
