### PR TITLE
chore: Use pull-request feature from Replexica

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,8 +115,11 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' }}
         shell: bash
       - uses: replexica/replexica@main
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           api-key: ${{ secrets.CI_REPLEXICA_API_KEY }}
+          pull-request: true
 
   type-check:
     name: Type check
@@ -152,7 +155,7 @@ jobs:
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-production-build.yml
     secrets: inherit
-  
+
   build-atoms:
     name: Production builds
     needs: [changes, check-label, deps]
@@ -238,7 +241,6 @@ jobs:
       [
         changes,
         lint,
-        i18n,
         type-check,
         unit-test,
         integration-test,


### PR DESCRIPTION
## What does this PR do?

Using this setting will tell Replexica to push to current PR running the job

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
