### PR TITLE
fix: potential fix for flaky layout shift

### DIFF
--- a/apps/web/modules/team/type-view.tsx
+++ b/apps/web/modules/team/type-view.tsx
@@ -4,7 +4,6 @@ import type { EmbedProps } from "app/WithEmbedSSR";
 import { useSearchParams } from "next/navigation";
 
 import { Booker } from "@calcom/atoms/monorepo";
-import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";
 import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 
 import type { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
@@ -40,7 +39,7 @@ function Type({
   const { profile, users, hidden, title } = eventData;
 
   return (
-    <main className={getBookerWrapperClasses({ isEmbed: !!isEmbed })}>
+    <>
       <BookerSeo
         username={user}
         eventSlug={slug}
@@ -83,10 +82,8 @@ function Type({
         crmOwnerRecordType={crmOwnerRecordType}
         crmAppSlug={crmAppSlug}
       />
-    </main>
+    </>
   );
 }
-
-Type.isBookingPage = true;
 
 export default Type;

--- a/apps/web/modules/team/type-view.tsx
+++ b/apps/web/modules/team/type-view.tsx
@@ -4,7 +4,6 @@ import type { EmbedProps } from "app/WithEmbedSSR";
 import { useSearchParams } from "next/navigation";
 
 import { Booker } from "@calcom/atoms/monorepo";
-import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 
 import type { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -25,7 +24,6 @@ function Type({
   slug,
   user,
   booking,
-  isEmbed,
   isBrandingHidden,
   eventData,
   isInstantMeeting,
@@ -33,56 +31,32 @@ function Type({
   teamMemberEmail,
   crmOwnerRecordType,
   crmAppSlug,
-  isSEOIndexable,
 }: PageProps) {
   const searchParams = useSearchParams();
-  const { profile, users, hidden, title } = eventData;
 
   return (
-    <>
-      <BookerSeo
-        username={user}
-        eventSlug={slug}
-        rescheduleUid={booking?.uid}
-        hideBranding={isBrandingHidden}
-        isTeamEvent
-        eventData={
-          profile && users && title && hidden !== undefined
-            ? {
-                profile,
-                users,
-                title,
-                hidden,
-              }
-            : undefined
-        }
-        entity={eventData.entity}
-        bookingData={booking}
-        isSEOIndexable={isSEOIndexable}
-      />
-      <Booker
-        username={user}
-        eventSlug={slug}
-        bookingData={booking}
-        isInstantMeeting={isInstantMeeting}
-        hideBranding={isBrandingHidden}
-        isTeamEvent
-        entity={{ ...eventData.entity, eventTypeId: eventData?.eventTypeId }}
-        durationConfig={eventData.metadata?.multipleDuration}
-        /* TODO: Currently unused, evaluate it is needed-
-         *       Possible alternative approach is to have onDurationChange.
-         */
-        duration={getMultipleDurationValue(
-          eventData.metadata?.multipleDuration,
-          searchParams?.get("duration"),
-          eventData.length
-        )}
-        orgBannerUrl={orgBannerUrl}
-        teamMemberEmail={teamMemberEmail}
-        crmOwnerRecordType={crmOwnerRecordType}
-        crmAppSlug={crmAppSlug}
-      />
-    </>
+    <Booker
+      username={user}
+      eventSlug={slug}
+      bookingData={booking}
+      isInstantMeeting={isInstantMeeting}
+      hideBranding={isBrandingHidden}
+      isTeamEvent
+      entity={{ ...eventData.entity, eventTypeId: eventData?.eventTypeId }}
+      durationConfig={eventData.metadata?.multipleDuration}
+      /* TODO: Currently unused, evaluate it is needed-
+       *       Possible alternative approach is to have onDurationChange.
+       */
+      duration={getMultipleDurationValue(
+        eventData.metadata?.multipleDuration,
+        searchParams?.get("duration"),
+        eventData.length
+      )}
+      orgBannerUrl={orgBannerUrl}
+      teamMemberEmail={teamMemberEmail}
+      crmOwnerRecordType={crmOwnerRecordType}
+      crmAppSlug={crmAppSlug}
+    />
   );
 }
 

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -1,4 +1,5 @@
 import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";
+import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -6,8 +7,38 @@ import type { PageProps } from "~/team/type-view";
 import TypePage from "~/team/type-view";
 
 const Page = (props: PageProps) => {
+  const {
+    eventData,
+    slug,
+    user,
+    booking,
+    isBrandingHidden,
+    isSEOIndexable,
+  } = props;
+  const { profile, users, hidden, title } = eventData;
+
   return (
     <main className={getBookerWrapperClasses({ isEmbed: !!props.isEmbed })}>
+      <BookerSeo
+        username={user}
+        eventSlug={slug}
+        rescheduleUid={booking?.uid}
+        hideBranding={isBrandingHidden}
+        isTeamEvent
+        eventData={
+          profile && users && title && hidden !== undefined
+            ? {
+                profile,
+                users,
+                title,
+                hidden,
+              }
+            : undefined
+        }
+        entity={eventData.entity}
+        bookingData={booking}
+        isSEOIndexable={isSEOIndexable}
+      />
       <TypePage {...props} />
     </main>
   );

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -2,7 +2,8 @@ import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/
 
 import PageWrapper from "@components/PageWrapper";
 
-import TypePage, { type PageProps } from "~/team/type-view";
+import type { PageProps } from "~/team/type-view";
+import TypePage from "~/team/type-view";
 
 const Page = (props: PageProps) => {
   return (

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -7,14 +7,7 @@ import type { PageProps } from "~/team/type-view";
 import TypePage from "~/team/type-view";
 
 const Page = (props: PageProps) => {
-  const {
-    eventData,
-    slug,
-    user,
-    booking,
-    isBrandingHidden,
-    isSEOIndexable,
-  } = props;
+  const { eventData, slug, user, booking, isBrandingHidden, isSEOIndexable } = props;
   const { profile, users, hidden, title } = eventData;
 
   return (

--- a/apps/web/pages/team/[slug]/[type].tsx
+++ b/apps/web/pages/team/[slug]/[type].tsx
@@ -1,10 +1,18 @@
+import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";
+
 import PageWrapper from "@components/PageWrapper";
 
 import TypePage, { type PageProps } from "~/team/type-view";
 
-const Page = (props: PageProps) => <TypePage {...props} />;
-
+const Page = (props: PageProps) => {
+  return (
+    <main className={getBookerWrapperClasses({ isEmbed: !!props.isEmbed })}>
+      <TypePage {...props} />
+    </main>
+  );
+};
+Page.isBookingPage = true;
 Page.PageWrapper = PageWrapper;
 
-export default Page;
 export { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
+export default Page;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Hypothesis:
- type-view.tsx is marked with "use client" but includes server-rendered content (the <main> wrapper)
- In production, Next.js is getting confused during hydration because the component is client-side but has server-rendered parts
- potential fix: split the component into server and client parts:

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
