### PR TITLE
fix: API V1 cancellationReason fallback/default and doc update

### DIFF
--- a/apps/api/v1/lib/validations/booking.ts
+++ b/apps/api/v1/lib/validations/booking.ts
@@ -38,6 +38,23 @@ export const schemaBookingGetParams = z.object({
 
 export type Status = z.infer<typeof schemaBookingGetParams>["status"];
 
+export const bookingCancelSchema = z.object({
+  id: z.number(),
+  allRemainingBookings: z.boolean().optional(),
+  cancelSubsequentBookings: z.boolean().optional(),
+  cancellationReason: z.string().optional().default("Not Provided"),
+  seatReferenceUid: z.string().optional(),
+  cancelledBy: z.string().email({ message: "Invalid email" }).optional(),
+  internalNote: z
+    .object({
+      id: z.number(),
+      name: z.string(),
+      cancellationReason: z.string().optional().nullable(),
+    })
+    .optional()
+    .nullable(),
+});
+
 const schemaBookingEditParams = z
   .object({
     title: z.string().optional(),

--- a/apps/api/v1/pages/api/bookings/[id]/_delete.ts
+++ b/apps/api/v1/pages/api/bookings/[id]/_delete.ts
@@ -2,8 +2,8 @@ import type { NextApiRequest } from "next";
 
 import handleCancelBooking from "@calcom/features/bookings/lib/handleCancelBooking";
 import { defaultResponder } from "@calcom/lib/server";
-import { bookingCancelSchema } from "@calcom/prisma/zod-utils";
 
+import { bookingCancelSchema } from "~/lib/validations/booking";
 import { schemaQueryIdParseInt } from "~/lib/validations/shared/queryIdTransformParseInt";
 
 /**
@@ -70,6 +70,7 @@ async function handler(req: NextApiRequest) {
       ...req.query,
       allRemainingBookings: req.query.allRemainingBookings === "true",
     });
+
   // Normalizing for universal handler
   req.body = { id, allRemainingBookings, cancellationReason };
   return await handleCancelBooking(req);

--- a/docs/api-reference/v1/openapi-v1.json
+++ b/docs/api-reference/v1/openapi-v1.json
@@ -1523,11 +1523,11 @@
           {
             "in": "query",
             "name": "cancellationReason",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "The reason for cancellation of the booking"
+            "description": "The reason for cancellation of the booking, not required except for hosts"
           }
         ],
         "tags": ["Bookings"],


### PR DESCRIPTION
## What does this PR do?

Adds cancellationReason fallback to make sure it satisfies the requirement of cancellationReason for hosts. Also adds an update to the docs.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Just send a cancellation request via API V1 as host

## Checklist

