### PR TITLE
feat: add assignment reason to routing insights

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2798,6 +2798,7 @@
   "routing_form_insights_booking_status": "Booking Status",
   "routing_form_insights_booking_at": "Booking At",
   "routing_form_insights_submitted_at": "Submitted At",
+  "routing_form_insights_assignment_reason":"Assignment Reason",
   "access_denied": "Access Denied",
   "salesforce_route_to_owner": "Contact owner will be the Round Robin host if available",
   "salesforce_do_not_route_to_owner": "Contact owner will not be forced (can still be host if it matches the attributes and Round Robin criteria)",

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -369,6 +369,19 @@ export function RoutingFormResponsesTable({
           </div>
         ),
       }),
+      columnHelper.accessor("routedToBooking", {
+        id: "assignmentReason",
+        header: t("routing_form_insights_assignment_reason"),
+        size: 250,
+        cell: (info) => {
+          const assignmentReason = info.getValue()?.assignmentReason;
+          return (
+            <div className="max-w-[250px]">
+              {assignmentReason && assignmentReason.length > 0 ? assignmentReason[0].reasonString : ""}
+            </div>
+          );
+        },
+      }),
       columnHelper.accessor("createdAt", {
         id: "submittedAt",
         header: t("routing_form_insights_submitted_at"),

--- a/packages/features/insights/server/routing-events.ts
+++ b/packages/features/insights/server/routing-events.ts
@@ -247,6 +247,9 @@ class RoutingEventsInsights {
             user: {
               select: { id: true, name: true, email: true, avatarUrl: true },
             },
+            assignmentReason: {
+              select: { reasonString: true },
+            },
           },
         },
         createdAt: true,

--- a/packages/features/insights/server/routing-events.ts
+++ b/packages/features/insights/server/routing-events.ts
@@ -587,6 +587,11 @@ class RoutingEventsInsights {
                 email: true,
               },
             },
+            assignmentReason: {
+              select: {
+                reasonString: true,
+              },
+            },
           },
         },
       },
@@ -615,6 +620,7 @@ class RoutingEventsInsights {
         "Attendee Name": response.routedToBooking?.attendees[0]?.name || "",
         "Attendee Email": response.routedToBooking?.attendees[0]?.email || "",
         "Attendee Timezone": response.routedToBooking?.attendees[0]?.timeZone || "",
+        "Assignment Reason": response.routedToBooking?.assignmentReason[0].reasonString || "",
         "Routed To Name": response.routedToBooking?.user?.name || "",
         "Routed To Email": response.routedToBooking?.user?.email || "",
       };


### PR DESCRIPTION
## What does this PR do?

Adds assignment reason to insights table and the csv export
![CleanShot 2024-12-04 at 07 58 12](https://github.com/user-attachments/assets/f1279bdc-d718-4022-a10c-f00d83403363)

## How should this be tested?
* Setup a routing form 
* Setup sales force
* Test a routing form
* Check reason in table and csv

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
