### PR TITLE
feat: block pending meetings for requires confirmation

### DIFF
--- a/apps/web/components/eventtype/EventAdvancedTab.tsx
+++ b/apps/web/components/eventtype/EventAdvancedTab.tsx
@@ -279,6 +279,7 @@ export const EventAdvancedTab = ({ eventType, team }: Pick<EventTypeSetupProps, 
         seatsEnabled={seatsEnabled}
         metadata={formMethods.getValues("metadata")}
         requiresConfirmation={requiresConfirmation}
+        requiresConfirmationWillBlockSlot={formMethods.getValues("requiresConfirmationWillBlockSlot")}
         onRequiresConfirmation={setRequiresConfirmation}
       />
       <Controller

--- a/apps/web/components/eventtype/RequiresConfirmationController.tsx
+++ b/apps/web/components/eventtype/RequiresConfirmationController.tsx
@@ -199,7 +199,7 @@ export default function RequiresConfirmationController({
                         <CheckboxField
                           checked={requiresConfirmationWillBlockSlot}
                           descriptionAsLabel
-                          description="Unconfirmed bookings still block calendar slots."
+                          description={t("requires_confirmation_will_block_slot_description")}
                           onChange={(e) => {
                             // We set should dirty to properly detect when we can submit the form
                             formMethods.setValue("requiresConfirmationWillBlockSlot", e.target.checked, {

--- a/apps/web/modules/event-types/views/event-types-single-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-single-view.tsx
@@ -301,6 +301,7 @@ const EventTypePage = (props: EventTypeSetupProps & { allActiveWorkflows?: Workf
       periodCountCalendarDays: eventType.periodCountCalendarDays ? true : false,
       schedulingType: eventType.schedulingType,
       requiresConfirmation: eventType.requiresConfirmation,
+      requiresConfirmationWillBlockSlot: eventType.requiresConfirmationWillBlockSlot,
       slotInterval: eventType.slotInterval,
       minimumBookingNotice: eventType.minimumBookingNotice,
       metadata: eventType.metadata,

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -846,6 +846,7 @@
   "disable_notes": "Hide notes in calendar",
   "disable_notes_description": "For privacy reasons, additional inputs and notes will be hidden in the calendar entry. They will still be sent to your email.",
   "requires_confirmation_description": "The booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent.",
+  "requires_confirmation_will_block_slot_description": "Unconfirmed bookings still block calendar slots.",
   "recurring_event": "Recurring Event",
   "recurring_event_description": "People can subscribe for recurring events",
   "cannot_be_used_with_paid_event_types": "It cannot be used with paid event types",

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -94,13 +94,13 @@ export async function getBusyTimes(params: {
   const endTimeAdjustedWithMaxBuffer = dayjs(endTimeDate).add(maxBuffer, "minute").toDate();
 
   // startTime is less than endTimeDate and endTime grater than startTimeDate
-  const sharedQuery = {
+  const sharedQuery: Prisma.BookingWhereInput = {
     startTime: { lte: endTimeAdjustedWithMaxBuffer },
     endTime: { gte: startTimeAdjustedWithMaxBuffer },
     status: {
       in: [BookingStatus.ACCEPTED],
     },
-  } as Prisma.BookingWhereInput;
+  };
 
   // INFO: Refactored to allow this method to take in a list of current bookings for the user.
   // Will keep support for retrieving a user's bookings if the caller does not already supply them.

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -100,7 +100,8 @@ export async function getBusyTimes(params: {
     status: {
       in: [BookingStatus.ACCEPTED],
     },
-  };
+  } as Prisma.BookingWhereInput;
+
   // INFO: Refactored to allow this method to take in a list of current bookings for the user.
   // Will keep support for retrieving a user's bookings if the caller does not already supply them.
   // This function is called from multiple places but we aren't refactoring all of them at this moment
@@ -122,6 +123,18 @@ export async function getBusyTimes(params: {
                 some: {
                   email: userEmail,
                 },
+              },
+            },
+            {
+              startTime: { lte: endTimeDate },
+              endTime: { gte: startTimeDate },
+              eventType: {
+                id: eventTypeId,
+                requiresConfirmation: true,
+                requiresConfirmationWillBlockSlot: true,
+              },
+              status: {
+                in: [BookingStatus.PENDING],
               },
             },
           ],

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -48,6 +48,7 @@ export type FormValues = {
   disableGuests: boolean;
   lockTimeZoneToggleOnBookingPage: boolean;
   requiresConfirmation: boolean;
+  requiresConfirmationWillBlockSlot: boolean;
   requiresBookerEmailVerification: boolean;
   recurringEvent: RecurringEvent | null;
   schedulingType: SchedulingType | null;

--- a/packages/lib/server/eventTypeSelect.ts
+++ b/packages/lib/server/eventTypeSelect.ts
@@ -12,6 +12,7 @@ export const eventTypeSelect = Prisma.validator<Prisma.EventTypeSelect>()({
   length: true,
   title: true,
   requiresConfirmation: true,
+  requiresConfirmationWillBlockSlot: true,
   position: true,
   offsetStart: true,
   profileId: true,

--- a/packages/lib/server/repository/eventType.ts
+++ b/packages/lib/server/repository/eventType.ts
@@ -443,6 +443,7 @@ export class EventTypeRepository {
       periodCountCalendarDays: true,
       lockTimeZoneToggleOnBookingPage: true,
       requiresConfirmation: true,
+      requiresConfirmationWillBlockSlot: true,
       requiresBookerEmailVerification: true,
       recurringEvent: true,
       hideCalendarNotes: true,

--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -102,6 +102,7 @@ export const buildEventType = (eventType?: Partial<EventType>): EventType => {
     recurringEvent: null,
     lockTimeZoneToggleOnBookingPage: false,
     requiresConfirmation: false,
+    requiresConfirmationWillBlockSlots: false,
     disableGuests: false,
     hideCalendarNotes: false,
     minimumBookingNotice: 120,

--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -102,6 +102,7 @@ export const buildEventType = (eventType?: Partial<EventType>): EventType => {
     recurringEvent: null,
     lockTimeZoneToggleOnBookingPage: false,
     requiresConfirmation: false,
+    requiresConfirmationWillBlockSlot: false,
     disableGuests: false,
     hideCalendarNotes: false,
     minimumBookingNotice: 120,

--- a/packages/prisma/migrations/20240823092832_add_requires_confirmation_will_block_slot/migration.sql
+++ b/packages/prisma/migrations/20240823092832_add_requires_confirmation_will_block_slot/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventType" ADD COLUMN     "requiresConfirmationWillBlockSlot" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -104,6 +104,7 @@ model EventType {
   periodCountCalendarDays                 Boolean?
   lockTimeZoneToggleOnBookingPage         Boolean                   @default(false)
   requiresConfirmation                    Boolean                   @default(false)
+  requiresConfirmationWillBlockSlot       Boolean                   @default(false)
   requiresBookerEmailVerification         Boolean                   @default(false)
   /// @zod.custom(imports.recurringEventType)
   recurringEvent                          Json?

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -641,6 +641,7 @@ export const allManagedEventTypeProps: { [k in keyof Omit<Prisma.EventTypeSelect
   customInputs: true,
   disableGuests: true,
   requiresConfirmation: true,
+  requiresConfirmationWillBlockSlot: true,
   eventName: true,
   metadata: true,
   children: true,

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -527,6 +527,18 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Pro
             },
           },
         },
+        {
+          startTime: { lte: endTimeDate },
+          endTime: { gte: startTimeDate },
+          eventType: {
+            id: eventType.id,
+            requiresConfirmation: true,
+            requiresConfirmationWillBlockSlot: true,
+          },
+          status: {
+            in: [BookingStatus.PENDING],
+          },
+        },
       ],
     },
     select: {
@@ -544,6 +556,8 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Pro
           afterEventBuffer: true,
           beforeEventBuffer: true,
           seatsPerTimeSlot: true,
+          requiresConfirmationWillBlockSlot: true,
+          requiresConfirmation: true,
         },
       },
       ...(!!eventType?.seatsPerTimeSlot && {


### PR DESCRIPTION
## What does this PR do?
This PR gives the user the choice to enable "requires confirmation" events to block the calendar when they are pending
![CleanShot 2024-08-23 at 14 04 40](https://github.com/user-attachments/assets/1fb14231-84fc-444a-82c4-9fed73a41442)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1) Create an event type with requires confirmation
2) Enable the new checkbox
3) Place a test booking with this event type
4) Notice even tho the event is pending - slot gets blocked
5) Meanwhile create a new event type that has requires confirmation but dont check this box
6) Make a test booking
7) Ensure that that slot is still bookable (as the block slots setting is disabled) 
8) profit
