### PR TITLE
chore: Back down vCPUs for public/slots routers

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -15,10 +15,10 @@
   ],
   "functions": {
     "pages/api/trpc/public/[trpc].ts": {
-      "memory": 2048
+      "memory": 1024
     },
     "pages/api/trpc/slots/[trpc].ts": {
-      "memory": 2048
+      "memory": 1024
     },
     "pages/api/trpc/appRoutingForms/[trpc].ts": {
       "memory": 2048


### PR DESCRIPTION
## What does this PR do?

These increases turned out to not actually improve performance all that much but it's costing us more than 4x (since we have the slots.getSchedule handler running under public which handles a lot of other calls) to run like this.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

