### PR TITLE
fix: #16869 unable to retrive timeZone for event

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/create.handler.ts
@@ -40,6 +40,7 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
   const userId = ctx.user.id;
   const isManagedEventType = schedulingType === SchedulingType.MANAGED;
   const isOrgAdmin = !!ctx.user?.organization?.isOrgAdmin;
+  const timeZone = ctx.user.timeZone;
 
   const locations: EventTypeLocation[] =
     inputLocations && inputLocations.length !== 0 ? inputLocations : await getDefaultLocations(ctx.user);
@@ -52,6 +53,7 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
     users: isManagedEventType || schedulingType ? undefined : { connect: { id: userId } },
     locations,
     schedule: scheduleId ? { connect: { id: scheduleId } } : undefined,
+    timeZone: timeZone,
   };
 
   if (teamId && schedulingType) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Issue: Earlier when the user tries to retrieve the timeZone using the command: curl --location 'https://api.cal.com/v1/event-types/968063?apiKey=<cal_live_xyz>' it returns null because while creating the event timeZone was not being set.

Fix: added timeZone (user's TimeZone) as a parameter while creating the event

- Fixes #16869 (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [✅] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
