### PR TITLE
chore: Remove passing optional prisma select prop to Repository classes

### DIFF
--- a/apps/web/app/future/availability/[schedule]/page.tsx
+++ b/apps/web/app/future/availability/[schedule]/page.tsx
@@ -43,12 +43,8 @@ const Page = async ({ params }: PageProps) => {
   let userData, schedule, travelSchedules;
 
   try {
-    userData = await UserRepository.findById({
-      id: userId,
-      select: {
-        timeZone: true,
-        defaultScheduleId: true,
-      },
+    userData = await UserRepository.getTimeZoneAndDefaultScheduleId({
+      userId,
     });
     if (!userData?.timeZone || !userData?.defaultScheduleId) {
       throw new Error("timeZone and defaultScheduleId not found");

--- a/apps/web/app/future/video/meeting-not-started/[uid]/page.tsx
+++ b/apps/web/app/future/video/meeting-not-started/[uid]/page.tsx
@@ -12,7 +12,7 @@ import MeetingNotStarted from "~/videos/views/videos-meeting-not-started-single-
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const p = { ...params, ...searchParams };
-  const booking = await BookingRepository.findBookingByUidWithOptionalSelect({
+  const booking = await BookingRepository.findBookingByUid({
     bookingUid: typeof p?.uid === "string" ? p.uid : "",
   });
 

--- a/apps/web/lib/video/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/video/[uid]/getServerSideProps.ts
@@ -20,34 +20,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   const ssr = await ssrInit(context);
 
-  const booking = await BookingRepository.findBookingByUidWithOptionalSelect({
+  const booking = await BookingRepository.findBookingForMeetingPage({
     bookingUid: context.query.uid as string,
-    select: {
-      uid: true,
-      description: true,
-      isRecorded: true,
-      user: {
-        select: {
-          id: true,
-          timeZone: true,
-          name: true,
-          email: true,
-          username: true,
-        },
-      },
-      references: {
-        select: {
-          id: true,
-          uid: true,
-          type: true,
-          meetingUrl: true,
-          meetingPassword: true,
-        },
-        where: {
-          type: "daily_video",
-        },
-      },
-    },
   });
 
   if (!booking || booking.references.length === 0 || !booking.references[0].meetingUrl) {

--- a/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.ts
@@ -6,23 +6,8 @@ import { type inferSSRProps } from "@lib/types/inferSSRProps";
 
 export type PageProps = inferSSRProps<typeof getServerSideProps>;
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const booking = await BookingRepository.findBookingByUidWithOptionalSelect({
+  const booking = await BookingRepository.findBookingForMeetingEndedPage({
     bookingUid: context.query.uid as string,
-    select: {
-      uid: true,
-      user: {
-        select: {
-          credentials: true,
-        },
-      },
-      references: {
-        select: {
-          uid: true,
-          type: true,
-          meetingUrl: true,
-        },
-      },
-    },
   });
 
   if (!booking) {

--- a/apps/web/lib/video/meeting-not-started/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/video/meeting-not-started/[uid]/getServerSideProps.ts
@@ -4,7 +4,7 @@ import { BookingRepository } from "@calcom/lib/server/repository/booking";
 
 // change the type
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const booking = await BookingRepository.findBookingByUidWithOptionalSelect({
+  const booking = await BookingRepository.findBookingByUid({
     bookingUid: context.query.uid as string,
   });
 

--- a/packages/lib/server/repository/booking.ts
+++ b/packages/lib/server/repository/booking.ts
@@ -113,18 +113,71 @@ export class BookingRepository {
     return allBookings;
   }
 
-  static async findBookingByUidWithOptionalSelect({
-    bookingUid,
-    select,
-  }: {
-    bookingUid: string;
-    select?: Prisma.BookingSelect;
-  }) {
+  static async findBookingByUid({ bookingUid }: { bookingUid: string }) {
     return await prisma.booking.findUnique({
       where: {
         uid: bookingUid,
       },
-      select: { ...bookingMinimalSelect, ...select },
+      select: bookingMinimalSelect,
+    });
+  }
+
+  static async findBookingForMeetingPage({ bookingUid }: { bookingUid: string }) {
+    return await prisma.booking.findUnique({
+      where: {
+        uid: bookingUid,
+      },
+      select: {
+        ...bookingMinimalSelect,
+        uid: true,
+        description: true,
+        isRecorded: true,
+        user: {
+          select: {
+            id: true,
+            timeZone: true,
+            name: true,
+            email: true,
+            username: true,
+          },
+        },
+        references: {
+          select: {
+            id: true,
+            uid: true,
+            type: true,
+            meetingUrl: true,
+            meetingPassword: true,
+          },
+          where: {
+            type: "daily_video",
+          },
+        },
+      },
+    });
+  }
+
+  static async findBookingForMeetingEndedPage({ bookingUid }: { bookingUid: string }) {
+    return await prisma.booking.findUnique({
+      where: {
+        uid: bookingUid,
+      },
+      select: {
+        ...bookingMinimalSelect,
+        uid: true,
+        user: {
+          select: {
+            credentials: true,
+          },
+        },
+        references: {
+          select: {
+            uid: true,
+            type: true,
+            meetingUrl: true,
+          },
+        },
+      },
     });
   }
 

--- a/packages/lib/server/repository/user.ts
+++ b/packages/lib/server/repository/user.ts
@@ -239,12 +239,12 @@ export class UserRepository {
     };
   }
 
-  static async findById({ id, select }: { id: number; select?: Prisma.UserSelect }) {
+  static async findById({ id }: { id: number }) {
     const user = await prisma.user.findUnique({
       where: {
         id,
       },
-      select: { ...userSelect, ...select },
+      select: userSelect,
     });
 
     if (!user) {
@@ -564,6 +564,18 @@ export class UserRepository {
       teamIds.push(team.teamId);
     }
     return teamIds;
+  }
+
+  static async getTimeZoneAndDefaultScheduleId({ userId }: { userId: number }) {
+    return await prisma.user.findUnique({
+      where: {
+        id: userId,
+      },
+      select: {
+        timeZone: true,
+        defaultScheduleId: true,
+      },
+    });
   }
 
   static async adminFindById(userId: number) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes CAL-4318 (Linear issue number - should be visible at the bottom of the GitHub issue description)
- Remove optional `select` prop from `UserRepository.findById`
- Turn `findBookingByUidWithOptionalSelect` into `findBookingByUid`, add `findBookingForMeetingPage` and `findBookingForMeetingEndedPage`

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Navigate to:
- future/availability/[schedule]
- future/video/[uid]
- future/video/meeting-not-started/[uid]
- future/video/meeting-ended/[uid]
- video/[uid]
- video/meeting-not-started/[uid]
- video/meeting-ended/[uid]