### PR TITLE
fix: `select_any_in` operator - Broken only for attributes

### DIFF
--- a/packages/app-store/routing-forms/TODO.md
+++ b/packages/app-store/routing-forms/TODO.md
@@ -8,7 +8,7 @@
 - [x] Connect Form Response to Booking
 - [x] Test with non option based attributes and form field input
 - [ ] Switching from Select to MultiSelect in attribute 
-    - [x] It immediately makes the Routing logic to not work. Fix it.
+    - [ ] It immediately makes the Routing logic to not work. Fix it.
     - [ ] It removes the selected option from Routing. Fix it.
     - [ ] Warnings are needed with recommendation to create new attribute instead in unsupported scenarios. We need to test for more such changes to Attribute types.
 - [ ] When choosing 'Value of Field' option in RAQB, show a warning somewhere if all options of the Form field aren't present in the attribute option.

--- a/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
+++ b/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
@@ -36,7 +36,7 @@ function buildQueryValue({
 }: {
   rules: {
     raqbFieldId: string;
-    value: string | number | string[];
+    value: string | number | string[] | [string[]];
     operator: string;
     valueSrc: NonNullable<BaseWidget["valueSrc"]>[];
     valueType: string[];
@@ -68,7 +68,7 @@ function buildSelectTypeFieldQueryValue({
 }: {
   rules: {
     raqbFieldId: string;
-    value: string | number | string[];
+    value: string | number | string[] | [string[]];
     operator: string;
     valueType?: string[];
   }[];

--- a/packages/app-store/routing-forms/trpc/raqbUtils.ts
+++ b/packages/app-store/routing-forms/trpc/raqbUtils.ts
@@ -138,6 +138,10 @@ const replaceFieldTemplateVariableWithOptionLabel = ({
  * Utilities to handle compatiblity when attribute's type changes
  */
 const attributeChangeCompatibility = {
+  /**
+   * FIXME: It isn't able to handle a case where for SINGLE_SELECT attribute, the queryValue->valueType is ["multiselect"]. It happens for select_any_in operator
+   * So, don't use it till that is fixed.
+   */
   getRaqbFieldTypeCompatibleWithQueryValue: function getRaqbFieldTypeCompatibleWithQueryValue({
     attributesQueryValue,
     raqbField,
@@ -163,6 +167,8 @@ const attributeChangeCompatibility = {
   },
   /**
    * Ensure the attribute value if of type same as the valueType in queryValue
+   * FIXME: It isn't able to handle a case where for SINGLE_SELECT attribute, the queryValue->valueType is ["multiselect"]. It happens for select_any_in operator
+   * So, don't use it till that is fixed.
    */
   ensureAttributeValueToBeOfRaqbFieldValueType: function ensureAttributeValueToBeOfRaqbFieldValueType({
     attributeValue,
@@ -197,11 +203,14 @@ function getAttributesData({
     const compatibleValueForAttributeAndFormFieldMatching = compatibleForAttributeAndFormFieldMatch(value);
 
     // We do this to ensure that correct jsonLogic is generated for an existing route even if the attribute's type changes
-    acc[attributeId] = attributeChangeCompatibility.ensureAttributeValueToBeOfRaqbFieldValueType({
-      attributeValue: compatibleValueForAttributeAndFormFieldMatching,
-      attributesQueryValue,
-      attributeId,
-    });
+    // acc[attributeId] = attributeChangeCompatibility.ensureAttributeValueToBeOfRaqbFieldValueType({
+    //   attributeValue: compatibleValueForAttributeAndFormFieldMatching,
+    //   attributesQueryValue,
+    //   attributeId,
+    // });
+
+    // Right now we can't trust ensureAttributeValueToBeOfRaqbFieldValueType to give us the correct value
+    acc[attributeId] = compatibleValueForAttributeAndFormFieldMatching;
 
     return acc;
   }, {} as Record<string, string | string[]>);
@@ -263,11 +272,14 @@ function getAttributesQueryBuilderConfig({
 
   const attributesQueryBuilderConfigFieldsWithCompatibleListValues = Object.fromEntries(
     Object.entries(attributesQueryBuilderConfig.fields).map(([raqbFieldId, raqbField]) => {
-      const raqbFieldType = attributeChangeCompatibility.getRaqbFieldTypeCompatibleWithQueryValue({
-        attributesQueryValue,
-        raqbField,
-        raqbFieldId,
-      });
+      // const raqbFieldType = attributeChangeCompatibility.getRaqbFieldTypeCompatibleWithQueryValue({
+      //   attributesQueryValue,
+      //   raqbField,
+      //   raqbFieldId,
+      // });
+
+      // Right now we can't trust getRaqbFieldTypeCompatibleWithQueryValue to give us the correct type
+      const raqbFieldType = raqbField.type;
 
       return [
         raqbFieldId,


### PR DESCRIPTION
## What does this PR do?

Using Any In with an attribute of type single_select was broken for attributes only. It fixes it and adds a test to ensure it doesn't break in future.

It isn't a regression. The initial implementation itself had this bug 

[Before fix loom](https://www.loom.com/share/a5bc67c1b12e4743b27d6cdb8d249226)
[After Fix loom](https://www.loom.com/share/bb7d945896de4ef88d7f5de97176eb63)

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
See loom
