### PR TITLE
fix: V1 API /slots defaulting orgSlug to api instead of null

### DIFF
--- a/apps/api/v1/pages/api/slots/_get.ts
+++ b/apps/api/v1/pages/api/slots/_get.ts
@@ -27,13 +27,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       isColdStart = false;
     }
 
-    const { usernameList, isTeamEvent, ...rest } = req.query;
+    const { usernameList, isTeamEvent, orgSlug ...rest } = req.query;
     const parsedIsTeamEvent = String(isTeamEvent).toLowerCase() === "true";
+    const parsedOrgSlug = orgSlug ? String(orgSlug) : null;
     let slugs = usernameList;
     if (!Array.isArray(usernameList)) {
       slugs = usernameList ? [usernameList] : undefined;
     }
-    const input = getScheduleSchema.parse({ usernameList: slugs, isTeamEvent: parsedIsTeamEvent, ...rest });
+    const input = getScheduleSchema.parse({
+      usernameList: slugs,
+      isTeamEvent: parsedIsTeamEvent,
+      orgSlug: parsedOrgSlug, 
+      ...rest 
+    });
     const timeZoneSupported = input.timeZone ? isSupportedTimeZone(input.timeZone) : false;
     const availableSlots = await getAvailableSlots({ ctx: await createContext({ req, res }), input });
     const slotsInProvidedTimeZone = timeZoneSupported

--- a/apps/api/v1/pages/api/slots/_get.ts
+++ b/apps/api/v1/pages/api/slots/_get.ts
@@ -27,7 +27,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       isColdStart = false;
     }
 
-    const { usernameList, isTeamEvent, orgSlug ...rest } = req.query;
+    const { usernameList, isTeamEvent, orgSlug, ...rest } = req.query;
     const parsedIsTeamEvent = String(isTeamEvent).toLowerCase() === "true";
     const parsedOrgSlug = orgSlug ? String(orgSlug) : null;
     let slugs = usernameList;

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -23,16 +23,13 @@ export const getScheduleSchema = z
     rescheduleUid: z.string().nullish(),
     // whether to do team event or user event
     isTeamEvent: z.boolean().optional().default(false),
-    orgSlug: z.string().nullish(),
+    orgSlug: z.string().nullish().default(null),
     teamMemberEmail: z.string().nullish(),
   })
   .transform((val) => {
     // Need this so we can pass a single username in the query string form public API
     if (val.usernameList) {
       val.usernameList = Array.isArray(val.usernameList) ? val.usernameList : [val.usernameList];
-    }
-    if (!val.orgSlug) {
-      val.orgSlug = null;
     }
     return val;
   })

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -341,7 +341,7 @@ export interface IGetAvailableSlots {
 }
 
 export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<IGetAvailableSlots> {
-  const orgDetails = input?.orgSlug
+  const orgDetails = input.orgSlug !== undefined
     ? {
         currentOrgDomain: input.orgSlug,
         isValidOrgDomain: !!input.orgSlug && !RESERVED_SUBDOMAINS.includes(input.orgSlug),

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -341,7 +341,7 @@ export interface IGetAvailableSlots {
 }
 
 export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<IGetAvailableSlots> {
-  const orgDetails = input.orgSlug !== undefined
+  const orgDetails = input?.orgSlug !== undefined
     ? {
         currentOrgDomain: input.orgSlug,
         isValidOrgDomain: !!input.orgSlug && !RESERVED_SUBDOMAINS.includes(input.orgSlug),


### PR DESCRIPTION
## What does this PR do?

The V1 API /slots is defaulting the `orgSlug` to 'api' instead of `null`, causing the cloud non-org users to not find a user as no user belongs to 'api' org.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
