### PR TITLE
chore: cleanup — remove HeadSeo from migrated app router components

### DIFF
--- a/apps/web/components/EnterprisePage.tsx
+++ b/apps/web/components/EnterprisePage.tsx
@@ -42,7 +42,7 @@ export default function EnterprisePage() {
   ];
   return (
     <div>
-      <Shell heading={t("enterprise")} subtitle={t("enterprise_description")}>
+      <Shell heading={t("enterprise")} subtitle={t("enterprise_description")} withoutSeo={true}>
         <UpgradeTip
           plan="enterprise"
           title={t("create_your_org")}

--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -237,6 +237,7 @@ export default function AvailabilityPage({ currentOrg }: PageProps) {
         title={t("availability")}
         description={t("configure_availability")}
         hideHeadingOnMobile
+        withoutSeo={true}
         withoutMain={false}
         CTA={
           <div className="flex gap-2">

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -246,6 +246,7 @@ function BookingsStatusLayout({ children }: { children: React.ReactNode }) {
   return (
     <Shell
       withoutMain={false}
+      withoutSeo={true}
       hideHeadingOnMobile
       heading={t("bookings")}
       subtitle={t("bookings_description")}

--- a/apps/web/modules/insights/layout.tsx
+++ b/apps/web/modules/insights/layout.tsx
@@ -36,6 +36,7 @@ export default function InsightsLayout({ children }: { children: React.ReactNode
     <div>
       <Shell
         withoutMain={false}
+        withoutSeo={true}
         heading={t("insights")}
         subtitle={t("insights_subtitle")}
         title={t("insights")}

--- a/apps/web/modules/more/more-page-view.tsx
+++ b/apps/web/modules/more/more-page-view.tsx
@@ -7,7 +7,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 export default function MorePage() {
   const { t } = useLocale();
   return (
-    <Shell hideHeadingOnMobile>
+    <Shell hideHeadingOnMobile withoutSeo={true}>
       <div className="max-w-screen-lg">
         <MobileNavigationMoreItems />
         <p className="text-subtle mt-6 text-xs leading-tight md:hidden">{t("more_page_footer")}</p>

--- a/apps/web/modules/settings/platform/billing/billing-view.tsx
+++ b/apps/web/modules/settings/platform/billing/billing-view.tsx
@@ -46,7 +46,12 @@ export default function PlatformBillingUpgrade() {
   if (!isPlatformUser)
     return (
       <div>
-        <Shell isPlatformUser={true} hideHeadingOnMobile withoutMain={false} SidebarContainer={<></>}>
+        <Shell
+          withoutSeo={true}
+          isPlatformUser={true}
+          hideHeadingOnMobile
+          withoutMain={false}
+          SidebarContainer={<></>}>
           <NoPlatformPlan />
         </Shell>
       </div>
@@ -59,6 +64,7 @@ export default function PlatformBillingUpgrade() {
         title={t("platform_billing")}
         hideHeadingOnMobile
         withoutMain={false}
+        withoutSeo={true}
         subtitle={t("manage_billing_description")}
         isPlatformUser={true}>
         <>

--- a/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-view.tsx
@@ -80,7 +80,7 @@ export default function EditOAuthClient() {
   if (isPlatformUser && isPaidUser) {
     return (
       <div>
-        <Shell title={t("oAuth_client_updation_form")} isPlatformUser={true}>
+        <Shell withoutSeo={true} title={t("oAuth_client_updation_form")} isPlatformUser={true}>
           <div className="m-2 md:mx-14 md:mx-5">
             <div className="border-subtle mx-auto block justify-between rounded-t-lg border px-4 py-6 sm:flex sm:px-6">
               <div className="flex w-full flex-col">
@@ -127,7 +127,12 @@ export default function EditOAuthClient() {
 
   return (
     <div>
-      <Shell isPlatformUser={true} hideHeadingOnMobile withoutMain={false} SidebarContainer={<></>}>
+      <Shell
+        withoutSeo={true}
+        isPlatformUser={true}
+        hideHeadingOnMobile
+        withoutMain={false}
+        SidebarContainer={<></>}>
         <NoPlatformPlan />
       </Shell>
     </div>

--- a/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view.tsx
@@ -42,7 +42,7 @@ export default function EditOAuthClientWebhooks() {
   if (isPlatformUser && isPaidUser) {
     return (
       <div>
-        <Shell title={t("webhook_update_form")} isPlatformUser={true}>
+        <Shell withoutSeo={true} title={t("webhook_update_form")} isPlatformUser={true}>
           <div className="m-2 md:mx-5">
             <div className="border-subtle mx-auto block justify-between rounded-t-lg border px-4 py-6 sm:flex sm:px-6">
               <div className="flex w-full flex-col">
@@ -126,7 +126,12 @@ export default function EditOAuthClientWebhooks() {
 
   return (
     <div>
-      <Shell isPlatformUser={true} hideHeadingOnMobile withoutMain={false} SidebarContainer={<></>}>
+      <Shell
+        withoutSeo={true}
+        isPlatformUser={true}
+        hideHeadingOnMobile
+        withoutMain={false}
+        SidebarContainer={<></>}>
         <NoPlatformPlan />
       </Shell>
     </div>

--- a/apps/web/modules/settings/platform/oauth-clients/create-new-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/create-new-view.tsx
@@ -64,7 +64,7 @@ export default function CreateOAuthClient() {
   if (isPlatformUser && isPaidUser) {
     return (
       <div>
-        <Shell title={t("oAuth_client_creation_form")} isPlatformUser={true}>
+        <Shell title={t("oAuth_client_creation_form")} isPlatformUser={true} withoutSeo={true}>
           <div className="m-2 md:mx-5">
             <div className="border-subtle mx-auto block justify-between rounded-t-lg border px-4 py-6 sm:flex sm:px-6">
               <div className="flex w-full flex-col">
@@ -85,7 +85,12 @@ export default function CreateOAuthClient() {
 
   return (
     <div>
-      <Shell isPlatformUser={true} hideHeadingOnMobile withoutMain={false} SidebarContainer={<></>}>
+      <Shell
+        withoutSeo={true}
+        isPlatformUser={true}
+        hideHeadingOnMobile
+        withoutMain={false}
+        SidebarContainer={<></>}>
         <NoPlatformPlan />
       </Shell>
     </div>

--- a/apps/web/modules/settings/platform/plans/platform-plans-view.tsx
+++ b/apps/web/modules/settings/platform/plans/platform-plans-view.tsx
@@ -20,6 +20,7 @@ export default function PlatformPlans() {
     <div>
       <Shell
         backPath
+        withoutSeo={true}
         isPlatformUser={true}
         heading={
           <h1 className="mx-2 mt-4 text-center text-xl md:text-2xl">

--- a/apps/web/modules/settings/platform/platform-view.tsx
+++ b/apps/web/modules/settings/platform/platform-view.tsx
@@ -82,6 +82,7 @@ export default function Platform() {
             title={t("platform")}
             description={t("platform_description")}
             hideHeadingOnMobile
+            withoutSeo={true}
             withoutMain={false}
             isPlatformUser={true}>
             <HelpCards />
@@ -112,6 +113,7 @@ export default function Platform() {
         isPlatformUser={true}
         hideHeadingOnMobile
         withoutMain={false}
+        withoutSeo={true}
         SidebarContainer={<></>}>
         <NoPlatformPlan />
       </Shell>

--- a/apps/web/modules/teams/teams-view.tsx
+++ b/apps/web/modules/teams/teams-view.tsx
@@ -18,6 +18,7 @@ function Teams(props: PageProps) {
   return (
     <Shell
       withoutMain={false}
+      withoutSeo={true}
       heading={t("teams")}
       subtitle={t("create_manage_teams_collaborative")}
       title={t("teams")}

--- a/apps/web/modules/upgrade/upgrade-view.tsx
+++ b/apps/web/modules/upgrade/upgrade-view.tsx
@@ -29,7 +29,7 @@ export default function UpgradePage() {
   const doesUserHaveOrgToUpgrade = trpc.viewer.organizations.checkIfOrgNeedsUpgrade.useQuery();
 
   return (
-    <Shell hideHeadingOnMobile>
+    <Shell hideHeadingOnMobile withoutSeo={true}>
       <div className="max-w-screen-lg">
         {doesUserHaveOrgToUpgrade.data ? (
           <EmptyScreen

--- a/packages/features/ee/workflows/pages/index.tsx
+++ b/packages/features/ee/workflows/pages/index.tsx
@@ -63,7 +63,7 @@ function WorkflowsPage({ filteredList }: PageProps) {
   });
 
   return (
-    <Shell withoutMain>
+    <Shell withoutMain withoutSeo={true}>
       <LicenseRequired>
         <ShellMain
           heading={t("workflows")}

--- a/packages/features/ee/workflows/pages/workflow.tsx
+++ b/packages/features/ee/workflows/pages/workflow.tsx
@@ -226,7 +226,7 @@ function WorkflowPage({
   });
 
   return session.data ? (
-    <Shell withoutMain backPath="/workflows">
+    <Shell withoutSeo={true} withoutMain backPath="/workflows">
       <LicenseRequired>
         <Form
           form={form}


### PR DESCRIPTION
## What does this PR do?

- HeadSeo is not needed in app router as metadata is handled by `generateMetadata` (built-in metadata api)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
