### PR TITLE
chore: Replace campsite.co with campsite.com

### DIFF
--- a/packages/app-store/campsite/api/add.ts
+++ b/packages/app-store/campsite/api/add.ts
@@ -36,7 +36,7 @@ async function handler(req: NextApiRequest) {
     scope: "read_user write_call_room",
   };
   const query = stringify(params);
-  const url = `https://auth.campsite.co/oauth/authorize?${query}`;
+  const url = `https://auth.campsite.com/oauth/authorize?${query}`;
   return { url };
 }
 

--- a/packages/app-store/campsite/api/callback.ts
+++ b/packages/app-store/campsite/api/callback.ts
@@ -18,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { code } = req.query;
   const { client_id, client_secret } = await getAppKeysFromSlug("campsite");
 
-  const result = await fetch(`https://auth.campsite.co/oauth/token`, {
+  const result = await fetch(`https://auth.campsite.com/oauth/token`, {
     method: "POST",
     body: JSON.stringify({
       grant_type: "authorization_code",

--- a/packages/app-store/campsite/config.json
+++ b/packages/app-store/campsite/config.json
@@ -4,11 +4,11 @@
   "slug": "campsite",
   "type": "campsite_conferencing",
   "logo": "icon.png",
-  "url": "https://campsite.co",
+  "url": "https://campsite.com",
   "variant": "conferencing",
   "categories": ["conferencing"],
   "publisher": "Campsite",
-  "email": "support@campsite.co",
+  "email": "support@campsite.com",
   "appData": {
     "location": {
       "type": "integrations:{SLUG}_conferencing",

--- a/packages/app-store/campsite/lib/VideoApiAdapter.ts
+++ b/packages/app-store/campsite/lib/VideoApiAdapter.ts
@@ -11,7 +11,7 @@ const CampsiteVideoApiAdapter = (credential: CredentialPayload): VideoApiAdapter
     createMeeting: async (_event: CalendarEvent): Promise<VideoCallData> => {
       const keys = credential.key as CampsiteToken;
       const { access_token } = keys;
-      const response = await fetch("https://api.campsite.co/v1/integrations/cal_dot_com/call_rooms", {
+      const response = await fetch("https://api.campsite.com/v1/integrations/cal_dot_com/call_rooms", {
         method: "POST",
         headers: {
           Authorization: `Bearer ${access_token}`,


### PR DESCRIPTION
## What does this PR do?

Campsite has a new domain name! This PR updates references in the Campsite integration code.

<img width="591" alt="Screenshot 2024-09-25 at 11 01 08 AM" src="https://github.com/user-attachments/assets/408aafcf-7145-4f3b-a06b-a5cde8e0b2ed">


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

N/A. We're serving the same application from `[auth/api].campsite.co` and `[auth/api].campsite.com`, so this will work! 