### PR TITLE
perf: no need for two db access for booking pages

### DIFF
--- a/apps/web/app/[user]/[type]/page.tsx
+++ b/apps/web/app/[user]/[type]/page.tsx
@@ -18,26 +18,17 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
   const props = await getData(legacyCtx);
 
-  const { booking, user: username, slug: eventSlug, isSEOIndexable, eventData, isBrandingHidden } = props;
+  const { booking, isSEOIndexable, eventData, isBrandingHidden } = props;
   const rescheduleUid = booking?.uid;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(legacyCtx.req, legacyCtx.params?.orgSlug);
 
-  const event = await EventRepository.getPublicEvent({
-    username,
-    eventSlug,
-    isTeamEvent: false,
-    org: isValidOrgDomain ? currentOrgDomain : null,
-    fromRedirectOfNonOrgLink: legacyCtx.query.orgRedirection === "true",
-  });
-
-  const profileName = event?.profile?.name ?? "";
-  const profileImage = event?.profile.image;
-  const title = event?.title ?? "";
+  const profileName = eventData?.profile?.name ?? "";
+  const profileImage = eventData?.profile.image;
+  const title = eventData?.title ?? "";
   const metadata = await generateEventBookingPageMetadata({
     event: {
-      hidden: event?.hidden ?? false,
+      hidden: eventData?.hidden ?? false,
       title,
-      users: event?.users ?? [],
+      users: eventData?.users ?? [],
     },
     hideBranding: isBrandingHidden,
     orgSlug: eventData?.entity.orgSlug ?? null,

--- a/apps/web/app/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/d/[link]/[slug]/page.tsx
@@ -4,9 +4,6 @@ import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 import { cookies, headers } from "next/headers";
 
-import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { EventRepository } from "@calcom/lib/server/repository/event";
-
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 import { type PageProps } from "@lib/d/[link]/[slug]/getServerSideProps";
@@ -17,21 +14,11 @@ export const generateMetadata = async ({ params, searchParams }: _PageProps) => 
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
   const pageProps = await getData(legacyCtx);
 
-  const { booking, user: username, slug: eventSlug, isTeamEvent, isBrandingHidden } = pageProps;
+  const { booking, eventData, isBrandingHidden } = pageProps;
   const rescheduleUid = booking?.uid;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(legacyCtx.req);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
 
-  const event = await EventRepository.getPublicEvent({
-    username,
-    eventSlug,
-    isTeamEvent,
-    org,
-    fromRedirectOfNonOrgLink: legacyCtx.query.orgRedirection === "true",
-  });
-
-  const profileName = event?.profile?.name ?? "";
-  const title = event?.title ?? "";
+  const profileName = eventData?.profile?.name ?? "";
+  const title = eventData?.title ?? "";
   return await _generateMetadata(
     (t) => `${rescheduleUid && !!booking ? t("reschedule") : ""} ${title} | ${profileName}`,
     (t) => `${rescheduleUid ? t("reschedule") : ""} ${title}`,

--- a/apps/web/app/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
@@ -5,7 +5,6 @@ import { WithLayout } from "app/layoutHOC";
 import { headers, cookies } from "next/headers";
 
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { EventRepository } from "@calcom/lib/server/repository/event";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps";
@@ -15,21 +14,13 @@ import Page from "~/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-mee
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const context = buildLegacyCtx(headers(), cookies(), params, searchParams);
-  const { slug: eventSlug, user: username, isBrandingHidden } = await getData(context);
+  const { isBrandingHidden, eventData } = await getData(context);
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
 
   const org = isValidOrgDomain ? currentOrgDomain : null;
 
-  const event = await EventRepository.getPublicEvent({
-    username,
-    eventSlug,
-    isTeamEvent: true,
-    org,
-    fromRedirectOfNonOrgLink: context.query.orgRedirection === "true",
-  });
-
-  const profileName = event?.profile.name ?? "";
-  const title = event?.title ?? "";
+  const profileName = eventData?.profile.name ?? "";
+  const title = eventData?.title ?? "";
 
   return await _generateMetadata(
     () => `${title} | ${profileName}`,

--- a/apps/web/app/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/team/[slug]/[type]/page.tsx
@@ -4,9 +4,6 @@ import { generateEventBookingPageMetadata } from "app/generateBookingPageMetadat
 import { WithLayout } from "app/layoutHOC";
 import { cookies, headers } from "next/headers";
 
-import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { EventRepository } from "@calcom/lib/server/repository/event";
-
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
 
@@ -15,8 +12,7 @@ import LegacyPage, { type PageProps as LegacyPageProps } from "~/team/type-view"
 export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
   const props = await getData(legacyCtx);
-  const { user: username, slug: eventSlug, booking, isSEOIndexable, eventData, isBrandingHidden } = props;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(legacyCtx.req, legacyCtx.params?.orgSlug);
+  const { booking, isSEOIndexable, eventData, isBrandingHidden } = props;
 
   return await generateEventBookingPageMetadata({
     profile: {

--- a/apps/web/app/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/team/[slug]/[type]/page.tsx
@@ -18,24 +18,16 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const { user: username, slug: eventSlug, booking, isSEOIndexable, eventData, isBrandingHidden } = props;
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(legacyCtx.req, legacyCtx.params?.orgSlug);
 
-  const event = await EventRepository.getPublicEvent({
-    username,
-    eventSlug,
-    isTeamEvent: true,
-    org: isValidOrgDomain ? currentOrgDomain : null,
-    fromRedirectOfNonOrgLink: legacyCtx.query.orgRedirection === "true",
-  });
-
   return await generateEventBookingPageMetadata({
     profile: {
-      name: event?.profile?.name ?? "",
-      image: event?.profile.image ?? "",
+      name: eventData?.profile?.name ?? "",
+      image: eventData?.profile.image ?? "",
     },
     event: {
-      title: event?.title ?? "",
-      hidden: event?.hidden ?? false,
+      title: eventData?.title ?? "",
+      hidden: eventData?.hidden ?? false,
       users: [
-        ...(event?.users || []).map((user) => ({
+        ...(eventData?.users || []).map((user) => ({
           name: `${user.name}`,
           username: `${user.username}`,
         })),

--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -121,6 +121,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
 
   return {
     props: {
+      eventData,
       entity: eventData.entity,
       duration: getMultipleDurationValue(
         eventData.metadata?.multipleDuration,

--- a/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
+++ b/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
@@ -55,6 +55,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
   return {
     props: {
+      eventData,
       entity: eventData.entity,
       eventTypeId: eventData.id,
       duration: getMultipleDurationValue(


### PR DESCRIPTION
## What does this PR do?

- perf improvements for booking pages

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.