### PR TITLE
fix: clear cancellation reason on other select

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -15,11 +15,13 @@ interface InternalNotePresetsSelectProps {
       label: string;
     } | null
   ) => void;
+  setCancellationReason: (reason: string) => void;
 }
 
 const InternalNotePresetsSelect = ({
   internalNotePresets,
   onPresetSelect,
+  setCancellationReason,
 }: InternalNotePresetsSelectProps) => {
   const { t } = useLocale();
   const [showOtherInput, setShowOtherInput] = useState(false);
@@ -31,6 +33,7 @@ const InternalNotePresetsSelect = ({
   const handleSelectChange = (option: { value: number | string; label: string } | null) => {
     if (option?.value === "other") {
       setShowOtherInput(true);
+      setCancellationReason("");
     } else {
       setShowOtherInput(false);
       onPresetSelect && onPresetSelect(option);
@@ -140,6 +143,7 @@ export default function CancelBooking(props: Props) {
             <>
               <InternalNotePresetsSelect
                 internalNotePresets={props.internalNotePresets}
+                setCancellationReason={setCancellationReason}
                 onPresetSelect={(option) => {
                   if (!option) return;
 


### PR DESCRIPTION
## What does this PR do?

![CleanShot 2025-01-29 at 10 46 42](https://github.com/user-attachments/assets/d1bfd5e0-db8a-468c-9cf7-469523034c38)


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Set internal notes with public cancellation reasons - create booking - cancel - change select to other and notice reason gets cleared

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
