### PR TITLE
fix: show sort state on column header

### DIFF
--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -303,13 +303,24 @@ const TableHeadLabel = ({ header }: { header: Header<any, any> }) => {
         <button
           type="button"
           className={classNames(
-            "group -ml-2 flex items-center gap-2 rounded-md px-2 py-1",
+            "group -ml-2 flex w-full items-center gap-2 rounded-md px-2 py-1",
             open && "bg-muted"
           )}>
-          {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+          <div
+            className="truncate"
+            title={
+              typeof header.column.columnDef.header === "string" ? header.column.columnDef.header : undefined
+            }>
+            {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+          </div>
+          {header.column.getIsSorted() === "asc" && <Icon name="arrow-up" className="h-4 w-4 shrink-0" />}
+          {header.column.getIsSorted() === "desc" && <Icon name="arrow-down" className="h-4 w-4 shrink-0" />}
           <Icon
             name="chevrons-up-down"
-            className={classNames("text-subtle h-4 w-4", !open && "opacity-0 group-hover:opacity-100")}
+            className={classNames(
+              "text-subtle h-4 w-4 shrink-0",
+              !open && "opacity-0 group-hover:opacity-100"
+            )}
           />
         </button>
       </PopoverTrigger>

--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import type { Table as ReactTableType } from "@tanstack/react-table";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   DataTable,
   DataTableToolbar,
   DataTablePagination,
   useFetchMoreOnBottomReached,
+  useDataTable,
+  useColumnFilters,
 } from "@calcom/features/data-table";
 
 export type DataTableWrapperProps<TData, TValue> = {
@@ -52,6 +54,20 @@ export function DataTableWrapper<TData, TValue>({
     fetchNextPage,
     isFetching,
   });
+  const { sorting, setSorting } = useDataTable();
+  const columnFilters = useColumnFilters();
+
+  useEffect(() => {
+    table.setState((prev) => ({
+      ...prev,
+      sorting,
+      columnFilters,
+    }));
+    table.setOptions((prev) => ({
+      ...prev,
+      onSortingChange: setSorting,
+    }));
+  }, [table, sorting, columnFilters]);
 
   return (
     <DataTable

--- a/packages/features/data-table/components/filters/FilterPopover.tsx
+++ b/packages/features/data-table/components/filters/FilterPopover.tsx
@@ -54,11 +54,6 @@ export function FilterPopover({ column }: FilterPopoverProps) {
   const icon = column.icon || FILTER_ICONS[column.type];
   const filterValue = useFilterValue(column.id, ZFilterValue);
   const { text, moreCount } = useSelectedLabels({ column, filterValue });
-  console.log("💡 icon", {
-    icon: column.icon,
-    type: column.type,
-    FILTER_ICONS,
-  });
   return (
     <Popover>
       <PopoverTrigger asChild>

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -312,7 +312,7 @@ export function RoutingFormResponsesTableContent() {
     isAll,
   });
 
-  const { sorting, setSorting } = useDataTable();
+  const { sorting } = useDataTable();
 
   const { data, fetchNextPage, isFetching, hasNextPage, isLoading } =
     trpc.viewer.insights.routingFormResponses.useInfiniteQuery(
@@ -538,11 +538,6 @@ export function RoutingFormResponsesTableContent() {
         bookingUserId: false,
       },
     },
-    state: {
-      sorting,
-      columnFilters,
-    },
-    onSortingChange: setSorting,
     getFacetedUniqueValues: (_, columnId) => () => {
       if (!headers) {
         return new Map();

--- a/packages/features/users/components/UserTable/PlatformManagedUsersTable.tsx
+++ b/packages/features/users/components/UserTable/PlatformManagedUsersTable.tsx
@@ -246,7 +246,6 @@ function UserListTableContent({ oAuthClientId }: PlatformManagedUsersTableProps)
     data: flatData,
     columns,
     enableRowSelection: true,
-    columnResizeMode: "onChange",
     debugTable: true,
     manualPagination: true,
     initialState: {

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -289,9 +289,7 @@ function UserListTableContent() {
         enableHiding: false,
         enableColumnFilter: false,
         size: 200,
-        header: () => {
-          return `Members`;
-        },
+        header: "Members",
         cell: ({ row }) => {
           const { username, email, avatarUrl } = row.original;
           return (
@@ -437,7 +435,6 @@ function UserListTableContent() {
     data: flatData,
     columns: memorisedColumns,
     enableRowSelection: true,
-    columnResizeMode: "onChange",
     debugTable: true,
     manualPagination: true,
     initialState: {
@@ -451,7 +448,6 @@ function UserListTableContent() {
       size: 150,
     },
     state: {
-      columnFilters,
       rowSelection,
     },
     getCoreRowModel: getCoreRowModel(),


### PR DESCRIPTION
## What does this PR do?

This PR adds sorting state on column headers.

![Screenshot 2025-01-28 at 17 43 50](https://github.com/user-attachments/assets/d9d14ee5-4af4-47ca-878e-f0be9f4d65fd)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Try sorting on /insights/routing or org member list.