### PR TITLE
chore: restore error pages for pages router to play safe

### DIFF
--- a/apps/web/components/error/error-page.tsx
+++ b/apps/web/components/error/error-page.tsx
@@ -61,7 +61,7 @@ export const ErrorPage: React.FC<Props> = (props) => {
           <h1 className="font-cal text-emphasis text-6xl">{statusCode}</h1>
           <h2 className="text-emphasis mt-6 max-w-2xl text-2xl font-medium">It's not you, it's us.</h2>
           <p className="text-default mb-6 mt-4 max-w-2xl text-sm">
-            Something went wrong on our end. Get in touch with our support team, and we’ll get it fixed right
+            Something went wrong on our end. Get in touch with our support team, and we'll get it fixed right
             away for you.
           </p>
 

--- a/apps/web/pages/404.tsx
+++ b/apps/web/pages/404.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import type { GetStaticPropsContext } from "next";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import {
+  getOrgDomainConfigFromHostname,
+  subdomainSuffix,
+} from "@calcom/features/ee/organizations/lib/orgDomains";
+import { DOCS_URL, IS_CALCOM, WEBSITE_URL } from "@calcom/lib/constants";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { HeadSeo } from "@calcom/ui";
+import { Icon } from "@calcom/ui";
+
+import PageWrapper from "@components/PageWrapper";
+
+import { getTranslations } from "@server/lib/getTranslations";
+
+enum pageType {
+  ORG = "org",
+  TEAM = "team",
+  USER = "user",
+  OTHER = "other",
+}
+
+export default function Custom404() {
+  const pathname = usePathname();
+  const { t } = useLocale();
+  const [username, setUsername] = useState<string>("");
+  const [currentPageType, setCurrentPageType] = useState<pageType>(pageType.USER);
+
+  const links = [
+    {
+      title: t("enterprise"),
+      description: "Learn more about organizations and subdomains in our enterprise plan.",
+      icon: "shield" as const,
+      href: `${WEBSITE_URL}/enterprise`,
+    },
+    {
+      title: t("documentation"),
+      description: t("documentation_description"),
+      icon: "file-text" as const,
+      href: DOCS_URL,
+    },
+    {
+      title: t("blog"),
+      description: t("blog_description"),
+      icon: "book-open" as const,
+      href: `${WEBSITE_URL}/blog`,
+    },
+  ];
+
+  const [url, setUrl] = useState(`${WEBSITE_URL}/signup`);
+  useEffect(() => {
+    const { isValidOrgDomain, currentOrgDomain } = getOrgDomainConfigFromHostname({
+      hostname: window.location.host,
+    });
+
+    const [routerUsername] = pathname?.replace("%20", "-").split(/[?#]/) ?? [];
+    if (routerUsername && (!isValidOrgDomain || !currentOrgDomain)) {
+      const splitPath = routerUsername.split("/");
+      if (splitPath[1] === "team" && splitPath.length === 3) {
+        // Accessing a non-existent team
+        setUsername(splitPath[2]);
+        setCurrentPageType(pageType.TEAM);
+        setUrl(
+          `${WEBSITE_URL}/signup?callbackUrl=settings/teams/new%3Fslug%3D${splitPath[2].replace("/", "")}`
+        );
+      } else {
+        setUsername(routerUsername);
+        setUrl(`${WEBSITE_URL}/signup?username=${routerUsername.replace("/", "")}`);
+      }
+    } else {
+      setUsername(currentOrgDomain ?? "");
+      setCurrentPageType(pageType.ORG);
+      setUrl(
+        `${WEBSITE_URL}/signup?callbackUrl=settings/organizations/new%3Fslug%3D${
+          currentOrgDomain?.replace("/", "") ?? ""
+        }`
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const isSuccessPage = pathname?.startsWith("/booking");
+  const isSubpage = pathname?.includes("/", 2) || isSuccessPage;
+
+  /**
+   * If we're on 404 and the route is insights it means it is disabled
+   * TODO: Abstract this for all disabled features
+   **/
+  const isInsights = pathname?.startsWith("/insights");
+  if (isInsights) {
+    return (
+      <>
+        <HeadSeo
+          title="Feature is currently disabled"
+          description={t("404_page_not_found")}
+          nextSeoProps={{
+            nofollow: true,
+            noindex: true,
+          }}
+        />
+        <div className="min-h-screen bg-white px-4" data-testid="404-page">
+          <main className="mx-auto max-w-xl pb-6 pt-16 sm:pt-24">
+            <div className="text-center">
+              <p className="text-sm font-semibold uppercase tracking-wide text-black">{t("error_404")}</p>
+              <h1 className="font-cal mt-2 text-4xl font-extrabold text-gray-900 sm:text-5xl">
+                Feature is currently disabled
+              </h1>
+            </div>
+            <div className="mt-12">
+              <div className="mt-8">
+                <Link href={WEBSITE_URL} className="text-base font-medium text-black hover:text-gray-500">
+                  {t("or_go_back_home")}
+                  <span aria-hidden="true"> &rarr;</span>
+                </Link>
+              </div>
+            </div>
+          </main>
+        </div>
+      </>
+    );
+  }
+
+  if (!username) return null;
+
+  return (
+    <>
+      <HeadSeo
+        title={t("404_page_not_found")}
+        description={t("404_page_not_found")}
+        nextSeoProps={{
+          nofollow: true,
+          noindex: true,
+        }}
+      />
+      <div className="bg-default min-h-screen px-4" data-testid="404-page">
+        <main className="mx-auto max-w-xl pb-6 pt-16 sm:pt-24">
+          <div className="text-center">
+            <p className="text-emphasis text-sm font-semibold uppercase tracking-wide">{t("error_404")}</p>
+            <h1 className="font-cal text-emphasis mt-2 text-4xl font-extrabold sm:text-5xl">
+              {isSuccessPage ? "Booking not found" : t("page_doesnt_exist")}
+            </h1>
+            {isSubpage && currentPageType !== pageType.TEAM ? (
+              <span className="mt-2 inline-block text-lg ">{t("check_spelling_mistakes_or_go_back")}</span>
+            ) : IS_CALCOM ? (
+              <a target="_blank" href={url} className="mt-2 inline-block text-lg" rel="noreferrer">
+                {t(`404_the_${currentPageType.toLowerCase()}`)}{" "}
+                <strong className="text-blue-500">{username}</strong> {t("is_still_available")}{" "}
+                <span className="text-blue-500">{t("register_now")}</span>.
+              </a>
+            ) : (
+              <span className="mt-2 inline-block text-lg">
+                {t(`404_the_${currentPageType.toLowerCase()}`)}{" "}
+                <strong className="text-lgtext-green-500 mt-2 inline-block">{username}</strong>{" "}
+                {t("is_still_available")}
+              </span>
+            )}
+          </div>
+          <div className="mt-12">
+            {((!isSubpage && IS_CALCOM) ||
+              currentPageType === pageType.ORG ||
+              currentPageType === pageType.TEAM) && (
+              <ul role="list" className="my-4">
+                <li className="border-2 border-green-500 px-4 py-2">
+                  <a
+                    href={url}
+                    target="_blank"
+                    className="relative flex items-start space-x-4 py-6 rtl:space-x-reverse"
+                    rel="noreferrer">
+                    <div className="flex-shrink-0">
+                      <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-green-50">
+                        <Icon name="check" className="h-6 w-6 text-green-500" aria-hidden="true" />
+                      </span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-emphasis text-base font-medium">
+                        <span className="focus-within:ring-empthasis rounded-sm focus-within:ring-2 focus-within:ring-offset-2">
+                          <span className="focus:outline-none">
+                            <span className="absolute inset-0" aria-hidden="true" />
+                            {t("register")}{" "}
+                            <strong className="text-green-500">{`${
+                              currentPageType === pageType.TEAM ? `${new URL(WEBSITE_URL).host}/team/` : ""
+                            }${username}${
+                              currentPageType === pageType.ORG ? `.${subdomainSuffix()}` : ""
+                            }`}</strong>
+                          </span>
+                        </span>
+                      </h3>
+                      <p className="text-subtle text-base">
+                        {t(`404_claim_entity_${currentPageType.toLowerCase()}`)}
+                      </p>
+                    </div>
+                    <div className="flex-shrink-0 self-center">
+                      <Icon name="chevron-right" className="text-muted h-5 w-5" aria-hidden="true" />
+                    </div>
+                  </a>
+                </li>
+              </ul>
+            )}
+            <h2 className="text-subtle text-sm font-semibold uppercase tracking-wide">
+              {t("popular_pages")}
+            </h2>
+            <ul role="list" className="border-subtle divide-subtle divide-y">
+              {links
+                .filter((_, idx) => currentPageType === pageType.ORG || idx !== 0)
+                .map((link, linkIdx) => (
+                  <li key={linkIdx} className="px-4 py-2">
+                    <a
+                      href={link.href}
+                      className="relative flex items-start space-x-4 py-6 rtl:space-x-reverse">
+                      <div className="flex-shrink-0">
+                        <span className="bg-muted flex h-12 w-12 items-center justify-center rounded-lg">
+                          <Icon name={link.icon} className="text-default h-6 w-6" aria-hidden="true" />
+                        </span>
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <h3 className="text-emphasis text-base font-medium">
+                          <span className="focus-within:ring-empthasis rounded-sm focus-within:ring-2 focus-within:ring-offset-2">
+                            <span className="absolute inset-0" aria-hidden="true" />
+                            {link.title}
+                          </span>
+                        </h3>
+                        <p className="text-subtle text-base">{link.description}</p>
+                      </div>
+                      <div className="flex-shrink-0 self-center">
+                        <Icon name="chevron-right" className="text-muted h-5 w-5" aria-hidden="true" />
+                      </div>
+                    </a>
+                  </li>
+                ))}
+            </ul>
+            <div className="mt-8">
+              <Link href={WEBSITE_URL} className="hover:text-subtle text-emphasis text-base font-medium">
+                {t("or_go_back_home")}
+                <span aria-hidden="true"> &rarr;</span>
+              </Link>
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}
+
+Custom404.PageWrapper = PageWrapper;
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
+  const i18n = await getTranslations(context);
+
+  return {
+    props: {
+      i18n,
+    },
+  };
+};

--- a/apps/web/pages/_error.tsx
+++ b/apps/web/pages/_error.tsx
@@ -1,0 +1,113 @@
+/**
+ * Typescript class based component for custom-error
+ * @link https://nextjs.org/docs/advanced-features/custom-error-page
+ */
+import type { NextPage, NextPageContext } from "next";
+import type { ErrorProps } from "next/error";
+import NextError from "next/error";
+import React from "react";
+
+import { getErrorFromUnknown } from "@calcom/lib/errors";
+import { HttpError } from "@calcom/lib/http-error";
+import logger from "@calcom/lib/logger";
+import { redactError } from "@calcom/lib/redactError";
+
+import { ErrorPage } from "@components/error/error-page";
+
+// Adds HttpException to the list of possible error types.
+type AugmentedError = (NonNullable<NextPageContext["err"]> & HttpError) | null;
+type CustomErrorProps = {
+  err?: AugmentedError;
+  message?: string;
+  hasGetInitialPropsRun?: boolean;
+} & Omit<ErrorProps, "err">;
+
+type AugmentedNextPageContext = Omit<NextPageContext, "err"> & {
+  err: AugmentedError;
+};
+
+const log = logger.getSubLogger({ prefix: ["[error]"] });
+
+const CustomError: NextPage<CustomErrorProps> = (props) => {
+  const { statusCode, err, message, hasGetInitialPropsRun } = props;
+
+  if (!hasGetInitialPropsRun && err) {
+    // getInitialProps is not called in case of
+    // https://github.com/vercel/next.js/issues/8592. As a workaround, we pass
+    // err via _app.tsx so it can be captured
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const e = getErrorFromUnknown(err);
+    // can be captured here
+    // e.g. Sentry.captureException(e);
+  }
+  return <ErrorPage statusCode={statusCode} error={err} message={message} />;
+};
+
+/**
+ * Partially adapted from the example in
+ * https://github.com/vercel/next.js/tree/canary/examples/with-sentry
+ */
+CustomError.getInitialProps = async (ctx: AugmentedNextPageContext) => {
+  const { res, err, asPath } = ctx;
+  const errorInitialProps = (await NextError.getInitialProps({
+    res,
+    err,
+  } as NextPageContext)) as CustomErrorProps;
+
+  // Workaround for https://github.com/vercel/next.js/issues/8592, mark when
+  // getInitialProps has run
+  errorInitialProps.hasGetInitialPropsRun = true;
+
+  // If a HttpError message, let's override defaults
+  if (err instanceof HttpError) {
+    const redactedError = redactError(err);
+    errorInitialProps.statusCode = err.statusCode;
+    errorInitialProps.title = redactedError.name;
+    errorInitialProps.message = redactedError.message;
+    errorInitialProps.err = {
+      ...redactedError,
+      url: err.url,
+      statusCode: err.statusCode,
+      cause: err.cause,
+      method: err.method,
+    };
+  }
+
+  if (res) {
+    // Running on the server, the response object is available.
+    //
+    // Next.js will pass an err on the server if a page's `getInitialProps`
+    // threw or returned a Promise that rejected
+
+    // Overrides http status code if present in errorInitialProps
+    res.statusCode = errorInitialProps.statusCode;
+
+    log.debug(`server side logged this: ${err?.toString() ?? JSON.stringify(err)}`);
+    log.info("return props, ", errorInitialProps);
+
+    return errorInitialProps;
+  } else {
+    // Running on the client (browser).
+    //
+    // Next.js will provide an err if:
+    //
+    //  - a page's `getInitialProps` threw or returned a Promise that rejected
+    //  - an exception was thrown somewhere in the React lifecycle (render,
+    //    componentDidMount, etc) that was caught by Next.js's React Error
+    //    Boundary. Read more about what types of exceptions are caught by Error
+    //    Boundaries: https://reactjs.org/docs/error-boundaries.html
+    if (err) {
+      log.info("client side logged this", err);
+      return errorInitialProps;
+    }
+  }
+
+  // If this point is reached, getInitialProps was called without any
+  // information about what the error might be. This is unexpected and may
+  // indicate a bug introduced in Next.js
+  new Error(`_error.tsx getInitialProps missing data at path: ${asPath}`);
+
+  return errorInitialProps;
+};
+
+export default CustomError;


### PR DESCRIPTION
## What does this PR do?

- Restore `pages/_error` and `pages/404` to play it safe. Theoretically, these should be error pages both for pages router and for app router. They shouldn't conflict with each other (theoretically). But I can't test this surely unless we test in production env (QA).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.