### PR TITLE
chore: Use no isolation for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,12 +9,11 @@ jobs:
     timeout-minutes: 20
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
       - run: yarn test
       # We could add different timezones here that we need to run our tests in
-      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly
+      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate --pool=threads
       - name: Run API v2 tests
         working-directory: apps/api/v2
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     name: Unit
     timeout-minutes: 20
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,7 @@ jobs:
     timeout-minutes: 20
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
       - run: yarn test -- --no-isolate --pool=threads

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,14 +7,14 @@ jobs:
   test:
     name: Unit
     timeout-minutes: 20
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - run: yarn test -- --no-isolate --pool=threads
+      - run: yarn test -- --no-isolate
       # We could add different timezones here that we need to run our tests in
-      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate --pool=threads
+      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate
       - name: Run API v2 tests
         working-directory: apps/api/v2
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - run: yarn test
+      - run: yarn test -- --no-isolate --pool=threads
       # We could add different timezones here that we need to run our tests in
       - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate --pool=threads
       - name: Run API v2 tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - run: yarn test -- --no-isolate
+      - run: yarn test -- --no-isolate --pool=threads
       # We could add different timezones here that we need to run our tests in
-      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate
+      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate --pool=threads
       - name: Run API v2 tests
         working-directory: apps/api/v2
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - run: yarn test -- --no-isolate --pool=threads
+      - run: yarn test -- --no-isolate
       # We could add different timezones here that we need to run our tests in
-      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate --pool=threads
+      - run: TZ=America/Los_Angeles yarn test -- --timeZoneDependentTestsOnly --no-isolate
       - name: Run API v2 tests
         working-directory: apps/api/v2
         run: |


### PR DESCRIPTION
## What does this PR do?

I noticed that the unit test runs take quite awhile to collect. This PR attempts to reduce that time by using --no-isolate and a 4vCPU machine.

transform 9.90s, setup 23.18s, collect 88.14s, tests 17.62s, environment 18.50s, prepare 8.70s

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
