### PR TITLE
chore: make generic function for separate or queries

### DIFF
--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -101,7 +101,9 @@ class EventsInsights {
       }
     );
 
-    return results.reduce((total: number, item: number) => total + (item || 0), 0);
+    return results.length > 1
+      ? results.reduce((total: number, item: number) => total + (item || 0), 0)
+      : results;
   };
 
   static getTotalCSAT = async (whereConditional: Prisma.BookingTimeStatusWhereInput) => {

--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -43,7 +43,7 @@ class EventsInsights {
   };
 
   static countGroupedByStatus = async (where: Prisma.BookingTimeStatusWhereInput) => {
-    const queryReference = (args) => prisma.bookingTimeStatus.groupBy(args);
+    const queryReference = async (args) => prisma.bookingTimeStatus.groupBy(args);
 
     const data = await EventsInsights.runSeparateQueriesForOrStatements(where, queryReference, {
       where,
@@ -85,12 +85,20 @@ class EventsInsights {
   };
 
   static getTotalNoShows = async (whereConditional: Prisma.BookingTimeStatusWhereInput) => {
-    return await prisma.bookingTimeStatus.count({
+    const queryReference = async (args) => prisma.bookingTimeStatus.count(args);
+
+    const originalWhereConditional = {
       where: {
         ...whereConditional,
         noShowHost: true,
       },
-    });
+    };
+
+    return await EventsInsights.runSeparateQueriesForOrStatements(
+      originalWhereConditional,
+      queryReference,
+      originalWhereConditional
+    );
   };
 
   static getTotalCSAT = async (whereConditional: Prisma.BookingTimeStatusWhereInput) => {


### PR DESCRIPTION
## What does this PR do?

Improving upon #16502, this makes a generic function for being able to dynamically swap out OR clauses for independent queries. This is not ideal in the best case, but unfortunately these OR clauses trigger Seq Scan instead of Index Scan and are mega slow, causing Insights to take forever to load, even on short timeframes.

This is a short-term solution while we continue to look for a better long-term solution for querying this data in 1 query instead of multiple.

Note that getting the typing correct for this is proving to be tricky and imho not worth burning extra time when this is a research/trial type of task that is urgently needed to get insights to a working state.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - We have decided that tests will be added to Insights after we verify this path forward will indeed fix the perf issues. 

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure no show counts in the "by status" section and the events timeline are correct
- Ensure the "by status" section is still correct
