### PR TITLE
perf: Add more specific spans to getBusyTimes

### DIFF
--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -1,5 +1,6 @@
 import type { Booking, EventType } from "@prisma/client";
 import { Prisma } from "@prisma/client";
+import * as Sentry from "@sentry/nextjs";
 
 import { getBusyCalendarTimes } from "@calcom/core/CalendarManager";
 import dayjs from "@calcom/dayjs";


### PR DESCRIPTION
## What does this PR do?

Trying to track down where the time is going after 3rd party calendar calls finish.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.