### PR TITLE
perf: use isTeamBooking filter in all of Insights

### DIFF
--- a/apps/web/pages/api/cron/monthlyDigestEmail.ts
+++ b/apps/web/pages/api/cron/monthlyDigestEmail.ts
@@ -102,12 +102,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         OR: [
           {
             teamId: team.id,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ],
         createdAt: {
@@ -132,12 +133,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         OR: [
           {
             teamId: team.id,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ],
       };

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -976,12 +976,13 @@ export const insightsRouter = router({
             teamId: {
               in: [user?.organizationId, ...teamsFromOrg.map((t) => t.id)],
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1002,12 +1003,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1114,12 +1116,13 @@ export const insightsRouter = router({
             teamId: {
               in: teamsFromOrg.map((t) => t.id),
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1138,12 +1141,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1531,12 +1535,13 @@ export const insightsRouter = router({
             teamId: {
               in: teamsFromOrg.map((t) => t.id),
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1555,12 +1560,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1664,12 +1670,13 @@ export const insightsRouter = router({
             teamId: {
               in: teamsFromOrg.map((t) => t.id),
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1688,12 +1695,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1797,12 +1805,13 @@ export const insightsRouter = router({
             teamId: {
               in: teamsFromOrg.map((t) => t.id),
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1821,12 +1830,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1930,12 +1940,13 @@ export const insightsRouter = router({
             teamId: {
               in: teamsFromOrg.map((t) => t.id),
             },
+            isTeamBooking: true,
           },
           {
             userId: {
               in: usersFromTeam.map((u) => u.userId),
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }
@@ -1954,12 +1965,13 @@ export const insightsRouter = router({
         bookingWhere["OR"] = [
           {
             teamId,
+            isTeamBooking: true,
           },
           {
             userId: {
               in: userIdsFromTeams,
             },
-            teamId: null,
+            isTeamBooking: false,
           },
         ];
       }


### PR DESCRIPTION
## What does this PR do?

Utilizes `isTeamBooking` in the rest of the Insights queries now that it's verified to be working with others.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - Same as other insights PRs. We will be writing a new test suite once the perf work is done.

## How should this be tested?

- Ensure insights data matches what was shown before
