### PR TITLE
perf: Include no shows in main status query

### DIFF
--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -278,20 +278,16 @@ export const insightsRouter = router({
       const [
         countGroupedByStatus,
         totalRatingsAggregate,
-        totalNoShow,
         totalCSAT,
         lastPeriodCountGroupedByStatus,
         lastPeriodTotalRatingsAggregate,
-        lastPeriodTotalNoShow,
         lastPeriodTotalCSAT,
       ] = await Promise.all([
         EventsInsights.countGroupedByStatus(baseWhereCondition),
         EventsInsights.getAverageRating(baseWhereCondition),
-        EventsInsights.getTotalNoShows(baseWhereCondition),
         EventsInsights.getTotalCSAT(baseWhereCondition),
         EventsInsights.countGroupedByStatus(lastPeriodBaseCondition),
         EventsInsights.getAverageRating(lastPeriodBaseCondition),
-        EventsInsights.getTotalNoShows(lastPeriodBaseCondition),
         EventsInsights.getTotalCSAT(lastPeriodBaseCondition),
       ]);
 
@@ -299,6 +295,7 @@ export const insightsRouter = router({
       const totalCompleted = countGroupedByStatus["completed"];
       const totalRescheduled = countGroupedByStatus["rescheduled"];
       const totalCancelled = countGroupedByStatus["cancelled"];
+      const totalNoShow = countGroupedByStatus["noShowHost"];
 
       const averageRating = totalRatingsAggregate._avg.rating
         ? parseFloat(totalRatingsAggregate._avg.rating.toFixed(1))
@@ -307,6 +304,7 @@ export const insightsRouter = router({
       const lastPeriodBaseBookingsCount = lastPeriodCountGroupedByStatus["_all"];
       const lastPeriodTotalRescheduled = lastPeriodCountGroupedByStatus["rescheduled"];
       const lastPeriodTotalCancelled = lastPeriodCountGroupedByStatus["cancelled"];
+      const lastPeriodTotalNoShow = lastPeriodCountGroupedByStatus["noShowHost"];
 
       const lastPeriodAverageRating = lastPeriodTotalRatingsAggregate._avg.rating
         ? parseFloat(lastPeriodTotalRatingsAggregate._avg.rating.toFixed(1))
@@ -542,16 +540,13 @@ export const insightsRouter = router({
           },
         };
 
-        const promisesResult = await Promise.all([
-          EventsInsights.countGroupedByStatus(whereConditional),
-          EventsInsights.getTotalNoShows(whereConditional),
-        ]);
+        const promisesResult = await Promise.all([EventsInsights.countGroupedByStatus(whereConditional)]);
 
         EventData["Created"] = promisesResult[0]["_all"];
         EventData["Completed"] = promisesResult[0]["completed"];
         EventData["Rescheduled"] = promisesResult[0]["rescheduled"];
         EventData["Cancelled"] = promisesResult[0]["cancelled"];
-        EventData["No-Show (Host)"] = promisesResult[1];
+        EventData["No-Show (Host)"] = promisesResult[0]["noShowHost"];
         result.push(EventData);
       }
 

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -540,13 +540,13 @@ export const insightsRouter = router({
           },
         };
 
-        const promisesResult = await Promise.all([EventsInsights.countGroupedByStatus(whereConditional)]);
+        const countsByStatus = await EventsInsights.countGroupedByStatus(whereConditional);
 
-        EventData["Created"] = promisesResult[0]["_all"];
-        EventData["Completed"] = promisesResult[0]["completed"];
-        EventData["Rescheduled"] = promisesResult[0]["rescheduled"];
-        EventData["Cancelled"] = promisesResult[0]["cancelled"];
-        EventData["No-Show (Host)"] = promisesResult[0]["noShowHost"];
+        EventData["Created"] = countsByStatus["_all"];
+        EventData["Completed"] = countsByStatus["completed"];
+        EventData["Rescheduled"] = countsByStatus["rescheduled"];
+        EventData["Cancelled"] = countsByStatus["cancelled"];
+        EventData["No-Show (Host)"] = countsByStatus["noShowHost"];
         result.push(EventData);
       }
 


### PR DESCRIPTION
## What does this PR do?

Reduces the number of queries needed by quite a lot. This will be 2 fewer + the # of times this is called to produce the event timeline, which could be up to 52 over the YTD stats. 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure all relevant stats related to no shows are still correct
