### PR TITLE
fix: type error in app/api/customer-card/route.ts

### DIFF
--- a/apps/web/app/api/customer-card/route.ts
+++ b/apps/web/app/api/customer-card/route.ts
@@ -20,7 +20,7 @@ const inputSchema = z.object({
   cardKeys: z.array(z.string()),
 });
 
-export async function handler(request: Request) {
+async function handler(request: Request) {
   const headersList = headers();
   const requestBody = await request.json();
 


### PR DESCRIPTION
## What does this PR do?

Fix type error during build due to exporting handler function instead where route handlers should only export HTTP methods  

`Type error: Route "app/api/customer-card/route.ts" does not match the required types of a Next.js Route.
"handler" is not a valid Route export field.`

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Yarn build
