### PR TITLE
fix: decide primary cal based on scoring system

### DIFF
--- a/packages/app-store/googlecalendar/api/callback.ts
+++ b/packages/app-store/googlecalendar/api/callback.ts
@@ -63,8 +63,6 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
       return;
     }
 
-    // Set the primary calendar as the first selected calendar
-
     oAuth2Client.setCredentials(key);
 
     const calendar = google.calendar({

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -681,7 +681,7 @@ export default class GoogleCalendarService implements Calendar {
             externalId: cal.id ?? "No id",
             integration: this.integrationName,
             name: cal.summary ?? "No name",
-            primary: cal.primary ?? cal.accessRole === "owner" ?? false,
+            primary: cal.primary || cal.accessRole === "owner" || this.credential.user?.email === cal.id,
             readOnly: !(cal.accessRole === "writer" || cal.accessRole === "owner") && true,
             email: cal.id ?? "",
           } satisfies IntegrationCalendar)

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -681,7 +681,7 @@ export default class GoogleCalendarService implements Calendar {
             externalId: cal.id ?? "No id",
             integration: this.integrationName,
             name: cal.summary ?? "No name",
-            primary: cal.primary ?? false,
+            primary: cal.primary ?? cal.accessRole === "owner" ?? false,
             readOnly: !(cal.accessRole === "writer" || cal.accessRole === "owner") && true,
             email: cal.id ?? "",
           } satisfies IntegrationCalendar)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Some people continue to have different accounts' calendar selected as primary calendar for them
- More specifically, even though two users have calendars, for which they have "owner" access role and whose id is matching their email, the calendar of a different account keeps getting connected to their Cal.com account

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
