### PR TITLE
fix: PR update workflow duplicate job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -153,13 +153,6 @@ jobs:
     uses: ./.github/workflows/production-build-without-database.yml
     secrets: inherit
 
-  build-docs:
-    name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/docs-build.yml
-    secrets: inherit
-
   integration-test:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2]


### PR DESCRIPTION
## What does this PR do?

#17101 added duplicate build-docs jobs (I believe due to a cherry-picking issue when building that branch)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
