### PR TITLE
fix: pass from org link to all instances of event.public

### DIFF
--- a/packages/features/bookings/Booker/types.ts
+++ b/packages/features/bookings/Booker/types.ts
@@ -25,6 +25,7 @@ export interface BookerProps {
    * Whether is a team or org, we gather basic info from both
    */
   entity: {
+    fromRedirectOfNonOrgLink?: boolean;
     considerUnpublished: boolean;
     isUnpublished?: boolean;
     orgSlug?: string | null;

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -19,7 +19,9 @@ export type useScheduleForEventReturnType = ReturnType<typeof useScheduleForEven
  * Using this hook means you only need to use one hook, instead
  * of combining multiple conditional hooks.
  */
-export const useEvent = ({ fromRedirectOfNonOrgLink }: { fromRedirectOfNonOrgLink?: boolean }) => {
+export const useEvent = ({
+  fromRedirectOfNonOrgLink,
+}: { fromRedirectOfNonOrgLink?: boolean } | undefined) => {
   const [username, eventSlug] = useBookerStore((state) => [state.username, state.eventSlug], shallow);
   const isTeamEvent = useBookerStore((state) => state.isTeamEvent);
   const org = useBookerStore((state) => state.org);

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -19,12 +19,11 @@ export type useScheduleForEventReturnType = ReturnType<typeof useScheduleForEven
  * Using this hook means you only need to use one hook, instead
  * of combining multiple conditional hooks.
  */
-export const useEvent = ({
-  fromRedirectOfNonOrgLink,
-}: { fromRedirectOfNonOrgLink?: boolean } | undefined) => {
-  const [username, eventSlug] = useBookerStore((state) => [state.username, state.eventSlug], shallow);
-  const isTeamEvent = useBookerStore((state) => state.isTeamEvent);
-  const org = useBookerStore((state) => state.org);
+export const useEvent = (props?: { fromRedirectOfNonOrgLink?: boolean }) => {
+  const [username, eventSlug, isTeamEvent, org] = useBookerStore(
+    (state) => [state.username, state.eventSlug, state.isTeamEvent, state.org],
+    shallow
+  );
 
   const event = trpc.viewer.public.event.useQuery(
     {
@@ -32,7 +31,7 @@ export const useEvent = ({
       eventSlug: eventSlug ?? "",
       isTeamEvent,
       org: org ?? null,
-      fromRedirectOfNonOrgLink,
+      fromRedirectOfNonOrgLink: props?.fromRedirectOfNonOrgLink,
     },
     {
       refetchOnWindowFocus: false,

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -19,7 +19,7 @@ export type useScheduleForEventReturnType = ReturnType<typeof useScheduleForEven
  * Using this hook means you only need to use one hook, instead
  * of combining multiple conditional hooks.
  */
-export const useEvent = () => {
+export const useEvent = ({ fromRedirectOfNonOrgLink }: { fromRedirectOfNonOrgLink?: boolean }) => {
   const [username, eventSlug] = useBookerStore((state) => [state.username, state.eventSlug], shallow);
   const isTeamEvent = useBookerStore((state) => state.isTeamEvent);
   const org = useBookerStore((state) => state.org);
@@ -30,8 +30,12 @@ export const useEvent = () => {
       eventSlug: eventSlug ?? "",
       isTeamEvent,
       org: org ?? null,
+      fromRedirectOfNonOrgLink,
     },
-    { refetchOnWindowFocus: false, enabled: Boolean(username) && Boolean(eventSlug) }
+    {
+      refetchOnWindowFocus: false,
+      enabled: Boolean(username) && Boolean(eventSlug),
+    }
   );
 
   return {
@@ -66,6 +70,7 @@ export const useScheduleForEvent = ({
   selectedDate,
   orgSlug,
   teamMemberEmail,
+  fromRedirectOfNonOrgLink,
 }: {
   prefetchNextMonth?: boolean;
   username?: string | null;
@@ -78,9 +83,10 @@ export const useScheduleForEvent = ({
   selectedDate?: string | null;
   orgSlug?: string;
   teamMemberEmail?: string | null;
+  fromRedirectOfNonOrgLink?: boolean;
 } = {}) => {
   const { timezone } = useTimePreferences();
-  const event = useEvent();
+  const event = useEvent({ fromRedirectOfNonOrgLink });
   const [usernameFromStore, eventSlugFromStore, monthFromStore, durationFromStore] = useBookerStore(
     (state) => [state.username, state.eventSlug, state.month, state.selectedDuration],
     shallow

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -30,7 +30,7 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const event = useEvent();
+  const event = useEvent({ fromRedirectOfNonOrgLink: props.entity.fromRedirectOfNonOrgLink });
   const bookerLayout = useBookerLayout(event.data);
 
   const selectedDate = searchParams?.get("date");
@@ -131,6 +131,7 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
     duration: props.duration,
     selectedDate,
     teamMemberEmail: props.teamMemberEmail,
+    fromRedirectOfNonOrgLink: props.entity.fromRedirectOfNonOrgLink,
   });
   const bookings = useBookings({
     event,


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where the duplicate call of event.public.useQuery had different query params due to a missing parameter. 

This fix should reduce the call time of this endpoint in booker by 50% as we don't need to double fetch the main bulk of data

## How should this be tested?

Load a public event and notice that the call only fires one event and they are not batched

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
