### PR TITLE
fix: filters ui breaking on mobile in routing insights page

### DIFF
--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -61,11 +61,10 @@ export function DataTableWrapper<TData, TValue>({
       variant={variant}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}>
       <DataTableToolbar.Root>
-        <div className="flex w-full flex-col gap-2 sm:flex-row">
-          <div className="flex w-full flex-wrap items-center justify-between gap-2">
-            <div className="flex justify-start gap-2">{ToolbarLeft}</div>
-            <div className="grow" />
-            <div className="flex justify-end gap-2">{ToolbarRight}</div>
+        <div className="flex w-full flex-col gap-2">
+          <div className="flex w-full flex-wrap justify-between gap-2">
+            <div className="flex flex-wrap gap-2">{ToolbarLeft}</div>
+            <div className="flex flex-wrap gap-2">{ToolbarRight}</div>
           </div>
         </div>
 


### PR DESCRIPTION
## What does this PR do?

- Fix ui breaking for filters in Datatable

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Before 

https://github.com/user-attachments/assets/02db7662-7303-4413-83b9-ba131a78187a

## After
https://github.com/user-attachments/assets/56ed0098-a6c3-48f2-80c5-87562ecb476f



