### PR TITLE
fix: add billing tab in platform navigation sidebar

### DIFF
--- a/packages/features/shell/navigation/Navigation.tsx
+++ b/packages/features/shell/navigation/Navigation.tsx
@@ -119,6 +119,11 @@ const platformNavigation: NavigationItemType[] = [
     icon: "ellipsis",
     target: "_blank",
   },
+  {
+    name: "Billing",
+    href: "/settings/platform/billing",
+    icon: "credit-card",
+  },
 ];
 
 export const getDesktopNavigationItems = (isPlatformNavigation = false) => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Shell got refactored and somehow the billing tab got removed from platform navigation sidebar, added it back. 

<br />
Before
<br />
<br />
<img width="249" alt="Screenshot 2024-10-11 at 11 44 39 AM" src="https://github.com/user-attachments/assets/8b642edf-ba42-45fe-a796-9aece65dff94">
<br />
<br />
After
<br />
<br />

<img width="249" alt="Screenshot 2024-10-11 at 11 44 58 AM" src="https://github.com/user-attachments/assets/38b41e9d-1ce2-4861-bef7-d15f1d7e8fd9">



<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
This can be tested in the webapp under `/settings/platform`

