### PR TITLE
perf: Reduce spans in highPerf temporarily

### DIFF
--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -415,8 +415,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     })
   );
 
-  //const getWorkingHoursSpan = Sentry.startInactiveSpan({ name: "getWorkingHours" });
-
   if (
     !(schedule?.availability || (eventType?.availability.length ? eventType.availability : user.availability))
   ) {
@@ -431,7 +429,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
   }));
 
   const workingHours = getWorkingHours({ timeZone }, availability);
-  //getWorkingHoursSpan.end();
 
   const dateOverrides: TimeRange[] = [];
   // NOTE: getSchedule is currently calling this function for every user in a team event
@@ -530,7 +527,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
 
   const datesOutOfOffice: IOutOfOfficeData = calculateOutOfOfficeRanges(outOfOfficeDays, availability);
 
-  //const buildDateRangesSpan = Sentry.startInactiveSpan({ name: "buildDateRanges" });
   const { dateRanges, oooExcludedDateRanges } = buildDateRanges({
     dateFrom,
     dateTo,
@@ -547,8 +543,6 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
       : [],
     outOfOffice: datesOutOfOffice,
   });
-
-  //buildDateRangesSpan.end();
 
   const formattedBusyTimes = detailedBusyTimes.map((busy) => ({
     start: dayjs(busy.start),

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -415,7 +415,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     })
   );
 
-  const getWorkingHoursSpan = Sentry.startInactiveSpan({ name: "getWorkingHours" });
+  //const getWorkingHoursSpan = Sentry.startInactiveSpan({ name: "getWorkingHours" });
 
   if (
     !(schedule?.availability || (eventType?.availability.length ? eventType.availability : user.availability))
@@ -431,7 +431,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
   }));
 
   const workingHours = getWorkingHours({ timeZone }, availability);
-  getWorkingHoursSpan.end();
+  //getWorkingHoursSpan.end();
 
   const dateOverrides: TimeRange[] = [];
   // NOTE: getSchedule is currently calling this function for every user in a team event
@@ -530,7 +530,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
 
   const datesOutOfOffice: IOutOfOfficeData = calculateOutOfOfficeRanges(outOfOfficeDays, availability);
 
-  const buildDateRangesSpan = Sentry.startInactiveSpan({ name: "buildDateRanges" });
+  //const buildDateRangesSpan = Sentry.startInactiveSpan({ name: "buildDateRanges" });
   const { dateRanges, oooExcludedDateRanges } = buildDateRanges({
     dateFrom,
     dateTo,
@@ -548,7 +548,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     outOfOffice: datesOutOfOffice,
   });
 
-  buildDateRangesSpan.end();
+  //buildDateRangesSpan.end();
 
   const formattedBusyTimes = detailedBusyTimes.map((busy) => ({
     start: dayjs(busy.start),


### PR DESCRIPTION
## What does this PR do?

To try and limit the number of spans we generate to be below 1000, removing these temporarily.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
