### PR TITLE
fix: react incompatiblity with nextjs error

### DIFF
--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -30,8 +30,8 @@
   "module": "./dist/Cal.es.mjs",
   "types": "./dist/embed-react/src/index.d.ts",
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## What does this PR do?
Updated the peer dependencies in `@calcom/embed-react` to support both Rect 18 and 19. This change allows the embed component to work with Nextjs projects which use React 19.

since the codebase is huge,
- the change updates peer dependencies to accept both React 18 and React 19 versions
- it also maintains backward compatibility with existing React 18 applications

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #18399 (GitHub issue number)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
![image](https://github.com/user-attachments/assets/ba16ac59-5c1e-483c-84d3-0f0b1298b2ee)
![image](https://github.com/user-attachments/assets/8a79f577-3fd5-4061-baed-d351b65a960d)
No errors regarding react compatibility anymore.
## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



