### PR TITLE
fix: add aria-label to timezone input for accessibility compliance

### DIFF
--- a/packages/ui/components/form/select/components.tsx
+++ b/packages/ui/components/form/select/components.tsx
@@ -23,6 +23,7 @@ export const InputComponent = <
         inputClassName
       )}
       {...props}
+      aria-label="Timezone Selection"
     />
   );
 };


### PR DESCRIPTION
## What does this PR do?

This PR addresses an accessibility issue with the timezone input element by adding an invisible aria-label for screen readers. This label ensures that the input element is correctly identified by assistive technologies, improving compliance with WCAG accessibility standards.

- Fixes #17186

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)-> N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Note: Testing was conducted using Lighthouse accessibility checks in Chrome DevTools and by verifying the input label in the Elements tab.)

## How should this be tested?

1. Run Google Lighthouse accessibility checks to verify that the input element no longer triggers warnings for missing Input element labels.
2. Use the browser's developer tools to inspect the timezone input and confirm that the aria-label="Timezone Selection" is applied correctly-
<img width="640" alt="Screenshot 2024-10-20 at 2 23 00 PM" src="https://github.com/user-attachments/assets/443c0d81-380a-42bf-b63d-7cab79807c8a">

- Are there environment variables that should be set?
No new environment variables are needed for this test.
- What are the minimal test data to have?
Access the event booking form and interact with the timezone selection field to observe the behavior with a screen reader.
- What is expected (happy path) to have (input and output)?
The timezone selection input should be accessible to screen readers, and no errors should be flagged by accessibility audits.
