### PR TITLE
fix: ensure migrated pages are added to config.matcher in middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -153,6 +153,13 @@ export const config = {
   // Next.js Doesn't support spread operator in config matcher, so, we must list all paths explicitly here.
   // https://github.com/vercel/next.js/discussions/42458
   matcher: [
+    "/d/:path*",
+    "/more/:path*",
+    "/maintenance/:path*",
+    "/enterprise/:path*",
+    "/upgrade/:path*",
+    "/connect-and-join/:path*",
+    "/insights/:path*",
     "/:path*/embed",
     "/api/auth/signup",
     "/api/trpc/:path*",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- For app router pages, we set custom headers in `middleware` which are always used in generating metadata (e.g., `x-locale` header that contains the user's locale)
- The middleware is just additional code running within the same function invocation - it doesn't trigger separate/additional serverless function calls that would increase costs.
- This PR will fix this issue where the metadata is not translated for some migrated pages

<img width="307" alt="Screenshot 2024-12-12 at 11 03 14 PM" src="https://github.com/user-attachments/assets/10a41f31-665f-449a-8b4e-65fccf615bc3" />


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
