### PR TITLE
perf: Remove zod from edge runtime

### DIFF
--- a/apps/web/abTest/middlewareFactory.ts
+++ b/apps/web/abTest/middlewareFactory.ts
@@ -1,7 +1,6 @@
 import { getBucket } from "abTest/utils";
 import type { NextMiddleware, NextRequest } from "next/server";
 import { NextResponse, URLPattern } from "next/server";
-import z from "zod";
 
 import { FUTURE_ROUTES_ENABLED_COOKIE_NAME, FUTURE_ROUTES_OVERRIDE_COOKIE_NAME } from "@calcom/lib/constants";
 
@@ -27,8 +26,6 @@ const ROUTES: [URLPattern, boolean][] = [
   enabled,
 ]);
 
-const bucketSchema = z.union([z.literal("legacy"), z.literal("future")]);
-
 export const abTestMiddlewareFactory =
   (next: (req: NextRequest) => Promise<NextResponse<unknown>>): NextMiddleware =>
   async (req: NextRequest) => {
@@ -45,11 +42,9 @@ export const abTestMiddlewareFactory =
       return response;
     }
 
-    const safeParsedBucket = override
-      ? { success: true as const, data: "future" as const }
-      : bucketSchema.safeParse(req.cookies.get(FUTURE_ROUTES_ENABLED_COOKIE_NAME)?.value);
+    const bucketValue = override ? "future" : req.cookies.get(FUTURE_ROUTES_ENABLED_COOKIE_NAME)?.value;
 
-    if (!safeParsedBucket.success) {
+    if (!bucketValue || !["future", "legacy"].includes(bucketValue)) {
       // cookie does not exist or it has incorrect value
       const bucket = getBucket();
 
@@ -68,7 +63,7 @@ export const abTestMiddlewareFactory =
       return NextResponse.rewrite(url, response);
     }
 
-    if (safeParsedBucket.data === "legacy") {
+    if (bucketValue === "legacy") {
       return response;
     }
 

--- a/apps/web/lib/csp.ts
+++ b/apps/web/lib/csp.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage, OutgoingMessage } from "http";
 import type { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import { IS_PRODUCTION } from "@calcom/lib/constants";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -47,6 +46,13 @@ const isPagePathRequest = (url: URL) => {
   return !isNonPagePathPrefix.test(pathname) && !isFile.test(pathname);
 };
 
+function safeParseString(value: unknown): { success: boolean; data?: string } {
+  if (typeof value === "string") {
+    return { success: true, data: value };
+  }
+  return { success: false };
+}
+
 export function csp(req: IncomingMessage | NextRequest | null, res: OutgoingMessage | NextResponse | null) {
   if (!req) {
     return { nonce: undefined };
@@ -54,7 +60,7 @@ export function csp(req: IncomingMessage | NextRequest | null, res: OutgoingMess
   const existingNonce = "cache" in req ? req.headers.get("x-nonce") : req.headers["x-nonce"];
 
   if (existingNonce) {
-    const existingNoneParsed = z.string().safeParse(existingNonce);
+    const existingNoneParsed = safeParseString(existingNonce);
     return { nonce: existingNoneParsed.success ? existingNoneParsed.data : "" };
   }
   if (!req.url) {

--- a/packages/features/auth/lib/getLocale.ts
+++ b/packages/features/auth/lib/getLocale.ts
@@ -5,7 +5,7 @@ import { getToken } from "next-auth/jwt";
 import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 
-//@ts-expect-error no type definitions
+// @ts-expect-error no type definitions
 import { i18n } from "@calcom/config/next-i18next.config";
 
 /**


### PR DESCRIPTION
## What does this PR do?

Edge middleware should be kept to minimal dependencies and the minimal usage of zod we do doesn't warrant the page overhead.

