### PR TITLE
perf: limit # of host members for OG image

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -86,7 +86,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           length: true,
           hidden: true,
           hosts: {
-            take: 5,
+            take: 3,
             select: {
               user: {
                 select: {

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -86,6 +86,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           length: true,
           hidden: true,
           hosts: {
+            take: 5,
             select: {
               user: {
                 select: {
@@ -135,6 +136,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       where: { id: eventTypeId },
       select: {
         users: {
+          take: 1,
           select: {
             username: true,
             name: true,

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -145,15 +145,14 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       },
     });
 
-    users =
-      data.length > 0
-        ? [
-            {
-              username: data[0].username ?? "",
-              name: data[0].name ?? "",
-            },
-          ]
-        : [];
+    if (data.length > 0) {
+      users = [
+        {
+          username: data[0].username ?? "",
+          name: data[0].name ?? "",
+        },
+      ];
+    }
   }
 
   const orgSlug = isValidOrgDomain ? currentOrgDomain : null;


### PR DESCRIPTION
## What does this PR do?

- Fetching all the hosts of event type is slow for an org that has lots of members assigned to an event, and it also makes the OG image URL too long

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
