### PR TITLE
fix: username visible in private booking link

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -78,6 +78,7 @@ const BookerComponent = ({
   hasValidLicense,
   isBookingDryRun: isBookingDryRunProp,
   renderCaptcha,
+  hashedLink,
 }: BookerProps & WrappedBookerProps) => {
   const searchParams = useCompatSearchParams();
   const isPlatformBookerEmbed = useIsPlatformBookerEmbed();
@@ -389,6 +390,7 @@ const BookerComponent = ({
                   event={event.data}
                   isPending={event.isPending}
                   isPlatform={isPlatform}
+                  isPrivateLink={!!hashedLink}
                   locale={userLocale}
                 />
                 {layout !== BookerLayouts.MONTH_VIEW &&

--- a/packages/features/bookings/Booker/components/EventMeta.tsx
+++ b/packages/features/bookings/Booker/components/EventMeta.tsx
@@ -47,6 +47,7 @@ export const EventMeta = ({
   event,
   isPending,
   isPlatform = true,
+  isPrivateLink,
   classNames,
   locale,
 }: {
@@ -73,6 +74,7 @@ export const EventMeta = ({
     | "autoTranslateDescriptionEnabled"
   > | null;
   isPending: boolean;
+  isPrivateLink: boolean;
   isPlatform?: boolean;
   classNames?: {
     eventMetaContainer?: string;
@@ -153,6 +155,7 @@ export const EventMeta = ({
             users={event.subsetOfUsers}
             profile={event.profile}
             entity={event.entity}
+            isPrivateLink={isPrivateLink}
           />
           <EventTitle className={`${classNames?.eventMetaTitle} my-2`}>
             {translatedTitle ?? event?.title}

--- a/packages/features/bookings/components/event-meta/Members.tsx
+++ b/packages/features/bookings/components/event-meta/Members.tsx
@@ -17,9 +17,16 @@ export interface EventMembersProps {
   users: BookerEvent["subsetOfUsers"];
   profile: BookerEvent["profile"];
   entity: BookerEvent["entity"];
+  isPrivateLink: boolean;
 }
 
-export const EventMembers = ({ schedulingType, users, profile, entity }: EventMembersProps) => {
+export const EventMembers = ({
+  schedulingType,
+  users,
+  profile,
+  entity,
+  isPrivateLink,
+}: EventMembersProps) => {
   const username = useBookerStore((state) => state.username);
   const isDynamic = !!(username && username.indexOf("+") > -1);
   const isEmbed = useIsEmbed();
@@ -40,7 +47,7 @@ export const EventMembers = ({ schedulingType, users, profile, entity }: EventMe
           {
             // We don't want booker to be able to see the list of other users or teams inside the embed
             href:
-              isEmbed || isPlatform
+              isEmbed || isPlatform || isPrivateLink
                 ? null
                 : entity.teamSlug
                 ? getTeamUrlSync({ orgSlug: entity.orgSlug, teamSlug: entity.teamSlug })
@@ -59,11 +66,12 @@ export const EventMembers = ({ schedulingType, users, profile, entity }: EventMe
         items={[
           ...orgOrTeamAvatarItem,
           ...shownUsers.map((user) => ({
-            href: isPlatform
-              ? null
-              : `${getBookerBaseUrlSync(user.profile?.organization?.slug ?? null)}/${
-                  user.profile?.username
-                }?redirect=false`,
+            href:
+              isPlatform || isPrivateLink
+                ? null
+                : `${getBookerBaseUrlSync(user.profile?.organization?.slug ?? null)}/${
+                    user.profile?.username
+                  }?redirect=false`,
             alt: user.name || "",
             title: user.name || "",
             image: getUserAvatarUrl(user),


### PR DESCRIPTION
## What does this PR do?

- Fixes CAL-5110
- The main purpose of single-use private links is to conceal the username from potential attendees, but they can still click your avatar to access the public page, which displays the username in the address bar.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Visit private booking links and hover the Avatar. It shouldn't have a link attached to it.

<img width="672" alt="Screenshot 2025-02-01 at 7 16 04 PM" src="https://github.com/user-attachments/assets/88cb558d-c869-4221-a992-8265112af753" />
