### PR TITLE
perf: optimize organization admin check

### DIFF
--- a/packages/lib/server/repository/profile.ts
+++ b/packages/lib/server/repository/profile.ts
@@ -375,6 +375,15 @@ export class ProfileRepository {
                 lockEventTypeCreationForUsers: true,
               },
             },
+            members: {
+              distinct: ["role"],
+              select: membershipSelect,
+              where: {
+                accepted: true,
+                // Filter out memberships that are not owned by the user
+                user: { profiles: { some: { id } } },
+              },
+            },
           },
         },
       },

--- a/packages/trpc/server/middlewares/sessionMiddleware.ts
+++ b/packages/trpc/server/middlewares/sessionMiddleware.ts
@@ -102,8 +102,8 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
   // This helps to prevent reaching the 4MB payload limit by avoiding base64 and instead passing the avatar url
 
   const locale = user?.locale ?? ctx.locale;
-  const { members, ..._organization } = user.profile?.organization || {};
-  const isOrgAdmin = members?.some((member) => ["OWNER", "ADMIN"].includes(member.role));
+  const { members = [], ..._organization } = user.profile?.organization || {};
+  const isOrgAdmin = members.some((member) => ["OWNER", "ADMIN"].includes(member.role));
 
   if (isOrgAdmin) {
     logger.debug("User is an org admin", safeStringify({ userId: user.id }));

--- a/packages/trpc/server/middlewares/sessionMiddleware.ts
+++ b/packages/trpc/server/middlewares/sessionMiddleware.ts
@@ -102,10 +102,8 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
   // This helps to prevent reaching the 4MB payload limit by avoiding base64 and instead passing the avatar url
 
   const locale = user?.locale ?? ctx.locale;
-  const isOrgAdmin = await UserRepository.isAdminOrOwnerOfTeam({
-    userId: user.id,
-    teamId: user.profile.organization?.id ?? -1,
-  });
+  const { members, ..._organization } = user.profile?.organization || {};
+  const isOrgAdmin = members?.some((member) => ["OWNER", "ADMIN"].includes(member.role));
 
   if (isOrgAdmin) {
     logger.debug("User is an org admin", safeStringify({ userId: user.id }));
@@ -113,7 +111,7 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
     logger.debug("User is not an org admin", safeStringify({ userId: user.id }));
   }
   const organization = {
-    ...user.profile?.organization,
+    ..._organization,
     id: user.profile?.organization?.id ?? null,
     isOrgAdmin,
     metadata: orgMetadata,


### PR DESCRIPTION
## What does this PR do?

Optimizes organization admin role checks by:
- Adding member role selection to the profile repository query
- Replacing database lookup with in-memory role check using the fetched member data
- Destructuring organization object to prevent member data from being included in the final response

## Mandatory Tasks

- [ ] I have self-reviewed the code
- [ ] I have updated the developer docs in /docs
- [ ] I confirm automated tests are in place

## How should this be tested?

1. Log in as an organization owner/admin
2. Verify that admin privileges are correctly maintained
3. Log in as a regular organization member
4. Verify that non-admin users cannot access admin-only features
5. Check network requests to ensure member data is not included in responses

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings