### PR TITLE
fix: Properly encoded metadata OpenGraph image parameters

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -89,12 +89,12 @@ export const constructAppImage = ({ name, slug, description }: AppImageProps): s
 export const constructGenericImage = ({ title, description }: GenericImageProps) => {
   const url = [
     `?type=generic`,
-    `&title=${encodeURIComponent(title)}`,
-    `&description=${encodeURIComponent(description)}`,
+    `&title=${title}`,
+    `&description=${description}`,
     // Joining a multiline string for readability.
   ].join("");
 
-  return url;
+  return encodeURIComponent(url);
 };
 
 const Wrapper = ({ children, variant = "light", rotateBackground }: WrapperProps) => (


### PR DESCRIPTION
## What does this PR do?

In the metadata, the OpenGraph image attribute (og-image) is malformed due to its API parameters not being completely encoded, leading to an incorrect API call to the dynamic opengraph image endpoint (i.e /api/social/og/image?type=generic&title=a+title&description=a+desc)

- Properly encoded OpenGraph image parameters, fully encoding the resulting string from constructGenericImage()
- Fixes #17931
- Fixes CAL-4823

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
- Loom Video with fix: https://www.loom.com/share/4f89328dd04b4871bb0f91d5d4905c1c?sid=559512f8-724d-40bd-ac6b-64bb513b0714
- Loom Video without fix (notice some of the URL params are not encoded): https://www.loom.com/share/a86bdadc1c6f4e448e9824a8bd5b9180 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Before changes, get the metadata's og-image attribute and try to access it on the browser.
2. View logs and observe API errors for the /api/social/og/image endpoint
3. Add changes in and repeat steps to see fixes

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? 
  - N/A
- What are the minimal test data to have?
  - N/A
- What is expected (happy path) to have (input and output)?
  - No malformed api call to /api/social/og/image
- Any other important info that could help to test that PR
  - N/A 

/claim #17931
