### PR TITLE
fix: async clipboard support in Safari

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -929,7 +929,7 @@ function SideBarContainer({ bannersHeight, isPlatformUser = false }: SideBarCont
 }
 
 function SideBar({ bannersHeight, user }: SideBarProps) {
-  const { copyToClipboard } = useCopy();
+  const { fetchAndCopyToClipboard } = useCopy();
   const { t, isLocaleReady } = useLocale();
   const orgBranding = useOrgBranding();
   const pathname = usePathname();
@@ -967,16 +967,19 @@ function SideBar({ bannersHeight, user }: SideBarProps) {
       ? {
           name: "copy_referral_link",
           href: "",
-          onClick: async (e: { preventDefault: () => void }) => {
+          onClick: (e: { preventDefault: () => void }) => {
             e.preventDefault();
-            const res = await fetch("/api/generate-referral-link", {
-              method: "POST",
-            });
-            const { shortLink } = await res.json();
-            copyToClipboard(shortLink, {
-              onSuccess: () => showToast(t("link_copied"), "success"),
-              onFailure: () => showToast("Copy to clipboard failed", "error"),
-            });
+            fetchAndCopyToClipboard(
+              fetch("/api/generate-referral-link", {
+                method: "POST",
+              })
+                .then((res) => res.json())
+                .then((res) => res.shortLink),
+              {
+                onSuccess: () => showToast(t("link_copied"), "success"),
+                onFailure: () => showToast("Copy to clipboard failed", "error"),
+              }
+            );
           },
           icon: "gift",
         }

--- a/packages/lib/hooks/useCopy.ts
+++ b/packages/lib/hooks/useCopy.ts
@@ -50,7 +50,10 @@ export function useCopy() {
       const text = new ClipboardItem({
         "text/plain": promise
           .then((text) => new Blob([text], { type: "text/plain" }))
-          .catch(() => onFailure()),
+          .catch(() => {
+            onFailure();
+            return "";
+          }),
       });
       navigator.clipboard.write([text]);
       onSuccess();

--- a/packages/lib/hooks/useCopy.ts
+++ b/packages/lib/hooks/useCopy.ts
@@ -27,11 +27,40 @@ export function useCopy() {
         "You need to use a secure context to use clipboard \n Please use the following link: ",
         text
       );
+      onFailure();
     }
   };
 
   const resetCopyStatus = () => {
     setIsCopied(false);
+  };
+
+  /** @see https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/ */
+  const fetchAndCopyToClipboard = (
+    promise: Promise<string>,
+    options: { onSuccess?: () => void; onFailure?: () => void } = {}
+  ) => {
+    const { onSuccess = noop, onFailure = noop } = options;
+    if (typeof ClipboardItem && navigator.clipboard.write) {
+      // NOTE: Safari locks down the clipboard API to only work when triggered
+      //   by a direct user interaction. You can't use it async in a promise.
+      //   But! You can wrap the promise in a ClipboardItem, and give that to
+      //   the clipboard API.
+      //   Found this on https://developer.apple.com/forums/thread/691873
+      const text = new ClipboardItem({
+        "text/plain": promise
+          .then((text) => new Blob([text], { type: "text/plain" }))
+          .catch(() => onFailure()),
+      });
+      navigator.clipboard.write([text]);
+      onSuccess();
+    } else {
+      // NOTE: Firefox has support for ClipboardItem and navigator.clipboard.write,
+      //   but those are behind `dom.events.asyncClipboard.clipboardItem` preference.
+      //   Good news is that other than Safari, Firefox does not care about
+      //   Clipboard API being used async in a Promise.
+      promise.then((text) => copyToClipboard(text, options)).catch(() => onFailure());
+    }
   };
 
   useEffect(() => {
@@ -41,5 +70,5 @@ export function useCopy() {
     }
   }, [isCopied]);
 
-  return { isCopied, copyToClipboard, resetCopyStatus };
+  return { isCopied, copyToClipboard, resetCopyStatus, fetchAndCopyToClipboard };
 }


### PR DESCRIPTION
## What does this PR do?

Improved clipboard functionality for better cross-browser compatibility, especially for Safari.

cc @steven-tey #16165 

### What changed?

- Introduced a new `fetchAndCopyToClipboard` function in the `useCopy` hook to handle asynchronous clipboard operations.
- Updated the referral link copying logic in `SideBar` component to use the new `fetchAndCopyToClipboard` function.
- Enhanced error handling in the `copyToClipboard` function to call `onFailure` when copying fails due to insecure context.

### How to test?

1. Navigate to the sidebar where the referral link copying feature is available.
2. Click on the "Copy Referral Link" option.
3. Verify that the link is successfully copied to the clipboard on different browsers, especially Safari.
4. Check if appropriate success or error toasts are displayed.


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- On Safari, Chrome and Firefox try copying the Dub referral code. They should work the same.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
