### PR TITLE
perf: Add index to EventType for parentId

### DIFF
--- a/packages/prisma/migrations/20241010171846_add_eventtype_parent_id_index/migration.sql
+++ b/packages/prisma/migrations/20241010171846_add_eventtype_parent_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "EventType_parentId_idx" ON "EventType"("parentId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -160,6 +160,7 @@ model EventType {
   @@index([teamId])
   @@index([scheduleId])
   @@index([secondaryEmailId])
+  @@index([parentId])
 }
 
 model Credential {


### PR DESCRIPTION
## What does this PR do?

We run lots of queries that filter by the `parentId` column in the `EventType` table, resulting in Seq Scans. We can improve read perf by having this index.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure the migration runs fine on qa/prod
- Analyze query performance before/after
