### PR TITLE
Fix booking filter by people not working

### DIFF
--- a/apps/api/v1/pages/api/bookings/_get.ts
+++ b/apps/api/v1/pages/api/bookings/_get.ts
@@ -196,6 +196,15 @@ function buildWhereClause(
             },
           },
         },
+        {
+          eventType: {
+            hosts: {
+              some: {
+                userId: { in: userIds },
+              },
+            },
+          },
+        },
       ],
     };
   }

--- a/packages/lib/bookings/getAllUserBookings.ts
+++ b/packages/lib/bookings/getAllUserBookings.ts
@@ -34,9 +34,6 @@ const getAllUserBookings = async ({ ctx, filters, bookingListingByStatus, take, 
   const bookingListingFilters: Record<InputByStatus, Prisma.BookingWhereInput> = {
     upcoming: {
       endTime: { gte: new Date() },
-      // These changes are needed to not show confirmed recurring events,
-      // as rescheduling or cancel for recurring event bookings should be
-      // handled separately for each occurrence
       OR: [
         {
           recurringEventId: { not: null },


### PR DESCRIPTION
Related to #17402

Update booking filter to correctly return bookings where the user is present, including non-organizer hosts.

* **apps/api/v1/pages/api/bookings/_get.ts**
  - Update `buildWhereClause` function to check all hosts, not just the organizer.
  - Modify `args.where` to include non-organizer hosts in the filter.

* **packages/lib/bookings/getAllUserBookings.ts**
  - Update `getAllUserBookings` function to account for non-organizer hosts.
  - Modify `bookingListingFilters` to include non-organizer hosts.

