### PR TITLE
perf: Batch user enrichment calls

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -560,8 +560,8 @@ async function getOwnerFromUsersArray(prisma: PrismaClient, eventTypeId: number)
 }
 
 const enrichHostsInBatches = async (event) => {
-  const batchSize = 20; // Set the batch size to 20
   const enrichedHosts = [];
+  const batchSize = 20;
 
   const processBatch = async (batch) => {
     const enrichedBatch = await Promise.all(
@@ -571,17 +571,16 @@ const enrichHostsInBatches = async (event) => {
         });
         return {
           ...host,
-          user: enrichedUser, // Update user in the host object
+          user: enrichedUser,
         };
       })
     );
     enrichedHosts.push(...enrichedBatch);
   };
 
-  // Process the hosts in batches of 20
   for (let i = 0; i < event.hosts.length; i += batchSize) {
-    const batch = event.hosts.slice(i, i + batchSize); // Get the current batch
-    await processBatch(batch); // Enrich the batch of hosts
+    const batch = event.hosts.slice(i, i + batchSize);
+    await processBatch(batch);
   }
 
   return enrichedHosts;
@@ -591,7 +590,6 @@ async function enrichUsersInBatches(users) {
   const usersWithUserProfile = [];
   const batchSize = 20;
 
-  // Function to process a batch
   const processBatch = async (batch) => {
     const enrichedUsers = await Promise.all(
       batch.map(async (user) => {
@@ -609,10 +607,9 @@ async function enrichUsersInBatches(users) {
     usersWithUserProfile.push(...enrichedUsers);
   };
 
-  // Loop through the users array in batches
   for (let i = 0; i < users.length; i += batchSize) {
     const batch = users.slice(i, i + batchSize);
-    await processBatch(batch); // process each batch sequentially
+    await processBatch(batch);
   }
 
   return usersWithUserProfile;


### PR DESCRIPTION
## What does this PR do?

Instead of running X number of queries sequentially, this batches them.

Ideally, we use joins better to get this data but at the moment the logic for determining this is quite complex so I'd prefer to go with a simpler solution for now.

Another option is to just pull back all profiles for all users/hosts in 1 query but we don't currently have those methods on the repo and they need to be built.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure all tests succeed and events are loaded as normal
