### PR TITLE
fix: add index to AssignmentReason

### DIFF
--- a/packages/prisma/migrations/20250108095727_assignment_reason_index/migration.sql
+++ b/packages/prisma/migrations/20250108095727_assignment_reason_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "AssignmentReason_bookingId_idx" ON "AssignmentReason"("bookingId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1711,6 +1711,8 @@ model AssignmentReason {
   booking      Booking              @relation(fields: [bookingId], references: [id], onDelete: Cascade)
   reasonEnum   AssignmentReasonEnum
   reasonString String
+
+  @@index([bookingId])
 }
 
 enum EventTypeAutoTranslatedField {


### PR DESCRIPTION
## What does this PR do?

The table `AssignmentReason` is mostly queried along with `bookingId`. This PR adds an index for it.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


## Checklist
