### PR TITLE
perf: no need for two query fetches for d link (private booking page)

### DIFF
--- a/apps/web/app/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/d/[link]/[slug]/page.tsx
@@ -4,9 +4,6 @@ import { _generateMetadata } from "app/_utils";
 import { WithLayout } from "app/layoutHOC";
 import { cookies, headers } from "next/headers";
 
-import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { EventRepository } from "@calcom/lib/server/repository/event";
-
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 import { type PageProps } from "@lib/d/[link]/[slug]/getServerSideProps";
@@ -17,24 +14,15 @@ export const generateMetadata = async ({ params, searchParams }: _PageProps) => 
   const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
   const pageProps = await getData(legacyCtx);
 
-  const { booking, user: username, slug: eventSlug, isTeamEvent } = pageProps;
+  const { booking, eventData, isBrandingHidden } = pageProps;
   const rescheduleUid = booking?.uid;
-  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(legacyCtx.req);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
 
-  const event = await EventRepository.getPublicEvent({
-    username,
-    eventSlug,
-    isTeamEvent,
-    org,
-    fromRedirectOfNonOrgLink: legacyCtx.query.orgRedirection === "true",
-  });
-
-  const profileName = event?.profile?.name ?? "";
-  const title = event?.title ?? "";
+  const profileName = eventData?.profile?.name ?? "";
+  const title = eventData?.title ?? "";
   return await _generateMetadata(
     (t) => `${rescheduleUid && !!booking ? t("reschedule") : ""} ${title} | ${profileName}`,
-    (t) => `${rescheduleUid ? t("reschedule") : ""} ${title}`
+    (t) => `${rescheduleUid ? t("reschedule") : ""} ${title}`,
+    isBrandingHidden
   );
 };
 

--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -121,6 +121,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
 
   return {
     props: {
+      eventData,
       entity: eventData.entity,
       duration: getMultipleDurationValue(
         eventData.metadata?.multipleDuration,


### PR DESCRIPTION
## What does this PR do?

- obvious perf improvements by removing 1 extra fetch

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

