### PR TITLE
fix: apiv2 updateNewTeamMemberEventTypes silently

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "dev:build:watch": "yarn workspace @calcom/platform-constants build:watch & yarn workspace @calcom/platform-utils build:watch & yarn workspace @calcom/platform-types build:watch",
     "dev:build": "yarn workspace @calcom/platform-constants build && yarn workspace @calcom/platform-enums build && yarn workspace @calcom/platform-utils build && yarn workspace @calcom/platform-types build ",
-    "dev": "yarn dev:build && docker-compose up -d && yarn copy-swagger-module && yarn start --watch",
+    "dev": "yarn dev:build && docker compose up -d && yarn copy-swagger-module && yarn start --watch",
     "dev:no-docker": "yarn dev:build && yarn copy-swagger-module && yarn start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node ./dist/apps/api/v2/src/main.js",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "dev:build:watch": "yarn workspace @calcom/platform-constants build:watch & yarn workspace @calcom/platform-utils build:watch & yarn workspace @calcom/platform-types build:watch",
     "dev:build": "yarn workspace @calcom/platform-constants build && yarn workspace @calcom/platform-enums build && yarn workspace @calcom/platform-utils build && yarn workspace @calcom/platform-types build ",
-    "dev": "yarn dev:build && docker compose up -d && yarn copy-swagger-module && yarn start --watch",
+    "dev": "yarn dev:build && docker-compose up -d && yarn copy-swagger-module && yarn start --watch",
     "dev:no-docker": "yarn dev:build && yarn copy-swagger-module && yarn start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node ./dist/apps/api/v2/src/main.js",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.57",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.58",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",

--- a/apps/api/v2/src/modules/organizations/controllers/teams/memberships/organizations-teams-memberships.controller.ts
+++ b/apps/api/v2/src/modules/organizations/controllers/teams/memberships/organizations-teams-memberships.controller.ts
@@ -31,6 +31,7 @@ import {
   HttpStatus,
   HttpCode,
   UnprocessableEntityException,
+  Logger,
 } from "@nestjs/common";
 import { ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
@@ -46,6 +47,8 @@ import { SkipTakePagination } from "@calcom/platform-types";
 @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
 @DocsTags("Orgs / Teams / Memberships")
 export class OrganizationsTeamsMembershipsController {
+  private logger = new Logger("OrganizationsTeamsMembershipsController");
+
   constructor(
     private organizationsTeamsMembershipsService: OrganizationsTeamsMembershipsService,
     private oganizationsEventTypesService: OrganizationsEventTypesService,
@@ -148,7 +151,11 @@ export class OrganizationsTeamsMembershipsController {
     );
 
     if (!currentMembership.accepted && updatedMembership.accepted) {
-      await updateNewTeamMemberEventTypes(updatedMembership.userId, teamId);
+      try {
+        await updateNewTeamMemberEventTypes(updatedMembership.userId, teamId);
+      } catch (err) {
+        this.logger.error("Could not update new team member eventTypes", err);
+      }
     }
 
     return {
@@ -175,7 +182,11 @@ export class OrganizationsTeamsMembershipsController {
 
     const membership = await this.organizationsTeamsMembershipsService.createOrgTeamMembership(teamId, data);
     if (membership.accepted) {
-      await updateNewTeamMemberEventTypes(user.id, teamId);
+      try {
+        await updateNewTeamMemberEventTypes(user.id, teamId);
+      } catch (err) {
+        this.logger.error("Could not update new team member eventTypes", err);
+      }
     }
     return {
       status: SUCCESS_STATUS,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Quick fix to avoid crashing organization team membership apiv2 endpoint when trying to update new team member event-types if one of the event-type is invalid

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

