### PR TITLE
chore: Found a critical index missing on profileId

### DIFF
--- a/packages/prisma/migrations/20241116180203_add_missing_profile_id_idx/migration.sql
+++ b/packages/prisma/migrations/20241116180203_add_missing_profile_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "EventType_profileId_idx" ON "EventType"("profileId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -163,6 +163,7 @@ model EventType {
   @@unique([userId, parentId])
   @@index([userId])
   @@index([teamId])
+  @@index([profileId])
   @@index([scheduleId])
   @@index([secondaryEmailId])
   @@index([parentId])


### PR DESCRIPTION
## What does this PR do?

Adds an index to `profileId`