### PR TITLE
fix: is Empty and is Not empty operators

### DIFF
--- a/packages/app-store/routing-forms/__tests__/zod.test.ts
+++ b/packages/app-store/routing-forms/__tests__/zod.test.ts
@@ -15,6 +15,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: ["John"],
+            valueSrc: ["value"],
           },
         },
       },
@@ -48,6 +49,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [],
+            valueSrc: ["value"],
           },
         },
       },
@@ -84,6 +86,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [],
+            valueSrc: ["value"],
           },
         },
       },
@@ -110,6 +113,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [[]],
+            valueSrc: ["value"],
           },
         },
       },
@@ -136,6 +140,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [undefined, undefined],
+            valueSrc: ["value"],
           },
         },
       },
@@ -162,6 +167,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [null],
+            valueSrc: ["value"],
           },
         },
       },
@@ -183,6 +189,7 @@ describe("queryValueValidationSchema", () => {
             field: "name",
             operator: "equal",
             value: [""],
+            valueSrc: ["value"],
           },
         },
       },
@@ -208,5 +215,43 @@ describe("queryValueValidationSchema", () => {
 
     const result2 = queryValueSaveValidationSchema.safeParse(undefined);
     expect(result2.success).toBe(true);
+  });
+
+  it("should allow fields with no value if valueSrc is empty", () => {
+    const result = queryValueSaveValidationSchema.safeParse({
+      id: "7",
+      type: "group",
+      children1: {
+        rule1: {
+          type: "rule",
+          properties: {
+            field: "name",
+            operator: "is_empty",
+            value: [],
+            valueSrc: [],
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should not allow fields with no value if valueSrc is not empty", () => {
+    const result = queryValueSaveValidationSchema.safeParse({
+      id: "7",
+      type: "group",
+      children1: {
+        rule1: {
+          type: "rule",
+          properties: {
+            field: "name",
+            operator: "is_empty",
+            value: [],
+            valueSrc: ["value"],
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/app-store/routing-forms/zod.ts
+++ b/packages/app-store/routing-forms/zod.ts
@@ -64,6 +64,7 @@ export enum RouteActionType {
 export const routeActionTypeSchema = z.nativeEnum(RouteActionType);
 /**
  * Stricter schema for validating before saving to DB
+ * It doesn't decide what will be saved, it is just to validate the data before saving
  */
 export const queryValueSaveValidationSchema = queryValueSchema
   .omit({ children1: true })
@@ -78,6 +79,7 @@ export const queryValueSaveValidationSchema = queryValueSchema
                 field: z.any().optional(),
                 operator: z.any().optional(),
                 value: z.any().optional(),
+                valueSrc: z.any().optional(),
               })
               .optional(),
           })
@@ -94,7 +96,13 @@ export const queryValueSaveValidationSchema = queryValueSchema
             if (!isObject(rule.properties)) return;
 
             const value = rule.properties.value || [];
-            if (!(value instanceof Array)) {
+            const valueSrc = rule.properties.valueSrc;
+            if (!(value instanceof Array) || !(valueSrc instanceof Array)) {
+              return;
+            }
+
+            if (!valueSrc.length) {
+              // If valueSrc is empty, value could be empty for operators like is_empty, is_not_empty
               return;
             }
 


### PR DESCRIPTION
## What does this PR do?

Reported over intercom - User not able to save existing form which is using `is Empty` operator
![image](https://github.com/user-attachments/assets/61cbc219-80c8-4118-ba60-2ec76159315d)
![image](https://github.com/user-attachments/assets/a8b72d61-232c-425c-8320-fec513263105)

[After Fix Loom](https://www.loom.com/share/c5ea179b4563448385bb927abea3c5e0)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

See loom
