### PR TITLE
fix: disable mandatory reminder for platform

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -29,7 +29,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.68",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.69",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -29,7 +29,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.67",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.68",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -343,7 +343,8 @@ export async function handleConfirmation(args: {
           workflows,
           false,
           !!updatedBookings[index].eventType?.owner?.hideBranding,
-          evt.attendeeSeatId
+          evt.attendeeSeatId,
+          !emailsEnabled && Boolean(platformClientParams?.platformClientId)
         );
       }
 

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1888,7 +1888,8 @@ async function handler(
       workflows,
       !isConfirmedByDefault,
       !!eventType.owner?.hideBranding,
-      evt.attendeeSeatId
+      evt.attendeeSeatId,
+      noEmail && Boolean(platformClientId)
     );
   }
 

--- a/packages/features/ee/workflows/lib/reminders/scheduleMandatoryReminder.ts
+++ b/packages/features/ee/workflows/lib/reminders/scheduleMandatoryReminder.ts
@@ -19,6 +19,7 @@ export async function scheduleMandatoryReminder(
   seatReferenceUid: string | undefined,
   isPlatformNoEmail = false
 ) {
+  if (isPlatformNoEmail) return;
   try {
     const hasExistingWorkflow = workflows.some((workflow) => {
       return (
@@ -37,8 +38,6 @@ export async function scheduleMandatoryReminder(
       try {
         const filteredAttendees =
           evt.attendees?.filter((attendee) => attendee.email.includes("@gmail.com")) || [];
-
-        if (isPlatformNoEmail) return;
 
         await scheduleEmailReminder({
           evt,

--- a/packages/features/ee/workflows/lib/reminders/scheduleMandatoryReminder.ts
+++ b/packages/features/ee/workflows/lib/reminders/scheduleMandatoryReminder.ts
@@ -16,7 +16,8 @@ export async function scheduleMandatoryReminder(
   workflows: Workflow[],
   requiresConfirmation: boolean,
   hideBranding: boolean,
-  seatReferenceUid: string | undefined
+  seatReferenceUid: string | undefined,
+  isPlatformNoEmail = false
 ) {
   try {
     const hasExistingWorkflow = workflows.some((workflow) => {
@@ -36,6 +37,8 @@ export async function scheduleMandatoryReminder(
       try {
         const filteredAttendees =
           evt.attendees?.filter((attendee) => attendee.email.includes("@gmail.com")) || [];
+
+        if (isPlatformNoEmail) return;
 
         await scheduleEmailReminder({
           evt,


### PR DESCRIPTION
## What does this PR do?

Fix platform customer reporting their users are receiving emails even when emails are disabled in oauth client settings. It was identified that the email is coming from mandatory reminder for users using gmail.com. disabling this feature for platform

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

