### PR TITLE
fix: routing-forms reporting - "in" operator logic is broken + overall refactor

### DIFF
--- a/packages/app-store/routing-forms/__tests__/jsonLogicToPrisma.test.ts
+++ b/packages/app-store/routing-forms/__tests__/jsonLogicToPrisma.test.ts
@@ -227,83 +227,137 @@ describe("jsonLogicToPrisma(Reporting)", () => {
         ],
       });
     });
-  });
 
-  it("should support where All Match ['Equals', 'Equals'] operator", () => {
-    const prismaWhere = jsonLogicToPrisma({
-      logic: {
-        and: [
-          { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "a"] },
-          { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "b"] },
+    it("should support 'Any In' operator", () => {
+      const prismaWhere = jsonLogicToPrisma({
+        logic: { and: [{ in: [{ var: "267c7817-81a5-4bef-9d5b-d0faa4cd0d71" }, ["C", "D"]] }] },
+      });
+      expect(prismaWhere).toEqual({
+        AND: [
+          {
+            OR: [
+              {
+                response: {
+                  path: ["267c7817-81a5-4bef-9d5b-d0faa4cd0d71", "value"],
+                  equals: "C",
+                },
+              },
+              {
+                response: {
+                  path: ["267c7817-81a5-4bef-9d5b-d0faa4cd0d71", "value"],
+                  equals: "D",
+                },
+              },
+            ],
+          },
         ],
-      },
+      });
     });
 
-    expect(prismaWhere).toEqual({
-      AND: [
-        {
-          response: {
-            path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
-            equals: "a",
+    it("should support 'Not In' operator", () => {
+      const prismaWhere = jsonLogicToPrisma({
+        logic: { and: [{ "!": { in: [{ var: "267c7817-81a5-4bef-9d5b-d0faa4cd0d71" }, ["C", "D"]] } }] },
+      });
+      expect(prismaWhere).toEqual({
+        AND: [
+          {
+            NOT: {
+              OR: [
+                {
+                  response: {
+                    path: ["267c7817-81a5-4bef-9d5b-d0faa4cd0d71", "value"],
+                    equals: "C",
+                  },
+                },
+                {
+                  response: {
+                    path: ["267c7817-81a5-4bef-9d5b-d0faa4cd0d71", "value"],
+                    equals: "D",
+                  },
+                },
+              ],
+            },
           },
-        },
-        {
-          response: {
-            path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
-            equals: "b",
-          },
-        },
-      ],
-    });
-  });
-
-  it("should support where Any Match ['Equals', 'Equals'] operator", () => {
-    const prismaWhere = jsonLogicToPrisma({
-      logic: {
-        or: [
-          { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "a"] },
-          { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "b"] },
         ],
-      },
+      });
     });
 
-    expect(prismaWhere).toEqual({
-      OR: [
-        {
-          response: {
-            path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
-            equals: "a",
-          },
-        },
-        {
-          response: {
-            path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
-            equals: "b",
-          },
-        },
-      ],
-    });
-  });
-
-  it("should support where None Match ['Equals', 'Equals'] operator", () => {
-    const prismaWhere = jsonLogicToPrisma({
-      logic: {
-        "!": {
-          or: [
-            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "abc"] },
-            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "abcd"] },
+    it("should support where All Match ['Equals', 'Equals'] operator", () => {
+      const prismaWhere = jsonLogicToPrisma({
+        logic: {
+          and: [
+            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "a"] },
+            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "b"] },
           ],
         },
-      },
+      });
+
+      expect(prismaWhere).toEqual({
+        AND: [
+          {
+            response: {
+              path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
+              equals: "a",
+            },
+          },
+          {
+            response: {
+              path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
+              equals: "b",
+            },
+          },
+        ],
+      });
     });
 
-    expect(prismaWhere).toEqual({
-      NOT: {
+    it("should support where Any Match ['Equals', 'Equals'] operator", () => {
+      const prismaWhere = jsonLogicToPrisma({
+        logic: {
+          or: [
+            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "a"] },
+            { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "b"] },
+          ],
+        },
+      });
+
+      expect(prismaWhere).toEqual({
         OR: [
-          { response: { path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"], equals: "abc" } },
-          { response: { path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"], equals: "abcd" } },
+          {
+            response: {
+              path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
+              equals: "a",
+            },
+          },
+          {
+            response: {
+              path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"],
+              equals: "b",
+            },
+          },
         ],
-      },
+      });
+    });
+
+    it("should support where None Match ['Equals', 'Equals'] operator", () => {
+      const prismaWhere = jsonLogicToPrisma({
+        logic: {
+          "!": {
+            or: [
+              { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "abc"] },
+              { "==": [{ var: "505d3c3c-aa71-4220-93a9-6fd1e1087939" }, "abcd"] },
+            ],
+          },
+        },
+      });
+
+      expect(prismaWhere).toEqual({
+        NOT: {
+          OR: [
+            { response: { path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"], equals: "abc" } },
+            { response: { path: ["505d3c3c-aa71-4220-93a9-6fd1e1087939", "value"], equals: "abcd" } },
+          ],
+        },
+      });
     });
   });
 });

--- a/packages/app-store/routing-forms/jsonLogicToPrisma.ts
+++ b/packages/app-store/routing-forms/jsonLogicToPrisma.ts
@@ -102,8 +102,10 @@ const convertSingleQueryToPrismaWhereClause = (
   const mainOperand = operands[0].var;
 
   let secondaryOperand;
+
   if (operatorName === "in") {
-    // For 'in' operator, second operand is an array of values
+    // case A: Item "in" array
+    // case B: String "in" string
     secondaryOperand = operands[1];
   } else if (operatorName === "all") {
     secondaryOperand = operands[1].in[1];
@@ -114,14 +116,11 @@ const convertSingleQueryToPrismaWhereClause = (
   const isNumberOperator = NumberOperators.includes(operatorName);
   const secondaryOperandAsNumber = typeof secondaryOperand === "string" ? Number(secondaryOperand) : null;
 
-  if (operatorName === "in") {
-    const valuesToCompareAgainst =
-      (Array.isArray(secondaryOperand) ? secondaryOperand : [secondaryOperand]) ?? [];
-
+  if (operatorName === "in" && Array.isArray(secondaryOperand)) {
     // Convert 'in' operator to union of OR clauses
     return negatePrismaWhereClauseIfNeeded(
       {
-        OR: valuesToCompareAgainst.map((value) => ({
+        OR: (secondaryOperand ?? []).map((value) => ({
           response: {
             path: [mainOperand, "value"],
             [`${OPERATOR_MAP["=="].operator}`]: value,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes CAL-4643
- Any in or Not in filters are not working in routing-forms reporting page

**Before**
<img width="1368" alt="Screenshot 2024-10-29 at 23 15 57" src="https://github.com/user-attachments/assets/1c3046ee-3bbb-4a7e-a05e-a78c1e5c211f">
<img width="1372" alt="Screenshot 2024-10-29 at 23 16 08" src="https://github.com/user-attachments/assets/8df0cda1-0370-48d4-96b0-44a968d0fe55">


**After**
- Loom: https://www.loom.com/share/abe1620f0019467f8d8ec2b4efe0bea8?sid=0adfa3c5-1b3b-4d59-9b04-fee2962a2eca

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
