### PR TITLE
fix: disables cache for tasker cron

### DIFF
--- a/apps/web/app/api/tasks/cron/route.ts
+++ b/apps/web/app/api/tasks/cron/route.ts
@@ -1,1 +1,4 @@
 export { GET } from "@calcom/features/tasker/api/cron";
+
+/** This runs each minute and we need fresh data each time */
+export const revalidate = 0;

--- a/apps/web/app/api/tasks/cron/route.ts
+++ b/apps/web/app/api/tasks/cron/route.ts
@@ -1,4 +1,7 @@
 export { GET } from "@calcom/features/tasker/api/cron";
 
-/** This runs each minute and we need fresh data each time */
+/**
+ * This runs each minute and we need fresh data each time
+ * @see https://nextjs.org/docs/app/building-your-application/caching#opting-out-2
+ **/
 export const revalidate = 0;


### PR DESCRIPTION
## What does this PR do?

This pull request adds a revalidation interval to the `apps/web/app/api/tasks/cron/route.ts` file to ensure fresh data is fetched each minute for the cron task.

* [`apps/web/app/api/tasks/cron/route.ts`](diffhunk://#diff-e5255c86df906996ec2a2138a46760cd32a278f0c972e2c40e9ad3779042c3d3R2-R4): Added a `revalidate` export with a value of `0` to run the task each minute and fetch fresh data.

This change addresses an anomaly with the cron used to run tasks. Previously, the cron was running correctly each minute, but the `scheduledAt` value in the query remained the same for several attempts before updating. This issue was likely caused by Vercel caching these calls and serving cached responses.

![image](https://github.com/user-attachments/assets/e1262c5b-ec85-4658-a696-bd92cb40b304)

By setting the revalidation interval to 0, we ensure that fresh data is fetched on each cron run, preventing the caching issue.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Set up the cron task to run every minute.
2. Monitor the `scheduledAt` value in the query for several minutes.
3. Verify that the `scheduledAt` value updates correctly on each cron run.
4. Check the Vercel logs to ensure that the cron task is not serving cached responses.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings