### PR TITLE
feat: match edit user sheet designs

### DIFF
--- a/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
+++ b/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
@@ -26,7 +26,6 @@ import {
   SheetFooter,
   Button,
   SheetTitle,
-  SheetDescription,
   Divider,
 } from "@calcom/ui";
 
@@ -170,9 +169,8 @@ export function EditForm({
         }}>
         <SheetHeader>
           <SheetTitle>{t("update_profile")}</SheetTitle>
-          <SheetDescription>{t("update_your_profile")}</SheetDescription>
         </SheetHeader>
-        <SheetBody className="bg-muted border-subtle flex flex-col gap-4 rounded-xl border p-4">
+        <SheetBody className="bg-muted border-subtle mt-6 gap-4 rounded-xl border p-4">
           <div className="">
             <Controller
               control={form.control}
@@ -216,6 +214,7 @@ export function EditForm({
             <Label>{t("timezone")}</Label>
             <TimezoneSelect value={watchTimezone ?? "America/Los_Angeles"} />
           </div>
+          <Divider />
           <AttributesList selectedUserId={selectedUser?.id} />
         </SheetBody>
         <SheetFooter>
@@ -312,7 +311,6 @@ function AttributesList(props: { selectedUserId: number }) {
   return (
     <div className="flex flex-col overflow-visible">
       <div className="flex flex-col gap-3 rounded-lg">
-        <label className="text-emphasis mb-1 mt-6 text-base font-bold">{t("attributes")}</label>
         {attributeFieldState.error && (
           <p className="text-error mb-2 block text-sm font-medium leading-none">
             {JSON.stringify(attributeFieldState.error)}

--- a/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
+++ b/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
@@ -26,6 +26,8 @@ import {
   SheetFooter,
   Button,
   SheetTitle,
+  SheetDescription,
+  Divider,
 } from "@calcom/ui";
 
 import type { UserTableAction } from "../types";
@@ -168,19 +170,22 @@ export function EditForm({
         }}>
         <SheetHeader>
           <SheetTitle>{t("update_profile")}</SheetTitle>
-
-          <div className="mt-6 flex flex-col gap-2">
+          <SheetDescription>{t("update_your_profile")}</SheetDescription>
+        </SheetHeader>
+        <SheetBody className="bg-muted border-subtle flex flex-col gap-4 rounded-xl border p-4">
+          <div className="">
             <Controller
               control={form.control}
               name="avatar"
               render={({ field: { value } }) => (
                 <div className="flex items-center">
-                  <Avatar alt={`${selectedUser?.name} avatar`} imageSrc={value} size="lg" />
+                  <Avatar alt={`${selectedUser?.name} avatar`} imageSrc={value} size="mdLg" />
                   <div className="ml-4">
                     <ImageUploader
                       target="avatar"
                       id="avatar-upload"
                       buttonMsg={t("change_avatar")}
+                      buttonSize="sm"
                       handleAvatarChange={(newAvatar) => {
                         form.setValue("avatar", newAvatar, { shouldDirty: true });
                       }}
@@ -191,14 +196,10 @@ export function EditForm({
               )}
             />
           </div>
-        </SheetHeader>
-        <SheetBody className="mt-4 flex h-full flex-col space-y-3 px-1">
-          <label className="text-emphasis mb-1 text-base font-bold">{t("profile")}</label>
-          <TextField label={t("username")} {...form.register("username")} />
+          <Divider />
           <TextField label={t("name")} {...form.register("name")} />
-          <TextField label={t("email")} {...form.register("email")} />
-
-          <TextAreaField label={t("bio")} {...form.register("bio")} className="min-h-24" />
+          <TextField label={t("username")} {...form.register("username")} />
+          <TextAreaField label={t("about")} {...form.register("bio")} className="min-h-24" />
           <div>
             <Label>{t("role")}</Label>
             <ToggleGroup

--- a/packages/ui/components/button/Button.tsx
+++ b/packages/ui/components/button/Button.tsx
@@ -59,7 +59,7 @@ export const buttonClasses = cva(
           "border border-default text-emphasis hover:text-red-700 dark:hover:text-red-100 focus-visible:text-red-700  hover:border-red-100 focus-visible:border-red-100 hover:bg-error  focus-visible:bg-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset focus-visible:ring-red-700 disabled:bg-red-100 disabled:border-red-200 disabled:text-red-700 disabled:hover:border-red-200 disabled:opacity-40",
       },
       size: {
-        sm: "px-3 py-2 leading-4 rounded-sm" /** For backwards compatibility */,
+        sm: "px-3 py-2 leading-4 rounded-md" /** For backwards compatibility */,
         base: "h-9 px-4 py-2.5 ",
         lg: "h-[36px] px-4 py-2.5 ",
       },

--- a/packages/ui/components/image-uploader/ImageUploader.tsx
+++ b/packages/ui/components/image-uploader/ImageUploader.tsx
@@ -6,7 +6,7 @@ import Cropper from "react-easy-crop";
 import checkIfItFallbackImage from "@calcom/lib/checkIfItFallbackImage";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import type { ButtonColor } from "../button";
+import type { ButtonColor, ButtonProps } from "../button";
 import { Button } from "../button";
 import { Dialog, DialogClose, DialogContent, DialogTrigger, DialogFooter } from "../dialog";
 import { showToast } from "../toast";
@@ -18,6 +18,7 @@ const MAX_IMAGE_SIZE = 512;
 type ImageUploaderProps = {
   id: string;
   buttonMsg: string;
+  buttonSize?: ButtonProps["size"];
   handleAvatarChange: (imageSrc: string) => void;
   imageSrc?: string;
   target: string;
@@ -78,6 +79,7 @@ export default function ImageUploader({
   uploadInstruction,
   disabled = false,
   testId,
+  buttonSize,
 }: ImageUploaderProps) {
   const { t } = useLocale();
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
@@ -130,6 +132,7 @@ export default function ImageUploader({
           color={triggerButtonColor ?? "secondary"}
           type="button"
           disabled={disabled}
+          size={buttonSize}
           data-testid={testId ? `open-upload-${testId}-dialog` : "open-upload-avatar-dialog"}
           className="cursor-pointer py-1 text-sm">
           {buttonMsg}


### PR DESCRIPTION
## What does this PR do?

Matches the designs we have for the edit sheet

Fixes: CAL-4090

Figma: https://www.figma.com/design/UajFu4M1APhn2AywAEJkJr/New-Features?node-id=22357-446870&t=zd6MgRF445X7rbNQ-4 

We can match 1-1 to the way attributes is proposed here without changing FE and BE logic and that felt like more issue than what it was worth for this tiny issue

Screenies:
![CleanShot 2024-12-18 at 10 39 55](https://github.com/user-attachments/assets/c94ec0b1-ea3e-4fc0-8989-4d4c11618433)
![CleanShot 2024-12-18 at 10 40 57](https://github.com/user-attachments/assets/96dacef6-6664-4cfc-b1d4-b83632e20a67)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Open edit members sheet

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
