### PR TITLE
build: Reduce bundle size from unnecessary bundeling react/jsx-runtime in embed-react package

### DIFF
--- a/packages/embeds/embed-react/vite.config.js
+++ b/packages/embeds/embed-react/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
+      external: ["react", "react/jsx-runtime", "react-dom", "react-dom/client"],
       output: {
         exports: "named",
         // Provide global variables to use in the UMD build

--- a/packages/embeds/embed-react/vite.config.js
+++ b/packages/embeds/embed-react/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ["react", "react-dom"],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
       output: {
         exports: "named",
         // Provide global variables to use in the UMD build


### PR DESCRIPTION
## What does this PR do?

Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Update the bundeling config for embed-react
2. Rebuild
3. Check dist size smaller, without any references to react/jsx-runtime
