### PR TITLE
feat: Salesforce - send routing form responses to Salesforce

### DIFF
--- a/packages/app-store/routing-forms/components/FormInputFields.tsx
+++ b/packages/app-store/routing-forms/components/FormInputFields.tsx
@@ -70,6 +70,7 @@ export default function FormInputFields(props: FormInputFieldsProps) {
                     ...response,
                     [field.id]: {
                       label: field.label,
+                      identifier: field?.identifier,
                       value: getFieldResponseForJsonLogic({ field, value }),
                     },
                   };

--- a/packages/app-store/routing-forms/trpc/response.schema.ts
+++ b/packages/app-store/routing-forms/trpc/response.schema.ts
@@ -6,6 +6,7 @@ export const ZResponseInputSchema = z.object({
   response: z.record(
     z.object({
       label: z.string(),
+      identifier: z.string().optional(),
       value: z.union([z.string(), z.number(), z.array(z.string())]),
     })
   ),

--- a/packages/app-store/routing-forms/types/types.d.ts
+++ b/packages/app-store/routing-forms/types/types.d.ts
@@ -22,6 +22,7 @@ export type FormResponse = Record<
   {
     value: number | string | string[];
     label: string;
+    identifier?: string;
   }
 >;
 

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -916,18 +916,26 @@ export default class SalesforceCRMService implements CRM {
 
     let valueToWrite = fieldValue;
 
-    // Check if we need to replace any values with values from the booking questions
-    const regexValueToReplace = /\{(.*?)\}/g;
-    valueToWrite = valueToWrite.replace(regexValueToReplace, (match, captured) => {
-      if (!calEventResponses) return valueToWrite;
-      return calEventResponses[captured]?.value ? calEventResponses[captured].value.toString() : match;
-    });
+    if (fieldValue.startsWith("{form: ")) {
+      // Get routing from response
+    } else {
+      // Get the value from the booking response
+      if (!calEventResponses) return;
+      valueToWrite = this.getTextValueFromBookingResponse(fieldValue, calEventResponses);
+    }
 
     // If a value wasn't found in the responses. Don't return the field name
     if (valueToWrite === fieldValue) return;
 
     // Trim incase the replacement values increased the length
     return valueToWrite.substring(0, fieldLength);
+  }
+
+  private getTextValueFromBookingResponse(fieldValue: string, calEventResponses: CalEventResponses) {
+    const regexValueToReplace = /\{(.*?)\}/g;
+    return fieldValue.replace(regexValueToReplace, (match, captured) => {
+      return calEventResponses[captured]?.value ? calEventResponses[captured].value.toString() : match;
+    });
   }
 
   private async getDateFieldValue(


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Allows users to identify a text field in a routing form response and send it to a record in Salesforce
- Also adds the field identifier to the routing form response

- Fixes CAL-4809 (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/ad47e1e9b68a496a9d1e43389f98f284

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Set the option to write to the attendee record as `{form:YourIdentifier}` as the value
- Create a booking through a routing form
- You should see the routing form response on the Salesforce record