### PR TITLE
fix: Add Stripe `past_due` to active team subscription status

### DIFF
--- a/packages/features/ee/billing/stripe-billling-service.ts
+++ b/packages/features/ee/billing/stripe-billling-service.ts
@@ -34,6 +34,6 @@ export class StripeBillingService implements BillingService {
     const subscription = await this.stripe.subscriptions.retrieve(subscriptionId);
     if (!subscription || !subscription.status) return false;
 
-    return subscription.status === "active";
+    return subscription.status === "active" || subscription.status === "past_due";
   }
 }

--- a/packages/features/ee/billing/teams/internal-team-billing.ts
+++ b/packages/features/ee/billing/teams/internal-team-billing.ts
@@ -165,6 +165,6 @@ export class InternalTeamBilling implements TeamBilling {
   async checkIfTeamHasActivePlan() {
     const { subscriptionId } = this.team.metadata;
     if (!subscriptionId) return false;
-    return billing.checkIfTeamHasActivePlan(subscriptionId);
+    return await billing.checkIfTeamHasActivePlan(subscriptionId);
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When checking for an active team subscription include the `past_due` subscription status as active in Cal

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
