### PR TITLE
feat: Send Attendee No Show Data To Salesforce

### DIFF
--- a/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
@@ -30,6 +30,9 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
   const createEventOnLeadCheckForContact = getAppData("createEventOnLeadCheckForContact") ?? false;
   const onBookingChangeRecordOwner = getAppData("onBookingChangeRecordOwner") ?? false;
   const onBookingChangeRecordOwnerName = getAppData("onBookingChangeRecordOwnerName") ?? [];
+  const sendNoShowAttendeeData = getAppData("sendNoShowAttendeeData") ?? false;
+  const sendNoShowAttendeeDataField = getAppData("sendNoShowAttendeeDataField") ?? "";
+
   const { t } = useLocale();
 
   const recordOptions = [
@@ -278,6 +281,25 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
             <Alert className="mt-2" severity="neutral" title={t("skip_rr_description")} />
           </div>
         ) : null}
+
+        <div className="ml-2 mt-4">
+          <Switch
+            label="Send no show attendee data to event object"
+            checked={sendNoShowAttendeeData}
+            onCheckedChange={(checked) => {
+              setAppData("sendNoShowAttendeeData", checked);
+            }}
+          />
+          {sendNoShowAttendeeData ? (
+            <div className="mt-2">
+              <p className="mb-2">Field name to check (must be checkbox data type)</p>
+              <InputField
+                value={sendNoShowAttendeeDataField}
+                onChange={(e) => setAppData("sendNoShowAttendeeDataField", e.target.value)}
+              />
+            </div>
+          ) : null}
+        </div>
       </>
     </AppCard>
   );

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -534,7 +534,6 @@ export default class SalesforceCRMService implements CRM {
     }
 
     for (const event of salesforceEvents) {
-      // const salesforceEvent = await conn.sobject("Event").retrieve(event.uid)
       const salesforceEvent = await conn.query(`SELECT WhoId FROM Event WHERE Id = '${event.uid}'`);
 
       let salesforceAttendeeEmail: string | undefined = undefined;
@@ -574,8 +573,6 @@ export default class SalesforceCRMService implements CRM {
         }
       }
     }
-
-    return;
   }
 
   private getExistingIdFromDuplicateError(error: any): string | null {

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -15,6 +15,7 @@ import type { CRM, Contact, CrmEvent } from "@calcom/types/CrmService";
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 import type { ParseRefreshTokenResponse } from "../../_utils/oauth/parseRefreshTokenResponse";
 import parseRefreshTokenResponse from "../../_utils/oauth/parseRefreshTokenResponse";
+import { default as appMeta } from "../config.json";
 import { SalesforceRecordEnum } from "./recordEnum";
 
 type ExtendedTokenResponse = TokenResponse & {
@@ -500,6 +501,81 @@ export default class SalesforceCRMService implements CRM {
     }
 
     return createdContacts;
+  }
+
+  async handleAttendeeNoShow(bookingUid: string, attendees: { email: string; noShow: boolean }[]) {
+    const appOptions = this.getAppOptions();
+    const { sendNoShowAttendeeData, sendNoShowAttendeeDataField } = appOptions;
+    const conn = await this.conn;
+    // Check that no show is enabled
+    if (!sendNoShowAttendeeData && !sendNoShowAttendeeDataField) {
+      this.log.warn(`No show settings not set for bookingUid ${bookingUid}`);
+      return;
+    }
+    // Get all Salesforce events associated with the booking
+    const salesforceEvents = await prisma.bookingReference.findMany({
+      where: {
+        type: appMeta.type,
+        booking: {
+          uid: bookingUid,
+        },
+      },
+    });
+
+    const salesforceEntity = await conn.describe("Event");
+    const fields = salesforceEntity.fields;
+    const noShowField = fields.find((field) => field.name === sendNoShowAttendeeDataField);
+
+    if (!noShowField && !noShowField.type !== "boolean") {
+      this.log.warn(
+        `No show field on Salesforce doesn't exist or is not of type boolean for bookingUid ${bookingUid}`
+      );
+      return;
+    }
+
+    for (const event of salesforceEvents) {
+      // const salesforceEvent = await conn.sobject("Event").retrieve(event.uid)
+      const salesforceEvent = await conn.query(`SELECT WhoId FROM Event WHERE Id = '${event.uid}'`);
+
+      let salesforceAttendeeEmail: string | undefined = undefined;
+      // Figure out if the attendee is a contact or lead
+      const contactQuery = await conn.query(
+        `SELECT Email FROM Contact WHERE Id = '${salesforceEvent.records[0].WhoId}'`
+      );
+      const leadQuery = await conn.query(
+        `SELECT Email FROM Lead WHERE Id = '${salesforceEvent.records[0].WhoId}'`
+      );
+
+      // Prioritize contacts over leads
+      if (contactQuery.records.length > 0) {
+        salesforceAttendeeEmail = contactQuery.records[0].Email;
+      } else if (leadQuery.records.length > 0) {
+        salesforceAttendeeEmail = leadQuery.records[0].Email;
+      } else {
+        this.log.warn(
+          `Could not find attendee for bookingUid ${bookingUid} and salesforce event id ${event.uid}`
+        );
+      }
+
+      if (salesforceAttendeeEmail) {
+        // Find the attendee no show data
+        const noShowData = attendees.find((attendee) => attendee.email === salesforceAttendeeEmail);
+
+        if (!noShowData) {
+          this.log.warn(
+            `No show data could not be found for ${salesforceAttendeeEmail} and bookingUid ${bookingUid}`
+          );
+        } else {
+          // Update the event with the no show data
+          await conn.sobject("Event").update({
+            Id: event.uid,
+            [sendNoShowAttendeeDataField]: noShowData.noShow,
+          });
+        }
+      }
+    }
+
+    return;
   }
 
   private getExistingIdFromDuplicateError(error: any): string | null {

--- a/packages/app-store/salesforce/zod.ts
+++ b/packages/app-store/salesforce/zod.ts
@@ -18,6 +18,8 @@ export const appDataSchema = eventTypeAppCardZod.extend({
   createEventOnLeadCheckForContact: z.boolean().optional(),
   onBookingChangeRecordOwner: z.boolean().optional(),
   onBookingChangeRecordOwnerName: z.string().optional(),
+  sendNoShowAttendeeData: z.boolean().optional(),
+  sendNoShowAttendeeDataField: z.string().optional(),
 });
 
 export const appKeysSchema = z.object({

--- a/packages/core/crmManager/crmManager.ts
+++ b/packages/core/crmManager/crmManager.ts
@@ -75,6 +75,8 @@ export default class CrmManager {
 
   public async handleAttendeeNoShow(bookingUid: string, attendees: { email: string; noShow: boolean }[]) {
     const crmService = await this.getCrmService(this.credential);
-    await crmService?.handleAttendeeNoShow(bookingUid, attendees);
+    if (crmService?.handleAttendeeNoShow) {
+      await crmService?.handleAttendeeNoShow(bookingUid, attendees);
+    }
   }
 }

--- a/packages/core/crmManager/crmManager.ts
+++ b/packages/core/crmManager/crmManager.ts
@@ -76,7 +76,7 @@ export default class CrmManager {
   public async handleAttendeeNoShow(bookingUid: string, attendees: { email: string; noShow: boolean }[]) {
     const crmService = await this.getCrmService(this.credential);
     if (crmService?.handleAttendeeNoShow) {
-      await crmService?.handleAttendeeNoShow(bookingUid, attendees);
+      await crmService.handleAttendeeNoShow(bookingUid, attendees);
     }
   }
 }

--- a/packages/core/crmManager/crmManager.ts
+++ b/packages/core/crmManager/crmManager.ts
@@ -72,4 +72,9 @@ export default class CrmManager {
     const createdContacts = (await crmService?.createContacts(contactsToCreate, organizerEmail)) || [];
     return createdContacts;
   }
+
+  public async handleAttendeeNoShow(bookingUid: string, attendees: { email: string; noShow: boolean }[]) {
+    const crmService = await this.getCrmService(this.credential);
+    await crmService?.handleAttendeeNoShow(bookingUid, attendees);
+  }
 }

--- a/packages/features/handleMarkNoShow.ts
+++ b/packages/features/handleMarkNoShow.ts
@@ -10,6 +10,10 @@ import { prisma } from "@calcom/prisma";
 import { WebhookTriggerEvents } from "@calcom/prisma/client";
 import type { TNoShowInputSchema } from "@calcom/trpc/server/routers/loggedInViewer/markNoShow.schema";
 
+import handleSendingAttendeeNoShowDataToApps from "./noShow/handleSendingAttendeeNoShowDataToApps";
+
+export type NoShowAttendees = { email: string; noShow: boolean }[];
+
 const buildResultPayload = async (
   bookingUid: string,
   attendeeEmails: string[],
@@ -41,7 +45,7 @@ const logFailedResults = (results: PromiseSettledResult<any>[]) => {
 };
 
 class ResponsePayload {
-  attendees: { email: string; noShow: boolean }[];
+  attendees: NoShowAttendees;
   noShowHost: boolean;
   message: string;
 
@@ -101,6 +105,8 @@ const handleMarkNoShow = async ({
 
       responsePayload.setAttendees(payload.attendees);
       responsePayload.setMessage(payload.message);
+
+      await handleSendingAttendeeNoShowDataToApps(bookingUid, attendees);
     }
 
     if (noShowHost) {

--- a/packages/features/noShow/handleSendingAttendeeNoShowDataToApps.ts
+++ b/packages/features/noShow/handleSendingAttendeeNoShowDataToApps.ts
@@ -1,0 +1,75 @@
+import type { z } from "zod";
+
+import type { eventTypeAppCardZod } from "@calcom/app-store/eventTypeAppCardZod";
+import CrmManager from "@calcom/core/crmManager/crmManager";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
+
+import type { NoShowAttendees } from "../handleMarkNoShow";
+import { noShowEnabledApps } from "./noShowEnabledApps";
+
+const log = logger.getSubLogger({ prefix: ["handleSendingNoShowDataToApps"] });
+
+export default async function handleSendingAttendeeNoShowDataToApps(
+  bookingUid: string,
+  attendees: NoShowAttendees
+) {
+  try {
+    // Get event type metadata
+    const eventTypeQuery = await prisma.booking.findFirst({
+      where: {
+        uid: bookingUid,
+      },
+      select: {
+        eventType: {
+          select: {
+            metadata: true,
+          },
+        },
+      },
+    });
+    if (!eventTypeQuery && !eventTypeQuery?.eventType?.metadata) {
+      log.warn(`For no show, could not find eventType for bookingUid ${bookingUid}`);
+      return;
+    }
+
+    const eventTypeMetadataParse = EventTypeMetaDataSchema.safeParse(eventTypeQuery?.eventType?.metadata);
+    if (!eventTypeMetadataParse.success) {
+      log.error(`Malformed event type metadata for bookingUid ${bookingUid}`);
+      return;
+    }
+    const eventTypeAppMetadata = eventTypeMetadataParse.data.apps;
+
+    for (const slug in eventTypeAppMetadata) {
+      if (noShowEnabledApps.includes(slug)) {
+        const app = eventTypeAppMetadata[slug];
+
+        const appCategory = app.appCategories[0];
+
+        if (appCategory === "crm") {
+          await handleCRMNoShow(bookingUid, app, attendees);
+        }
+      }
+    }
+
+    return;
+  } catch (e) {}
+}
+
+async function handleCRMNoShow(
+  bookingUid: string,
+  appData: z.infer<typeof eventTypeAppCardZod>,
+  attendees: NoShowAttendees
+) {
+  // Handle checking if no she in CrmService
+
+  const credential = await prisma.credential.findFirst({
+    where: {
+      id: appData.credentialId,
+    },
+  });
+
+  const crm = new CrmManager(credential, appData);
+  await crm.handleAttendeeNoShow(bookingUid, attendees);
+}

--- a/packages/features/noShow/noShowEnabledApps.ts
+++ b/packages/features/noShow/noShowEnabledApps.ts
@@ -1,0 +1,2 @@
+/** Slugs of apps that have the option to send no show data to */
+export const noShowEnabledApps = ["salesforce"];

--- a/packages/types/CrmService.d.ts
+++ b/packages/types/CrmService.d.ts
@@ -39,4 +39,8 @@ export interface CRM {
   }) => Promise<Contact[]>;
   createContacts: (contactsToCreate: ContactCreateInput[], organizerEmail?: string) => Promise<Contact[]>;
   getAppOptions: () => any;
+  handleAttendeeNoShow?: (
+    bookingUid: string,
+    attendees: { email: string; noShow: boolean }[]
+  ) => Promise<void>;
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR, allows users to send no show attendee data to a custom field in the Salesforce event object.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/909932ccdfe64114b952a368c0008084

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a no show custom field on the event object in Salesforce
	- The field should be a checkbox
- Enable the option in the event type and enter the no show field name
- Create a booking
- Set the attendee as a no-show
- The field should be set in Salesforce

