### PR TITLE
feat: enable all users to create platform team

### DIFF
--- a/packages/features/ee/platform/components/CreateANewPlatformForm.tsx
+++ b/packages/features/ee/platform/components/CreateANewPlatformForm.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { uuid } from "short-uuid";
 
 import { deriveOrgNameFromEmail } from "@calcom/ee/organizations/components/CreateANewOrganizationForm";
 import { deriveSlugFromEmail } from "@calcom/ee/organizations/components/CreateANewOrganizationForm";
@@ -89,7 +90,7 @@ const CreateANewPlatformFormChild = ({ session }: { session: Ensure<SessionConte
             setServerErrorMessage(null);
             createOrganizationMutation.mutate({
               ...v,
-              slug: `${v.name.toLocaleLowerCase()}_platform`,
+              slug: `${v.name.toLocaleLowerCase()}-platform-${uuid().substring(0, 20)}`,
             });
           }
         }}>

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -99,6 +99,8 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
       id: true,
       role: true,
       email: true,
+      completedOnboarding: true,
+      emailVerified: true,
       teams: {
         select: {
           team: {
@@ -116,6 +118,7 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
   if (!loggedInUser) throw new TRPCError({ code: "UNAUTHORIZED", message: "You are not authorized." });
 
   const IS_USER_ADMIN = loggedInUser.role === UserPermissionRole.ADMIN;
+  const verifiedUser = loggedInUser.completedOnboarding && !!loggedInUser.emailVerified;
 
   // We only allow creating an annual billing period if you are a system admin
   const billingPeriod = (IS_USER_ADMIN ? billingPeriodRaw : BillingPeriod.MONTHLY) ?? BillingPeriod.MONTHLY;
@@ -131,7 +134,14 @@ export const createHandler = async ({ input, ctx }: CreateOptions) => {
     });
   }
 
-  if (isNotACompanyEmail(orgOwnerEmail)) {
+  if (isPlatform && !verifiedUser) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You need to complete onboarding before creating a platform team",
+    });
+  }
+
+  if (isNotACompanyEmail(orgOwnerEmail) && !isPlatform) {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Use company email to create an organization" });
   }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR enables all users to create a platform team. Previously the org creation used to throw an error if they email being provided is not a company email, but now with the free platform plan we don't want. Hence everyone with a valid email account should be able to create a platform team.
- Also makes sure that each platform team created has a unique slug

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] (N/A) I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
This can be tested in local dev in the web app
- Start api v2 in local
- Go to `/settings/platform/new` and create a new platform team with an email account that is not a company email eg. gmail
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
