### PR TITLE
revert: unstick actions column on org member list

### DIFF
--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -339,7 +339,8 @@ export function UserListTable() {
         id: "actions",
         enableHiding: false,
         meta: {
-          sticky: { position: "right" },
+          // TODO: fix the CSS to make the actions column sticky
+          // sticky: { position: "right" },
         },
         cell: ({ row }) => {
           const user = row.original;


### PR DESCRIPTION
## What does this PR do?

This PR reverts a part of #17554 because it introduced a regression.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

In the organization member list, this dropdown from the last column has been broken since #17554 .

![Screenshot 2024-11-15 at 09 46 31](https://github.com/user-attachments/assets/dc1343cc-2ea5-4111-b578-f1076e48e288)

![Screenshot 2024-11-15 at 09 46 41](https://github.com/user-attachments/assets/6ea74995-1905-4986-8f02-b63ca45bd02e)

It should go away after this PR, but the action column is no longer sticky, though.