### PR TITLE
feat: fetch SEO data for booking pages in server

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -102,7 +102,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   // Calling the tRPC fetch to get the public event data is incredibly slow
   // for large teams and we don't want to add it back. Future refactors will happen
   // to speed up this call.
-  const usernameList = getUsernameList(username);
+  const usernameList = getUsernameList(teamSlug);
   const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
   const usersInOrgContext = await UserRepository.findUsersByUsername({
     usernameList,

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -69,6 +69,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           },
         },
       },
+      logoUrl: true,
       name: true,
       slug: true,
       eventTypes: {
@@ -106,6 +107,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   // to speed up this call.
   const usernameList = getUsernameList(teamSlug);
   const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
+  const name = team.parent?.name ?? team.name ?? null;
   const usersInOrgContext = await UserRepository.findUsersByUsername({
     usernameList,
     orgSlug: team.parent?.slug || null,
@@ -152,17 +154,17 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           considerUnpublished: isUnpublished && !fromRedirectOfNonOrgLink,
           orgSlug,
           teamSlug: team.slug ?? null,
-          name: team.parent?.name ?? team.name ?? null,
+          name,
         },
         length: eventData.length,
         metadata: EventTypeMetaDataSchema.parse(eventData.metadata),
-        profile: team.parent
-          ? {
-              image: getPlaceholderAvatar(team.parent?.logoUrl, team.parent?.name),
-              name: team.parent?.name ?? null,
-              username: orgSlug ?? null,
-            }
-          : null,
+        profile: {
+          image: team.parent
+            ? getPlaceholderAvatar(team.parent.logoUrl, team.parent.name)
+            : getPlaceholderAvatar(team.logoUrl, team.name),
+          name,
+          username: orgSlug ?? null,
+        },
         title: eventData.title,
         users: usersInOrgContext.map((user) => ({
           ...user,

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -118,6 +118,13 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   const organizationSettings = OrganizationRepository.utils.getOrganizationSEOSettings(team);
   const allowSEOIndexing = organizationSettings?.allowSEOIndexing ?? false;
+  const publicEventData = await ssr.viewer.public.event.fetch({
+    username: teamSlug,
+    eventSlug: meetingSlug,
+    org: isValidOrgDomain ? currentOrgDomain : null,
+    fromRedirectOfNonOrgLink,
+    isTeamEvent: !!team,
+  });
 
   return {
     props: {
@@ -132,6 +139,12 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
         },
         length: eventData.length,
         metadata: EventTypeMetaDataSchema.parse(eventData.metadata),
+        ...(publicEventData && {
+          profile: publicEventData.profile,
+          title: publicEventData.title,
+          users: publicEventData.users,
+          hidden: publicEventData.hidden,
+        }),
       },
       booking,
       user: teamSlug,

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -123,7 +123,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     eventSlug: meetingSlug,
     org: isValidOrgDomain ? currentOrgDomain : null,
     fromRedirectOfNonOrgLink,
-    isTeamEvent: !!team,
+    isTeamEvent: true,
   });
 
   return {

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -156,15 +156,13 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
         },
         length: eventData.length,
         metadata: EventTypeMetaDataSchema.parse(eventData.metadata),
-        profile: {
-          ...(team.parent
-            ? {
-                image: getPlaceholderAvatar(team.parent?.logoUrl, team.parent?.name),
-                name: team.parent?.name,
-                username: orgSlug,
-              }
-            : {}),
-        },
+        profile: team.parent
+          ? {
+              image: getPlaceholderAvatar(team.parent?.logoUrl, team.parent?.name),
+              name: team.parent?.name ?? null,
+              username: orgSlug ?? null,
+            }
+          : null,
         title: eventData.title,
         users: usersInOrgContext.map((user) => ({
           ...user,

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -20,6 +20,7 @@ import {
   bookerLayoutOptions,
   userMetadata as userMetadataSchema,
 } from "@calcom/prisma/zod-utils";
+import type { BookerLayoutSettings } from "@calcom/prisma/zod-utils";
 
 import { getTemporaryOrgRedirect } from "@lib/getTemporaryOrgRedirect";
 

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -14,8 +14,10 @@ import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import { RedirectType } from "@calcom/prisma/client";
 import {
+  BookerLayouts,
   EventTypeMetaDataSchema,
   bookerLayouts as bookerLayoutsSchema,
+  bookerLayoutOptions,
   userMetadata as userMetadataSchema,
 } from "@calcom/prisma/zod-utils";
 
@@ -148,6 +150,10 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   }
 
   const firstUsersMetadata = userMetadataSchema.parse(usersInOrgContext[0].metadata || {});
+  const defaultEventBookerLayouts = {
+    enabledLayouts: [...bookerLayoutOptions],
+    defaultLayout: BookerLayouts.MONTH_VIEW,
+  } as BookerLayoutSettings;
 
   return {
     props: {
@@ -179,7 +185,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
             : {}),
         },
         title: eventData.title,
-        users: users.map((user) => ({
+        users: usersInOrgContext.map((user) => ({
           ...user,
           metadata: undefined,
           bookerUrl: getBookerBaseUrlSync(user.profile?.organization?.slug ?? null),

--- a/apps/web/modules/team/type-view.tsx
+++ b/apps/web/modules/team/type-view.tsx
@@ -37,6 +37,7 @@ function Type({
   isSEOIndexable,
 }: PageProps) {
   const searchParams = useSearchParams();
+  const { profile, users, hidden, title } = eventData;
 
   return (
     <main className={getBookerWrapperClasses({ isEmbed: !!isEmbed })}>
@@ -46,12 +47,16 @@ function Type({
         rescheduleUid={booking?.uid}
         hideBranding={isBrandingHidden}
         isTeamEvent
-        eventData={{
-          profile: eventData.profile,
-          users: eventData.users,
-          hidden: eventData.hidden,
-          title: eventData.title,
-        }}
+        eventData={
+          profile && users && title && hidden !== undefined
+            ? {
+                profile,
+                users,
+                title,
+                hidden,
+              }
+            : undefined
+        }
         entity={eventData.entity}
         bookingData={booking}
         isSEOIndexable={isSEOIndexable}

--- a/apps/web/modules/team/type-view.tsx
+++ b/apps/web/modules/team/type-view.tsx
@@ -46,6 +46,12 @@ function Type({
         rescheduleUid={booking?.uid}
         hideBranding={isBrandingHidden}
         isTeamEvent
+        eventData={{
+          profile: eventData.profile,
+          users: eventData.users,
+          hidden: eventData.hidden,
+          title: eventData.title,
+        }}
         entity={eventData.entity}
         bookingData={booking}
         isSEOIndexable={isSEOIndexable}

--- a/apps/web/modules/users/views/users-type-public-view.tsx
+++ b/apps/web/modules/users/views/users-type-public-view.tsx
@@ -35,7 +35,7 @@ function Type({
   orgBannerUrl,
 }: PageProps) {
   const searchParams = useSearchParams();
-
+  const { profile, users, hidden, title } = eventData;
   return (
     <main className={getBookerWrapperClasses({ isEmbed: !!isEmbed })}>
       <BookerSeo
@@ -44,12 +44,16 @@ function Type({
         rescheduleUid={rescheduleUid ?? undefined}
         hideBranding={isBrandingHidden}
         isSEOIndexable={isSEOIndexable ?? true}
-        eventData={{
-          profile: eventData.profile,
-          users: eventData.users,
-          hidden: eventData.hidden,
-          title: eventData.title,
-        }}
+        eventData={
+          profile && users && title && hidden !== undefined
+            ? {
+                profile,
+                users,
+                title,
+                hidden,
+              }
+            : undefined
+        }
         entity={eventData.entity}
         bookingData={booking}
       />

--- a/apps/web/modules/users/views/users-type-public-view.tsx
+++ b/apps/web/modules/users/views/users-type-public-view.tsx
@@ -44,6 +44,12 @@ function Type({
         rescheduleUid={rescheduleUid ?? undefined}
         hideBranding={isBrandingHidden}
         isSEOIndexable={isSEOIndexable ?? true}
+        eventData={{
+          profile: eventData.profile,
+          users: eventData.users,
+          hidden: eventData.hidden,
+          title: eventData.title,
+        }}
         entity={eventData.entity}
         bookingData={booking}
       />

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -17,10 +17,20 @@ import { RedirectType } from "@calcom/prisma/client";
 import { getTemporaryOrgRedirect } from "@lib/getTemporaryOrgRedirect";
 
 type Props = {
-  eventData: Pick<
-    NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
-    "id" | "length" | "metadata" | "entity" | "profile" | "title" | "users" | "hidden"
-  >;
+  eventData: Omit<
+    Pick<
+      NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
+      "id" | "length" | "metadata" | "entity" | "profile" | "title" | "users" | "hidden"
+    >,
+    "profile"
+  > & {
+    profile: {
+      image: string | undefined;
+      name: string | null;
+      username: string | null;
+    };
+  };
+
   booking?: GetBookingType;
   rescheduleUid: string | null;
   bookingUid: string | null;
@@ -143,7 +153,11 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
         ...eventData.metadata,
         multipleDuration: [15, 30, 45, 60, 90],
       },
-      profile: eventData.profile,
+      profile: {
+        image: eventData.profile.image,
+        name: eventData.profile.name ?? null,
+        username: eventData.profile.username ?? null,
+      },
       title: eventData.title,
       users: eventData.users,
       hidden: eventData.hidden,
@@ -235,7 +249,11 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       entity: eventData.entity,
       length: eventData.length,
       metadata: eventData.metadata,
-      profile: eventData.profile,
+      profile: {
+        image: eventData.profile.image,
+        name: eventData.profile.name ?? null,
+        username: eventData.profile.username ?? null,
+      },
       title: eventData.title,
       users: eventData.users,
       hidden: eventData.hidden,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -19,7 +19,7 @@ import { getTemporaryOrgRedirect } from "@lib/getTemporaryOrgRedirect";
 type Props = {
   eventData: Pick<
     NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
-    "id" | "length" | "metadata" | "entity"
+    "id" | "length" | "metadata" | "entity" | "profile" | "title" | "users" | "hidden"
   >;
   booking?: GetBookingType;
   rescheduleUid: string | null;
@@ -143,6 +143,10 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
         ...eventData.metadata,
         multipleDuration: [15, 30, 45, 60, 90],
       },
+      profile: eventData.profile,
+      title: eventData.title,
+      users: eventData.users,
+      hidden: eventData.hidden,
     },
     user: usernames.join("+"),
     slug,
@@ -231,6 +235,10 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       entity: eventData.entity,
       length: eventData.length,
       metadata: eventData.metadata,
+      profile: eventData.profile,
+      title: eventData.title,
+      users: eventData.users,
+      hidden: eventData.hidden,
     },
     user: username,
     slug,

--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -1,5 +1,6 @@
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
+import type { getPublicEvent } from "@calcom/features/eventtypes/lib/getPublicEvent";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { HeadSeo } from "@calcom/ui";
@@ -11,6 +12,10 @@ interface BookerSeoProps {
   hideBranding?: boolean;
   isSEOIndexable?: boolean;
   isTeamEvent?: boolean;
+  eventData?: Pick<
+    NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
+    "profile" | "title" | "users" | "hidden"
+  >;
   entity: {
     fromRedirectOfNonOrgLink: boolean;
     orgSlug?: string | null;
@@ -30,9 +35,10 @@ export const BookerSeo = (props: BookerSeoProps) => {
     entity,
     isSEOIndexable,
     bookingData,
+    eventData,
   } = props;
   const { t } = useLocale();
-  const { data: event } = trpc.viewer.public.event.useQuery(
+  const { data: _event } = trpc.viewer.public.event.useQuery(
     {
       username,
       eventSlug,
@@ -40,8 +46,9 @@ export const BookerSeo = (props: BookerSeoProps) => {
       org: entity.orgSlug ?? null,
       fromRedirectOfNonOrgLink: entity.fromRedirectOfNonOrgLink,
     },
-    { refetchOnWindowFocus: false }
+    { refetchOnWindowFocus: false, enabled: !eventData }
   );
+  const event = eventData ?? _event;
 
   const profileName = event?.profile.name ?? "";
   const profileImage = event?.profile.image;

--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -12,10 +12,16 @@ interface BookerSeoProps {
   hideBranding?: boolean;
   isSEOIndexable?: boolean;
   isTeamEvent?: boolean;
-  eventData?: Pick<
-    NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
-    "profile" | "title" | "users" | "hidden"
-  >;
+  eventData?: Omit<
+    Pick<NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>, "profile" | "title" | "users" | "hidden">,
+    "profile"
+  > & {
+    profile: {
+      image: string | undefined;
+      name: string | null;
+      username: string | null;
+    };
+  };
   entity: {
     fromRedirectOfNonOrgLink: boolean;
     orgSlug?: string | null;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

 - Pass data needed for SEO data from the server and avoid extra fetching in client-side for org/team/user booking pages

e.g., this video shows that the title is there in the initial load (previously, it was empty on initial load) for a team booking page

https://github.com/user-attachments/assets/4947541c-27db-4519-bdc8-78f8d483b2af



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
