### PR TITLE
chore: expose metadata on platform booker atom

### DIFF
--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -75,6 +75,7 @@ export type BookerPlatformWrapperAtomProps = Omit<
   onDeleteSlotError?: (data: ApiErrorResponse) => void;
   locationUrl?: string;
   view?: VIEW_TYPE;
+  metadata?: Record<string, string>;
 };
 
 type VIEW_TYPE = keyof typeof BookerLayouts;
@@ -343,7 +344,7 @@ export const BookerPlatformWrapper = (
     event,
     bookingForm: bookerForm.bookingForm,
     hashedLink: props.hashedLink,
-    metadata: {},
+    metadata: props.metadata ?? {},
     handleBooking: props?.handleCreateBooking ?? createBooking,
     handleInstantBooking: createInstantBooking,
     handleRecBooking: createRecBooking,
@@ -389,7 +390,7 @@ export const BookerPlatformWrapper = (
     if (isOverlayCalendarEnabled && view === "MONTH_VIEW") {
       localStorage.removeItem("overlayCalendarSwitchDefault");
     }
-     setIsOverlayCalendarEnabled(Boolean(localStorage?.getItem?.("overlayCalendarSwitchDefault")));
+    setIsOverlayCalendarEnabled(Boolean(localStorage?.getItem?.("overlayCalendarSwitchDefault")));
   }, [view, isOverlayCalendarEnabled]);
 
   return (

--- a/packages/platform/examples/base/src/pages/booking.tsx
+++ b/packages/platform/examples/base/src/pages/booking.tsx
@@ -96,6 +96,7 @@ export default function Bookings(props: { calUsername: string; calEmail: string 
                 setBookingTitle(data.data.title ?? "");
                 router.push(`/${data.data.uid}`);
               }}
+              metadata={{ CustomKey: "CustomValue" }}
               duration={eventTypeDuration}
               customClassNames={{
                 bookerContainer: "!bg-[#F5F2FE] [&_button:!rounded-full] border-subtle border",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allow users of platform booker atom to pass metadata prop, in order to have this data in the webhook returned data 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/140) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

