### PR TITLE
fix: adjust table height for a few rows on /bookings

### DIFF
--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -244,17 +244,20 @@ function BookingsContent({ status }: BookingsProps) {
                 </div>
               )}
 
-              <DataTableWrapper
-                table={table}
-                testId={`${status}-bookings`}
-                bodyTestId="bookings"
-                hideHeader={true}
-                isPending={query.isFetching && !flatData}
-                hasNextPage={query.hasNextPage}
-                fetchNextPage={query.fetchNextPage}
-                isFetching={query.isFetching}
-                variant="compact"
-              />
+              {flatData.length > 0 && (
+                <DataTableWrapper
+                  table={table}
+                  testId={`${status}-bookings`}
+                  bodyTestId="bookings"
+                  hideHeader={true}
+                  isPending={query.isFetching && !flatData}
+                  hasNextPage={query.hasNextPage}
+                  fetchNextPage={query.fetchNextPage}
+                  isFetching={query.isFetching}
+                  variant="compact"
+                  containerClassName="!h-[inherit] max-h-[80dvh]"
+                />
+              )}
             </>
           )}
           {query.status === "success" && isEmpty && (

--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -29,6 +29,8 @@ export type DataTableProps<TData, TValue> = {
   children?: React.ReactNode;
   identifier?: string;
   enableColumnResizing?: boolean;
+  className?: string;
+  containerClassName?: string;
 };
 
 export function DataTable<TData, TValue>({
@@ -44,6 +46,8 @@ export function DataTable<TData, TValue>({
   enableColumnResizing,
   testId,
   bodyTestId,
+  className,
+  containerClassName,
   ...rest
 }: DataTableProps<TData, TValue> & React.ComponentPropsWithoutRef<"div">) {
   const pathname = usePathname() as string | null;
@@ -88,7 +92,7 @@ export function DataTable<TData, TValue>({
 
   return (
     <div
-      className={classNames("grid", rest.className)}
+      className={classNames("grid", className)}
       style={{
         gridTemplateRows: "auto 1fr auto",
         gridTemplateAreas: "'header' 'body' 'footer'",
@@ -100,7 +104,8 @@ export function DataTable<TData, TValue>({
         onScroll={onScroll}
         className={classNames(
           "relative h-[80dvh] overflow-auto", // Set a fixed height for the container
-          "scrollbar-thin border-subtle relative rounded-md border"
+          "scrollbar-thin border-subtle relative rounded-md border",
+          containerClassName
         )}
         style={{ gridArea: "body" }}>
         <TableNew

--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -23,6 +23,8 @@ export type DataTableWrapperProps<TData, TValue> = {
   totalDBRowCount?: number;
   ToolbarLeft?: React.ReactNode;
   ToolbarRight?: React.ReactNode;
+  className?: string;
+  containerClassName?: string;
   children?: React.ReactNode;
 };
 
@@ -39,6 +41,8 @@ export function DataTableWrapper<TData, TValue>({
   hideHeader,
   ToolbarLeft,
   ToolbarRight,
+  className,
+  containerClassName,
   children,
 }: DataTableWrapperProps<TData, TValue>) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -59,6 +63,8 @@ export function DataTableWrapper<TData, TValue>({
       enableColumnResizing={true}
       hideHeader={hideHeader}
       variant={variant}
+      className={className}
+      containerClassName={containerClassName}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}>
       <DataTableToolbar.Root>
         <div className="flex w-full flex-col gap-2">


### PR DESCRIPTION
## What does this PR do?

/bookings page showed a big empty box even if there is nothing to display as a regression of https://github.com/calcom/cal.com/pull/18589

### Before

![Screenshot 2025-01-17 at 10 25 45](https://github.com/user-attachments/assets/c9f816cc-b606-486c-81a4-f9185ce096a4)


### After

#### a few rows

![Screenshot 2025-01-17 at 10 29 22](https://github.com/user-attachments/assets/a18b700a-f3c0-40f2-88d4-1eb894293128)

#### no row

![Screenshot 2025-01-17 at 10 30 36](https://github.com/user-attachments/assets/4a22bafe-e6d1-4d56-8cb3-9aa1ba5ae3a9)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
