### PR TITLE
chore: Move pre-commit commands to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint-staged
-
-yarn app-store:build && git add packages/app-store/*.generated.*

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+set -e
+
+yarn lint-staged
+yarn app-store:build && git add packages/app-store/*.generated.*
+
+git stash -q --keep-index
+
+# Check for new file changes after running the above commands
+if ! git diff --cached --quiet; then
+  echo "Error: The build process modified files. Please commit the changes and try again."
+  git stash pop -q
+  exit 1
+fi
+
+# Restore stashed changes if nothing went wrong
+git stash pop -q

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,5 +15,5 @@ if ! git diff --cached --quiet; then
   exit 1
 fi
 
-# Restore stashed changes if nothing went wrong
+# Restore stashed changes if nothing went wrong. Testing commit
 git stash pop -q

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,5 +15,5 @@ if ! git diff --cached --quiet; then
   exit 1
 fi
 
-# Restore stashed changes if nothing went wrong. Testing commit
+# Restore stashed changes if nothing went wrong.
 git stash pop -q

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,7 +3,10 @@
 
 set -e
 
+echo "Info: Running lint-staged"
 yarn lint-staged
+
+echo "Info: Running app-store:build"
 yarn app-store:build && git add packages/app-store/*.generated.*
 
 git stash -q --keep-index

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,6 @@ git checkout HEAD~1 yarn.lock
 git commit -m "Revert yarn.lock changes"
 ```
 
-_NB_: You may have to bypass the pre-commit hook with by appending `--no-verify` to the git commit
 If you've pushed the commit with the `yarn.lock`:
 
 1.  Correct the commit locally using the above method.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "lint:report": "turbo run lint:report",
     "lint": "turbo run lint",
     "postinstall": "husky install && turbo run post-install",
-    "pre-commit": "lint-staged",
     "predev": "echo 'Checking env files'",
     "prisma": "yarn workspace @calcom/prisma prisma",
     "start": "turbo run start --scope=\"@calcom/web\"",


### PR DESCRIPTION
## What does this PR do?

Our commits take around 4s to complete right now. Instead of having these commands on pre-commit, we'll now have them on pre-push to improve DX.

On a side note, I noticed that all yarn commands in our monorepo have a delay of a few seconds to even startup. I moved the app-store-cli out of the monorepo as a test and running `yarn app-store:build` takes 1.2s total instead of 4s like in the mono repo. Will continue researching that further.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A - I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Make a change locally that would trigger a change either via `lint-staged` or in the app store build and ensure the push is blocked.
