### PR TITLE
chore: Extract some refactor work from util.ts to improve error handling

### DIFF
--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -1,3 +1,29 @@
+import { ErrorCode } from "@calcom/lib/errorCodes";
+
+export class ErrorWithCode extends Error {
+  code: ErrorCode;
+  data?: Record<string, unknown>;
+  constructor(code: ErrorCode, message?: string, data?: Record<string, unknown>) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+  static get Factory() {
+    return new Proxy(ErrorWithCode, {
+      get(_, prop: string) {
+        if (prop in ErrorCode) {
+          const code = ErrorCode[prop as keyof typeof ErrorCode];
+          return (message?: string, data?: Record<string, any>) => new ErrorWithCode(code, message, data);
+        }
+        throw new Error(`Unknown error code: ${prop}`);
+      },
+    }) as unknown as Record<
+      keyof typeof ErrorCode,
+      (message?: string, data?: Record<string, any>) => ErrorWithCode
+    >;
+  }
+}
+
 export function getErrorFromUnknown(cause: unknown): Error & { statusCode?: number; code?: string } {
   if (cause instanceof Error) {
     return cause;


### PR DESCRIPTION
## What does this PR do?

* Adds `ErrorWithCode`
  ```typescript
  import { ErrorWithCode } from "@calcom/lib/errors";
  // list of factory functions is auto-completed and found in @calcom/lib/errorCodes.ts
  throw ErrorWithCode.Factory.EventTypeNotFound();
  ```
* Removes deprecated NotFoundError import from Prisma. 
* Also fixes the @prisma/client import, `import { PrismaClientKnownRequestError, NotFoundError } from "@prisma/client/runtime/library";` is 3x the size.