### PR TITLE
fix: Enhance SCIM payload handling and attribute creation

### DIFF
--- a/packages/features/ee/dsync/lib/__tests__/getAttributesFromScimPayload.test.ts
+++ b/packages/features/ee/dsync/lib/__tests__/getAttributesFromScimPayload.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import getAttributesFromScimPayload from "../getAttributesFromScimPayload";
 
+const directoryId = "xxx-xxx-xxx-xxx";
 describe("getAttributesFromScimPayload", () => {
   it("should return empty object for unsupported events", () => {
     const event = {
@@ -10,7 +11,7 @@ describe("getAttributesFromScimPayload", () => {
       data: { raw: { schemas: [] } },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({});
   });
 
@@ -28,7 +29,7 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
       department: "Engineering",
       title: "Software Engineer",
@@ -48,7 +49,7 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
       skills: ["JavaScript", "TypeScript", "React"],
     });
@@ -68,7 +69,7 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
       department: "Engineering",
     });
@@ -87,7 +88,7 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({});
   });
 
@@ -108,7 +109,7 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
       department: "Engineering",
       location: "Remote",
@@ -128,13 +129,13 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
       department: "Engineering",
     });
   });
 
-  it("should extract from core namespace as well.", () => {
+  it("should extract from core namespace as well ignoring the core attributes as defined in the SCIM spec.", () => {
     const event = {
       event: "user.created",
       data: {
@@ -152,13 +153,14 @@ describe("getAttributesFromScimPayload", () => {
       },
     } as DirectorySyncEvent;
 
-    const result = getAttributesFromScimPayload(event);
+    const result = getAttributesFromScimPayload({ event, directoryId });
     expect(result).toEqual({
-      userName: "kush@acme.com",
-      displayName: "Kush",
       territory: "XANAM",
-      externalId: "00ulb1kpy4EMATtuS5d7",
-      groups: [],
+      // Core Attributes won't be there - It avoids unnecessary warnings about attributes not defined in cal.com
+      // userName: "kush@acme.com",
+      // displayName: "Kush",
+      // externalId: "00ulb1kpy4EMATtuS5d7",
+      // groups: [],
     });
   });
 });

--- a/packages/features/ee/organizations/pages/settings/attributes/attributes-create-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/attributes/attributes-create-view.tsx
@@ -38,13 +38,10 @@ function CreateAttributesPage() {
         <AttributeForm
           header={<CreateAttributeHeader isPending={mutation.isPending} />}
           onSubmit={(values) => {
-            // Create set of attributes to get unique values
-            const uniqueAttributes = new Set(values.options.map((option) => option.value));
+            const { attrName, ...rest } = values;
             mutation.mutate({
-              name: values.attrName,
-              type: values.type,
-              isLocked: values.isLocked,
-              options: Array.from(uniqueAttributes).map((value) => ({ value })),
+              ...rest,
+              name: attrName,
             });
           }}
         />

--- a/packages/trpc/server/routers/viewer/attributes/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/create.handler.ts
@@ -7,6 +7,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TrpcSessionUser } from "../../../trpc";
 import type { ZCreateAttributeSchema } from "./create.schema";
+import { getOptionsWithValidContains } from "./utils";
 
 type GetOptions = {
   ctx: {
@@ -28,8 +29,8 @@ const createAttributesHandler = async ({ input, ctx }: GetOptions) => {
   }
 
   const slug = slugify(input.name);
-  const options = input.options.map((v) => v.value);
-  const optionsWithoutDuplicates = Array.from(new Set(options));
+  const uniqueOptions = getOptionsWithValidContains(input.options);
+
   const typeHasOptions = typesWithOptions.includes(input.type);
 
   let attributes: Attribute;
@@ -55,10 +56,11 @@ const createAttributesHandler = async ({ input, ctx }: GetOptions) => {
   // TEXT/NUMBER don't have options
   if (typeHasOptions) {
     await prisma.attributeOption.createMany({
-      data: optionsWithoutDuplicates.map((value) => ({
+      data: uniqueOptions.map(({ value, isGroup }) => ({
         attributeId: attributes.id,
         value,
         slug: slugify(value),
+        isGroup,
       })),
     });
   }

--- a/packages/trpc/server/routers/viewer/attributes/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/attributes/create.schema.ts
@@ -4,7 +4,7 @@ export const createAttributeSchema = z.object({
   name: z.string(),
   type: z.enum(["TEXT", "NUMBER", "SINGLE_SELECT", "MULTI_SELECT"]),
   isLocked: z.boolean().optional(),
-  options: z.array(z.object({ value: z.string() })),
+  options: z.array(z.object({ value: z.string(), isGroup: z.boolean().optional() })),
 });
 
 export type ZCreateAttributeSchema = z.infer<typeof createAttributeSchema>;

--- a/packages/trpc/server/routers/viewer/attributes/edit.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/edit.handler.ts
@@ -5,6 +5,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TrpcSessionUser } from "../../../trpc";
 import type { ZEditAttributeSchema } from "./edit.schema";
+import { getOptionsWithValidContains } from "./utils";
 
 type GetOptions = {
   ctx: {
@@ -114,29 +115,6 @@ const editAttributesHandler = async ({ input, ctx }: GetOptions) => {
 
   return attributes;
 };
-
-/**
- * Ensures that contains has no non-existent sub-options
- */
-function getOptionsWithValidContains(options: ZEditAttributeSchema["options"]) {
-  return options.map(({ contains, ...option }) => {
-    if (!contains)
-      return {
-        ...option,
-        contains: [],
-      };
-    const possibleSubOptions = options
-      .filter((option) => !option.isGroup)
-      .filter((option): option is typeof option & { id: string } => option.id !== undefined);
-
-    const possibleSubOptionsIds = possibleSubOptions.map((option) => option.id);
-
-    return {
-      ...option,
-      contains: contains.filter((subOptionId) => possibleSubOptionsIds.includes(subOptionId)),
-    };
-  });
-}
 
 async function validateOptionsBelongToAttribute(
   options: ZEditAttributeSchema["options"],

--- a/packages/trpc/server/routers/viewer/attributes/utils.test.ts
+++ b/packages/trpc/server/routers/viewer/attributes/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+import { getOptionsWithValidContains } from "./utils";
+
+type Option = {
+  id?: string;
+  value: string;
+  contains?: string[];
+  isGroup?: boolean;
+};
+
+describe("getOptionsWithValidContains", () => {
+  it("should remove duplicate options based on value", () => {
+    const options: Option[] = [
+      { id: "1", value: "option1" },
+      { id: "2", value: "option1" }, // Duplicate value
+      { id: "3", value: "option2" },
+    ];
+
+    const result = getOptionsWithValidContains(options);
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe("option1");
+    expect(result[1].value).toBe("option2");
+  });
+
+  it("should initialize empty contains array if not provided", () => {
+    const options: Option[] = [
+      { id: "1", value: "option1" },
+      { id: "2", value: "option2" },
+    ];
+
+    const result = getOptionsWithValidContains(options);
+    expect(result[0].contains).toEqual([]);
+    expect(result[1].contains).toEqual([]);
+  });
+
+  it("should filter out non-existent sub-options from contains array", () => {
+    const options: Option[] = [
+      { id: "1", value: "option1", contains: ["2", "3", "nonexistent"] },
+      { id: "2", value: "option2" },
+      { id: "3", value: "option3" },
+    ];
+
+    const result = getOptionsWithValidContains(options);
+    expect(result[0].contains).toEqual(["2", "3"]);
+    expect(result[1].contains).toEqual([]);
+    expect(result[2].contains).toEqual([]);
+  });
+
+  it("should handle empty options array", () => {
+    const options: Option[] = [];
+    const result = getOptionsWithValidContains(options);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/trpc/server/routers/viewer/attributes/utils.ts
+++ b/packages/trpc/server/routers/viewer/attributes/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Ensures that contains has no non-existent sub-options
+ */
+export function getOptionsWithValidContains<
+  T extends { id?: string; value: string; contains?: string[]; isGroup?: boolean }
+>(options: T[]): T[] {
+  return options
+    .filter((obj, index, self) => index === self.findIndex((t) => t.value === obj.value))
+    .map(({ contains, ...option }) => {
+      if (!contains)
+        return {
+          ...option,
+          contains: [] as string[],
+        } as T;
+      const possibleSubOptions = options
+        .filter((option) => !option.isGroup)
+        .filter((option): option is typeof option & { id: string } => option.id !== undefined);
+
+      const possibleSubOptionsIds = possibleSubOptions.map((option) => option.id);
+
+      return {
+        ...option,
+        contains: contains.filter((subOptionId) => possibleSubOptionsIds.includes(subOptionId)),
+      } as T;
+    });
+}


### PR DESCRIPTION
- fix: the issue where a user update from Okta didn't sync attributes
- fix: When creating a new attribute, OptionGroup was getting saved as regular Option itself.
- Ignore core user attributes( as defined in the SCIM spec)  from attributes syncing

Detailed Changes:
- Updated `getAttributesFromScimPayload` to accept `directoryId` and ignore core attributes as defined in the SCIM spec.
- Modified `handleUserEvents` to pass `directoryId` when calling `getAttributesFromScimPayload`.
- Improved test cases for `getAttributesFromScimPayload` to reflect the new parameter and behavior.
- Refactored attribute creation logic in `attributes-create-view.tsx` to streamline attribute submission.
- Updated attribute creation schema to include optional `isGroup` property for options.
- Introduced utility function `getOptionsWithValidContains` to ensure valid sub-option references during attribute creation.

These changes improve the robustness of user event handling and attribute management in the application.

## What does this PR do?
- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Create an attribute with option group
- Try syncing the attribute from Okta for an already synced user.