### PR TITLE
fix: cut off select in reassign dialog

### DIFF
--- a/apps/web/components/dialog/ReassignDialog.tsx
+++ b/apps/web/components/dialog/ReassignDialog.tsx
@@ -114,7 +114,10 @@ export const ReassignDialog = ({ isOpenDialog, setIsOpenDialog, teamId, bookingI
       onOpenChange={(open) => {
         setIsOpenDialog(open);
       }}>
-      <DialogContent title={t("reassign_round_robin_host")} description={t("reassign_to_another_rr_host")}>
+      <DialogContent
+        title={t("reassign_round_robin_host")}
+        description={t("reassign_to_another_rr_host")}
+        enableOverflow>
         {/* TODO add team member reassignment*/}
         <Form form={form} handleSubmit={handleSubmit} ref={animationParentRef}>
           <RadioArea.Group


### PR DESCRIPTION
## What does this PR do?

Before: 
<img width="611" alt="Screenshot 2024-10-22 at 11 13 26 AM" src="https://github.com/user-attachments/assets/c821323e-65e6-4c98-9370-1db93d5c6062">

After: 
![Screenshot 2024-10-22 at 11 11 57 AM](https://github.com/user-attachments/assets/53de1246-c9f2-42be-82d4-39b61fc82fca)
