### PR TITLE
fix: app router not-found page cannot be static

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -236,8 +236,6 @@ export const generateMetadata = async () => {
   };
 };
 
-export const dynamic = "force-static";
-
 export default WithLayout({
   ServerPage: NotFound,
 });


### PR DESCRIPTION
## What does this PR do?

- We cannot make `app/not-found.tsx` static. It's always rendered dynamically by Next.js because it needs to be able to handle not-found states that are triggered dynamically during runtime.
- Did a local build and tested

### Unexpected error thrown

### not found flag is thrown


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.