### PR TITLE
fix: multiselect "Any in" operator for a user with just one option assigned for the attribute

### DIFF
--- a/packages/app-store/routing-forms/__tests__/config.test.ts
+++ b/packages/app-store/routing-forms/__tests__/config.test.ts
@@ -87,9 +87,12 @@ describe("Query Builder Config", () => {
       assertCommonStructure(AttributesBaseConfig);
     });
 
-    it("should support multiselect_some_in operator for multiselect", () => {
+    it("should support multiselect_some_in and multiselect_not_some_in operators for multiselect", () => {
       expect(AttributesBaseConfig.types.multiselect.widgets.multiselect.operators).toContain(
         "multiselect_some_in"
+      );
+      expect(AttributesBaseConfig.types.multiselect.widgets.multiselect.operators).toContain(
+        "multiselect_not_some_in"
       );
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/BasicConfig.ts
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/BasicConfig.ts
@@ -189,6 +189,10 @@ const operators: Operators = {
       };
     },
   },
+  multiselect_not_some_in: {
+    label: "Not any in",
+    reversedOp: "multiselect_some_in",
+  },
   multiselect_equals: {
     label: "All in",
     reversedOp: "multiselect_not_equals",

--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/config/config.tsx
@@ -133,9 +133,9 @@ function getTypes(configFor: ConfigFor) {
   const multiSelectOperators = BasicConfig.types.multiselect.widgets.multiselect.operators || [];
 
   if (configFor === ConfigFor.Attributes) {
-    // Attributes don't need reporting at the moment. So, we can support multiselect_some_in operator for attributes.
+    // Attributes don't need reporting at the moment. So, we can support multiselect_some_in and multiselect_not_some_in operators for attributes.
     // We could probably use them in FormFields later once they are supported through Prisma query as well
-    multiSelectOperators.push("multiselect_some_in");
+    multiSelectOperators.push("multiselect_some_in", "multiselect_not_some_in");
   }
 
   const types: Types = {

--- a/packages/app-store/routing-forms/lib/getAttributes.ts
+++ b/packages/app-store/routing-forms/lib/getAttributes.ts
@@ -107,7 +107,10 @@ export async function getAttributesForTeam({ teamId }: { teamId: number }) {
 }
 
 type AttributeId = string;
-type AttributeOptionValue = string | string[];
+type AttributeOptionValueWithType = {
+  type: Attribute["type"];
+  value: string | string[];
+};
 
 export async function getTeamMembersWithAttributeOptionValuePerAttribute({ teamId }: { teamId: number }) {
   const attributesToUser = await getAttributeToUserWithMembershipAndAttributesForTeam({ teamId });
@@ -121,19 +124,25 @@ export async function getTeamMembersWithAttributeOptionValuePerAttribute({ teamI
     }
 
     const attributes = acc[userId].attributes;
-    const attributeValue = attributes[attribute.id];
+    const attributeValue = attributes[attribute.id]?.value;
     if (attributeValue instanceof Array) {
       // Push to existing array
       attributeValue.push(value);
     } else if (attributeValue) {
       // Make it an array
-      attributes[attribute.id] = [attributeValue, value];
+      attributes[attribute.id] = {
+        type: attribute.type,
+        value: [attributeValue, value],
+      };
     } else {
       // Set it as a string
-      attributes[attribute.id] = value;
+      attributes[attribute.id] = {
+        type: attribute.type,
+        value,
+      };
     }
     return acc;
-  }, {} as Record<number, { userId: number; attributes: Record<AttributeId, AttributeOptionValue> }>);
+  }, {} as Record<number, { userId: number; attributes: Record<AttributeId, AttributeOptionValueWithType> }>);
 
   return Object.values(teamMembers);
 }

--- a/packages/app-store/routing-forms/lib/getAttributes.ts
+++ b/packages/app-store/routing-forms/lib/getAttributes.ts
@@ -112,6 +112,8 @@ type AttributeOptionValueWithType = {
   value: string | string[];
 };
 
+type UserId = number;
+
 export async function getTeamMembersWithAttributeOptionValuePerAttribute({ teamId }: { teamId: number }) {
   const attributesToUser = await getAttributeToUserWithMembershipAndAttributesForTeam({ teamId });
 
@@ -126,23 +128,23 @@ export async function getTeamMembersWithAttributeOptionValuePerAttribute({ teamI
     const attributes = acc[userId].attributes;
     const attributeValue = attributes[attribute.id]?.value;
     if (attributeValue instanceof Array) {
-      // Push to existing array
+      // Value already exists, so push to it
       attributeValue.push(value);
     } else if (attributeValue) {
-      // Make it an array
+      // Value already exists, so push to it and also make it an array before pushing
       attributes[attribute.id] = {
         type: attribute.type,
         value: [attributeValue, value],
       };
     } else {
-      // Set it as a string
+      // Set the first value
       attributes[attribute.id] = {
         type: attribute.type,
         value,
       };
     }
     return acc;
-  }, {} as Record<number, { userId: number; attributes: Record<AttributeId, AttributeOptionValueWithType> }>);
+  }, {} as Record<UserId, { userId: UserId; attributes: Record<AttributeId, AttributeOptionValueWithType> }>);
 
   return Object.values(teamMembers);
 }

--- a/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
+++ b/packages/app-store/routing-forms/trpc/__tests__/utils.test.ts
@@ -455,6 +455,7 @@ describe("findTeamMembersMatchingAttributeLogicOfRoute", () => {
     mockAttributesScenario({
       attributes: [Attribute1],
       teamMembersWithAttributeOptionValuePerAttribute: [
+        // user 1 has only one option selected for the attribute
         { userId: 1, attributes: { [Attribute1.id]: Option1OfAttribute1.value } },
       ],
     });
@@ -527,6 +528,7 @@ describe("findTeamMembersMatchingAttributeLogicOfRoute", () => {
       teamMembersWithAttributeOptionValuePerAttribute: [
         {
           userId: 1,
+          // user 1 has two options selected for the attribute
           attributes: { [Attribute1.id]: [Option2OfAttribute1.value, Option1OfAttribute1.value] },
         },
       ],

--- a/packages/app-store/routing-forms/trpc/raqbUtils.ts
+++ b/packages/app-store/routing-forms/trpc/raqbUtils.ts
@@ -212,7 +212,6 @@ function getAttributesData({
   >;
   attributesQueryValue: NonNullable<LocalRoute["attributesQueryValue"]>;
 }) {
-  console.log({ attributesData: JSON.stringify(attributesData) });
   return Object.entries(attributesData).reduce((acc, [attributeId, { value, type: attributeType }]) => {
     const compatibleValueForAttributeAndFormFieldMatching = compatibleForAttributeAndFormFieldMatch(value);
 
@@ -225,6 +224,8 @@ function getAttributesData({
 
     // Right now we can't trust ensureAttributeValueToBeOfRaqbFieldValueType to give us the correct value
     acc[attributeId] =
+      // multiselect attribute's value must be an array as all the operators multiselect_some_in, multiselect_all_in and their respective not operators expect an array
+      // If we add an operator that doesn't expect an array, we need to somehow make it operator based.
       attributeType === AttributeType.MULTI_SELECT
         ? ensureArray(compatibleValueForAttributeAndFormFieldMatching)
         : compatibleValueForAttributeAndFormFieldMatching;

--- a/packages/app-store/routing-forms/trpc/raqbUtils.ts
+++ b/packages/app-store/routing-forms/trpc/raqbUtils.ts
@@ -3,6 +3,7 @@ import type { JsonGroup, JsonItem, JsonRule, JsonTree } from "react-awesome-quer
 
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
+import { AttributeType } from "@calcom/prisma/enums";
 
 import type { AttributesQueryBuilderConfigWithRaqbFields } from "../lib/getQueryBuilderConfig";
 import { getQueryBuilderConfigForAttributes } from "../lib/getQueryBuilderConfig";
@@ -202,10 +203,17 @@ function getAttributesData({
   attributesData,
   attributesQueryValue,
 }: {
-  attributesData: Record<string, string | string[]>;
+  attributesData: Record<
+    string,
+    {
+      value: string | string[];
+      type: Attribute["type"];
+    }
+  >;
   attributesQueryValue: NonNullable<LocalRoute["attributesQueryValue"]>;
 }) {
-  return Object.entries(attributesData).reduce((acc, [attributeId, value]) => {
+  console.log({ attributesData: JSON.stringify(attributesData) });
+  return Object.entries(attributesData).reduce((acc, [attributeId, { value, type: attributeType }]) => {
     const compatibleValueForAttributeAndFormFieldMatching = compatibleForAttributeAndFormFieldMatch(value);
 
     // We do this to ensure that correct jsonLogic is generated for an existing route even if the attribute's type changes
@@ -216,7 +224,10 @@ function getAttributesData({
     // });
 
     // Right now we can't trust ensureAttributeValueToBeOfRaqbFieldValueType to give us the correct value
-    acc[attributeId] = compatibleValueForAttributeAndFormFieldMatching;
+    acc[attributeId] =
+      attributeType === AttributeType.MULTI_SELECT
+        ? ensureArray(compatibleValueForAttributeAndFormFieldMatching)
+        : compatibleValueForAttributeAndFormFieldMatching;
 
     return acc;
   }, {} as Record<string, string | string[]>);


### PR DESCRIPTION
## What does this PR do?

So, if a user has multiselect attribute but only one option is selected for the user. Then any in operator won't work on it.

- Fixes multiselect "Any in" operator for a user with just one option assigned for the attribute
- Supports Not Any in as well to exclude those that match "Any in"


[After Fix behaviour demo](https://www.loom.com/share/9e7da6195e4741ec9732b2b9cbe1a63d)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


