### PR TITLE
fix: update profile photo logic in google cal integration

### DIFF
--- a/packages/app-store/googlecalendar/api/callback.ts
+++ b/packages/app-store/googlecalendar/api/callback.ts
@@ -191,13 +191,23 @@ async function updateProfilePhoto(oAuth2Client: Auth.OAuth2Client, userId: numbe
     const oauth2 = google.oauth2({ version: "v2", auth: oAuth2Client });
     const userDetails = await oauth2.userinfo.get();
     if (userDetails.data?.picture) {
-      // Using updateMany here since if the user already has a profile it would throw an error because no records were found to update the profile picture
-      await prisma.user.updateMany({
-        where: { id: userId, avatarUrl: null },
-        data: {
-          avatarUrl: userDetails.data.picture,
+      // Check if the user has no avatar
+      const user = await prisma.user.findFirst({
+        where: {
+          id: userId,
+          avatarUrl: null,
         },
+        select: { id: true },
       });
+
+      if (user) {
+        await prisma.user.update({
+          where: { id: userId },
+          data: {
+            avatarUrl: userDetails.data.picture,
+          },
+        });
+      }
     }
   } catch (error) {
     logger.error("Error updating avatarUrl from google calendar connect", error);


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- prisma in the logic throws this error 

<img width="906" alt="Screenshot 2024-11-01 at 14 04 10" src="https://github.com/user-attachments/assets/a4be0a79-1d4f-4dc8-a23c-769a1925b600">


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Remove your avatar and try integrating a google calendar. It should update the avatar but prior to this PR it wouldn't.
