### PR TITLE
fix: add decoding logic to app router params

### DIFF
--- a/apps/web/lib/buildLegacyCtx.tsx
+++ b/apps/web/lib/buildLegacyCtx.tsx
@@ -55,6 +55,7 @@ export const buildLegacyCtx = (
     query: { ...searchParams, ...params },
     // decoding is required to be backward compatible with Pages Router
     // because Next.js App Router does not auto-decode query params while Pages Router does
+    // e.g., params: { name: "John%20Doe" } => params: { name: "John Doe" }
     params: decodeParams(params),
     req: { headers: buildLegacyHeaders(headers), cookies: buildLegacyCookies(cookies) },
     res: new Proxy(Object.create(null), {

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -106,6 +106,9 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
 
   if (isDynamicGroup) {
     const destinationUrl = `/${usernameList.join("+")}/dynamic`;
+
+    // EXAMPLE - context.params: { orgSlug: 'acme', user: 'member0+owner1' }
+    // EXAMPLE - context.query: { redirect: 'undefined', orgRedirection: 'undefined', user: 'member0+owner1' }
     const originalQueryString = new URLSearchParams(context.query as Record<string, string>).toString();
     const destinationWithQuery = `${destinationUrl}?${originalQueryString}`;
     log.debug(`Dynamic group detected, redirecting to ${destinationUrl}`);

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -178,7 +178,7 @@ export const getUsernameList = (users: string | string[] | undefined): string[] 
   // So, even though this code handles even if individual user is dynamic link, that isn't a possibility right now.
   users = arrayCast(users);
 
-  const allUsers = users.map((user) => user.replace(/( |%20|%2b)/g, "+").split("+")).flat();
+  const allUsers = users.map((user) => user.replace(/( |%20|%2B)/g, "+").split("+")).flat();
   return Array.prototype.concat(...allUsers.map((userSlug) => slugify(userSlug)));
 };
 

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -178,7 +178,7 @@ export const getUsernameList = (users: string | string[] | undefined): string[] 
   // So, even though this code handles even if individual user is dynamic link, that isn't a possibility right now.
   users = arrayCast(users);
 
-  const allUsers = users.map((user) => user.replace(/( |%20|%2B)/g, "+").split("+")).flat();
+  const allUsers = users.map((user) => user.replace(/( |%20|%2b)/gi, "+").split("+")).flat();
   return Array.prototype.concat(...allUsers.map((userSlug) => slugify(userSlug)));
 };
 


### PR DESCRIPTION
## What does this PR do?

- Fixes Dynamic Pages. The problem was that App Router `params` does not decode special characters while Page Router's `context.params` in `getServerSideProps`

## Tested

<img width="1507" alt="Screenshot 2025-01-16 at 7 58 04 AM" src="https://github.com/user-attachments/assets/56b8e96f-b7f2-426b-b959-1c532d74e45b" />
<img width="1070" alt="Screenshot 2025-01-16 at 7 58 16 AM" src="https://github.com/user-attachments/assets/182d651e-1bad-4dff-a76b-06290c76751d" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

