### PR TITLE
fix: Add new api-key CTA button is missing in settings/developer/api-keys

### DIFF
--- a/apps/web/app/future/settings/(settings)/developer/api-keys/page.tsx
+++ b/apps/web/app/future/settings/(settings)/developer/api-keys/page.tsx
@@ -25,7 +25,7 @@ const Page = async () => {
       description={t("create_first_api_key_description", { appName: APP_NAME })}
       CTA={<NewApiKeyButton />}
       borderInShellHeader={true}>
-      <ApiKeysView />
+      <ApiKeysView isAppDir={true} />
     </SettingsHeader>
   );
 };

--- a/apps/web/modules/settings/developer/api-keys-view.tsx
+++ b/apps/web/modules/settings/developer/api-keys-view.tsx
@@ -22,7 +22,7 @@ import {
 const SkeletonLoader = ({ title, description }: { title: string; description: string }) => {
   return (
     <SkeletonContainer>
-      <Meta title={title} description={description} borderInShellHeader={true} />
+      {!isAppDir ? <Meta title={title} description={description} borderInShellHeader={true} /> : null}
       <div className="divide-subtle border-subtle space-y-6 rounded-b-lg border border-t-0 px-6 py-4">
         <SkeletonText className="h-8 w-full" />
         <SkeletonText className="h-8 w-full" />
@@ -31,7 +31,7 @@ const SkeletonLoader = ({ title, description }: { title: string; description: st
   );
 };
 
-const ApiKeysView = () => {
+const ApiKeysView = ({ isAppDir }: { isAppDir?: boolean }) => {
   const { t } = useLocale();
 
   const { data, isPending } = trpc.viewer.apiKeys.list.useQuery();
@@ -58,6 +58,7 @@ const ApiKeysView = () => {
   if (isPending || !data) {
     return (
       <SkeletonLoader
+        isAppDir={isAppDir}
         title={t("api_keys")}
         description={t("create_first_api_key_description", { appName: APP_NAME })}
       />
@@ -66,6 +67,14 @@ const ApiKeysView = () => {
 
   return (
     <>
+      {!isAppDir ? (
+        <Meta
+          title={t("api_keys")}
+          description={t("create_first_api_key_description", { appName: APP_NAME })}
+          CTA={<NewApiKeyButton />}
+          borderInShellHeader={true}
+        />
+      ) : null}
       <LicenseRequired>
         <div>
           {data?.length ? (

--- a/apps/web/modules/settings/developer/api-keys-view.tsx
+++ b/apps/web/modules/settings/developer/api-keys-view.tsx
@@ -19,7 +19,15 @@ import {
   SkeletonText,
 } from "@calcom/ui";
 
-const SkeletonLoader = ({ title, description }: { title: string; description: string }) => {
+const SkeletonLoader = ({
+  title,
+  description,
+  isAppDir,
+}: {
+  title: string;
+  description: string;
+  isAppDir?: boolean;
+}) => {
   return (
     <SkeletonContainer>
       {!isAppDir ? <Meta title={title} description={description} borderInShellHeader={true} /> : null}

--- a/apps/web/pages/settings/developer/api-keys.tsx
+++ b/apps/web/pages/settings/developer/api-keys.tsx
@@ -1,27 +1,11 @@
 import { getLayout } from "@calcom/features/settings/layouts/SettingsLayout";
-import { APP_NAME } from "@calcom/lib/constants";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { Meta } from "@calcom/ui";
 
 import PageWrapper from "@components/PageWrapper";
 
 import ApiKeysView from "~/settings/developer/api-keys-view";
-import NewApiKeyButton from "~/settings/developer/components/CreateApiKeyButton";
 
 const Page = () => {
-  const { t } = useLocale();
-
-  return (
-    <>
-      <Meta
-        title={t("api_keys")}
-        description={t("create_first_api_key_description", { appName: APP_NAME })}
-        CTA={<NewApiKeyButton />}
-        borderInShellHeader={true}
-      />
-      <ApiKeysView />
-    </>
-  );
+  return <ApiKeysView />;
 };
 
 Page.getLayout = getLayout;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Add new api-key CTA button that is missing in settings/developer/api-keys

<img width="1440" alt="Screenshot 2024-09-14 at 20 44 08" src="https://github.com/user-attachments/assets/03dfb01e-c91b-4377-9f79-a2afd5ce11d1">

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

Navigate to `/settings/developer/api-keys`