### PR TITLE
fix: Salesforce - Check for existing lead when "Account" is set

### DIFF
--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -419,6 +419,13 @@ export default class SalesforceCRMService implements CRM {
       }
 
       if (appOptions.createLeadIfAccountNull) {
+        // Check to see if the lead exists already
+        const leadQuery = await conn.query(`SELECT Id, Email FROM Lead WHERE Email = '${attendee.email}'`);
+        if (leadQuery.records.length) {
+          const contact = leadQuery.records[0] as { Id: string; Email: string };
+          return [{ id: contact.Id, email: contact.Email }];
+        }
+
         await Promise.all(
           contactsToCreate.map(async (attendee) => {
             return await conn


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When the option to create a new lead if a contact didn't exist under an account was enabled, it didn't check if a lead previously existed.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://www.loom.com/share/707087b490f94d218ff20827e221de7f

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

