### PR TITLE
feat: Only require confirmation for free email domains

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2822,5 +2822,6 @@
   "rr_distribution_method_balanced_description": "We will monitor how many bookings have been made with each host and compare this with others, disabling some hosts that are too far ahead so bookings are evenly distributed.",
   "exclude_emails_that_contain" : "Exclude emails that contain ...",
   "exclude_emails_match_found_error_message" : "Please enter a valid work email address",
+  "require_confirmation_for_free_email": "Only require confirmation for free email providers (Ex. @gmail.com, @outlook.com)", 
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -744,6 +744,7 @@ async function handler(
     userId,
     originalRescheduledBookingOrganizerId: originalRescheduledBooking?.user?.id,
     paymentAppData,
+    bookerEmail,
   });
 
   // If the Organizer himself is rescheduling, the booker should be sent the communication in his timezone and locale.

--- a/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getEventTypesFromDB.ts
@@ -56,6 +56,7 @@ export const getEventTypesFromDB = async (eventTypeId: number) => {
       periodCountCalendarDays: true,
       lockTimeZoneToggleOnBookingPage: true,
       requiresConfirmation: true,
+      requiresConfirmationForFreeEmail: true,
       requiresBookerEmailVerification: true,
       maxLeadThreshold: true,
       minimumBookingNotice: true,

--- a/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
@@ -72,6 +72,7 @@ export default function RequiresConfirmationController({
   );
 
   const requiresConfirmationWillBlockSlot = formMethods.getValues("requiresConfirmationWillBlockSlot");
+  const requiresConfirmationForFreeEmail = formMethods.getValues("requiresConfirmationForFreeEmail");
 
   return (
     <div className="block items-start sm:flex">
@@ -237,6 +238,21 @@ export default function RequiresConfirmationController({
                           onChange={(e) => {
                             // We set should dirty to properly detect when we can submit the form
                             formMethods.setValue("requiresConfirmationWillBlockSlot", e.target.checked, {
+                              shouldDirty: true,
+                            });
+                          }}
+                        />
+                        <CheckboxField
+                          checked={requiresConfirmationForFreeEmail}
+                          descriptionAsLabel
+                          description={t("require_confirmation_for_free_email")}
+                          className={customClassNames?.conditionalConfirmationRadio?.checkbox}
+                          descriptionClassName={
+                            customClassNames?.conditionalConfirmationRadio?.checkboxDescription
+                          }
+                          onChange={(e) => {
+                            // We set should dirty to properly detect when we can submit the form
+                            formMethods.setValue("requiresConfirmationForFreeEmail", e.target.checked, {
                               shouldDirty: true,
                             });
                           }}

--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -81,6 +81,7 @@ export type FormValues = {
   lockTimeZoneToggleOnBookingPage: boolean;
   requiresConfirmation: boolean;
   requiresConfirmationWillBlockSlot: boolean;
+  requiresConfirmationForFreeEmail: boolean;
   requiresBookerEmailVerification: boolean;
   recurringEvent: RecurringEvent | null;
   schedulingType: SchedulingType | null;

--- a/packages/lib/server/repository/eventType.ts
+++ b/packages/lib/server/repository/eventType.ts
@@ -444,6 +444,7 @@ export class EventTypeRepository {
       periodCountCalendarDays: true,
       lockTimeZoneToggleOnBookingPage: true,
       requiresConfirmation: true,
+      requiresConfirmationForFreeEmail: true,
       requiresConfirmationWillBlockSlot: true,
       requiresBookerEmailVerification: true,
       autoTranslateDescriptionEnabled: true,

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -88,6 +88,7 @@ export const useEventTypeForm = ({
       schedulingType: eventType.schedulingType,
       requiresConfirmation: eventType.requiresConfirmation,
       requiresConfirmationWillBlockSlot: eventType.requiresConfirmationWillBlockSlot,
+      requiresConfirmationForFreeEmail: eventType.requiresConfirmationForFreeEmail,
       slotInterval: eventType.slotInterval,
       minimumBookingNotice: eventType.minimumBookingNotice,
       metadata: eventType.metadata,
@@ -188,6 +189,7 @@ export const useEventTypeForm = ({
   };
 
   const getDirtyFields = (values: FormValues): Partial<FormValues> => {
+    console.log("🚀 ~ getDirtyFields ~ values:", values);
     if (!isFormDirty) {
       return {};
     }
@@ -368,6 +370,7 @@ export const useEventTypeForm = ({
     }, {}) as EventTypeUpdateInput;
 
     if (dirtyFieldExists) {
+      console.log("🚀 ~ handleSubmit ~ filteredPayload:", filteredPayload);
       onSubmit({ ...filteredPayload, id: eventType.id });
     }
   };

--- a/packages/prisma/migrations/20241129194340_add_requires_confirmation_for_free_email_to_eventtype/migration.sql
+++ b/packages/prisma/migrations/20241129194340_add_requires_confirmation_for_free_email_to_eventtype/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventType" ADD COLUMN     "requiresConfirmationForFreeEmail" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -109,6 +109,7 @@ model EventType {
   lockTimeZoneToggleOnBookingPage         Boolean                   @default(false)
   requiresConfirmation                    Boolean                   @default(false)
   requiresConfirmationWillBlockSlot       Boolean                   @default(false)
+  requiresConfirmationForFreeEmail        Boolean                   @default(false)
   requiresBookerEmailVerification         Boolean                   @default(false)
   autoTranslateDescriptionEnabled         Boolean                   @default(false)
   /// @zod.custom(imports.recurringEventType)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds the option to only require confirmation for a booking if the attendee email is a free email domain


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/482aaa00cc6e4aeb9f27640d1d0cf057

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Enable requires confirmation on an event type and check off only for free email domains
- Create a booking with a free email domain
	- It should require confirmation
- Create a booking with a non free email domain
	- The booking should automatically go through
