### PR TITLE
perf: Load OOO in bulk for getSlots

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -623,7 +623,7 @@ const calculateOutOfOfficeRanges = (
   outOfOfficeDays: GetUserAvailabilityInitialData["outOfOfficeDays"],
   availability: GetUserAvailabilityParamsDTO["availability"]
 ): IOutOfOfficeData => {
-  if (!outOfOfficeDays || !outOfOfficeDays.length) {
+  if (!outOfOfficeDays || outOfOfficeDays.length === 0) {
     return {};
   }
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -638,18 +638,18 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Pro
           },
 
           end: {
-            gte: startTimeDate,
+            gte: endTimeDate,
           },
         },
         // end is between dateFrom and dateTo but start is outside of range
         // (start <= 'dateFrom' OR end <= 'dateTo')
         {
           start: {
-            lte: endTimeDate,
+            lte: startTimeDate,
           },
 
           end: {
-            lte: startTimeDate,
+            lte: endTimeDate,
           },
         },
       ],

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -614,6 +614,73 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Pro
 
   const currentBookingsAllUsers = [...resultOne, ...resultTwo, ...resultThree];
 
+  const outOfOfficeDaysAllUsers = await prisma.outOfOfficeEntry.findMany({
+    where: {
+      userId: {
+        in: allUserIds,
+      },
+      OR: [
+        // outside of range
+        // (start <= 'dateTo' AND end >= 'dateFrom')
+        {
+          start: {
+            lte: endTimeDate,
+          },
+          end: {
+            gte: startTimeDate,
+          },
+        },
+        // start is between dateFrom and dateTo but end is outside of range
+        // (start <= 'dateTo' AND end >= 'dateTo')
+        {
+          start: {
+            lte: endTimeDate,
+          },
+
+          end: {
+            gte: startTimeDate,
+          },
+        },
+        // end is between dateFrom and dateTo but start is outside of range
+        // (start <= 'dateFrom' OR end <= 'dateTo')
+        {
+          start: {
+            lte: endTimeDate,
+          },
+
+          end: {
+            lte: startTimeDate,
+          },
+        },
+      ],
+    },
+    select: {
+      id: true,
+      start: true,
+      end: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      toUser: {
+        select: {
+          id: true,
+          username: true,
+          name: true,
+        },
+      },
+      reason: {
+        select: {
+          id: true,
+          emoji: true,
+          reason: true,
+        },
+      },
+    },
+  });
+
   const bookingLimits = parseBookingLimit(eventType?.bookingLimits);
   const durationLimits = parseDurationLimit(eventType?.durationLimits);
   let busyTimesFromLimitsBookingsAllUsers: Awaited<ReturnType<typeof getBusyTimesForLimitChecks>> = [];
@@ -639,6 +706,7 @@ export async function getAvailableSlots({ input, ctx }: GetScheduleOptions): Pro
           const { attendees: _attendees, ...bookingWithoutAttendees } = bookings;
           return bookingWithoutAttendees;
         }),
+      outOfOfficeDays: outOfOfficeDaysAllUsers.filter((o) => o.user.id === currentUser.id),
     };
   });
 


### PR DESCRIPTION
## What does this PR do?

We had this query nested inside of `getUserAvailability` which is run for every user inside of a team event, which can be hundreds. This will instead pre-load this data for all users in 1 query.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure OOO is still taken into account for users in a team event

