### PR TITLE
fix: #17779 Foreign uppercase characters not recognized as such in signup form

### DIFF
--- a/apps/web/modules/auth/forgot-password/[id]/forgot-password-single-view.tsx
+++ b/apps/web/modules/auth/forgot-password/[id]/forgot-password-single-view.tsx
@@ -108,7 +108,7 @@ export default function Page({ requestId, isRequestExpired, csrfToken }: PagePro
                   },
                   pattern: {
                     message: "Should contain a number, uppercase and lowercase letters",
-                    value: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).*$/gm,
+                    value: /^(?=.*\d)(?=.*\p{Ll})(?=.*\p{Lu})(?=.*[\p{Ll}\p{Lu}]).*$/gmu,
                   },
                 })}
                 label={t("new_password")}

--- a/apps/web/modules/settings/security/password-view.tsx
+++ b/apps/web/modules/settings/security/password-view.tsx
@@ -212,7 +212,7 @@ const PasswordView = ({ user }: PasswordViewProps) => {
                     },
                     pattern: {
                       message: "Should contain a number, uppercase and lowercase letters",
-                      value: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).*$/gm,
+                      value: /^(?=.*\d)(?=.*\p{Ll})(?=.*\p{Lu})(?=.*[\p{Ll}\p{Lu}]).*$/gmu,
                     },
                   })}
                   label={t("new_password")}

--- a/packages/features/auth/lib/isPasswordValid.ts
+++ b/packages/features/auth/lib/isPasswordValid.ts
@@ -5,16 +5,16 @@ export function isPasswordValid(
   strict?: boolean
 ): { caplow: boolean; num: boolean; min: boolean; admin_min: boolean };
 export function isPasswordValid(password: string, breakdown?: boolean, strict?: boolean) {
-  let cap = false, // Has uppercase characters
-    low = false, // Has lowercase characters
+  let cap = false, // Has uppercase characters (Unicode aware)
+    low = false, // Has lowercase characters (Unicode aware)
     num = false, // At least one number
     min = false, // Eight characters, or fifteen in strict mode.
     admin_min = false;
   if (password.length >= 7 && (!strict || password.length > 14)) min = true;
   if (strict && password.length > 14) admin_min = true;
   if (password.match(/\d/)) num = true;
-  if (password.match(/[a-z]/)) low = true;
-  if (password.match(/[A-Z]/)) cap = true;
+  if (password.match(/\p{Ll}/u)) low = true;
+  if (password.match(/\p{Lu}/u)) cap = true;
 
   if (!breakdown) return cap && low && num && min && (strict ? admin_min : true);
 

--- a/packages/features/auth/lib/validPassword.ts
+++ b/packages/features/auth/lib/validPassword.ts
@@ -1,8 +1,13 @@
 export function validPassword(password: string) {
   if (password.length < 7) return false;
 
-  if (!/[A-Z]/.test(password) || !/[a-z]/.test(password)) return false;
+  // Match uppercase characters (Unicode aware) using \p{Lu}
+  if (!/\p{Lu}/u.test(password)) return false;
 
+  // Match lowercase characters (Unicode aware) using \p{Ll}
+  if (!/\p{Ll}/u.test(password)) return false;
+
+  // Match at least one digit
   if (!/\d+/.test(password)) return false;
 
   return true;

--- a/packages/features/auth/lib/validPassword.ts
+++ b/packages/features/auth/lib/validPassword.ts
@@ -1,13 +1,11 @@
 export function validPassword(password: string) {
   if (password.length < 7) return false;
 
-  // Match uppercase characters (Unicode aware) using \p{Lu}
+
   if (!/\p{Lu}/u.test(password)) return false;
 
-  // Match lowercase characters (Unicode aware) using \p{Ll}
   if (!/\p{Ll}/u.test(password)) return false;
 
-  // Match at least one digit
   if (!/\d+/.test(password)) return false;
 
   return true;


### PR DESCRIPTION
## What does this PR do?

It fixes the bug where password field in signup and settings page does not validate the foreign characters like Á or á as valid uppercase/lowercase characters.

- Fixes #17779 (GitHub issue number)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**Screenshots**
Uppercase Å works:
![image](https://github.com/user-attachments/assets/1ce7838c-0481-4559-bd2b-ca81b6a38a76)

Lowercase å works:
![image](https://github.com/user-attachments/assets/186eef77-1770-41bc-be8c-32ade1fa4a42)


## Mandatory Tasks (DO NOT REMOVE)

- [✓] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [✓] N/A
- [✓] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to /signup page. Click 'continue with email'. In the password field, put five lowercase characters, one digit and an uppercase foreign/accented character like Á or put five uppercase characters, one digit and one lowercase foreign/accented character like á.  

- Are there environment variables that should be set?
None required

- What are the minimal test data to have?
For testing uppercase foreign letters, ensure that the test input includes uppercase characters with accented letters (e.g., Á, Ö,).
For testing lowercase foreign letters, ensure that the test input includes lowercase characters with accented letters (e.g., á, ö).

- What is expected (happy path) to have (input and output)?
Input: On signup in the create account form, the password input contains one uppercase foreign character, five lower case characters and a digit.(e.g., Åbcdef123).
Output: The form should correctly validate and accept uppercase foreign letters as uppercase and not show any validation errors, maintaining the case integrity of the entered text.
Ensure the system correctly handles the characters and processes them as uppercase (and not as lowercase or invalid input).

- Any other important info that could help to test that PR
Some examples that should be valid password inputs: Åbcdef123, åBCDEF123, àíôüŕş1ABCD, abcdef@123ÀÑŠØŘ

## Checklist

<!-- Remove bullet points below that don't apply to you -->

