### PR TITLE
fix: early return if no users are found to prevent prisma error

### DIFF
--- a/packages/features/insights/server/routing-events.ts
+++ b/packages/features/insights/server/routing-events.ts
@@ -730,7 +730,7 @@ class RoutingEventsInsights {
       }>
     >`
       WITH routed_responses AS (
-        SELECT DISTINCT ON (b."userId") 
+        SELECT DISTINCT ON (b."userId")
           b."userId",
           u.id,
           u.name,
@@ -758,6 +758,20 @@ class RoutingEventsInsights {
 
     const hasMoreUsers = users.length === limit;
 
+    // Return early if no users found
+    if (users.length === 0) {
+      return {
+        users: {
+          data: [],
+          nextCursor: undefined,
+        },
+        periodStats: {
+          data: [],
+          nextCursor: undefined,
+        },
+      };
+    }
+
     // Get periods with pagination
     const periodStats = await prisma.$queryRaw<
       Array<{
@@ -770,7 +784,7 @@ class RoutingEventsInsights {
       WITH RECURSIVE date_range AS (
         SELECT date_trunc(${dayjsPeriod}, ${startDate}::timestamp) as date
         UNION ALL
-        SELECT date + (CASE 
+        SELECT date + (CASE
           WHEN ${dayjsPeriod} = 'day' THEN interval '1 day'
           WHEN ${dayjsPeriod} = 'week' THEN interval '1 week'
           WHEN ${dayjsPeriod} = 'month' THEN interval '1 month'
@@ -792,7 +806,7 @@ class RoutingEventsInsights {
       ),
       -- Generate combinations for paginated periods
       date_user_combinations AS (
-        SELECT 
+        SELECT
           period_start,
           user_id as "userId"
         FROM paginated_periods
@@ -800,7 +814,7 @@ class RoutingEventsInsights {
       ),
       -- Count bookings per user per period
       booking_counts AS (
-        SELECT 
+        SELECT
           b."userId",
           date_trunc(${dayjsPeriod}, b."createdAt") as period_start,
           COUNT(DISTINCT b.id)::integer as total
@@ -814,13 +828,13 @@ class RoutingEventsInsights {
         GROUP BY 1, 2
       )
       -- Join everything together
-      SELECT 
+      SELECT
         c."userId",
         c.period_start,
         COALESCE(b.total, 0)::integer as total
       FROM date_user_combinations c
-      LEFT JOIN booking_counts b ON 
-        b."userId" = c."userId" AND 
+      LEFT JOIN booking_counts b ON
+        b."userId" = c."userId" AND
         b.period_start = c.period_start
       ORDER BY c.period_start ASC, c."userId" ASC
     `;
@@ -830,7 +844,7 @@ class RoutingEventsInsights {
       WITH RECURSIVE date_range AS (
         SELECT date_trunc(${dayjsPeriod}, ${startDate}::timestamp) as date
         UNION ALL
-        SELECT date + (CASE 
+        SELECT date + (CASE
           WHEN ${dayjsPeriod} = 'day' THEN interval '1 day'
           WHEN ${dayjsPeriod} = 'week' THEN interval '1 week'
           WHEN ${dayjsPeriod} = 'month' THEN interval '1 month'
@@ -848,7 +862,7 @@ class RoutingEventsInsights {
         total_bookings: number;
       }>
     >`
-      SELECT 
+      SELECT
         b."userId",
         COUNT(*)::integer as total_bookings
       FROM "App_RoutingForms_FormResponse" r
@@ -965,7 +979,7 @@ class RoutingEventsInsights {
       }>
     >`
       WITH routed_responses AS (
-        SELECT DISTINCT ON (b."userId") 
+        SELECT DISTINCT ON (b."userId")
           b."userId",
           u.id,
           u.name,
@@ -998,7 +1012,7 @@ class RoutingEventsInsights {
       WITH RECURSIVE date_range AS (
         SELECT date_trunc(${dayjsPeriod}, ${startDate}::timestamp) as date
         UNION ALL
-        SELECT date + (CASE 
+        SELECT date + (CASE
           WHEN ${dayjsPeriod} = 'day' THEN interval '1 day'
           WHEN ${dayjsPeriod} = 'week' THEN interval '1 week'
           WHEN ${dayjsPeriod} = 'month' THEN interval '1 month'
@@ -1010,14 +1024,14 @@ class RoutingEventsInsights {
         SELECT unnest(ARRAY[${Prisma.join(usersQuery.map((u) => u.id))}]) as user_id
       ),
       date_user_combinations AS (
-        SELECT 
+        SELECT
           date as period_start,
           user_id as "userId"
         FROM date_range
         CROSS JOIN all_users
       ),
       booking_counts AS (
-        SELECT 
+        SELECT
           b."userId",
           date_trunc(${dayjsPeriod}, b."createdAt") as period_start,
           COUNT(DISTINCT b.id)::integer as total
@@ -1030,13 +1044,13 @@ class RoutingEventsInsights {
         ${whereClause}
         GROUP BY 1, 2
       )
-      SELECT 
+      SELECT
         c."userId",
         c.period_start,
         COALESCE(b.total, 0)::integer as total
       FROM date_user_combinations c
-      LEFT JOIN booking_counts b ON 
-        b."userId" = c."userId" AND 
+      LEFT JOIN booking_counts b ON
+        b."userId" = c."userId" AND
         b.period_start = c.period_start
       ORDER BY c.period_start ASC, c."userId" ASC
     `;
@@ -1048,7 +1062,7 @@ class RoutingEventsInsights {
         total_bookings: number;
       }>
     >`
-      SELECT 
+      SELECT
         b."userId",
         COUNT(*)::integer as total_bookings
       FROM "App_RoutingForms_FormResponse" r


### PR DESCRIPTION
## What does this PR do?

Fixes sentry error for primsa.join on empty array

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Change your seed to be like 95 (we use intervals of 10 in infinite scroll so this works well to replicate) users into acme org.
Load insights/routing
Scroll to bottom and notice there is no error in console

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
