### PR TITLE
chore: Allow redirecting /docs to external docs solution

### DIFF
--- a/apps/api/v2/.env.example
+++ b/apps/api/v2/.env.example
@@ -27,3 +27,4 @@ CALCOM_LICENSE_KEY=
 API_KEY_PREFIX=cal_
 GET_LICENSE_KEY_URL="https://console.cal.com/api/license"
 IS_E2E=false
+DOCS_URL=

--- a/apps/api/v2/src/app.module.ts
+++ b/apps/api/v2/src/app.module.ts
@@ -1,6 +1,7 @@
 import appConfig from "@/config/app";
 import { CustomThrottlerGuard } from "@/lib/throttler-guard";
 import { AppLoggerMiddleware } from "@/middleware/app.logger.middleware";
+import { RedirectsMiddleware } from "@/middleware/app.redirects.middleware";
 import { RewriterMiddleware } from "@/middleware/app.rewrites.middleware";
 import { JsonBodyMiddleware } from "@/middleware/body/json.body.middleware";
 import { RawBodyMiddleware } from "@/middleware/body/raw.body.middleware";
@@ -79,6 +80,8 @@ export class AppModule implements NestModule {
       .forRoutes("*")
       .apply(AppLoggerMiddleware)
       .forRoutes("*")
+      .apply(RedirectsMiddleware)
+      .forRoutes("/")
       .apply(RewriterMiddleware)
       .forRoutes("/");
   }

--- a/apps/api/v2/src/env.ts
+++ b/apps/api/v2/src/env.ts
@@ -19,6 +19,7 @@ export type Environment = {
   CALCOM_LICENSE_KEY: string;
   GET_LICENSE_KEY_URL: string;
   API_KEY_PREFIX: string;
+  DOCS_URL: string;
 };
 
 export const getEnv = <K extends keyof Environment>(key: K, fallback?: Environment[K]): Environment[K] => {

--- a/apps/api/v2/src/main.ts
+++ b/apps/api/v2/src/main.ts
@@ -114,11 +114,14 @@ async function generateSwagger(app: NestExpressApplication<Server>) {
   }
 
   fs.writeFileSync(outputFile, JSON.stringify(document, null, 2), { encoding: "utf8" });
-  SwaggerModule.setup("docs", app, document, {
-    customCss: ".swagger-ui .topbar { display: none }",
-  });
 
-  logger.log(`Swagger documentation available in the "/docs" endpoint\n`);
+  if (!process.env.DOCS_URL) {
+    SwaggerModule.setup("docs", app, document, {
+      customCss: ".swagger-ui .topbar { display: none }",
+    });
+
+    logger.log(`Swagger documentation available in the "/docs" endpoint\n`);
+  }
 }
 
 run().catch((error: Error) => {

--- a/apps/api/v2/src/middleware/app.redirects.middleware.ts
+++ b/apps/api/v2/src/middleware/app.redirects.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { Request, Response } from "express";
+
+@Injectable()
+export class RedirectsMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: () => void) {
+    if (process.env.DOCS_URL && (req.url.startsWith("/v2/docs") || req.url.startsWith("/docs"))) {
+      return res.redirect(process.env.DOCS_URL);
+    }
+    next();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

We will be redirecting the /docs route to cal.com/docs/api/v2

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Set the DOCS_URL env variable to a different URL and ensure that going to /docs redirects to that URL you supplied
