### PR TITLE
fix: no availability on reschedule with load balancing

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -477,7 +477,7 @@ async function handler(
     logger: loggerWithEventDetails,
     routedTeamMemberIds: routedTeamMemberIds ?? null,
     contactOwnerEmail,
-    isSameHostReschedule: eventType.rescheduleWithSameRoundRobinHost && reqBody.rescheduleUid,
+    isSameHostReschedule: !!(eventType.rescheduleWithSameRoundRobinHost && reqBody.rescheduleUid),
   });
 
   // We filter out users but ensure allHostUsers remain same.

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -477,6 +477,7 @@ async function handler(
     logger: loggerWithEventDetails,
     routedTeamMemberIds: routedTeamMemberIds ?? null,
     contactOwnerEmail,
+    isSameHostReschedule: eventType.rescheduleWithSameRoundRobinHost && reqBody.rescheduleUid,
   });
 
   // We filter out users but ensure allHostUsers remain same.

--- a/packages/features/bookings/lib/handleNewBooking/loadAndValidateUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/loadAndValidateUsers.ts
@@ -42,6 +42,7 @@ type InputProps = {
   logger: Logger<unknown>;
   routedTeamMemberIds: number[] | null;
   contactOwnerEmail: string | null;
+  isSameHostReschedule: boolean;
 };
 
 export async function loadAndValidateUsers({
@@ -52,6 +53,7 @@ export async function loadAndValidateUsers({
   logger,
   routedTeamMemberIds,
   contactOwnerEmail,
+  isSameHostReschedule,
 }: InputProps): Promise<Users> {
   let users: Users = await loadUsers({
     eventType,
@@ -110,7 +112,7 @@ export async function loadAndValidateUsers({
       email: host.user.email,
       user: host.user,
     })),
-    maxLeadThreshold: eventType.maxLeadThreshold,
+    maxLeadThreshold: isSameHostReschedule ? null : eventType.maxLeadThreshold,
   });
   if (qualifiedHosts.length) {
     // remove users that are not in the qualified hosts array

--- a/packages/lib/bookings/findQualifiedHosts.ts
+++ b/packages/lib/bookings/findQualifiedHosts.ts
@@ -3,18 +3,19 @@ import type { SchedulingType } from "@calcom/prisma/enums";
 
 import { filterHostsByLeadThreshold } from "./filterHostsByLeadThreshold";
 
-export const findQualifiedHosts = async <
-  T extends { email: string; id: number } & Record<string, unknown>
->(eventType: {
-  id: number;
-  maxLeadThreshold: number | null;
-  hosts?: ({ isFixed: boolean; createdAt: Date; priority?: number | null; weight?: number | null } & {
-    user: T;
-  })[];
-  users: T[];
-  schedulingType: SchedulingType | null;
-  rescheduleWithSameRoundRobinHost: boolean;
-}): Promise<
+export const findQualifiedHosts = async <T extends { email: string; id: number } & Record<string, unknown>>(
+  eventType: {
+    id: number;
+    maxLeadThreshold: number | null;
+    hosts?: ({ isFixed: boolean; createdAt: Date; priority?: number | null; weight?: number | null } & {
+      user: T;
+    })[];
+    users: T[];
+    schedulingType: SchedulingType | null;
+    rescheduleWithSameRoundRobinHost: boolean;
+  },
+  isReschedule: boolean
+): Promise<
   {
     isFixed: boolean;
     email: string;
@@ -29,7 +30,8 @@ export const findQualifiedHosts = async <
     ? await filterHostsByLeadThreshold({
         eventTypeId: eventType.id,
         hosts,
-        maxLeadThreshold: !eventType.rescheduleWithSameRoundRobinHost ? eventType.maxLeadThreshold : null,
+        maxLeadThreshold:
+          isReschedule && eventType.rescheduleWithSameRoundRobinHost ? null : eventType.maxLeadThreshold,
       })
     : fallbackHosts;
   return qualifiedHosts;

--- a/packages/lib/bookings/findQualifiedHosts.ts
+++ b/packages/lib/bookings/findQualifiedHosts.ts
@@ -13,6 +13,7 @@ export const findQualifiedHosts = async <
   })[];
   users: T[];
   schedulingType: SchedulingType | null;
+  rescheduleWithSameRoundRobinHost: boolean;
 }): Promise<
   {
     isFixed: boolean;
@@ -28,7 +29,7 @@ export const findQualifiedHosts = async <
     ? await filterHostsByLeadThreshold({
         eventTypeId: eventType.id,
         hosts,
-        maxLeadThreshold: eventType.maxLeadThreshold,
+        maxLeadThreshold: !eventType.rescheduleWithSameRoundRobinHost ? eventType.maxLeadThreshold : null,
       })
     : fallbackHosts;
   return qualifiedHosts;

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -479,7 +479,11 @@ async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<I
     throw new TRPCError({ message: "Invalid time range given.", code: "BAD_REQUEST" });
   }
 
-  const eventHosts = await monitorCallbackAsync(findQualifiedHosts<GetAvailabilityUser>, eventType);
+  const eventHosts = await monitorCallbackAsync(
+    findQualifiedHosts<GetAvailabilityUser>,
+    eventType,
+    !!input.rescheduleUid
+  );
   const hostsAfterSegmentMatching = await findMatchingHostsWithEventSegment({
     eventType,
     normalizedHosts: eventHosts,


### PR DESCRIPTION
## What does this PR do?

When 'load balancing' and 'reschedule with same round robin host' are enabled it could happen that no availability was shown on a reschedule. This happened when this user reached the max threshold. We should never block the user's availability when it's a reschedule with same round robin host