### PR TITLE
feat: update github workflows to install playwright in a separate job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,7 +97,7 @@ jobs:
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/yarn-install.yml
 
-  playwright:
+  install-playwright:
     name: Install playwright
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: [changes, check-label, deps]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,6 +97,14 @@ jobs:
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/yarn-install.yml
 
+  playwright:
+    name: Install playwright
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' }}
+    steps:
+      - uses: ./.github/actions/yarn-playwright-install
+
   type-check:
     name: Type check
     needs: [changes, check-label, deps]
@@ -155,35 +163,35 @@ jobs:
 
   e2e:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
   e2e-api-v2:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
     secrets: inherit
 
   e2e-app-store:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,7 +191,7 @@ jobs:
 
   e2e-embed-react:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, install-playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
     name: Install playwright
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' }}
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     steps:
       - uses: ./.github/actions/yarn-playwright-install
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,7 @@ jobs:
 
   e2e-app-store:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, install-playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,7 +163,7 @@ jobs:
 
   e2e:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, install-playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -184,7 +184,7 @@ jobs:
 
   e2e-embed:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, install-playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -170,7 +170,7 @@ jobs:
 
   e2e-api-v2:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2, playwright]
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, install-playwright]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
     secrets: inherit

--- a/.github/workflows/yarn-install.yml
+++ b/.github/workflows/yarn-install.yml
@@ -15,4 +15,3 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-      - uses: ./.github/actions/yarn-playwright-install


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #17025 (GitHub issue number)
- Fixes CAL-4487 (Linear issue number - should be visible at the bottom of the GitHub issue description)

This PR moves the Playwright installation into a separate job within the GitHub workflow. The goal is to prevent the Playwright installation from blocking other jobs like builds and unit tests that don't require it, reducing workflow time by around 40 seconds when cached.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure the Playwright job runs only when the ready-for-e2e label is present.
- Confirm other jobs like builds, linting, and unit tests are not blocked by the Playwright installation.
- Check that overall workflow time is reduced by moving Playwright installation to a separate job.