### PR TITLE
chore: add Prisma playground

### DIFF
--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -18,7 +18,8 @@
     "post-install": "yarn generate-schemas",
     "seed-app-store": "ts-node --transpile-only ./seed-app-store.ts",
     "delete-app": "ts-node --transpile-only ./delete-app.ts",
-    "seed-insights": "ts-node --transpile-only ./seed-insights.ts"
+    "seed-insights": "ts-node --transpile-only ./seed-insights.ts",
+    "playground": "ts-node --transpile-only ./playground.ts"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"

--- a/packages/prisma/playground.ts
+++ b/packages/prisma/playground.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient({
+  log: ["query", "info", "warn", "error"],
+});
+
+// @ts-expect-error type mismatch
+prisma.$on("query", (e) => {
+  // @ts-expect-error type mismatch
+  console.log("Parameters:", e.params);
+});
+
+async function main() {
+  // This is a playground to test prisma queries
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## What does this PR do?

This PR adds a playground file where you can write and test Prisma queries. This can be helpful especially when you're writing a complicated query and don't want to manually test the flow endlessly to see if the query works.