### PR TITLE
build: Node alpine libssl symlink fix

### DIFF
--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.20 as build
+FROM node:18-alpine as build
 
 ARG DATABASE_DIRECT_URL
 ARG DATABASE_URL
@@ -6,6 +6,7 @@ ARG DATABASE_URL
 WORKDIR /calcom
 
 RUN set -eux;
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
 ENV NODE_ENV="production"
 ENV NODE_OPTIONS="--max-old-space-size=8192"


### PR DESCRIPTION
## What does this PR do?

Provides a better fix; in the latest version of libssl on Alpine Linux libssl has moved from `/usr` to `/usr/lib`. An open PR exists @ Prisma to fix this going forward but in the mean time we can symlink this as a semi-permanent safe solution.

The benefit of not locking the version is mitigation for future libssl (or other) zerodays. A Symlink solution is preferred.

https://github.com/prisma/prisma/pull/25824