### PR TITLE
fix: correct domain for link column in org member table

### DIFF
--- a/apps/web/test/lib/generateCsv.test.ts
+++ b/apps/web/test/lib/generateCsv.test.ts
@@ -1,5 +1,5 @@
 import type { Table } from "@tanstack/react-table";
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import type { UserTableUser } from "@calcom/features/users/components/UserTable/types";
 import { generateCsvRawForMembersTable, generateHeaderFromReactTable } from "@calcom/lib/csvUtils";
@@ -52,19 +52,8 @@ function createMockTable(data: UserTableUser[]): Table<UserTableUser> {
   } as unknown as Table<UserTableUser>;
 }
 
-describe("generate Csv for Org Users Table", () => {
-  beforeAll(() => {
-    vi.stubGlobal("window", {
-      location: {
-        origin: "https://acme.cal.com",
-      },
-    });
-  });
-
-  afterAll(() => {
-    vi.unstubAllGlobals();
-  });
-
+describe("generate Csv for Org Users Table @test", () => {
+  const orgDomain = "https://acme.cal.com";
   const mockAttributeIds = ["attr1", "attr2"];
   const mockUser: UserTableUser = {
     id: 1,
@@ -81,7 +70,7 @@ describe("generate Csv for Org Users Table", () => {
   };
 
   it("should throw if no headers", () => {
-    expect(() => generateCsvRawForMembersTable([], [], mockAttributeIds)).toThrow();
+    expect(() => generateCsvRawForMembersTable([], [], mockAttributeIds, orgDomain)).toThrow();
   });
 
   it("should generate correct CSV headers", () => {
@@ -89,7 +78,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       [],
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
     const headers = csv?.split("\n")[0];
     expect(headers).toBe("Members,Link,Role,Teams,Attribute 1,Attribute 2");
@@ -108,7 +98,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`
@@ -133,7 +124,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`
@@ -158,7 +150,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`
@@ -180,7 +173,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`
@@ -202,7 +196,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`
@@ -226,7 +221,8 @@ describe("generate Csv for Org Users Table", () => {
     const csv = generateCsvRawForMembersTable(
       generateHeaderFromReactTable(mockTable) ?? [],
       mockData,
-      mockAttributeIds
+      mockAttributeIds,
+      orgDomain
     );
 
     expect(csv).toMatchInlineSnapshot(`

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -456,7 +456,12 @@ export function UserListTable() {
       }
 
       const ATTRIBUTE_IDS = attributes?.map((attr) => attr.id) ?? [];
-      const csvRaw = generateCsvRawForMembersTable(headers, allMembers as UserTableUser[], ATTRIBUTE_IDS);
+      const csvRaw = generateCsvRawForMembersTable(
+        headers,
+        allMembers as UserTableUser[],
+        ATTRIBUTE_IDS,
+        domain
+      );
       if (!csvRaw) {
         throw new Error("Generating CSV file failed.");
       }

--- a/packages/lib/csvUtils.ts
+++ b/packages/lib/csvUtils.ts
@@ -96,7 +96,8 @@ export const generateHeaderFromReactTable = (table: Table<UserTableUser>): strin
 export const generateCsvRawForMembersTable = (
   headers: string[],
   rows: UserTableUser[],
-  ATTRIBUTE_IDS: string[]
+  ATTRIBUTE_IDS: string[],
+  orgDomain: string
 ): string => {
   if (!headers.length) {
     throw new Error("The header is empty.");
@@ -126,7 +127,7 @@ export const generateCsvRawForMembersTable = (
 
     const requiredColumns = [
       email, // Members column
-      `${window.location.origin}/${username}`, // Link column
+      `${orgDomain}/${username}`, // Link column
       role, // Role column
       sanitizeValue(teams.map((team) => team.name).join(",")), // Teams column
     ];


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Follow-up of #17695
- We need to use org domain (not web app domain) for org member's public page, because some users do not have `orgRedirecting` enabled.

<img width="744" alt="Screenshot 2024-11-18 at 1 16 45 PM" src="https://github.com/user-attachments/assets/86639135-27ce-41fc-8b93-f9ed0e76c919">


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
