### PR TITLE
fix: filling users logic

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -6,10 +6,7 @@ import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { getBookingForReschedule } from "@calcom/features/bookings/lib/get-booking";
 import { getSlugOrRequestedSlug, orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
-import { getUsernameList } from "@calcom/lib/defaultEvents";
-import { getBookerBaseUrlSync } from "@calcom/lib/getBookerUrl/client";
 import { OrganizationRepository } from "@calcom/lib/server/repository/organization";
-import { UserRepository } from "@calcom/lib/server/repository/user";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import { RedirectType } from "@calcom/prisma/client";
@@ -58,6 +55,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     },
     select: {
       id: true,
+      isPrivate: true,
       hideBranding: true,
       parent: {
         select: {
@@ -87,6 +85,16 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           metadata: true,
           length: true,
           hidden: true,
+          hosts: {
+            select: {
+              user: {
+                select: {
+                  name: true,
+                  username: true,
+                },
+              },
+            },
+          },
         },
       },
       isOrganization: true,
@@ -103,21 +111,46 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       notFound: true,
     } as const;
   }
+  const eventData = team.eventTypes[0];
+  const eventTypeId = eventData.id;
 
   // INFO: This code was pulled from getPublicEvent and used here.
   // Calling the tRPC fetch to get the public event data is incredibly slow
   // for large teams and we don't want to add it back. Future refactors will happen
   // to speed up this call.
-  const usernameList = getUsernameList(teamSlug);
+  let users: { username: string; name: string }[] = [];
+  if (!team.isPrivate && eventData.hosts.length) {
+    users = eventData.hosts
+      .filter((host) => host.user.username)
+      .map((host) => ({
+        username: host.user.username ?? "",
+        name: host.user.name ?? "",
+      }));
+  }
+  if (!team.isPrivate && !eventData.hosts.length) {
+    // backward compatibility logic
+    // for team event types that have users[] but not hosts[]
+    const { users: data } = await prisma.eventType.findUniqueOrThrow({
+      where: { id: eventTypeId },
+      select: {
+        users: {
+          select: {
+            username: true,
+            name: true,
+          },
+        },
+      },
+    });
+    users = data
+      .filter((user) => user.username)
+      .map((user) => ({
+        username: user.username ?? "",
+        name: user.name ?? "",
+      }));
+  }
+
   const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
   const name = team.parent?.name ?? team.name ?? null;
-  const usersInOrgContext = await UserRepository.findUsersByUsername({
-    usernameList,
-    orgSlug: team.parent?.slug || null,
-  });
-
-  const eventData = team.eventTypes[0];
-  const eventTypeId = eventData.id;
 
   let booking: GetBookingType | null = null;
   if (rescheduleUid) {
@@ -169,11 +202,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           username: orgSlug ?? null,
         },
         title: eventData.title,
-        users: usersInOrgContext.map((user) => ({
-          ...user,
-          metadata: undefined,
-          bookerUrl: getBookerBaseUrlSync(user.profile?.organization?.slug ?? null),
-        })),
+        users,
         hidden: eventData.hidden,
       },
       booking,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -22,13 +22,17 @@ type Props = {
       NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>,
       "id" | "length" | "metadata" | "entity" | "profile" | "title" | "users" | "hidden"
     >,
-    "profile"
+    "profile" | "users"
   > & {
     profile: {
       image: string | undefined;
       name: string | null;
       username: string | null;
     };
+    users: {
+      username: string;
+      name: string;
+    }[];
   };
 
   booking?: GetBookingType;
@@ -159,7 +163,7 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
         username: eventData.profile.username ?? null,
       },
       title: eventData.title,
-      users: eventData.users,
+      users: eventData.users.map((user) => ({ username: user.username ?? "", name: user.name ?? "" })),
       hidden: eventData.hidden,
     },
     user: usernames.join("+"),
@@ -255,7 +259,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
         username: eventData.profile.username ?? null,
       },
       title: eventData.title,
-      users: eventData.users,
+      users: eventData.users.map((user) => ({ username: user.username ?? "", name: user.name ?? "" })),
       hidden: eventData.hidden,
     },
     user: username,

--- a/packages/features/bookings/components/BookerSeo.tsx
+++ b/packages/features/bookings/components/BookerSeo.tsx
@@ -14,13 +14,17 @@ interface BookerSeoProps {
   isTeamEvent?: boolean;
   eventData?: Omit<
     Pick<NonNullable<Awaited<ReturnType<typeof getPublicEvent>>>, "profile" | "title" | "users" | "hidden">,
-    "profile"
+    "profile" | "users"
   > & {
     profile: {
       image: string | undefined;
       name: string | null;
       username: string | null;
     };
+    users: {
+      username: string;
+      name: string;
+    }[];
   };
   entity: {
     fromRedirectOfNonOrgLink: boolean;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://app.campsite.com/cal/posts/lojq7cf8uuk1

### Tested

<img width="1262" alt="Screenshot 2024-12-11 at 10 11 41 PM" src="https://github.com/user-attachments/assets/37ea5d7f-b46e-4c9d-9e25-22ec659636d8" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

1. Login with Admin account
2. Create a team and team event-type
3. Enable this setting

<img width="992" alt="Screenshot 2024-12-11 at 10 14 02 PM" src="https://github.com/user-attachments/assets/c2c6049f-f782-4986-b844-e31fa3fc857d" />

4. Go to booking page. You should be seeing something like:

<img width="757" alt="Screenshot 2024-12-11 at 10 14 15 PM" src="https://github.com/user-attachments/assets/9a5a161b-a3cc-476f-8544-7195f032b756" />

5. Test the OG image