### PR TITLE
fix: update current cursor

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
@@ -55,7 +55,7 @@ export const getEventTypesFromGroup = async ({
     const filteredBatch = await filterEventTypes(batch.eventTypes, ctx.user.id, shouldListUserEvents, teamId);
     eventTypes.push(...filteredBatch);
     paginationCursor = batch.nextCursor;
-    hasMoreResults = batch.nextCursor !== undefined;
+    hasMoreResults = !!batch.nextCursor;
   };
 
   while (eventTypes.length < limit && (hasMoreResults || isFirstFetch)) {

--- a/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
@@ -46,26 +46,26 @@ export const getEventTypesFromGroup = async ({
     !isFilterSet || isUpIdInFilter || (isFilterSet && filters?.upIds && !isUpIdInFilter);
 
   const eventTypes: MappedEventType[] = [];
-  let currentCursor = cursor;
-  let nextCursor: number | null | undefined = undefined;
-  let isFetchingForFirstTime = true;
+  let paginationCursor = cursor;
+  let hasMoreResults = true;
+  let isFirstFetch = true;
 
   const fetchAndFilterEventTypes = async () => {
-    const batch = await fetchEventTypesBatch(ctx, input, shouldListUserEvents, currentCursor, searchQuery);
+    const batch = await fetchEventTypesBatch(ctx, input, shouldListUserEvents, paginationCursor, searchQuery);
     const filteredBatch = await filterEventTypes(batch.eventTypes, ctx.user.id, shouldListUserEvents, teamId);
     eventTypes.push(...filteredBatch);
-    currentCursor = batch.nextCursor;
-    nextCursor = batch.nextCursor;
+    paginationCursor = batch.nextCursor;
+    hasMoreResults = batch.nextCursor !== undefined;
   };
 
-  while (eventTypes.length < limit && (nextCursor || isFetchingForFirstTime)) {
+  while (eventTypes.length < limit && (hasMoreResults || isFirstFetch)) {
     await fetchAndFilterEventTypes();
-    isFetchingForFirstTime = false;
+    isFirstFetch = false;
   }
 
   return {
     eventTypes,
-    nextCursor: nextCursor ?? undefined,
+    nextCursor: paginationCursor ?? undefined,
   };
 };
 

--- a/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
@@ -46,7 +46,7 @@ export const getEventTypesFromGroup = async ({
     !isFilterSet || isUpIdInFilter || (isFilterSet && filters?.upIds && !isUpIdInFilter);
 
   const eventTypes: MappedEventType[] = [];
-  const currentCursor = cursor;
+  let currentCursor = cursor;
   let nextCursor: number | null | undefined = undefined;
   let isFetchingForFirstTime = true;
 
@@ -54,6 +54,7 @@ export const getEventTypesFromGroup = async ({
     const batch = await fetchEventTypesBatch(ctx, input, shouldListUserEvents, currentCursor, searchQuery);
     const filteredBatch = await filterEventTypes(batch.eventTypes, ctx.user.id, shouldListUserEvents, teamId);
     eventTypes.push(...filteredBatch);
+    currentCursor = batch.nextCursor;
     nextCursor = batch.nextCursor;
   };
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Some users seeing duplicate event types

Reason:- 

- When fetchAndFilterEventTypes() function return event types < 10 and more event types exists we fetch the next batch but current cursor wasn't updated so it was fetching the same set of event types

BEFORE:-


https://github.com/user-attachments/assets/95a56e1c-3562-4dbb-b207-5368fc5d26c9



AFTER:- 

https://github.com/user-attachments/assets/8bdf3403-dfee-49bb-90af-a0a8fa847168



<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Create more than 10 managed event types

