### PR TITLE
fix: saml does not add future members to eventtype

### DIFF
--- a/packages/features/auth/signup/utils/createOrUpdateMemberships.ts
+++ b/packages/features/auth/signup/utils/createOrUpdateMemberships.ts
@@ -12,7 +12,7 @@ export const createOrUpdateMemberships = async ({
 }: {
   user: Pick<User, "id">;
   team: Pick<Team, "id" | "parentId" | "isOrganization"> & {
-    organizationSettings: OrganizationSettings | null;
+    organizationSettings?: Pick<OrganizationSettings, "orgAutoAcceptEmail"> | null;
   };
 }) => {
   return await prisma.$transaction(async (tx) => {

--- a/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
+++ b/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
@@ -1,8 +1,7 @@
-import { ProfileRepository } from "@calcom/lib/server/repository/profile";
+import { createOrUpdateMemberships } from "@calcom/features/auth/signup/utils/createOrUpdateMemberships";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import type { IdentityProvider } from "@calcom/prisma/enums";
-import { MembershipRole } from "@calcom/prisma/enums";
 
 import dSyncUserSelect from "./dSyncUserSelect";
 
@@ -50,24 +49,16 @@ const createUsersAndConnectToOrg = async (
     },
     select: dSyncUserSelect,
   });
-
-  await prisma.membership.createMany({
-    data: users.map((user) => ({
-      accepted: true,
-      userId: user.id,
-      teamId: organizationId,
-      role: MembershipRole.MEMBER,
-    })),
-  });
-
-  await prisma.profile.createMany({
-    data: users.map((user) => ({
-      uid: ProfileRepository.generateProfileUid(),
-      userId: user.id,
-      // The username is already set when creating the user
-      username: user.username!,
-      organizationId,
-    })),
+  // assign created users to organization.
+  users.forEach(async (user) => {
+    await createOrUpdateMemberships({
+      user,
+      team: {
+        id: organizationId,
+        isOrganization: true,
+        parentId: null, // orgs don't have a parentId
+      },
+    });
   });
 
   return users;

--- a/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
+++ b/packages/features/ee/dsync/lib/users/createUsersAndConnectToOrg.ts
@@ -49,8 +49,8 @@ const createUsersAndConnectToOrg = async (
     },
     select: dSyncUserSelect,
   });
-  // assign created users to organization.
-  users.forEach(async (user) => {
+  // Assign created users to organization
+  for (const user of users) {
     await createOrUpdateMemberships({
       user,
       team: {
@@ -59,8 +59,7 @@ const createUsersAndConnectToOrg = async (
         parentId: null, // orgs don't have a parentId
       },
     });
-  });
-
+  }
   return users;
 };
 


### PR DESCRIPTION
## What does this PR do?

* Makes typings for createOrUpdateMemberships more precise.
* replace createMany profile/membership with the createOrUpdateMemberships function.