### PR TITLE
chore: Update CI to not run all checks for docs/translations

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(**.md|.github/CODEOWNERS)"
+              - "!(**.md|.github/CODEOWNERS|docs/**|apps/web/public/static/locales/**/common.json)"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |


### PR DESCRIPTION
## What does this PR do?

When we only update the docs or translations, we don't need to run the entire suite of checks.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure that submitting docs changes doesn't run the entire suite of checks
- Ensure the ability to merge isn't blocked
