### PR TITLE
chore: make rate limit logs verbose api-v2

### DIFF
--- a/apps/api/v2/src/lib/throttler-guard.ts
+++ b/apps/api/v2/src/lib/throttler-guard.ts
@@ -56,7 +56,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
     const tracker = await this.getTracker(request);
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" generated based on: Bearer token "${request.get(
         "Authorization"
       )}", OAuth client ID "${request.get(X_CAL_CLIENT_ID)}" and IP "${request.ip}"`
@@ -89,7 +89,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
   private async handleNonApiKeyRequest(tracker: string, response: Response): Promise<boolean> {
     const rateLimit = this.getDefaultRateLimit(tracker);
-    this.logger.log(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
+    this.logger.verbose(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
       ${JSON.stringify(rateLimit, null, 2)}
     `);
 
@@ -135,7 +135,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
     const cachedRateLimits = await this.storageService.redis.get(cacheKey);
     if (cachedRateLimits) {
-      this.logger.log(`Tracker "${tracker}" rate limits retrieved from redis cache:
+      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from redis cache:
         ${cachedRateLimits}
       `);
       return rateLimitsSchema.parse(JSON.parse(cachedRateLimits));
@@ -158,13 +158,13 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     });
 
     if (rateLimits) {
-      this.logger.log(`Tracker "${tracker}" rate limits retrieved from database:
+      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from database:
         ${JSON.stringify(rateLimits, null, 2)}`);
     }
 
     if (!rateLimits || rateLimits.length === 0) {
       rateLimits = [this.getDefaultRateLimit(tracker)];
-      this.logger.log(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
+      this.logger.verbose(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
         ${JSON.stringify(rateLimits, null, 2)}`);
     }
 
@@ -194,10 +194,10 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     );
     response.setHeader(`X-RateLimit-Reset-${nameFirstUpper}`, timeToBlockExpire || timeToExpire);
 
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" incremented. isBlocked ${isBlocked}, totalHits ${totalHits}, timeToExpire ${timeToExpire}, timeToBlockExpire ${timeToBlockExpire}`
     );
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" response headers:
         X-RateLimit-Limit-${nameFirstUpper}: ${limit},
         X-RateLimit-Remaining-${nameFirstUpper}: ${timeToBlockExpire ? 0 : Math.max(0, limit - totalHits)},
@@ -227,7 +227,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
       return `ip_${request.ip}`;
     }
 
-    this.logger.log(`no tracker found: ${request.url}`);
+    this.logger.verbose(`no tracker found: ${request.url}`);
     return "unknown";
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

rate limit logs are spamming api-v2 logs too much, shifting to verbose logs useable when debugging

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


