### PR TITLE
fix: hydration error coming from useLastUsed hook

### DIFF
--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -281,9 +281,7 @@ PageProps & WithNonceProps<{}>) {
                 disabled={formState.isSubmitting}
                 className="w-full justify-center">
                 <span>{twoFactorRequired ? t("submit") : t("sign_in")}</span>
-                {lastUsed === "credentials" && (
-                  <span className="absolute right-3 text-xs text-gray-600">{t("last_used")}</span>
-                )}
+                {lastUsed === "credentials" && <LastUsed className="text-gray-600" />}
               </Button>
             </div>
           </form>

--- a/packages/lib/hooks/useLastUsed.tsx
+++ b/packages/lib/hooks/useLastUsed.tsx
@@ -1,15 +1,20 @@
 import { useState, useEffect } from "react";
 
+import classNames from "@calcom/lib/classNames";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localStorage } from "@calcom/lib/webstorage";
 
-type LoginType = "saml" | "google" | "credentials" | undefined;
+type LoginType = "saml" | "google" | "credentials";
 
 export function useLastUsed() {
-  const [lastUsed, setLastUsed] = useState<LoginType>(() => {
+  const [lastUsed, setLastUsed] = useState<LoginType>();
+
+  useEffect(() => {
     const storedValue = localStorage.getItem("last_cal_login");
-    return storedValue ? (storedValue as LoginType) : undefined;
-  });
+    if (storedValue) {
+      setLastUsed(storedValue as LoginType);
+    }
+  }, []);
 
   useEffect(() => {
     if (lastUsed) {
@@ -22,7 +27,9 @@ export function useLastUsed() {
   return [lastUsed, setLastUsed] as const;
 }
 
-export const LastUsed = () => {
+export const LastUsed = ({ className }: { className?: string }) => {
   const { t } = useLocale();
-  return <span className="text-subtle absolute right-3 text-xs">{t("last_used")}</span>;
+  return (
+    <span className={classNames("text-subtle absolute right-3 text-xs", className)}>{t("last_used")}</span>
+  );
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fix `useLastUsed` hook to prevent a hydration error coming from HTML mismatch
- I discovered the bug in login page
<img width="762" alt="Screenshot 2024-09-29 at 18 28 13" src="https://github.com/user-attachments/assets/5d2f88bf-72d3-4001-af2a-73e5691ec984">

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
