### PR TITLE
feat: Display who a RR automatic reassign was routed too 

### DIFF
--- a/apps/web/components/dialog/ReassignDialog.tsx
+++ b/apps/web/components/dialog/ReassignDialog.tsx
@@ -106,10 +106,10 @@ export const ReassignDialog = ({ isOpenDialog, setIsOpenDialog, teamId, bookingI
   });
 
   const roundRobinReassignMutation = trpc.viewer.teams.roundRobinReassign.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       await utils.viewer.bookings.get.invalidate();
       setIsOpenDialog(false);
-      showToast(t("booking_reassigned"), "success");
+      showToast(t("booking_reassigned_to_host", { host: data?.reassignedTo.name }), "success");
     },
     onError: async (error) => {
       if (error.message.includes(ErrorCode.NoAvailableUsersFound)) {

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2736,5 +2736,6 @@
   "event_end_time_in_attendee_timezone_info": "Event End Time In Attendee Timezone",
   "salesforce_create_event_on_contact": "Create event on contact, if it exists. Else fallback to lead",
   "salesforce_owner_name_to_change": "Owner name to change",
+  "booking_reassigned_to_host": "Booking reassigned to {{host}}",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -519,6 +519,15 @@ export const roundRobinReassignment = async ({
       hideBranding: !!eventType?.owner?.hideBranding,
     });
   }
+
+  return {
+    bookingId,
+    reassignedTo: {
+      id: reassignedRRHost.id,
+      name: reassignedRRHost.name,
+      email: reassignedRRHost.email,
+    },
+  };
 };
 
 export default roundRobinReassignment;

--- a/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinReassign.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/roundRobin/roundRobinReassign.handler.ts
@@ -23,7 +23,7 @@ export const roundRobinReassignHandler = async ({ ctx, input }: RoundRobinReassi
     throw new TRPCError({ code: "FORBIDDEN", message: "You do not have permission" });
   }
 
-  await roundRobinReassignment({ bookingId, orgId: ctx.user.organizationId });
+  return await roundRobinReassignment({ bookingId, orgId: ctx.user.organizationId });
 };
 
 export default roundRobinReassignHandler;


### PR DESCRIPTION
## What does this PR do?

Fixes: CAL-4564


## How should this be tested?
1) Reassign Round Robin automatic
2) See toast

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
