### PR TITLE
fix: custom templates on team plan

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -91,7 +91,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     { enabled: !!teamId }
   );
 
-  const { hasActiveTeamPlan } = useHasActiveTeamPlan(teamId);
+  const { hasActiveTeamPlan } = useHasActiveTeamPlan();
 
   const { data: _verifiedEmails } = trpc.viewer.workflows.getVerifiedEmails.useQuery({ teamId });
 

--- a/packages/lib/hooks/useHasPaidPlan.ts
+++ b/packages/lib/hooks/useHasPaidPlan.ts
@@ -42,7 +42,7 @@ export function useHasEnterprisePlan() {
 export function useHasActiveTeamPlan(teamId?: number) {
   if (IS_SELF_HOSTED) return { isPending: false, hasActiveTeamPlan: true };
 
-  const { data, isPending } = trpc.viewer.teams.hasActiveTeamPlan.useQuery({ teamId });
+  const { data, isPending } = trpc.viewer.teams.hasActiveTeamPlan.useQuery();
 
   return { isPending, hasActiveTeamPlan: !!data };
 }

--- a/packages/trpc/server/routers/viewer/teams/_router.tsx
+++ b/packages/trpc/server/routers/viewer/teams/_router.tsx
@@ -12,7 +12,6 @@ import { ZGetSchema } from "./get.schema";
 import { ZGetMemberAvailabilityInputSchema } from "./getMemberAvailability.schema";
 import { ZGetMembershipbyUserInputSchema } from "./getMembershipbyUser.schema";
 import { ZGetUserConnectedAppsInputSchema } from "./getUserConnectedApps.schema";
-import { ZHasActiveTeamPlanSchema } from "./hasActiveTeamPlan.schema";
 import { ZHasEditPermissionForUserSchema } from "./hasEditPermissionForUser.schema";
 import { ZInviteMemberInputSchema } from "./inviteMember/inviteMember.schema";
 import { ZInviteMemberByTokenSchemaInputSchema } from "./inviteMemberByToken.schema";
@@ -223,7 +222,7 @@ export const viewerTeamsRouter = router({
     );
     return handler(opts);
   }),
-  hasActiveTeamPlan: authedProcedure.input(ZHasActiveTeamPlanSchema).query(async (opts) => {
+  hasActiveTeamPlan: authedProcedure.query(async (opts) => {
     const handler = await importHandler(
       namespaced("hasActiveTeamPlan"),
       () => import("./hasActiveTeamPlan.handler")

--- a/packages/trpc/server/routers/viewer/teams/hasActiveTeamPlan.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/hasActiveTeamPlan.handler.ts
@@ -24,7 +24,7 @@ export const hasActiveTeamPlanHandler = async ({ ctx }: HasActiveTeamPlanOptions
 
   if (!teams.length) return false;
 
-  // check if user as at least on membership with an active plan
+  // check if user has at least on membership with an active plan
   for (const team of teams) {
     const teamBillingService = new InternalTeamBilling(team);
     const isPlanActive = await teamBillingService.checkIfTeamHasActivePlan();

--- a/packages/trpc/server/routers/viewer/teams/hasActiveTeamPlan.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/hasActiveTeamPlan.schema.ts
@@ -1,7 +1,1 @@
-import { z } from "zod";
-
-export const ZHasActiveTeamPlanSchema = z.object({
-  teamId: z.number().optional(),
-});
-
-export type THasActiveTeamPlanSchema = z.infer<typeof ZHasActiveTeamPlanSchema>;
+export {};

--- a/packages/trpc/server/routers/viewer/workflows/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.handler.ts
@@ -84,7 +84,6 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   if (!isCurrentUsernamePremium) {
     isTeamsPlan = await hasActiveTeamPlanHandler({
       ctx,
-      input: { teamId: userWorkflow?.teamId ?? undefined },
     });
   }
   const hasPaidPlan = IS_SELF_HOSTED || isCurrentUsernamePremium || isTeamsPlan;


### PR DESCRIPTION
## What does this PR do?

Custom templates should be available also for user workflows if the user is a member of a active team plan.