### PR TITLE
fix: improve useInViewObserver hook to trigger when observer is in view on mount

### DIFF
--- a/packages/lib/hooks/useInViewObserver.ts
+++ b/packages/lib/hooks/useInViewObserver.ts
@@ -14,6 +14,11 @@ export const useInViewObserver = (onInViewCallback: () => void, root?: Element |
       return;
     }
 
+    if (node && node.getBoundingClientRect().top < window.innerHeight) {
+      // Trigger callback immediately if element is already in view on mount
+      onInViewCallback();
+    }
+
     let observer: IntersectionObserver;
     if (node && node.parentElement) {
       observer = new IntersectionObserver(
@@ -35,7 +40,7 @@ export const useInViewObserver = (onInViewCallback: () => void, root?: Element |
         observer.disconnect();
       }
     };
-  }, [node]);
+  }, [onInViewCallback, node]);
 
   return {
     ref: setRef,


### PR DESCRIPTION
## What does this PR do?
This pull request makes inViewObserver trigger when ref element already intersect view port on mount.  

Currently,  inViewObserver triggers only when ref element "enters" view port after component mount. This makes infinite scroll loading behavior doesn't work on first page load if view port contains inViewObserver ref element

This PR makes inViewObserver always trigger when ref element is in view, even on first mount, making its behavior more consistent. 

As a consequence, any infinite scrolling list that use inViewObserver will continue to load element on first mount up until the point ref element doesn't intersect the view port any more. 

## Before
https://github.com/user-attachments/assets/a0427255-e82d-4d96-99ef-2a8fe9584b24

## After 
https://github.com/user-attachments/assets/cbaa4bf2-c26e-4546-852d-1e49312f8f67

 Loom Video: https://www.loom.com/share/60b418ebda554e90a711a6ed0be295f4?sid=4e41bb73-9501-4f0f-8df2-e0d2953c64c4

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Visit any infinite loading list that uses inViewObserver 
- List should loads data until inViewObserver ref element is below view port 
- Scroll to inViewObserver ref element should trigger callback 