### PR TITLE
feat: add tooltip to button for better UX

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -46,6 +46,7 @@
   "event_request_reassigned": "Your scheduled event was reassigned",
   "event_reassigned_subtitle": "You will no longer have the event on your calendar and your round robin likelihood will not be negatively impacted",
   "organizer": "Organizer",
+  "owner_permission_needed": "You need to be an owner of the organization.",
   "reassigned_to": "Reassigned to",
   "need_to_reschedule_or_cancel": "Need to reschedule or cancel?",
   "you_can_view_booking_details_with_this_url": "You can view the booking details from this url {{url}} and add the event to your calendar",

--- a/packages/features/ee/organizations/pages/settings/general.tsx
+++ b/packages/features/ee/organizations/pages/settings/general.tsx
@@ -210,7 +210,11 @@ const GeneralView = ({ currentOrg, isAdminOrOwner, localeProp }: GeneralViewProp
       </div>
 
       <SectionBottomActions align="end">
-        <Button disabled={isDisabled} color="primary" type="submit">
+        <Button
+          disabled={isDisabled}
+          color="primary"
+          type="submit"
+          tooltip={!isAdminOrOwner ? t("owner_permission_needed") : undefined}>
           {t("update")}
         </Button>
       </SectionBottomActions>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In `/settings/organizations/general`, `Update` button is disabled if you are not the owner of the organization. We need some tooltip, otherwise it looks like a bug.

## After
<img width="361" alt="Screenshot 2024-11-27 at 10 21 52 AM" src="https://github.com/user-attachments/assets/6ba1692f-e626-494d-93f7-1acb26dabf8f">

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.