### PR TITLE
chore: routing table nits

### DIFF
--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -393,7 +393,7 @@ export function RoutingFormResponsesTable({
   if (isHeadersLoading || (isFetching && !data)) {
     return (
       <div
-        className="grid h-[75dvh]"
+        className="grid h-[85dvh]"
         style={{ gridTemplateRows: "auto 1fr auto", gridTemplateAreas: "'header' 'body' 'footer'" }}>
         <div
           className="scrollbar-thin border-subtle relative h-full overflow-auto rounded-md border"

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -251,7 +251,7 @@ export function RoutingFormResponsesTable({
       }
     );
 
-  const { data, fetchNextPage, isFetching, hasNextPage } =
+  const { data, fetchNextPage, isFetching, hasNextPage, isLoading } =
     trpc.viewer.insights.routingFormResponses.useInfiniteQuery(
       {
         teamId: selectedTeamId,
@@ -390,7 +390,7 @@ export function RoutingFormResponsesTable({
     totalDBRowCount
   );
 
-  if (isHeadersLoading || (isFetching && !data)) {
+  if (isHeadersLoading || ((isFetching || isLoading) && !data)) {
     return (
       <div
         className="grid h-[85dvh]"

--- a/packages/features/insights/filters/DateSelect.tsx
+++ b/packages/features/insights/filters/DateSelect.tsx
@@ -92,6 +92,8 @@ export const DateSelect = () => {
         value={selectedPreset}
         className="w-40 capitalize text-black"
         defaultValue={selectedPreset}
+        styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
+        menuPortalTarget={document.body}
         onChange={(e) => {
           if (e) {
             updateDateRange(e.value);

--- a/packages/ui/components/data-table/DataTable.tsx
+++ b/packages/ui/components/data-table/DataTable.tsx
@@ -59,7 +59,7 @@ export function DataTable<TData, TValue>({
   return (
     <div
       className={classNames(
-        "grid h-[75dvh]", // Set a fixed height for the container
+        "grid h-[85dvh]", // Set a fixed height for the container
         rest.className
       )}
       style={{


### PR DESCRIPTION
## What does this PR do?

Date filter select z-index being below table in arc/chrome

![CleanShot 2024-11-19 at 10 13 56](https://github.com/user-attachments/assets/7604d193-5b21-49e5-9175-bb2a14501bd8)

Makes table 10% bigger in height 

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
