### PR TITLE
perf: Separate OR clauses from Insights counts

### DIFF
--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -51,7 +51,7 @@ class EventsInsights {
       (aggregate: { [x: string]: number }, item) => {
         if (typeof item.timeStatus === "string") {
           aggregate[item.timeStatus] = item._count._all;
-          aggregate._all += item._count._all;
+          aggregate["_all"] += item._count._all;
         }
         return aggregate;
       },

--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -50,7 +50,7 @@ class EventsInsights {
     return data.reduce(
       (aggregate: { [x: string]: number }, item) => {
         if (typeof item.timeStatus === "string") {
-          aggregate[item.timeStatus] = item._count._all;
+          aggregate[item.timeStatus] += item._count._all;
           aggregate["_all"] += item._count._all;
         }
         return aggregate;

--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -14,14 +14,14 @@ type TimeViewType = "week" | "month" | "year" | "day";
 
 class EventsInsights {
   static countGroupedByStatus = async (where: Prisma.BookingTimeStatusWhereInput) => {
-    let data;
+    let data: Awaited<ReturnType<typeof prisma.bookingTimeStatus.groupBy>>;
     if (!!where["OR"]) {
       const queries = [];
       const existingWhereOr = where["OR"];
-      delete where["OR"];
+      const { OR, ...whereWithoutOr } = where;
       for (let i = 0; i < existingWhereOr.length; i++) {
         const newWhere = {
-          ...where,
+          ...whereWithoutOr,
           ...existingWhereOr[i],
         };
         queries.push(
@@ -36,7 +36,7 @@ class EventsInsights {
       }
 
       const results = await Promise.all(queries);
-      data = [...results];
+      data = results.flat();
     } else {
       data = await prisma.bookingTimeStatus.groupBy({
         where,

--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -14,11 +14,11 @@ type TimeViewType = "week" | "month" | "year" | "day";
 
 class EventsInsights {
   static countGroupedByStatus = async (where: Prisma.BookingTimeStatusWhereInput) => {
-    let data: Awaited<ReturnType<typeof prisma.bookingTimeStatus.groupBy>>;
+    let data;
     if (!!where["OR"]) {
       const queries = [];
       const existingWhereOr = where["OR"];
-      const { OR, ...whereWithoutOr } = where;
+      const { OR: throwAwayOr, ...whereWithoutOr } = where;
       for (let i = 0; i < existingWhereOr.length; i++) {
         const newWhere = {
           ...whereWithoutOr,
@@ -51,7 +51,7 @@ class EventsInsights {
       (aggregate: { [x: string]: number }, item) => {
         if (typeof item.timeStatus === "string") {
           aggregate[item.timeStatus] = item._count._all;
-          aggregate["_all"] += item._count._all;
+          aggregate._all += item._count._all;
         }
         return aggregate;
       },


### PR DESCRIPTION
## What does this PR do?

Similar to the approach taken in #16398 and #16410, we are breaking down the `OR` clauses that cause `Seq Scan` on the `Booking` and `EventType` tables. This will instead run separate queries which properly utilize the indices and result in `Index Scan` instead.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - We have decided that tests will be added to Insights after we verify this path forward will indeed fix the perf issues.

## How should this be tested?

- Test insights to ensure the results of the queries have not changed.
