### PR TITLE
fix: Prettier error and EmailField import error due to Attributes query PR

### DIFF
--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.tsx
@@ -1,11 +1,19 @@
 import type { ChangeEvent } from "react";
-import type { Settings, Widgets, SelectWidgetProps, SelectWidget } from "react-awesome-query-builder";
+import type {
+  Settings,
+  Widgets,
+  SelectWidgetProps,
+  SelectWidget as SelectWidgetType,
+} from "react-awesome-query-builder";
+
+import { EmailField as EmailWidget } from "@calcom/ui";
 
 import widgetsComponents from "../widgets";
 // Figure out why routing-forms/env.d.ts doesn't work
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
-import BasicConfig, { Operators, Types } from "./BasicConfig";
+import type { Operators, Types } from "./BasicConfig";
+import BasicConfig from "./BasicConfig";
 
 const enum ConfigFor {
   FormFields = "FormFields",
@@ -22,7 +30,6 @@ const {
   Button,
   ButtonGroup,
   Provider,
-  EmailWidget,
 } = widgetsComponents;
 
 const renderComponent = function <T1>(props: T1 | undefined, Component: React.FC<T1>) {
@@ -77,7 +84,7 @@ function getWidgets(_configFor: ConfigFor) {
           listValues: { title: string; value: string }[];
         }
       ) => renderComponent(props, MultiSelectWidget),
-    } as SelectWidget,
+    } as SelectWidgetType,
     select: {
       ...BasicConfig.widgets.select,
       factory: (
@@ -85,7 +92,7 @@ function getWidgets(_configFor: ConfigFor) {
           listValues: { title: string; value: string }[];
         }
       ) => renderComponent(props, SelectWidget),
-    } as SelectWidget,
+    } as SelectWidgetType,
     phone: {
       ...BasicConfig.widgets.text,
       factory: (props) => {

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
@@ -8,7 +8,7 @@ import type {
   ProviderProps,
 } from "react-awesome-query-builder";
 
-import { Button as CalButton, TextField, TextArea, EmailField } from "@calcom/ui";
+import { Button as CalButton, TextField, TextArea } from "@calcom/ui";
 import { Icon } from "@calcom/ui";
 
 const Select = dynamic(
@@ -371,7 +371,6 @@ const widgets = {
   ButtonGroup,
   Conjs,
   Provider,
-  EmailWidget: EmailField,
 };
 
 export default widgets;

--- a/packages/app-store/routing-forms/lib/evaluateRaqbLogic.test.ts
+++ b/packages/app-store/routing-forms/lib/evaluateRaqbLogic.test.ts
@@ -6,7 +6,7 @@ import { evaluateRaqbLogic, RaqbLogicResult } from "./evaluateRaqbLogic";
 vi.mock("../components/react-awesome-query-builder/widgets", () => ({
   default: {},
 }));
-vi.mock("@calcom/ui");
+vi.mock("@calcom/ui", () => ({}));
 
 describe("evaluateRaqbLogic", () => {
   it("should return a match for multiselect_equals", () => {

--- a/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
+++ b/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
-import { BaseWidget, JsonTree } from "react-awesome-query-builder";
+import type { BaseWidget } from "react-awesome-query-builder";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { AttributeType } from "@calcom/prisma/enums";
+import type { AttributeType } from "@calcom/prisma/enums";
 
 import { RoutingFormFieldType } from "../../lib/FieldTypes";
 import { RaqbLogicResult } from "../../lib/evaluateRaqbLogic";
@@ -14,7 +14,7 @@ vi.mock("../../lib/getAttributes");
 vi.mock("../../components/react-awesome-query-builder/widgets", () => ({
   default: {},
 }));
-vi.mock("@calcom/ui");
+vi.mock("@calcom/ui", () => ({}));
 
 function mockAttributesScenario({
   attributes,


### PR DESCRIPTION
## What does this PR do?

- Fix prettier error during pre-commit hook. I don't usually use pre-commit hook and depend on CLI to highlight issues which I why I didn't see this issue locally. Issue occured because SelectWidget was defined both as a type and a value in config.tsx
Reported by @SomayChauhan 
![image](https://github.com/user-attachments/assets/cbd31eb6-5d1b-453f-9eaa-e3e2104ddda9)

- EmailField import error in `website` repo only. Reported by @JeroenReumkens. Some weird circular dependency thing started happening as soon as I imported EmailField in widgets(I have reverted that to previous approach to quickly fix it)
![image](https://github.com/user-attachments/assets/7257d3b4-ea49-4153-bc06-057682c488b0)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

