### PR TITLE
fix: Tooltip must be used within TooltipProvider

### DIFF
--- a/apps/web/pages/auth/setup/index.tsx
+++ b/apps/web/pages/auth/setup/index.tsx
@@ -3,6 +3,8 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Meta } from "@calcom/ui";
 
+import PageWrapper from "@components/PageWrapper";
+
 import { getServerSideProps } from "@server/lib/setup/getServerSideProps";
 
 import type { PageProps } from "~/auth/setup-view";
@@ -10,6 +12,7 @@ import Setup from "~/auth/setup-view";
 
 const Page = (props: PageProps) => {
   const { t } = useLocale();
+
   return (
     <>
       <Meta title={t("setup")} description={t("setup_description")} />
@@ -17,6 +20,8 @@ const Page = (props: PageProps) => {
     </>
   );
 };
+
+Page.PageWrapper = PageWrapper;
 export default Page;
 
 export { getServerSideProps };

--- a/apps/web/pages/auth/setup/index.tsx
+++ b/apps/web/pages/auth/setup/index.tsx
@@ -12,7 +12,6 @@ import Setup from "~/auth/setup-view";
 
 const Page = (props: PageProps) => {
   const { t } = useLocale();
-
   return (
     <>
       <Meta title={t("setup")} description={t("setup_description")} />


### PR DESCRIPTION
## Fix #16833

After installing Cal.com for the first time, users are not able to run go through the setup process on the client due to `PageWrapper` not being applied to `/auth/setup`.

- Fixes #16833

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Do a fresh install of Cal.com; clone the repo into a new workspace and run `yarn dev` after installing dependencies
2. Create a new Postgres DB so that Cal.com recognizes that a setup is required
3. Head over to localhost:3000. 
4. After getting redirected to localhost:3000/auth/setup, an error will occur: "Tooltip must be used within TooltipProvider"

- Are there environment variables that should be set?
Nope
- What are the minimal test data to have? 
An new DB with no users
- What is expected (happy path) to have (input and output)? 
No errors when going to localhost:3000/auth/setup
- Any other important info that could help to test that PR
