### PR TITLE
perf: Cache yarn install state across Vercel builds

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,10 @@
 {
+  "build": {
+    "env": {
+      "YARN_CACHE_FOLDER": "/vercel/cache/yarn"
+    },
+    "cache": ["node_modules", "/vercel/cache/yarn", "/vercel/cache/.yarn-cache"]
+  },
   "crons": [
     {
       "path": "/api/cron/calendar-cache-cleanup",


### PR DESCRIPTION
## What does this PR do?

Caches yarn install state and node_modules across builds

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Run multiple deployments back to back and ensure the install process is very fast after the initial run
