### PR TITLE
fix: missing responsive design in org members page

### DIFF
--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -475,38 +475,46 @@ export function UserListTable() {
         isPending={isPending}
         onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}>
         <DataTableToolbar.Root className="lg:max-w-screen-2xl">
-          <div className="flex w-full gap-2">
-            <DataTableToolbar.SearchBar table={table} onSearch={(value) => setDebouncedSearchTerm(value)} />
-            <DataTableToolbar.CTA
-              type="button"
-              color="secondary"
-              StartIcon="file-down"
-              loading={isDownloading}
-              onClick={() => handleDownload()}
-              data-testid="export-members-button">
-              {t("download")}
-            </DataTableToolbar.CTA>
-            {/* We have to omit member because we don't want the filter to show but we can't disable filtering as we need that for the search bar */}
-            <DataTableFilters.FilterButton table={table} omit={["member"]} />
-            <DataTableFilters.ColumnVisibilityButton table={table} />
-            {adminOrOwner && (
+          <div className="flex w-full flex-col gap-2 sm:flex-row">
+            <div className="w-full sm:w-auto sm:min-w-[200px] sm:flex-1">
+              <DataTableToolbar.SearchBar
+                table={table}
+                onSearch={(value) => setDebouncedSearchTerm(value)}
+                className="sm:max-w-64 max-w-full"
+              />
+            </div>
+            <div className="flex flex-nowrap items-center gap-2 md:flex-wrap">
               <DataTableToolbar.CTA
                 type="button"
-                color="primary"
-                StartIcon="plus"
-                className="rounded-md"
-                onClick={() =>
-                  dispatch({
-                    type: "INVITE_MEMBER",
-                    payload: {
-                      showModal: true,
-                    },
-                  })
-                }
-                data-testid="new-organization-member-button">
-                {t("add")}
+                color="secondary"
+                StartIcon="file-down"
+                loading={isDownloading}
+                onClick={() => handleDownload()}
+                data-testid="export-members-button">
+                {t("download")}
               </DataTableToolbar.CTA>
-            )}
+              {/* We have to omit member because we don't want the filter to show but we can't disable filtering as we need that for the search bar */}
+              <DataTableFilters.FilterButton table={table} omit={["member"]} />
+              <DataTableFilters.ColumnVisibilityButton table={table} />
+              {adminOrOwner && (
+                <DataTableToolbar.CTA
+                  type="button"
+                  color="primary"
+                  StartIcon="plus"
+                  className="rounded-md"
+                  onClick={() =>
+                    dispatch({
+                      type: "INVITE_MEMBER",
+                      payload: {
+                        showModal: true,
+                      },
+                    })
+                  }
+                  data-testid="new-organization-member-button">
+                  {t("add")}
+                </DataTableToolbar.CTA>
+              )}
+            </div>
           </div>
           <div className="flex gap-2 justify-self-start">
             <DataTableFilters.ActiveFilters table={table} />

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -483,7 +483,7 @@ export function UserListTable() {
                 className="sm:max-w-64 max-w-full"
               />
             </div>
-            <div className="flex flex-nowrap items-center gap-2 md:flex-wrap">
+            <div className="flex flex-wrap items-center gap-2">
               <DataTableToolbar.CTA
                 type="button"
                 color="secondary"

--- a/packages/ui/components/data-table/DataTableToolbar.tsx
+++ b/packages/ui/components/data-table/DataTableToolbar.tsx
@@ -34,10 +34,11 @@ interface SearchBarProps<TData> {
   table: Table<TData>;
   searchKey?: string;
   onSearch?: (value: string) => void;
+  className?: string;
 }
 
 function SearchBarComponent<TData>(
-  { table, searchKey, onSearch }: SearchBarProps<TData>,
+  { table, searchKey, onSearch, className }: SearchBarProps<TData>,
   ref: React.Ref<HTMLInputElement>
 ) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -51,7 +52,7 @@ function SearchBarComponent<TData>(
     return (
       <Input
         ref={ref}
-        className="max-w-64 mb-0 mr-auto rounded-md"
+        className={`max-w-64 mb-0 mr-auto rounded-md ${className ?? ""}`}
         placeholder="Search"
         value={searchTerm}
         onChange={(event) => setSearchTerm(event.target.value.trim())}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- the new download button smashes the search bar tiny

**Before**
<img width="501" alt="before" src="https://github.com/user-attachments/assets/36c31eb3-6634-44ad-a25c-520533be9783">

**After**
https://github.com/user-attachments/assets/8a7fa6d3-1f85-49b1-aa8d-79d9991b7e7b



<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to settings/organizations/members