### PR TITLE
fix: Last used label in button shown in 2-factor code and backup screen

### DIFF
--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -282,7 +282,7 @@ PageProps & WithNonceProps<{}>) {
                 disabled={formState.isSubmitting}
                 className="w-full justify-center">
                 <span>{twoFactorRequired ? t("submit") : t("sign_in")}</span>
-                {lastUsed === "credentials" && <LastUsed className="text-gray-600" />}
+                {lastUsed === "credentials" && !twoFactorRequired && <LastUsed className="text-gray-600" />}
               </Button>
             </div>
           </form>


### PR DESCRIPTION
## What does this PR do?

Last used label in button shown in 2-factor code and backup screen. Ideally it should be shown only in the first screen to indicate user what they used before, it doesn't make sense to show in 2-factor code and backup screen

Issue:

https://github.com/user-attachments/assets/99829e87-7535-4d19-b132-1bb84ffb0afb

After fix:

https://github.com/user-attachments/assets/df37a6bb-85ea-42b0-8f0d-76d25dc2884c

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Login and setup 2-factor auth
- Logout and check the `Last Used` label in `Sign in` button and 2-factor code and backup screen