### PR TITLE
feat: Allow non-calcom domains to run team slug pages

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -5,8 +5,8 @@ import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import type { GetBookingType } from "@calcom/features/bookings/lib/get-booking";
 import { getBookingForReschedule } from "@calcom/features/bookings/lib/get-booking";
 import { getSlugOrRequestedSlug, orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
+import { getOrganizationSEOSettings } from "@calcom/features/ee/organizations/lib/orgSettings";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
-import { OrganizationRepository } from "@calcom/lib/server/repository/organization";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import { RedirectType } from "@calcom/prisma/client";
@@ -179,7 +179,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     eventData,
   });
 
-  const organizationSettings = OrganizationRepository.utils.getOrganizationSEOSettings(team);
+  const organizationSettings = getOrganizationSEOSettings(team);
   const allowSEOIndexing = organizationSettings?.allowSEOIndexing ?? false;
 
   if (!eventData) {

--- a/packages/features/ee/organizations/lib/orgSettings.ts
+++ b/packages/features/ee/organizations/lib/orgSettings.ts
@@ -1,0 +1,38 @@
+import type { OrganizationSettings } from "@calcom/prisma/client";
+
+type MinimumOrganizationSettings = Pick<
+  OrganizationSettings,
+  "orgAutoAcceptEmail" | "orgProfileRedirectsToVerifiedDomain" | "allowSEOIndexing"
+>;
+
+type SEOOrganizationSettings = Pick<OrganizationSettings, "allowSEOIndexing">;
+
+export const getOrganizationSettings = (team: {
+  isOrganization: boolean;
+  organizationSettings: MinimumOrganizationSettings | null;
+  parent: {
+    organizationSettings: MinimumOrganizationSettings | null;
+  } | null;
+}) => {
+  if (!team) return null;
+  if (team.isOrganization) return team.organizationSettings ?? null;
+  if (!team.parent) return null;
+  return team.parent.organizationSettings ?? null;
+};
+
+export const getOrganizationSEOSettings = (team: {
+  isOrganization: boolean;
+  organizationSettings: SEOOrganizationSettings | null;
+  parent: {
+    organizationSettings: SEOOrganizationSettings | null;
+  } | null;
+}) => {
+  if (!team) return null;
+  if (team.isOrganization) return team.organizationSettings ?? null;
+  if (!team.parent) return null;
+  return team.parent.organizationSettings ?? null;
+};
+
+export const getVerifiedDomain = (settings: Pick<OrganizationSettings, "orgAutoAcceptEmail">) => {
+  return settings.orgAutoAcceptEmail;
+};

--- a/packages/lib/server/repository/organization.ts
+++ b/packages/lib/server/repository/organization.ts
@@ -3,7 +3,6 @@ import { IS_TEAM_BILLING_ENABLED } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { prisma } from "@calcom/prisma";
-import type { OrganizationSettings } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
@@ -11,11 +10,6 @@ import { createAProfileForAnExistingUser } from "../../createAProfileForAnExisti
 import { getParsedTeam } from "./teamUtils";
 import { UserRepository } from "./user";
 
-type MinimumOrganizationSettings = Pick<
-  OrganizationSettings,
-  "orgAutoAcceptEmail" | "orgProfileRedirectsToVerifiedDomain" | "allowSEOIndexing"
->;
-type SEOOrganizationSettings = Pick<OrganizationSettings, "allowSEOIndexing">;
 const orgSelect = {
   id: true,
   name: true,
@@ -356,38 +350,4 @@ export class OrganizationRepository {
 
     return org?.calVideoLogo;
   }
-
-  static utils = {
-    /**
-     * Gets the organization setting if the team is an organization.
-     * If not, it gets the organization setting of the parent organization.
-     */
-    getOrganizationSettings: (team: {
-      isOrganization: boolean;
-      organizationSettings: MinimumOrganizationSettings | null;
-      parent: {
-        organizationSettings: MinimumOrganizationSettings | null;
-      } | null;
-    }) => {
-      if (!team) return null;
-      if (team.isOrganization) return team.organizationSettings ?? null;
-      if (!team.parent) return null;
-      return team.parent.organizationSettings ?? null;
-    },
-    getOrganizationSEOSettings: (team: {
-      isOrganization: boolean;
-      organizationSettings: SEOOrganizationSettings | null;
-      parent: {
-        organizationSettings: SEOOrganizationSettings | null;
-      } | null;
-    }) => {
-      if (!team) return null;
-      if (team.isOrganization) return team.organizationSettings ?? null;
-      if (!team.parent) return null;
-      return team.parent.organizationSettings ?? null;
-    },
-    getVerifiedDomain(settings: Pick<OrganizationSettings, "orgAutoAcceptEmail">) {
-      return settings.orgAutoAcceptEmail;
-    },
-  };
 }


### PR DESCRIPTION
## What does this PR do?

* Fixup repository anti pattern
* Don't auto redirect when we're not on Cal.com pages. (good for vercel URLs e.g. where we don't have org subdomains)