### PR TITLE
fix: password validation bug for pt-BR version

### DIFF
--- a/apps/web/public/static/locales/pt-BR/common.json
+++ b/apps/web/public/static/locales/pt-BR/common.json
@@ -577,7 +577,7 @@
   "forgotten_secret_description": "Caso tenha perdido ou esquecido o segredo, você poderá alterá-lo. Mas fique ciente de que todas as integrações com esse segredo precisarão ser atualizadas",
   "current_incorrect_password": "Senha atual está incorreta",
   "password_hint_caplow": "Mistura de letras maiúsculas e minúsculas",
-  "password_hint_min": "Mínimo de oito caracteres",
+  "password_hint_min": "Mínimo de sete caracteres",
   "password_hint_admin_min": "No mínimo 15 caracteres",
   "password_hint_num": "Contém pelo menos um número",
   "max_limit_allowed_hint": "O tamanho deve ser de {{limit}} ou menos caracteres",


### PR DESCRIPTION
The password validation in the Portuguese version allows a minimum of 8 characters, despite the standard being 7 characters. 

## What does this PR do?
Translated previous statement in `common.json` to Mínimo de sete caracteres <= Minimum seven characters. It now works as expected.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #18250 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.