### PR TITLE
perf: Increase vCPU for slots and routing forms

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -18,7 +18,10 @@
       "memory": 768
     },
     "pages/api/trpc/slots/[trpc].ts": {
-      "memory": 768
+      "memory": 2048
+    },
+    "pages/api/trpc/appRoutingForms/[trpc].ts": {
+      "memory": 2048
     }
   }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -15,7 +15,7 @@
   ],
   "functions": {
     "pages/api/trpc/public/[trpc].ts": {
-      "memory": 768
+      "memory": 2048
     },
     "pages/api/trpc/slots/[trpc].ts": {
       "memory": 2048


### PR DESCRIPTION
## What does this PR do?

These endpoints are CPU heavy and need a pick-me-up. As you increase memory in the Vercel config, they give you more vCPU.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Upon deployment, make sure the serverless functions are deployed with the correct amount of memory.
