### PR TITLE
fix: default to 100 when attribute weight undefined

### DIFF
--- a/packages/lib/server/getLuckyUser.ts
+++ b/packages/lib/server/getLuckyUser.ts
@@ -868,15 +868,15 @@ function getAverageAttributeWeights<
           );
 
           allRRHosts.forEach((rrHost) => {
-            const weight = attributeOptionWithUsers?.assignedUsers.find(
+            const assignedUser = attributeOptionWithUsers?.assignedUsers.find(
               (assignedUser) => rrHost.user.id === assignedUser.member.userId
-            )?.weight;
+            );
 
-            if (weight) {
+            if (assignedUser) {
               if (allRRHostsWeights.has(rrHost.user.id)) {
-                allRRHostsWeights.get(rrHost.user.id)?.push(weight);
+                allRRHostsWeights.get(rrHost.user.id)?.push(assignedUser.weight ?? 100);
               } else {
-                allRRHostsWeights.set(rrHost.user.id, [weight]);
+                allRRHostsWeights.set(rrHost.user.id, [assignedUser.weight ?? 100]);
               }
             }
           });
@@ -897,6 +897,7 @@ function getAverageAttributeWeights<
     "getAverageAttributeWeights",
     safeStringify({ allRRHosts, attributesQueryValueChild, attributeWithWeights, averageWeightsHosts })
   );
+
   return averageWeightsHosts;
 }
 


### PR DESCRIPTION
## What does this PR do?

In `getAverageAttributeWeights` we didn't add the weight for the host if the attribute weight was undefined, but in that case, we want to default to weight 100. 