### PR TITLE
chore: fixed docs support URL

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -24,7 +24,7 @@
   "topbarLinks": [
     {
       "name": "Support",
-      "url": "mailto:support@cal.com"
+      "url": "https://go.cal.com/support"
     }
   ],
   "topbarCtaButton": {


### PR DESCRIPTION
lets link to our support intercom widget vs email