### PR TITLE
fix: remove padding for custom data table header

### DIFF
--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -306,15 +306,15 @@ const TableHeadLabel = ({ header }: { header: Header<any, any> }) => {
   const canSort = header.column.getCanSort();
 
   if (!canSort && !canHide) {
-    return (
-      <div
-        className="truncate px-2 py-1"
-        title={
-          typeof header.column.columnDef.header === "string" ? header.column.columnDef.header : undefined
-        }>
-        {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-      </div>
-    );
+    if (typeof header.column.columnDef.header === "string") {
+      return (
+        <div className="truncate px-2 py-1" title={header.column.columnDef.header}>
+          {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+        </div>
+      );
+    } else {
+      return header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext());
+    }
   }
 
   return (


### PR DESCRIPTION
## What does this PR do?

This PR fixes a regression. It removes padding for custom column header for DataTable.

![Screenshot 2025-02-03 at 14 01 26](https://github.com/user-attachments/assets/b8228066-0ae3-4101-8dcb-6f8fbeea21dd)

![Screenshot 2025-02-03 at 14 01 33](https://github.com/user-attachments/assets/8e16112c-f435-4341-b011-5372a084e370)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Team member list
- Organization member list