### PR TITLE
Add Most Cancelled Bookings to insights

### DIFF
--- a/apps/web/modules/insights/insights-view.tsx
+++ b/apps/web/modules/insights/insights-view.tsx
@@ -11,6 +11,7 @@ import {
   RecentFeedbackTable,
   HighestRatedMembersTable,
   LowestRatedMembersTable,
+  MostCancelledBookingsTable,
 } from "@calcom/features/insights/components";
 import { FiltersProvider } from "@calcom/features/insights/context/FiltersProvider";
 import { Filters } from "@calcom/features/insights/filters";
@@ -43,6 +44,7 @@ export default function InsightsPage() {
           <HighestRatedMembersTable />
           <LowestRatedMembersTable />
         </div>
+        <MostCancelledBookingsTable />
         <small className="text-default block text-center">
           {t("looking_for_more_insights")}{" "}
           <a

--- a/packages/features/insights/components/MostCancelledBookingsTable.tsx
+++ b/packages/features/insights/components/MostCancelledBookingsTable.tsx
@@ -1,0 +1,45 @@
+import { Title } from "@tremor/react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc";
+
+import { useFilterContext } from "../context/provider";
+import { CardInsights } from "./Card";
+import { LoadingInsight } from "./LoadingInsights";
+import { TotalBookingUsersTable } from "./TotalBookingUsersTable";
+
+export const MostCancelledBookingsTable = () => {
+  const { t } = useLocale();
+  const { filter } = useFilterContext();
+  const { dateRange, selectedEventTypeId, isAll, initialConfig } = filter;
+  const [startDate, endDate] = dateRange;
+  const { selectedTeamId: teamId } = filter;
+
+  const { data, isSuccess, isPending } = trpc.viewer.insights.mostCancelledBookings.useQuery(
+    {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      teamId,
+      eventTypeId: selectedEventTypeId ?? undefined,
+      isAll,
+    },
+    {
+      staleTime: 30000,
+      trpc: {
+        context: { skipBatch: true },
+      },
+      enabled: !!(initialConfig?.teamId || initialConfig?.userId || initialConfig?.isAll),
+    }
+  );
+
+  if (isPending) return <LoadingInsight />;
+
+  if (!isSuccess || !startDate || !endDate || !teamId) return null;
+
+  return (
+    <CardInsights>
+      <Title className="text-emphasis">{t("most_cancelled_bookings")}</Title>
+      <TotalBookingUsersTable data={data} />
+    </CardInsights>
+  );
+};


### PR DESCRIPTION
Add "Most Cancelled Bookings" section to insights main page.

* **New Component**: Create `MostCancelledBookingsTable` in `packages/features/insights/components/MostCancelledBookingsTable.tsx` to display the most cancelled bookings.
  - Import necessary modules and hooks.
  - Use `trpc.viewer.insights.mostCancelledBookings.useQuery` to fetch data.
  - Render a table with the fetched data.
* **Insights Main Page**: Modify `apps/web/modules/insights/insights-view.tsx` to include the new component.
  - Import `MostCancelledBookingsTable`.
  - Add `MostCancelledBookingsTable` to the insights main page.

