### PR TITLE
fix: When crating a new event from a team event list, the cancel button redirects to /event-types #

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -116,7 +116,6 @@ export default function CreateEventTypeDialog({
       name="new"
       clearQueryParamsOnClose={[
         "eventPage",
-        "teamId",
         "type",
         "description",
         "title",


### PR DESCRIPTION
## What does this PR do?
-Fixes the redirect to /event-types from create team event on pressing cancel by not removing teamId from QueryParams

- Fixes #17863 (GitHub issue number)
- Fixes CAL-17863 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).


## How should this be tested?
- Press cancel after opening the Dialog in create team event, it should not redirect to /event-types

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I haven't checked if my changes generate no new warnings
