### PR TITLE
fix: clients not receiving appointment details by email

### DIFF
--- a/apps/api/v1/pages/api/bookings/_post.ts
+++ b/apps/api/v1/pages/api/bookings/_post.ts
@@ -7,6 +7,7 @@ import { HttpError } from "@calcom/lib/http-error";
 import { defaultResponder } from "@calcom/lib/server";
 
 import { getAccessibleUsers } from "~/lib/utils/retrieveScopedAccessibleUsers";
+import { sendAppointmentConfirmationEmail } from "@calcom/emails/email-manager"; // P2541
 
 /**
  * @swagger
@@ -225,7 +226,9 @@ async function handler(req: NextApiRequest) {
   }
 
   try {
-    return await handleNewBooking(req, getBookingDataSchemaForApi);
+    const booking = await handleNewBooking(req, getBookingDataSchemaForApi); // P8b51
+    await sendAppointmentConfirmationEmail(booking, booking.attendees[0]); // P8b51
+    return booking; // P8b51
   } catch (error: unknown) {
     const knownError = error as Error;
     if (knownError?.message === ErrorCode.NoAvailableUsersFound) {

--- a/apps/api/v2/src/modules/email/email.service.ts
+++ b/apps/api/v2/src/modules/email/email.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { sendAppointmentConfirmationEmail } from "@calcom/emails/email-manager"; // P11ff
 
 import { sendSignupToOrganizationEmail, getTranslation } from "@calcom/platform-libraries";
 
@@ -28,4 +29,8 @@ export class EmailService {
       translation,
     });
   }
+
+  public async sendAppointmentConfirmationEmail(calEvent: any, attendee: any) { // P56a1
+    await sendAppointmentConfirmationEmail(calEvent, attendee); // P56a1
+  } // P56a1
 }

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import { cloneDeep } from "lodash";
 import type { TFunction } from "next-i18next";
 import type { z } from "zod";
@@ -74,6 +73,7 @@ import OrganizerScheduledEmail from "./templates/organizer-scheduled-email";
 import SlugReplacementEmail from "./templates/slug-replacement-email";
 import type { TeamInvite } from "./templates/team-invite-email";
 import TeamInviteEmail from "./templates/team-invite-email";
+import AppointmentConfirmationEmail from "./templates/appointment-confirmation-email"; // P311d
 
 type EventTypeMetadata = z.infer<typeof EventTypeMetaDataSchema>;
 
@@ -713,3 +713,8 @@ export const sendAdminOrganizationNotification = async (input: OrganizationNotif
 export const sendBookingRedirectNotification = async (bookingRedirect: IBookingRedirect) => {
   await sendEmail(() => new BookingRedirectEmailNotification(bookingRedirect));
 };
+
+export const sendAppointmentConfirmationEmail = async (calEvent: CalendarEvent, attendee: Person) => { // P08ab
+  const calendarEvent = formatCalEvent(calEvent);
+  await sendEmail(() => new AppointmentConfirmationEmail(calendarEvent, attendee));
+}; // P08ab


### PR DESCRIPTION
Related to #17662

Add functionality to send appointment confirmation emails to clients after booking creation.

* **packages/emails/email-manager.ts**
  - Add `sendAppointmentConfirmationEmail` function to send appointment confirmation emails to clients.
  - Import necessary modules and templates for the new function.

* **apps/api/v1/pages/api/bookings/_post.ts**
  - Import `sendAppointmentConfirmationEmail` function.
  - Call `sendAppointmentConfirmationEmail` function after a booking is created.

* **apps/api/v2/src/modules/email/email.service.ts**
  - Add `sendAppointmentConfirmationEmail` method to send appointment confirmation emails to clients.
  - Import necessary modules and templates for the new method.

* **apps/api/v1/test/lib/bookings/_post.test.ts**
  - Add test cases to verify that `sendAppointmentConfirmationEmail` function is called after a booking is created.

