### PR TITLE
chore: Move Replexica to run on pushes to main

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -5,7 +5,7 @@ on:
       - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   i18n:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-main
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,25 @@
+name: Run i18n AI automation
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  i18n:
+    name: Run i18n
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: replexica/replexica@main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          api-key: ${{ secrets.CI_REPLEXICA_API_KEY }}
+          pull-request: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,29 +97,6 @@ jobs:
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/yarn-install.yml
 
-  i18n:
-    name: Run i18n
-    runs-on: buildjet-2vcpu-ubuntu-2204
-    permissions:
-      actions: write
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      # Doing this custom checkout of the common.json files from the PR since we don't
-      # want to checkout the entire branch for security reasons as this job is granted
-      # write permissions.
-      - run: git fetch --depth=2 origin ${{ github.event.pull_request.head.sha }}
-        if: ${{ github.event.pull_request.head.sha != '' }}
-      - run: find apps/web/public/static/locales/** -name "common.json" | xargs git checkout ${{ github.event.pull_request.head.sha }} --
-        if: ${{ github.event.pull_request.head.sha != '' }}
-        shell: bash
-      - run: git checkout ${{ github.event.pull_request.head.sha }} -- i18n.json
-        if: ${{ github.event.pull_request.head.sha != '' }}
-      - uses: replexica/replexica@main
-        with:
-          api-key: ${{ secrets.CI_REPLEXICA_API_KEY }}
-
   type-check:
     name: Type check
     needs: [changes, check-label, deps]


### PR DESCRIPTION
## What does this PR do?

After talking with Replexica, we decided it was best at this point to move the automation to run on pushes to main since the `pull_request_target` workflow alongside our desire to not checkout full external branches when GitHub actions have write permissions makes the workflow too clunky.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Once merged, ensure pushes to main trigger this job and a new PR is opened if there are translations done
