### PR TITLE
fix: event-type atom tabs controlled by prop

### DIFF
--- a/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
@@ -96,7 +96,7 @@ export const usePlatformTabsNavigations = ({ formMethods, eventType, team, tabs 
       });
 
     // If there is a team put this navigation item within the tabs
-    if (team && tabs.includes("assignment")) {
+    if (team && tabs.includes("team")) {
       navigation.splice(2, 0, {
         name: "assignment",
         onClick: () => setCurrentTab("team"),

--- a/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
@@ -63,7 +63,7 @@ export const usePlatformTabsNavigations = ({ formMethods, eventType, team, tabs 
       currentTab,
     });
 
-    if (!requirePayment) {
+    if (!requirePayment && tabs.includes("recurring")) {
       navigation.splice(3, 0, {
         name: "recurring",
         onClick: () => setCurrentTab("recurring"),
@@ -74,28 +74,29 @@ export const usePlatformTabsNavigations = ({ formMethods, eventType, team, tabs 
       });
     }
 
-    navigation.splice(1, 0, {
-      name: "availability",
-      onClick: () => setCurrentTab("availability"),
-      isActive: currentTab === "availability",
-      href: `${url}?tabName=availability`,
-      icon: "calendar",
-      info:
-        isManagedEventType || isChildrenManagedEventType
-          ? formMethods.getValues("schedule") === null
-            ? "members_default_schedule"
-            : isChildrenManagedEventType
-            ? `${
-                formMethods.getValues("scheduleName")
-                  ? `${formMethods.getValues("scheduleName")} - ${t("managed")}`
-                  : `default_schedule_name`
-              }`
-            : formMethods.getValues("scheduleName") ?? `default_schedule_name`
-          : formMethods.getValues("scheduleName") ?? `default_schedule_name`,
-    });
+    tabs.includes("availability") &&
+      navigation.splice(1, 0, {
+        name: "availability",
+        onClick: () => setCurrentTab("availability"),
+        isActive: currentTab === "availability",
+        href: `${url}?tabName=availability`,
+        icon: "calendar",
+        info:
+          isManagedEventType || isChildrenManagedEventType
+            ? formMethods.getValues("schedule") === null
+              ? "members_default_schedule"
+              : isChildrenManagedEventType
+              ? `${
+                  formMethods.getValues("scheduleName")
+                    ? `${formMethods.getValues("scheduleName")} - ${t("managed")}`
+                    : `default_schedule_name`
+                }`
+              : formMethods.getValues("scheduleName") ?? `default_schedule_name`
+            : formMethods.getValues("scheduleName") ?? `default_schedule_name`,
+      });
 
     // If there is a team put this navigation item within the tabs
-    if (team) {
+    if (team && tabs.includes("assignment")) {
       navigation.splice(2, 0, {
         name: "assignment",
         onClick: () => setCurrentTab("team"),


### PR DESCRIPTION
## What does this PR do?

Fix tabs not being controller by event-type atom tabs prop

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

event-type atom with tabs props