### PR TITLE
feat: prevent sending multiple instant meeting request

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2168,7 +2168,7 @@
   "select_time": "Select Time",
   "select_date": "Select Date",
   "connecting_you_to_someone": "We are connecting you to someone.",
-  "please_do_not_close_this_tab": "Please do not close this tab",
+  "please_do_not_close_this_tab": "Please do not close or refresh this page",
   "see_all_available_times": "See all available times",
   "org_team_names_example_1": "e.g. Marketing Team",
   "org_team_names_example_2": "e.g. Sales Team",

--- a/packages/features/bookings/Booker/components/RedirectToInstantMeetingModal.tsx
+++ b/packages/features/bookings/Booker/components/RedirectToInstantMeetingModal.tsx
@@ -94,7 +94,7 @@ export const RedirectToInstantMeetingModal = ({
           ) : (
             <div className="text-center">
               <p className="font-medium">{t("connecting_you_to_someone")}</p>
-              <p className="font-medium">{t("please_do_not_close_this_tab")}</p>
+              <p className="font-bold">{t("please_do_not_close_this_tab")}</p>
               <p className="mt-2 font-medium">
                 {t("please_schedule_future_call", {
                   seconds: formatTime(timeRemaining),

--- a/packages/features/bookings/Booker/components/hooks/useBookings.ts
+++ b/packages/features/bookings/Booker/components/hooks/useBookings.ts
@@ -13,6 +13,7 @@ import type { BookerEvent } from "@calcom/features/bookings/types";
 import { getFullName } from "@calcom/features/form-builder/utils";
 import { useBookingSuccessRedirect } from "@calcom/lib/bookingSuccessRedirect";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { localStorage } from "@calcom/lib/webstorage";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import { trpc } from "@calcom/trpc";
@@ -85,22 +86,63 @@ export interface IUseBookingErrors {
 }
 export type UseBookingsReturnType = ReturnType<typeof useBookings>;
 
+const STORAGE_KEY = "instantBookingData";
+
+const storeInLocalStorage = ({
+  eventTypeId,
+  expiryTime,
+  bookingId,
+}: {
+  eventTypeId: number;
+  expiryTime: Date;
+  bookingId: number;
+}) => {
+  const value = JSON.stringify({ eventTypeId, expiryTime, bookingId });
+  localStorage.setItem(STORAGE_KEY, value);
+};
+
 export const useBookings = ({ event, hashedLink, bookingForm, metadata, teamMemberEmail }: IUseBookings) => {
   const router = useRouter();
   const eventSlug = useBookerStore((state) => state.eventSlug);
+  const eventTypeId = useBookerStore((state) => state.eventId);
+  const isInstantMeeting = useBookerStore((state) => state.isInstantMeeting);
+
   const rescheduleUid = useBookerStore((state) => state.rescheduleUid);
   const bookingData = useBookerStore((state) => state.bookingData);
   const timeslot = useBookerStore((state) => state.selectedTimeslot);
   const { t } = useLocale();
   const bookingSuccessRedirect = useBookingSuccessRedirect();
   const bookerFormErrorRef = useRef<HTMLDivElement>(null);
+
   const [instantMeetingTokenExpiryTime, setExpiryTime] = useState<Date | undefined>();
   const [instantVideoMeetingUrl, setInstantVideoMeetingUrl] = useState<string | undefined>();
   const duration = useBookerStore((state) => state.selectedDuration);
 
   const isRescheduling = !!rescheduleUid && !!bookingData;
 
-  const bookingId = parseInt(getQueryParam("bookingId") || "0");
+  const bookingId = parseInt(getQueryParam("bookingId") ?? "0");
+
+  useEffect(() => {
+    if (!isInstantMeeting) return;
+
+    const storedInfo = localStorage.getItem(STORAGE_KEY);
+
+    if (storedInfo) {
+      const parsedInfo = JSON.parse(storedInfo);
+
+      const parsedInstantBookingInfo =
+        parsedInfo.eventTypeId === eventTypeId &&
+        isInstantMeeting &&
+        new Date(parsedInfo.expiryTime) > new Date()
+          ? parsedInfo
+          : null;
+
+      if (parsedInstantBookingInfo) {
+        setExpiryTime(parsedInstantBookingInfo.expiryTime);
+        updateQueryParam("bookingId", parsedInstantBookingInfo.bookingId);
+      }
+    }
+  }, [eventTypeId, isInstantMeeting]);
 
   const _instantBooking = trpc.viewer.bookings.getInstantBookingLocation.useQuery(
     {
@@ -239,6 +281,14 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, teamMemb
   const createInstantBookingMutation = useMutation({
     mutationFn: createInstantBooking,
     onSuccess: (responseData) => {
+      if (eventTypeId) {
+        storeInLocalStorage({
+          eventTypeId,
+          expiryTime: responseData.expires,
+          bookingId: responseData.bookingId,
+        });
+      }
+
       updateQueryParam("bookingId", responseData.bookingId);
       setExpiryTime(responseData.expires);
     },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://github.com/calcom/cal.com/issues/16606 (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)


https://github.com/user-attachments/assets/3898db0b-8f86-4361-a831-22e2a2f784fb



<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->


1) Create an org team event type
2) go to event type settings and go to instant booking tab and enable it.
3) Go to booking page and click on "Connect now" modal. Now try to reload the page or try to submit instant booking again for this event type within 90 seconds. you should see the modal like in the above video