### PR TITLE
fix: add onTouchEnd for mobile apps

### DIFF
--- a/packages/platform/atoms/connect/OAuthConnect.tsx
+++ b/packages/platform/atoms/connect/OAuthConnect.tsx
@@ -77,6 +77,10 @@ export const OAuthConnect: FC<
           tooltipOffset={10}
           tooltipClassName="p-0 text-inherit bg-inherit"
           className={cn("", !isDisabled && "cursor-pointer", className)}
+          onTouchEnd={() => {
+            connect();
+            onSuccess?.();
+          }}
           onClick={() => {
             connect();
             onSuccess?.();
@@ -100,6 +104,10 @@ export const OAuthConnect: FC<
           !isDisabled && "cursor-pointer",
           className
         )}
+        onTouchEnd={() => {
+          connect();
+          onSuccess?.();
+        }}
         onClick={() => connect()}>
         {displayedLabel}
       </Button>


### PR DESCRIPTION
## What does this PR do?

Users reported Connect atoms were not clickable on their mobile app created with Cordova

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

