### PR TITLE
fix: give reason to reassign - allow team members to reassign even if busy

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2699,6 +2699,7 @@
   "confirm_reassign_unavailable": "Manual Reassign to unavailable host",
   "reassign_unavailable_team_member_description": "Are you sure you want to reassign this booking to an unavailable host?",
   "yes_reassign": "Yes, reassign",
+  "reassign_reason": "Reason for reassigning",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2696,7 +2696,7 @@
   "add_new_field": "Add new field",
   "you_dont_have_access_to_reroute_this_booking": "You don't have access to reroute this booking",
   "form_response_not_found": "Form response not found",
-  "confirm_reassign_unavailable": "Manual Reassign to unavailable host",
+  "confirm_reassign_unavailable": "Host unavailable",
   "reassign_unavailable_team_member_description": "Are you sure you want to reassign this booking to an unavailable host?",
   "yes_reassign": "Yes, reassign",
   "reassign_reason": "Reason for reassigning",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2700,6 +2700,7 @@
   "reassign_unavailable_team_member_description": "Are you sure you want to reassign this booking to an unavailable host?",
   "yes_reassign": "Yes, reassign",
   "reassign_reason": "Reason for reassigning",
+  "reassigned_by": "Reassigned by",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }
 

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -193,7 +193,7 @@ export const sendRoundRobinCancelledEmailsAndSMS = async (
   calEvent: CalendarEvent,
   members: Person[],
   eventTypeMetadata?: EventTypeMetadata,
-  reassignedTo?: { name: string | null; email: string; reason?: string }
+  reassignedTo?: { name: string | null; email: string }
 ) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const calendarEvent = formatCalEvent(calEvent);

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -193,7 +193,7 @@ export const sendRoundRobinCancelledEmailsAndSMS = async (
   calEvent: CalendarEvent,
   members: Person[],
   eventTypeMetadata?: EventTypeMetadata,
-  reassignedTo?: { name: string | null; email: string }
+  reassignedTo?: { name: string | null; email: string; reason?: string }
 ) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const calendarEvent = formatCalEvent(calEvent);

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -144,11 +144,17 @@ export const sendScheduledEmailsAndSMS = async (
 };
 
 // for rescheduled round robin booking that assigned new members
-export const sendRoundRobinScheduledEmailsAndSMS = async (
-  calEvent: CalendarEvent,
-  members: Person[],
-  eventTypeMetadata?: EventTypeMetadata
-) => {
+export const sendRoundRobinScheduledEmailsAndSMS = async ({
+  calEvent,
+  members,
+  eventTypeMetadata,
+  reassigned,
+}: {
+  calEvent: CalendarEvent;
+  members: Person[];
+  eventTypeMetadata?: EventTypeMetadata;
+  reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
+}) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const formattedCalEvent = formatCalEvent(calEvent);
   const emailsAndSMSToSend: Promise<unknown>[] = [];
@@ -156,7 +162,7 @@ export const sendRoundRobinScheduledEmailsAndSMS = async (
 
   for (const teamMember of members) {
     emailsAndSMSToSend.push(
-      sendEmail(() => new OrganizerScheduledEmail({ calEvent: formattedCalEvent, teamMember }))
+      sendEmail(() => new OrganizerScheduledEmail({ calEvent: formattedCalEvent, teamMember, reassigned }))
     );
     if (teamMember.phoneNumber) {
       emailsAndSMSToSend.push(eventScheduledSMS.sendSMSToAttendee(teamMember));

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -153,7 +153,7 @@ export const sendRoundRobinScheduledEmailsAndSMS = async ({
   calEvent: CalendarEvent;
   members: Person[];
   eventTypeMetadata?: EventTypeMetadata;
-  reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
+  reassigned?: { reason?: string; byUser?: string };
 }) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const formattedCalEvent = formatCalEvent(calEvent);
@@ -205,7 +205,6 @@ export const sendRoundRobinCancelledEmailsAndSMS = async (
   const calendarEvent = formatCalEvent(calEvent);
   const emailsAndSMSToSend: Promise<unknown>[] = [];
   const successfullyReScheduledSMS = new EventCancelledSMS(calEvent);
-
   for (const teamMember of members) {
     if (!reassignedTo) {
       emailsAndSMSToSend.push(
@@ -213,7 +212,10 @@ export const sendRoundRobinCancelledEmailsAndSMS = async (
       );
     } else {
       emailsAndSMSToSend.push(
-        sendEmail(() => new OrganizerReassignedEmail({ calEvent: calendarEvent, teamMember, reassignedTo }))
+        sendEmail(
+          () =>
+            new OrganizerReassignedEmail({ calEvent: calendarEvent, teamMember, reassigned: reassignedTo })
+        )
       );
     }
 

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -153,7 +153,7 @@ export const sendRoundRobinScheduledEmailsAndSMS = async ({
   calEvent: CalendarEvent;
   members: Person[];
   eventTypeMetadata?: EventTypeMetadata;
-  reassigned?: { reason?: string; byUser?: string };
+  reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
 }) => {
   if (eventTypeDisableHostEmail(eventTypeMetadata)) return;
   const formattedCalEvent = formatCalEvent(calEvent);

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -27,7 +27,7 @@ export const BaseScheduledEmail = (
     locale: string;
     timeFormat: TimeFormat | undefined;
     isOrganizer?: boolean;
-    reassignedTo?: { name: string | null; email: string };
+    reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
   } & Partial<React.ComponentProps<typeof BaseEmailHtml>>
 ) => {
   const { t, timeZone, locale, timeFormat: timeFormat_ } = props;
@@ -81,18 +81,20 @@ export const BaseScheduledEmail = (
           withSpacer
         />
       )}
-      {props.reassignedTo && (
+      {props.reassigned && !props.reassigned.byUser && (
         <>
           <Info
             label={t("reassigned_to")}
             description={
-              <PersonInfo name={props.reassignedTo.name || undefined} email={props.reassignedTo.email} />
+              <PersonInfo name={props.reassigned.name || undefined} email={props.reassigned.email} />
             }
             withSpacer
           />
-          {props.reassigned?.byUser && (
-            <Info label={t("reassigned_by")} description={props.reassigned.byUser} withSpacer />
-          )}
+        </>
+      )}
+      {props.reassigned && props.reassigned.byUser && (
+        <>
+          <Info label={t("reassigned_by")} description={props.reassigned.byUser} withSpacer />
           {props.reassigned?.reason && (
             <Info label={t("reason")} description={props.reassigned.reason} withSpacer />
           )}

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -27,7 +27,7 @@ export const BaseScheduledEmail = (
     locale: string;
     timeFormat: TimeFormat | undefined;
     isOrganizer?: boolean;
-    reassignedTo?: { name: string | null; email: string; reason?: string };
+    reassignedTo?: { name: string | null; email: string };
   } & Partial<React.ComponentProps<typeof BaseEmailHtml>>
 ) => {
   const { t, timeZone, locale, timeFormat: timeFormat_ } = props;
@@ -89,9 +89,6 @@ export const BaseScheduledEmail = (
           }
           withSpacer
         />
-      )}
-      {props.reassignedTo?.reason && (
-        <Info label={t("reason")} description={props.reassignedTo.reason} withSpacer />
       )}
       <Info label={t("what")} description={props.calEvent.title} withSpacer />
       <WhenInfo timeFormat={timeFormat} calEvent={props.calEvent} t={t} timeZone={timeZone} locale={locale} />

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -27,7 +27,7 @@ export const BaseScheduledEmail = (
     locale: string;
     timeFormat: TimeFormat | undefined;
     isOrganizer?: boolean;
-    reassignedTo?: { name: string | null; email: string };
+    reassignedTo?: { name: string | null; email: string; reason?: string };
   } & Partial<React.ComponentProps<typeof BaseEmailHtml>>
 ) => {
   const { t, timeZone, locale, timeFormat: timeFormat_ } = props;
@@ -89,6 +89,9 @@ export const BaseScheduledEmail = (
           }
           withSpacer
         />
+      )}
+      {props.reassignedTo?.reason && (
+        <Info label={t("reason")} description={props.reassignedTo.reason} withSpacer />
       )}
       <Info label={t("what")} description={props.calEvent.title} withSpacer />
       <WhenInfo timeFormat={timeFormat} calEvent={props.calEvent} t={t} timeZone={timeZone} locale={locale} />

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -82,13 +82,21 @@ export const BaseScheduledEmail = (
         />
       )}
       {props.reassignedTo && (
-        <Info
-          label={t("reassigned_to")}
-          description={
-            <PersonInfo name={props.reassignedTo.name || undefined} email={props.reassignedTo.email} />
-          }
-          withSpacer
-        />
+        <>
+          <Info
+            label={t("reassigned_to")}
+            description={
+              <PersonInfo name={props.reassignedTo.name || undefined} email={props.reassignedTo.email} />
+            }
+            withSpacer
+          />
+          {props.reassigned?.byUser && (
+            <Info label={t("reassigned_by")} description={props.reassigned.byUser} withSpacer />
+          )}
+          {props.reassigned?.reason && (
+            <Info label={t("reason")} description={props.reassigned.reason} withSpacer />
+          )}
+        </>
       )}
       <Info label={t("what")} description={props.calEvent.title} withSpacer />
       <WhenInfo timeFormat={timeFormat} calEvent={props.calEvent} t={t} timeZone={timeZone} locale={locale} />

--- a/packages/emails/src/templates/OrganizerReassignedEmail.tsx
+++ b/packages/emails/src/templates/OrganizerReassignedEmail.tsx
@@ -9,7 +9,7 @@ export const OrganizerReassignedEmail = (props: React.ComponentProps<typeof Orga
       subject="event_reassigned_subject"
       subtitle={<>{t("event_reassigned_subtitle")}</>}
       callToAction={null}
-      reassignedTo={props.reassignedTo}
+      reassigned={props.reassigned}
       {...props}
     />
   );

--- a/packages/emails/src/templates/OrganizerScheduledEmail.tsx
+++ b/packages/emails/src/templates/OrganizerScheduledEmail.tsx
@@ -10,7 +10,7 @@ export const OrganizerScheduledEmail = (
     newSeat?: boolean;
     attendeeCancelled?: boolean;
     teamMember?: Person;
-    reassignedTo?: { email: string; name: string | null; reason?: string };
+    reassignedTo?: { email: string; name: string | null };
   } & Partial<React.ComponentProps<typeof BaseScheduledEmail>>
 ) => {
   let subject;

--- a/packages/emails/src/templates/OrganizerScheduledEmail.tsx
+++ b/packages/emails/src/templates/OrganizerScheduledEmail.tsx
@@ -10,7 +10,7 @@ export const OrganizerScheduledEmail = (
     newSeat?: boolean;
     attendeeCancelled?: boolean;
     teamMember?: Person;
-    reassignedTo?: { email: string; name: string | null };
+    reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
   } & Partial<React.ComponentProps<typeof BaseScheduledEmail>>
 ) => {
   let subject;
@@ -60,7 +60,7 @@ export const OrganizerScheduledEmail = (
           </>
         )
       }
-      reassignedTo={props.reassignedTo}
+      reassigned={props.reassigned}
       {...props}
       attendee={attendee}
     />

--- a/packages/emails/src/templates/OrganizerScheduledEmail.tsx
+++ b/packages/emails/src/templates/OrganizerScheduledEmail.tsx
@@ -10,7 +10,7 @@ export const OrganizerScheduledEmail = (
     newSeat?: boolean;
     attendeeCancelled?: boolean;
     teamMember?: Person;
-    reassignedTo?: { email: string; name: string | null };
+    reassignedTo?: { email: string; name: string | null; reason?: string };
   } & Partial<React.ComponentProps<typeof BaseScheduledEmail>>
 ) => {
   let subject;

--- a/packages/emails/templates/organizer-reassigned-email.ts
+++ b/packages/emails/templates/organizer-reassigned-email.ts
@@ -23,7 +23,7 @@ export default class OrganizerReassignedEmail extends OrganizerScheduledEmail {
       html: await renderEmail("OrganizerReassignedEmail", {
         attendee: this.calEvent.organizer,
         calEvent: this.calEvent,
-        reassignedTo: this.reassignedTo,
+        reassigned: this.reassigned,
       }),
       text: this.getTextBody("event_request_reassigned"),
     };

--- a/packages/emails/templates/organizer-scheduled-email.ts
+++ b/packages/emails/templates/organizer-scheduled-email.ts
@@ -17,13 +17,13 @@ export default class OrganizerScheduledEmail extends BaseEmail {
   t: TFunction;
   newSeat?: boolean;
   teamMember?: Person;
-  reassignedTo?: { name: string | null; email: string };
+  reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
 
   constructor(input: {
     calEvent: CalendarEvent;
     newSeat?: boolean;
     teamMember?: Person;
-    reassignedTo?: { email: string; name: string | null };
+    reassigned?: { name: string | null; email: string; reason?: string; byUser?: string };
   }) {
     super();
     this.name = "SEND_BOOKING_CONFIRMATION";
@@ -31,7 +31,7 @@ export default class OrganizerScheduledEmail extends BaseEmail {
     this.t = this.calEvent.organizer.language.translate;
     this.newSeat = input.newSeat;
     this.teamMember = input.teamMember;
-    this.reassignedTo = input.reassignedTo;
+    this.reassigned = input.reassigned;
   }
 
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
@@ -53,6 +53,7 @@ export default class OrganizerScheduledEmail extends BaseEmail {
         attendee: this.calEvent.organizer,
         teamMember: this.teamMember,
         newSeat: this.newSeat,
+        reassigned: this.reassigned,
       }),
       text: this.getTextBody(),
     };

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1231,7 +1231,11 @@ async function handler(
           rescheduledMembers,
           eventType.metadata
         );
-        sendRoundRobinScheduledEmailsAndSMS(copyEventAdditionalInfo, newBookedMembers, eventType.metadata);
+        sendRoundRobinScheduledEmailsAndSMS({
+          calEvent: copyEventAdditionalInfo,
+          members: newBookedMembers,
+          eventTypeMetadata: eventType.metadata,
+        });
         sendRoundRobinCancelledEmailsAndSMS(copyEventAdditionalInfo, cancelledMembers, eventType.metadata);
       } else {
         // send normal rescheduled emails (non round robin event, where organizers stay the same)

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -282,15 +282,24 @@ export const roundRobinManualReassignment = async ({
   const { cancellationReason, ...evtWithoutCancellationReason } = evt;
 
   // Send emails
-  await sendRoundRobinScheduledEmailsAndSMS(evtWithoutCancellationReason, [
-    {
-      ...newUser,
-      name: newUser.name || "",
-      username: newUser.username || "",
-      timeFormat: getTimeFormatStringFromUserTimeFormat(newUser.timeFormat),
-      language: { translate: newUserT, locale: newUser.locale || "en" },
+  await sendRoundRobinScheduledEmailsAndSMS({
+    calEvent: evtWithoutCancellationReason,
+    members: [
+      {
+        ...newUser,
+        name: newUser.name || "",
+        username: newUser.username || "",
+        timeFormat: getTimeFormatStringFromUserTimeFormat(newUser.timeFormat),
+        language: { translate: newUserT, locale: newUser.locale || "en" },
+      },
+    ],
+    reassigned: {
+      name: originalOrganizer.name || "",
+      email: originalOrganizer.email,
+      reason: reassignReason,
+      byUser: originalOrganizer.name,
     },
-  ]);
+  });
 
   // Send cancellation email to previous RR host
   const cancelledEvt = cloneDeep(evt);

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -292,8 +292,10 @@ export const roundRobinManualReassignment = async ({
       },
     ],
     reassigned: {
+      name: newUser.name,
+      email: newUser.email,
       reason: reassignReason,
-      byUser: originalOrganizer.name,
+      byUser: originalOrganizer.name | undefined,
     },
   });
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -314,7 +314,13 @@ export const roundRobinManualReassignment = async ({
         },
       ],
       eventType?.metadata as EventTypeMetadata,
-      { name: newUser.name, email: newUser.email }
+      {
+        name: newUser.name,
+        email: newUser.email,
+        reason: reassignReason
+          ? `${reassignReason}: Reassigned by ${originalOrganizer.name}`
+          : `Reassigned by ${originalOrganizer.name}`,
+      }
     );
   }
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -295,7 +295,7 @@ export const roundRobinManualReassignment = async ({
       name: newUser.name,
       email: newUser.email,
       reason: reassignReason,
-      byUser: originalOrganizer.name | undefined,
+      byUser: originalOrganizer.name || undefined,
     },
   });
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -314,13 +314,7 @@ export const roundRobinManualReassignment = async ({
         },
       ],
       eventType?.metadata as EventTypeMetadata,
-      {
-        name: newUser.name,
-        email: newUser.email,
-        reason: reassignReason
-          ? `${reassignReason}: Reassigned by ${originalOrganizer.name}`
-          : `Reassigned by ${originalOrganizer.name}`,
-      }
+      { name: newUser.name, email: newUser.email }
     );
   }
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -42,10 +42,12 @@ export const roundRobinManualReassignment = async ({
   bookingId,
   newUserId,
   orgId,
+  reassignReason,
 }: {
   bookingId: number;
   newUserId: number;
   orgId: number | null;
+  reassignReason?: string;
 }) => {
   const roundRobinReassignLogger = logger.getSubLogger({
     prefix: ["roundRobinManualReassign", `${bookingId}`],
@@ -162,6 +164,9 @@ export const roundRobinManualReassignment = async ({
         userId: newUserId,
         title: newBookingTitle,
         userPrimaryEmail: newUser.email,
+        reassignReason: reassignReason
+          ? `${reassignReason}: Reassigned by ${originalOrganizer.name}`
+          : undefined,
       },
       select: bookingSelect,
     });

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -164,9 +164,7 @@ export const roundRobinManualReassignment = async ({
         userId: newUserId,
         title: newBookingTitle,
         userPrimaryEmail: newUser.email,
-        reassignReason: reassignReason
-          ? `${reassignReason}: Reassigned by ${originalOrganizer.name}`
-          : undefined,
+        reassignReason,
       },
       select: bookingSelect,
     });
@@ -294,8 +292,6 @@ export const roundRobinManualReassignment = async ({
       },
     ],
     reassigned: {
-      name: originalOrganizer.name || "",
-      email: originalOrganizer.email,
       reason: reassignReason,
       byUser: originalOrganizer.name,
     },

--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -324,15 +324,18 @@ export const roundRobinReassignment = async ({
   });
 
   // Send to new RR host
-  await sendRoundRobinScheduledEmailsAndSMS(evt, [
-    {
-      ...reassignedRRHost,
-      name: reassignedRRHost.name || "",
-      username: reassignedRRHost.username || "",
-      timeFormat: getTimeFormatStringFromUserTimeFormat(reassignedRRHost.timeFormat),
-      language: { translate: reassignedRRHostT, locale: reassignedRRHost.locale || "en" },
-    },
-  ]);
+  await sendRoundRobinScheduledEmailsAndSMS({
+    calEvent: evt,
+    members: [
+      {
+        ...reassignedRRHost,
+        name: reassignedRRHost.name || "",
+        username: reassignedRRHost.username || "",
+        timeFormat: getTimeFormatStringFromUserTimeFormat(reassignedRRHost.timeFormat),
+        language: { translate: reassignedRRHostT, locale: reassignedRRHost.locale || "en" },
+      },
+    ],
+  });
 
   if (previousRRHost) {
     // Send to cancelled RR host

--- a/packages/lib/test/builder.ts
+++ b/packages/lib/test/builder.ts
@@ -56,6 +56,7 @@ export const buildBooking = (
     cancelledBy: null,
     rescheduledBy: null,
     cancellationReason: null,
+    reassignReason: null,
     rejectionReason: null,
     dynamicEventSlugRef: null,
     dynamicGroupSlugRef: null,

--- a/packages/prisma/migrations/20241025143558_add_reassign_reason_to_booking/migration.sql
+++ b/packages/prisma/migrations/20241025143558_add_reassign_reason_to_booking/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Booking" ADD COLUMN     "reassignReason" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -607,6 +607,7 @@ model Booking {
   destinationCalendarId        Int?
   cancellationReason           String?
   rejectionReason              String?
+  reassignReason               String?
   dynamicEventSlugRef          String?
   dynamicGroupSlugRef          String?
   rescheduled                  Boolean?

--- a/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinManualReassign.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinManualReassign.handler.ts
@@ -14,7 +14,7 @@ type RoundRobinManualReassignOptions = {
 };
 
 export const roundRobinManualReassignHandler = async ({ ctx, input }: RoundRobinManualReassignOptions) => {
-  const { bookingId, teamMemberId } = input;
+  const { bookingId, teamMemberId, reassignReason } = input;
 
   // Check if user has access to change booking
   const isAllowed = await BookingRepository.doesUserIdHaveAccessToBooking({ userId: ctx.user.id, bookingId });
@@ -23,7 +23,12 @@ export const roundRobinManualReassignHandler = async ({ ctx, input }: RoundRobin
     throw new TRPCError({ code: "FORBIDDEN", message: "You do not have permission" });
   }
 
-  await roundRobinManualReassignment({ bookingId, newUserId: teamMemberId, orgId: ctx.user.organizationId });
+  await roundRobinManualReassignment({
+    bookingId,
+    newUserId: teamMemberId,
+    orgId: ctx.user.organizationId,
+    reassignReason,
+  });
 
   return { success: true };
 };

--- a/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinManualReassign.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinManualReassign.schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const ZRoundRobinManualReassignInputSchema = z.object({
   bookingId: z.number(),
   teamMemberId: z.number(),
+  reassignReason: z.string().optional(),
 });
 
 export type TRoundRobinManualReassignInputSchema = z.infer<typeof ZRoundRobinManualReassignInputSchema>;


### PR DESCRIPTION
## What does this PR do?
Loom: https://www.loom.com/share/0a0ae115863d46c0bc651756b5c10d50
Partially fixes CAL-4609 - will add reroute in another PR

Also adds reason and reassigned by to the email sent out

Emails: 
New host:
<img width="706" alt="Screenshot 2024-10-25 at 1 52 16 PM" src="https://github.com/user-attachments/assets/0d5a5927-c941-4a53-a9b2-16db1827c349">

previous host: 
<img width="648" alt="Screenshot 2024-10-25 at 1 52 41 PM" src="https://github.com/user-attachments/assets/c8dfef8e-0370-40d6-b70c-35c0a994af31">



## How should this be tested?
Test reassign as a member and a admin. Go to reassign to a busy member. Get a modal popup where you need to fill in a reason. 
