### PR TITLE
fix: Resolve lint errors by updating RerouteDialog.test.tsx

### DIFF
--- a/apps/web/components/dialog/__tests__/RerouteDialog.test.tsx
+++ b/apps/web/components/dialog/__tests__/RerouteDialog.test.tsx
@@ -248,7 +248,7 @@ async function mockMessageFromOpenedTab({ type, data }: { type: string; data: an
   return messageReceivedPromise;
 }
 
-function expectEventTypeInfoInCurrentRouting({
+async function expectEventTypeInfoInCurrentRouting({
   eventTypeText,
   eventTypeHref,
 }: {
@@ -257,10 +257,10 @@ function expectEventTypeInfoInCurrentRouting({
 }) {
   const eventTypeEl = screen.getByTestId("current-routing-status-event-type");
   expect(eventTypeEl).toHaveTextContent(eventTypeText);
-  expect(eventTypeEl.querySelector("a")).toHaveAttribute("href", eventTypeHref);
+  await expect(eventTypeEl.querySelector("a")).toHaveAttribute("href", eventTypeHref);
 }
 
-function expectEventTypeInfoInReroutePreview({
+async function expectEventTypeInfoInReroutePreview({
   eventTypeText,
   eventTypeHref,
 }: {
@@ -269,7 +269,7 @@ function expectEventTypeInfoInReroutePreview({
 }) {
   const eventTypeEl = screen.getByTestId("reroute-preview-event-type");
   expect(eventTypeEl).toHaveTextContent(eventTypeText);
-  expect(eventTypeEl.querySelector("a")).toHaveAttribute("href", eventTypeHref);
+  await expect(eventTypeEl.querySelector("a")).toHaveAttribute("href", eventTypeHref);
 }
 
 function expectOrganizerInfoInCurrentRouting({ organizerText }: { organizerText: string }) {


### PR DESCRIPTION
## What does this PR do?

Another step of fixing build by fixing pre-running lint errors
![image](https://github.com/user-attachments/assets/45de914b-3dbf-402f-b469-c98a92beddc7)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I didn't updated the developer docs.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Install dependencies by running `yarn`
- Running `yarn --cwd apps/web workspace @calcom/web run build` and see the error disappear
