### PR TITLE
fix: metadata and broken og image 

### DIFF
--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -84,6 +84,9 @@ export const DOCS_URL = "https://cal.com/docs";
 export const DEVELOPER_DOCS = "https://developer.cal.com";
 export const SEO_IMG_DEFAULT = `${CAL_URL}/og-image.png`;
 export const SEO_IMG_OGIMG = `${CAL_URL}/api/social/og/image`;
+// The Dynamic OG Image is passed through Next's Image API to further optimize it.
+// This results in a 80% smaller image 🤯. It is however important that for the query
+// /api/social/og/image endpoint is dynamically generating the image
 export const SEO_IMG_OGIMG_VIDEO = `${CAL_URL}/video-og-image.png`;
 export const IS_STRIPE_ENABLED = !!(
   process.env.STRIPE_CLIENT_ID &&

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -83,13 +83,7 @@ export const POWERED_BY_URL = "https://go.cal.com/booking";
 export const DOCS_URL = "https://cal.com/docs";
 export const DEVELOPER_DOCS = "https://developer.cal.com";
 export const SEO_IMG_DEFAULT = `${CAL_URL}/og-image.png`;
-// The Dynamic OG Image is passed through Next's Image API to further optimize it.
-// This results in a 80% smaller image 🤯. It is however important that for the query
-// parameters you pass to the /api/social/og/image endpoint, you wrap them in encodeURIComponent
-// as well, otherwise the URL won't be valid.
-export const SEO_IMG_OGIMG = `${CAL_URL}/_next/image?w=1200&q=100&url=${encodeURIComponent(
-  `/api/social/og/image`
-)}`;
+export const SEO_IMG_OGIMG = `${CAL_URL}/api/social/og/image`;
 export const SEO_IMG_OGIMG_VIDEO = `${CAL_URL}/video-og-image.png`;
 export const IS_STRIPE_ENABLED = !!(
   process.env.STRIPE_CLIENT_ID &&


### PR DESCRIPTION
## What does this PR do?
- The OpenGraph image attribute in the metadata is malformed due to improperly encoded parameters, resulting in an incorrect API call to the OpenGraph image endpoint (i.e., /api/social/og/image?type=generic&title=a+title&description=a+desc).
-  The issue arises because Next.js's image optimization expects the url parameter to be a publicly accessible static image or a URL that returns an image directly. Since the /api/social/og/image endpoint is dynamically generating the image, Next.js can't optimize the image using its /_next/image system, and that's why we are getting a 404.
- This PR fixes API URL in the og:image Meta Tag


- Fixes #17931
- Fixes CAL-17931

https://www.loom.com/share/3e537446117b4e43bec71deef583f178?sid=dd65fbba-4a75-42d8-a476-cd660bee2d01

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Are there environment variables that should be set? - N/A
- What are the minimal test data to have? - N/A
- What is expected (happy path) to have (input and output)? - Successful API call to /api/social/og/image
- Any other important info that could help to test that PR - N/A

/claim #17931
