### PR TITLE
perf: Removed unused attendees count

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -171,11 +171,6 @@ const _getCurrentSeats = async (
           email: true,
         },
       },
-      _count: {
-        select: {
-          attendees: true,
-        },
-      },
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

In examining DB perf, this query being executed is quite slow. The agg count that's added by prisma isn't used.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure all tests are passing related to slots
