### PR TITLE
feat: Add onConnectError prop to allow actions on failures

### DIFF
--- a/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewPlatformWrapper.tsx
+++ b/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewPlatformWrapper.tsx
@@ -47,6 +47,7 @@ type ConferencingAppsViewPlatformWrapperProps = {
   disableToasts?: boolean;
   returnTo?: string;
   onErrorReturnTo?: string;
+  onConnectError?: () => void;
 };
 
 type RemoveAppParams = { callback: () => void; app?: App["slug"] };
@@ -174,6 +175,7 @@ export const ConferencingAppsViewPlatformWrapper = ({
     onError: () => {
       queryClient.invalidateQueries({ queryKey: [atomsConferencingAppsQueryKey] });
       showToast(`Error: unable to install app`, "error");
+      onConnectError?.();
     },
     returnTo,
     onErrorReturnTo,

--- a/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewPlatformWrapper.tsx
+++ b/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewPlatformWrapper.tsx
@@ -73,6 +73,7 @@ export const ConferencingAppsViewPlatformWrapper = ({
   disableToasts = false,
   returnTo,
   onErrorReturnTo,
+  onConnectError,
 }: ConferencingAppsViewPlatformWrapperProps) => {
   const { t } = useLocale();
   const queryClient = useQueryClient();


### PR DESCRIPTION
## What does this PR do?

We would like to perform an action such as displaying a modal to prompt the user to connect their google calendar if the app install for Google meet fails.

Adding a `onConnectError` will allow users to perform a custom action on failure, especially if the toasts are disabled.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
