### PR TITLE
feat: add no-show-to-edit-list

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -258,6 +258,17 @@ function BookingListItem(booking: BookingItemProps) {
     },
   ];
 
+  if (booking.eventType.schedulingType === SchedulingType.ROUND_ROBIN) {
+    editBookingActions.push({
+      id: "reassign ",
+      label: t("reassign"),
+      onClick: () => {
+        setIsOpenReassignDialog(true);
+      },
+      icon: "users" as const,
+    });
+  }
+
   if (!booking.isBookingInPast) {
     editBookingActions.push({
       id: "no_show",

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -103,7 +103,7 @@ const isBookingReroutable = (booking: ParsedBooking): booking is ReroutableBooki
 function BookingListItem(booking: BookingItemProps) {
   const parsedBooking = buildParsedBooking(booking);
 
-  const { userId, userTimeZone, userTimeFormat, userEmail } = booking.loggedInUser;
+  const { userTimeZone, userTimeFormat, userEmail } = booking.loggedInUser;
   const {
     t,
     i18n: { language },
@@ -467,7 +467,7 @@ function BookingListItem(booking: BookingItemProps) {
       {isNoShowDialogOpen && (
         <NoShowAttendeesDialog
           bookingUid={booking.uid}
-          attendees={booking.attendees}
+          attendees={attendeeList}
           setIsOpen={setIsNoShowDialogOpen}
           isOpen={isNoShowDialogOpen}
         />

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -16,7 +16,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useGetTheme } from "@calcom/lib/hooks/useTheme";
 import isSmsCalEmail from "@calcom/lib/isSmsCalEmail";
 import { getEveryFreqFor } from "@calcom/lib/recurringStrings";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { RouterInputs, RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
@@ -269,7 +269,7 @@ function BookingListItem(booking: BookingItemProps) {
     });
   }
 
-  if (!booking.isBookingInPast) {
+  if (isBookingInPast) {
     editBookingActions.push({
       id: "no_show",
       label: t("mark_as_no_show"),


### PR DESCRIPTION
## What does this PR do?

Fixes: CAL-4583

Adds a way to mark members as no show in dropdown

![image](https://github.com/user-attachments/assets/17418934-cb85-4f86-91b9-ae1a1684d2cd)
![image](https://github.com/user-attachments/assets/f26c32e4-1b60-45dd-9629-6c9184528962)

## How should this be tested?
Goto bookings/past
Click edit dropdown
Click mark as no show
Mark users as noshow