### PR TITLE
fix: Failed foreign key constraint check due to daily_video 0

### DIFF
--- a/packages/prisma/migrations/20240924112248_booking_reference_null_credential_on_delete/migration.sql
+++ b/packages/prisma/migrations/20240924112248_booking_reference_null_credential_on_delete/migration.sql
@@ -5,7 +5,6 @@ DROP INDEX "BookingReference_credentialId_idx";
 UPDATE "BookingReference" br
 SET "credentialId" = NULL
 WHERE br."credentialId" IS NOT NULL
-    AND br."credentialId" != 0
     AND NOT EXISTS (
         SELECT 1
         FROM "Credential" c


### PR DESCRIPTION
## What does this PR do?

Removes the 0 values as this breaks the foreign key constraint. 0'ing daily_video is deprecated after the introduction of isGlobal