### PR TITLE
fix: improve qr readability of alby payment integration

### DIFF
--- a/packages/app-store/alby/components/AlbyPaymentComponent.tsx
+++ b/packages/app-store/alby/components/AlbyPaymentComponent.tsx
@@ -87,9 +87,9 @@ export const AlbyPaymentComponent = (props: IAlbyPaymentComponentProps) => {
               <p className="text-sm">Click or scan the invoice below to pay</p>
               <Link
                 href={`lightning:${paymentRequest}`}
-                className="inline-flex items-center justify-center rounded-2xl rounded-md border border-transparent p-2
-                font-medium text-black shadow-sm hover:brightness-95 focus:outline-none focus:ring-offset-2">
-                <QRCode size={128} value={paymentRequest} />
+                className="inline-flex items-center justify-center rounded-2xl rounded-md border border-transparent p-2 bg-white
+                font-medium text-black shadow-sm hover:brightness-95 focus:outline-none focus:ring-offset-2 p-2">
+                <QRCode size={192} value={paymentRequest} />
               </Link>
 
               <Button

--- a/packages/app-store/alby/components/AlbyPaymentComponent.tsx
+++ b/packages/app-store/alby/components/AlbyPaymentComponent.tsx
@@ -81,8 +81,8 @@ export const AlbyPaymentComponent = (props: IAlbyPaymentComponentProps) => {
           {showQRCode && (
             <>
               <div className="flex items-center justify-center gap-2">
-                <p className="text-xs">Waiting for payment...</p>
                 <Spinner className="h-4 w-4" />
+                <p className="text-xs">Waiting for payment</p>
               </div>
               <p className="text-sm">Click or scan the invoice below to pay</p>
               <Link


### PR DESCRIPTION
## What does this PR do?
 - Enlarges and adds some whitespace around the QR for better readability by QR scanners
 - Rearranges some elements for better readability by humans

![Screenshot from 2024-12-18 16-25-47](https://github.com/user-attachments/assets/167ebc11-1586-4ad5-ad23-51b2c81c9f29)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Book an event that uses the Alby payment integration.  