### PR TITLE
[TESTING ONLY - DON'T MERGE] fix: Labeling ready-for-e2e not triggering tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
       - gh-actions-test-branch
   workflow_dispatch:
   workflow_run:
-    workflows: ["PR Reviewed"]
+    workflows: ["PR Reviewed"] # Adding a comment here for testing
     types:
       - completed
 


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where tests are not triggered when an approval is submitted and the `ready-for-e2e` label is added.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Approve a PR that targets `gh-actions-test-branch` (maybe even this PR) and ensure the `ready-for-e2e` label is added and the e2e tests are run
