### PR TITLE
fix: bookings limits error

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -266,6 +266,14 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     currentSeats = await getCurrentSeats(eventType, dateFrom, dateTo);
   }
 
+  const userSchedule = user.schedules.filter(
+    (schedule) => !user?.defaultScheduleId || schedule.id === user?.defaultScheduleId
+  )[0];
+
+  const schedule = eventType?.schedule ? eventType.schedule : userSchedule;
+
+  const timeZone = schedule?.timeZone || eventType?.timeZone || user.timeZone;
+
   const bookingLimits = parseBookingLimit(eventType?.bookingLimits);
   const durationLimits = parseDurationLimit(eventType?.durationLimits);
 
@@ -274,8 +282,8 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
       ? await getBusyTimesFromLimits(
           bookingLimits,
           durationLimits,
-          dateFrom,
-          dateTo,
+          dateFrom.tz(timeZone),
+          dateTo.tz(timeZone),
           duration,
           eventType,
           initialData?.busyTimesFromLimitsBookings ?? []
@@ -314,12 +322,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     ...busyTimesFromLimits,
   ];
 
-  const userSchedule = user.schedules.filter(
-    (schedule) => !user?.defaultScheduleId || schedule.id === user?.defaultScheduleId
-  )[0];
-
-  const schedule = eventType?.schedule ? eventType.schedule : userSchedule;
-
   const isDefaultSchedule = userSchedule && userSchedule.id === schedule.id;
 
   log.debug(
@@ -332,8 +334,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
   );
 
   const startGetWorkingHours = performance.now();
-
-  const timeZone = schedule?.timeZone || eventType?.timeZone || user.timeZone;
 
   if (
     !(schedule?.availability || (eventType?.availability.length ? eventType.availability : user.availability))


### PR DESCRIPTION
## What does this PR do?

Fixes an existing bug with booking limits when host and attendees were in different timezones. Slots didn't load correctly and when trying to confirm the booking it was throwing `Could not book the meeting.
Booking Limit for this event type has been reached`

- Fixes #14436
- Fixes CAL-3458
- Fixes #15005
- Fixes CAL-3692