### PR TITLE
feat:  Implement api key rate limiting

### DIFF
--- a/apps/api/v2/src/lib/throttler-guard.ts
+++ b/apps/api/v2/src/lib/throttler-guard.ts
@@ -1,45 +1,101 @@
-import { isApiKey } from "@/lib/api-key";
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Reflector } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModuleOptions, ThrottlerStorage } from "@nestjs/throttler";
 import { Request } from "express";
-
+import { PrismaService } from "../prisma.service";  // Assuming Prisma service is used
+import { Cache } from 'cache-manager';  // Nest.js cache manager, inject as required
+ 
 import { X_CAL_CLIENT_ID } from "@calcom/platform-constants";
-
+import { isApiKey } from "@/lib/api-key";
+ 
 @Injectable()
 export class CustomThrottlerGuard extends ThrottlerGuard {
   private logger = new Logger("CustomThrottlerGuard");
-
+ 
   constructor(
     options: ThrottlerModuleOptions,
     storageService: ThrottlerStorage,
     reflector: Reflector,
-    private readonly config: ConfigService
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,  // Prisma service to query DB
+    private readonly cacheManager: Cache  // Cache manager for caching limits
   ) {
     super(options, storageService, reflector);
   }
-
+ 
+  protected async handleRequest(context: any, limit: number, ttl: number): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const tracker = await this.getTracker(request);
+ 
+    if (tracker.startsWith("api_key_")) {
+      // Check if rate limit exists in cache
+      const cachedRateLimit = await this.cacheManager.get<RateLimits>(tracker);
+      let rateLimits: RateLimits;
+ 
+      if (cachedRateLimit) {
+        rateLimits = cachedRateLimit;
+      } else {
+        // Fetch rate limits from the database
+        rateLimits = await this.prisma.rateLimits.findUnique({
+          where: { apiKeyId: tracker.replace("api_key_", "") }
+        });
+ 
+        // Default values if no limits found in DB
+        if (!rateLimits) {
+          rateLimits = { ttl, limit, blockDuration: 60 }; // Default block duration in seconds
+        }
+ 
+        // Cache the result for 1 hour
+        await this.cacheManager.set(tracker, rateLimits, { ttl: 3600 });
+      }
+ 
+      // Increment usage
+      const usage = await this.storageService.increment(tracker, rateLimits.ttl);
+ 
+      // Check if blocked
+      if (usage > rateLimits.limit) {
+        if (usage - rateLimits.limit >= rateLimits.blockDuration) {
+          throw new Error("Rate limit exceeded. Try again later.");
+        }
+        throw new Error("Blocked due to exceeding rate limit.");
+      }
+ 
+      return true;
+    } else {
+      // Use default rate limiting for non-API key trackers
+      const usage = await this.storageService.increment(tracker, ttl);
+      
+      if (usage > limit) {
+        throw new Error("Rate limit exceeded. Try again later.");
+      }
+ 
+      return true;
+    }
+  }
+ 
+  // Retaining the getTracker method from earlier
   protected async getTracker(request: Request): Promise<string> {
     const authorizationHeader = request.get("Authorization")?.replace("Bearer ", "");
-
+ 
     if (authorizationHeader) {
       return isApiKey(authorizationHeader, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")
         ? `api_key_${authorizationHeader}`
         : `access_token_${authorizationHeader}`;
     }
-
+ 
     const oauthClientId = request.get(X_CAL_CLIENT_ID);
-
+ 
     if (oauthClientId) {
       return oauthClientId;
     }
-
+ 
     if (request.ip) {
       return request.ip;
     }
-
+ 
     this.logger.log(`no tracker found: ${request.url}`);
     return "unknown";
   }
 }
+ 


### PR DESCRIPTION
## What does this PR do?



Summary of Changes:
New Rate Limiting Logic:
 
Introduces a method to handle rate limits specifically for API keys. The method retrieves rate limit settings from a Prisma database based on the API key and applies these settings to manage request throttling.
Caching Rate Limits:
 
Implements caching for rate limits to reduce database queries. If the rate limits for an API key are not in the cache, it fetches them from the database and stores them in the cache for one hour.
Usage Tracking:
 
Tracks the number of requests made using an API key by incrementing usage in the storage service. If the usage exceeds the defined limit, it checks the blockDuration to determine if the key should be blocked temporarily.
Error Handling:
 
Throws a 429 Too Many Requests error when the API key usage exceeds the allowed limit or if it is currently blocked.
Default Rate Limits for Other Trackers:
 
Maintains the default rate limiting logic for non-API key requests, ensuring that all requests are still subjected to some form of rate limiting.
Purpose of the PR:
Enhanced Throttling: This PR enhances the throttling mechanism in the application by allowing different rate limits for different API keys, enabling better control over resource usage and preventing abuse.
 
Improved Performance: By caching rate limit settings, the PR aims to improve the performance of the application by reducing the number of database calls required for rate limiting checks.
 
Flexible Rate Limiting: It introduces flexibility in managing how different clients (identified by their API keys) can interact with the API, thus allowing for tailored rate limits based on the usage patterns of specific clients.
 
Dependency:

Prisma:
 
@prisma/client: For interacting with the database and managing the RateLimits schema. This should be installed alongside the Prisma schema definition in your project.
prisma: The development dependency needed to generate the client based on your Prisma schema.

Prisma Schema: 

model RateLimits {
  id            Int      @id @default(autoincrement())
  apiKeyId      String   @unique
  ttl           Int
  limit         Int
  blockDuration Int
}

- Fixes #16824 
- Fixes CAL-4413 



## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Test Description:

The primary goal of the test is to ensure that the rate-limiting mechanism works as intended for both API keys and non-API key requests. The following scenarios should be tested:
 
Valid API Key within Limit: Ensure that a request with a valid API key within the defined rate limits is successful.
Valid API Key Exceeding Limit: Ensure that once the request limit for a valid API key is exceeded, subsequent requests return a 429 Too Many Requests error.

Blocked API Key: Ensure that after a key has been blocked, requests during the block duration return a 429 Too Many Requests error.

Non-API Key Request: Ensure that non-API key requests are also limited according to default settings.
Test Configuration

Environment Setup:
 
Ensure you have a local or development instance of your NestJS application running.
Make sure you have Prisma set up with a local database. The RateLimits table should be populated with test data for the API keys you want to test.
Ensure that caching is configured correctly (e.g., using in-memory caching).
Sample Rate Limit Configuration: Populate the RateLimits table with the following test data (for example):
 
sql:

INSERT INTO RateLimits (apiKeyId, ttl, limit, blockDuration) VALUES
('test_api_key', 3600, 5, 60);  -- Allow 5 requests per hour, block for 60 seconds if exceeded.
Steps to Reproduce the Tests

Run the NestJS Application:
 
bash:

npm run start:dev
Testing Valid API Key within Limit:
 
Use a tool like Postman or curl to make requests.
Send a request with the valid API key:

bash:

curl -X GET http://localhost:3000/api/endpoint -H "Authorization: Bearer test_api_key"
Ensure you get a 200 OK response.

Testing Valid API Key Exceeding Limit:
 
Send 5 requests in quick succession:
bash:

for i in {1..5}; do curl -X GET http://localhost:3000/api/endpoint -H "Authorization: Bearer test_api_key"; done
The first 5 requests should return 200 OK, and the 6th request should return a 429 Too Many Requests error.

Testing Blocked API Key:
 
After exceeding the limit, wait for the block duration (60 seconds).
Attempt to make another request:

bash:

curl -X GET http://localhost:3000/api/endpoint -H "Authorization: Bearer test_api_key"
It should return a 429 Too Many Requests error during the block period. After 60 seconds, it should return 200 OK.
Testing Non-API Key Request:
 
Send a request without an API key:

bash:

curl -X GET http://localhost:3000/api/endpoint
Ensure it returns 200 OK based on the default limits.
Relevant Test Configuration Details
Node.js Version: Ensure you are using the same Node.js version as in production or specified in your project (check your package.json).
NestJS Version: Ensure your NestJS framework and relevant packages are up-to-date.
Database: The test should be performed against a test or development database to avoid impacting production data.
Cache Configuration: If using Redis or any other cache, ensure it’s running and correctly configured.

## Checklist




