### PR TITLE
Fix getSchedule not using dwd credentials

### DIFF
--- a/packages/lib/domainWideDelegation/server.ts
+++ b/packages/lib/domainWideDelegation/server.ts
@@ -107,7 +107,7 @@ export async function getAllDomainWideDelegationCredentialsForUser({
     buildDomainWideDelegationConferencingCredential({ domainWideDelegation, user }),
   ].filter((credential): credential is NonNullable<typeof credential> => credential !== null);
 
-  log.debug("Returned", { domainWideDelegationCredentials });
+  log.debug("Returned", safeStringify({ domainWideDelegationCredentials }));
   return domainWideDelegationCredentials;
 }
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -21,6 +21,7 @@ import {
 import { RESERVED_SUBDOMAINS } from "@calcom/lib/constants";
 import { getUTCOffsetByTimezone } from "@calcom/lib/date-fns";
 import { getDefaultEvent } from "@calcom/lib/defaultEvents";
+import { getAllDomainWideDelegationCalendarCredentialsForUser } from "@calcom/lib/domainWideDelegation/server";
 import {
   isTimeOutOfBounds,
   calculatePeriodLimits,
@@ -410,6 +411,35 @@ export function getUsersWithCredentialsConsideringContactOwner({
   );
 
   return contactOwnerAndFixedHosts;
+}
+
+async function getEnrichedUsersWithCredentialsConsideringContactOwner({
+  contactOwnerEmail,
+  hosts,
+}: {
+  contactOwnerEmail: string | null | undefined;
+  hosts: {
+    isFixed?: boolean;
+    user: GetAvailabilityUser;
+  }[];
+}) {
+  const hostsWithContactOwner = getUsersWithCredentialsConsideringContactOwner({
+    contactOwnerEmail,
+    hosts,
+  });
+
+  const hostsWithDwdCredentials = await Promise.all(
+    hostsWithContactOwner.map(async (host) => {
+      const dwdCredentials = await getAllDomainWideDelegationCalendarCredentialsForUser({
+        user: host,
+      });
+      return {
+        ...host,
+        credentials: [...host.credentials, ...dwdCredentials],
+      };
+    })
+  );
+  return hostsWithDwdCredentials;
 }
 
 const getStartTime = (startTimeInput: string, timeZone?: string, minimumBookingNotice?: number) => {
@@ -842,7 +872,7 @@ async function getExistingBookings(
       in: "ACCEPTED"[];
     };
   },
-  usersWithCredentials: ReturnType<typeof getUsersWithCredentialsConsideringContactOwner>,
+  usersWithCredentials: Awaited<ReturnType<typeof getEnrichedUsersWithCredentialsConsideringContactOwner>>,
   allUserIds: number[]
 ) {
   const bookingsSelect = Prisma.validator<Prisma.BookingSelect>()({
@@ -1051,10 +1081,13 @@ const calculateHostsAndAvailabilities = async ({
     );
   }
 
-  const usersWithCredentials = monitorCallbackSync(getUsersWithCredentialsConsideringContactOwner, {
-    contactOwnerEmail,
-    hosts: routedHostsWithContactOwnerAndFixedHosts,
-  });
+  const usersWithCredentials = await monitorCallbackAsync(
+    getEnrichedUsersWithCredentialsConsideringContactOwner,
+    {
+      contactOwnerEmail,
+      hosts: routedHostsWithContactOwnerAndFixedHosts,
+    }
+  );
 
   loggerWithEventDetails.debug("Using users", {
     usersWithCredentials: usersWithCredentials.map((user) => user.email),


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where on booking page slots weren't considering the dwd credentials to fetch busy times
