### PR TITLE
fix: API v2 E2E Docker rate limiting

### DIFF
--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -45,6 +45,9 @@ jobs:
           - 5432:5432
       redis:
         image: redis:latest
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
## What does this PR do?

Fixes Docker rate limiting errors we have seen in GitHub actions.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
