### PR TITLE
chore: get platform me from trpc instead of apiv2

### DIFF
--- a/apps/web/components/settings/platform/hooks/usePlatformMe.ts
+++ b/apps/web/components/settings/platform/hooks/usePlatformMe.ts
@@ -1,21 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@calcom/trpc/react";
 
-import type { UserResponse } from "@calcom/platform-types";
-
-export const usePlatformMe = () => {
-  const QUERY_KEY = "get-platform-me";
-  const platformMeQuery = useQuery<UserResponse>({
-    queryKey: [QUERY_KEY],
-    queryFn: async (): Promise<UserResponse> => {
-      const response = await fetch(`/api/v2/me`, {
-        method: "get",
-        headers: { "Content-type": "application/json" },
-      });
-      const data = await response.json();
-
-      return data.data as UserResponse;
+export function usePlatformMe() {
+  const meQuery = trpc.viewer.platformMe.useQuery(undefined, {
+    retry(failureCount) {
+      return failureCount > 3;
     },
+    // 5 minutes
+    staleTime: 300000,
   });
 
-  return platformMeQuery;
-};
+  return meQuery;
+}
+
+export default usePlatformMe;

--- a/packages/trpc/server/routers/loggedInViewer/_router.tsx
+++ b/packages/trpc/server/routers/loggedInViewer/_router.tsx
@@ -16,6 +16,7 @@ import { ZLocationOptionsInputSchema } from "./locationOptions.schema";
 import { ZNoShowInputSchema } from "./markNoShow.schema";
 import { ZOutOfOfficeInputSchema, ZOutOfOfficeDelete } from "./outOfOffice.schema";
 import { me } from "./procedures/me";
+import { platformMe } from "./procedures/platformMe";
 import { teamsAndUserProfilesQuery } from "./procedures/teamsAndUserProfilesQuery";
 import { ZRemoveNotificationsSubscriptionInputSchema } from "./removeNotificationsSubscription.schema";
 import { ZRoutingFormOrderInputSchema } from "./routingFormOrder.schema";
@@ -31,6 +32,7 @@ const namespaced = (s: string) => `${NAMESPACE}.${s}`;
 
 type AppsRouterHandlerCache = {
   me?: typeof import("./me.handler").meHandler;
+  platformMe?: typeof import("./platformMe.handler").platformMeHandler;
   shouldVerifyEmail?: typeof import("./shouldVerifyEmail.handler").shouldVerifyEmailHandler;
   deleteMe?: typeof import("./deleteMe.handler").deleteMeHandler;
   deleteMeWithoutPassword?: typeof import("./deleteMeWithoutPassword.handler").deleteMeWithoutPasswordHandler;
@@ -70,6 +72,7 @@ const UNSTABLE_HANDLER_CACHE: AppsRouterHandlerCache = {};
 
 export const loggedInViewerRouter = router({
   me,
+  platformMe,
 
   deleteMe: authedProcedure.input(ZDeleteMeInputSchema).mutation(async ({ ctx, input }) => {
     if (!UNSTABLE_HANDLER_CACHE.deleteMe) {

--- a/packages/trpc/server/routers/loggedInViewer/platformMe.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/platformMe.handler.ts
@@ -1,0 +1,39 @@
+import type { Session } from "next-auth";
+
+import { ProfileRepository } from "@calcom/lib/server/repository/profile";
+import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
+
+type MeOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+    session: Session;
+  };
+};
+
+export const platformMeHandler = async ({ ctx }: MeOptions) => {
+  const { user: sessionUser } = ctx;
+
+  const allUserEnrichedProfiles = await ProfileRepository.findAllProfilesForUserIncludingMovedUser(
+    sessionUser
+  );
+
+  const mainProfile =
+    allUserEnrichedProfiles.find((profile) => sessionUser.movedToProfileId === profile.id) ||
+    allUserEnrichedProfiles.find((profile) => sessionUser.organizationId === profile.organizationId) ||
+    allUserEnrichedProfiles[0];
+
+  return {
+    id: sessionUser.id,
+    username: sessionUser.username,
+    email: sessionUser.email,
+    timeFormat: sessionUser.timeFormat,
+    timeZone: sessionUser.timeZone,
+    defaultScheduleId: sessionUser.defaultScheduleId,
+    weekStart: sessionUser.weekStart,
+    organizationId: mainProfile.organizationId,
+    organization: {
+      isPlatform: mainProfile.organization?.isPlatform ?? false,
+      id: mainProfile.organizationId ?? null,
+    },
+  };
+};

--- a/packages/trpc/server/routers/loggedInViewer/procedures/platformMe.ts
+++ b/packages/trpc/server/routers/loggedInViewer/procedures/platformMe.ts
@@ -1,0 +1,7 @@
+import authedProcedure from "../../../procedures/authedProcedure";
+
+export const platformMe = authedProcedure.query(async ({ ctx }) => {
+  const handler = (await import("../platformMe.handler")).platformMeHandler;
+
+  return handler({ ctx });
+});


### PR DESCRIPTION
## What does this PR do?

In the effort to detach API v2 from web, query platform me profile from trpc instead of calling api v2

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<img width="1123" alt="Screenshot 2024-09-06 at 10 08 43" src="https://github.com/user-attachments/assets/1f2d5bb9-c12a-46be-a9f4-1dece2c966c3">
