### PR TITLE
chore: tech debt clearing - simplify `isThemeSupported` usage

### DIFF
--- a/apps/web/app/layoutHOC.tsx
+++ b/apps/web/app/layoutHOC.tsx
@@ -52,7 +52,6 @@ export function WithLayout<T extends Record<string, any>>({
         requiresLicense={requiresLicense || !!(Page && "requiresLicense" in Page && Page.requiresLicense)}
         nonce={nonce}
         themeBasis={null}
-        isThemeSupported={Page && "isThemeSupported" in Page ? (Page.isThemeSupported as boolean) : undefined}
         isBookingPage={isBookingPage || !!(Page && "isBookingPage" in Page && Page.isBookingPage)}
         {...props}>
         {pageWithServerLayout}

--- a/apps/web/components/PageWrapperAppDir.tsx
+++ b/apps/web/components/PageWrapperAppDir.tsx
@@ -18,7 +18,6 @@ export type PageWrapperProps = Readonly<{
   nonce: string | undefined;
   themeBasis: string | null;
   dehydratedState?: DehydratedState;
-  isThemeSupported?: boolean;
   isBookingPage?: boolean;
   i18n?: SSRConfig;
 }>;

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -20,6 +20,7 @@ import { FeatureProvider } from "@calcom/features/flags/context/provider";
 import { useFlags } from "@calcom/features/flags/hooks";
 
 import useIsBookingPage from "@lib/hooks/useIsBookingPage";
+import useIsThemeSupported from "@lib/hooks/useIsThemeSupported";
 import PlainChat from "@lib/plain/plainChat";
 import type { WithLocaleProps } from "@lib/withLocale";
 import type { WithNonceProps } from "@lib/withNonce";
@@ -48,7 +49,6 @@ export type AppProps = Omit<
 > & {
   Component: NextAppProps["Component"] & {
     requiresLicense?: boolean;
-    isThemeSupported?: boolean;
     isBookingPage?: boolean | ((arg: { router: NextAppProps["router"] }) => boolean);
     getLayout?: (page: React.ReactElement) => ReactNode;
     PageWrapper?: (props: AppProps) => JSX.Element;
@@ -129,7 +129,7 @@ type CalcomThemeProps = Readonly<{
   themeBasis: string | null;
   nonce: string | undefined;
   children: React.ReactNode;
-  isThemeSupported?: boolean;
+  isThemeSupported: boolean;
 }>;
 
 const CalcomThemeProvider = (props: CalcomThemeProps) => {
@@ -196,8 +196,7 @@ function getThemeProviderProps({
 }) {
   const themeSupport = props.isBookingPage
     ? ThemeSupport.Booking
-    : // if isThemeSupported is explicitly false, we don't use theme there
-    props.isThemeSupported === false
+    : props.isThemeSupported === false
     ? ThemeSupport.None
     : ThemeSupport.App;
 
@@ -263,6 +262,7 @@ function OrgBrandProvider({ children }: { children: React.ReactNode }) {
 const AppProviders = (props: PageWrapperProps) => {
   // No need to have intercom on public pages - Good for Page Performance
   const isBookingPage = useIsBookingPage();
+  const isThemeSupported = useIsThemeSupported();
 
   const RemainingProviders = (
     <EventCollectionProvider options={{ apiPath: "/api/collect-events" }}>
@@ -273,7 +273,7 @@ const AppProviders = (props: PageWrapperProps) => {
           <CalcomThemeProvider
             themeBasis={props.themeBasis}
             nonce={props.nonce}
-            isThemeSupported={/* undefined gets treated as true */ props.isThemeSupported}
+            isThemeSupported={isThemeSupported}
             isBookingPage={props.isBookingPage || isBookingPage}>
             <FeatureFlagsProvider>
               <OrgBrandProvider>{props.children}</OrgBrandProvider>

--- a/apps/web/lib/hooks/useIsThemeSupported.ts
+++ b/apps/web/lib/hooks/useIsThemeSupported.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+const THEME_UNSUPPORTED_ROUTES = ["/auth/setup"];
+
+export default function useIsThemeSupported(): boolean {
+  const pathname = usePathname();
+
+  // Check if current pathname matches any unsupported route
+  const isUnsupportedRoute = THEME_UNSUPPORTED_ROUTES.some((route) => pathname?.startsWith(route));
+
+  return !isUnsupportedRoute;
+}


### PR DESCRIPTION
## What does this PR do?

- App Router currently checks if the Component has a prop called `isThemeSupported`.
- `/auth/setup` is the only route with`isThemeSupported = false`. So I created a simple hook.

<img width="495" alt="Screenshot 2025-01-18 at 6 03 24 PM" src="https://github.com/user-attachments/assets/b68e0e71-a739-4b20-bda4-5f0941158560" />
- `/auth/setup` is currently in Pages router btw, so this change doesn't affect production 



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

