### PR TITLE
fix: api/routing-forms/responses

### DIFF
--- a/packages/app-store/routing-forms/api/responses/[formId].ts
+++ b/packages/app-store/routing-forms/api/responses/[formId].ts
@@ -11,9 +11,6 @@ import { ensureStringOrStringArray, getLabelsFromOptionIds } from "../../lib/rep
 import type { FormResponse, SerializableForm } from "../../types/types";
 
 type Fields = NonNullable<SerializableForm<App_RoutingForms_Form>["fields"]>;
-function escapeCsvText(str: string) {
-  return str.replace(/,/, "%2C");
-}
 
 function getHumanReadableFieldResponseValue({
   field,
@@ -57,7 +54,7 @@ async function* getResponses(formId: string, fields: Fields) {
         const serializedValue = readableValues.map((value) => sanitizeValue(value)).join(" | ");
         csvCells.push(serializedValue);
       });
-      csvCells.push(sanitizeValue(response.createdAt.toISOString()));
+      csvCells.push(response.createdAt.toISOString());
       csv.push(csvCells.join(","));
     });
     skip += take;

--- a/packages/app-store/routing-forms/api/responses/[formId].ts
+++ b/packages/app-store/routing-forms/api/responses/[formId].ts
@@ -2,6 +2,7 @@ import type { App_RoutingForms_Form } from "@prisma/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getSession } from "next-auth/react";
 
+import { sanitizeValue } from "@calcom/lib/csvUtils";
 import { entityPrismaWhereClause, canEditEntity } from "@calcom/lib/entityPermissionUtils";
 import prisma from "@calcom/prisma";
 
@@ -52,12 +53,11 @@ async function* getResponses(formId: string, fields: Fields) {
       fields.forEach((field) => {
         const fieldResponse = fieldResponses[field.id];
         const value = fieldResponse?.value || "";
-        const serializedValue = getHumanReadableFieldResponseValue({ field, value })
-          .map((value) => escapeCsvText(value))
-          .join(" | ");
+        const readableValues = getHumanReadableFieldResponseValue({ field, value });
+        const serializedValue = readableValues.map((value) => sanitizeValue(value)).join(" | ");
         csvCells.push(serializedValue);
       });
-      csvCells.push(response.createdAt.toISOString());
+      csvCells.push(sanitizeValue(response.createdAt.toISOString()));
       csv.push(csvCells.join(","));
     });
     skip += take;

--- a/packages/app-store/routing-forms/components/SingleForm.tsx
+++ b/packages/app-store/routing-forms/components/SingleForm.tsx
@@ -98,7 +98,7 @@ const Actions = ({
           tooltip={t("copy_link_to_form")}
         />
 
-        <Tooltip content="Download Responses">
+        <Tooltip content={t("download_responses")}>
           <FormAction
             data-testid="download-responses"
             routingForm={form}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Wrong csv file was being generated.

## Original
<img width="1353" alt="Screenshot 2024-11-04 at 13 22 48" src="https://github.com/user-attachments/assets/30369b40-6073-4f2b-9272-13ef4968ff2b">

## Before fix
<img width="1190" alt="Screenshot 2024-11-04 at 13 23 46" src="https://github.com/user-attachments/assets/43d2fe22-8637-4c65-b754-5954497d30ef">

## After fix
<img width="1179" alt="Screenshot 2024-11-04 at 13 23 01" src="https://github.com/user-attachments/assets/6c4ce7ed-8803-4471-be30-ed723cdfd358">


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Go to routing forms and press "Download responses"
<img width="1164" alt="Screenshot 2024-11-04 at 13 04 25" src="https://github.com/user-attachments/assets/8624340f-1c02-4512-a5d9-6627caf62d1c">
