### PR TITLE
feat: v1 booking "created at" field in response

### DIFF
--- a/apps/api/v1/lib/validations/booking.ts
+++ b/apps/api/v1/lib/validations/booking.ts
@@ -120,4 +120,5 @@ export const schemaBookingReadPublic = Booking.extend({
   fromReschedule: true,
   cancelledBy: true,
   rescheduledBy: true,
+  createdAt: true,
 });

--- a/apps/api/v1/lib/validations/booking.ts
+++ b/apps/api/v1/lib/validations/booking.ts
@@ -23,6 +23,7 @@ const schemaBookingBaseBodyParams = Booking.pick({
   status: true,
   rescheduledBy: true,
   cancelledBy: true,
+  createdAt: true,
 }).partial();
 
 export const schemaBookingCreateBodyParams = extendedBookingCreateBody.merge(schemaQueryUserId.partial());


### PR DESCRIPTION
## What does this PR do?

Adds createdAt in response object for GET bookings

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

