### PR TITLE
fix: convert People filter on /insights/routing from single select to multi select

### DIFF
--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -28,6 +28,7 @@ import {
   dataTableFilter,
   useDataTable,
   ZDateRangeFilterValue,
+  ZMultiSelectFilterValue,
   ZSingleSelectFilterValue,
   DateRangeFilter,
   type FilterableColumn,
@@ -280,7 +281,9 @@ export function RoutingFormResponsesTableContent() {
   const teamId = orgTeamsType === "team" ? selectedTeamId : undefined;
   const userId = orgTeamsType === "yours" ? session.data?.user.id : undefined;
 
-  const memberUserId = useFilterValue("bookingUserId", ZSingleSelectFilterValue)?.data as number | undefined;
+  const memberUserIds = useFilterValue("bookingUserId", ZMultiSelectFilterValue)?.data as
+    | number[]
+    | undefined;
   const routingFormId = useFilterValue("formId", ZSingleSelectFilterValue)?.data as string | undefined;
   const createdAtRange = useFilterValue("createdAt", ZDateRangeFilterValue)?.data;
   const startDate = createdAtRange?.startDate ?? dayjs().subtract(1, "week").startOf("day").toISOString();
@@ -317,7 +320,7 @@ export function RoutingFormResponsesTableContent() {
         startDate,
         endDate,
         userId,
-        memberUserId,
+        memberUserIds,
         isAll,
         routingFormId,
         columnFilters,
@@ -361,7 +364,7 @@ export function RoutingFormResponsesTableContent() {
         enableColumnFilter: true,
         enableSorting: false,
         meta: {
-          filter: { type: "single_select" },
+          filter: { type: "multi_select" },
         },
         cell: () => null,
       }),
@@ -619,8 +622,8 @@ export function RoutingFormResponsesTableContent() {
               endDate={endDate}
               teamId={teamId}
               userId={userId}
-              isAll={isAll ?? false}
-              memberUserId={memberUserId}
+              isAll={isAll}
+              memberUserIds={memberUserIds}
               routingFormId={routingFormId}
               columnFilters={columnFilters}
               sorting={sorting}

--- a/packages/features/insights/filters/Download/RoutingFormResponsesDownload.tsx
+++ b/packages/features/insights/filters/Download/RoutingFormResponsesDownload.tsx
@@ -14,7 +14,7 @@ type RoutingData = RouterOutputs["viewer"]["insights"]["routingFormResponsesForD
 type Props = {
   teamId: number | undefined;
   userId: number | undefined;
-  memberUserId: number | undefined;
+  memberUserIds: number[] | undefined;
   routingFormId: string | undefined;
   isAll: boolean;
   startDate: string;
@@ -31,7 +31,7 @@ type Batch = {
 export const RoutingFormResponsesDownload = ({
   teamId,
   userId,
-  memberUserId,
+  memberUserIds,
   routingFormId,
   isAll,
   startDate,
@@ -55,8 +55,8 @@ export const RoutingFormResponsesDownload = ({
       startDate,
       endDate,
       userId,
-      memberUserId,
-      isAll: isAll ?? false,
+      memberUserIds,
+      isAll: isAll,
       routingFormId,
       columnFilters,
       sorting,

--- a/packages/features/insights/server/raw-data.schema.ts
+++ b/packages/features/insights/server/raw-data.schema.ts
@@ -1,6 +1,8 @@
 import z from "zod";
 
-const rawDataInputSchema = z.object({
+import { ZColumnFilter, ZSorting } from "@calcom/features/data-table";
+
+export const rawDataInputSchema = z.object({
   startDate: z.string(),
   endDate: z.string(),
   teamId: z.coerce.number().optional().nullable(),
@@ -12,4 +14,18 @@ const rawDataInputSchema = z.object({
 
 export type RawDataInput = z.infer<typeof rawDataInputSchema>;
 
-export { rawDataInputSchema };
+export const routingFormResponsesInputSchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+  teamId: z.coerce.number().optional(),
+  userId: z.coerce.number().optional(),
+  memberUserIds: z.number().array().optional(),
+  isAll: z.coerce.boolean(),
+  routingFormId: z.string().optional(),
+  cursor: z.number().optional(),
+  limit: z.number().optional(),
+  columnFilters: z.array(ZColumnFilter),
+  sorting: z.array(ZSorting),
+});
+
+export type RoutingFormResponsesInput = z.infer<typeof routingFormResponsesInputSchema>;

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -3,8 +3,10 @@ import md5 from "md5";
 import { z } from "zod";
 
 import dayjs from "@calcom/dayjs";
-import { ZColumnFilter, ZSorting } from "@calcom/features/data-table";
-import { rawDataInputSchema } from "@calcom/features/insights/server/raw-data.schema";
+import {
+  rawDataInputSchema,
+  routingFormResponsesInputSchema,
+} from "@calcom/features/insights/server/raw-data.schema";
 import { randomString } from "@calcom/lib/random";
 import type { readonlyPrisma } from "@calcom/prisma";
 import { BookingStatus } from "@calcom/prisma/enums";
@@ -1588,53 +1590,36 @@ export const insightsRouter = router({
       return stats;
     }),
   routingFormResponses: userBelongsToTeamProcedure
-    .input(
-      rawDataInputSchema.extend({
-        routingFormId: z.string().optional(),
-        cursor: z.number().optional(),
-        limit: z.number().optional(),
-        columnFilters: z.array(ZColumnFilter),
-        sorting: z.array(ZSorting),
-      })
-    )
+    .input(routingFormResponsesInputSchema)
     .query(async ({ ctx, input }) => {
-      const { startDate, endDate } = input;
       return await RoutingEventsInsights.getRoutingFormPaginatedResponses({
-        teamId: input.teamId ?? null,
-        startDate,
-        endDate,
-        isAll: input.isAll ?? false,
+        teamId: input.teamId,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        isAll: input.isAll,
         organizationId: ctx.user.organizationId ?? null,
-        routingFormId: input.routingFormId ?? null,
+        routingFormId: input.routingFormId,
         cursor: input.cursor,
-        userId: input.userId ?? null,
-        memberUserId: input.memberUserId ?? null,
+        userId: input.userId,
+        memberUserIds: input.memberUserIds,
         limit: input.limit,
         columnFilters: input.columnFilters,
         sorting: input.sorting,
       });
     }),
   routingFormResponsesForDownload: userBelongsToTeamProcedure
-    .input(
-      rawDataInputSchema.extend({
-        routingFormId: z.string().optional(),
-        cursor: z.number().optional(),
-        limit: z.number().optional(),
-        columnFilters: z.array(ZColumnFilter),
-        sorting: z.array(ZSorting),
-      })
-    )
+    .input(routingFormResponsesInputSchema)
     .query(async ({ ctx, input }) => {
       return await RoutingEventsInsights.getRoutingFormPaginatedResponsesForDownload({
-        teamId: input.teamId ?? null,
+        teamId: input.teamId,
         startDate: input.startDate,
         endDate: input.endDate,
-        isAll: input.isAll ?? false,
+        isAll: input.isAll,
         organizationId: ctx.user.organizationId ?? null,
-        routingFormId: input.routingFormId ?? null,
+        routingFormId: input.routingFormId,
         cursor: input.cursor,
-        userId: input.userId ?? null,
-        memberUserId: input.memberUserId ?? null,
+        userId: input.userId,
+        memberUserIds: input.memberUserIds,
         limit: input.limit ?? BATCH_SIZE,
         columnFilters: input.columnFilters,
         sorting: input.sorting,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes CAL-5049

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Try "People" filter on /insights/routing. You should be able to select more than one person.