### PR TITLE
fix: load more rows if the existing ones do not fill the space

### DIFF
--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -4,7 +4,7 @@ import type { Row } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
 import type { Table as ReactTableType } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 
 import classNames from "@calcom/lib/classNames";
 import { Icon, TableNew, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@calcom/ui";
@@ -44,6 +44,14 @@ export function DataTable<TData, TValue>({
         : undefined,
     overscan: 10,
   });
+
+  useEffect(() => {
+    if (rowVirtualizer.getVirtualItems().length >= rows.length && tableContainerRef.current) {
+      setTimeout(() => {
+        onScroll?.({ target: tableContainerRef.current });
+      }, 100);
+    }
+  }, [rowVirtualizer.getVirtualItems().length, rows.length, tableContainerRef.current]);
 
   const virtualRows = rowVirtualizer.getVirtualItems();
 
@@ -152,7 +160,7 @@ export function DataTable<TData, TValue>({
                             width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                           }}
                           className={classNames(
-                            "flex shrink-0 items-center overflow-auto",
+                            "flex shrink-0 items-center overflow-hidden",
                             variant === "compact" && "p-1.5",
                             meta?.sticky && "group-hover:bg-muted bg-default sticky"
                           )}>

--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -14,7 +14,7 @@ export interface DataTableProps<TData, TValue> {
   tableContainerRef: React.RefObject<HTMLDivElement>;
   isPending?: boolean;
   onRowMouseclick?: (row: Row<TData>) => void;
-  onScroll?: (e: React.UIEvent<HTMLDivElement, UIEvent>) => void;
+  onScroll?: (e: Pick<React.UIEvent<HTMLDivElement, UIEvent>, "target">) => void;
   tableOverlay?: React.ReactNode;
   variant?: "default" | "compact";
   "data-testid"?: string;
@@ -47,12 +47,13 @@ export function DataTable<TData, TValue>({
 
   useEffect(() => {
     if (rowVirtualizer.getVirtualItems().length >= rows.length && tableContainerRef.current) {
+      const target = tableContainerRef.current;
       // Right after the last row is rendered, tableContainer's scrollHeight is
       // temporarily larger than the actual height of the table, so we need to
       // wait for a short time before calling onScroll to ensure the scrollHeight
       // is correct.
       setTimeout(() => {
-        onScroll?.({ target: tableContainerRef.current });
+        onScroll?.({ target });
       }, 100);
     }
   }, [rowVirtualizer.getVirtualItems().length, rows.length, tableContainerRef.current]);

--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -47,6 +47,10 @@ export function DataTable<TData, TValue>({
 
   useEffect(() => {
     if (rowVirtualizer.getVirtualItems().length >= rows.length && tableContainerRef.current) {
+      // Right after the last row is rendered, tableContainer's scrollHeight is
+      // temporarily larger than the actual height of the table, so we need to
+      // wait for a short time before calling onScroll to ensure the scrollHeight
+      // is correct.
       setTimeout(() => {
         onScroll?.({ target: tableContainerRef.current });
       }, 100);

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -262,7 +262,7 @@ export function RoutingFormResponsesTable({
         routingFormId: selectedRoutingFormId ?? undefined,
         bookingStatus: selectedBookingStatus ?? undefined,
         fieldFilter: selectedRoutingFormFilter ?? undefined,
-        limit: 10,
+        limit: 30,
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
## What does this PR do?

This fixes a bug that DataTable won't load more rows when all of the currently loaded rows are displayed without scroll.

### Before

You had to somehow trigger a scroll event (even if it's a horizontal scroll) to load more.

https://github.com/user-attachments/assets/fec83556-2ebb-4f9b-8717-5d9c3897a172


### After

After rendering DataTable, if the virtualizer actually rendered all the fetched rows, then it means we could fetch once.

https://github.com/user-attachments/assets/a3522a0a-693f-41d7-a18d-e8d62efb85c2



## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

See the video above.
