### PR TITLE
chore: ensure idempotency cancel booking api v2

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -196,6 +196,15 @@ export class BookingsController_2024_08_13 {
     @Body(new CancelBookingInputPipe())
     body: CancelBookingInput
   ): Promise<CancelBookingOutput_2024_08_13> {
+    // TODO: implement Idempotency middleware
+    const alreadyCancelledBooking = await this.bookingsService.getBooking(bookingUid);
+    if (!Array.isArray(alreadyCancelledBooking) && alreadyCancelledBooking.status === "cancelled") {
+      return {
+        status: SUCCESS_STATUS,
+        data: alreadyCancelledBooking,
+      };
+    }
+
     const cancelledBooking = await this.bookingsService.cancelBooking(request, bookingUid, body);
 
     return {

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/seated-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/seated-bookings.e2e-spec.ts
@@ -614,6 +614,45 @@ describe("Bookings Endpoints 2024-08-13", () => {
         });
     });
 
+    it("should return already cancelled seated booking (idempotency)", async () => {
+      const body: CancelSeatedBookingInput_2024_08_13 = {
+        seatUid: createdSeatedBooking.seatUid,
+      };
+
+      return request(app.getHttpServer())
+        .post(`/v2/bookings/${createdSeatedBooking.uid}/cancel`)
+        .send(body)
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
+        .expect(200)
+        .then(async (response) => {
+          const responseBody: RescheduleBookingOutput_2024_08_13 = response.body;
+          expect(responseBody.status).toEqual(SUCCESS_STATUS);
+          expect(responseBody.data).toBeDefined();
+          expect(responseDataIsGetSeatedBooking(responseBody.data)).toBe(true);
+
+          if (responseDataIsGetSeatedBooking(responseBody.data)) {
+            const data: GetSeatedBookingOutput_2024_08_13 = responseBody.data;
+            expect(data.id).toBeDefined();
+            expect(data.uid).toBeDefined();
+            expect(data.hosts[0].id).toEqual(user.id);
+            expect(data.status).toEqual("cancelled");
+            expect(data.start).toEqual(createdSeatedBooking.start);
+            expect(data.end).toEqual(createdSeatedBooking.end);
+            expect(data.duration).toEqual(60);
+            expect(data.eventTypeId).toEqual(seatedEventTypeId);
+            expect(data.eventType).toEqual({
+              id: seatedEventTypeId,
+              slug: seatedTventTypeSlug,
+            });
+            expect(data.attendees.length).toEqual(0);
+            expect(data.location).toBeDefined();
+            expect(data.absentHost).toEqual(false);
+          } else {
+            throw new Error("Invalid response data - expected booking but received array response");
+          }
+        });
+    });
+
     function responseDataIsCreateSeatedBooking(data: any): data is CreateSeatedBookingOutput_2024_08_13 {
       return data.hasOwnProperty("seatUid");
     }


### PR DESCRIPTION
## What does this PR do?

Ensure idempotency when cancelling bookings on api v2

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

 yarn test:e2e bookings.controller.e2e-spec.ts
