### PR TITLE
fix: disable sending sms when email is present

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-scheduling.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-scheduling.test.ts
@@ -783,8 +783,6 @@ describe("handleNewBooking", () => {
               subscriberUrl: "http://my-webhook.example.com",
               videoCallUrl: `${WEBAPP_URL}/video/${createdBooking.uid}`,
             });
-
-            expectSMSToBeTriggered({ sms, toNumber: TEST_ATTENDEE_NUMBER });
           },
           timeout
         );

--- a/packages/sms/sms-manager.ts
+++ b/packages/sms/sms-manager.ts
@@ -3,6 +3,7 @@ import { getSenderId } from "@calcom/features/ee/workflows/lib/alphanumericSende
 import * as twilio from "@calcom/features/ee/workflows/lib/reminders/providers/twilioProvider";
 import { checkSMSRateLimit } from "@calcom/lib/checkRateLimitAndThrowError";
 import { SENDER_ID } from "@calcom/lib/constants";
+import isSmsCalEmail from "@calcom/lib/isSmsCalEmail";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import prisma from "@calcom/prisma";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
@@ -76,10 +77,10 @@ export default abstract class SMSManager {
 
   async sendSMSToAttendee(attendee: Person) {
     const teamId = this.teamId;
-    if (!this.isTeamEvent || !teamId) return;
-
     const attendeePhoneNumber = attendee.phoneNumber;
-    if (!attendeePhoneNumber) return;
+    const isPhoneOnlyBooking = attendeePhoneNumber && isSmsCalEmail(attendee.email);
+
+    if (!this.isTeamEvent || !teamId || !attendeePhoneNumber || !isPhoneOnlyBooking) return;
 
     const smsMessage = this.getMessage(attendee);
     const senderID = getSenderId(attendeePhoneNumber, SENDER_ID);


### PR DESCRIPTION
## What does this PR do?

- Fixes #XXXX (GitHub issue number)
- Fixes https://linear.app/calcom/issue/CAL-5009/every-time-someone-books-the-host-gets-a-text (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Go to event type settings 
2) Enable phone number question and make it required 

Make sure SMS is not sent if email is available