### PR TITLE
fix: DatePicker not showing up in mobile mode when hideEventTypeDetails is true

### DIFF
--- a/packages/embeds/embed-core/playground.ts
+++ b/packages/embeds/embed-core/playground.ts
@@ -474,7 +474,7 @@ if (only === "all" || only == "ns:monthView") {
     //@ts-ignore
     {
       elementOrSelector: "#cal-booking-place-monthView .place",
-      calLink: "pro/paid",
+      calLink: "free/30min",
       config: {
         iframeAttrs: {
           id: "cal-booking-place-monthView-iframe",
@@ -499,7 +499,7 @@ if (only === "all" || only == "ns:weekView") {
     //@ts-ignore
     {
       elementOrSelector: "#cal-booking-place-weekView .place",
-      calLink: "pro/paid",
+      calLink: "free/30min",
       config: {
         iframeAttrs: {
           id: "cal-booking-place-weekView-iframe",
@@ -528,7 +528,7 @@ if (only === "all" || only == "ns:columnView") {
     //@ts-ignore
     {
       elementOrSelector: "#cal-booking-place-columnView .place",
-      calLink: "pro/paid",
+      calLink: "free/30min",
       config: {
         iframeAttrs: {
           id: "cal-booking-place-columnView-iframe",

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -259,6 +259,8 @@ const BookerComponent = ({
     return null;
   }
 
+  const shouldShowMeta = !hideEventTypeDetails;
+
   return (
     <>
       {event.data && !isPlatform ? <BookingPageTagManager eventType={event.data} /> : <></>}
@@ -327,7 +329,7 @@ const BookerComponent = ({
                 )}
               </BookerSection>
             )}
-            {!hideEventTypeDetails && (
+            {shouldShowMeta && (
               <StickyOnDesktop key="meta" className={classNames("relative z-10 flex [grid-area:meta]")}>
                 <BookerSection
                   area="meta"
@@ -375,7 +377,13 @@ const BookerComponent = ({
             <BookerSection
               key="datepicker"
               area="main"
-              visible={bookerState !== "booking" && layout === BookerLayouts.MONTH_VIEW}
+              visible={
+                bookerState !== "booking" &&
+                (layout === BookerLayouts.MONTH_VIEW ||
+                  // Meta possibly can show DatePicker but if meta is not shown, then DatePicker must be shown here
+                  // FIXME: We need proper state management for this(depending on layout and bookerState)
+                  !shouldShowMeta)
+              }
               {...fadeInLeft}
               initial="visible"
               className={`ml-[-1px] h-full flex-shrink px-5 py-3 lg:w-[var(--booker-main-width)] ${


### PR DESCRIPTION
## What does this PR do?
- DatePicker was not showing up in mobile mode when hideEventTypeDetails is true

Regression from #16906

**After**
[Loom showing Week,Month,Column,hideEventTypeDetail=true views in both mobile and desktop viewports](https://www.loom.com/share/270ef296523c4f9185e19d609ab9ce38)

**Before**
https://www.loom.com/share/b682eec83d0e4ac29bab0484c5dd8810

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
See Looms

Test in a followup
- https://github.com/calcom/cal.com/issues/17039