### PR TITLE
fix: flaky one in locale e2e test

### DIFF
--- a/apps/web/playwright/locale.e2e.ts
+++ b/apps/web/playwright/locale.e2e.ts
@@ -437,7 +437,7 @@ test.describe("authorized user sees changed translations (de->ar)", async () => 
       await page.waitForLoadState("domcontentloaded");
 
       await page.locator(".bg-default > div > div:nth-child(2)").first().click();
-      await page.locator("#react-select-2-option-0").click();
+      await page.getByTestId("select-option-ar").click();
 
       await page.getByRole("button", { name: "Aktualisieren" }).click();
 


### PR DESCRIPTION
## What does this PR do?

- Getting the select option component via "#react-select-2-option-0" is not stable; e.g., I had to run twice to pass the test in #16948 
- Based on local testing, it's sometimes react-select-3, not react-select-2; 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.