### PR TITLE
fix: private team does not hide team members for managed event type

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/getEventTypesFromGroup.handler.ts
@@ -172,6 +172,7 @@ export const getEventTypesFromGroup = async ({
     mappedEventTypes.forEach((evType) => {
       evType.users = [];
       evType.hosts = [];
+      evType.children = [];
     });
 
   return { eventTypes: mappedEventTypes, nextCursor: nextCursor ?? undefined };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, when a team is private, it doesn’t hide the assigned children for non-admin/owner members.

More Context:- https://app.campsite.com/cal/posts/lgpk4zoqibhr

