### PR TITLE
fix: split firstname lastname support, phone support & timezone specific startTime in success redirect params

### DIFF
--- a/packages/lib/bookingSuccessRedirect.ts
+++ b/packages/lib/bookingSuccessRedirect.ts
@@ -76,8 +76,17 @@ export const getBookingRedirectExtraParams = (booking: SuccessRedirectBookingTyp
   ];
 
   // Helper function to extract response details (e.g., phone, attendee's first and last name)
-  function extractResponseDetails(booking: BookingResponseType, obj: ResultType): ResultType {
-    const responses = { ...obj };
+  function extractResponseDetails(booking, obj: ResultType): ResultType {
+    type Responses = {
+      phone?: string;
+      name:
+        | {
+            firstName: string;
+            lastName: string;
+          }
+        | string;
+    };
+    const responses = { ...obj } as unknown as Responses;
     if (booking.responses?.phone) responses.phone = booking.responses.phone;
     if (booking.responses?.name?.firstName) responses.attendeeFirstName = booking.responses.name.firstName;
     if (booking.responses?.name?.lastName) responses.attendeeLastName = booking.responses.name.lastName;
@@ -85,7 +94,7 @@ export const getBookingRedirectExtraParams = (booking: SuccessRedirectBookingTyp
   }
 
   // Helper function to extract user details (e.g., host name and time zone)
-  function extractUserDetails(booking: BookingResponseType, obj: ResultType): ResultType {
+  function extractUserDetails(booking, obj: ResultType): ResultType {
     if (booking.user?.name) {
       const hostStartTime = dayjs(booking.startTime).tz(booking.user.timeZone).format();
       return {
@@ -98,7 +107,7 @@ export const getBookingRedirectExtraParams = (booking: SuccessRedirectBookingTyp
   }
 
   // Helper function to extract attendee and guest details
-  function extractAttendeesAndGuests(booking: BookingResponseType, obj: ResultType): ResultType {
+  function extractAttendeesAndGuests(booking, obj: ResultType): ResultType {
     if (!Array.isArray(booking.attendees) || booking.attendees.length === 0) return obj;
 
     const attendeeName = booking.attendees[0]?.name || null;

--- a/packages/prisma/selects/payment.ts
+++ b/packages/prisma/selects/payment.ts
@@ -18,15 +18,18 @@ export const paymentDataSelect = Prisma.validator<Prisma.PaymentSelect>()({
       title: true,
       startTime: true,
       endTime: true,
+      responses: true,
       user: {
         select: {
           name: true,
+          timeZone: true,
         },
       },
       attendees: {
         select: {
           email: true,
           name: true,
+          timeZone: true,
         },
       },
       eventTypeId: true,


### PR DESCRIPTION
## What does this PR do?

Adds support for the following to success redirect params:
- Firstname - Lastname split
- phone
- timezone specific startTime for host
- timezone specific startTime for primary attendee/booker

- Fixes CAL-4699 (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
