### PR TITLE
fix: add back global-error.tsx

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -12,12 +12,12 @@ import { ErrorPage } from "@components/error/error-page";
 
 const log = logger.getSubLogger({ prefix: ["[error]"] });
 
-type ErrorProps = {
+export type ErrorProps = {
   error: Error;
-  reset: () => void;
+  reset?: () => void;
 };
 
-export default function Error({ error, reset }: ErrorProps) {
+export default function Error({ error }: ErrorProps) {
   React.useEffect(() => {
     log.error(error);
 

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { type NextPage } from "next";
+
+import CustomError from "./error";
+import type { ErrorProps } from "./error";
+
+export const GlobalError: NextPage<ErrorProps> = (props) => {
+  return (
+    <html>
+      <body>
+        <CustomError {...props} />
+      </body>
+    </html>
+  );
+};
+
+export default GlobalError;


### PR DESCRIPTION
## What does this PR do?

- we have a hypothesis that removing `app/global-error` introduced double render bugs
