### PR TITLE
fix: Left align instead of right aligned rating feedback in insights

### DIFF
--- a/packages/features/insights/components/FeedbackTable.tsx
+++ b/packages/features/insights/components/FeedbackTable.tsx
@@ -44,7 +44,7 @@ export const FeedbackTable = ({
                     <strong className="text-default">{item.rating}</strong>
                   </Text>
                 </TableCell>
-                <TableCell className="text-right">
+                <TableCell className="text-left">
                   <Text>
                     <strong className="text-default">{item.feedback}</strong>
                   </Text>


### PR DESCRIPTION
## What does this PR do?

Changes right aligned to left aligned text in rating feedback.

Why?
- Visit insights and look at Recent Ratings. 

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
