### PR TITLE
fix: Added proper updates/interactivity on the "Getting started" app integ…

### DIFF
--- a/apps/web/components/getting-started/components/AppConnectionItem.tsx
+++ b/apps/web/components/getting-started/components/AppConnectionItem.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useState } from "react";
 
 import type { TDependencyData } from "@calcom/app-store/_appRegistry";
 import { InstallAppButtonWithoutPlanCheck } from "@calcom/app-store/components";
@@ -25,6 +26,10 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
   const { t } = useLocale();
   const setDefaultConferencingApp = trpc.viewer.appsRouter.setDefaultConferencingApp.useMutation();
   const dependency = props.dependencyData?.find((data) => !data.installed);
+
+  const [isInstalling, setInstalling] = useState(false);
+  const utils = trpc.useUtils();
+
   return (
     <div className="flex flex-row items-center justify-between p-5">
       <div className="flex items-center space-x-3">
@@ -39,6 +44,8 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
             if (defaultInstall && slug) {
               setDefaultConferencingApp.mutate({ slug });
             }
+            setInstalling(false);
+            utils.viewer.integrations.invalidate();
           },
         }}
         render={(buttonProps) => (
@@ -47,7 +54,7 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
             color="secondary"
             disabled={installed || !!dependency}
             type="button"
-            loading={buttonProps?.isPending}
+            loading={isInstalling || buttonProps?.loading}
             tooltip={
               dependency ? (
                 <div className="items-start space-x-2.5">
@@ -86,6 +93,7 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
               // Save cookie key to return url step
               document.cookie = `return-to=${window.location.href};path=/;max-age=3600;SameSite=Lax`;
               buttonProps && buttonProps.onClick && buttonProps?.onClick(event);
+              setInstalling(true);
             }}>
             {installed ? t("installed") : t("connect")}
           </Button>

--- a/apps/web/components/getting-started/components/AppConnectionItem.tsx
+++ b/apps/web/components/getting-started/components/AppConnectionItem.tsx
@@ -7,7 +7,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import type { App } from "@calcom/types/App";
-import { Badge, Button, Icon } from "@calcom/ui";
+import { Badge, Button, Icon, showToast } from "@calcom/ui";
 
 interface IAppConnectionItem {
   title: string;
@@ -46,6 +46,10 @@ const AppConnectionItem = (props: IAppConnectionItem) => {
             }
             setInstalling(false);
             utils.viewer.integrations.invalidate();
+            showToast(t("app_successfully_installed"), "success");
+          },
+          onError: (error) => {
+            if (error instanceof Error) showToast(error.message || t("app_could_not_be_installed"), "error");
           },
         }}
         render={(buttonProps) => (

--- a/apps/web/modules/getting-started/[[...step]]/onboarding-view.tsx
+++ b/apps/web/modules/getting-started/[[...step]]/onboarding-view.tsx
@@ -4,6 +4,7 @@ import { signOut } from "next-auth/react";
 import Head from "next/head";
 import { usePathname, useRouter } from "next/navigation";
 import { Suspense } from "react";
+import { Toaster } from "react-hot-toast";
 import { z } from "zod";
 
 import { classNames } from "@calcom/lib";
@@ -185,6 +186,7 @@ const OnboardingPage = (props: PageProps) => {
           </div>
         </div>
       </div>
+      <Toaster position="bottom-right" />
     </div>
   );
 };

--- a/packages/app-store/components.tsx
+++ b/packages/app-store/components.tsx
@@ -37,7 +37,7 @@ export const InstallAppButtonWithoutPlanCheck = (
           onClick: () => {
             mutation.mutate({ type: props.type });
           },
-          loading: mutation.isPending,
+          loading: mutation.data?.setupPending,
         })}
       </>
     );


### PR DESCRIPTION
## What does this PR do?

- InstallAppButtonWithoutPlanCheck properly vends the mutation data in the render's props
- Fixed the improper props wiring in the AppConnectionItem
- Added a loading state for reactivity
- Added toaster for error/success confirmation

- Loom Video: https://www.loom.com/share/c394fc8e94964636bd016c85c72b7782?sid=108960f6-f1e5-46c1-8ebc-00cce78690bf

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #17900 (GitHub issue number)
- Fixes CAL-4818 (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? 
 - **N/A**
- What are the minimal test data to have? 
 - A user configured to view the "getting started" page.
- What is expected (happy path) to have (input and output)?
  - When the user clicks on a "connect" button, the loading animation should play, and the TRPC query should be invalidated on success.
- Any other important info that could help to test that PR
  - **N/A**
  

/claim #17900
