### PR TITLE
fix: improvements for canceling workflow reminders

### DIFF
--- a/packages/features/ee/workflows/lib/getWorkflowReminders.ts
+++ b/packages/features/ee/workflows/lib/getWorkflowReminders.ts
@@ -199,7 +199,7 @@ export async function getAllUnscheduledReminders(): Promise<PartialWorkflowRemin
     method: WorkflowMethods.EMAIL,
     scheduled: false,
     scheduledDate: {
-      lte: dayjs().add(72, "hour").toISOString(),
+      lte: dayjs().add(2, "hour").toISOString(),
     },
     OR: [{ cancelled: false }, { cancelled: null }],
   };

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -286,6 +286,7 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
   ) {
     // Sendgrid to schedule emails
     // Can only schedule at least 60 minutes and at most 72 hours in advance
+    // To limit the amount of canceled sends we schedule at most 2 hours in advance
     if (
       currentDate.isBefore(scheduledDate.subtract(1, "hour")) &&
       !scheduledDate.isAfter(currentDate.add(2, "hour"))
@@ -327,8 +328,8 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
       } catch (error) {
         log.error(`Error scheduling email with error ${error}`);
       }
-    } else if (scheduledDate.isAfter(currentDate.add(72, "hour"))) {
-      // Write to DB and send to CRON if scheduled reminder date is past 72 hours
+    } else if (scheduledDate.isAfter(currentDate.add(2, "hour"))) {
+      // Write to DB and send to CRON if scheduled reminder date is past 2 hours
       if (!isMandatoryReminder) {
         await prisma.workflowReminder.create({
           data: {

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -288,7 +288,7 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
     // Can only schedule at least 60 minutes and at most 72 hours in advance
     if (
       currentDate.isBefore(scheduledDate.subtract(1, "hour")) &&
-      !scheduledDate.isAfter(currentDate.add(72, "hour"))
+      !scheduledDate.isAfter(currentDate.add(2, "hour"))
     ) {
       try {
         // If sendEmail failed then workflowReminer will not be created, failing E2E tests

--- a/packages/features/ee/workflows/lib/test/workflows.test.ts
+++ b/packages/features/ee/workflows/lib/test/workflows.test.ts
@@ -86,8 +86,8 @@ const mockBookings = [
     eventTypeId: 1,
     userId: 101,
     status: BookingStatus.ACCEPTED,
-    startTime: `2024-05-22T04:00:00.000Z`,
-    endTime: `2024-05-22T04:30:00.000Z`,
+    startTime: `2024-05-20T14:00:00.000Z`,
+    endTime: `2024-05-20T14:30:00.000Z`,
     attendees: [{ email: "attendee@example.com", locale: "en" }],
   },
   {
@@ -95,8 +95,8 @@ const mockBookings = [
     eventTypeId: 1,
     userId: 101,
     status: BookingStatus.ACCEPTED,
-    startTime: `2024-05-23T04:00:00.000Z`,
-    endTime: `2024-05-23T04:30:00.000Z`,
+    startTime: `2024-05-20T14:30:00.000Z`,
+    endTime: `2024-05-20T15:00:00.000Z`,
     attendees: [{ email: "attendee@example.com", locale: "en" }],
   },
   {
@@ -436,8 +436,8 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-22T03:00:00.000"),
-      new Date("2024-05-23T03:00:00.000Z"),
+      new Date("2024-05-20T13:00:00.000"),
+      new Date("2024-05-20T13:30:00.000Z"),
       new Date("2024-06-01T03:30:00.000Z"),
       new Date("2024-06-02T03:30:00.000Z"),
     ];
@@ -520,8 +520,8 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-22T05:30:00.000"),
-      new Date("2024-05-23T05:30:00.000Z"),
+      new Date("2024-05-20T15:30:00.000"),
+      new Date("2024-05-20T16:00:00.000Z"),
       new Date("2024-06-01T06:00:00.000Z"),
       new Date("2024-06-02T06:00:00.000Z"),
     ];
@@ -529,11 +529,7 @@ describe("scheduleBookingReminders", () => {
     scheduledWorkflowReminders.forEach((reminder, index) => {
       expect(expectedScheduledDates[index].toISOString()).toStrictEqual(reminder.scheduledDate.toISOString());
       expect(reminder.method).toBe(WorkflowMethods.EMAIL);
-      if (index < 2) {
-        expect(reminder.scheduled).toBe(true);
-      } else {
-        expect(reminder.scheduled).toBe(false);
-      }
+      expect(reminder.scheduled).toBe(false); // all are more than 2 hours in advance
     });
   });
 
@@ -553,7 +549,7 @@ describe("scheduleBookingReminders", () => {
           {
             name: "Workflow",
             userId: 101,
-            trigger: "BEFORE_EVENT",
+            trigger: "AFTER_EVENT",
             action: "SMS_NUMBER",
             template: "REMINDER",
             activeOn: [],
@@ -621,13 +617,13 @@ describe("scheduleBookingReminders", () => {
     expectSMSWorkflowToBeTriggered({
       sms,
       toNumber: "000",
-      includedString: "2024 May 22 at 9:30am Asia/Kolkata",
+      includedString: "2024 May 20 at 7:30pm Asia/Kolkata",
     });
 
     expectSMSWorkflowToBeTriggered({
       sms,
       toNumber: "000",
-      includedString: "2024 May 23 at 9:30am Asia/Kolkata",
+      includedString: "2024 May 20 at 8:00pm Asia/Kolkata",
     });
 
     // sms are too far in future
@@ -655,10 +651,10 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-22T01:00:00.000"),
-      new Date("2024-05-23T01:00:00.000Z"),
-      new Date("2024-06-01T01:30:00.000Z"),
-      new Date("2024-06-02T01:30:00.000Z"),
+      new Date("2024-05-20T17:30:00.000"),
+      new Date("2024-05-20T18:00:00.000Z"),
+      new Date("2024-06-01T08:00:00.000Z"),
+      new Date("2024-06-02T08:00:00.000Z"),
     ];
 
     scheduledWorkflowReminders.forEach((reminder, index) => {


### PR DESCRIPTION
## What does this PR do?

Sendgrid doesn't allow more than 100 different batch ids in a 'paused' or 'pending cancellation' state at one time. I am assuming we sometimes reach that limit and that's why in some cases canceled bookings still send reminders. Currently, we have 88 batch ids in the queue, so pretty close to the limit already. 

With this PR we now schedule emails only 2 hours before they are scheduled instead of 72 hour before. This reduces the amount of scheduled emails that need to be canceled.