### PR TITLE
chore: Remove --quiet from husky pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,7 +12,7 @@ yarn app-store:build && git add packages/app-store/*.generated.*
 git stash -q --keep-index
 
 # Check for new file changes after running the above commands
-if ! git diff --cached --quiet; then
+if ! git diff --cached; then
   echo "Error: The build process modified files. Please commit the changes and try again."
   git stash pop -q
   exit 1


### PR DESCRIPTION
## What does this PR do?

The release is blocked and I can't see why. Removing the --quiet param to get more details.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A -  I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A - I confirm automated tests are in place that prove my fix is effective or that my feature works.

