### PR TITLE
feat: Added OutOfOfficeEntry date overlapping field and switch

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2709,5 +2709,6 @@
   "attendee_timezone_info": "Attendee Timezone",
   "event_start_time_in_attendee_timezone_info": "Event Start Time In Attendee Timezone",
   "event_end_time_in_attendee_timezone_info": "Event End Time In Attendee Timezone",
+  "allow_overlapping_dates": "Allow dates to overlap other entries",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -27,6 +27,7 @@ export type BookingRedirectForm = {
   reasonId: number;
   notes?: string;
   uuid?: string | null;
+  allowOverlap?: boolean;
 };
 
 type Option = { value: number; label: string };
@@ -86,6 +87,7 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
           offset: dayjs().utcOffset(),
           toTeamUserId: null,
           reasonId: 1,
+          allowOverlap: false,
         },
   });
 
@@ -140,9 +142,27 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                       onDatesChange={(values) => {
                         onChange(values);
                       }}
+                      minDate={new Date(0)}
                     />
                   )}
                 />
+                <div className="p-2 pb-0">
+                  <Controller
+                    name="allowOverlap"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                      <Switch
+                        data-testid="dates-allow-overlap-switch"
+                        checked={value}
+                        id="dates-allow-overlap-switch"
+                        onCheckedChange={(state) => {
+                          onChange(state);
+                        }}
+                        label={t("allow_overlapping_dates")}
+                      />
+                    )}
+                  />
+                </div>
               </div>
             </div>
 

--- a/packages/prisma/migrations/20241029200553_add_overlap_to_ooo/migration.sql
+++ b/packages/prisma/migrations/20241029200553_add_overlap_to_ooo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "OutOfOfficeEntry" ADD COLUMN     "allowOverlap" BOOLEAN DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1359,17 +1359,18 @@ model Avatar {
 }
 
 model OutOfOfficeEntry {
-  id       Int                @id @default(autoincrement())
-  uuid     String             @unique
-  start    DateTime
-  end      DateTime
-  notes    String?
-  userId   Int
-  user     User               @relation(fields: [userId], references: [id], onDelete: Cascade)
-  toUserId Int?
-  toUser   User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
-  reasonId Int?
-  reason   OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
+  id           Int                @id @default(autoincrement())
+  uuid         String             @unique
+  start        DateTime
+  end          DateTime
+  notes        String?
+  userId       Int
+  user         User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  toUserId     Int?
+  toUser       User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
+  reasonId     Int?
+  reason       OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
+  allowOverlap Boolean?           @default(false)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/packages/trpc/server/routers/loggedInViewer/outOfOffice.schema.ts
+++ b/packages/trpc/server/routers/loggedInViewer/outOfOffice.schema.ts
@@ -10,6 +10,7 @@ export const ZOutOfOfficeInputSchema = z.object({
   toTeamUserId: z.number().nullable(),
   reasonId: z.number(),
   notes: z.string().nullable().optional(),
+  allowOverlap: z.boolean().optional(),
 });
 
 export type TOutOfOfficeInputSchema = z.infer<typeof ZOutOfOfficeInputSchema>;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #17368 (GitHub issue number)
- Fixes CAL-4631 (Linear issue number - should be visible at the bottom of the GitHub issue description)

Loom video: [Example of past dates and overlapping dates](https://www.loom.com/share/b2eb1375f42347a99aa13cb74c17c247?sid=573977ae-ee52-480b-932b-0597476c9d0a)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

I tested this via `yarn playwright test ./apps/web/playwright/out-of-office.e2e.ts`

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
n/a
- What are the minimal test data to have?
n/a
- What is expected (happy path) to have (input and output)?
n/a
- Any other important info that could help to test that PR
n/a

/claim #17368