### PR TITLE
perf: Allow bypassing 3rd party calendar busy times

### DIFF
--- a/apps/api/v1/pages/api/availability/_get.ts
+++ b/apps/api/v1/pages/api/availability/_get.ts
@@ -199,6 +199,7 @@ async function handler(req: NextApiRequest) {
       eventTypeId,
       userId,
       returnDateOverrides: true,
+      bypassBusyCalendarTimes: false,
     });
   const team = await prisma.team.findUnique({
     where: { id: teamId },

--- a/apps/api/v1/pages/api/availability/_get.ts
+++ b/apps/api/v1/pages/api/availability/_get.ts
@@ -236,6 +236,7 @@ async function handler(req: NextApiRequest) {
         dateTo,
         eventTypeId,
         returnDateOverrides: true,
+        bypassBusyCalendarTimes: false,
       }),
     };
   });

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -43,6 +43,7 @@ export async function getBusyTimes(params: {
         };
       })[]
     | null;
+  bypassBusyCalendarTimes: boolean;
 }) {
   const {
     credentials,
@@ -58,6 +59,7 @@ export async function getBusyTimes(params: {
     seatedEvent,
     rescheduleUid,
     duration,
+    bypassBusyCalendarTimes = false,
   } = params;
 
   logger.silly(
@@ -234,7 +236,7 @@ export async function getBusyTimes(params: {
   );
   performance.mark("prismaBookingGetEnd");
   performance.measure(`prisma booking get took $1'`, "prismaBookingGetStart", "prismaBookingGetEnd");
-  if (credentials?.length > 0) {
+  if (credentials?.length > 0 && !bypassBusyCalendarTimes) {
     const startConnectedCalendarsGet = performance.now();
     const calendarBusyTimes = await getBusyCalendarTimes(
       username,

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -44,6 +44,7 @@ const availabilitySchema = z
     duration: z.number().optional(),
     withSource: z.boolean().optional(),
     returnDateOverrides: z.boolean(),
+    bypassBusyCalendarTimes: z.boolean().optional(),
   })
   .refine((data) => !!data.username || !!data.userId, "Either username or userId should be filled in.");
 
@@ -243,6 +244,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     beforeEventBuffer?: number;
     duration?: number;
     returnDateOverrides: boolean;
+    bypassBusyCalendarTimes: boolean;
   },
   initialData?: {
     user?: GetUser;
@@ -276,6 +278,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     beforeEventBuffer,
     duration,
     returnDateOverrides,
+    bypassBusyCalendarTimes = false,
   } = availabilitySchema.parse(query);
 
   if (!dateFrom.isValid() || !dateTo.isValid()) {
@@ -389,6 +392,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     rescheduleUid: initialData?.rescheduleUid || null,
     duration,
     currentBookings: initialData?.currentBookings,
+    bypassBusyCalendarTimes,
   });
 
   const detailedBusyTimes: EventBusyDetails[] = [

--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -89,6 +89,7 @@ export async function ensureAvailableUsers(
       dateTo: endDateTimeUtc.format(),
       beforeEventBuffer: eventType.beforeEventBuffer,
       afterEventBuffer: eventType.afterEventBuffer,
+      bypassBusyCalendarTimes: false,
     },
     initialData: {
       eventType,

--- a/packages/trpc/server/routers/viewer/availability/user.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/user.handler.ts
@@ -11,5 +11,8 @@ type UserOptions = {
 };
 
 export const userHandler = async ({ input }: UserOptions) => {
-  return getUserAvailability({ returnDateOverrides: true, ...input }, undefined);
+  return getUserAvailability(
+    { returnDateOverrides: true, bypassBusyCalendarTimes: false, ...input },
+    undefined
+  );
 };

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -28,6 +28,7 @@ export const getScheduleSchema = z
     routedTeamMemberIds: z.array(z.number()).nullish(),
     skipContactOwner: z.boolean().nullish(),
     _enableTroubleshooter: z.boolean().optional(),
+    _bypassCalendarBusyTimes: z.boolean().optional(),
   })
   .transform((val) => {
     // Need this so we can pass a single username in the query string form public API

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -406,7 +406,10 @@ export const getAvailableSlots = async (
 };
 
 async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<IGetAvailableSlots> {
-  const { _enableTroubleshooter: enableTroubleshooter = false } = input;
+  const {
+    _enableTroubleshooter: enableTroubleshooter = false,
+    _bypassCalendarBusyTimes: bypassBusyCalendarTimes = false,
+  } = input;
   const orgDetails = input?.orgSlug
     ? {
         currentOrgDomain: input.orgSlug,
@@ -598,6 +601,7 @@ async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<I
       beforeEventBuffer: eventType.beforeEventBuffer,
       duration: input.duration || 0,
       returnDateOverrides: false,
+      bypassBusyCalendarTimes,
     },
     initialData: {
       eventType,

--- a/packages/trpc/server/routers/viewer/teams/getMemberAvailability.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/getMemberAvailability.handler.ts
@@ -46,6 +46,7 @@ export const getMemberAvailabilityHandler = async ({ ctx, input }: GetMemberAvai
       dateFrom: input.dateFrom,
       dateTo: input.dateTo,
       returnDateOverrides: true,
+      bypassBusyCalendarTimes: false,
     },
     { user: member.user, busyTimesFromLimitsBookings: [] }
   );


### PR DESCRIPTION
## What does this PR do?

To help with debugging perf, we can skip the calls to 3rd party calendars.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

