### PR TITLE
fix: Zoho Calendar is allowing bookings during busy schedules

### DIFF
--- a/packages/app-store/zohocalendar/lib/CalendarService.ts
+++ b/packages/app-store/zohocalendar/lib/CalendarService.ts
@@ -236,11 +236,11 @@ export default class ZohoCalendarService implements Calendar {
   }
 
   private parseDateTime = (dateTimeStr: string) => {
-    // Check if the string matches the date-only format (YYYYMMDDZ)
-    if (/^\d{8}Z$/.test(dateTimeStr)) {
-      return dayjs.utc(dateTimeStr.slice(0, 8), "YYYYMMDD");
-    }
-    return dayjs.utc(dateTimeStr, "YYYYMMDD[T]HHmmss[Z]");
+    const dateOnlyFormat = "YYYYMMDD";
+    const dateTimeFormat = "YYYYMMDD[T]HHmmss[Z]";
+    // Check if the string matches the date-only format (YYYYMMDDZ) or date-time format
+    const format = /^\d{8}Z$/.test(dateTimeStr) ? dateOnlyFormat : dateTimeFormat;
+    return dayjs.utc(dateTimeStr, format);
   };
 
   private async getBusyData(dateFrom: string, dateTo: string, userEmail: string) {

--- a/packages/app-store/zohocalendar/lib/CalendarService.ts
+++ b/packages/app-store/zohocalendar/lib/CalendarService.ts
@@ -235,6 +235,14 @@ export default class ZohoCalendarService implements Calendar {
     }
   }
 
+  private parseDateTime = (dateTimeStr: string) => {
+    // Check if the string matches the date-only format (YYYYMMDDZ)
+    if (/^\d{8}Z$/.test(dateTimeStr)) {
+      return dayjs.utc(dateTimeStr.slice(0, 8), "YYYYMMDD");
+    }
+    return dayjs.utc(dateTimeStr, "YYYYMMDD[T]HHmmss[Z]");
+  };
+
   private async getBusyData(dateFrom: string, dateTo: string, userEmail: string) {
     const query = stringify({
       sdate: dateFrom,
@@ -256,8 +264,8 @@ export default class ZohoCalendarService implements Calendar {
         .filter((freebusy: FreeBusy) => freebusy.fbtype === "busy")
         .map((freebusy: FreeBusy) => ({
           // using dayjs utc plugin because by default, dayjs parses and displays in local time, which causes a mismatch
-          start: dayjs.utc(freebusy.startTime, "YYYYMMDD[T]HHmmss[Z]").toISOString(),
-          end: dayjs.utc(freebusy.endTime, "YYYYMMDD[T]HHmmss[Z]").toISOString(),
+          start: this.parseDateTime(freebusy.startTime).toISOString(),
+          end: this.parseDateTime(freebusy.endTime).toISOString(),
         })) || []
     );
   }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://linear.app/calcom/issue/CAL-3900/zoho-calendar-allowing-to-book-on-a-reserved-slot
- Fixes https://github.com/calcom/cal.com/issues/16177

