### PR TITLE
feat: allows forcing/skipping calendar cache serving

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -10,6 +10,7 @@ import { MeetLocationType } from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import { CalendarCache } from "@calcom/features/calendar-cache/calendar-cache";
 import type { FreeBusyArgs } from "@calcom/features/calendar-cache/calendar-cache.repository.interface";
+import { getTimeMax, getTimeMin } from "@calcom/features/calendar-cache/lib/datesForCache";
 import { getLocation, getRichDescription } from "@calcom/lib/CalEventParser";
 import type CalendarService from "@calcom/lib/CalendarService";
 import {
@@ -510,16 +511,22 @@ export default class GoogleCalendarService implements Calendar {
     return apiResponse.json;
   }
 
-  async getCacheOrFetchAvailability(args: FreeBusyArgs): Promise<EventBusyDate[] | null> {
-    const { timeMin, timeMax, items } = args;
-    let freeBusyResult: calendar_v3.Schema$FreeBusyResponse = {};
+  async getFreeBusyResult(
+    args: FreeBusyArgs,
+    shouldServeCache?: boolean
+  ): Promise<calendar_v3.Schema$FreeBusyResponse> {
+    if (shouldServeCache === false) return await this.fetchAvailability(args);
     const calendarCache = await CalendarCache.init(null);
     const cached = await calendarCache.getCachedAvailability(this.credential.id, args);
-    if (cached) {
-      freeBusyResult = cached.value as unknown as calendar_v3.Schema$FreeBusyResponse;
-    } else {
-      freeBusyResult = await this.fetchAvailability({ timeMin, timeMax, items });
-    }
+    if (cached) return cached.value as unknown as calendar_v3.Schema$FreeBusyResponse;
+    return await this.fetchAvailability(args);
+  }
+
+  async getCacheOrFetchAvailability(
+    args: FreeBusyArgs,
+    shouldServeCache?: boolean
+  ): Promise<EventBusyDate[] | null> {
+    const freeBusyResult = await this.getFreeBusyResult(args, shouldServeCache);
     if (!freeBusyResult.calendars) return null;
 
     const result = Object.values(freeBusyResult.calendars).reduce((c, i) => {
@@ -537,7 +544,8 @@ export default class GoogleCalendarService implements Calendar {
   async getAvailability(
     dateFrom: string,
     dateTo: string,
-    selectedCalendars: IntegrationCalendar[]
+    selectedCalendars: IntegrationCalendar[],
+    shouldServeCache?: boolean
   ): Promise<EventBusyDate[]> {
     this.log.debug("Getting availability", safeStringify({ dateFrom, dateTo, selectedCalendars }));
     const calendar = await this.authedCalendar();
@@ -563,11 +571,14 @@ export default class GoogleCalendarService implements Calendar {
 
       // /freebusy from google api only allows a date range of 90 days
       if (diff <= 90) {
-        const freeBusyData = await this.getCacheOrFetchAvailability({
-          timeMin: dateFrom,
-          timeMax: dateTo,
-          items: calsIds.map((id) => ({ id })),
-        });
+        const freeBusyData = await this.getCacheOrFetchAvailability(
+          {
+            timeMin: dateFrom,
+            timeMax: dateTo,
+            items: calsIds.map((id) => ({ id })),
+          },
+          shouldServeCache
+        );
         if (!freeBusyData) throw new Error("No response from google calendar");
 
         return freeBusyData;
@@ -583,11 +594,14 @@ export default class GoogleCalendarService implements Calendar {
           if (endDate.isAfter(originalEndDate)) endDate = originalEndDate;
 
           busyData.push(
-            ...((await this.getCacheOrFetchAvailability({
-              timeMin: startDate.format(),
-              timeMax: endDate.format(),
-              items: calsIds.map((id) => ({ id })),
-            })) || [])
+            ...((await this.getCacheOrFetchAvailability(
+              {
+                timeMin: startDate.format(),
+                timeMax: endDate.format(),
+                items: calsIds.map((id) => ({ id })),
+              },
+              shouldServeCache
+            )) || [])
           );
 
           startDate = endDate.add(1, "minutes");
@@ -672,12 +686,7 @@ export default class GoogleCalendarService implements Calendar {
   }
   async unwatchCalendar({ calendarId }: { calendarId: string }) {
     const credentialId = this.credential.id;
-    const sc = await prisma.selectedCalendar.findFirst({
-      where: {
-        credentialId,
-        externalId: calendarId,
-      },
-    });
+    const sc = await SelectedCalendarRepository.findByExternalId(credentialId, calendarId);
     // Delete the calendar cache to force a fresh cache
     await prisma.calendarCache.deleteMany({ where: { credentialId } });
     const calendar = await this.authedCalendar();
@@ -699,6 +708,12 @@ export default class GoogleCalendarService implements Calendar {
       googleChannelResourceUri: null,
       googleChannelExpiration: null,
     });
+    // Populate the cache back for the remaining calendars, if any
+    const remainingCalendars =
+      sc?.credential?.selectedCalendars.filter((sc) => sc.externalId !== calendarId) || [];
+    if (remainingCalendars.length > 0) {
+      await this.fetchAvailabilityAndSetCache(remainingCalendars);
+    }
   }
 
   async setAvailabilityInCache(args: FreeBusyArgs, data: calendar_v3.Schema$FreeBusyResponse): Promise<void> {
@@ -707,12 +722,11 @@ export default class GoogleCalendarService implements Calendar {
   }
 
   async fetchAvailabilityAndSetCache(selectedCalendars: IntegrationCalendar[]) {
-    const date = new Date();
     const parsedArgs = {
       /** Expand the start date to the start of the month */
-      timeMin: new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0).toISOString(),
+      timeMin: getTimeMax(),
       /** Expand the end date to the end of the month */
-      timeMax: new Date(date.getFullYear(), date.getMonth() + 1, 0, 0, 0, 0, 0).toISOString(),
+      timeMax: getTimeMin(),
       items: selectedCalendars.map((sc) => ({ id: sc.externalId })),
     };
     const data = await this.fetchAvailability(parsedArgs);

--- a/packages/core/CalendarManager.ts
+++ b/packages/core/CalendarManager.ts
@@ -8,7 +8,6 @@ import { getUid } from "@calcom/lib/CalEventParser";
 import logger from "@calcom/lib/logger";
 import { getPiiFreeCalendarEvent, getPiiFreeCredential } from "@calcom/lib/piiFreeData";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { performance } from "@calcom/lib/server/perfObserver";
 import type {
   CalendarEvent,
   EventBusyDate,
@@ -136,51 +135,6 @@ const cleanIntegrationKeys = (
   return rest;
 };
 
-// here I will fetch the page json file.
-export const getCachedResults = async (
-  withCredentials: CredentialPayload[],
-  dateFrom: string,
-  dateTo: string,
-  selectedCalendars: SelectedCalendar[]
-): Promise<EventBusyDate[][]> => {
-  const calendarCredentials = withCredentials.filter((credential) => credential.type.endsWith("_calendar"));
-  const calendars = await Promise.all(calendarCredentials.map((credential) => getCalendar(credential)));
-  performance.mark("getBusyCalendarTimesStart");
-  const results = calendars.map(async (c, i) => {
-    /** Filter out nulls */
-    if (!c) return [];
-    /** We rely on the index so we can match credentials with calendars */
-    const { type, appId } = calendarCredentials[i];
-    /** We just pass the calendars that matched the credential type,
-     * TODO: Migrate credential type or appId
-     */
-    const passedSelectedCalendars = selectedCalendars.filter((sc) => sc.integration === type);
-    if (!passedSelectedCalendars.length) return [];
-    /** We extract external Ids so we don't cache too much */
-    const selectedCalendarIds = passedSelectedCalendars.map((sc) => sc.externalId);
-    /** If we don't then we actually fetch external calendars (which can be very slow) */
-    performance.mark("eventBusyDatesStart");
-    const eventBusyDates = await c.getAvailability(dateFrom, dateTo, passedSelectedCalendars);
-    performance.mark("eventBusyDatesEnd");
-    performance.measure(
-      `[getAvailability for ${selectedCalendarIds.join(", ")}][$1]'`,
-      "eventBusyDatesStart",
-      "eventBusyDatesEnd"
-    );
-
-    return eventBusyDates.map((a: object) => ({ ...a, source: `${appId}` }));
-  });
-  const awaitedResults = await Promise.all(results);
-  performance.mark("getBusyCalendarTimesEnd");
-  performance.measure(
-    `getBusyCalendarTimes took $1 for creds ${calendarCredentials.map((cred) => cred.id)}`,
-    "getBusyCalendarTimesStart",
-    "getBusyCalendarTimesEnd"
-  );
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return awaitedResults as any;
-};
-
 /**
  * Get months between given dates
  * @returns ["2023-04", "2024-05"]
@@ -203,7 +157,8 @@ export const getBusyCalendarTimes = async (
   withCredentials: CredentialPayload[],
   dateFrom: string,
   dateTo: string,
-  selectedCalendars: SelectedCalendar[]
+  selectedCalendars: SelectedCalendar[],
+  shouldServeCache?: boolean
 ) => {
   let results: EventBusyDate[][] = [];
   // const months = getMonths(dateFrom, dateTo);
@@ -212,7 +167,13 @@ export const getBusyCalendarTimes = async (
     const startDate = dayjs(dateFrom).subtract(11, "hours").format();
     // Add 14 hours from the start date to avoid problems in UTC+ time zones.
     const endDate = dayjs(dateTo).endOf("month").add(14, "hours").format();
-    results = await getCalendarsEvents(withCredentials, startDate, endDate, selectedCalendars);
+    results = await getCalendarsEvents(
+      withCredentials,
+      startDate,
+      endDate,
+      selectedCalendars,
+      shouldServeCache
+    );
   } catch (e) {
     log.warn(safeStringify(e));
   }

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -44,6 +44,7 @@ export async function getBusyTimes(params: {
       })[]
     | null;
   bypassBusyCalendarTimes: boolean;
+  shouldServeCache?: boolean;
 }) {
   const {
     credentials,
@@ -60,6 +61,7 @@ export async function getBusyTimes(params: {
     rescheduleUid,
     duration,
     bypassBusyCalendarTimes = false,
+    shouldServeCache,
   } = params;
 
   logger.silly(
@@ -243,7 +245,8 @@ export async function getBusyTimes(params: {
       credentials,
       startTime,
       endTime,
-      selectedCalendars
+      selectedCalendars,
+      shouldServeCache
     );
     const endConnectedCalendarsGet = performance.now();
     logger.debug(

--- a/packages/core/getCalendarsEvents.test.ts
+++ b/packages/core/getCalendarsEvents.test.ts
@@ -127,7 +127,12 @@ describe("getCalendarsEvents", () => {
       [selectedCalendar]
     );
 
-    expect(getAvailabilitySpy).toHaveBeenCalledWith("2010-12-01", "2010-12-04", [selectedCalendar]);
+    expect(getAvailabilitySpy).toHaveBeenCalledWith(
+      "2010-12-01",
+      "2010-12-04",
+      [selectedCalendar],
+      undefined
+    );
     expect(result).toEqual([
       availability.map((av) => ({
         ...av,
@@ -190,12 +195,18 @@ describe("getCalendarsEvents", () => {
       [selectedGoogleCalendar, selectedOfficeCalendar]
     );
 
-    expect(getGoogleAvailabilitySpy).toHaveBeenCalledWith("2010-12-01", "2010-12-04", [
-      selectedGoogleCalendar,
-    ]);
-    expect(getOfficeAvailabilitySpy).toHaveBeenCalledWith("2010-12-01", "2010-12-04", [
-      selectedOfficeCalendar,
-    ]);
+    expect(getGoogleAvailabilitySpy).toHaveBeenCalledWith(
+      "2010-12-01",
+      "2010-12-04",
+      [selectedGoogleCalendar],
+      undefined
+    );
+    expect(getOfficeAvailabilitySpy).toHaveBeenCalledWith(
+      "2010-12-01",
+      "2010-12-04",
+      [selectedOfficeCalendar],
+      undefined
+    );
     expect(result).toEqual([
       googleAvailability.map((av) => ({
         ...av,

--- a/packages/core/getCalendarsEvents.ts
+++ b/packages/core/getCalendarsEvents.ts
@@ -11,7 +11,8 @@ const getCalendarsEvents = async (
   withCredentials: CredentialPayload[],
   dateFrom: string,
   dateTo: string,
-  selectedCalendars: SelectedCalendar[]
+  selectedCalendars: SelectedCalendar[],
+  shouldServeCache?: boolean
 ): Promise<EventBusyDate[][]> => {
   const calendarCredentials = withCredentials
     .filter((credential) => credential.type.endsWith("_calendar"))
@@ -45,7 +46,12 @@ const getCalendarsEvents = async (
         selectedCalendars: passedSelectedCalendars.map(getPiiFreeSelectedCalendar),
       })
     );
-    const eventBusyDates = await c.getAvailability(dateFrom, dateTo, passedSelectedCalendars);
+    const eventBusyDates = await c.getAvailability(
+      dateFrom,
+      dateTo,
+      passedSelectedCalendars,
+      shouldServeCache
+    );
     performance.mark("eventBusyDatesEnd");
     performance.measure(
       `[getAvailability for ${selectedCalendarIds.join(", ")}][$1]'`,

--- a/packages/core/getUserAvailability.ts
+++ b/packages/core/getUserAvailability.ts
@@ -45,6 +45,7 @@ const availabilitySchema = z
     withSource: z.boolean().optional(),
     returnDateOverrides: z.boolean(),
     bypassBusyCalendarTimes: z.boolean().optional(),
+    shouldServeCache: z.boolean().optional(),
   })
   .refine((data) => !!data.username || !!data.userId, "Either username or userId should be filled in.");
 
@@ -245,6 +246,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     duration?: number;
     returnDateOverrides: boolean;
     bypassBusyCalendarTimes: boolean;
+    shouldServeCache?: boolean;
   },
   initialData?: {
     user?: GetUser;
@@ -279,6 +281,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     duration,
     returnDateOverrides,
     bypassBusyCalendarTimes = false,
+    shouldServeCache,
   } = availabilitySchema.parse(query);
 
   if (!dateFrom.isValid() || !dateTo.isValid()) {
@@ -393,6 +396,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     duration,
     currentBookings: initialData?.currentBookings,
     bypassBusyCalendarTimes,
+    shouldServeCache,
   });
 
   const detailedBusyTimes: EventBusyDetails[] = [

--- a/packages/features/bookings/lib/book-event-form/booking-to-mutation-input-mapper.tsx
+++ b/packages/features/bookings/lib/book-event-form/booking-to-mutation-input-mapper.tsx
@@ -53,7 +53,7 @@ export const mapBookingToMutationInput = ({
   const skipContactOwner = searchParams.get("cal.skipContactOwner") === "true";
   const reroutingFormResponses = searchParams.get("cal.reroutingFormResponses");
   const isBookingDryRun = searchParams.get("cal.isBookingDryRun") === "true";
-  const _cacheParam = searchParams.get("cal.cache");
+  const _cacheParam = searchParams?.get("cal.cache");
   const _shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
 
   return {

--- a/packages/features/bookings/lib/book-event-form/booking-to-mutation-input-mapper.tsx
+++ b/packages/features/bookings/lib/book-event-form/booking-to-mutation-input-mapper.tsx
@@ -53,6 +53,8 @@ export const mapBookingToMutationInput = ({
   const skipContactOwner = searchParams.get("cal.skipContactOwner") === "true";
   const reroutingFormResponses = searchParams.get("cal.reroutingFormResponses");
   const isBookingDryRun = searchParams.get("cal.isBookingDryRun") === "true";
+  const _cacheParam = searchParams.get("cal.cache");
+  const _shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
 
   return {
     ...values,
@@ -83,6 +85,7 @@ export const mapBookingToMutationInput = ({
     // In case of rerouting, the form responses are actually the responses that we need to update.
     reroutingFormResponses: reroutingFormResponses ? JSON.parse(reroutingFormResponses) : undefined,
     _isDryRun: isBookingDryRun,
+    _shouldServeCache,
   };
 };
 

--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -52,7 +52,8 @@ export async function ensureAvailableUsers(
     users: IsFixedAwareUser[];
   },
   input: { dateFrom: string; dateTo: string; timeZone: string; originalRescheduledBooking?: BookingType },
-  loggerWithEventDetails: Logger<unknown>
+  loggerWithEventDetails: Logger<unknown>,
+  shouldServeCache?: boolean
   // ReturnType hint of at least one IsFixedAwareUser, as it's made sure at least one entry exists
 ): Promise<[IsFixedAwareUser, ...IsFixedAwareUser[]]> {
   const availableUsers: IsFixedAwareUser[] = [];
@@ -91,6 +92,7 @@ export async function ensureAvailableUsers(
       beforeEventBuffer: eventType.beforeEventBuffer,
       afterEventBuffer: eventType.afterEventBuffer,
       bypassBusyCalendarTimes: false,
+      shouldServeCache,
     },
     initialData: {
       eventType,

--- a/packages/features/calendar-cache/calendar-cache.repository.ts
+++ b/packages/features/calendar-cache/calendar-cache.repository.ts
@@ -6,6 +6,7 @@ import type { Calendar } from "@calcom/types/Calendar";
 
 import type { ICalendarCacheRepository } from "./calendar-cache.repository.interface";
 import { watchCalendarSchema } from "./calendar-cache.repository.schema";
+import { getTimeMax, getTimeMin } from "./lib/datesForCache";
 
 const log = logger.getSubLogger({ prefix: ["CalendarCacheRepository"] });
 
@@ -14,18 +15,6 @@ const ENABLE_EXPANDED_CACHE = process.env.ENABLE_EXPANDED_CACHE !== "0";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ONE_MONTH_IN_MS = 30 * MS_PER_DAY;
 const CACHING_TIME = ONE_MONTH_IN_MS;
-
-/** Expand the start date to the start of the month */
-function getTimeMin(timeMin: string) {
-  const dateMin = new Date(timeMin);
-  return new Date(dateMin.getFullYear(), dateMin.getMonth(), 1, 0, 0, 0, 0).toISOString();
-}
-
-/** Expand the end date to the end of the month */
-function getTimeMax(timeMax: string) {
-  const dateMax = new Date(timeMax);
-  return new Date(dateMax.getFullYear(), dateMax.getMonth() + 1, 0, 0, 0, 0, 0).toISOString();
-}
 
 export function parseKeyForCache(args: FreeBusyArgs): string {
   const { timeMin: _timeMin, timeMax: _timeMax, items } = args;

--- a/packages/features/calendar-cache/lib/datesForCache.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.ts
@@ -1,0 +1,16 @@
+/** Expand the start date to the beginning of the current month */
+export const getTimeMin = (timeMin?: string) => {
+  const date = timeMin ? new Date(timeMin) : new Date();
+  date.setDate(1);
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString();
+};
+
+/** Expand the end date to the end of the next month */
+export function getTimeMax(timeMax?: string) {
+  const date = timeMax ? new Date(timeMax) : new Date();
+  date.setMonth(date.getMonth() + 2);
+  date.setDate(0);
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString();
+}

--- a/packages/features/calendar-cache/lib/getShouldServeCache.ts
+++ b/packages/features/calendar-cache/lib/getShouldServeCache.ts
@@ -1,0 +1,8 @@
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+
+export async function getShouldServeCache(shouldServeCache?: boolean | undefined, teamId?: number) {
+  if (typeof shouldServeCache === "boolean") return shouldServeCache;
+  if (!teamId) return undefined;
+  const featureRepo = new FeaturesRepository();
+  return await featureRepo.checkIfTeamHasFeature(teamId, "calendar-cache-serve");
+}

--- a/packages/features/flags/config.ts
+++ b/packages/features/flags/config.ts
@@ -4,6 +4,7 @@
  **/
 export type AppFlags = {
   "calendar-cache": boolean;
+  "calendar-cache-serve": boolean;
   emails: boolean;
   insights: boolean;
   teams: boolean;

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -3,4 +3,5 @@ import type { AppFlags } from "./config";
 export interface IFeaturesRepository {
   checkIfFeatureIsEnabledGlobally(slug: keyof AppFlags): Promise<boolean>;
   checkIfUserHasFeature(userId: number, slug: string): Promise<boolean>;
+  checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags): Promise<boolean>;
 }

--- a/packages/features/flags/features.repository.mock.ts
+++ b/packages/features/flags/features.repository.mock.ts
@@ -4,6 +4,9 @@ export class MockFeaturesRepository implements IFeaturesRepository {
   async checkIfUserHasFeature(userId: number, slug: string) {
     return slug === "mock-feature";
   }
+  async checkIfTeamHasFeature(team: number, slug: string) {
+    return slug === "mock-feature";
+  }
   async checkIfFeatureIsEnabledGlobally() {
     return true;
   }

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -70,8 +70,7 @@ export class FeaturesRepository implements IFeaturesRepository {
       const teamFeature = await db.teamFeatures.findUnique({
         where: { teamId_featureId: { teamId, featureId } },
       });
-      if (teamFeature) return true;
-      return false;
+      return !!teamFeature;
     } catch (err) {
       captureException(err);
       throw err;

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -65,4 +65,16 @@ export class FeaturesRepository implements IFeaturesRepository {
       throw err;
     }
   }
+  async checkIfTeamHasFeature(teamId: number, featureId: keyof AppFlags) {
+    try {
+      const teamFeature = await db.teamFeatures.findUnique({
+        where: { teamId_featureId: { teamId, featureId } },
+      });
+      if (teamFeature) return true;
+      return false;
+    } catch (err) {
+      captureException(err);
+      throw err;
+    }
+  }
 }

--- a/packages/features/flags/hooks/index.ts
+++ b/packages/features/flags/hooks/index.ts
@@ -5,6 +5,7 @@ const initialData: AppFlags = {
   organizations: false,
   teams: false,
   "calendar-cache": false,
+  "calendar-cache-serve": false,
   emails: false,
   insights: false,
   webhooks: false,

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -48,7 +48,8 @@ export const useSchedule = ({
   const searchParams = useSearchParams();
   const routedTeamMemberIds = searchParams ? getRoutedTeamMemberIdsFromSearchParams(searchParams) : null;
   const skipContactOwner = searchParams ? searchParams.get("cal.skipContactOwner") === "true" : false;
-  const shouldServeCache = searchParams ? searchParams.get("cal.cache") === "true" : undefined;
+  const _cacheParam = searchParams.get("cal.cache");
+  const shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
 
   const input = {
     isTeamEvent,

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -48,7 +48,7 @@ export const useSchedule = ({
   const searchParams = useSearchParams();
   const routedTeamMemberIds = searchParams ? getRoutedTeamMemberIdsFromSearchParams(searchParams) : null;
   const skipContactOwner = searchParams ? searchParams.get("cal.skipContactOwner") === "true" : false;
-  const _cacheParam = searchParams.get("cal.cache");
+  const _cacheParam = searchParams?.get("cal.cache");
   const shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
 
   const input = {

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -48,6 +48,7 @@ export const useSchedule = ({
   const searchParams = useSearchParams();
   const routedTeamMemberIds = searchParams ? getRoutedTeamMemberIdsFromSearchParams(searchParams) : null;
   const skipContactOwner = searchParams ? searchParams.get("cal.skipContactOwner") === "true" : false;
+  const shouldServeCache = searchParams ? searchParams.get("cal.cache") === "true" : undefined;
 
   const input = {
     isTeamEvent,
@@ -68,6 +69,7 @@ export const useSchedule = ({
     teamMemberEmail,
     routedTeamMemberIds,
     skipContactOwner,
+    shouldServeCache,
   };
 
   const options = {

--- a/packages/lib/server/repository/selectedCalendar.ts
+++ b/packages/lib/server/repository/selectedCalendar.ts
@@ -115,4 +115,25 @@ export class SelectedCalendarRepository {
       },
     });
   }
+  static async findByExternalId(credentialId: number, externalId: string) {
+    return await prisma.selectedCalendar.findFirst({
+      where: {
+        credentialId,
+        externalId,
+      },
+      select: {
+        googleChannelResourceId: true,
+        googleChannelId: true,
+        credential: {
+          select: {
+            selectedCalendars: {
+              orderBy: {
+                externalId: "asc",
+              },
+            },
+          },
+        },
+      },
+    });
+  }
 }

--- a/packages/lib/server/repository/selectedCalendar.ts
+++ b/packages/lib/server/repository/selectedCalendar.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@prisma/client";
 
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { prisma } from "@calcom/prisma";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
@@ -59,26 +60,32 @@ export class SelectedCalendarRepository {
   }
   /** Retrieve calendars that are being watched but shouldn't be anymore */
   static async getNextBatchToUnwatch(limit = 100) {
-    const nextBatch = await prisma.selectedCalendar.findMany({
-      take: limit,
-      where: {
-        user: {
-          teams: {
-            every: {
-              team: {
-                features: {
-                  none: {
-                    featureId: "calendar-cache",
-                  },
+    const where: Prisma.SelectedCalendarWhereInput = {
+      // RN we only support google calendar subscriptions for now
+      integration: "google_calendar",
+      googleChannelExpiration: { not: null },
+    };
+    const featureRepo = new FeaturesRepository();
+    const calendarCache = await featureRepo.checkIfFeatureIsEnabledGlobally("calendar-cache");
+    // If calendar cache is disabled globally, we skip team features and unwatch all subscriptions
+    if (!calendarCache) {
+      where.user = {
+        teams: {
+          every: {
+            team: {
+              features: {
+                none: {
+                  featureId: "calendar-cache",
                 },
               },
             },
           },
         },
-        // RN we only support google calendar subscriptions for now
-        integration: "google_calendar",
-        googleChannelExpiration: { not: null },
-      },
+      };
+    }
+    const nextBatch = await prisma.selectedCalendar.findMany({
+      take: limit,
+      where,
     });
     return nextBatch;
   }

--- a/packages/prisma/migrations/20241216000000_add_calendar_cache_serve/migration.sql
+++ b/packages/prisma/migrations/20241216000000_add_calendar_cache_serve/migration.sql
@@ -1,0 +1,9 @@
+INSERT INTO
+  "Feature" (slug, enabled, description, "type")
+VALUES
+  (
+    'calendar-cache-serve',
+    false,
+    'Wether to serve calendar cache by default or not per team/user basis.',
+    'OPERATIONAL'
+  ) ON CONFLICT (slug) DO NOTHING;

--- a/packages/prisma/migrations/20241216000000_add_calendar_cache_serve/migration.sql
+++ b/packages/prisma/migrations/20241216000000_add_calendar_cache_serve/migration.sql
@@ -4,6 +4,6 @@ VALUES
   (
     'calendar-cache-serve',
     false,
-    'Wether to serve calendar cache by default or not per team/user basis.',
+    'Whether to serve calendar cache by default or not on a team/user basis.',
     'OPERATIONAL'
   ) ON CONFLICT (slug) DO NOTHING;

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -265,6 +265,8 @@ export const bookingCreateBodySchema = z.object({
    * Used to identify if the booking is a dry run.
    */
   _isDryRun: z.boolean().optional(),
+  /** Wether to override the cache */
+  _shouldServeCache: z.boolean().optional(),
 });
 
 export const requiredCustomInputSchema = z.union([

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -265,7 +265,7 @@ export const bookingCreateBodySchema = z.object({
    * Used to identify if the booking is a dry run.
    */
   _isDryRun: z.boolean().optional(),
-  /** Wether to override the cache */
+  /** Whether to override the cache */
   _shouldServeCache: z.boolean().optional(),
 });
 

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -29,6 +29,7 @@ export const getScheduleSchema = z
     skipContactOwner: z.boolean().nullish(),
     _enableTroubleshooter: z.boolean().optional(),
     _bypassCalendarBusyTimes: z.boolean().optional(),
+    _shouldServeCache: z.boolean().optional(),
   })
   .transform((val) => {
     // Need this so we can pass a single username in the query string form public API

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -12,7 +12,7 @@ import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
 import { getSlugOrRequestedSlug, orgDomainConfig } from "@calcom/ee/organizations/lib/orgDomains";
 import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEventTypeLoggingEnabled";
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { getShouldServeCache } from "@calcom/features/calendar-cache/lib/getShouldServeCache";
 import { parseBookingLimit, parseDurationLimit } from "@calcom/lib";
 import { findQualifiedHosts } from "@calcom/lib/bookings/findQualifiedHosts";
 import {
@@ -449,14 +449,7 @@ async function _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<I
     throw new TRPCError({ code: "NOT_FOUND" });
   }
 
-  const teamId = eventType.team?.id;
-  const featureRepo = new FeaturesRepository();
-  const shouldServeCache =
-    /** If we set the parameter use that, else check if the team has the feature enabled */
-    typeof _shouldServeCache === "boolean" || !teamId
-      ? _shouldServeCache
-      : await featureRepo.checkIfTeamHasFeature(teamId, "calendar-cache-serve");
-
+  const shouldServeCache = await getShouldServeCache(_shouldServeCache, eventType.team?.id);
   if (isEventTypeLoggingEnabled({ eventTypeId: eventType.id })) {
     logger.settings.minLevel = 2;
   }

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -262,7 +262,8 @@ export interface Calendar {
   getAvailability(
     dateFrom: string,
     dateTo: string,
-    selectedCalendars: IntegrationCalendar[]
+    selectedCalendars: IntegrationCalendar[],
+    shouldServeCache?: boolean
   ): Promise<EventBusyDate[]>;
 
   fetchAvailabilityAndSetCache?(selectedCalendars: IntegrationCalendar[]): Promise<unknown>;


### PR DESCRIPTION
Folow up to #11928

## What does this PR do?

This pull request introduces several enhancements and refactors to the calendar service, focusing on caching and availability fetching mechanisms. The key changes include the introduction of a new `shouldServeCache` parameter, refactoring of cache-related functions, and updates to various calendar service methods to incorporate these changes.

Enhancements to caching and availability fetching:

* [`packages/app-store/googlecalendar/lib/CalendarService.ts`](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L513-R529): Introduced the `shouldServeCache` parameter in multiple methods, refactored `getCacheOrFetchAvailability` to use a new helper method `getFreeBusyResult`, and updated cache handling in `unwatchCalendar`. [[1]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L513-R529) [[2]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L566-R581) [[3]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L586-R604) [[4]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L675-R689) [[5]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L710-R729)

* [`packages/core/CalendarManager.ts`](diffhunk://#diff-1edf77640cddbeb991fcd8211c16508c055ff086f3c04f58a4e951f1e6710b14L139-L183): Removed the `getCachedResults` function and added the `shouldServeCache` parameter to `getBusyCalendarTimes` and related functions to improve cache handling. [[1]](diffhunk://#diff-1edf77640cddbeb991fcd8211c16508c055ff086f3c04f58a4e951f1e6710b14L139-L183) [[2]](diffhunk://#diff-1edf77640cddbeb991fcd8211c16508c055ff086f3c04f58a4e951f1e6710b14L206-R161) [[3]](diffhunk://#diff-1edf77640cddbeb991fcd8211c16508c055ff086f3c04f58a4e951f1e6710b14L215-R176)

* [`packages/core/getBusyTimes.ts`](diffhunk://#diff-d3d426265221c77cb2fa5ccde7a3cfcf61db38f62011c3653e97c0aa79096afeR47): Added the `shouldServeCache` parameter to the `getBusyTimes` function to control cache usage. [[1]](diffhunk://#diff-d3d426265221c77cb2fa5ccde7a3cfcf61db38f62011c3653e97c0aa79096afeR47) [[2]](diffhunk://#diff-d3d426265221c77cb2fa5ccde7a3cfcf61db38f62011c3653e97c0aa79096afeR64) [[3]](diffhunk://#diff-d3d426265221c77cb2fa5ccde7a3cfcf61db38f62011c3653e97c0aa79096afeL246-R249)

* [`packages/core/getCalendarsEvents.ts`](diffhunk://#diff-b15e52ad5aa461f1c933ef3a852dcfaf5278fa7798855e238f01cba46207adf8L14-R15): Updated the `getCalendarsEvents` function to include the `shouldServeCache` parameter for better cache management. [[1]](diffhunk://#diff-b15e52ad5aa461f1c933ef3a852dcfaf5278fa7798855e238f01cba46207adf8L14-R15) [[2]](diffhunk://#diff-b15e52ad5aa461f1c933ef3a852dcfaf5278fa7798855e238f01cba46207adf8L48-R54)

* [`packages/features/calendar-cache/lib/datesForCache.ts`](diffhunk://#diff-394e8011261a8266dcd61e91e2401d8c31708d7a2b8448ca87e2ef9fd5ee8f19R1-R16): Added new utility functions `getTimeMin` and `getTimeMax` to handle date range expansions for caching purposes.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Scenario 1

- Have a team with a TeamFeature entry for both "calendar-cache" and "calendar-cache-serve"
- Test out a booking normally
- Test out a booking with `?cal.cache=false` parameter. It should skip cache altogether.

### Scenario 2

- Have a team with a TeamFeature entry for both "calendar-cache"only.
- Test out a booking normally
- Test out a booking with `?cal.cache=true` parameter. It should force cache serving.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
