### PR TITLE
fix: added aria-label to prev and next month buttons

### DIFF
--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -358,7 +358,7 @@ const DatePicker = ({
               color="minimal"
               variant="icon"
               StartIcon="chevron-left"
-              aria-label="Next Month"
+              aria-label="Previous Month"
             />
             <Button
               className={classNames(
@@ -370,7 +370,7 @@ const DatePicker = ({
               color="minimal"
               variant="icon"
               StartIcon="chevron-right"
-              aria-label="Previous Month"
+              aria-label="Next Month"
             />
           </div>
         </div>

--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -358,6 +358,7 @@ const DatePicker = ({
               color="minimal"
               variant="icon"
               StartIcon="chevron-left"
+              aria-label="Next Month"
             />
             <Button
               className={classNames(
@@ -369,6 +370,7 @@ const DatePicker = ({
               color="minimal"
               variant="icon"
               StartIcon="chevron-right"
+              aria-label="Previous Month"
             />
           </div>
         </div>


### PR DESCRIPTION
## What does this PR do?
This PR addresses the accessibility issue with the previous and next buttons. Required aria-label tag has been added in the buttons.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://github.com/calcom/cal.com/issues/17185

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run Google Lighthouse accessibility checks to verify that the button element no longer triggers warnings for missing Input element labels.
2. Use the browser's developer tools to inspect the button and confirm that the aria-label="next month" and aria-label="previous month" is applied correctly.

![image](https://github.com/user-attachments/assets/6ac07c37-df96-4caa-b4e8-4128d4f7d4b1)

<img width="1630" alt="image" src="https://github.com/user-attachments/assets/5e1ce73a-e104-44bb-93e9-5b86ac53be08">


<img width="1680" alt="image" src="https://github.com/user-attachments/assets/86067243-6cba-44e7-bd2d-f99e3e22ea68">

- Are there environment variables that should be set?
 No new environment variables are needed for this test
 
- What are the minimal test data to have?
 Access the event booking form and interact with the previous and next month buttons to observe the behavior with a screen reader.
- What is expected (happy path) to have (input and output)?
 The screen readers should announce the labels when buttons are focused via tab.

