### PR TITLE
fix: update OOO e2e tests to remove flakiness

### DIFF
--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -21,8 +21,12 @@ test.describe("Out of office", () => {
     await user.apiLogin();
 
     await page.goto("/settings/my-account/out-of-office");
+    await page.waitForLoadState("domcontentloaded");
 
-    await page.getByTestId("add_entry_ooo").click();
+    const addOOOButton = page.getByTestId("add_entry_ooo");
+    const dateButton = page.locator('[data-testid="date-range"]');
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
+
     await page.getByTestId("reason_select").click();
 
     await page.getByTestId("select-option-4").click();
@@ -68,8 +72,12 @@ test.describe("Out of office", () => {
     await user.apiLogin();
 
     await page.goto(`/settings/my-account/out-of-office`);
+    await page.waitForLoadState("domcontentloaded");
 
-    await page.getByTestId("add_entry_ooo").click();
+    const addOOOButton = page.getByTestId("add_entry_ooo");
+    const dateButton = page.locator('[data-testid="date-range"]');
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
+
     await page.getByTestId("reason_select").click();
 
     await page.getByTestId("select-option-4").click();
@@ -204,10 +212,13 @@ test.describe("Out of office", () => {
     await user.apiLogin();
 
     await page.goto("/settings/my-account/out-of-office");
+    await page.waitForLoadState("domcontentloaded");
 
-    await page.getByTestId("add_entry_ooo").click();
+    const addOOOButton = page.getByTestId("add_entry_ooo");
+    const dateButton = page.locator('[data-testid="date-range"]');
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
 
-    await page.locator('[data-testid="date-range"]').click();
+    await dateButton.click();
 
     await selectToAndFromDates(page, "13", "22", true);
 
@@ -244,10 +255,13 @@ test.describe("Out of office", () => {
     await user.apiLogin();
 
     await page.goto("/settings/my-account/out-of-office");
+    await page.waitForLoadState("domcontentloaded");
 
-    await page.getByTestId("add_entry_ooo").click();
+    const addOOOButton = page.getByTestId("add_entry_ooo");
+    const dateButton = page.locator('[data-testid="date-range"]');
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
 
-    await page.locator('[data-testid="date-range"]').click();
+    await dateButton.click();
 
     await selectToAndFromDates(page, "13", "22");
 
@@ -256,9 +270,8 @@ test.describe("Out of office", () => {
     await expect(page.locator(`data-testid=table-redirect-n-a`)).toBeVisible();
 
     // add another entry
-    await page.getByTestId("add_entry_ooo").click();
-
-    await page.locator('[data-testid="date-range"]').click();
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
+    await dateButton.click();
 
     await selectToAndFromDates(page, "11", "24");
 
@@ -274,10 +287,13 @@ test.describe("Out of office", () => {
     await user.apiLogin();
 
     await page.goto("/settings/my-account/out-of-office");
+    await page.waitForLoadState("domcontentloaded");
 
-    await page.getByTestId("add_entry_ooo").click();
+    const addOOOButton = page.getByTestId("add_entry_ooo");
+    const dateButton = page.locator('[data-testid="date-range"]');
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
 
-    await page.locator('[data-testid="date-range"]').click();
+    await dateButton.click();
 
     await selectToAndFromDates(page, "13", "22");
 
@@ -286,9 +302,8 @@ test.describe("Out of office", () => {
     await expect(page.locator(`data-testid=table-redirect-n-a`)).toBeVisible();
 
     // add another entry
-    await page.getByTestId("add_entry_ooo").click();
-
-    await page.locator('[data-testid="date-range"]').click();
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
+    await dateButton.click();
 
     await selectToAndFromDates(page, "13", "22");
 
@@ -308,13 +323,13 @@ test.describe("Out of office", () => {
 
     //Creates 2 OOO entries:
     //First OOO is created on Next month 1st - 3rd
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "1", "3");
     await expect(page.locator(`data-testid=table-redirect-n-a`).nth(0)).toBeVisible();
 
     //Second OOO is created on Next month 4th - 6th
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "4", "6");
     await expect(page.locator(`data-testid=table-redirect-n-a`).nth(1)).toBeVisible();
@@ -341,7 +356,7 @@ test.describe("Out of office", () => {
     const dateButton = await page.locator('[data-testid="date-range"]');
 
     //As owner,OOO is created on Next month 1st - 3rd, forwarding to 'member-1'
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "1", "3", "member-1");
     await expect(
@@ -352,7 +367,7 @@ test.describe("Out of office", () => {
     await member1User?.apiLogin();
     await page.goto("/settings/my-account/out-of-office");
     await page.waitForLoadState();
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "4", "5", "owner");
     await expect(page.locator(`data-testid=table-redirect-${owner.username ?? "n-a"}`).nth(0)).toBeVisible();
@@ -380,7 +395,7 @@ test.describe("Out of office", () => {
     const dateButton = await page.locator('[data-testid="date-range"]');
 
     //As owner,OOO is created on Next month 1st - 3rd, forwarding to 'member-1'
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "1", "3", "member-1");
     await expect(
@@ -391,7 +406,7 @@ test.describe("Out of office", () => {
     await member1User?.apiLogin();
     await page.goto("/settings/my-account/out-of-office");
     await page.waitForLoadState();
-    await clickUntilDialogVisible(addOOOButton, dateButton);
+    await clickUntilDialogVisible(addOOOButton, dateButton, page, "outOfOfficeReasonList?batch=1");
     await dateButton.click();
     await selectDateAndCreateOOO(page, "2", "5", "owner", 400);
     await expect(page.locator(`text=${t("booking_redirect_infinite_not_allowed")}`)).toBeTruthy();


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #18368 
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Root cause for flakiness of some of the OOO e2e tests: (Based on Analysis done on some of the recent E2E Results)
1. Playwright tries to select the OOO Reason option, though the `outOfOfficeReasonList?batch=1` trpc endpoint response is still not yet received.
2. Sometimes though Playwright clicks on `+Add` button to create OOO, the dialog is not yet open.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] - N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.