### PR TITLE
fix: use `userPhone` instead of `phone` for switch case

### DIFF
--- a/packages/platform/atoms/event-types/atom-api-transformers/transformApiEventTypeForAtom.ts
+++ b/packages/platform/atoms/event-types/atom-api-transformers/transformApiEventTypeForAtom.ts
@@ -194,7 +194,7 @@ function getLocations(locations: EventTypeOutput_2024_06_14["locations"]) {
         return displayLocationPublicly ? location : { ...location, address: "" };
       case "link":
         return displayLocationPublicly ? location : { ...location, link: "" };
-      case "phone":
+      case "userPhone":
         return displayLocationPublicly
           ? location
           : {

--- a/packages/platform/atoms/event-types/atom-api-transformers/transformApiEventTypeForAtom.ts
+++ b/packages/platform/atoms/event-types/atom-api-transformers/transformApiEventTypeForAtom.ts
@@ -190,7 +190,7 @@ function getLocations(locations: EventTypeOutput_2024_06_14["locations"]) {
     const { displayLocationPublicly, type } = location;
 
     switch (type) {
-      case "address":
+      case "inPerson":
         return displayLocationPublicly ? location : { ...location, address: "" };
       case "link":
         return displayLocationPublicly ? location : { ...location, link: "" };


### PR DESCRIPTION
Currently this switch case never gets to the last case ("phone") as the type expected is wrong.

Here the type may have value `userPhone` and not `phone`.

## What does this PR do?

The existing case to hide the location based on the `displayLocationPublicly` field and `type` never hid the phone number as the type expected was wrong. Instead of checking for `phone` it should have checked for `userPhone`

See issue below for context:

- Fixes #16382

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
