### PR TITLE
feat: Removed query parameter from event type URL when opening the link

### DIFF
--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -46,9 +46,12 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
   const date = dayjs(selectedDate).format("YYYY-MM-DD");
 
   useEffect(() => {
+    console.log("inside useffect");
     // This event isn't processed by BookingPageTagManager because BookingPageTagManager hasn't loaded when it is fired. I think we should have a queue in fire method to handle this.
     sdkActionManager?.fire("navigatedToBooker", {});
-  }, []);
+    //This removes the queryparameters from the url as soon as it gets added on every cliks on layout or calender dates
+    history.replaceState(null, "", window.location.pathname);
+  });
 
   useInitializeBookerStore({
     ...props,

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -46,7 +46,6 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
   const date = dayjs(selectedDate).format("YYYY-MM-DD");
 
   useEffect(() => {
-    console.log("inside useffect");
     // This event isn't processed by BookingPageTagManager because BookingPageTagManager hasn't loaded when it is fired. I think we should have a queue in fire method to handle this.
     sdkActionManager?.fire("navigatedToBooker", {});
     //This removes the queryparameters from the url as soon as it gets added on every cliks on layout or calender dates


### PR DESCRIPTION
## What does this PR do?

This pull request includes query parameter related changes, if you go to the Event Type and check the preview of any available event i.e. 15 min , 30 min and after loading the page it removes all the query parameters available in the search bar of the browser.

- Fixes  #18076
- Fixes CAL-4868

## Loom Video 
 Loom Video: https://www.loom.com/share/946945aee5ff4aeaa7f6edd704fe8ce0?sid=43afc60b-7b61-467d-8eba-65889c32af2d


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go To Even Types then click on 'Preview' Button of any event like 15 min or 30 min or secret and check the url in search bar after loading the page whether query parameter is showing up or not or
- Copy any event url i.e 15 min or 30 min and paste it in search bar and check if query paramters are showing up or not


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I haven't checked if my changes generate no new warnings
