### PR TITLE
fix: nested scrolls on /bookings/upcoming

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -68,6 +68,7 @@ type BookingItemProps = BookingItem & {
     userTimeFormat: number | null | undefined;
     userEmail: string | undefined;
   };
+  isToday: boolean;
 };
 
 type ParsedBooking = ReturnType<typeof buildParsedBooking>;
@@ -511,7 +512,10 @@ function BookingListItem(booking: BookingItemProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div data-testid="booking-item" className="hover:bg-muted group w-full">
+      <div
+        data-testid="booking-item"
+        data-today={String(booking.isToday)}
+        className="hover:bg-muted group w-full">
         <div className="flex flex-col sm:flex-row">
           <div className="hidden align-top ltr:pl-3 rtl:pr-6 sm:table-cell sm:min-w-[12rem]">
             <div className="flex h-full items-center">

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -173,7 +173,7 @@ function BookingsContent({ status }: BookingsProps) {
           return false;
         }
         shownBookings[booking.recurringEventId] = [booking];
-      } else if (status === "next") {
+      } else if (status === "upcoming") {
         return (
           dayjs(booking.startTime).tz(user?.timeZone).format("YYYY-MM-DD") !==
           dayjs().tz(user?.timeZone).format("YYYY-MM-DD")
@@ -195,7 +195,7 @@ function BookingsContent({ status }: BookingsProps) {
     );
   }, [query.data]);
 
-  const bookingsToday = useMemo(() => {
+  const bookingsToday = useMemo<RowData[]>(() => {
     return (
       query.data?.pages.map((page) =>
         page.bookings
@@ -205,7 +205,7 @@ function BookingsContent({ status }: BookingsProps) {
               dayjs().tz(user?.timeZone).format("YYYY-MM-DD")
           )
           .map((booking) => ({
-            type: "data",
+            type: "data" as const,
             booking,
             recurringInfo: page.recurringInfo.find(
               (info) => info.recurringEventId === booking.recurringEventId
@@ -217,7 +217,13 @@ function BookingsContent({ status }: BookingsProps) {
 
   const finalData = useMemo<RowData[]>(() => {
     if (bookingsToday.length > 0 && status === "upcoming") {
-      return [{ type: "today" }, ...bookingsToday, { type: "next" }, ...flatData];
+      const merged: RowData[] = [
+        { type: "today" as const },
+        ...bookingsToday,
+        { type: "next" as const },
+        ...flatData,
+      ];
+      return merged;
     } else {
       return flatData;
     }

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -89,6 +89,7 @@ type RowData =
   | {
       type: "data";
       booking: BookingOutput;
+      isToday: boolean;
       recurringInfo?: RecurringInfo;
     }
   | {
@@ -124,10 +125,11 @@ function BookingsContent({ status }: BookingsProps) {
         id: "custom-view",
         cell: (props) => {
           if (props.row.original.type === "data") {
-            const { booking, recurringInfo } = props.row.original;
+            const { booking, recurringInfo, isToday } = props.row.original;
             return (
               <BookingListItem
                 key={booking.id}
+                isToday={isToday}
                 loggedInUser={{
                   userId: user?.id,
                   userTimeZone: user?.timeZone,
@@ -157,7 +159,7 @@ function BookingsContent({ status }: BookingsProps) {
     ];
   }, [user, status]);
 
-  const isEmpty = !query.data?.pages[0]?.bookings.length;
+  const isEmpty = useMemo(() => !query.data?.pages[0]?.bookings.length, [query.data]);
 
   const flatData = useMemo<RowData[]>(() => {
     const shownBookings: Record<string, BookingOutput[]> = {};
@@ -191,6 +193,7 @@ function BookingsContent({ status }: BookingsProps) {
           recurringInfo: page.recurringInfo.find(
             (info) => info.recurringEventId === booking.recurringEventId
           ),
+          isToday: false,
         }))
       ) || []
     );
@@ -211,6 +214,7 @@ function BookingsContent({ status }: BookingsProps) {
             recurringInfo: page.recurringInfo.find(
               (info) => info.recurringEventId === booking.recurringEventId
             ),
+            isToday: true,
           }))
       )[0] || []
     );

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -84,16 +84,17 @@ export default function Bookings(props: BookingsProps) {
   );
 }
 
-type RowData = {
-  type: "data";
-  booking: BookingOutput;
-  recurringInfo?: RecurringInfo;
-} & {
-  type: "today" | "next";
-};
+type RowData =
+  | {
+      type: "data";
+      booking: BookingOutput;
+      recurringInfo?: RecurringInfo;
+    }
+  | {
+      type: "today" | "next";
+    };
 
 function BookingsContent({ status }: BookingsProps) {
-  console.log("💡 BookingsContent");
   const { data: filterQuery } = useFilterQuery();
 
   const { t } = useLocale();

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -11,6 +11,7 @@ import type { ReactElement } from "react";
 import { useMemo, useState } from "react";
 import type { z } from "zod";
 
+import { WipeMyCalActionButton } from "@calcom/app-store/wipemycalother/components";
 import dayjs from "@calcom/dayjs";
 import { FilterToggle } from "@calcom/features/bookings/components/FilterToggle";
 import { FiltersContainer } from "@calcom/features/bookings/components/FiltersContainer";
@@ -251,17 +252,22 @@ function BookingsContent({ status }: BookingsProps) {
           )}
           {(query.status === "pending" || query.isPaused) && <SkeletonLoader />}
           {query.status === "success" && !isEmpty && (
-            <DataTableWrapper
-              table={table}
-              testId={`${status}-bookings`}
-              bodyTestId="bookings"
-              hideHeader={true}
-              isPending={query.isFetching && !flatData}
-              hasNextPage={query.hasNextPage}
-              fetchNextPage={query.fetchNextPage}
-              isFetching={query.isFetching}
-              variant="compact"
-            />
+            <>
+              {!!bookingsToday.length && status === "upcoming" && (
+                <WipeMyCalActionButton bookingStatus={status} bookingsEmpty={isEmpty} />
+              )}
+              <DataTableWrapper
+                table={table}
+                testId={`${status}-bookings`}
+                bodyTestId="bookings"
+                hideHeader={true}
+                isPending={query.isFetching && !flatData}
+                hasNextPage={query.hasNextPage}
+                fetchNextPage={query.fetchNextPage}
+                isFetching={query.isFetching}
+                variant="compact"
+              />
+            </>
           )}
           {query.status === "success" && isEmpty && (
             <div className="flex items-center justify-center pt-2 xl:pt-0">

--- a/apps/web/playwright/wipe-my-cal.e2e.ts
+++ b/apps/web/playwright/wipe-my-cal.e2e.ts
@@ -42,9 +42,9 @@ test.describe("Wipe my Cal App Test", () => {
     await page.goto("/bookings/upcoming");
     await expect(page.locator("data-testid=wipe-today-button")).toBeVisible();
 
-    const $openBookingCount = await page.locator('[data-testid="bookings"] > *').count();
-    const $todayBookingCount = await page.locator('[data-testid="today-bookings"] > *').count();
-    expect($openBookingCount + $todayBookingCount).toBe(3);
+    const $nonTodayBookingCount = await page.locator('[data-today="false"]').count();
+    const $todayBookingCount = await page.locator('[data-today="true"]').count();
+    expect($nonTodayBookingCount + $todayBookingCount).toBe(3);
 
     await page.locator("data-testid=wipe-today-button").click();
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2927,5 +2927,6 @@
   "managed_users_description": "See all the managed users created by your OAuth client",
   "select_oAuth_client": "Select Oauth Client",
   "on_every_instance": "On every instance",
+  "next": "Next",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -66,16 +66,18 @@ export function DataTableWrapper<TData, TValue>({
       className={className}
       containerClassName={containerClassName}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}>
-      <DataTableToolbar.Root>
-        <div className="flex w-full flex-col gap-2">
-          <div className="flex w-full flex-wrap justify-between gap-2">
-            <div className="flex flex-wrap gap-2">{ToolbarLeft}</div>
-            <div className="flex flex-wrap gap-2">{ToolbarRight}</div>
+      {(ToolbarLeft || ToolbarRight) && (
+        <DataTableToolbar.Root>
+          <div className="flex w-full flex-col gap-2">
+            <div className="flex w-full flex-wrap justify-between gap-2">
+              <div className="flex flex-wrap gap-2">{ToolbarLeft}</div>
+              <div className="flex flex-wrap gap-2">{ToolbarRight}</div>
+            </div>
           </div>
-        </div>
 
-        {children}
-      </DataTableToolbar.Root>
+          {children}
+        </DataTableToolbar.Root>
+      )}
 
       {totalDBRowCount && (
         <div style={{ gridArea: "footer", marginTop: "1rem" }}>


### PR DESCRIPTION
## What does this PR do?

This PR removes nested scrolls on /bookings/upcoming.

### Details

We used to have two different sections (today, and the rest). In this PR, we've combined them all into a single DataTable. To differentiate the sections, I've added dummy rows as section headers.

![Screenshot 2025-01-20 at 11 08 48](https://github.com/user-attachments/assets/24075ec7-5edd-46bf-be3f-605618d6eb22)

![Screenshot 2025-01-20 at 11 08 56](https://github.com/user-attachments/assets/7c4c2b0b-83a3-4fdc-9054-e8cae9560028)

⬆️ Feel free to suggest a different label for the second section. (Instead of "Next", it could be... "Upcoming", "Later", ...)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- The scroll on /bookings/upcoming works well
- It should be the same with /bookings/[others] (The sections only exist on /bookings/upcoming, though)