### PR TITLE
fix: Description not rendered as html in select event types screen when installing an app

### DIFF
--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import { ScrollableArea, Badge, Button, Avatar } from "@calcom/ui";
 
@@ -58,9 +59,13 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
             </small>
           </div>
           {Boolean(description) && (
-            <div className="text-subtle line-clamp-4 break-words  text-sm sm:max-w-[650px] [&>*:not(:first-child)]:hidden [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600">
-              {description}
-            </div>
+            <div
+              className="text-subtle line-clamp-4 break-words text-sm sm:max-w-[650px] [&>*:not(:first-child)]:hidden [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: markdownToSafeHTML(description),
+              }}
+            />
           )}
           <div className="mt-2 flex flex-row flex-wrap gap-2">
             {Boolean(durations.length) &&


### PR DESCRIPTION
## What does this PR do?

Description not rendered properly in select event types screen if it has html elements when installing an app

Issue:

![Screenshot 2024-12-23 at 5 43 32 PM](https://github.com/user-attachments/assets/5b4eecb3-5f82-4c1e-8a72-1c3a782615a6)

After solution:

![Screenshot 2024-12-23 at 5 46 54 PM](https://github.com/user-attachments/assets/4bab8262-4852-4913-bdf7-bac9ef00a898)

**Note: Right now there is a trimming happening which is similar behaviour we have in `/event-types` screen**

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Create an event with a description having links, bold or italic components
- Install any app where selecting event type screen comes like google meet
- Verify the html is properly rendered similar to other places like event types screen

