### PR TITLE
perf: Add index for invalid column in Credential

### DIFF
--- a/packages/prisma/migrations/20241018121846_add_credentials_invalid_index/migration.sql
+++ b/packages/prisma/migrations/20241018121846_add_credentials_invalid_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Credential_invalid_idx" ON "Credential"("invalid");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -193,6 +193,7 @@ model Credential {
   @@index([userId])
   @@index([appId])
   @@index([subscriptionId])
+  @@index([invalid])
 }
 
 enum IdentityProvider {


### PR DESCRIPTION
## What does this PR do?

Our query to get invalid app credentials is the biggest hog of DB resources we have at the moment. This will help fix it. I have a new query coming that will improve perf as well.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
