### PR TITLE
fix: app store title

### DIFF
--- a/apps/web/app/future/apps/page.tsx
+++ b/apps/web/app/future/apps/page.tsx
@@ -4,7 +4,7 @@ import { WithLayout } from "app/layoutHOC";
 
 import { getServerSideProps } from "@lib/apps/getServerSideProps";
 
-import AppsPage, { LayoutWrapper } from "~/apps/apps-view";
+import AppsPage from "~/apps/apps-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(
@@ -14,7 +14,6 @@ export const generateMetadata = async () => {
 };
 
 export default WithLayout({
-  getLayout: LayoutWrapper,
   getData: withAppDirSsr(getServerSideProps),
   Page: AppsPage,
 });

--- a/apps/web/components/apps/layouts/AppsLayout.tsx
+++ b/apps/web/components/apps/layouts/AppsLayout.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/navigation";
 import type { ComponentProps } from "react";
 import React from "react";
 
-import { ShellMain } from "@calcom/features/shell/Shell";
+import Shell from "@calcom/features/shell/Shell";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { EmptyScreen } from "@calcom/ui";
 
@@ -11,7 +11,7 @@ type AppsLayoutProps = {
   children: React.ReactNode;
   actions?: (className?: string) => JSX.Element;
   emptyStore?: boolean;
-} & Omit<ComponentProps<typeof ShellMain>, "actions">;
+} & Omit<ComponentProps<typeof Shell>, "actions">;
 
 export default function AppsLayout({ children, actions, emptyStore, ...rest }: AppsLayoutProps) {
   const { t } = useLocale();
@@ -21,7 +21,7 @@ export default function AppsLayout({ children, actions, emptyStore, ...rest }: A
 
   if (session.status === "loading") return <></>;
   return (
-    <ShellMain {...rest} actions={actions?.("block")} hideHeadingOnMobile>
+    <Shell {...rest} actions={actions?.("block")} hideHeadingOnMobile>
       <div className="flex flex-col xl:flex-row">
         <main className="w-full">
           {emptyStore ? (
@@ -37,6 +37,6 @@ export default function AppsLayout({ children, actions, emptyStore, ...rest }: A
           )}
         </main>
       </div>
-    </ShellMain>
+    </Shell>
   );
 }

--- a/apps/web/modules/apps/apps-view.tsx
+++ b/apps/web/modules/apps/apps-view.tsx
@@ -102,7 +102,7 @@ export const LayoutWrapper = (page: React.ReactElement) => {
 
   return (
     <Shell
-      title={t("app_store")}
+      title={t("app_store") !== "app_store" ? t("app_store") : "App Store"}
       description={t("app_store_description")}
       withoutMain={true}
       hideHeadingOnMobile>

--- a/apps/web/modules/apps/apps-view.tsx
+++ b/apps/web/modules/apps/apps-view.tsx
@@ -63,7 +63,6 @@ export default function Apps({ categories, appStore, userAdminTeams }: PageProps
   return (
     <AppsLayout
       isPublic
-      withoutMain
       heading={t("app_store")}
       subtitle={t("app_store_description")}
       actions={(className) => (

--- a/apps/web/modules/apps/apps-view.tsx
+++ b/apps/web/modules/apps/apps-view.tsx
@@ -3,7 +3,6 @@
 import type { ChangeEventHandler } from "react";
 import { useState } from "react";
 
-import Shell from "@calcom/features/shell/Shell";
 import { classNames } from "@calcom/lib";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";
@@ -64,6 +63,7 @@ export default function Apps({ categories, appStore, userAdminTeams }: PageProps
   return (
     <AppsLayout
       isPublic
+      withoutMain
       heading={t("app_store")}
       subtitle={t("app_store_description")}
       actions={(className) => (
@@ -96,17 +96,3 @@ export default function Apps({ categories, appStore, userAdminTeams }: PageProps
     </AppsLayout>
   );
 }
-
-export const LayoutWrapper = (page: React.ReactElement) => {
-  const { t } = useLocale();
-
-  return (
-    <Shell
-      title={t("app_store") !== "app_store" ? t("app_store") : "App Store"}
-      description={t("app_store_description")}
-      withoutMain={true}
-      hideHeadingOnMobile>
-      {page}
-    </Shell>
-  );
-};

--- a/apps/web/pages/apps/index.tsx
+++ b/apps/web/pages/apps/index.tsx
@@ -3,12 +3,11 @@ import { getServerSideProps } from "@lib/apps/getServerSideProps";
 import PageWrapper from "@components/PageWrapper";
 
 import type { PageProps } from "~/apps/apps-view";
-import Apps, { LayoutWrapper } from "~/apps/apps-view";
+import Apps from "~/apps/apps-view";
 
 const Page = (props: PageProps) => <Apps {...props} />;
 
 Page.PageWrapper = PageWrapper;
-Page.getLayout = LayoutWrapper;
 
 export { getServerSideProps };
 

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -136,10 +136,10 @@ export default function Shell(props: LayoutProps) {
 
 export function ShellMain(props: LayoutProps) {
   const router = useRouter();
-  const { isLocaleReady: _isLocaleReady, t } = useLocale();
+  const { isLocaleReady, t } = useLocale();
 
   const { buttonToShow, isLoading, enableNotifications, disableNotifications } = useNotifications();
-  const isLocaleReady = true;
+
   return (
     <>
       {(props.heading || !!props.backPath) && (

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -136,10 +136,10 @@ export default function Shell(props: LayoutProps) {
 
 export function ShellMain(props: LayoutProps) {
   const router = useRouter();
-  const { isLocaleReady, t } = useLocale();
+  const { isLocaleReady: _isLocaleReady, t } = useLocale();
 
   const { buttonToShow, isLoading, enableNotifications, disableNotifications } = useNotifications();
-
+  const isLocaleReady = true;
   return (
     <>
       {(props.heading || !!props.backPath) && (


### PR DESCRIPTION
<img width="220" alt="Screenshot 2024-10-24 at 16 03 21" src="https://github.com/user-attachments/assets/9a07f556-0968-4300-96be-aff415cfbcc2">

The app store title isn't working

I looked into it and the translation key exists:
<img width="334" alt="Screenshot 2024-10-24 at 16 03 59" src="https://github.com/user-attachments/assets/4eb74b9a-b05a-4a79-8234-11ef77150260">

And I can't quite figure out why the translations in the shell aren't working, so here's a low effort fix