### PR TITLE
fix: modify error handling of incompleteBookingWriteToRecord

### DIFF
--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -1324,8 +1324,9 @@ export default class SalesforceCRMService implements CRM {
         ...writeOnRecordBody,
       })
       .catch((e) => {
+        const contactId = personRecord.Id || "unknown";
         // catch the error and throw a new one with a more descriptive message
-        const errorMessage = `Error updating person record for contactId ${personRecord.Id}: ${
+        const errorMessage = `Error updating person record for contactId '${contactId}': ${
           e instanceof Error ? e.message : String(e)
         }`;
         throw new Error(errorMessage);

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -1324,7 +1324,7 @@ export default class SalesforceCRMService implements CRM {
         ...writeOnRecordBody,
       })
       .catch((e) => {
-        const contactId = personRecord.Id || "unknown";
+        const contactId = personRecord?.Id || "unknown";
         // catch the error and throw a new one with a more descriptive message
         const errorMessage = `Error updating person record for contactId '${contactId}': ${
           e instanceof Error ? e.message : String(e)

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -1302,7 +1302,9 @@ export default class SalesforceCRMService implements CRM {
     }
 
     if (!personRecord) {
-      throw new Error(`No contact or lead found for email ${email}`);
+      this.log.info(`No contact or lead found for email ${email}`);
+      // No salesforce entity to update, skip and report success (unrecoverable)
+      return;
     }
     // Ensure the fields exist on the record
     const existingFields = await this.ensureFieldsExistOnObject(
@@ -1322,7 +1324,11 @@ export default class SalesforceCRMService implements CRM {
         ...writeOnRecordBody,
       })
       .catch((e) => {
-        this.log.error(`Error updating person record for contactId ${personRecord?.Id}`, e);
+        // catch the error and throw a new one with a more descriptive message
+        const errorMessage = `Error updating person record for contactId ${personRecord.Id}: ${
+          e instanceof Error ? e.message : String(e)
+        }`;
+        throw new Error(errorMessage);
       });
   }
 }


### PR DESCRIPTION
## What does this PR do?

* DON'T throw error when personRecord is not found in Salesforce (email does not exist in CRM, unrecoverable)
* DO throw error when personRecord update fails (for any reason) - we need to know.