### PR TITLE
fix: correct line-breaks in calendar event description

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -78,8 +78,9 @@ export const getWho = (
   const hideAttendees = Boolean(seatsPerTimeSlot && !seatsShowAttendees);
   const attendeesText = getAttendeesText(t, hideAttendees, attendees);
   const teamMembersText = getTeamMembersText(t, team?.members);
+  const whoTexts = [organizerText, teamMembersText, attendeesText].filter(Boolean).join("\n\n");
 
-  return `${t("who")}:\n${organizerText}${teamMembersText}${attendeesText}`;
+  return `${t("who")}:\n${whoTexts}`;
 };
 
 export const getAdditionalNotes = (

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -2,7 +2,7 @@ import type { TFunction } from "next-i18next";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 
-import type { CalendarEvent, Person } from "@calcom/types/Calendar";
+import type { CalendarEvent, Person, TeamMember } from "@calcom/types/Calendar";
 
 import { WEBAPP_URL } from "./constants";
 import getLabelValueMapFromResponses from "./getLabelValueMapFromResponses";
@@ -10,28 +10,55 @@ import isSmsCalEmail from "./isSmsCalEmail";
 
 const translator = short();
 
-// The odd indentation in this file is necessary because otherwise the leading tabs will be applied into the event description.
-
-export const getWhat = (calEvent: Pick<CalendarEvent, "title">, t: TFunction) => {
-  return `
-${t("what")}:
-${calEvent.title}
-  `;
+export const getWhat = (calEvent: Pick<CalendarEvent, "title">, t: TFunction): string => {
+  return `${t("what")}:\n${calEvent.title.trim()}`;
 };
 
 export const getWhen = (
   calEvent: Pick<CalendarEvent, "organizer" | "attendees" | "seatsPerTimeSlot">,
   t: TFunction
-) => {
+): string => {
   return calEvent.seatsPerTimeSlot
-    ? `
-${t("organizer_timezone")}:
-${calEvent.organizer.timeZone}
-  `
-    : `
-${t("invitee_timezone")}:
-${calEvent.attendees[0].timeZone}
-  `;
+    ? `${t("organizer_timezone")}:\n${calEvent.organizer.timeZone.trim()}`
+    : `${t("invitee_timezone")}:\n${calEvent.attendees[0].timeZone.trim()}`;
+};
+
+const getAttendeesText = (t: TFunction, hideAttendees: boolean, attendees?: Person[]): string => {
+  if (hideAttendees || !attendees || attendees.length === 0) return "";
+
+  // This will generate something like this:
+  // John Doe
+  // john.doe@acme.com
+  //
+  // Nic Doe
+  // nic.doe@acme.com
+  //
+  // jane.doe@acme.com - Guest
+  //
+  // simon.doe@acme.com - Guest
+  return attendees
+    .map((attendee) => {
+      const { name, email, phoneNumber } = attendee;
+      const label = !isSmsCalEmail(email) ? `${email}` : `${phoneNumber}`;
+      if (name) return `${name.trim()}\n${label.trim()}`;
+      // Guests don't have a name.
+      return `${label.trim()} - ${t("guest")}`;
+    })
+    .join("\n\n");
+};
+
+const getTeamMembersText = (t: TFunction, teamMembers?: TeamMember[]): string => {
+  if (!teamMembers || teamMembers.length === 0) return "";
+
+  // This will generate something like this:
+  // John Doe - Team Member
+  // john.doe@acme.com
+  //
+  // Jane Doe - Team Member
+  // jane.doe@acme.com
+  return teamMembers
+    .map((member) => `${member.name.trim()} - ${t("team_member")}\n${member.email.trim()}`)
+    .join("\n\n");
 };
 
 export const getWho = (
@@ -40,78 +67,41 @@ export const getWho = (
     "attendees" | "seatsPerTimeSlot" | "seatsShowAttendees" | "organizer" | "team"
   >,
   t: TFunction
-) => {
-  let attendeesFromCalEvent = [...calEvent.attendees];
-  if (calEvent.seatsPerTimeSlot && !calEvent.seatsShowAttendees) {
-    attendeesFromCalEvent = [];
-  }
-  const attendees = attendeesFromCalEvent
-    .map((attendee) => {
-      return `
-${attendee?.name || t("guest")}
-${!isSmsCalEmail(attendee.email) ? `${attendee.email}\n` : `${attendee.phoneNumber}\n`}
+): string => {
+  const { attendees, organizer, team, seatsPerTimeSlot, seatsShowAttendees } = calEvent;
 
-`;
-    })
+  const organizerText = `${organizer.name} - ${t("organizer")}\n${organizer.email}`;
+  const hideAttendees = Boolean(seatsPerTimeSlot && !seatsShowAttendees);
+  const attendeesText = getAttendeesText(t, hideAttendees, attendees);
+  const teamMembersText = getTeamMembersText(t, team?.members);
 
-    .join("");
-
-  const organizer = `
-${calEvent.organizer.name} - ${t("organizer")}
-${calEvent.organizer.email}
-  `;
-
-  const teamMembers = calEvent.team?.members
-    ? calEvent.team.members.map((member) => {
-        return `
-${member.name} - ${t("team_member")}
-${member.email}
-    `;
-      })
-    : [];
-
-  return `
-${t("who")}:
-${organizer + attendees + teamMembers.join("")}
-  `;
+  return `${t("who")}:\n${organizerText}${teamMembersText}${attendeesText}`;
 };
 
-export const getAdditionalNotes = (calEvent: Pick<CalendarEvent, "additionalNotes">, t: TFunction) => {
-  if (!calEvent.additionalNotes) {
-    return "";
-  }
-  return `
-${t("additional_notes")}:
-${calEvent.additionalNotes}
-  `;
+export const getAdditionalNotes = (
+  calEvent: Pick<CalendarEvent, "additionalNotes">,
+  t: TFunction
+): string => {
+  if (!calEvent.additionalNotes) return "";
+  return `${t("additional_notes")}:\n${calEvent.additionalNotes.trim()}`;
 };
 
-export const getUserFieldsResponses = (calEvent: Parameters<typeof getLabelValueMapFromResponses>[0]) => {
+export const getUserFieldsResponses = (
+  calEvent: Parameters<typeof getLabelValueMapFromResponses>[0]
+): string => {
   const labelValueMap = getLabelValueMapFromResponses(calEvent);
 
-  if (!labelValueMap) {
-    return "";
-  }
-  const responsesString = Object.keys(labelValueMap)
-    .map((key) => {
-      if (!labelValueMap) return "";
-      if (labelValueMap[key] !== "") {
-        return `
-${key}:
-${labelValueMap[key]}
-  `;
-      }
-    })
-    .join("");
+  if (!labelValueMap) return "";
 
-  return responsesString;
+  return Object.keys(labelValueMap)
+    .map((key) => (labelValueMap[key] !== "" ? `${key}:\n${labelValueMap[key]}` : ""))
+    .join("\n\n");
 };
 
-export const getAppsStatus = (calEvent: Pick<CalendarEvent, "appsStatus">, t: TFunction) => {
-  if (!calEvent.appsStatus) {
-    return "";
-  }
-  return `\n${t("apps_status")}
+export const getAppsStatus = (calEvent: Pick<CalendarEvent, "appsStatus">, t: TFunction): string => {
+  if (!calEvent.appsStatus) return "";
+
+  return `${t("apps_status")}:
       ${calEvent.appsStatus.map((app) => {
         return `\n- ${app.appName} ${
           app.success >= 1 ? `✅ ${app.success > 1 ? `(x${app.success})` : ""}` : ""
@@ -124,23 +114,20 @@ export const getAppsStatus = (calEvent: Pick<CalendarEvent, "appsStatus">, t: TF
     `;
 };
 
-export const getDescription = (calEvent: Pick<CalendarEvent, "description">, t: TFunction) => {
-  if (!calEvent.description) {
-    return "";
-  }
-  return `\n${t("description")}
-    ${calEvent.description}
-    `;
+export const getDescription = (calEvent: Pick<CalendarEvent, "description">, t: TFunction): string => {
+  if (!calEvent.description) return "";
+
+  return `${t("description")}:\n${calEvent.description.trim()}`;
 };
+
 export const getLocation = (
   calEvent: Parameters<typeof getVideoCallUrlFromCalEvent>[0] & Parameters<typeof getProviderName>[0]
-) => {
+): string => {
   const meetingUrl = getVideoCallUrlFromCalEvent(calEvent);
-  if (meetingUrl) {
-    return meetingUrl;
-  }
+  if (meetingUrl) return meetingUrl;
+
   const providerName = getProviderName(calEvent);
-  return providerName || calEvent.location || "";
+  return (providerName || calEvent.location || "").trim();
 };
 
 export const getProviderName = (calEvent: Pick<CalendarEvent, "location">): string => {
@@ -168,7 +155,7 @@ const getSeatReferenceId = (calEvent: Pick<CalendarEvent, "attendeeSeatId">): st
   return calEvent.attendeeSeatId ? calEvent.attendeeSeatId : "";
 };
 
-export const getBookingUrl = (calEvent: CalendarEvent) => {
+export const getBookingUrl = (calEvent: CalendarEvent): string => {
   if (calEvent.platformClientId) {
     if (!calEvent.platformBookingUrl) return "";
     return `${calEvent.platformBookingUrl}/${getUid(calEvent)}?slug=${calEvent.type}&username=${
@@ -184,7 +171,7 @@ export const getPlatformManageLink = (
     Parameters<typeof getRescheduleLink>[0]["calEvent"] &
     Pick<CalendarEvent, "platformBookingUrl" | "platformRescheduleUrl" | "team">,
   t: TFunction
-) => {
+): string => {
   const shouldDisplayReschedule = !calEvent.recurringEvent && calEvent.platformRescheduleUrl;
   let res =
     calEvent.platformBookingUrl || shouldDisplayReschedule || calEvent.platformCancelUrl
@@ -214,7 +201,7 @@ export const getManageLink = (
   calEvent: Parameters<typeof getPlatformManageLink>[0] &
     Pick<CalendarEvent, "platformClientId" | "bookerUrl">,
   t: TFunction
-) => {
+): string => {
   if (calEvent.platformClientId) {
     return getPlatformManageLink(calEvent, t);
   }
@@ -333,39 +320,34 @@ export const getRichDescription = (
 ) => {
   const t = t_ ?? calEvent.organizer.language.translate;
 
-  return `
-${getCancellationReason(calEvent, t)}
-${getWhat(calEvent, t)}
-${getWhen(calEvent, t)}
-${getWho(calEvent, t)}
-${t("where")}:
-${getLocation(calEvent)}
-${getDescription(calEvent, t)}
-${getAdditionalNotes(calEvent, t)}
-${getUserFieldsResponses(calEvent)}
-${includeAppStatus ? getAppsStatus(calEvent, t) : ""}
-${
-  // TODO: Only the original attendee can make changes to the event
-  // Guests cannot
-  calEvent.seatsPerTimeSlot ? "" : getManageLink(calEvent, t)
-}
-${
-  calEvent.paymentInfo
-    ? `
-${t("pay_now")}:
-${calEvent.paymentInfo.link}
-`
-    : ""
-}
-  `.trim();
+  const location = getLocation(calEvent);
+  const locationField = location.length > 0 ? `${t("where")}:\n${location}` : "";
+
+  return [
+    getCancellationReason(calEvent, t),
+    getWhat(calEvent, t),
+    getWhen(calEvent, t),
+    getWho(calEvent, t),
+    locationField,
+    getDescription(calEvent, t),
+    getAdditionalNotes(calEvent, t),
+    getUserFieldsResponses(calEvent),
+    includeAppStatus ? getAppsStatus(calEvent, t) : "",
+    // TODO: Only the original attendee can make changes to the event
+    // Guests cannot
+    calEvent.seatsPerTimeSlot ? "" : getManageLink(calEvent, t),
+    calEvent.paymentInfo ? `${t("pay_now")}:\n${calEvent.paymentInfo.link}` : "",
+  ]
+    .filter(Boolean) // Remove empty strings
+    .join("\n\n");
 };
 
-export const getCancellationReason = (calEvent: Pick<CalendarEvent, "cancellationReason">, t: TFunction) => {
+export const getCancellationReason = (
+  calEvent: Pick<CalendarEvent, "cancellationReason">,
+  t: TFunction
+): string => {
   if (!calEvent.cancellationReason) return "";
-  return `
-${t("cancellation_reason")}:
-${calEvent.cancellationReason}
- `;
+  return `${t("cancellation_reason")}:\n${calEvent.cancellationReason}`;
 };
 
 export const isDailyVideoCall = (calEvent: Pick<CalendarEvent, "videoCallData">): boolean => {

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -26,18 +26,18 @@ export const getWhen = (
 const getAttendeesText = (t: TFunction, hideAttendees: boolean, attendees?: Person[]): string => {
   if (hideAttendees || !attendees || attendees.length === 0) return "";
 
-/*
-This will generate something like this:
-  John Doe
-  john.doe@acme.com
-  
-  Nic Doe
-  nic.doe@acme.com
-  
-  jane.doe@acme.com - Guest
-  
-  simon.doe@acme.com - Guest
-*/
+  /*
+    This will generate something like this:
+    John Doe
+    john.doe@acme.com
+
+    Nic Doe
+    nic.doe@acme.com
+
+    jane.doe@acme.com - Guest
+
+    simon.doe@acme.com - Guest
+  */
   return attendees
     .map((attendee) => {
       const { name, email, phoneNumber } = attendee;
@@ -52,12 +52,14 @@ This will generate something like this:
 const getTeamMembersText = (t: TFunction, teamMembers?: TeamMember[]): string => {
   if (!teamMembers || teamMembers.length === 0) return "";
 
-  // This will generate something like this:
-  // John Doe - Team Member
-  // john.doe@acme.com
-  //
-  // Jane Doe - Team Member
-  // jane.doe@acme.com
+  /*
+    This will generate something like this:
+    John Doe - Team Member
+    john.doe@acme.com
+
+    Jane Doe - Team Member
+    jane.doe@acme.com
+  */
   return teamMembers
     .map((member) => `${member.name.trim()} - ${t("team_member")}\n${member.email.trim()}`)
     .join("\n\n");

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -26,16 +26,18 @@ export const getWhen = (
 const getAttendeesText = (t: TFunction, hideAttendees: boolean, attendees?: Person[]): string => {
   if (hideAttendees || !attendees || attendees.length === 0) return "";
 
-  // This will generate something like this:
-  // John Doe
-  // john.doe@acme.com
-  //
-  // Nic Doe
-  // nic.doe@acme.com
-  //
-  // jane.doe@acme.com - Guest
-  //
-  // simon.doe@acme.com - Guest
+/*
+This will generate something like this:
+  John Doe
+  john.doe@acme.com
+  
+  Nic Doe
+  nic.doe@acme.com
+  
+  jane.doe@acme.com - Guest
+  
+  simon.doe@acme.com - Guest
+*/
   return attendees
     .map((attendee) => {
       const { name, email, phoneNumber } = attendee;


### PR DESCRIPTION
## What does this PR do?

Reviewing the function `getRichDescription` in `CalEventParser` and its sub-functions in the same file, in order to correct all those double/triple/quadruple line-breaks in the event descriptions. No functional change, just cleaning the UI.

### BEFORE
![393995966-eb981a69-8a84-468e-8876-ced85249911a](https://github.com/user-attachments/assets/b5836237-c2f8-4f8a-89c1-765ddf745a04)

### AFTER
![Screenshot 2024-12-10 at 16 13 47](https://github.com/user-attachments/assets/6d41454e-36e8-40ad-b4bc-724bca3e9a01)
![Screenshot 2024-12-10 at 16 14 07](https://github.com/user-attachments/assets/50378f38-2ff1-417f-abe8-4b4d94b8d786)

Also adding explicit output types on all functions.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

To reproduce:
- Plug a calendar as organizer
- Book as a client
- Event should appear in calendar and shouldn't contain double/triple/quadruple line-breaks

## Checklist