### PR TITLE
perf: get invalid credentials

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/checkForInvalidAppCredentials.ts
+++ b/packages/trpc/server/routers/loggedInViewer/checkForInvalidAppCredentials.ts
@@ -31,7 +31,7 @@ export const checkInvalidAppCredentials = async ({ ctx }: checkInvalidAppCredent
     INNER JOIN "Team" AS "t" ON "t"."id" = "Credential"."teamId"
     INNER JOIN "Membership" AS "m" ON "m"."teamId" = "t"."id"
     WHERE "m"."userId" = ${userId} AND "m"."accepted" = true AND "m"."role" IN
-          (CAST('MEMBER'::text AS "MembershipRole"),CAST('ADMIN'::text AS "MembershipRole"))
+          (CAST('ADMIN'::text AS "MembershipRole"),CAST('OWNER'::text AS "MembershipRole"))
           AND "m"."teamId" IS NOT NULL AND "t"."id" IS NOT NULL
       AND "Credential"."invalid" = true`;
 

--- a/packages/trpc/server/routers/loggedInViewer/checkForInvalidAppCredentials.ts
+++ b/packages/trpc/server/routers/loggedInViewer/checkForInvalidAppCredentials.ts
@@ -24,7 +24,7 @@ export const checkInvalidAppCredentials = async ({ ctx }: checkInvalidAppCredent
   const apps = await prisma.$queryRaw<AppType[]>`
     SELECT "Credential"."id", "Credential"."appId"
     FROM "Credential"
-    WHERE "Credential"."userId" = ${userId} AND "Credential"."invalid" = false
+    WHERE "Credential"."userId" = ${userId} AND "Credential"."invalid" = true
     UNION
     SELECT "Credential"."id", "Credential"."appId"
     FROM "Credential"
@@ -33,7 +33,7 @@ export const checkInvalidAppCredentials = async ({ ctx }: checkInvalidAppCredent
     WHERE "m"."userId" = ${userId} AND "m"."accepted" = true AND "m"."role" IN
           (CAST('MEMBER'::text AS "MembershipRole"),CAST('ADMIN'::text AS "MembershipRole"))
           AND "m"."teamId" IS NOT NULL AND "t"."id" IS NOT NULL
-      AND "Credential"."invalid" = false`;
+      AND "Credential"."invalid" = true`;
 
   const appNamesAndSlugs: InvalidAppCredentialBannerProps[] = [];
   for (const app of apps) {


### PR DESCRIPTION
## What does this PR do?

This query is currently the biggest hog of resources on the DB. With the new index on `invalid`, this will run in 0.1ms versus 200ms+.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure all tests pass
- Ensure that any invalid app creds are triggered by this query still
