### PR TITLE
chore: Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/on-changes-requested.yml
+++ b/.github/workflows/on-changes-requested.yml
@@ -15,7 +15,7 @@ jobs:
             printf '{
               "pr_number": ${{ github.event.pull_request.number }}
             }' >> context.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: context.json
           path: ./


### PR DESCRIPTION
## What does this PR do?

We had 1 instance of actions/upload-artifact still using v3 which is going out of support in January.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- After this is merged to main (testing it beforehand is cumbersome and not worth the effort imo), ensure that requesting changes on a PR puts the PR back into draft
