### PR TITLE
fix: Embed - Do not reuse the modal on reopening it.

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -690,7 +690,10 @@ class CalApi {
     if (__prerender) {
       this.preloadedModalUid = uid;
     } else {
-      this.modalUid = uid;
+      // Intentionally not setting it to have the behaviour of reusing the same modal. Because it causes outdated content that might not be valid based on
+      // 1. The time difference b/w reopening(availability getting changed in b/w)
+      // 2. User using different query params but they not being used because of the same modal being reused. Happens in case of headless router being opened in embed
+      // this.modalUid = uid;
     }
 
     if (typeof config.iframeAttrs === "string" || config.iframeAttrs instanceof Array) {

--- a/packages/platform/types/api.ts
+++ b/packages/platform/types/api.ts
@@ -43,7 +43,7 @@ export class Pagination {
   @Transform(({ value }: { value: string }) => value && parseInt(value))
   @IsNumber()
   @Min(1)
-  @Max(100)
+  @Max(250)
   @IsOptional()
   limit?: number;
 
@@ -51,7 +51,7 @@ export class Pagination {
   @ApiProperty({ required: false, description: "The number of items to skip", example: 0 })
   @IsNumber()
   @Min(0)
-  @Max(100)
+  @Max(250)
   @IsOptional()
   offset?: number | null;
 }


### PR DESCRIPTION
Don't reuse the modal.

This behaviour though was intended long time back wasn't working for a long time and got recently fixed in #17016. So, reverting it with a reason now.