### PR TITLE
fix: accomodate input timezone while create user without on-boarding and default timezone

### DIFF
--- a/packages/prisma/migrations/20241219153717_default_value_for_timezone_in_schedule_table/migration.sql
+++ b/packages/prisma/migrations/20241219153717_default_value_for_timezone_in_schedule_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Schedule" ALTER COLUMN "timeZone" SET DEFAULT 'Europe/London';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -683,7 +683,7 @@ model Schedule {
   eventType            EventType[]
   instantMeetingEvents EventType[]    @relation("InstantMeetingSchedule")
   name                 String
-  timeZone             String?
+  timeZone             String?        @default("Europe/London")
   availability         Availability[]
   Host                 Host[]
 

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -358,6 +358,7 @@ export async function createNewUsersConnectToOrgIfExists({
                     })),
                   },
                 },
+                ...(timeZone && { timeZone }),
               },
             },
           },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)
- as follow-up for https://github.com/calcom/cal.com/pull/16855
- refer https://github.com/calcom/cal.com/pull/16855#issuecomment-2553331713

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] -N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.