### PR TITLE
fix: prevent creating multiple platform orgs

### DIFF
--- a/apps/web/pages/settings/platform/new/index.tsx
+++ b/apps/web/pages/settings/platform/new/index.tsx
@@ -27,7 +27,7 @@ const Page = () => {
       router.push("/settings/platform");
       // user has a regular org redirect to organization settings
     } else {
-      router.push("/settings/organizations");
+      router.push("/settings/organizations/profile");
     }
     // display loader while redirection is happening
     return <SkeletonLoader />;

--- a/apps/web/pages/settings/platform/new/index.tsx
+++ b/apps/web/pages/settings/platform/new/index.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from "next/navigation";
 
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
-import SkeletonLoader from "@calcom/features/ee/teams/components/SkeletonLoaderAvailabilityTimes";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Meta } from "@calcom/ui";
+import { SkeletonContainer, SkeletonText } from "@calcom/ui";
 
 import { getServerSideProps } from "@lib/settings/organizations/new/getServerSideProps";
 
@@ -11,6 +11,18 @@ import PageWrapper from "@components/PageWrapper";
 import usePlatformMe from "@components/settings/platform/hooks/usePlatformMe";
 
 import CreateNewOrganizationPage, { LayoutWrapper } from "~/settings/platform/new/create-new-view";
+
+const SkeletonLoader = () => {
+  return (
+    <SkeletonContainer>
+      <div className="mr-3">
+        <SkeletonText className="h-4 w-28" />
+        <SkeletonText className="mt-3 h-11 w-full" />
+        <SkeletonText className="mt-2 h-11 w-full" />
+      </div>
+    </SkeletonContainer>
+  );
+};
 
 const Page = () => {
   const { t } = useLocale();

--- a/apps/web/pages/settings/platform/new/index.tsx
+++ b/apps/web/pages/settings/platform/new/index.tsx
@@ -1,15 +1,38 @@
+import { useRouter } from "next/navigation";
+
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
+import SkeletonLoader from "@calcom/features/ee/teams/components/SkeletonLoaderAvailabilityTimes";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Meta } from "@calcom/ui";
 
 import { getServerSideProps } from "@lib/settings/organizations/new/getServerSideProps";
 
 import PageWrapper from "@components/PageWrapper";
+import usePlatformMe from "@components/settings/platform/hooks/usePlatformMe";
 
 import CreateNewOrganizationPage, { LayoutWrapper } from "~/settings/platform/new/create-new-view";
 
 const Page = () => {
   const { t } = useLocale();
+  const { isFetching, data: platformMe } = usePlatformMe();
+  const router = useRouter();
+
+  if (isFetching) {
+    return <SkeletonLoader />;
+  }
+
+  if (platformMe?.organization?.id) {
+    // if user has a platform org redirect to platform dashboard
+    if (platformMe?.organization?.isPlatform) {
+      router.push("/settings/platform");
+      // user has a regular org redirect to organization settings
+    } else {
+      router.push("/settings/organizations");
+    }
+    // display loader while redirection is happening
+    return <SkeletonLoader />;
+  }
+
   return (
     <LicenseRequired>
       <Meta

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1,6 +1,5 @@
 // This is your Prisma Schema file
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
-// CI Cache Busting Number - 1
 
 datasource db {
   provider  = "postgresql"

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1,5 +1,6 @@
 // This is your Prisma Schema file
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
+// CI Cache Busting Number - 1
 
 datasource db {
   provider  = "postgresql"


### PR DESCRIPTION
## What does this PR do?

Prevent users from creating  multiple platform orgs by redcirecting them to their platform dashboard if they already have a platform org. if the user already owns a regular org and is trying to create a platform org, redirect to org settings.


loader displayed while fetching profile data or redirecting: <img width="950" alt="Screenshot 2024-09-10 at 10 19 51" src="https://github.com/user-attachments/assets/b6956c1f-2b54-404e-b099-d554fafec365">

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- create a platform org via accessing platform/settings/new
- try to create a new platform org by accessing again platform/settings/new, you should not be able to.
- instead you should be redirected to platform/settings where the platform dashboard is located
