### PR TITLE
chore: Double available memory on api/book/event

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -26,6 +26,9 @@
     },
     "pages/router/embed.tsx": {
       "memory": 2048
+    },
+    "pages/api/book/event.ts": {
+      "memory": 2048
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Backport of https://github.com/calcom/cal.com/commit/3ca24230e52711952165b46f97c78d96c9f8d579