### PR TITLE
fix: Update callback.ts to work with AU location

### DIFF
--- a/packages/app-store/zohocalendar/api/callback.ts
+++ b/packages/app-store/zohocalendar/api/callback.ts
@@ -24,16 +24,7 @@ function getOAuthBaseUrl(domain: string): string {
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const { code, location } = req.query;
-  let serverLocation = location
 
-  if (location === "us") {
-    serverLocation = "com"
-  }
-
-  if (location === "au") {
-    serverLocation = "com.au"
-  }
-    
   const state = decodeOAuthState(req);
 
   if (code && typeof code !== "string") {
@@ -60,7 +51,16 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     redirect_uri: `${WEBAPP_URL}/api/integrations/${config.slug}/callback`,
     code,
   };
-  const server_location = serverLocation;
+
+  let server_location;
+
+  if (location === "us") {
+    server_location = "com";
+  } else if (location === "au") {
+    server_location = "com.au";
+  } else {
+    server_location = location;
+  }
 
   const query = stringify(params);
 

--- a/packages/app-store/zohocalendar/api/callback.ts
+++ b/packages/app-store/zohocalendar/api/callback.ts
@@ -24,7 +24,16 @@ function getOAuthBaseUrl(domain: string): string {
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const { code, location } = req.query;
+  let serverLocation = location
 
+  if (location === "us") {
+    serverLocation = "com"
+  }
+
+  if (location === "au") {
+    serverLocation = "com.au"
+  }
+    
   const state = decodeOAuthState(req);
 
   if (code && typeof code !== "string") {
@@ -51,9 +60,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     redirect_uri: `${WEBAPP_URL}/api/integrations/${config.slug}/callback`,
     code,
   };
-  const server_location = location === "us" ? "com" :
-                        location === "au" ? "com.au" :
-                        location;
+  const server_location = serverLocation;
 
   const query = stringify(params);
 

--- a/packages/app-store/zohocalendar/api/callback.ts
+++ b/packages/app-store/zohocalendar/api/callback.ts
@@ -51,7 +51,9 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     redirect_uri: `${WEBAPP_URL}/api/integrations/${config.slug}/callback`,
     code,
   };
-  const server_location = location === "us" ? "com" : location;
+  const server_location = location === "us" ? "com" :
+                        location === "au" ? "com.au" :
+                        location;
 
   const query = stringify(params);
 


### PR DESCRIPTION

## What does this PR do?

This PR fixes the fact the Zoho server address for AU accounts. As per https://accounts.zoho.com/oauth/serverinfo, the server location for au is .com.au instead of .au


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A ----> I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Attempting to link an AU Zoho account currently results in "fetch failed" error during OAuth. After this PR is merged, AU Zoho accounts should be able to connect their calendar.
