### PR TITLE
perf: Modified Insights view to use UNION for user/team bookings

### DIFF
--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -363,12 +363,13 @@ class EventsInsights {
             userId: {
               in: userIdsFromOrg,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
           {
             teamId: {
               in: [organizationId, ...teamsFromOrg.map((t) => t.id)],
             },
+            isTeamBooking: true,
           },
         ],
       };
@@ -390,12 +391,13 @@ class EventsInsights {
         OR: [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeam,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ],
       };

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -213,12 +213,13 @@ export const insightsRouter = router({
               userId: {
                 in: userIdsFromOrg,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
             {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
+              isTeamBooking: true,
             },
           ],
         };
@@ -240,12 +241,13 @@ export const insightsRouter = router({
           OR: [
             {
               teamId,
+              isTeamBooking: true,
             },
             {
               userId: {
                 in: userIdsFromTeam,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
           ],
         };
@@ -438,12 +440,13 @@ export const insightsRouter = router({
               userId: {
                 in: userIdsFromOrg,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
             {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
+              isTeamBooking: true,
             },
           ],
         };
@@ -465,12 +468,13 @@ export const insightsRouter = router({
           OR: [
             {
               teamId,
+              isTeamBooking: true,
             },
             {
               userId: {
                 in: userIdsFromTeams,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
           ],
         };
@@ -614,12 +618,13 @@ export const insightsRouter = router({
               userId: {
                 in: userIdsFromOrg,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
             {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
+              isTeamBooking: true,
             },
           ],
         };
@@ -642,12 +647,13 @@ export const insightsRouter = router({
           OR: [
             {
               teamId,
+              isTeamBooking: true,
             },
             {
               userId: {
                 in: userIdsFromTeams,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
           ],
         };
@@ -815,10 +821,11 @@ export const insightsRouter = router({
               teamId: {
                 in: [ctx.user?.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
+              isTeamBooking: true,
             },
             {
               userId: ctx.user?.id,
-              teamId: null,
+              isTeamBooking: false,
             },
           ],
         };
@@ -841,12 +848,13 @@ export const insightsRouter = router({
           OR: [
             {
               teamId,
+              isTeamBooking: true,
             },
             {
               userId: {
                 in: userIdsFromTeams,
               },
-              teamId: null,
+              isTeamBooking: false,
             },
           ],
         };

--- a/packages/prisma/migrations/20240909162522_union_insights_data/migration.sql
+++ b/packages/prisma/migrations/20240909162522_union_insights_data/migration.sql
@@ -1,0 +1,71 @@
+CREATE OR REPLACE VIEW public."BookingTimeStatus"
+AS
+SELECT
+    "Booking".id,
+    "Booking".uid,
+    "Booking"."eventTypeId",
+    "Booking".title,
+    "Booking".description,
+    "Booking"."startTime",
+    "Booking"."endTime",
+    "Booking"."createdAt",
+    "Booking".location,
+    "Booking".paid,
+    "Booking".status,
+    "Booking".rescheduled,
+    "Booking"."userId",
+    et."teamId",
+    et.length AS "eventLength",
+    CASE
+        WHEN "Booking".rescheduled IS TRUE THEN 'rescheduled'::text
+        WHEN "Booking".status = 'cancelled'::"BookingStatus" AND "Booking".rescheduled IS NULL THEN 'cancelled'::text
+        WHEN "Booking"."endTime" < now() THEN 'completed'::text
+        WHEN "Booking"."endTime" > now() THEN 'uncompleted'::text
+        ELSE NULL::text
+    END AS "timeStatus",
+    et."parentId" AS "eventParentId",
+    "u"."email" AS "userEmail",
+    "u"."username" AS "username",
+    "Booking"."ratingFeedback",
+    "Booking"."rating",
+    "Booking"."noShowHost",
+    false as "isTeamBooking"
+FROM "Booking"
+LEFT JOIN "EventType" et ON "Booking"."eventTypeId" = et.id
+LEFT JOIN users u ON u.id = "Booking"."userId"
+WHERE et."teamId" IS NULL
+UNION
+SELECT
+    "Booking".id,
+    "Booking".uid,
+    "Booking"."eventTypeId",
+    "Booking".title,
+    "Booking".description,
+    "Booking"."startTime",
+    "Booking"."endTime",
+    "Booking"."createdAt",
+    "Booking".location,
+    "Booking".paid,
+    "Booking".status,
+    "Booking".rescheduled,
+    "Booking"."userId",
+    et."teamId",
+    et.length AS "eventLength",
+    CASE
+        WHEN "Booking".rescheduled IS TRUE THEN 'rescheduled'::text
+        WHEN "Booking".status = 'cancelled'::"BookingStatus" AND "Booking".rescheduled IS NULL THEN 'cancelled'::text
+        WHEN "Booking"."endTime" < now() THEN 'completed'::text
+        WHEN "Booking"."endTime" > now() THEN 'uncompleted'::text
+        ELSE NULL::text
+    END AS "timeStatus",
+    et."parentId" AS "eventParentId",
+    "u"."email" AS "userEmail",
+    "u"."username" AS "username",
+    "Booking"."ratingFeedback",
+    "Booking"."rating",
+    "Booking"."noShowHost",
+    true as "isTeamBooking"
+FROM "Booking"
+LEFT JOIN "EventType" et ON "Booking"."eventTypeId" = et.id
+LEFT JOIN users u ON u.id = "Booking"."userId"
+WHERE "et"."teamId" IS NOT NULL

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1229,6 +1229,7 @@ view BookingTimeStatus {
   ratingFeedback String?
   rating         Int?
   noShowHost     Boolean?
+  isTeamBooking  Boolean
 }
 
 model CalendarCache {


### PR DESCRIPTION
## What does this PR do?

Instead of needing to run separate queries for everything insights-related, I decided to fix the fundamental issue with filtering the `userId` and `teamId`. Putting the UNION in the view itself solves this problem because we can change the filters to use `isTeamBooking`, allowing Postgres to more smartly retrieve the data for users and teams, utilitizing the proper indexes instead of doing `Seq Scan`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - Same as other PRs for these perf changes. We are going to add a full test suite once these improvements are confirmed and we 100% decide to not use an external reporting solution.

## How should this be tested?

- Ensure insights reporting is still correct
