### PR TITLE
fix: Exclude .next from TS & fixup ImageResponse types

### DIFF
--- a/apps/web/pages/api/social/og/image.tsx
+++ b/apps/web/pages/api/social/og/image.tsx
@@ -1,5 +1,5 @@
-import { ImageResponse } from "@vercel/og";
 import type { NextApiRequest } from "next";
+import { ImageResponse } from "next/server";
 import type { SatoriOptions } from "satori";
 import { z } from "zod";
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -34,5 +34,5 @@
     "../../packages/features/bookings/lib/getUserBooking.ts",
     "../../packages/features/Segment.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## What does this PR do?

