### PR TITLE
fix: (Hotfix)any group of rules in routing

### DIFF
--- a/packages/lib/raqb/zod.test.ts
+++ b/packages/lib/raqb/zod.test.ts
@@ -247,4 +247,17 @@ describe("queryValueValidationSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("should allow properties in the query that has rule grouping details", () => {
+    const result = raqbQueryValueSchema.parse({
+      id: "8",
+      type: "group",
+      properties: {
+        not: false,
+        conjunction: "OR",
+      },
+    });
+    expect(result.properties.not).toBe(false);
+    expect(result.properties.conjunction).toBe("OR");
+  });
 });

--- a/packages/lib/raqb/zod.ts
+++ b/packages/lib/raqb/zod.ts
@@ -88,11 +88,13 @@ export const raqbQueryValueSchema = z.union([
     id: z.string().optional(),
     type: z.literal("group"),
     children1: raqbChildren1Schema.optional(),
+    properties: z.any(),
   }),
   z.object({
     id: z.string().optional(),
     type: z.literal("switch_group"),
     children1: raqbChildren1Schema.optional(),
+    properties: z.any(),
   }),
 ]);
 


### PR DESCRIPTION
## What does this PR do?

Regression from #17361

Fixes the issue of "Any" group of rules using "All" logic only.
