### PR TITLE
feat: Salesforce when create contacts under an account if creating leads is chosen [CAL-4713]

### DIFF
--- a/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
@@ -93,6 +93,20 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
     value: "",
   });
 
+  // Used when creating events under leads or contacts under account
+  const CreateContactUnderAccount = () => {
+    return (
+      <Switch
+        label={t("salesforce_create_new_contact_under_account")}
+        labelOnLeading
+        checked={createNewContactUnderAccount}
+        onCheckedChange={(checked) => {
+          setAppData("createNewContactUnderAccount", checked);
+        }}
+      />
+    );
+  };
+
   return (
     <AppCard
       returnTo={`${WEBAPP_URL}${pathname}?tabName=apps`}
@@ -142,19 +156,15 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
                 setAppData("createEventOnLeadCheckForContact", checked);
               }}
             />
+            <div className="mt-4">
+              <CreateContactUnderAccount />
+            </div>
           </div>
         ) : null}
         {createEventOnSelectedOption.value === SalesforceRecordEnum.ACCOUNT ? (
           <>
             <div className="mb-4">
-              <Switch
-                label={t("salesforce_create_new_contact_under_account")}
-                labelOnLeading
-                checked={createNewContactUnderAccount}
-                onCheckedChange={(checked) => {
-                  setAppData("createNewContactUnderAccount", checked);
-                }}
-              />
+              <CreateContactUnderAccount />
             </div>
             <div>
               <Switch

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -400,32 +400,53 @@ export default class SalesforceCRMService implements CRM {
       : [];
   }
 
-  async createContacts(contactsToCreate: { email: string; name: string }[], organizerEmail?: string) {
+  async createContacts(contactsToCreate: Attendee[], organizerEmail?: string) {
     const conn = await this.conn;
     const appOptions = this.getAppOptions();
     const createEventOn = appOptions.createEventOn ?? SalesforceRecordEnum.CONTACT;
+    // See if the organizer exists in the CRM
     const organizerId = organizerEmail ? await this.getSalesforceUserIdFromEmail(organizerEmail) : undefined;
     const createdContacts: { id: string; email: string }[] = [];
 
-    if (createEventOn === SalesforceRecordEnum.CONTACT || createEventOn === SalesforceRecordEnum.LEAD) {
-      // See if the organizer exists in the CRM
+    if (createEventOn === SalesforceRecordEnum.CONTACT) {
       await Promise.all(
         contactsToCreate.map(async (attendee) => {
-          return await conn
-            .sobject(createEventOn)
-            .create(
-              this.generateCreateRecordBody({
-                attendee,
-                recordType: createEventOn,
-                organizerId,
-              })
-            )
-            .then((result) => {
-              if (result.success) {
-                createdContacts.push({ id: result.id, email: attendee.email });
-              }
-            });
+          return await this.createAttendeeRecord({
+            attendee,
+            recordType: SalesforceRecordEnum.CONTACT,
+            organizerId,
+          }).then((result) => {
+            createdContacts.push(...result);
+          });
         })
+      );
+    }
+
+    if (createEventOn === SalesforceRecordEnum.LEAD) {
+      // Base this off of the first contact
+      const attendee = contactsToCreate[0];
+
+      if (appOptions.createNewContactUnderAccount) {
+        // Check for an account
+        const accountId = await this.getAccountIdBasedOnEmailDomainOfContacts(attendee.email);
+
+        if (accountId) {
+          const createdAccountContacts = await this.createNewContactUnderAnAccount({
+            attendee,
+            accountId,
+            organizerId,
+          });
+
+          if (createdContacts.length > 0) {
+            createdContacts.push(...createdAccountContacts);
+          }
+        }
+      }
+
+      await this.createAttendeeRecord({ attendee, recordType: SalesforceRecordEnum.LEAD, organizerId }).then(
+        (result) => {
+          createdContacts.push(...result);
+        }
       );
     }
 
@@ -443,34 +464,16 @@ export default class SalesforceCRMService implements CRM {
       let contactCreated = false;
 
       if (accountId && appOptions.createNewContactUnderAccount) {
-        // First see if the contact already exists and connect it to the account
-        const userQuery = await conn.query(`SELECT Id, Email FROM Contact WHERE Email = '${attendee.email}'`);
-        if (userQuery.records.length) {
-          const contact = userQuery.records[0] as { Id: string; Email: string };
-          await conn.sobject(SalesforceRecordEnum.CONTACT).update({
-            // The first argument is the WHERE clause
-            Id: contact.Id,
-            AccountId: accountId,
-          });
-          return [{ id: contact.Id, email: contact.Email }];
-        }
+        const createdAccountContacts = await this.createNewContactUnderAnAccount({
+          attendee,
+          accountId,
+          organizerId,
+        });
 
-        await conn
-          .sobject(SalesforceRecordEnum.CONTACT)
-          .create({
-            ...this.generateCreateRecordBody({
-              attendee,
-              recordType: SalesforceRecordEnum.CONTACT,
-              organizerId,
-            }),
-            AccountId: accountId,
-          })
-          .then((result) => {
-            if (result.success) {
-              createdContacts.push({ id: result.id, email: attendee.email });
-              contactCreated = true;
-            }
-          });
+        if (createdContacts.length > 0) {
+          createdContacts.push(...createdAccountContacts);
+          contactCreated = true;
+        }
       }
 
       if (!accountId && appOptions.createLeadIfAccountNull && !contactCreated) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR enables the option to create contacts under an account if choosing to create events on leads. The PR uses current functionality to search if the attendee or contacts that share the same email domain as the attendee belong to an account. Then create the contact under the account and the event.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

