### PR TITLE
perf: Insights - put teamId filter first

### DIFF
--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -210,16 +210,16 @@ export const insightsRouter = router({
           ...whereConditional,
           OR: [
             {
-              userId: {
-                in: userIdsFromOrg,
-              },
-              isTeamBooking: false,
-            },
-            {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
               isTeamBooking: true,
+            },
+            {
+              userId: {
+                in: userIdsFromOrg,
+              },
+              isTeamBooking: false,
             },
           ],
         };
@@ -437,16 +437,16 @@ export const insightsRouter = router({
         whereConditional = {
           OR: [
             {
-              userId: {
-                in: userIdsFromOrg,
-              },
-              isTeamBooking: false,
-            },
-            {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
               isTeamBooking: true,
+            },
+            {
+              userId: {
+                in: userIdsFromOrg,
+              },
+              isTeamBooking: false,
             },
           ],
         };
@@ -615,16 +615,16 @@ export const insightsRouter = router({
           ...bookingWhere,
           OR: [
             {
-              userId: {
-                in: userIdsFromOrg,
-              },
-              isTeamBooking: false,
-            },
-            {
               teamId: {
                 in: [ctx.user.organizationId, ...teamsFromOrg.map((t) => t.id)],
               },
               isTeamBooking: true,
+            },
+            {
+              userId: {
+                in: userIdsFromOrg,
+              },
+              isTeamBooking: false,
             },
           ],
         };


### PR DESCRIPTION
## What does this PR do?

Looking at performance, we can optimize further by searching bookings associated with a team first and then letting the userId filter run. For big orgs, this will run faster.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure insights results don't change
