### PR TITLE
fixes #17536 : When expanding Reason for rejecting text box button doesn't move and obscures the box 

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -487,20 +487,23 @@ function BookingListItem(booking: BookingItemProps) {
               }
               value={rejectionReason}
               onChange={(e) => setRejectionReason(e.target.value)}
+              className="max-h-96"
             />
           </div>
 
-          <DialogFooter>
-            <DialogClose />
-            <Button
-              disabled={mutation.isPending}
-              data-testid="rejection-confirm"
-              onClick={() => {
-                bookingConfirm(false);
-              }}>
-              {t("rejection_confirmation")}
-            </Button>
-          </DialogFooter>
+          <div>
+            <DialogFooter>
+              <DialogClose />
+              <Button
+                disabled={mutation.isPending}
+                data-testid="rejection-confirm"
+                onClick={() => {
+                  bookingConfirm(false);
+                }}>
+                {t("rejection_confirmation")}
+              </Button>
+            </DialogFooter>
+          </div>
         </DialogContent>
       </Dialog>
       <tr data-testid="booking-item" className="hover:bg-muted group flex flex-col transition sm:flex-row">


### PR DESCRIPTION
## What does this PR do?

This PR fixes the position of the buttons when expanding the text box.

- Fixes #17536 (GitHub issue number)

Video showing the final result:

https://github.com/user-attachments/assets/0fb8497e-19d6-4d8f-b8ef-8b3975f63427


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.