### PR TITLE
revert: "fix: improve useInViewObserver hook to trigger when observer is in view on mount"

### DIFF
--- a/packages/lib/hooks/useInViewObserver.ts
+++ b/packages/lib/hooks/useInViewObserver.ts
@@ -14,11 +14,6 @@ export const useInViewObserver = (onInViewCallback: () => void, root?: Element |
       return;
     }
 
-    if (node && node.getBoundingClientRect().top < window.innerHeight) {
-      // Trigger callback immediately if element is already in view on mount
-      onInViewCallback();
-    }
-
     let observer: IntersectionObserver;
     if (node && node.parentElement) {
       observer = new IntersectionObserver(
@@ -40,7 +35,7 @@ export const useInViewObserver = (onInViewCallback: () => void, root?: Element |
         observer.disconnect();
       }
     };
-  }, [onInViewCallback, node]);
+  }, [node]);
 
   return {
     ref: setRef,


### PR DESCRIPTION
Reverts calcom/cal.com#18446

too many bookings.get calls till all bookings are loading

![Screenshot 2025-01-07 at 9 43 28 PM](https://github.com/user-attachments/assets/22a9954f-8f67-4337-8bd7-f183bc33cef0)

how to reproduce?

Seed 100+ bookings and then go to /bookings/upcoming and make sure `viewer.bookings.get` is not called too many times
