### PR TITLE
chore: fetch schedule server-side for availability type page

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export const revalidateSchedulePage = async (id: number) => {
+  revalidatePath(`/availability/${id.toString()}`);
+};

--- a/apps/web/app/availability/[schedule]/page.tsx
+++ b/apps/web/app/availability/[schedule]/page.tsx
@@ -1,7 +1,6 @@
 import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
-import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { z } from "zod";
@@ -42,11 +41,6 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   );
 };
 
-export const revalidatePage = async (id: number) => {
-  "use server";
-  revalidatePath(`availability/${id.toString()}`);
-};
-
 const Page = async ({ params, searchParams }: PageProps) => {
   const parsed = querySchema.safeParse({ ...params, ...searchParams });
   if (!parsed.success) {
@@ -83,7 +77,6 @@ const Page = async ({ params, searchParams }: PageProps) => {
     return (
       <AvailabilitySettingsWebWrapper
         scheduleFetched={schedule}
-        revalidatePage={revalidatePage}
         //  travelSchedules={travelSchedules}
       />
     );

--- a/apps/web/app/availability/[schedule]/page.tsx
+++ b/apps/web/app/availability/[schedule]/page.tsx
@@ -70,9 +70,9 @@ const Page = async ({ params, searchParams }: PageProps) => {
       timeZone: userData.timeZone,
       defaultScheduleId: userData.defaultScheduleId,
     });
-    const revalidatePage = async () => {
+    const revalidatePage = async (id?: string) => {
       "use server";
-      revalidatePath(`availability/${scheduleId}`);
+      revalidatePath(`availability/${id ?? scheduleId}`);
     };
     // try {
     //   travelSchedules = await TravelScheduleRepository.findTravelSchedulesByUserId(userId);

--- a/apps/web/app/availability/[schedule]/page.tsx
+++ b/apps/web/app/availability/[schedule]/page.tsx
@@ -89,5 +89,5 @@ const Page = async ({ params, searchParams }: PageProps) => {
     notFound();
   }
 };
-export const revalidate = 0;
+
 export default WithLayout({ ServerPage: Page });

--- a/apps/web/app/availability/[schedule]/page.tsx
+++ b/apps/web/app/availability/[schedule]/page.tsx
@@ -1,15 +1,16 @@
 import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
+import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { z } from "zod";
 
-// import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
+import { getServerSessionForAppDir } from "@calcom/feature-auth/lib/get-server-session-for-app-dir";
 import { ScheduleRepository } from "@calcom/lib/server/repository/schedule";
-
 // import { TravelScheduleRepository } from "@calcom/lib/server/repository/travelSchedule";
-// import { UserRepository } from "@calcom/lib/server/repository/user";
+import { UserRepository } from "@calcom/lib/server/repository/user";
+
 import { AvailabilitySettingsWebWrapper } from "~/availability/[schedule]/schedule-view";
 
 const querySchema = z.object({
@@ -46,47 +47,47 @@ const Page = async ({ params, searchParams }: PageProps) => {
   if (!parsed.success) {
     notFound();
   }
-  // const scheduleId = Number(params.schedule);
+  const scheduleId = parsed.data.schedule;
 
-  // const session = await getServerSessionForAppDir();
-  // const userId = session?.user?.id;
-  // if (!userId) {
-  //   notFound();
-  // }
+  const session = await getServerSessionForAppDir();
+  const userId = session?.user?.id;
+  if (!userId) {
+    notFound();
+  }
 
-  // let userData, schedule, travelSchedules;
+  try {
+    const userData = await UserRepository.getTimeZoneAndDefaultScheduleId({
+      userId,
+    });
+    if (!userData?.timeZone || !userData?.defaultScheduleId) {
+      throw new Error("timeZone and defaultScheduleId not found");
+    }
 
-  // try {
-  //   userData = await UserRepository.getTimeZoneAndDefaultScheduleId({
-  //     userId,
-  //   });
-  //   if (!userData?.timeZone || !userData?.defaultScheduleId) {
-  //     throw new Error("timeZone and defaultScheduleId not found");
-  //   }
-  // } catch (e) {
-  //   notFound();
-  // }
+    const schedule = await ScheduleRepository.findDetailedScheduleById({
+      scheduleId,
+      isManagedEventType: false,
+      userId,
+      timeZone: userData.timeZone,
+      defaultScheduleId: userData.defaultScheduleId,
+    });
+    const revalidatePage = async () => {
+      "use server";
+      revalidatePath(`availability/${scheduleId}`);
+    };
+    // try {
+    //   travelSchedules = await TravelScheduleRepository.findTravelSchedulesByUserId(userId);
+    // } catch (e) {}
 
-  // try {
-  //   schedule = await ScheduleRepository.findDetailedScheduleById({
-  //     scheduleId,
-  //     isManagedEventType: false,
-  //     userId,
-  //     timeZone: userData.timeZone,
-  //     defaultScheduleId: userData.defaultScheduleId,
-  //   });
-  // } catch (e) {}
-
-  // try {
-  //   travelSchedules = await TravelScheduleRepository.findTravelSchedulesByUserId(userId);
-  // } catch (e) {}
-
-  return (
-    <AvailabilitySettingsWebWrapper
-
-    // scheduleFetched={schedule} travelSchedules={travelSchedules}
-    />
-  );
+    return (
+      <AvailabilitySettingsWebWrapper
+        scheduleFetched={schedule}
+        revalidatePage={revalidatePage}
+        //  travelSchedules={travelSchedules}
+      />
+    );
+  } catch (e) {
+    notFound();
+  }
 };
-
+export const revalidate = 0;
 export default WithLayout({ ServerPage: Page });

--- a/apps/web/app/availability/[schedule]/page.tsx
+++ b/apps/web/app/availability/[schedule]/page.tsx
@@ -42,6 +42,11 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   );
 };
 
+export const revalidatePage = async (id: number) => {
+  "use server";
+  revalidatePath(`availability/${id.toString()}`);
+};
+
 const Page = async ({ params, searchParams }: PageProps) => {
   const parsed = querySchema.safeParse({ ...params, ...searchParams });
   if (!parsed.success) {
@@ -70,10 +75,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
       timeZone: userData.timeZone,
       defaultScheduleId: userData.defaultScheduleId,
     });
-    const revalidatePage = async (id?: string) => {
-      "use server";
-      revalidatePath(`availability/${id ?? scheduleId}`);
-    };
+
     // try {
     //   travelSchedules = await TravelScheduleRepository.findTravelSchedulesByUserId(userId);
     // } catch (e) {}

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -72,14 +72,13 @@ export const AvailabilitySettingsWebWrapper = ({
 
   const updateMutation = trpc.viewer.availability.schedule.update.useMutation({
     onSuccess: async ({ prevDefaultId, currentDefaultId, ...data }) => {
-      if (prevDefaultId && currentDefaultId) {
+      if (prevDefaultId && currentDefaultId && prevDefaultId !== currentDefaultId) {
         // check weather the default schedule has been changed by comparing  previous default schedule id and current default schedule id.
-        if (prevDefaultId !== currentDefaultId) {
-          // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
-          await revalidatePage(prevDefaultId.toString());
-        }
+        // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
+        await Promise.all([revalidatePage(prevDefaultId.toString()), revalidatePage()]);
+      } else {
+        await revalidatePage();
       }
-      await revalidatePage();
       utils.viewer.availability.list.invalidate();
       showToast(
         t("availability_updated_successfully", {

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -17,7 +17,7 @@ import { showToast } from "@calcom/ui";
 
 type PageProps = {
   scheduleFetched: Awaited<ReturnType<typeof ScheduleRepository.findDetailedScheduleById>>;
-  revalidatePage: () => Promise<void>;
+  revalidatePage: (id?: string) => Promise<void>;
   travelSchedules?: Awaited<ReturnType<typeof TravelScheduleRepository.findTravelSchedulesByUserId>>;
 };
 
@@ -72,6 +72,13 @@ export const AvailabilitySettingsWebWrapper = ({
 
   const updateMutation = trpc.viewer.availability.schedule.update.useMutation({
     onSuccess: async ({ prevDefaultId, currentDefaultId, ...data }) => {
+      if (prevDefaultId && currentDefaultId) {
+        // check weather the default schedule has been changed by comparing  previous default schedule id and current default schedule id.
+        if (prevDefaultId !== currentDefaultId) {
+          // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
+          await revalidatePage(prevDefaultId.toString());
+        }
+      }
       await revalidatePage();
       utils.viewer.availability.list.invalidate();
       showToast(

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -54,9 +54,9 @@ export const AvailabilitySettingsWebWrapper = ({
         eventTypeIds,
       },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
+          await revalidatePage();
           utils.viewer.availability.list.invalidate();
-          revalidatePage();
           callback();
           showToast(t("success"), "success");
         },
@@ -80,9 +80,8 @@ export const AvailabilitySettingsWebWrapper = ({
           utils.viewer.availability.schedule.get.refetch({ scheduleId: prevDefaultId });
         }
       }
-      utils.viewer.availability.schedule.get.invalidate({ scheduleId: data.schedule.id });
+      await revalidatePage();
       utils.viewer.availability.list.invalidate();
-      revalidatePage();
       showToast(
         t("availability_updated_successfully", {
           scheduleName: data.schedule.name,

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -17,7 +17,7 @@ import { showToast } from "@calcom/ui";
 
 type PageProps = {
   scheduleFetched: Awaited<ReturnType<typeof ScheduleRepository.findDetailedScheduleById>>;
-  revalidatePage: (id?: string) => Promise<void>;
+  revalidatePage: (id: number) => Promise<void>;
   travelSchedules?: Awaited<ReturnType<typeof TravelScheduleRepository.findTravelSchedulesByUserId>>;
 };
 
@@ -54,7 +54,7 @@ export const AvailabilitySettingsWebWrapper = ({
       },
       {
         onSuccess: async () => {
-          await revalidatePage();
+          await revalidatePage(scheduleId);
           utils.viewer.availability.list.invalidate();
           callback();
           showToast(t("success"), "success");
@@ -74,9 +74,9 @@ export const AvailabilitySettingsWebWrapper = ({
       if (prevDefaultId && currentDefaultId && prevDefaultId !== currentDefaultId) {
         // check weather the default schedule has been changed by comparing  previous default schedule id and current default schedule id.
         // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
-        await Promise.all([revalidatePage(prevDefaultId.toString()), revalidatePage()]);
+        await Promise.all([revalidatePage(prevDefaultId), revalidatePage(scheduleId)]);
       } else {
-        await revalidatePage();
+        await revalidatePage(scheduleId);
       }
       utils.viewer.availability.list.invalidate();
       showToast(

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { revalidateSchedulePage } from "app/actions";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -17,13 +18,11 @@ import { showToast } from "@calcom/ui";
 
 type PageProps = {
   scheduleFetched: Awaited<ReturnType<typeof ScheduleRepository.findDetailedScheduleById>>;
-  revalidatePage: (id: number) => Promise<void>;
   travelSchedules?: Awaited<ReturnType<typeof TravelScheduleRepository.findTravelSchedulesByUserId>>;
 };
 
 export const AvailabilitySettingsWebWrapper = ({
   scheduleFetched: schedule,
-  revalidatePage,
   travelSchedules: travelSchedulesProp,
 }: PageProps) => {
   const searchParams = useCompatSearchParams();
@@ -54,7 +53,7 @@ export const AvailabilitySettingsWebWrapper = ({
       },
       {
         onSuccess: async () => {
-          await revalidatePage(scheduleId);
+          await revalidateSchedulePage(scheduleId);
           utils.viewer.availability.list.invalidate();
           callback();
           showToast(t("success"), "success");
@@ -74,9 +73,9 @@ export const AvailabilitySettingsWebWrapper = ({
       if (prevDefaultId && currentDefaultId && prevDefaultId !== currentDefaultId) {
         // check weather the default schedule has been changed by comparing  previous default schedule id and current default schedule id.
         // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
-        await Promise.all([revalidatePage(prevDefaultId), revalidatePage(scheduleId)]);
+        await Promise.all([revalidateSchedulePage(prevDefaultId), revalidateSchedulePage(scheduleId)]);
       } else {
-        await revalidatePage(scheduleId);
+        await revalidateSchedulePage(scheduleId);
       }
       utils.viewer.availability.list.invalidate();
       showToast(

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -72,14 +72,6 @@ export const AvailabilitySettingsWebWrapper = ({
 
   const updateMutation = trpc.viewer.availability.schedule.update.useMutation({
     onSuccess: async ({ prevDefaultId, currentDefaultId, ...data }) => {
-      if (prevDefaultId && currentDefaultId) {
-        // check weather the default schedule has been changed by comparing  previous default schedule id and current default schedule id.
-        if (prevDefaultId !== currentDefaultId) {
-          // if not equal, invalidate previous default schedule id and refetch previous default schedule id.
-          utils.viewer.availability.schedule.get.invalidate({ scheduleId: prevDefaultId });
-          utils.viewer.availability.schedule.get.refetch({ scheduleId: prevDefaultId });
-        }
-      }
       await revalidatePage();
       utils.viewer.availability.list.invalidate();
       showToast(

--- a/apps/web/modules/availability/[schedule]/schedule-view.tsx
+++ b/apps/web/modules/availability/[schedule]/schedule-view.tsx
@@ -22,7 +22,7 @@ type PageProps = {
 };
 
 export const AvailabilitySettingsWebWrapper = ({
-  scheduleFetched,
+  scheduleFetched: schedule,
   revalidatePage,
   travelSchedules: travelSchedulesProp,
 }: PageProps) => {
@@ -31,10 +31,9 @@ export const AvailabilitySettingsWebWrapper = ({
   const router = useRouter();
   const utils = trpc.useUtils();
   const me = useMeQuery();
-  const scheduleId = searchParams?.get("schedule") ? Number(searchParams.get("schedule")) : -1;
+  const scheduleId = schedule.id;
   const fromEventType = searchParams?.get("fromEventType");
   const { timeFormat } = me.data || { timeFormat: null };
-  const schedule = scheduleFetched;
 
   const { data: travelSchedulesData } = trpc.viewer.getTravelSchedules.useQuery(undefined, {
     enabled: !travelSchedulesProp,

--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { revalidatePage as revalidateSchedulePage } from "app/availability/[schedule]/page";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import { useCallback, useState } from "react";
@@ -63,7 +64,7 @@ export function AvailabilityList({ schedules }: RouterOutputs["viewer"]["availab
 
   const updateMutation = trpc.viewer.availability.schedule.update.useMutation({
     onSuccess: async ({ schedule }) => {
-      await utils.viewer.availability.list.invalidate();
+      await Promise.all([utils.viewer.availability.list.invalidate(), revalidateSchedulePage(schedule.id)]);
       showToast(
         t("availability_updated_successfully", {
           scheduleName: schedule.name,

--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { revalidatePage as revalidateSchedulePage } from "app/availability/[schedule]/page";
+import { revalidateSchedulePage } from "app/actions";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import { useCallback, useState } from "react";

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Fragment } from "react";
 
 import { availabilityAsString } from "@calcom/lib/availability";
@@ -39,20 +38,12 @@ export function ScheduleListItem({
   duplicateFunction: ({ scheduleId }: { scheduleId: number }) => void;
 }) {
   const { t, i18n } = useLocale();
-  const router = useRouter();
 
   const { data, isPending } = trpc.viewer.availability.schedule.get.useQuery({ scheduleId: schedule.id });
 
-  // Prefetch the schedule data when hovering over the link
-  const handleMouseEnter = () => {
-    router.prefetch(`/availability/${schedule.id}`);
-  };
-
   return (
     <li key={schedule.id}>
-      <div
-        className="hover:bg-muted flex items-center justify-between py-5 transition ltr:pl-4 rtl:pr-4 sm:ltr:pl-0 sm:rtl:pr-0"
-        onMouseEnter={handleMouseEnter}>
+      <div className="hover:bg-muted flex items-center justify-between py-5 transition ltr:pl-4 rtl:pr-4 sm:ltr:pl-0 sm:rtl:pr-0">
         <div className="group flex w-full items-center justify-between sm:px-6">
           <Link
             href={`/availability/${schedule.id}`}

--- a/packages/features/schedules/components/ScheduleListItem.tsx
+++ b/packages/features/schedules/components/ScheduleListItem.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Fragment } from "react";
 
 import { availabilityAsString } from "@calcom/lib/availability";
@@ -38,12 +39,20 @@ export function ScheduleListItem({
   duplicateFunction: ({ scheduleId }: { scheduleId: number }) => void;
 }) {
   const { t, i18n } = useLocale();
+  const router = useRouter();
 
   const { data, isPending } = trpc.viewer.availability.schedule.get.useQuery({ scheduleId: schedule.id });
 
+  // Prefetch the schedule data when hovering over the link
+  const handleMouseEnter = () => {
+    router.prefetch(`/availability/${schedule.id}`);
+  };
+
   return (
     <li key={schedule.id}>
-      <div className="hover:bg-muted flex items-center justify-between py-5 transition ltr:pl-4 rtl:pr-4 sm:ltr:pl-0 sm:rtl:pr-0">
+      <div
+        className="hover:bg-muted flex items-center justify-between py-5 transition ltr:pl-4 rtl:pr-4 sm:ltr:pl-0 sm:rtl:pr-0"
+        onMouseEnter={handleMouseEnter}>
         <div className="group flex w-full items-center justify-between sm:px-6">
           <Link
             href={`/availability/${schedule.id}`}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- there's a flickering moment when visiting `/availability/[schedule]` page. UI hierarchy is complicated for this page, so fetching schedule server side is a quicker fix.

### before fix: 

https://github.com/user-attachments/assets/3d45df03-4207-4be3-b7b5-5d61735071c5



### after fix:

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to https://dev-dgxv47rl7-cal-staging.vercel.app/availability/9 in admin account and test