### PR TITLE
fix: disable cancelling past events

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -289,17 +289,22 @@ function BookingListItem(booking: BookingItemProps) {
   }
 
   let bookedActions: ActionType[] = [
-    {
-      id: "cancel",
-      label: isTabRecurring && isRecurring ? t("cancel_all_remaining") : t("cancel_event"),
-      /* When cancelling we need to let the UI and the API know if the intention is to
-               cancel all remaining bookings or just that booking instance. */
-      href: `/booking/${booking.uid}?cancel=true${
-        isTabRecurring && isRecurring ? "&allRemainingBookings=true" : ""
-      }${booking.seatsReferences.length ? `&seatReferenceUid=${getSeatReferenceUid()}` : ""}
-      `,
-      icon: "x" as const,
-    },
+    // Only show cancel action for upcoming bookings
+    ...(!isBookingInPast
+      ? [
+          {
+            id: "cancel",
+            label: isTabRecurring && isRecurring ? t("cancel_all_remaining") : t("cancel_event"),
+            /* When cancelling we need to let the UI and the API know if the intention is to
+                   cancel all remaining bookings or just that booking instance. */
+            href: `/booking/${booking.uid}?cancel=true${
+              isTabRecurring && isRecurring ? "&allRemainingBookings=true" : ""
+            }${booking.seatsReferences.length ? `&seatReferenceUid=${getSeatReferenceUid()}` : ""}
+          `,
+            icon: "x" as const,
+          },
+        ]
+      : []),
     {
       id: "edit_booking",
       label: t("edit"),


### PR DESCRIPTION
## What does this PR do?

- Disable cancelling past event records in bookings
- TODO: Maybe create a new type of action like delete event record instead as past events should not be cancelled to avoid sending notifications to attendees 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.
