### PR TITLE
build: Change alpine image to one compatible with Prisma

### DIFF
--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as build
+FROM node:18-alpine3.20 as build
 
 ARG DATABASE_DIRECT_URL
 ARG DATABASE_URL


### PR DESCRIPTION
## What does this PR do?

Alpine Linux 3.21 isn't compatible with Prisma at this point in time, so reverting the image to the previous 3.20 version.

https://github.com/prisma/prisma/issues/25817