### PR TITLE
fix: Team Form - Email going to form owner and user doesn't have the option to disable it

### DIFF
--- a/packages/app-store/routing-forms/trpc/utils.ts
+++ b/packages/app-store/routing-forms/trpc/utils.ts
@@ -191,16 +191,18 @@ export async function onFormSubmission(
     return acc;
   }, [] as OrderedResponses);
 
-  if (form.settings?.emailOwnerOnSubmission) {
+  if (form.teamId) {
+    if (form.userWithEmails?.length) {
+      moduleLogger.debug(
+        `Preparing to send Form Response email for Form:${form.id} to users: ${form.userWithEmails.join(",")}`
+      );
+      await sendResponseEmail(form, orderedResponses, form.userWithEmails);
+    }
+  } else if (form.settings?.emailOwnerOnSubmission) {
     moduleLogger.debug(
       `Preparing to send Form Response email for Form:${form.id} to form owner: ${form.user.email}`
     );
     await sendResponseEmail(form, orderedResponses, [form.user.email]);
-  } else if (form.userWithEmails?.length) {
-    moduleLogger.debug(
-      `Preparing to send Form Response email for Form:${form.id} to users: ${form.userWithEmails.join(",")}`
-    );
-    await sendResponseEmail(form, orderedResponses, form.userWithEmails);
   }
 }
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -520,7 +520,10 @@ export const successRedirectUrl = z
 
 export const RoutingFormSettings = z
   .object({
+    // Applicable only for User Forms
     emailOwnerOnSubmission: z.boolean(),
+
+    // Applicable only for Team Forms
     sendUpdatesTo: z.array(z.number()).optional(),
     sendToAll: z.boolean().optional(),
   })


### PR DESCRIPTION
## What does this PR do?

[Demo Loom for the fix](https://www.loom.com/share/eb4cde3ad7424e499f92df0058688398)
Fixes CAL-4905


The issue came when a form was created and no changes were made to the Email sending component. Once any change was done to that(e.g. adding a member there), `emailOwnerOnSubmission` gets disabled. This is also fixed now.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] Not Needed -  I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Create a new User Form. Verify that response email is sent automatically to owner. Disabling the toggle, stops sending the email
- Create a new team Form. Verify that response email is not sent to anyone. 
	- Add some members, and verify that email is sent to them
	- Toggle all future members and verify that email is sent to all of them. This doesn't work already. Filed a [separate bug](https://github.com/calcom/cal.com/issues/18223)

