### PR TITLE
fix: make theme logic safe and add better e2e tests

### DIFF
--- a/apps/web/modules/settings/my-account/appearance-view.tsx
+++ b/apps/web/modules/settings/my-account/appearance-view.tsx
@@ -192,15 +192,21 @@ const AppearanceView = ({
       </div>
       <Form
         form={userAppThemeFormMethods}
-        handleSubmit={(values) => {
+        handleSubmit={({ appTheme }) => {
+          if (appTheme === "light" || appTheme === "dark") {
+            mutation.mutate({
+              appTheme,
+            });
+            return;
+          }
           mutation.mutate({
-            appTheme: values.appTheme === "" ? null : values.appTheme,
+            appTheme: null,
           });
         }}>
         <div className="border-subtle flex flex-col justify-between border-x px-6 py-8 sm:flex-row">
           <ThemeLabel
             variant="system"
-            value={undefined}
+            value="system"
             label={t("theme_system")}
             defaultChecked={user.appTheme === null}
             register={userAppThemeFormMethods.register}
@@ -244,17 +250,21 @@ const AppearanceView = ({
           </div>
           <Form
             form={userThemeFormMethods}
-            handleSubmit={(values) => {
+            handleSubmit={({ theme }) => {
+              if (theme === "light" || theme === "dark") {
+                mutation.mutate({
+                  theme,
+                });
+                return;
+              }
               mutation.mutate({
-                // Radio values don't support null as values, therefore we convert an empty string
-                // back to null here.
-                theme: values.theme === "" ? null : values.theme,
+                theme: null,
               });
             }}>
             <div className="border-subtle flex flex-col justify-between border-x px-6 py-8 sm:flex-row">
               <ThemeLabel
                 variant="system"
-                value={undefined}
+                value="system"
                 label={t("theme_system")}
                 defaultChecked={user.theme === null}
                 register={userThemeFormMethods.register}

--- a/apps/web/playwright/change-theme.e2e.ts
+++ b/apps/web/playwright/change-theme.e2e.ts
@@ -1,10 +1,70 @@
 import { expect } from "@playwright/test";
-import { testBothFutureAndLegacyRoutes } from "playwright/lib/future-legacy-routes";
 
 import { test } from "./lib/fixtures";
 
-testBothFutureAndLegacyRoutes.describe("Change Theme Test", () => {
-  test("change theme to dark", async ({ page, users }) => {
+test.describe("Change App Theme Test", () => {
+  test("change app theme to dark", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.apiLogin();
+    await page.goto("/settings/my-account/appearance");
+    await page.click('[data-testid="appTheme-dark"]');
+    await page.click('[data-testid="update-app-theme-btn"]');
+
+    const toast = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast).toBeTruthy();
+
+    const darkModeClass = await page.getAttribute("html", "class");
+    expect(darkModeClass).toContain("dark");
+
+    const themeValue = await page.evaluate(() => localStorage.getItem("app-theme"));
+    expect(themeValue).toBe("dark");
+  });
+
+  test("change app theme to light", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.apiLogin();
+    await page.goto("/settings/my-account/appearance");
+    await page.click('[data-testid="appTheme-light"]');
+    await page.click('[data-testid="update-app-theme-btn"]');
+
+    const toast = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast).toBeTruthy();
+
+    const darkModeClass = await page.getAttribute("html", "class");
+    expect(darkModeClass).toContain("light");
+
+    const themeValue = await page.evaluate(() => localStorage.getItem("app-theme"));
+    expect(themeValue).toBe("light");
+  });
+
+  test("change app theme to system", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.apiLogin();
+
+    await page.goto("/settings/my-account/appearance");
+    await page.click('[data-testid="appTheme-light"]');
+    await page.click('[data-testid="update-app-theme-btn"]');
+    const toast1 = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast1).toBeTruthy();
+
+    await page.click('[data-testid="appTheme-system"]');
+    await page.click('[data-testid="update-app-theme-btn"]');
+    const toast2 = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast2).toBeTruthy();
+
+    await page.waitForTimeout(3000);
+    const themeValue = await page.evaluate(() => localStorage.getItem("app-theme"));
+    expect(themeValue).toBe("system");
+
+    const systemTheme = await page.evaluate(() => {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    });
+    expect(await page.getAttribute("html", "class")).toContain(systemTheme);
+  });
+});
+
+test.describe("Change Booking Page Theme Test", () => {
+  test("change booking page theme to dark", async ({ page, users }) => {
     const pro = await users.create();
     await pro.apiLogin();
 
@@ -19,11 +79,11 @@ testBothFutureAndLegacyRoutes.describe("Change Theme Test", () => {
     expect(toast).toBeTruthy();
     //Go to the profile page and check if the theme is dark
     await page.goto(`/${pro.username}`);
-    const darkModeClass = await page.getAttribute("html", "class");
-    expect(darkModeClass).toContain("dark");
+    const htmlClass = await page.getAttribute("html", "class");
+    expect(htmlClass).toContain("dark");
   });
 
-  test("change theme to light", async ({ page, users }) => {
+  test("change booking page theme to light", async ({ page, users }) => {
     const pro = await users.create();
     await pro.apiLogin();
 
@@ -38,7 +98,31 @@ testBothFutureAndLegacyRoutes.describe("Change Theme Test", () => {
     expect(toast).toBeTruthy();
     //Go to the profile page and check if the theme is light
     await page.goto(`/${pro.username}`);
-    const darkModeClass = await page.getAttribute("html", "class");
-    expect(darkModeClass).toContain("light");
+    const htmlClass = await page.getAttribute("html", "class");
+    expect(htmlClass).toContain("light");
+  });
+
+  test("change booking page theme to system", async ({ page, users }) => {
+    const pro = await users.create();
+    await pro.apiLogin();
+
+    await page.goto("/settings/my-account/appearance");
+
+    await page.click('[data-testid="theme-light"]');
+    await page.click('[data-testid="update-theme-btn"]');
+    const toast1 = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast1).toBeTruthy();
+
+    await page.click('[data-testid="theme-system"]');
+    await page.click('[data-testid="update-theme-btn"]');
+    const toast2 = await page.waitForSelector('[data-testid="toast-success"]');
+    expect(toast2).toBeTruthy();
+    await page.goto(`/${pro.username}`);
+
+    const systemTheme = await page.evaluate(() => {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    });
+
+    expect(await page.getAttribute("html", "class")).toContain(systemTheme);
   });
 });

--- a/packages/features/ee/organizations/pages/settings/appearance.tsx
+++ b/packages/features/ee/organizations/pages/settings/appearance.tsx
@@ -78,9 +78,15 @@ const OrgAppearanceView = ({
     <div>
       <Form
         form={themeForm}
-        handleSubmit={(value) => {
+        handleSubmit={({ theme }) => {
+          if (theme === "light" || theme === "dark") {
+            mutation.mutate({
+              theme,
+            });
+            return;
+          }
           mutation.mutate({
-            theme: value.theme === "" ? null : value.theme,
+            theme: null,
           });
         }}>
         <div className="border-subtle mt-6 flex items-center rounded-t-xl border p-6 text-sm">
@@ -92,7 +98,7 @@ const OrgAppearanceView = ({
         <div className="border-subtle flex flex-col justify-between border-x px-6 py-8 sm:flex-row">
           <ThemeLabel
             variant="system"
-            value={undefined}
+            value="system"
             label={t("theme_system")}
             defaultChecked={currentOrg.theme === null}
             register={themeForm.register}

--- a/packages/features/ee/teams/pages/team-appearance-view.tsx
+++ b/packages/features/ee/teams/pages/team-appearance-view.tsx
@@ -90,10 +90,10 @@ const ProfileView = ({ team, isAppDir }: ProfileViewProps) => {
         <>
           <Form
             form={themeForm}
-            handleSubmit={(values) => {
+            handleSubmit={({ theme }) => {
               mutation.mutate({
                 id: team.id,
-                theme: values.theme === "" ? null : values.theme,
+                theme: theme === "light" || theme === "dark" ? theme : null,
               });
             }}>
             <div className="border-subtle mt-6 flex items-center rounded-t-xl border p-6 text-sm">
@@ -105,7 +105,7 @@ const ProfileView = ({ team, isAppDir }: ProfileViewProps) => {
             <div className="border-subtle flex flex-col justify-between border-x px-6 py-8 sm:flex-row">
               <ThemeLabel
                 variant="system"
-                value={null}
+                value="system"
                 label={t("theme_system")}
                 defaultChecked={team.theme === null}
                 register={themeForm.register}

--- a/packages/features/settings/ThemeLabel.tsx
+++ b/packages/features/settings/ThemeLabel.tsx
@@ -1,6 +1,6 @@
 interface ThemeLabelProps {
   variant: "light" | "dark" | "system";
-  value: "light" | "dark" | "system" | null;
+  value: "light" | "dark" | "system";
   label: string;
   defaultChecked?: boolean;
   register: any;

--- a/packages/features/settings/ThemeLabel.tsx
+++ b/packages/features/settings/ThemeLabel.tsx
@@ -1,6 +1,6 @@
 interface ThemeLabelProps {
   variant: "light" | "dark" | "system";
-  value?: "light" | "dark" | null;
+  value: "light" | "dark" | "system" | null;
   label: string;
   defaultChecked?: boolean;
   register: any;

--- a/packages/ui/styles/useCalcomTheme.tsx
+++ b/packages/ui/styles/useCalcomTheme.tsx
@@ -8,6 +8,10 @@ type CssVariables = Record<string, string>;
 const useCalcomTheme = (theme: Record<string, CssVariables>) => {
   useEffect(() => {
     Object.entries(theme).forEach(([key, value]) => {
+      if (!value) {
+        // should not be reached
+        return;
+      }
       if (key === "root") {
         const root = document.documentElement;
         Object.entries(value).forEach(([key, value]) => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

**Tldr:**
1. The bug is NOT in production
2. Setting an app theme to ”system” in my-account/appearance sets the value of app-theme in localStorage to "on"—it should be set to ”system”
3. Don’t even know where “on” is coming from. I’m debugging.

My recent [PR](https://github.com/calcom/cal.com/pull/16793) that’s completely replaced pages router with app router for settings/my-account pages introduced this bug:

https://www.loom.com/share/7b43f7a3a47e4d83b1be3b14fde89248?sid=519c6e6a-0cf1-44d8-8e4d-1dbb82d1d3b9

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
