### PR TITLE
fix: Undefined user in insights data

### DIFF
--- a/packages/features/insights/components/TotalBookingUsersTable.tsx
+++ b/packages/features/insights/components/TotalBookingUsersTable.tsx
@@ -17,13 +17,13 @@ export const TotalBookingUsersTable = ({
       }[]
     | undefined;
 }) => {
-  const filteredUsers = data && data?.length > 0 ? data?.filter((item) => !!item.user) : [];
+  const filteredData = data && data?.length > 0 ? data?.filter((item) => !!item.user) : [];
   return (
     <Table>
       <TableBody>
         <>
-          {filteredUsers.length > 0 ? (
-            filteredUsers.map((item) => (
+          {filteredData.length > 0 ? (
+            filteredData.map((item) => (
               <TableRow key={item.userId}>
                 <TableCell className="flex flex-row">
                   <Avatar

--- a/packages/features/insights/components/TotalBookingUsersTable.tsx
+++ b/packages/features/insights/components/TotalBookingUsersTable.tsx
@@ -17,12 +17,13 @@ export const TotalBookingUsersTable = ({
       }[]
     | undefined;
 }) => {
+  const filteredUsers = data && data?.length > 0 ? data?.filter((item) => !!item.user) : [];
   return (
     <Table>
       <TableBody>
         <>
-          {data && data?.length > 0 ? (
-            data?.map((item) => (
+          {filteredUsers.length > 0 ? (
+            filteredUsers.map((item) => (
               <TableRow key={item.userId}>
                 <TableCell className="flex flex-row">
                   <Avatar


### PR DESCRIPTION
## What does this PR do?

Fixes 
<img width="560" alt="Screenshot 2024-08-27 at 1 35 33 AM" src="https://github.com/user-attachments/assets/9447954e-1b56-458f-a810-ecc331172a7b">

TBD if this is a result of bad data or if this always happens when a user is deleted perhaps? For now, we need this patched and the investigation into root cause will continue.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A - Won't be adding an E2E to specifically cover this since we are rewriting the insights page soon. 

## How should this be tested?

- Run insights over a wide range of data and ensure everything loads

