### PR TITLE
fix: overlay calendar view for `Booker` atom

### DIFF
--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -381,14 +381,16 @@ export const BookerPlatformWrapper = (
         });
         setBookingData(null);
       }
-      if (isOverlayCalendarEnabled) {
-        localStorage.setItem("overlayCalendarSwitchDefault", "true");
-      } else {
-        localStorage.removeItem("overlayCalendarSwitchDefault");
-      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (isOverlayCalendarEnabled && view === "MONTH_VIEW") {
+      localStorage.removeItem("overlayCalendarSwitchDefault");
+      setIsOverlayCalendarEnabled(Boolean(localStorage?.getItem?.("overlayCalendarSwitchDefault")));
+    }
+  }, [view, isOverlayCalendarEnabled]);
 
   return (
     <AtomsWrapper>

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -388,8 +388,8 @@ export const BookerPlatformWrapper = (
   useEffect(() => {
     if (isOverlayCalendarEnabled && view === "MONTH_VIEW") {
       localStorage.removeItem("overlayCalendarSwitchDefault");
-      setIsOverlayCalendarEnabled(Boolean(localStorage?.getItem?.("overlayCalendarSwitchDefault")));
     }
+     setIsOverlayCalendarEnabled(Boolean(localStorage?.getItem?.("overlayCalendarSwitchDefault")));
   }, [view, isOverlayCalendarEnabled]);
 
   return (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When Booker atom is in month view we always want the overlay calendar default switch to be false since we don't display overlay calendar switch and settings modal in month view

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Go into `/packages/platform/examples/base` and start the examples app, in the booking page try to change the view for the Booker atom by changing the value of view prop from `WEEK_ VIEW` to `COLUMN_VIEW` or `MONTH_VIEW`
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
