### PR TITLE
fix: do not send email/SMS if rescheduling to same slot

### DIFF
--- a/apps/web/components/dialog/RerouteDialog.tsx
+++ b/apps/web/components/dialog/RerouteDialog.tsx
@@ -467,6 +467,7 @@ const NewRoutingManager = ({
     // TODO: Long term, we should refactor handleNewBooking and use a different route specific for this purpose,
     createBookingMutation.mutate({
       rescheduleUid: booking.uid,
+      isRerouteToSameTimeslot: true,
       // rescheduleReason,
       reroutingFormResponses: reroutingFormResponses,
       ...getTimeslotFields(),

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1164,7 +1164,7 @@ async function handler(
     }
 
     evt.appsStatus = handleAppsStatus(results, booking, reqAppsStatus);
-    console.log("reschedulingToSameSlot", noEmail);
+
     if (noEmail !== true && isConfirmedByDefault) {
       const copyEvent = cloneDeep(evt);
       const copyEventAdditionalInfo = {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -338,11 +338,6 @@ async function handler(
     ? await getOriginalRescheduledBooking(rescheduleUid, !!eventType.seatsPerTimeSlot)
     : null;
 
-  const reschedulingToSameSlot = originalRescheduledBooking
-    ? new Date(reqBody.start).getTime() === new Date(originalRescheduledBooking.startTime).getTime() &&
-      eventTypeId === originalRescheduledBooking.eventTypeId
-    : false;
-
   let luckyUserResponse;
   let isFirstSeat = true;
 
@@ -1230,7 +1225,7 @@ async function handler(
             matchOriginalMemberWithNewMember(orignalMember, member)
           )
         );
-        if (!reschedulingToSameSlot) {
+        if (!reqBody.isRerouteToSameTimeslot) {
           sendRoundRobinRescheduledEmailsAndSMS(
             copyEventAdditionalInfo,
             rescheduledMembers,
@@ -1243,7 +1238,7 @@ async function handler(
           eventTypeMetadata: eventType.metadata,
         });
         sendRoundRobinCancelledEmailsAndSMS(copyEventAdditionalInfo, cancelledMembers, eventType.metadata);
-      } else if (!reschedulingToSameSlot) {
+      } else if (!reqBody.isRerouteToSameTimeslot) {
         // send normal rescheduled emails (non round robin event, where organizers stay the same)
         await sendRescheduledEmailsAndSMS(
           {

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -253,6 +253,7 @@ export const bookingCreateBodySchema = z.object({
   routedTeamMemberIds: z.array(z.number()).nullish(),
   routingFormResponseId: z.number().optional(),
   skipContactOwner: z.boolean().optional(),
+  isRerouteToSameTimeslot: z.boolean().optional(),
 
   /**
    * Holds the corrected responses of the Form for a booking, provided during rerouting


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes CAL-4621
- Currently, we send a rescheduling email to the attendee when rerouting to the same timeslot. That’s confusing because the time stays the same.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
