### PR TITLE
fix: include app directory in rewrites generation logic + migrate /reschedule pages to App Router

### DIFF
--- a/apps/web/app/reschedule/[uid]/embed/page.tsx
+++ b/apps/web/app/reschedule/[uid]/embed/page.tsx
@@ -1,23 +1,17 @@
 import { withAppDirSsr } from "app/WithAppDirSsr";
+import withEmbedSsrAppDir from "app/WithEmbedSSR";
 import type { PageProps } from "app/_types";
-import { _generateMetadata } from "app/_utils";
-import { headers, cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/reschedule/[uid]/getServerSideProps";
 
-export const generateMetadata = async () =>
-  await _generateMetadata(
-    () => "",
-    () => ""
-  );
-
 const getData = withAppDirSsr(getServerSideProps);
+const getEmbedData = withEmbedSsrAppDir(getData);
 
 const Page = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
-
-  await getData(legacyCtx);
+  await getEmbedData(legacyCtx);
 
   return null;
 };

--- a/apps/web/app/reschedule/[uid]/page.tsx
+++ b/apps/web/app/reschedule/[uid]/page.tsx
@@ -1,14 +1,15 @@
-import { getServerSideProps as _getServerSideProps } from "@pages/reschedule/[uid]";
+import { withAppDirSsr } from "app/WithAppDirSsr";
 import type { PageProps } from "app/_types";
-import { cookies, headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
-import withEmbedSsr from "@lib/withEmbedSsr";
+import { getServerSideProps } from "@lib/reschedule/[uid]/getServerSideProps";
 
-const getData = withEmbedSsr(_getServerSideProps);
+const getData = withAppDirSsr(getServerSideProps);
 
 const Page = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
+
   await getData(legacyCtx);
 
   return null;

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -192,6 +192,7 @@ export const config = {
     "/teams",
     "/future/teams/",
     "/settings/:path*",
+    "/reschedule/:path*",
     "/availability/:path*",
     "/booking/:path*",
   ],

--- a/apps/web/pages/reschedule/[uid].tsx
+++ b/apps/web/pages/reschedule/[uid].tsx
@@ -1,6 +1,0 @@
-export default function Type() {
-  // Just redirect to the schedule page to reschedule it.
-  return null;
-}
-
-export { getServerSideProps } from "@lib/reschedule/[uid]/getServerSideProps";

--- a/apps/web/pages/reschedule/[uid]/embed.tsx
+++ b/apps/web/pages/reschedule/[uid]/embed.tsx
@@ -1,7 +1,0 @@
-import withEmbedSsr from "@lib/withEmbedSsr";
-
-import { getServerSideProps as _getServerSideProps } from "../[uid]";
-
-export { default } from "../[uid]";
-
-export const getServerSideProps = withEmbedSsr(_getServerSideProps);

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -11,7 +11,7 @@ const BEFORE_REWRITE_EXCLUDE_PAGES = (exports.pages = glob
       .replace(/\/.*/, "")
   )
   // "/future" is a temporary directory for incremental migration to App Router
-  .filter((v, i, self) => self.indexOf(v) === i && !["[user]", "future", "_trpc"].some(prefix => v.startsWith(prefix)));
+  .filter((v, i, self) => self.indexOf(v) === i && !["[user]", "future", "_trpc"].some(prefix => v.startsWith(prefix))));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -2,7 +2,7 @@ const glob = require("glob");
 const { getSubdomainRegExp } = require("./getSubdomainRegExp");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
 // Pages found here are excluded from redirects in beforeFiles in next.config.js
-const BEFORE_REWRITE_EXCLUDE_PAGES = (exports.pages = glob
+let pages = (exports.pages = glob
   .sync("{pages,app}/**/[^_]*.{tsx,js,ts}", { cwd: __dirname })
   .map((filename) =>
     filename
@@ -40,7 +40,7 @@ function getRegExpMatchingAllReservedRoutes(suffix) {
   const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel"];
   const nextJsSpecialPaths = ["_next", "public"];
 
-  let beforeRewriteExcludePages = BEFORE_REWRITE_EXCLUDE_PAGES.concat(otherNonExistingRoutePrefixes).concat(
+  let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes).concat(
     nextJsSpecialPaths
   );
   return beforeRewriteExcludePages.join(`${suffix}|`) + suffix;

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -40,9 +40,7 @@ function getRegExpMatchingAllReservedRoutes(suffix) {
   const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel"];
   const nextJsSpecialPaths = ["_next", "public"];
 
-  let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes).concat(
-    nextJsSpecialPaths
-  );
+  let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes).concat(nextJsSpecialPaths);
   return beforeRewriteExcludePages.join(`${suffix}|`) + suffix;
 }
 

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -2,14 +2,14 @@ const glob = require("glob");
 const { getSubdomainRegExp } = require("./getSubdomainRegExp");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
 let pages = (exports.pages = glob
-  .sync("pages/**/[^_]*.{tsx,js,ts}", { cwd: __dirname })
-  .map((filename) =>
+  .sync("{pages,app}/**/[^_]*.{tsx,js,ts}", { cwd: __dirname })
+  .map((filename) => 
     filename
-      .substr(6)
+      .replace(/^(pages|app)\//, '')
       .replace(/(\.tsx|\.js|\.ts)/, "")
       .replace(/\/.*/, "")
   )
-  .filter((v, i, self) => self.indexOf(v) === i && !v.startsWith("[user]")));
+  .filter((v, i, self) => self.indexOf(v) === i && !v.startsWith("[user]") && !v.startsWith("future"))); // "/future" is a temporary directory for incremental migration to App Router
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -11,7 +11,7 @@ const BEFORE_REWRITE_EXCLUDE_PAGES = (exports.pages = glob
       .replace(/\/.*/, "")
   )
   // "/future" is a temporary directory for incremental migration to App Router
-  .filter((v, i, self) => self.indexOf(v) === i && !v.startsWith("[user]") && !v.startsWith("future")));
+  .filter((v, i, self) => self.indexOf(v) === i && !["[user]", "future", "_trpc"].some(prefix => v.startsWith(prefix)));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -1,15 +1,17 @@
 const glob = require("glob");
 const { getSubdomainRegExp } = require("./getSubdomainRegExp");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
-let pages = (exports.pages = glob
+// Pages found here are excluded from redirects in beforeFiles in next.config.js
+const BEFORE_REWRITE_EXCLUDE_PAGES = (exports.pages = glob
   .sync("{pages,app}/**/[^_]*.{tsx,js,ts}", { cwd: __dirname })
-  .map((filename) => 
+  .map((filename) =>
     filename
-      .replace(/^(pages|app)\//, '')
+      .replace(/^(pages|app)\//, "")
       .replace(/(\.tsx|\.js|\.ts)/, "")
       .replace(/\/.*/, "")
   )
-  .filter((v, i, self) => self.indexOf(v) === i && !v.startsWith("[user]") && !v.startsWith("future"))); // "/future" is a temporary directory for incremental migration to App Router
+  // "/future" is a temporary directory for incremental migration to App Router
+  .filter((v, i, self) => self.indexOf(v) === i && !v.startsWith("[user]") && !v.startsWith("future")));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages
@@ -32,7 +34,9 @@ function getRegExpMatchingAllReservedRoutes(suffix) {
   const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel"];
   const nextJsSpecialPaths = ["_next", "public"];
 
-  let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes).concat(nextJsSpecialPaths);
+  let beforeRewriteExcludePages = BEFORE_REWRITE_EXCLUDE_PAGES.concat(otherNonExistingRoutePrefixes).concat(
+    nextJsSpecialPaths
+  );
   return beforeRewriteExcludePages.join(`${suffix}|`) + suffix;
 }
 

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -14,9 +14,17 @@ let pages = (exports.pages = glob
   .filter(
     (v, i, self) =>
       self.indexOf(v) === i &&
-      !["[user]", "future", "_trpc", "WithAppDirSsg", "WithAppDirSsr", "WithEmbedSSR"].some((prefix) =>
-        v.startsWith(prefix)
-      )
+      ![
+        "[user]",
+        "future",
+        "_trpc",
+        "layout",
+        "layoutHOC",
+        "WithAppDirSsg",
+        "global-error",
+        "WithAppDirSsr",
+        "WithEmbedSSR",
+      ].some((prefix) => v.startsWith(prefix))
   ));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -11,7 +11,13 @@ const BEFORE_REWRITE_EXCLUDE_PAGES = (exports.pages = glob
       .replace(/\/.*/, "")
   )
   // "/future" is a temporary directory for incremental migration to App Router
-  .filter((v, i, self) => self.indexOf(v) === i && !["[user]", "future", "_trpc"].some(prefix => v.startsWith(prefix))));
+  .filter(
+    (v, i, self) =>
+      self.indexOf(v) === i &&
+      !["[user]", "future", "_trpc", "WithAppDirSsg", "WithAppDirSsr", "WithEmbedSSR"].some((prefix) =>
+        v.startsWith(prefix)
+      )
+  ));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages

--- a/apps/web/test/lib/pagesAndRewritePaths.test.ts
+++ b/apps/web/test/lib/pagesAndRewritePaths.test.ts
@@ -1,0 +1,45 @@
+import { it, expect, describe } from "vitest";
+
+import { pages } from "./apps/web/pagesAndRewritePaths.js";
+
+describe("pagesAndRewritePaths", () => {
+  describe("beforeFiles must exclude routes in pages/app router", () => {
+    const BEFORE_REWRITE_EXCLUDE_PAGES = [
+      "apps",
+      "availability",
+      "booking",
+      "connect-and-join",
+      "enterprise",
+      "error",
+      "getting-started",
+      "insights",
+      "maintenance",
+      "more",
+      "not-found",
+      "reschedule",
+      "settings",
+      "teams",
+      "upgrade",
+      "video",
+      "workflows",
+      "403",
+      "404",
+      "500",
+      "bookings",
+      "event-types",
+      "icons",
+      "org",
+      "payment",
+      "routing-forms",
+      "signup",
+      "team",
+      "d",
+    ];
+
+    it("should include all required routes", () => {
+      BEFORE_REWRITE_EXCLUDE_PAGES.forEach((route) => {
+        expect(pages).toContain(route);
+      });
+    });
+  });
+});

--- a/apps/web/test/lib/pagesAndRewritePaths.test.ts
+++ b/apps/web/test/lib/pagesAndRewritePaths.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, describe } from "vitest";
 
-import { pages } from "../../pagesAndRewritePaths";
+import { pages } from "../../pagesAndRewritePaths.js";
 
 describe("pagesAndRewritePaths", () => {
   describe("beforeFiles must exclude routes in pages/app router", () => {

--- a/apps/web/test/lib/pagesAndRewritePaths.test.ts
+++ b/apps/web/test/lib/pagesAndRewritePaths.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, describe } from "vitest";
 
-import { pages } from "./apps/web/pagesAndRewritePaths.js";
+import { pages } from "../../pagesAndRewritePaths";
 
 describe("pagesAndRewritePaths", () => {
   describe("beforeFiles must exclude routes in pages/app router", () => {


### PR DESCRIPTION
### This PR does the following:
- Cherry-picks the PR to migrate /reschedule pages to App Router (#18150)
- Includes `/app` directory in rewrites generation logic. Previously it only included `/pages` directory.