### PR TITLE
Fix troubleshooter availability to match actual availability

### DIFF
--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -206,7 +206,7 @@ export const getBusyCalendarTimes = async (
   selectedCalendars: SelectedCalendar[]
 ) => {
   let results: EventBusyDate[][] = [];
-  // const months = getMonths(dateFrom, dateTo);
+  const months = getMonths(dateFrom, dateTo);
   try {
     // Subtract 11 hours from the start date to avoid problems in UTC- time zones.
     const startDate = dayjs(dateFrom).subtract(11, "hours").format();


### PR DESCRIPTION
Related to #17395

Update `getBusyCalendarTimes` function in `packages/core/CalendarManager.ts` to handle month boundaries correctly.

* Uncomment the `months` variable initialization to ensure month boundaries are considered when fetching calendar events.

