### PR TITLE
chore: make throttler logs verbose

### DIFF
--- a/apps/api/v2/src/lib/logger.ts
+++ b/apps/api/v2/src/lib/logger.ts
@@ -1,6 +1,6 @@
 import { WinstonTransport as AxiomTransport } from "@axiomhq/winston";
 import type { LoggerOptions } from "winston";
-import { format, transports as Transports } from "winston";
+import { format, transports as Transports, config } from "winston";
 import type Transport from "winston-transport";
 
 const formattedTimestamp = format.timestamp({
@@ -8,14 +8,7 @@ const formattedTimestamp = format.timestamp({
 });
 
 const colorizer = format.colorize({
-  colors: {
-    fatal: "red",
-    error: "red",
-    warn: "yellow",
-    info: "blue",
-    debug: "white",
-    trace: "grey",
-  },
+  colors: config.npm.colors,
 });
 
 const WINSTON_DEV_FORMAT = format.combine(
@@ -26,14 +19,7 @@ const WINSTON_DEV_FORMAT = format.combine(
 );
 const WINSTON_PROD_FORMAT = format.combine(format.errors({ stack: true }), formattedTimestamp, format.json());
 
-export const logLevels = {
-  fatal: 0,
-  error: 1,
-  warn: 2,
-  info: 3,
-  debug: 4,
-  trace: 5,
-} as const;
+export const logLevels = config.npm.levels;
 
 export const loggerConfig = (): LoggerOptions => {
   const isProduction = process.env.NODE_ENV === "production";

--- a/apps/api/v2/src/lib/throttler-guard.ts
+++ b/apps/api/v2/src/lib/throttler-guard.ts
@@ -56,7 +56,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
     const tracker = await this.getTracker(request);
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" generated based on: Bearer token "${request.get(
         "Authorization"
       )}", OAuth client ID "${request.get(X_CAL_CLIENT_ID)}" and IP "${request.ip}"`
@@ -89,7 +89,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
   private async handleNonApiKeyRequest(tracker: string, response: Response): Promise<boolean> {
     const rateLimit = this.getDefaultRateLimit(tracker);
-    this.logger.log(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
+    this.logger.verbose(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
       ${JSON.stringify(rateLimit, null, 2)}
     `);
 
@@ -135,7 +135,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
     const cachedRateLimits = await this.storageService.redis.get(cacheKey);
     if (cachedRateLimits) {
-      this.logger.log(`Tracker "${tracker}" rate limits retrieved from redis cache:
+      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from redis cache:
         ${cachedRateLimits}
       `);
       return rateLimitsSchema.parse(JSON.parse(cachedRateLimits));
@@ -158,13 +158,13 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     });
 
     if (rateLimits) {
-      this.logger.log(`Tracker "${tracker}" rate limits retrieved from database:
+      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from database:
         ${JSON.stringify(rateLimits, null, 2)}`);
     }
 
     if (!rateLimits || rateLimits.length === 0) {
       rateLimits = [this.getDefaultRateLimit(tracker)];
-      this.logger.log(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
+      this.logger.verbose(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
         ${JSON.stringify(rateLimits, null, 2)}`);
     }
 
@@ -194,10 +194,10 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     );
     response.setHeader(`X-RateLimit-Reset-${nameFirstUpper}`, timeToBlockExpire || timeToExpire);
 
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" incremented. isBlocked ${isBlocked}, totalHits ${totalHits}, timeToExpire ${timeToExpire}, timeToBlockExpire ${timeToBlockExpire}`
     );
-    this.logger.log(
+    this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" response headers:
         X-RateLimit-Limit-${nameFirstUpper}: ${limit},
         X-RateLimit-Remaining-${nameFirstUpper}: ${timeToBlockExpire ? 0 : Math.max(0, limit - totalHits)},
@@ -227,7 +227,7 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
       return `ip_${request.ip}`;
     }
 
-    this.logger.log(`no tracker found: ${request.url}`);
+    this.logger.verbose(`no tracker found: ${request.url}`);
     return "unknown";
   }
 }


### PR DESCRIPTION
## What does this PR do?

Throttler guard logs are spamming production logs too much, shifting to verbose level
<img width="1260" alt="Screenshot 2024-11-26 at 11 05 25" src="https://github.com/user-attachments/assets/6544c023-d71a-4cea-91a4-f8306816b959">

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


