### PR TITLE
fix: managed events with internal notes

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -136,7 +136,7 @@ export default function CancelBooking(props: Props) {
       )}
       {!error && (
         <div className="mt-5 sm:mt-6">
-          {props.isHost && teamId && (
+          {props.isHost && props.internalNotePresets.length > 0 && (
             <>
               <InternalNotePresetsSelect
                 internalNotePresets={props.internalNotePresets}

--- a/apps/web/lib/booking.ts
+++ b/apps/web/lib/booking.ts
@@ -80,6 +80,11 @@ export const getEventTypesFromDB = async (id: number) => {
       schedulingType: true,
       periodStartDate: true,
       periodEndDate: true,
+      parent: {
+        select: {
+          teamId: true,
+        },
+      },
     },
   });
 

--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -194,7 +194,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   const { currentOrgDomain } = orgDomainConfig(context.req);
 
-  async function getInternalNotePresets(teamId: number) {
+  async function getInternalNotePresets(teamId: number | null) {
+    if (!teamId || !isLoggedInUserHost) return [];
     return await prisma.internalNotePreset.findMany({
       where: {
         teamId,
@@ -206,6 +207,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       },
     });
   }
+
+  const internalNotes = await getInternalNotePresets(eventType.team?.id ?? eventType.parent?.teamId ?? null);
 
   return {
     props: {
@@ -224,7 +227,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       requiresLoginToUpdate,
       rescheduledToUid,
       isLoggedInUserHost,
-      internalNotePresets: eventType?.team?.id ? await getInternalNotePresets(eventType.team.id) : [],
+      internalNotePresets: internalNotes,
     },
   };
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes the implementation of internal notes to work outside of just a "team event type" context. Allows the cancelation reason to transfer across to managed event types and not just specific team events.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Create a managed event type on a team
Create Internal note presets in settings > [team name] > settings
Create a booking on managed event type
Cancel booking > Select internal note or "other" 
Cancel booking

Try the same with a normal team event type.
Try again with a normal booking that doesnt have internal notes enabled. 

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
