### PR TITLE
fix: Routes with custom event redirects

### DIFF
--- a/packages/lib/server/repository/eventType.ts
+++ b/packages/lib/server/repository/eventType.ts
@@ -34,6 +34,28 @@ const userSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
 });
 
+const includeWithHostsAndTeam = {
+  hosts: {
+    select: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      weight: true,
+      priority: true,
+      createdAt: true,
+    },
+  },
+  team: {
+    select: {
+      parentId: true,
+    },
+  },
+};
+
 export class EventTypeRepository {
   private static generateCreateEventTypeData = (eventTypeCreateData: IEventType) => {
     const {
@@ -711,5 +733,42 @@ export class EventTypeRepository {
         ],
       },
     });
+  }
+
+  /** Prioritize searching if the slug belongs to a team event type */
+  static async findBySlugAndUserIdOrTeamId({
+    slug,
+    teamId,
+    userId,
+  }: {
+    slug: string;
+    teamId?: number;
+    userId?: number;
+  }) {
+    if (!teamId || !userId) return;
+
+    if (teamId) {
+      const eventType = await prisma.eventType.findFirst({
+        where: {
+          slug,
+          teamId,
+        },
+        include: includeWithHostsAndTeam,
+      });
+      if (eventType) return eventType;
+    }
+
+    if (userId) {
+      const eventType = await prisma.eventType.findFirst({
+        where: {
+          slug,
+          userId,
+        },
+        include: includeWithHostsAndTeam,
+      });
+      if (eventType) return eventType;
+    }
+
+    return null;
   }
 }

--- a/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
+++ b/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
@@ -168,8 +168,8 @@ export const findTeamMembersMatchingAttributeLogicOfRouteHandler = async ({
   const eventType = eventTypeId
     ? await EventTypeRepository.findByIdIncludeHostsAndTeam({ id: eventTypeId })
     : await EventTypeRepository.findBySlugAndUserIdOrTeamId({
-        // Assume that the slug was saved in the format of team/{teamName}/{eventSlug}
-        slug: eventTypeUrl.split("/")[2],
+        // Assume that the slug was saved in the format of team/{teamName}/{eventSlug}?query
+        slug: eventTypeUrl.split("/")[2].split("?")[0],
         teamId: form?.teamId,
         userId: form.userId,
       });

--- a/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
+++ b/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
@@ -152,10 +152,11 @@ export const findTeamMembersMatchingAttributeLogicOfRouteHandler = async ({
   }
 
   const eventTypeId = route.action.eventTypeId;
+  const eventTypeUrl = route.action.value;
   // e.g. /team/abc/team-event-type
   const eventTypeRedirectPath = route.action.value;
 
-  if (!eventTypeId) {
+  if (!eventTypeId && !eventTypeUrl) {
     // If it ever happens, should automatically be fixed by saving the form again from route-builder.
     // Legacy route actions do not have eventTypeId.
     throw new TRPCError({
@@ -164,7 +165,14 @@ export const findTeamMembersMatchingAttributeLogicOfRouteHandler = async ({
     });
   }
 
-  const eventType = await EventTypeRepository.findByIdIncludeHostsAndTeam({ id: eventTypeId });
+  const eventType = eventTypeId
+    ? await EventTypeRepository.findByIdIncludeHostsAndTeam({ id: eventTypeId })
+    : await EventTypeRepository.findBySlugAndUserIdOrTeamId({
+        // Assume that the slug was saved in the format of team/{teamName}/{eventSlug}
+        slug: eventTypeUrl.split("/")[2],
+        teamId: form?.teamId,
+        userId: form.userId,
+      });
 
   if (!eventType) {
     throw new TRPCError({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes when a route a custom event redirect by handling the `eventTypeId` being saved as 0 and searching for the event type via the slug.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

https://www.loom.com/share/71261b5efc11480c8539d41d471e9716

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a route with a custom event redirect. Add a query string as well
- Test the route. It should route successfully
