### PR TITLE
fix: flakyness on booking questions tests

### DIFF
--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -812,6 +812,7 @@ test.describe("Text area min and max characters text", () => {
       // Expect the native <input> element to show an error message
 
       let validationMessage = await minInput?.evaluate((input: any) => input?.validationMessage as string);
+      // FIXME: This error message will be localized depending on the browser locale.
       expect(validationMessage?.toString()).toBe("Value must be less than or equal to 5.");
 
       await page.fill(minLengthSelector, "0");

--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -81,8 +81,8 @@ test.describe("Manage Booking Questions", () => {
         });
 
         await doOnFreshPreview(page, context, async (page) => {
-          const allFieldsLocator = await expectSystemFieldsToBeThereOnBookingPage({ page });
-          const userFieldLocator = allFieldsLocator.nth(5);
+          await expectSystemFieldsToBeThereOnBookingPage({ page });
+          const userFieldLocator = page.locator('[data-fob-field-name="agree-to-terms"]');
 
           await expect(userFieldLocator.locator('[name="agree-to-terms"]')).toBeVisible();
           expect(await getLabelText(userFieldLocator)).toBe("Agree to terms");
@@ -295,8 +295,8 @@ async function runTestStepsCommonForTeamAndUserEventType(
     });
 
     await doOnFreshPreview(page, context, async (page) => {
-      const allFieldsLocator = await expectSystemFieldsToBeThereOnBookingPage({ page });
-      const userFieldLocator = allFieldsLocator.nth(5);
+      await expectSystemFieldsToBeThereOnBookingPage({ page });
+      const userFieldLocator = page.locator('[data-fob-field-name="how-are-you"]');
 
       await expect(userFieldLocator.locator('[name="how-are-you"]')).toBeVisible();
       expect(await getLabelText(userFieldLocator)).toBe("How are you?");
@@ -420,13 +420,12 @@ async function expectSystemFieldsToBeThereOnBookingPage({
     guests: string[];
   }>;
 }) {
-  const allFieldsLocator = page.locator("[data-fob-field-name]:not(.hidden)");
-  const nameLocator = allFieldsLocator.nth(0);
-  const emailLocator = allFieldsLocator.nth(1);
+  const nameLocator = page.locator('[data-fob-field-name="name"]');
+  const emailLocator = page.locator('[data-fob-field-name="email"]');
   // Location isn't rendered unless explicitly set which isn't the case here
   // const locationLocator = allFieldsLocator.nth(2);
-  const additionalNotes = allFieldsLocator.nth(3);
-  const guestsLocator = allFieldsLocator.nth(4);
+  const additionalNotes = page.locator('[data-fob-field-name="notes"]');
+  const guestsLocator = page.locator('[data-fob-field-name="guests"]');
 
   if (isFirstAndLastNameVariant) {
     if (values?.name) {
@@ -466,7 +465,6 @@ async function expectSystemFieldsToBeThereOnBookingPage({
   } else {
     await expect(guestsLocator.locator("[data-testid='add-guests']")).toBeVisible();
   }
-  return allFieldsLocator;
 }
 
 //TODO: Add one question for each type and see they are rendering labels and only once and are showing appropriate native component


### PR DESCRIPTION
## What does this PR do?

-  Changes index based locators to a fixed name ones.
- Sometimes the fields weren't detected in the expected index, [causing timeouts](https://github.com/calcom/cal.com/actions/runs/10727157854/job/29749245665?pr=16113).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- yarn e2e apps/web/playwright/manage-booking-questions.e2e.ts

