### PR TITLE
fix: no availability email frequency fix

### DIFF
--- a/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
+++ b/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
@@ -12,6 +12,7 @@ export type OrganizationAdminNoSlotsEmailInput = {
   slug: string;
   startTime: string;
   editLink: string;
+  teamSlug: string;
 };
 
 export const OrganizationAdminNoSlotsEmail = (
@@ -33,7 +34,7 @@ export const OrganizationAdminNoSlotsEmail = (
           <br />
           <br />
           Please note: It has been brought to our attention that {props.user} has not had any availability
-          when a user has visited {props.user}/{props.slug}
+          when a user has visited {props.teamSlug}/{props.slug}
           <br />
           <br />
           There’s a few reasons why this could be happening

--- a/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
+++ b/packages/emails/src/templates/OrganizationAdminNoSlots.tsx
@@ -11,6 +11,7 @@ export type OrganizationAdminNoSlotsEmailInput = {
   user: string;
   slug: string;
   startTime: string;
+  endTime: string;
   editLink: string;
   teamSlug: string;
 };
@@ -34,14 +35,19 @@ export const OrganizationAdminNoSlotsEmail = (
           <br />
           <br />
           Please note: It has been brought to our attention that {props.user} has not had any availability
-          when a user has visited {props.teamSlug}/{props.slug}
+          when a user has visited {props.teamSlug}/{props.slug}.
+          <br />
+          Start time: {props.startTime}
+          <br />
+          End time: {props.endTime}
           <br />
           <br />
-          There’s a few reasons why this could be happening
+          There’s a few reasons why this could be happening:
           <br />
-          The user does not have any calendars connected
-          <br />
-          Their schedules attached to this event are not enabled
+          <ul>
+            <li>The user does not have any calendars connected</li>
+            <li>Their schedules attached to this event are not enabled</li>
+          </ul>
         </Trans>
       </p>
       <div style={{ marginTop: "3rem", marginBottom: "0.75rem" }}>

--- a/packages/emails/templates/organization-admin-no-slots-email.ts
+++ b/packages/emails/templates/organization-admin-no-slots-email.ts
@@ -13,6 +13,8 @@ export type OrganizationAdminNoSlotsEmailInput = {
   user: string;
   slug: string;
   startTime: string;
+  endTime: string;
+  teamSlug: string;
   editLink: string;
 };
 
@@ -42,8 +44,8 @@ Hi Admins,
 It has been brought to our attention that ${this.adminNoSlots.user} has not had availability users have visited ${this.adminNoSlots.user}/${this.adminNoSlots.slug}.
 
 There’s a few reasons why this could be happening
-The user does not have any calendars connected
-Their schedules attached to this event are not enabled
+* The user does not have any calendars connected
+* Their schedules attached to this event are not enabled
 
 We recommend checking their availability to resolve this
     `;

--- a/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.test.ts
@@ -77,6 +77,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(), // Mocking Dayjs format function
+      endTime: dayjs().add(1, "hour"),
     };
     const orgDetails = {
       currentOrgDomain: "org1",
@@ -106,6 +107,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(), // Mocking Dayjs format function
+      endTime: dayjs().add(1, "hour"),
     };
     const orgDetails = {
       currentOrgDomain: "org1",
@@ -140,6 +142,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -193,6 +196,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -220,6 +224,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -251,6 +256,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -303,6 +309,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -359,6 +366,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
       username: "user1",
       eventSlug: "event1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {
@@ -419,6 +427,7 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
     const baseEventDetails = {
       username: "user1",
       startTime: dayjs(),
+      endTime: dayjs().add(1, "hour"),
     };
 
     const orgDetails = {

--- a/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.test.ts
@@ -117,4 +117,343 @@ describe("(Orgs) Send admin notifications when a user has no availability", () =
 
     expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).not.toHaveBeenCalled();
   });
+  it("Should only send notifications to admins of the specified teamId", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    // Mock finding team members - one from correct team, one from different team
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "correctteam@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    // Mock Redis to simulate second no-slots occurrence
+    mocked.lrange.mockResolvedValueOnce([""]); // This will trigger email sending
+
+    // Call with specific teamId
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123, // specific teamId
+    });
+
+    // Verify that membership query included correct teamId
+    expect(prismaMock.membership.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          team: expect.objectContaining({
+            id: 123,
+          }),
+        }),
+      })
+    );
+
+    // Verify email was sent only once (to the one correct team member)
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: {
+          email: "correctteam@test.com",
+        },
+      })
+    );
+  });
+
+  it("Should not send notifications when no teamId is provided", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      // teamId intentionally omitted
+    });
+
+    expect(prismaMock.membership.findMany).not.toHaveBeenCalled();
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).not.toHaveBeenCalled();
+  });
+
+  it("Should not send notifications when no orgDomain is provided", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: null, // No org domain
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    expect(prismaMock.team.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.membership.findMany).not.toHaveBeenCalled();
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).not.toHaveBeenCalled();
+  });
+
+  it("Should not send notifications when Redis environment variables are not set", async () => {
+    // Temporarily unset Redis env vars
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    expect(prismaMock.team.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.membership.findMany).not.toHaveBeenCalled();
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).not.toHaveBeenCalled();
+
+    // Restore env vars
+    process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+  });
+
+  it("Should handle multiple admins correctly", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    // Mock multiple team admins
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin1@test.com",
+          locale: "en",
+        },
+      },
+      {
+        user: {
+          email: "admin2@test.com",
+          locale: "fr",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    mocked.lrange.mockResolvedValueOnce([""]);
+
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    // Verify emails were sent to both admins
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(2);
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: {
+          email: "admin1@test.com",
+        },
+      })
+    );
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: {
+          email: "admin2@test.com",
+        },
+      })
+    );
+  });
+
+  it("Should not send duplicate notifications within NO_SLOTS_NOTIFICATION_FREQUENCY", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const eventDetails = {
+      username: "user1",
+      eventSlug: "event1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    // First notification cycle
+    mocked.lrange.mockResolvedValueOnce([""]); // Simulate one previous no-slots occurrence
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    // Verify first notification was sent
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+
+    // Reset call counts
+    vi.clearAllMocks();
+
+    // Simulate another notification attempt within the frequency window
+    mocked.lrange.mockResolvedValueOnce([""]); // Again simulate one previous occurrence
+    await handleNotificationWhenNoSlots({
+      eventDetails,
+      orgDetails,
+      teamId: 123,
+    });
+
+    // Verify no additional notifications were sent
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).not.toHaveBeenCalled();
+
+    // Verify Redis operations
+    expect(mocked.expire).toHaveBeenCalledWith(expect.any(String), expect.any(Number));
+    expect(mocked.lpush).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should maintain separate notification frequencies for different event types", async () => {
+    const redisService = new RedisService();
+    const mocked = vi.mocked(redisService);
+
+    prismaMock.team.findFirst.mockResolvedValue({
+      organizationSettings: {
+        adminGetsNoSlotsNotification: true,
+      },
+    });
+
+    prismaMock.membership.findMany.mockResolvedValue([
+      {
+        user: {
+          email: "admin@test.com",
+          locale: "en",
+        },
+      },
+    ]);
+
+    const baseEventDetails = {
+      username: "user1",
+      startTime: dayjs(),
+    };
+
+    const orgDetails = {
+      currentOrgDomain: "org1",
+      isValidOrgDomain: true,
+    };
+
+    // First event type notification
+    mocked.lrange.mockResolvedValueOnce([""]); // Simulate one previous no-slots occurrence
+    await handleNotificationWhenNoSlots({
+      eventDetails: { ...baseEventDetails, eventSlug: "event1" },
+      orgDetails,
+      teamId: 123,
+    });
+
+    // Verify first notification was sent
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+
+    // Reset call counts but keep Redis mock state
+    vi.clearAllMocks();
+
+    // Different event type should trigger its own notification
+    mocked.lrange.mockResolvedValueOnce([""]); // Simulate one previous no-slots occurrence
+    await handleNotificationWhenNoSlots({
+      eventDetails: { ...baseEventDetails, eventSlug: "event2" },
+      orgDetails,
+      teamId: 123,
+    });
+
+    // Verify second notification was sent (different event type)
+    expect(CalcomEmails.sendOrganizationAdminNoSlotsNotification).toHaveBeenCalledTimes(1);
+
+    // Verify Redis operations used different keys
+    const lpushCalls = mocked.lpush.mock.calls;
+    expect(lpushCalls.length).toBe(2);
+    expect(lpushCalls[0][0]).not.toBe(lpushCalls[1][0]); // Different Redis keys used
+  });
 });

--- a/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.ts
+++ b/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.ts
@@ -9,6 +9,7 @@ type EventDetails = {
   username: string;
   eventSlug: string;
   startTime: Dayjs;
+  endTime: Dayjs;
   visitorTimezone?: string;
   visitorUid?: string;
 };
@@ -129,7 +130,8 @@ export const handleNotificationWhenNoSlots = async ({
         },
         user: eventDetails.username,
         slug: eventDetails.eventSlug,
-        startTime: eventDetails.startTime.format("YYYY-MM"),
+        startTime: eventDetails.startTime.format("YYYY-MM-DD"),
+        endTime: eventDetails.endTime.format("YYYY-MM-DD"),
         // For now navigate here - when impersonation via parameter has been pushed we will impersonate and then navigate to availability
         editLink: `${WEBAPP_URL}/availability?type=team`,
         teamSlug: teamSlug?.slug ?? "",

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -846,6 +846,7 @@ async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<I
         eventDetails: {
           username: input.usernameList?.[0],
           startTime: startTime,
+          endTime: endTime,
           eventSlug: eventType.slug,
         },
         orgDetails,

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -849,6 +849,7 @@ async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<I
           eventSlug: eventType.slug,
         },
         orgDetails,
+        teamId: eventType.team?.id,
       });
     } catch (e) {
       loggerWithEventDetails.error(


### PR DESCRIPTION
## What does this PR do?

Fixing this without notification service because it was becoming more annoying for deel

Fixes the spam of emails to organization admins/owners for no availability on users. The issue was is they were getting notifications for everyone inside their organization rather than just the specific team. 


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Enable Redis by using the dev upstash credentials in upstash (see bitwarden)
Enable `adminGetsNoSlotsNotification` in settings/general for orgs
Create a RR event with no availability (or book out an entire month)
Navigate to that month once. Check emails
Navigate to that months twice. Check emails have only gone to team admins and not the entire organization admins/owners
Visit a third time and check emails - none will be sent. 

> [!TIP]
> Note: The TTL on the redis keys in dev are 60s so you have to be quick. You can change that value here `cal.com/packages/trpc/server/routers/viewer/slots/handleNotificationWhenNoSlots.ts:L21`



## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
