### PR TITLE
chore: remove extra fetching and get user locale from headers in settings pages

### DIFF
--- a/apps/web/app/_utils.tsx
+++ b/apps/web/app/_utils.tsx
@@ -27,6 +27,15 @@ export const getFixedT = async (locale: string, ns = "common") => {
   return i18n.getFixedT(locale, ns);
 };
 
+export const getTranslate = async () => {
+  const headersList = await headers();
+  // If "x-locale" does not exist in header,
+  // ensure that config.matcher in middleware includes the page you are testing
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
+  return t;
+};
+
 export const _generateMetadata = async (
   getTitle: (t: TFunction<string, undefined>) => string,
   getDescription: (t: TFunction<string, undefined>) => string,

--- a/apps/web/app/settings/(admin-layout)/admin/apps/[category]/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/apps/[category]/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import AdminAppsList from "@calcom/features/apps/AdminAppsList";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -12,10 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("apps")} description={t("admin_apps_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/apps/[category]/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/apps/[category]/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import AdminAppsList from "@calcom/features/apps/AdminAppsList";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -12,9 +12,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("apps")} description={t("admin_apps_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/flags/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/flags/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import { FlagListingView } from "@calcom/features/flags/pages/flag-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader title={t("feature_flags")} description={t("admin_flags_description")}>
       <FlagListingView />

--- a/apps/web/app/settings/(admin-layout)/admin/flags/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/flags/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import { FlagListingView } from "@calcom/features/flags/pages/flag-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader title={t("feature_flags")} description={t("admin_flags_description")}>
       <FlagListingView />

--- a/apps/web/app/settings/(admin-layout)/admin/impersonation/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/impersonation/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import ImpersonationView from "~/settings/admin/impersonation-view";
@@ -13,9 +13,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader title={t("admin")} description={t("impersonation")}>
       <ImpersonationView />

--- a/apps/web/app/settings/(admin-layout)/admin/impersonation/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/impersonation/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -13,10 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader title={t("admin")} description={t("impersonation")}>
       <ImpersonationView />

--- a/apps/web/app/settings/(admin-layout)/admin/lockedSMS/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/lockedSMS/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import LockedSMSView from "~/settings/admin/locked-sms-view";
@@ -12,8 +12,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader title={t("lockedSMS")} description={t("admin_lockedSMS_description")}>
       <LockedSMSView />

--- a/apps/web/app/settings/(admin-layout)/admin/lockedSMS/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/lockedSMS/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -12,9 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader title={t("lockedSMS")} description={t("admin_lockedSMS_description")}>
       <LockedSMSView />

--- a/apps/web/app/settings/(admin-layout)/admin/oAuth/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/oAuth/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -12,9 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader title={t("oAuth")} description={t("admin_oAuth_description")}>
       <LegacyPage />

--- a/apps/web/app/settings/(admin-layout)/admin/oAuth/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/oAuth/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import LegacyPage from "~/settings/admin/oauth-view";
@@ -12,8 +12,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader title={t("oAuth")} description={t("admin_oAuth_description")}>
       <LegacyPage />

--- a/apps/web/app/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
@@ -1,9 +1,9 @@
 import { type Params } from "app/_types";
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { z } from "zod";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { OrgForm } from "@calcom/features/ee/organizations/pages/settings/admin/AdminOrgEditPage";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -35,8 +35,9 @@ const Page = async ({ params }: { params: Params }) => {
 
   try {
     const org = await OrganizationRepository.adminFindById({ id: input.data.id });
-    const session = await getServerSessionForAppDir();
-    const t = await getFixedT(session?.user.locale || "en");
+    const headersList = await headers();
+    const locale = headersList.get("x-locale");
+    const t = await getFixedT(locale ?? "en");
     return (
       <SettingsHeader
         title={`${t("editing_org")}: ${org.name}`}

--- a/apps/web/app/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { type Params } from "app/_types";
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 import { notFound } from "next/navigation";
 import { z } from "zod";
 
@@ -35,9 +34,7 @@ const Page = async ({ params }: { params: Params }) => {
 
   try {
     const org = await OrganizationRepository.adminFindById({ id: input.data.id });
-    const headersList = await headers();
-    const locale = headersList.get("x-locale");
-    const t = await getFixedT(locale ?? "en");
+    const t = await getTranslate();
     return (
       <SettingsHeader
         title={`${t("editing_org")}: ${org.name}`}

--- a/apps/web/app/settings/(admin-layout)/admin/organizations/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/organizations/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import AdminOrgTable from "@calcom/features/ee/organizations/pages/settings/admin/AdminOrgPage";
@@ -13,10 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader title={t("organizations")} description={t("orgs_page_description")}>
       <LicenseRequired>

--- a/apps/web/app/settings/(admin-layout)/admin/organizations/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/organizations/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import AdminOrgTable from "@calcom/features/ee/organizations/pages/settings/admin/AdminOrgPage";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -13,9 +13,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader title={t("organizations")} description={t("orgs_page_description")}>
       <LicenseRequired>

--- a/apps/web/app/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
@@ -1,9 +1,9 @@
 import { type Params } from "app/_types";
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { z } from "zod";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { UsersEditView } from "@calcom/features/ee/users/pages/users-edit-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -37,8 +37,9 @@ const Page = async ({ params }: { params: Params }) => {
 
   try {
     const user = await UserRepository.adminFindById(input.data.id);
-    const session = await getServerSessionForAppDir();
-    const t = await getFixedT(session?.user.locale || "en");
+    const headersList = await headers();
+    const locale = headersList.get("x-locale");
+    const t = await getFixedT(locale ?? "en");
 
     return (
       <SettingsHeader title={t("editing_user")} description={t("admin_users_edit_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { type Params } from "app/_types";
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 import { notFound } from "next/navigation";
 import { z } from "zod";
 
@@ -37,9 +36,7 @@ const Page = async ({ params }: { params: Params }) => {
 
   try {
     const user = await UserRepository.adminFindById(input.data.id);
-    const headersList = await headers();
-    const locale = headersList.get("x-locale");
-    const t = await getFixedT(locale ?? "en");
+    const t = await getTranslate();
 
     return (
       <SettingsHeader title={t("editing_user")} description={t("admin_users_edit_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/users/add/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/add/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import UsersAddView from "@calcom/features/ee/users/pages/users-add-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("add_new_user")} description={t("admin_users_add_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/users/add/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/add/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import UsersAddView from "@calcom/features/ee/users/pages/users-add-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("add_new_user")} description={t("admin_users_add_description")}>

--- a/apps/web/app/settings/(admin-layout)/admin/users/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import UsersListingView from "@calcom/features/ee/users/pages/users-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { Button } from "@calcom/ui";
@@ -12,8 +12,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
   return (
     <SettingsHeader
       title={t("users")}

--- a/apps/web/app/settings/(admin-layout)/admin/users/page.tsx
+++ b/apps/web/app/settings/(admin-layout)/admin/users/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import UsersListingView from "@calcom/features/ee/users/pages/users-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -12,9 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   return (
     <SettingsHeader
       title={t("users")}

--- a/apps/web/app/settings/(settings-layout)/billing/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/billing/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import BillingView from "~/settings/billing/billing-view";
@@ -13,8 +13,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/billing/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/billing/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -13,9 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/developer/api-keys/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/api-keys/page.tsx
@@ -1,5 +1,4 @@
-import { getFixedT, _generateMetadata } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate, _generateMetadata } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -13,11 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  // FIXME: Refactor me once next-auth endpoint is migrated to App Router
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/developer/api-keys/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/api-keys/page.tsx
@@ -1,6 +1,6 @@
 import { getFixedT, _generateMetadata } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME } from "@calcom/lib/constants";
 
@@ -14,9 +14,10 @@ export const generateMetadata = async () =>
 
 const Page = async () => {
   // FIXME: Refactor me once next-auth endpoint is migrated to App Router
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { PageProps } from "app/_types";
 import { getFixedT, _generateMetadata } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { EditWebhookView } from "@calcom/features/webhooks/pages/webhook-edit-view";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -14,9 +14,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async ({ params }: PageProps) => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
   const id = typeof params?.id === "string" ? params.id : undefined;
 
   const webhook = await WebhookRepository.findByWebhookId(id);

--- a/apps/web/app/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
@@ -1,6 +1,5 @@
 import type { PageProps } from "app/_types";
-import { getFixedT, _generateMetadata } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate, _generateMetadata } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { EditWebhookView } from "@calcom/features/webhooks/pages/webhook-edit-view";
@@ -14,10 +13,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async ({ params }: PageProps) => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   const id = typeof params?.id === "string" ? params.id : undefined;
 
   const webhook = await WebhookRepository.findByWebhookId(id);

--- a/apps/web/app/settings/(settings-layout)/developer/webhooks/new/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/webhooks/new/page.tsx
@@ -1,6 +1,6 @@
 import { getFixedT, _generateMetadata } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { NewWebhookView } from "@calcom/features/webhooks/pages/webhook-new-view";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -12,9 +12,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/developer/webhooks/new/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/developer/webhooks/new/page.tsx
@@ -1,5 +1,4 @@
-import { getFixedT, _generateMetadata } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate, _generateMetadata } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { NewWebhookView } from "@calcom/features/webhooks/pages/webhook-new-view";
@@ -12,10 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/my-account/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/appearance/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import AppearancePage from "~/settings/my-account/appearance-view";
@@ -13,8 +13,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("appearance")} description={t("appearance_description")}>

--- a/apps/web/app/settings/(settings-layout)/my-account/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/appearance/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -13,9 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("appearance")} description={t("appearance_description")}>

--- a/apps/web/app/settings/(settings-layout)/my-account/calendars/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/calendars/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { Button } from "@calcom/ui";
@@ -14,9 +13,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   const AddCalendarButton = () => {
     return (

--- a/apps/web/app/settings/(settings-layout)/my-account/calendars/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/calendars/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { Button } from "@calcom/ui";
 
@@ -14,8 +14,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   const AddCalendarButton = () => {
     return (

--- a/apps/web/app/settings/(settings-layout)/my-account/conferencing/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/conferencing/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import { ConferencingAppsViewWebWrapper } from "@calcom/atoms/monorepo";
 
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <ConferencingAppsViewWebWrapper

--- a/apps/web/app/settings/(settings-layout)/my-account/conferencing/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/conferencing/page.tsx
@@ -1,8 +1,8 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
 import { ConferencingAppsViewWebWrapper } from "@calcom/atoms/monorepo";
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <ConferencingAppsViewWebWrapper

--- a/apps/web/app/settings/(settings-layout)/my-account/general/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/general/page.tsx
@@ -1,8 +1,8 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
 import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import GeneralQueryView from "~/settings/my-account/general-view";
@@ -14,9 +14,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
   const revalidatePage = async () => {
     "use server";
     revalidatePath("settings/my-account/general");

--- a/apps/web/app/settings/(settings-layout)/my-account/general/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/general/page.tsx
@@ -1,7 +1,6 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
+import { getTranslate } from "app/_utils";
 import { revalidatePath } from "next/cache";
-import { headers } from "next/headers";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -14,10 +13,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
   const revalidatePage = async () => {
     "use server";
     revalidatePath("settings/my-account/general");

--- a/apps/web/app/settings/(settings-layout)/my-account/out-of-office/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/out-of-office/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import CreateNewOutOfOfficeEntryButton from "@calcom/features/settings/outOfOffice/CreateNewOutOfOfficeEntryButton";
@@ -13,10 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/my-account/out-of-office/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/out-of-office/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import CreateNewOutOfOfficeEntryButton from "@calcom/features/settings/outOfOffice/CreateNewOutOfOfficeEntryButton";
 import { OutOfOfficeEntriesList } from "@calcom/features/settings/outOfOffice/OutOfOfficeEntriesList";
@@ -13,9 +13,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/my-account/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/profile/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME } from "@calcom/lib/constants";
 
@@ -14,8 +14,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/my-account/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/my-account/profile/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -14,9 +13,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/admin-api/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/admin-api/page.tsx
@@ -1,6 +1,6 @@
 import { getFixedT, _generateMetadata } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import { AdminAPIView } from "@calcom/features/ee/organizations/pages/settings/admin-api";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,9 +11,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/admin-api/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/admin-api/page.tsx
@@ -1,5 +1,4 @@
-import { getFixedT, _generateMetadata } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate, _generateMetadata } from "app/_utils";
 
 import { AdminAPIView } from "@calcom/features/ee/organizations/pages/settings/admin-api";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,10 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/attributes/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/attributes/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
 import OrgSettingsAttributesPage from "@calcom/ee/organizations/pages/settings/attributes/attributes-list-view";
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("attributes")} description={t("attribute_meta_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/attributes/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/attributes/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import OrgSettingsAttributesPage from "@calcom/ee/organizations/pages/settings/attributes/attributes-list-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("attributes")} description={t("attribute_meta_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/dsync/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/dsync/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import DirectorySyncTeamView from "@calcom/features/ee/dsync/page/team-dsync-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("directory_sync")} description={t("directory_sync_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/dsync/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/dsync/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import DirectorySyncTeamView from "@calcom/features/ee/dsync/page/team-dsync-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("directory_sync")} description={t("directory_sync_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/general/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/general/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/general";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("general")} description={t("general_description")} borderInShellHeader={true}>

--- a/apps/web/app/settings/(settings-layout)/organizations/general/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/general/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/general";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("general")} description={t("general_description")} borderInShellHeader={true}>

--- a/apps/web/app/settings/(settings-layout)/organizations/privacy/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/privacy/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import PrivacyView from "@calcom/features/ee/organizations/pages/settings/privacy";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("privacy")} description={t("privacy_organization_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/privacy/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/privacy/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import PrivacyView from "@calcom/features/ee/organizations/pages/settings/privacy";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("privacy")} description={t("privacy_organization_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/profile/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/profile";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/profile/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/profile";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/sso/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/sso/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import OrgSSOView from "@calcom/features/ee/sso/page/orgs-sso-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("sso_configuration")} description={t("sso_configuration_description_orgs")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/sso/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/sso/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import OrgSSOView from "@calcom/features/ee/sso/page/orgs-sso-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("sso_configuration")} description={t("sso_configuration_description_orgs")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/teams/pages/team-appearance-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/teams/pages/team-appearance-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage, {
   TeamMembersCTA,
 } from "@calcom/features/ee/organizations/pages/settings/other-team-members-view";
@@ -13,8 +13,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage, {
   TeamMembersCTA,
@@ -13,9 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/other-team-profile-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("profile")} description={t("profile_team_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/other-team-profile-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("profile")} description={t("profile_team_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/other-team-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("org_admin_other_teams")} description={t("org_admin_other_teams_description")}>

--- a/apps/web/app/settings/(settings-layout)/organizations/teams/other/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/organizations/teams/other/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/organizations/pages/settings/other-team-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("org_admin_other_teams")} description={t("org_admin_other_teams_description")}>

--- a/apps/web/app/settings/(settings-layout)/security/impersonation/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/impersonation/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import ProfileImpersonationViewWrapper from "~/settings/security/impersonation-view";
@@ -13,9 +13,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/security/impersonation/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/impersonation/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -13,10 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/security/password/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/password/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -13,10 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("password")} description={t("password_description")} borderInShellHeader={true}>

--- a/apps/web/app/settings/(settings-layout)/security/password/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/password/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import PasswordViewWrapper from "~/settings/security/password-view";
@@ -13,9 +13,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("password")} description={t("password_description")} borderInShellHeader={true}>

--- a/apps/web/app/settings/(settings-layout)/security/sso/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/sso/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SAMLSSO from "@calcom/features/ee/sso/page/user-sso-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -12,10 +11,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/security/sso/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/sso/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SAMLSSO from "@calcom/features/ee/sso/page/user-sso-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -12,9 +12,10 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/security/two-factor-auth/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/two-factor-auth/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import TwoFactorAuthView from "~/settings/security/two-factor-auth-view";
@@ -12,9 +12,10 @@ export const generateMetadata = async () =>
     (t) => t("add_an_extra_layer_of_security")
   );
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
 
-  const t = await getFixedT(session?.user.locale || "en");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/security/two-factor-auth/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/security/two-factor-auth/page.tsx
@@ -1,6 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -12,10 +11,7 @@ export const generateMetadata = async () =>
     (t) => t("add_an_extra_layer_of_security")
   );
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/appearance/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/teams/pages/team-appearance-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/appearance/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/appearance/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/teams/pages/team-appearance-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/bookingLimits/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/bookingLimits/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import TeamBookingLimitsView from "@calcom/features/ee/teams/pages/team-booking-limits-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/bookingLimits/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/bookingLimits/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import TeamBookingLimitsView from "@calcom/features/ee/teams/pages/team-booking-limits-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/members/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/members/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/teams/pages/team-members-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("team_members")} description={t("members_team_description")}>

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/members/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/members/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/teams/pages/team-members-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("team_members")} description={t("members_team_description")}>

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/profile/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/teams/pages/team-profile-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/[id]/profile/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/[id]/profile/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/teams/pages/team-profile-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader

--- a/apps/web/app/settings/(settings-layout)/teams/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/teams/pages/team-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
@@ -11,8 +11,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("teams")} description={t("create_manage_teams_collaborative")}>

--- a/apps/web/app/settings/(settings-layout)/teams/page.tsx
+++ b/apps/web/app/settings/(settings-layout)/teams/page.tsx
@@ -1,5 +1,4 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
-import { headers } from "next/headers";
+import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage from "@calcom/features/ee/teams/pages/team-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -11,9 +10,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("teams")} description={t("create_manage_teams_collaborative")}>

--- a/apps/web/app/settings/organizations/members/page.tsx
+++ b/apps/web/app/settings/organizations/members/page.tsx
@@ -1,6 +1,5 @@
-import { _generateMetadata, getFixedT } from "app/_utils";
+import { _generateMetadata, getTranslate } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { headers } from "next/headers";
 
 import LegacyPage from "@calcom/features/ee/organizations/pages/members";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
@@ -13,9 +12,7 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const headersList = await headers();
-  const locale = headersList.get("x-locale");
-  const t = await getFixedT(locale ?? "en");
+  const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("organization_members")} description={t("organization_description")}>

--- a/apps/web/app/settings/organizations/members/page.tsx
+++ b/apps/web/app/settings/organizations/members/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getFixedT } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
+import { headers } from "next/headers";
 
-import { getServerSessionForAppDir } from "@calcom/features/auth/lib/get-server-session-for-app-dir";
 import LegacyPage from "@calcom/features/ee/organizations/pages/members";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import SettingsLayoutAppDir from "@calcom/features/settings/appDir/SettingsLayoutAppDir";
@@ -13,8 +13,9 @@ export const generateMetadata = async () =>
   );
 
 const Page = async () => {
-  const session = await getServerSessionForAppDir();
-  const t = await getFixedT(session?.user.locale || "en");
+  const headersList = await headers();
+  const locale = headersList.get("x-locale");
+  const t = await getFixedT(locale ?? "en");
 
   return (
     <SettingsHeader title={t("organization_members")} description={t("organization_description")}>

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -166,7 +166,6 @@ export const config = {
 
     "/event-types",
     "/future/event-types/",
-    "/settings/admin/:path*",
     "/apps/installed/:category/",
     "/future/apps/installed/:category/",
     "/apps/:slug/",
@@ -179,7 +178,6 @@ export const config = {
     "/future/apps/categories/:category/",
     "/workflows/:path*",
     "/future/workflows/:path*",
-    "/settings/teams/:path*",
     "/getting-started/:step/",
     "/future/getting-started/:step/",
     "/apps",
@@ -190,6 +188,7 @@ export const config = {
     "/future/video/:path*",
     "/teams",
     "/future/teams/",
+    "/settings/:path*",
   ],
 };
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This removes all instances of getServerSessionForAppDir in settings pages and rather fetches locale from headers
- Translations continue to work fine as in screencast

https://github.com/user-attachments/assets/1a8e710c-dc16-4fad-a4fc-a592e5bdb865

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


