### PR TITLE
fix: Certain query params being filtered out from embed

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -440,16 +440,20 @@ export class Cal {
     return Object.fromEntries(Object.entries(params).filter(([key, value]) => !excludeParam(key, value)));
   }
 
+  private getQueryParamsFromPage() {
+    const queryParamsFromPage = getQueryParamsFromPage();
+    // Ensure valid params are used from the page.
+    return this.filterParams(queryParamsFromPage);
+  }
+
   private buildFilteredQueryParams(queryParamsFromConfig: PrefillAndIframeAttrsConfig): URLSearchParams {
-    const queryParamsFromPageUrl = globalCal.config?.forwardQueryParams ? getQueryParamsFromPage() : {};
+    const queryParamsFromPageUrl = globalCal.config?.forwardQueryParams ? this.getQueryParamsFromPage() : {};
 
     // Query Params via config have higher precedence
     const mergedQueryParams = { ...queryParamsFromPageUrl, ...queryParamsFromConfig };
 
-    const filteredQueryParams = this.filterParams(mergedQueryParams);
-
     const searchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(filteredQueryParams)) {
+    for (const [key, value] of Object.entries(mergedQueryParams)) {
       if (value === undefined) {
         continue;
       }


### PR DESCRIPTION
## What does this PR do?

- No params are filtered out now by default.
- With forwardQueryParams feature enabled, we are filtering out the page query params. Config query params will still be unfiltered. This should allow `rescheduleUid`(and other reserved query params) in `config` to keep on working even with the `forwardQueryParams` feature enabled

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x]  N/A I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
