### PR TITLE
perf: improve routing insights view (2)

### DIFF
--- a/packages/prisma/migrations/20250109161330_update_routing_form_response/migration.sql
+++ b/packages/prisma/migrations/20250109161330_update_routing_form_response/migration.sql
@@ -1,0 +1,72 @@
+CREATE OR REPLACE VIEW "RoutingFormResponse" AS
+SELECT
+  r.id,
+  r.response,
+  (
+    SELECT jsonb_object_agg(
+      key,
+      CASE
+        WHEN jsonb_typeof(value->'value') = 'string'
+        THEN jsonb_build_object(
+          'label', value->'label',
+          'value', lower((value->>'value')::text)
+        )
+        ELSE value
+      END
+    )
+    FROM jsonb_each(r.response::jsonb)
+  ) as "responseLowercase",
+  f.id as "formId",
+  f.name as "formName",
+  f."teamId" as "formTeamId",
+  f."userId" as "formUserId",
+  b.uid as "bookingUid",
+  b.status as "bookingStatus",
+  CASE b.status
+    WHEN 'accepted' THEN 1
+    WHEN 'pending' THEN 2
+    WHEN 'awaiting_host' THEN 3
+    WHEN 'cancelled' THEN 4
+    WHEN 'rejected' THEN 5
+  END as "bookingStatusOrder",
+  b."createdAt" as "bookingCreatedAt",
+  b."startTime" as "bookingStartTime",
+  b."endTime" as "bookingEndTime",
+  (SELECT
+    json_agg(
+      json_build_object(
+        'name', a.name, 'timeZone', a."timeZone", 'email', a.email
+      )
+    )
+    FROM "Attendee" a
+    WHERE "a"."bookingId" = b.id
+  ) as "bookingAttendees",
+  u.id as "bookingUserId",
+  u.name as "bookingUserName",
+  u.email as "bookingUserEmail",
+  u."avatarUrl" as "bookingUserAvatarUrl",
+  COALESCE(
+    (
+      SELECT
+        ar."reasonString"
+      FROM "AssignmentReason" ar
+      WHERE ar."bookingId" = b.id
+      LIMIT 1
+    ),
+    ''
+  ) as "bookingAssignmentReason",
+  COALESCE(
+    (
+      SELECT
+        LOWER(ar."reasonString")
+      FROM "AssignmentReason" ar
+      WHERE ar."bookingId" = b.id
+      LIMIT 1
+    ),
+    ''
+  ) as "bookingAssignmentReasonLowercase",
+  r."createdAt" as "createdAt"
+FROM "App_RoutingForms_FormResponse" r
+LEFT JOIN "App_RoutingForms_Form" f ON r."formId" = f.id
+LEFT JOIN "Booking" b ON r."routedToBookingUid" = b.uid
+LEFT JOIN "users" u ON b."userId" = u.id


### PR DESCRIPTION
## What does this PR do?

This is a follow-up of #18557. It removes `assignment_reasons_agg` and moves it into a subquery.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

diff of the two migrations:

![Screenshot 2025-01-09 at 18 01 27](https://github.com/user-attachments/assets/1f151af2-032b-44b6-8a3b-7818a564cb01)
![Screenshot 2025-01-09 at 18 01 38](https://github.com/user-attachments/assets/5df356ee-4526-419f-a093-843774681193)
![Screenshot 2025-01-09 at 18 01 53](https://github.com/user-attachments/assets/f42a3cb5-84c5-473b-b37e-84f9ecc33e16)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

