### PR TITLE
fix: no available users found while booking recurring event

### DIFF
--- a/packages/dayjs/index.ts
+++ b/packages/dayjs/index.ts
@@ -27,6 +27,6 @@ dayjs.extend(duration);
 
 export type Dayjs = dayjs.Dayjs;
 
-export type { ConfigType } from "dayjs";
+export type { ConfigType, ManipulateType } from "dayjs";
 
 export default dayjs;

--- a/packages/features/bookings/Booker/components/DatePicker.tsx
+++ b/packages/features/bookings/Booker/components/DatePicker.tsx
@@ -18,7 +18,12 @@ export const DatePicker = ({
   scrollToTimeSlots,
 }: {
   event: {
-    data?: { users: Pick<User, "weekStart">[] } | null;
+    data?: {
+      users: Pick<User, "weekStart">[];
+      recurringEvent: {
+        freq: number;
+      };
+    } | null;
   };
   schedule: useScheduleForEventReturnType;
   classNames?: {
@@ -32,12 +37,19 @@ export const DatePicker = ({
   scrollToTimeSlots?: () => void;
 }) => {
   const { i18n } = useLocale();
-  const [month, selectedDate] = useBookerStore((state) => [state.month, state.selectedDate], shallow);
+  const [month, selectedDate, occurenceCount] = useBookerStore(
+    (state) => [state.month, state.selectedDate, state.occurenceCount],
+    shallow
+  );
   const [setSelectedDate, setMonth, setDayCount] = useBookerStore(
     (state) => [state.setSelectedDate, state.setMonth, state.setDayCount],
     shallow
   );
-  const nonEmptyScheduleDays = useNonEmptyScheduleDays(schedule?.data?.slots);
+
+  const nonEmptyScheduleDays = useNonEmptyScheduleDays(schedule?.data?.slots, {
+    occurenceCount,
+    recurringEventFreq: event?.data?.recurringEvent?.freq,
+  });
   const browsingDate = month ? dayjs(month) : dayjs().startOf("month");
 
   const onMonthChange = (date: Dayjs) => {

--- a/packages/features/bookings/Booker/components/DatePicker.tsx
+++ b/packages/features/bookings/Booker/components/DatePicker.tsx
@@ -22,7 +22,7 @@ export const DatePicker = ({
       users: Pick<User, "weekStart">[];
       recurringEvent: {
         freq: number;
-      };
+      } | null;
     } | null;
   };
   schedule: useScheduleForEventReturnType;

--- a/packages/features/schedules/lib/use-schedule/useNonEmptyScheduleDays.ts
+++ b/packages/features/schedules/lib/use-schedule/useNonEmptyScheduleDays.ts
@@ -1,23 +1,79 @@
 import { useMemo } from "react";
 
+import type { ManipulateType } from "@calcom/dayjs";
+import dayjs from "@calcom/dayjs";
+import { yyyymmdd } from "@calcom/lib/date-fns";
+import { Frequency } from "@calcom/prisma/zod-utils";
+
 import type { Slots } from "../use-schedule";
 
-export const getNonEmptyScheduleDays = (slots?: Slots) => {
-  if (typeof slots === "undefined") return [];
+type AdditionalParams = {
+  occurenceCount?: null | number;
+  recurringEventFreq?: Frequency;
+};
 
-  const nonEmptyDays: string[] = [];
+const retainDaysWithFirstTwoSlotsAvailable = (
+  nonEmptyDays: Set<string>,
+  occurenceCount: number,
+  recurringEventFreq: Frequency
+) => {
+  const isDateSlotAvailable = (date: string) => nonEmptyDays.has(date);
 
+  // If occurenceCount is 1, no modifications are needed
+  if (occurenceCount === 1) return;
+
+  const freqKey = Frequency[recurringEventFreq]?.toLowerCase();
+
+  // Only process supported frequency types
+  if (!["weekly", "monthly", "yearly"].includes(freqKey)) return;
+
+  const frequencyToSuffix: Record<string, ManipulateType> = {
+    weekly: "week",
+    monthly: "month",
+    yearly: "year",
+  };
+
+  const suffix = frequencyToSuffix[freqKey];
+
+  if (suffix) {
+    nonEmptyDays.forEach((date) => {
+      const nextDateSlot = yyyymmdd(dayjs(date).add(1, suffix));
+      if (!isDateSlotAvailable(nextDateSlot)) {
+        nonEmptyDays.delete(date);
+      }
+    });
+  }
+};
+
+export const getNonEmptyScheduleDays = (slots?: Slots, additionalParams?: AdditionalParams) => {
+  if (!slots || typeof slots === "undefined") return [];
+  const nonEmptyDays = new Set<string>();
+
+  // Populate initial set of non-empty days
   Object.keys(slots).forEach((date) => {
     if (slots[date].some((slot) => !(slot?.away && !slot.toUser) && slots[date].length > 0)) {
-      nonEmptyDays.push(date);
+      nonEmptyDays.add(date);
     }
   });
 
-  return nonEmptyDays;
+  // For recurring events
+  if (
+    additionalParams?.occurenceCount &&
+    (additionalParams?.recurringEventFreq || additionalParams?.recurringEventFreq == 0)
+  ) {
+    retainDaysWithFirstTwoSlotsAvailable(
+      nonEmptyDays,
+      additionalParams.occurenceCount,
+      additionalParams.recurringEventFreq
+    );
+  }
+
+  return Array.from(nonEmptyDays);
 };
 
-export const useNonEmptyScheduleDays = (slots?: Slots) => {
-  const days = useMemo(() => getNonEmptyScheduleDays(slots), [slots]);
-
-  return days;
+export const useNonEmptyScheduleDays = (slots?: Slots, additionalParams?: AdditionalParams) => {
+  return useMemo(
+    () => getNonEmptyScheduleDays(slots, additionalParams),
+    [slots, additionalParams?.occurenceCount, additionalParams?.recurringEventFreq]
+  );
 };


### PR DESCRIPTION
- No available users error was coming while booking recurring event since the 'first two slots' should be available logic was present while booking but not while showing availability

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #18072(GitHub issue number)


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Loom Video: https://www.loom.com/share/26090f95cfed4818b167ca9ad0759582

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a recurring event
- Pick a date for which the next interval's slot does not exist [For example if you picked week recurring, the next week date]
- The date slot for which the next interval's date slot does not exist, should not be selectable
- Also , manually change the input occurences count to 1 for edge case, in the case of 1, all slots should appear and this logic will not apply
