### PR TITLE
chore: Remove separate OR queries for Insights

### DIFF
--- a/packages/features/insights/server/events.ts
+++ b/packages/features/insights/server/events.ts
@@ -1,5 +1,3 @@
-import type { AcceleratePromise } from "@prisma/extension-accelerate";
-
 import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
 import { readonlyPrisma as prisma } from "@calcom/prisma";
@@ -10,49 +8,8 @@ import type { RawDataInput } from "./raw-data.schema";
 type TimeViewType = "week" | "month" | "year" | "day";
 
 class EventsInsights {
-  static runSeparateQueriesForOrStatements = async <T, R>(
-    where: Prisma.BookingTimeStatusWhereInput,
-
-    queryReference: (args: T) => AcceleratePromise<R>,
-
-    originalArgs: T
-  ) => {
-    if (!where["OR"]) {
-      return await queryReference(originalArgs);
-    }
-
-    const queries = [];
-    const existingWhereOr = where["OR"];
-    const { OR: _throwAwayOr, ...whereWithoutOr } = where;
-    for (let i = 0; i < existingWhereOr.length; i++) {
-      const newWhere = {
-        ...whereWithoutOr,
-        ...existingWhereOr[i],
-      };
-      queries.push(
-        queryReference({
-          ...originalArgs,
-          where: newWhere,
-        })
-      );
-    }
-
-    const results = await Promise.all(queries);
-    return results.flat();
-  };
-
   static countGroupedByStatus = async (where: Prisma.BookingTimeStatusWhereInput) => {
-    const queryReference = (args: Prisma.BookingTimeStatusGroupByArgs) =>
-      // casting since TS is not able to infer the type of the output of the query properly
-      // Typescript infers this as AcceleratePromise<{}[]> which is not specific enough
-      prisma.bookingTimeStatus.groupBy(args) as unknown as AcceleratePromise<
-        Prisma.BookingTimeStatusGroupByOutputType[]
-      >;
-
-    const data = await EventsInsights.runSeparateQueriesForOrStatements<
-      Prisma.BookingTimeStatusGroupByArgs,
-      Prisma.BookingTimeStatusGroupByOutputType[]
-    >(where, queryReference, {
+    const data = await prisma.bookingTimeStatus.groupBy({
       where,
       by: ["timeStatus"],
       _count: {
@@ -92,27 +49,12 @@ class EventsInsights {
   };
 
   static getTotalNoShows = async (whereConditional: Prisma.BookingTimeStatusWhereInput) => {
-    const queryReference = (args: Prisma.BookingTimeStatusCountArgs) => prisma.bookingTimeStatus.count(args);
-    const originalWhereConditional = {
-      ...whereConditional,
-      noShowHost: true,
-    };
-
-    const results = await EventsInsights.runSeparateQueriesForOrStatements<
-      Prisma.BookingTimeStatusCountArgs,
-      number
-    >(originalWhereConditional, queryReference, {
+    return await prisma.bookingTimeStatus.count({
       where: {
-        ...originalWhereConditional,
+        ...whereConditional,
+        noShowHost: true,
       },
     });
-
-    // we don't know if WHERE clause contains OR, so we need to check if it's an array
-    if (Array.isArray(results)) {
-      return results.reduce((total: number, item: number) => total + (item || 0), 0);
-    }
-
-    return results;
   };
 
   static getTotalCSAT = async (whereConditional: Prisma.BookingTimeStatusWhereInput) => {


### PR DESCRIPTION
## What does this PR do?

Now that I've confirmed #16558 fixes the perf problems, we no longer need to run separate queries for the `OR` clauses on `userId/teamId`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - Same as other insights perf PRs. We will be adding a full test suite soon.

## How should this be tested?

- Ensure insights reporting data stays the same
