### PR TITLE
chore: Update `dclid` → `dub_id`

### DIFF
--- a/apps/web/lib/settings/license-key/new/getServerSideProps.tsx
+++ b/apps/web/lib/settings/license-key/new/getServerSideProps.tsx
@@ -7,7 +7,9 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const session = await getServerSession({
     req: context.req,
     res: context.res,
-    authOptions: getOptions({ getDclid: () => context.req.cookies.dclid }),
+    authOptions: getOptions({
+      getDubId: () => context.req.cookies.dub_id || context.req.cookies.dclid,
+    }),
   });
   // Disable this check if we ever make this self serve.
   if (session?.user.role !== "ADMIN") {

--- a/apps/web/pages/api/auth/[...nextauth].tsx
+++ b/apps/web/pages/api/auth/[...nextauth].tsx
@@ -5,6 +5,6 @@ import { getOptions } from "@calcom/features/auth/lib/next-auth-options";
 
 // pass req to NextAuth: https://github.com/nextauthjs/next-auth/discussions/469
 const handler = (req: NextApiRequest, res: NextApiResponse) =>
-  NextAuth(req, res, getOptions({ getDclid: () => req.cookies.dclid }));
+  NextAuth(req, res, getOptions({ getDubId: () => req.cookies.dub_id || req.cookies.dclid }));
 
 export default handler;

--- a/packages/features/auth/lib/get-server-session-for-app-dir.ts
+++ b/packages/features/auth/lib/get-server-session-for-app-dir.ts
@@ -4,5 +4,9 @@ import { cookies } from "next/headers";
 import { getOptions } from "./next-auth-options";
 
 export async function getServerSessionForAppDir() {
-  return await getServerSession(getOptions({ getDclid: () => cookies().get("dclid")?.value }));
+  return await getServerSession(
+    getOptions({
+      getDubId: () => cookies().get("dub_id")?.value || cookies().get("dclid")?.value,
+    })
+  );
 }

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -408,10 +408,10 @@ const mapIdentityProvider = (providerName: string) => {
 };
 
 export const getOptions = ({
-  getDclid,
+  getDubId,
 }: {
   /** so we can extract the Dub cookie in both pages and app routers */
-  getDclid: () => string | undefined;
+  getDubId: () => string | undefined;
 }): AuthOptions => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -948,15 +948,15 @@ export const getOptions = ({
       // we should use NextAuth's isNewUser flag instead: https://next-auth.js.org/configuration/events#signin
       const isNewUser = new Date(user.createdAt) > new Date(Date.now() - 10 * 60 * 1000);
       if ((isENVDev || IS_CALCOM) && process.env.DUB_API_KEY && isNewUser) {
-        const dclid = getDclid();
-        // check if there's a dclid cookie set by @dub/analytics
-        if (dclid) {
+        const clickId = getDubId();
+        // check if there's a clickId (dub_id) cookie set by @dub/analytics
+        if (clickId) {
           // here we use waitUntil – meaning this code will run async to not block the main thread
           waitUntil(
             // if so, send a lead event to Dub
             // @see https://d.to/conversions/next-auth
             dub.track.lead({
-              clickId: dclid,
+              clickId,
               eventName: "Sign Up",
               customerId: user.id.toString(),
               customerName: user.name,


### PR DESCRIPTION
We're changing the name of our `dclid` cookie to `dub_id` – main reason being `dclid` is used by doubleclick.net (AKA Google) and the query param can potentially be stripped away/blocked by popular browsers / adblockers.

We've shipped this with backwards compatibility in mind, so your existing code will work, but we recommend upgrading your setup to use `dub_id` (whilst keeping `dclid` for backwards compatibility as well). 