### PR TITLE
fix: Better defaulting to NEXT_PUBLIC_LOGGER_LEVEL=4

### DIFF
--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -3,7 +3,7 @@ import { Logger } from "tslog";
 import { IS_PRODUCTION } from "./constants";
 
 const logger = new Logger({
-  minLevel: parseInt(process.env.NEXT_PUBLIC_LOGGER_LEVEL ?? "4"),
+  minLevel: parseInt(process.env.NEXT_PUBLIC_LOGGER_LEVEL || "4"),
   maskValuesOfKeys: ["password", "passwordConfirmation", "credentials", "credential"],
   prettyLogTimeZone: IS_PRODUCTION ? "UTC" : "local",
   prettyErrorStackTemplate: "  • {{fileName}}\t{{method}}\n\t{{filePathWithLine}}", // default

--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -8,7 +8,7 @@ const logger = new Logger({
   prettyLogTimeZone: IS_PRODUCTION ? "UTC" : "local",
   prettyErrorStackTemplate: "  • {{fileName}}\t{{method}}\n\t{{filePathWithLine}}", // default
   prettyErrorTemplate: "\n{{errorName}} {{errorMessage}}\nerror stack:\n{{errorStack}}", // default
-  prettyLogTemplate: "{{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}", // default with exclusion of `{{filePathWithLine}}`
+  prettyLogTemplate: "{{hh}}:{{MM}}:{{ss}}:{{ms}} [{{logLevelName}}] ", // default with exclusion of `{{filePathWithLine}}`
   stylePrettyLogs: true,
   prettyLogStyles: {
     name: "yellow",


### PR DESCRIPTION
## What does this PR do?

I was wondering why my console was so vocal even though I had `NEXT_PUBLIC_LOGGER_LEVEL=` in my .env; That's because that's an `""` - not undefined, so ?? would never work if the env var is actually set to "". || works in both cases.