### PR TITLE
fix: `getAttributeRoutingConfig` find the route based on the chosenRouteId

### DIFF
--- a/apps/web/lib/__tests__/getTeamMemberEmailFromCrm.test.ts
+++ b/apps/web/lib/__tests__/getTeamMemberEmailFromCrm.test.ts
@@ -79,6 +79,8 @@ async function createRoutingFormWithResponse({
     },
   });
 
+  const routeId = v4();
+
   const form = await prismock.app_RoutingForms_Form.create({
     data: {
       ...formData,
@@ -88,7 +90,7 @@ async function createRoutingFormWithResponse({
           id: v4(),
           type: "group",
         },
-        id: v4(),
+        id: routeId,
         ...route,
       })),
       user: {
@@ -101,6 +103,7 @@ async function createRoutingFormWithResponse({
 
   const responseRecord = await prismock.app_RoutingForms_FormResponse.create({
     data: {
+      chosenRouteId: routeId,
       response: {},
       form: {
         connect: {

--- a/apps/web/lib/getTeamMemberEmailFromCrm.ts
+++ b/apps/web/lib/getTeamMemberEmailFromCrm.ts
@@ -68,6 +68,14 @@ async function getAttributeRoutingConfig(
     },
     select: {
       routes: true,
+      responses: {
+        where: {
+          id: routingFormResponseId,
+        },
+        select: {
+          chosenRouteId: true,
+        },
+      },
     },
   });
   if (!routingFormQuery || !routingFormQuery?.routes) return null;
@@ -76,10 +84,9 @@ async function getAttributeRoutingConfig(
   if (!parsedRoutes.success || !parsedRoutes.data) return null;
 
   // Find the route with the attributeRoutingConfig
-  // FIXME: There could be multiple routes with same action.eventTypeId, we should actually ensure we have the chosenRouteId in here and use that route.
   const route = parsedRoutes.data.find((route) => {
     if ("action" in route) {
-      return route.action.eventTypeId === eventTypeId;
+      return route.id === routingFormQuery.responses[0].chosenRouteId;
     }
   });
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We were parsing routes based on `eventTypeId` but routes could be pointing to the same event type. This was causing misroutings.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

