### PR TITLE
chore: rewrite imports of prisma enums to @calcom/prisma/enums

### DIFF
--- a/packages/features/ee/workflows/lib/allowDisablingStandardEmails.ts
+++ b/packages/features/ee/workflows/lib/allowDisablingStandardEmails.ts
@@ -1,5 +1,4 @@
-import { WorkflowTriggerEvents } from "@calcom/prisma/client";
-import { WorkflowActions } from "@calcom/prisma/enums";
+import { WorkflowActions, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 
 import type { Workflow } from "./types";
 

--- a/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventCancelledTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventCancelledTemplate.ts
@@ -1,7 +1,6 @@
-import { WorkflowActions } from "@prisma/client";
-
 import dayjs from "@calcom/dayjs";
 import { TimeFormat } from "@calcom/lib/timeFormat";
+import { WorkflowActions } from "@calcom/prisma/enums";
 
 export const whatsappEventCancelledTemplate = (
   isEditingMode: boolean,

--- a/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventCompletedTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventCompletedTemplate.ts
@@ -1,7 +1,6 @@
-import { WorkflowActions } from "@prisma/client";
-
 import dayjs from "@calcom/dayjs";
 import { TimeFormat } from "@calcom/lib/timeFormat";
+import { WorkflowActions } from "@calcom/prisma/enums";
 
 export const whatsappEventCompletedTemplate = (
   isEditingMode: boolean,

--- a/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventReminderTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventReminderTemplate.ts
@@ -1,7 +1,6 @@
-import { WorkflowActions } from "@prisma/client";
-
 import dayjs from "@calcom/dayjs";
 import { TimeFormat } from "@calcom/lib/timeFormat";
+import { WorkflowActions } from "@calcom/prisma/enums";
 
 export const whatsappReminderTemplate = (
   isEditingMode: boolean,

--- a/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventRescheduledTemplate.ts
+++ b/packages/features/ee/workflows/lib/reminders/templates/whatsapp/whatsappEventRescheduledTemplate.ts
@@ -1,7 +1,6 @@
-import { WorkflowActions } from "@prisma/client";
-
 import dayjs from "@calcom/dayjs";
 import { TimeFormat } from "@calcom/lib/timeFormat";
+import { WorkflowActions } from "@calcom/prisma/enums";
 
 export const whatsappEventRescheduledTemplate = (
   isEditingMode: boolean,


### PR DESCRIPTION
## What does this PR do?

Importing enums should be done from @calcom/prisma/enums to avoid importing the prisma client


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

