### PR TITLE
feat: Add column visibility filters to routing insights table

### DIFF
--- a/apps/web/modules/insights/insights-routing-view.tsx
+++ b/apps/web/modules/insights/insights-routing-view.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { RoutingFormResponsesTable, RoutingKPICards } from "@calcom/features/insights/components";
+import {
+  FailedBookingsByField,
+  RoutingFormResponsesTable,
+  RoutingKPICards,
+} from "@calcom/features/insights/components";
 import { FiltersProvider } from "@calcom/features/insights/context/FiltersProvider";
 import { RoutingInsightsFilters } from "@calcom/features/insights/filters/routing/FilterBar";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -25,6 +29,8 @@ export default function InsightsPage() {
               </div>
             )}
           </RoutingFormResponsesTable>
+
+          <FailedBookingsByField />
 
           <small className="text-default block text-center">
             {t("looking_for_more_insights")}{" "}

--- a/apps/web/modules/insights/insights-routing-view.tsx
+++ b/apps/web/modules/insights/insights-routing-view.tsx
@@ -1,12 +1,8 @@
 "use client";
 
-import {
-  RoutingFormResponsesTable,
-  RoutingKPICards,
-  FailedBookingsByField,
-} from "@calcom/features/insights/components";
+import { RoutingFormResponsesTable, RoutingKPICards } from "@calcom/features/insights/components";
 import { FiltersProvider } from "@calcom/features/insights/context/FiltersProvider";
-import { Filters } from "@calcom/features/insights/filters";
+import { RoutingInsightsFilters } from "@calcom/features/insights/filters/routing/FilterBar";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 import InsightsLayout from "./layout";
@@ -17,14 +13,18 @@ export default function InsightsPage() {
   return (
     <InsightsLayout>
       <FiltersProvider>
-        <Filters showRoutingFilters />
-
         <div className="mb-4 space-y-4">
-          <RoutingKPICards />
-
-          <RoutingFormResponsesTable />
-
-          <FailedBookingsByField />
+          <RoutingFormResponsesTable>
+            {/* We now render the "filters and KPI as a children of the table but we still need to pass the table instance to it so we can access column status in the toolbar.*/}
+            {(table) => (
+              <div className="header mb-4">
+                <div className="flex items-center justify-between">
+                  <RoutingInsightsFilters table={table} />
+                </div>
+                <RoutingKPICards />
+              </div>
+            )}
+          </RoutingFormResponsesTable>
 
           <small className="text-default block text-center">
             {t("looking_for_more_insights")}{" "}

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -216,7 +216,11 @@ function BookingStatusCell({
 
 export type RoutingFormTableType = ReturnType<typeof useReactTable<RoutingFormTableRow>>;
 
-export function RoutingFormResponsesTable() {
+export function RoutingFormResponsesTable({
+  children,
+}: {
+  children?: React.ReactNode | ((table: RoutingFormTableType) => React.ReactNode);
+}) {
   const { t } = useLocale();
   const { filter } = useFilterContext();
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -442,8 +446,9 @@ export function RoutingFormResponsesTable() {
             fetchMoreOnBottomReached(e.target as HTMLDivElement);
           }
         }}
-        isPending={isFetching && !data}
-      />
+        isPending={isFetching && !data}>
+        {typeof children === "function" ? children(table) : children}
+      </DataTable>
     </div>
   );
 }

--- a/packages/features/insights/filters/routing/FilterBar.tsx
+++ b/packages/features/insights/filters/routing/FilterBar.tsx
@@ -1,0 +1,76 @@
+import type { RoutingFormTableType } from "@calcom/features/insights/components/RoutingFormResponsesTable";
+import { useFilterContext } from "@calcom/features/insights/context/provider";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button, Icon, Tooltip, DataTableFilters } from "@calcom/ui";
+
+import { BookingStatusFilter } from "../BookingStatusFilter";
+import { DateSelect } from "../DateSelect";
+import { RoutingDownload } from "../Download";
+import { FilterType } from "../FilterType";
+import { RoutingFormFieldFilter } from "../RoutingFormFieldFilter";
+import { RoutingFormFilterList } from "../RoutingFormFilterList";
+import { TeamAndSelfList } from "../TeamAndSelfList";
+import { UserListInTeam } from "../UsersListInTeam";
+
+const ClearFilters = () => {
+  const { t } = useLocale();
+  const { filter, clearFilters } = useFilterContext();
+  const { selectedFilter } = filter;
+
+  if (!selectedFilter || selectedFilter?.length < 1) return null;
+
+  return (
+    <Tooltip content={t("clear_filters")}>
+      <Button
+        variant="icon"
+        color="secondary"
+        target="_blank"
+        rel="noreferrer"
+        className="min-w-24 h-[38px] border-0"
+        onClick={() => {
+          clearFilters();
+        }}>
+        <Icon name="x" className="mr-1 h-4 w-4" />
+        {t("clear")}
+      </Button>
+    </Tooltip>
+  );
+};
+
+export const RoutingInsightsFilters = ({ table }: { table: RoutingFormTableType }) => {
+  const { filter } = useFilterContext();
+  const { selectedFilter } = filter;
+
+  // Get all filters that relate to the routing form
+  const routingFormFieldIds = selectedFilter
+    ? selectedFilter.map((filter) => {
+        if (filter.startsWith("rf_")) return filter.substring(3);
+      })
+    : [];
+
+  return (
+    <div className="mt-6 flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-between">
+      <div className="flex flex-wrap gap-2 sm:flex-row sm:justify-start">
+        <TeamAndSelfList omitOrg={true} />
+
+        <UserListInTeam />
+
+        <RoutingFormFilterList />
+        <BookingStatusFilter />
+        {routingFormFieldIds.map((fieldId) => {
+          if (fieldId) return <RoutingFormFieldFilter key={fieldId} fieldId={fieldId} />;
+        })}
+
+        <FilterType showRoutingFilters={true} />
+
+        <ClearFilters />
+      </div>
+
+      <div className="flex flex-col-reverse sm:flex-row sm:flex-nowrap sm:justify-between">
+        <RoutingDownload />
+        <DateSelect />
+        <DataTableFilters.ColumnVisibilityButton table={table} />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## What does this PR do?

Re-adds column visibility to the Routing Insights that was reverted in: https://github.com/calcom/cal.com/pull/17688

Demo:
https://github.com/user-attachments/assets/38441dfa-6f68-4d6f-86bc-a0b9ce4b1f78

## How should this be tested?

Load routing insights. Use column visibility filters to hide/show columns that are present in the datatable.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
