### PR TITLE
fix: remove duplicate teams layout

### DIFF
--- a/apps/web/app/future/settings/(settings)/teams/layout.tsx
+++ b/apps/web/app/future/settings/(settings)/teams/layout.tsx
@@ -1,5 +1,0 @@
-import { WithLayout } from "app/layoutHOC";
-
-import { getLayout } from "@calcom/features/settings/appDir/SettingsLayoutAppDir";
-
-export default WithLayout({ getServerLayout: getLayout })<"L">;


### PR DESCRIPTION
## What does this PR do?
Before:
![CleanShot 2024-09-13 at 10 21 14](https://github.com/user-attachments/assets/31a091f3-ac22-4ac4-bfe2-b988a36b6aa4)

After:
![CleanShot 2024-09-13 at 10 38 02](https://github.com/user-attachments/assets/626c9f11-554a-44e4-84c9-1b4b257793e4)

There is already a layout in (settings)/layout.tsx so we don't need the same in settings/teams

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Enable app router teams and visit settings

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
