### PR TITLE
fix: add teamId to platform urls

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -177,7 +177,9 @@ export const getPlatformManageLink = (calEvent: CalendarEvent, t: TFunction) => 
   if (calEvent.platformBookingUrl) {
     res += `Check Here: ${calEvent.platformBookingUrl}/${getUid(calEvent)}?slug=${calEvent.type}&username=${
       calEvent.organizer.username
-    }&changes=true${calEvent.platformCancelUrl || shouldDisplayReschedule ? ` ${t("or_lowercase")} ` : ""}`;
+    }${calEvent?.team ? `&teamId=${calEvent.team.id}` : ""}&changes=true${
+      calEvent.platformCancelUrl || shouldDisplayReschedule ? ` ${t("or_lowercase")} ` : ""
+    }`;
   }
   if (calEvent.platformCancelUrl) {
     res += `${t("cancel")}: ${getCancelLink(calEvent)}`;
@@ -215,6 +217,7 @@ export const getPlatformCancelLink = (
     platformCancelLink.searchParams.append("cancel", "true");
     platformCancelLink.searchParams.append("allRemainingBookings", String(!!calEvent.recurringEvent));
     if (seatUid) platformCancelLink.searchParams.append("seatReferenceUid", seatUid);
+    if (calEvent?.team) platformCancelLink.searchParams.append("teamId", calEvent.team.id.toString());
     return platformCancelLink.toString();
   }
   return "";
@@ -250,6 +253,7 @@ export const getPlatformRescheduleLink = (
     calEvent.organizer.username &&
       platformRescheduleLink.searchParams.append("username", calEvent.organizer.username);
     platformRescheduleLink.searchParams.append("reschedule", "true");
+    if (calEvent?.team) platformRescheduleLink.searchParams.append("teamId", calEvent.team.id.toString());
     return platformRescheduleLink.toString();
   }
   return "";


### PR DESCRIPTION
## What does this PR do?

 small change to add teamId to platform redirect urls now that platform can manage teams

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

