### PR TITLE
refactor: bulk update modal logic shifted to web wrapper

### DIFF
--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { SetStateAction, Dispatch } from "react";
 import { useMemo, useState, useEffect } from "react";
 import { Controller, useFieldArray, useForm, useWatch } from "react-hook-form";
 
@@ -14,7 +15,6 @@ import { availabilityAsString } from "@calcom/lib/availability";
 import classNames from "@calcom/lib/classNames";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { sortAvailabilityStrings } from "@calcom/lib/weekstart";
-import { trpc } from "@calcom/trpc";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import type { TimeRange, WorkingHours } from "@calcom/types/schedule";
 import {
@@ -32,7 +32,6 @@ import {
   TimezoneSelect as WebTimezoneSelect,
   Tooltip,
   VerticalDivider,
-  showToast,
 } from "@calcom/ui";
 import { Icon } from "@calcom/ui";
 
@@ -97,6 +96,12 @@ type AvailabilitySettingsProps = {
   customClassNames?: CustomClassNames;
   disableEditableHeading?: boolean;
   enableOverrides?: boolean;
+  bulkUpdateModalProps?: {
+    isOpen: boolean;
+    setIsOpen: Dispatch<SetStateAction<boolean>>;
+    save: ({ eventTypeIds }: { eventTypeIds: number[] }) => void;
+    isSaving: boolean;
+  };
 };
 
 const DeleteDialogButton = ({
@@ -246,20 +251,10 @@ export function AvailabilitySettings({
   customClassNames,
   disableEditableHeading = false,
   enableOverrides = false,
+  bulkUpdateModalProps,
 }: AvailabilitySettingsProps) {
   const [openSidebar, setOpenSidebar] = useState(false);
-  const [bulkUpdateModal, setBulkUpdateModal] = useState(false);
   const { t, i18n } = useLocale();
-
-  const utils = trpc.useUtils();
-  const bulkUpdateDefaultAvailabilityMutation =
-    trpc.viewer.availability.schedule.bulkUpdateToDefaultAvailability.useMutation({
-      onSuccess: () => {
-        utils.viewer.availability.list.invalidate();
-        setBulkUpdateModal(false);
-        showToast(t("success"), "success");
-      },
-    });
 
   const form = useForm<AvailabilityFormValues>({
     defaultValues: {
@@ -353,7 +348,7 @@ export function AvailabilitySettings({
                       checked={value}
                       onCheckedChange={(checked) => {
                         onChange(checked);
-                        setBulkUpdateModal(checked);
+                        bulkUpdateModalProps?.setIsOpen(checked);
                       }}
                     />
                   )}
@@ -362,12 +357,12 @@ export function AvailabilitySettings({
             ) : null}
           </div>
 
-          {bulkUpdateModal && (
+          {bulkUpdateModalProps && bulkUpdateModalProps?.isOpen && (
             <BulkEditDefaultForEventsModal
-              isPending={bulkUpdateDefaultAvailabilityMutation.isPending}
-              open={bulkUpdateModal}
-              setOpen={setBulkUpdateModal}
-              bulkUpdateFunction={bulkUpdateDefaultAvailabilityMutation.mutate}
+              isPending={bulkUpdateModalProps?.isSaving}
+              open={bulkUpdateModalProps?.isOpen}
+              setOpen={bulkUpdateModalProps.setIsOpen}
+              bulkUpdateFunction={bulkUpdateModalProps?.save}
             />
           )}
 

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsWebWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsWebWrapper.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import { withErrorFromUnknown } from "@calcom/lib/getClientErrorFromUnknown";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
@@ -28,6 +29,16 @@ export const AvailabilitySettingsWebWrapper = () => {
 
   const { data: travelSchedules, isPending: isPendingTravelSchedules } =
     trpc.viewer.getTravelSchedules.useQuery();
+
+  const [isBulkUpdateModalOpen, setIsBulkUpdateModalOpen] = useState(false);
+  const bulkUpdateDefaultAvailabilityMutation =
+    trpc.viewer.availability.schedule.bulkUpdateToDefaultAvailability.useMutation({
+      onSuccess: () => {
+        utils.viewer.availability.list.invalidate();
+        setIsBulkUpdateModalOpen(false);
+        showToast(t("success"), "success");
+      },
+    });
 
   const isDefaultSchedule = me.data?.defaultScheduleId === scheduleId;
 
@@ -100,6 +111,12 @@ export const AvailabilitySettingsWebWrapper = () => {
             dateOverrides: dateOverrides.flatMap((override) => override.ranges),
             ...values,
           });
+      }}
+      bulkUpdateModalProps={{
+        isOpen: isBulkUpdateModalOpen,
+        setIsOpen: setIsBulkUpdateModalOpen,
+        save: bulkUpdateDefaultAvailabilityMutation.mutate,
+        isSaving: bulkUpdateDefaultAvailabilityMutation.isPending,
       }}
     />
   );


### PR DESCRIPTION
## What does this PR do?

Shifted trpc related logic of the bulk update modal inside of availability settings to the appropriate web wrapper

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A- I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

go to /availability and try to set a new schedule as default schedule, it should open a modal to bulk update the schedules of your event-types