### PR TITLE
fix: use userId as ratelimit identifier

### DIFF
--- a/apps/api/v1/lib/helpers/rateLimitApiKey.test.ts
+++ b/apps/api/v1/lib/helpers/rateLimitApiKey.test.ts
@@ -28,6 +28,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({
       method: "GET",
       query: {},
+      userId: testUserId,
     });
 
     await rateLimitApiKey(req, res, vi.fn() as any);
@@ -93,6 +94,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     (checkRateLimitAndThrowError as any).mockRejectedValue(new Error("Rate limit exceeded"));

--- a/apps/api/v1/lib/helpers/rateLimitApiKey.test.ts
+++ b/apps/api/v1/lib/helpers/rateLimitApiKey.test.ts
@@ -13,6 +13,8 @@ import { rateLimitApiKey } from "~/lib/helpers/rateLimitApiKey";
 type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
 
+const testUserId = 123;
+
 vi.mock("@calcom/lib/checkRateLimitAndThrowError", () => ({
   checkRateLimitAndThrowError: vi.fn(),
 }));
@@ -38,6 +40,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     (checkRateLimitAndThrowError as any).mockResolvedValueOnce({
@@ -50,7 +53,7 @@ describe("rateLimitApiKey middleware", () => {
     await rateLimitApiKey(req, res, vi.fn() as any);
 
     expect(checkRateLimitAndThrowError).toHaveBeenCalledWith({
-      identifier: "test-key",
+      identifier: testUserId.toString(),
       rateLimitingType: "api",
       onRateLimiterResponse: expect.any(Function),
     });
@@ -60,6 +63,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     const rateLimiterResponse: RatelimitResponse = {
@@ -104,6 +108,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     const rateLimiterResponse: RatelimitResponse = {
@@ -127,8 +132,8 @@ describe("rateLimitApiKey middleware", () => {
     await rateLimitApiKey(req, res, vi.fn() as any);
 
     expect(handleAutoLock).toHaveBeenCalledWith({
-      identifier: "test-key",
-      identifierType: "apiKey",
+      identifier: testUserId.toString(),
+      identifierType: "userId",
       rateLimitResponse: rateLimiterResponse,
     });
 
@@ -140,6 +145,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     const rateLimiterResponse: RatelimitResponse = {
@@ -163,8 +169,8 @@ describe("rateLimitApiKey middleware", () => {
     await rateLimitApiKey(req, res, vi.fn() as any);
 
     expect(handleAutoLock).toHaveBeenCalledWith({
-      identifier: "test-key",
-      identifierType: "apiKey",
+      identifier: testUserId.toString(),
+      identifierType: "userId",
       rateLimitResponse: rateLimiterResponse,
     });
 
@@ -176,6 +182,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     const rateLimiterResponse: RatelimitResponse = {
@@ -200,8 +207,8 @@ describe("rateLimitApiKey middleware", () => {
     await rateLimitApiKey(req, res, next);
 
     expect(handleAutoLock).toHaveBeenCalledWith({
-      identifier: "test-key",
-      identifierType: "apiKey",
+      identifier: testUserId.toString(),
+      identifierType: "userId",
       rateLimitResponse: rateLimiterResponse,
     });
 
@@ -214,6 +221,7 @@ describe("rateLimitApiKey middleware", () => {
     const { req, res } = createMocks({
       method: "GET",
       query: { apiKey: "test-key" },
+      userId: testUserId,
     });
 
     // Mock checkRateLimitAndThrowError to throw HttpError

--- a/apps/api/v1/lib/helpers/rateLimitApiKey.ts
+++ b/apps/api/v1/lib/helpers/rateLimitApiKey.ts
@@ -9,8 +9,9 @@ export const rateLimitApiKey: NextMiddleware = async (req, res, next) => {
 
   // TODO: Add a way to add trusted api keys
   try {
+    const identifier = req.userId.toString();
     await checkRateLimitAndThrowError({
-      identifier: req.query.apiKey as string,
+      identifier,
       rateLimitingType: "api",
       onRateLimiterResponse: async (response) => {
         res.setHeader("X-RateLimit-Limit", response.limit);
@@ -19,8 +20,8 @@ export const rateLimitApiKey: NextMiddleware = async (req, res, next) => {
 
         try {
           const didLock = await handleAutoLock({
-            identifier: req.query.apiKey as string, // Casting as this is verified in another middleware
-            identifierType: "apiKey",
+            identifier,
+            identifierType: "userId",
             rateLimitResponse: response,
           });
 

--- a/apps/api/v1/lib/helpers/rateLimitApiKey.ts
+++ b/apps/api/v1/lib/helpers/rateLimitApiKey.ts
@@ -6,6 +6,7 @@ import { HttpError } from "@calcom/lib/http-error";
 
 export const rateLimitApiKey: NextMiddleware = async (req, res, next) => {
   if (!req.userId) return res.status(401).json({ message: "No userId provided" });
+  if (!req.query.apiKey) return res.status(401).json({ message: "No apiKey provided" });
 
   // TODO: Add a way to add trusted api keys
   try {

--- a/apps/api/v1/lib/helpers/rateLimitApiKey.ts
+++ b/apps/api/v1/lib/helpers/rateLimitApiKey.ts
@@ -5,7 +5,7 @@ import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowE
 import { HttpError } from "@calcom/lib/http-error";
 
 export const rateLimitApiKey: NextMiddleware = async (req, res, next) => {
-  if (!req.query.apiKey) return res.status(401).json({ message: "No apiKey provided" });
+  if (!req.userId) return res.status(401).json({ message: "No userId provided" });
 
   // TODO: Add a way to add trusted api keys
   try {


### PR DESCRIPTION
Using raw api keys as identifiers is problematic because they are logged
and are accessible via Unkey's UI.

My first idea was to use the api key's primary key, which would solve
this just fine.
But after looking at the implementation it seemed easier to use the user's id, which is what most people are interested in limiting, not the actual keys. 
Also the userId was already passed in the requests context, which made it easier. Sean confirmed that ratelimiting the user, not their keys made more sense, so here we are.
