### PR TITLE
fix: Error on existing booking when credential is deleted

### DIFF
--- a/packages/prisma/migrations/20240924112248_booking_reference_null_credential_on_delete/migration.sql
+++ b/packages/prisma/migrations/20240924112248_booking_reference_null_credential_on_delete/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "BookingReference_credentialId_idx";
+
+-- Remove disconnected Credentials from bookingReference to prevent foreign key constraint error
+UPDATE "BookingReference"
+SET "credentialId" = NULL
+WHERE "credentialId" IS NOT NULL
+AND "credentialId" NOT IN (SELECT "id" FROM "Credential");
+
+-- AddForeignKey
+ALTER TABLE "BookingReference" ADD CONSTRAINT "BookingReference_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -183,6 +183,7 @@ model Credential {
   selectedCalendars    SelectedCalendar[]
   invalid              Boolean?              @default(false)
   CalendarCache        CalendarCache[]
+  references           BookingReference[]
 
   @@index([userId])
   @@index([appId])
@@ -533,10 +534,11 @@ model BookingReference {
   bookingId                  Int?
   externalCalendarId         String?
   deleted                    Boolean?
-  credentialId               Int?
+
+  credential   Credential? @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+  credentialId Int?
 
   @@index([bookingId])
-  @@index([credentialId])
   @@index([type])
   @@index([uid])
 }


### PR DESCRIPTION
## What does this PR do?

Turns credentialId into relation to utilise SetNull onDelete referential action.

The value of NULL is handled much better by our existing codebase than a `disconnected` relationship and fixes the appId error as without a credential the CalendarManager does not attempt to update the connected calendar.

It also updates existing BookingReference's that have disconnected Credentials.

Fixes #16772 