### PR TITLE
fix: connect apple calendar atom nested <button>'s

### DIFF
--- a/packages/platform/atoms/connect/apple/AppleConnect.tsx
+++ b/packages/platform/atoms/connect/apple/AppleConnect.tsx
@@ -76,7 +76,7 @@ export const AppleConnect: FC<Partial<Omit<OAuthConnectProps, "redir">>> = ({
   return (
     <AtomsWrapper>
       <Dialog open={isDialogOpen}>
-        <DialogTrigger>
+        <DialogTrigger asChild>
           <Button
             StartIcon="calendar-days"
             color="primary"


### PR DESCRIPTION
Linear [CAL-4368](https://linear.app/calcom/issue/CAL-4368/platform-fix-apple-calendar-connect-button-nesting)