### PR TITLE
fix: buffers in handleNewBooking

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -87,6 +87,8 @@ export async function ensureAvailableUsers(
       returnDateOverrides: false,
       dateFrom: startDateTimeUtc.format(),
       dateTo: endDateTimeUtc.format(),
+      beforeEventBuffer: eventType.beforeEventBuffer,
+      afterEventBuffer: eventType.afterEventBuffer,
     },
     initialData: {
       eventType,

--- a/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
@@ -70,6 +70,8 @@ export const getEventTypesFromDB = async (eventTypeId: number) => {
       rescheduleWithSameRoundRobinHost: true,
       assignAllTeamMembers: true,
       isRRWeightsEnabled: true,
+      beforeEventBuffer: true,
+      afterEventBuffer: true,
       parentId: true,
       parent: {
         select: {

--- a/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
@@ -474,6 +474,101 @@ describe("handleNewBooking", () => {
   );
 
   describe("Buffers", () => {
+    test("should throw error when booking is not respecting buffers with event types that have before and after buffer ", async ({}) => {
+      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+
+      const booker = getBooker({
+        email: "booker@example.com",
+        name: "Booker",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+      });
+
+      const { dateString: nextDayDateString } = getDate({ dateIncrement: 1 });
+
+      await createBookingScenario(
+        getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 15,
+              length: 15,
+              beforeEventBuffer: 60,
+              afterEventBuffer: 60,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          bookings: [
+            {
+              eventTypeId: 1,
+              userId: 101,
+              status: BookingStatus.ACCEPTED,
+              startTime: `${nextDayDateString}T07:00:00.000Z`,
+              endTime: `${nextDayDateString}T07:15:00.000Z`,
+            },
+          ],
+          organizer,
+        })
+      );
+
+      // 7:00 - 7:15 busy
+      // 6:00 - 7:00 before event buffer
+      // 5:00 - 6:00 after event buffer
+      const mockBookingBeforeData = getMockRequestDataForBooking({
+        data: {
+          start: `${nextDayDateString}T05:15:00.000Z`,
+          end: `${nextDayDateString}T05:30:00.000Z`,
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const { req: reqBookingBefore } = createMockNextJsRequest({
+        method: "POST",
+        body: mockBookingBeforeData,
+      });
+      await expect(async () => await handleNewBooking(reqBookingBefore)).rejects.toThrowError(
+        "no_available_users_found_error"
+      );
+
+      // 7:00 - 7:15 busy
+      // 7:17 - 8:15 after event buffer
+      // 8:15 - 9:15 before event buffer
+      const mockBookingAfterData = getMockRequestDataForBooking({
+        data: {
+          start: `${nextDayDateString}T09:00:00.000Z`,
+          end: `${nextDayDateString}T09:15:00.000Z`,
+          eventTypeId: 1,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const { req: reqBookingAfter } = createMockNextJsRequest({
+        method: "POST",
+        body: mockBookingAfterData,
+      });
+      await expect(async () => await handleNewBooking(reqBookingAfter)).rejects.toThrowError(
+        "no_available_users_found_error"
+      );
+    });
+
     test(`should throw error when booking is within a before event buffer of an existing booking
         `, async ({}) => {
       const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;


### PR DESCRIPTION
## What does this PR do?

`handleNewBooking` didn't respect all buffers, so for round-robin event types and API bookings, users could get booked without buffers being respected

- Fixes #17414
- Fixes CAL-4649

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x]  N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Create 30 min event type with 1 hour before and 1 hour after buffer
- Book 12:00 - 12:30
- Load availability and see that 10:00 is not available 
- Pick the earliest slot 9:30 and change start time in URL to 10:00
- Now try to book that 10:00 slot. Before this succeed, now you get an error
