### PR TITLE
fix: platform event-type atom team delete

### DIFF
--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -41,6 +41,7 @@ export type EventTypePlatformWrapperProps = {
   customClassNames?: {
     atomsWrapper?: string;
   };
+  disableToasts?: boolean;
 };
 
 const EventType = ({
@@ -52,6 +53,7 @@ const EventType = ({
   id,
   allowDelete = true,
   customClassNames,
+  disableToasts = false,
   ...props
 }: EventTypeSetupProps & EventTypePlatformWrapperProps) => {
   const { t } = useLocale();
@@ -129,7 +131,9 @@ const EventType = ({
   const slug = form.watch("slug") ?? eventType.slug;
 
   const showToast = (message: string, variant: "success" | "warning" | "error") => {
-    toast({ description: message });
+    if (!disableToasts) {
+      toast({ description: message });
+    }
   };
 
   const tabMap = {

--- a/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
+++ b/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
@@ -9,10 +9,15 @@ import { useAtomsContext } from "../../useAtomsContext";
 
 export const QUERY_KEY = "use-delete-team-event-by-id";
 export type UseDeleteTeamEventTypeProps = {
-  onSuccess?: () => void;
+  onSuccess?: (data: ResponseDataType) => void;
   onError?: (err: Error) => void;
   onSettled?: () => void;
 };
+
+export type ResponseDataType = NonNullable<
+  Pick<EventType, "id" | "slug" | "title"> & { lengthInMinutes: number }
+>;
+
 export const useDeleteTeamEventTypeById = ({
   onSuccess,
   onError,
@@ -30,9 +35,9 @@ export const useDeleteTeamEventTypeById = ({
       if (!organizationId) throw new Error("organization id is required");
 
       const pathname = `/organizations/${organizationId}/teams/${teamId}/${V2_ENDPOINTS.eventTypes}/${eventTypeId}`;
-      return http?.delete<ApiResponse<EventType>>(pathname).then((res) => {
+      return http?.delete<ApiResponse<ResponseDataType>>(pathname).then((res) => {
         if (res.data.status === SUCCESS_STATUS) {
-          return (res.data as ApiSuccessResponse<EventType>).data;
+          return (res.data as ApiSuccessResponse<ResponseDataType>).data;
         }
         throw new Error(res.data.error.message);
       });

--- a/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
+++ b/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
@@ -1,0 +1,37 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { V2_ENDPOINTS, SUCCESS_STATUS } from "@calcom/platform-constants";
+import type { ApiResponse, ApiSuccessResponse } from "@calcom/platform-types";
+import type { EventType } from "@calcom/prisma/client";
+
+import http from "../../../lib/http";
+import { useAtomsContext } from "../../useAtomsContext";
+
+export const QUERY_KEY = "use-delete-team- event-by-id";
+export type UseDeleteEventTypeProps = {
+  onSuccess?: () => void;
+  onError?: (err: Error) => void;
+  onSettled?: () => void;
+};
+export const useDeleteTeamEventTypeById = ({ onSuccess, onError, onSettled }: UseDeleteEventTypeProps) => {
+  const { organizationId } = useAtomsContext();
+
+  return useMutation({
+    onSuccess,
+    onError,
+    onSettled,
+    mutationFn: ({ eventTypeId, teamId }: { eventTypeId: number; teamId: number }) => {
+      if (!eventTypeId) throw new Error("Event type id is required");
+      if (!teamId) throw new Error("team id is required");
+      if (!organizationId) throw new Error("organization id is required");
+
+      const pathname = `/organizations/${organizationId}/teams/${teamId}/${V2_ENDPOINTS.eventTypes}/${eventTypeId}`;
+      return http?.delete<ApiResponse<EventType>>(pathname).then((res) => {
+        if (res.data.status === SUCCESS_STATUS) {
+          return (res.data as ApiSuccessResponse<EventType>).data;
+        }
+        throw new Error(res.data.error.message);
+      });
+    },
+  });
+};

--- a/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
+++ b/packages/platform/atoms/hooks/event-types/private/useDeleteTeamEventTypeById.ts
@@ -7,13 +7,17 @@ import type { EventType } from "@calcom/prisma/client";
 import http from "../../../lib/http";
 import { useAtomsContext } from "../../useAtomsContext";
 
-export const QUERY_KEY = "use-delete-team- event-by-id";
-export type UseDeleteEventTypeProps = {
+export const QUERY_KEY = "use-delete-team-event-by-id";
+export type UseDeleteTeamEventTypeProps = {
   onSuccess?: () => void;
   onError?: (err: Error) => void;
   onSettled?: () => void;
 };
-export const useDeleteTeamEventTypeById = ({ onSuccess, onError, onSettled }: UseDeleteEventTypeProps) => {
+export const useDeleteTeamEventTypeById = ({
+  onSuccess,
+  onError,
+  onSettled,
+}: UseDeleteTeamEventTypeProps) => {
   const { organizationId } = useAtomsContext();
 
   return useMutation({


### PR DESCRIPTION
## What does this PR do?

Trying to delete a team event-type with atom was using the endpoint to delete non team event-types

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A- I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
