### PR TITLE
chore: switch pr's i18n job to in-branch mode

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,12 +114,11 @@ jobs:
       - run: find apps/web/public/static/locales/** -name "common.json" | xargs git checkout ${{ github.event.pull_request.head.sha }} --
         if: ${{ github.event.pull_request.head.sha != '' }}
         shell: bash
+      - run: git checkout ${{ github.event.pull_request.head.sha }} -- i18n.json
+        if: ${{ github.event.pull_request.head.sha != '' }}
       - uses: replexica/replexica@main
-        env:
-          GH_TOKEN: ${{ github.token }}
         with:
           api-key: ${{ secrets.CI_REPLEXICA_API_KEY }}
-          pull-request: true
 
   type-check:
     name: Type check


### PR DESCRIPTION
## What does this PR do?

Updates PR's i18n job, to creat commits in the PR's branch instead of opening pull requests.

Prep work for https://github.com/calcom/cal.com/pull/16381

Note: The current i18n job https://github.com/calcom/cal.com/actions/runs/10605517802/job/29394462961?pr=16390#step:6:74 is expected to fail, as its current settings are incompatible with its permissions. Mering this PR fixes that.

cc @keithwillcode.