### PR TITLE
perf: use react svg cache from root level

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -2,11 +2,15 @@
 
 import { TrpcProvider } from "app/_trpc/trpc-provider";
 import { SessionProvider } from "next-auth/react";
+import CacheProvider from "react-inlinesvg/provider";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <TrpcProvider>{children}</TrpcProvider>
+      <TrpcProvider>
+        {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
+        <CacheProvider>{children}</CacheProvider>
+      </TrpcProvider>
     </SessionProvider>
   );
 }

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -12,7 +12,6 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import { useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
-import CacheProvider from "react-inlinesvg/provider";
 
 import DynamicPostHogProvider from "@calcom/features/ee/event-tracking/lib/posthog/providerDynamic";
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
@@ -277,10 +276,7 @@ const AppProviders = (props: PageWrapperProps) => {
             isThemeSupported={/* undefined gets treated as true */ props.isThemeSupported}
             isBookingPage={props.isBookingPage || isBookingPage}>
             <FeatureFlagsProvider>
-              <OrgBrandProvider>
-                {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
-                <CacheProvider>{props.children}</CacheProvider>
-              </OrgBrandProvider>
+              <OrgBrandProvider>{props.children}</OrgBrandProvider>
             </FeatureFlagsProvider>
           </CalcomThemeProvider>
         </TooltipProvider>

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -11,7 +11,6 @@ import dynamic from "next/dynamic";
 import type { ParsedUrlQuery } from "querystring";
 import type { PropsWithChildren, ReactNode } from "react";
 import { useEffect } from "react";
-import CacheProvider from "react-inlinesvg/provider";
 
 import DynamicPostHogProvider from "@calcom/features/ee/event-tracking/lib/posthog/providerDynamic";
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
@@ -307,10 +306,7 @@ const AppProviders = (props: AppPropsWithChildren) => {
             router={props.router}>
             <FeatureFlagsProvider>
               <OrgBrandProvider>
-                {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
-                <CacheProvider>
-                  <MetaProvider>{props.children}</MetaProvider>
-                </CacheProvider>
+                <MetaProvider>{props.children}</MetaProvider>
               </OrgBrandProvider>
             </FeatureFlagsProvider>
           </CalcomThemeProvider>

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "http";
 import { SessionProvider } from "next-auth/react";
 import type { AppContextType } from "next/dist/shared/lib/utils";
 import React, { useEffect } from "react";
+import CacheProvider from "react-inlinesvg/provider";
 
 import { trpc } from "@calcom/trpc/react";
 
@@ -20,7 +21,10 @@ function MyApp(props: AppProps) {
 
   return (
     <SessionProvider session={pageProps.session ?? undefined}>
-      {Component.PageWrapper ? <Component.PageWrapper {...props} /> : <Component {...pageProps} />}
+      {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
+      <CacheProvider>
+        {Component.PageWrapper ? <Component.PageWrapper {...props} /> : <Component {...pageProps} />}
+      </CacheProvider>
     </SessionProvider>
   );
 }


### PR DESCRIPTION
## What does this PR do?

- Obvious perf optimization by moving React SVG Cache Provider to the root-level from route-level



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

