### PR TITLE
fix: Incorrect booking 500s

### DIFF
--- a/apps/web/pages/api/book/event.ts
+++ b/apps/web/pages/api/book/event.ts
@@ -18,10 +18,14 @@ async function handler(req: NextApiRequest & { userId?: number }, res: NextApiRe
     });
   }
 
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: userIp,
-  });
+  try {
+    await checkRateLimitAndThrowError({
+      rateLimitingType: "core",
+      identifier: userIp,
+    });
+  } catch (error) {
+    return res.status(429).json({ message: "Rate limit exceeded" });
+  }
 
   const session = await getServerSession({ req, res });
   /* To mimic API behavior and comply with types */

--- a/apps/web/pages/api/book/instant-event.ts
+++ b/apps/web/pages/api/book/instant-event.ts
@@ -9,10 +9,14 @@ import { defaultResponder } from "@calcom/lib/server";
 async function handler(req: NextApiRequest & { userId?: number }, res: NextApiResponse) {
   const userIp = getIP(req);
 
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: `instant.event-${userIp}`,
-  });
+  try {
+    await checkRateLimitAndThrowError({
+      rateLimitingType: "core",
+      identifier: `instant.event-${userIp}`,
+    });
+  } catch (error) {
+    return res.status(429).json({ message: "Rate limit exceeded" });
+  }
 
   const session = await getServerSession({ req, res });
   req.userId = session?.user?.id || -1;

--- a/apps/web/pages/api/book/recurring-event.ts
+++ b/apps/web/pages/api/book/recurring-event.ts
@@ -20,10 +20,15 @@ async function handler(req: NextApiRequest & { userId?: number }, res: NextApiRe
     });
   }
 
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: userIp,
-  });
+  try {
+    await checkRateLimitAndThrowError({
+      rateLimitingType: "core",
+      identifier: userIp,
+    });
+  } catch (error) {
+    return res.status(429).json({ message: "Rate limit exceeded" });
+  }
+
   const session = await getServerSession({ req, res });
   /* To mimic API behavior and comply with types */
   req.userId = session?.user?.id || -1;


### PR DESCRIPTION
## What does this PR do?

These rate limit exceptions were causing 500s to be returned from the server, which is incorrect. They need to return as 429 directly from the origin server.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
