### PR TITLE
fix: remove unused attribute columns for /insights/routing

### DIFF
--- a/packages/app-store/routing-forms/lib/FieldTypes.ts
+++ b/packages/app-store/routing-forms/lib/FieldTypes.ts
@@ -8,6 +8,18 @@ export const enum RoutingFormFieldType {
   EMAIL = "email",
 }
 
+export const isValidRoutingFormFieldType = (type: string): type is RoutingFormFieldType => {
+  return [
+    RoutingFormFieldType.TEXT,
+    RoutingFormFieldType.NUMBER,
+    RoutingFormFieldType.TEXTAREA,
+    RoutingFormFieldType.SINGLE_SELECT,
+    RoutingFormFieldType.MULTI_SELECT,
+    RoutingFormFieldType.PHONE,
+    RoutingFormFieldType.EMAIL,
+  ].includes(type as RoutingFormFieldType);
+};
+
 export const FieldTypes = [
   {
     label: "Short Text",

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -270,7 +270,7 @@ export function RoutingFormResponsesTable() {
 
   const headers = useMemo(() => {
     if (!headersRaw) return;
-    return headersRaw.filter((header) => isValidRoutingFormFieldType(header.type));
+    return headersRaw.filter((header) => header.label && isValidRoutingFormFieldType(header.type));
   }, [headersRaw]);
 
   const { data: forms } = trpc.viewer.insights.getRoutingFormsForFilters.useQuery({

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -29,7 +29,7 @@ import classNames from "@calcom/lib/classNames";
 import { useCopy } from "@calcom/lib/hooks/useCopy";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { BookingStatus } from "@calcom/prisma/enums";
-import { RoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
+import { RoutingFormFieldType, isValidRoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
 import { trpc, type RouterOutputs } from "@calcom/trpc";
 import {
   Badge,
@@ -258,7 +258,7 @@ export function RoutingFormResponsesTable() {
     useInsightsParameters();
 
   const {
-    data: headers,
+    data: headersRaw,
     isLoading: isHeadersLoading,
     isSuccess: isHeadersSuccess,
   } = trpc.viewer.insights.routingFormResponsesHeaders.useQuery({
@@ -267,6 +267,11 @@ export function RoutingFormResponsesTable() {
     isAll,
     routingFormId,
   });
+
+  const headers = useMemo(() => {
+    if (!headersRaw) return;
+    return headersRaw.filter((header) => isValidRoutingFormFieldType(header.type));
+  }, [headersRaw]);
 
   const { data: forms } = trpc.viewer.insights.getRoutingFormsForFilters.useQuery({
     userId,


### PR DESCRIPTION
## What does this PR do?

If a routing form has attributes that has invalid `type` attribute (for example, an empty string), let's not display this column on /insights/routing. It must be mis-configured or not in use.

Spotted this on the QA database ↓

![Screenshot 2025-02-03 at 14 46 40](https://github.com/user-attachments/assets/2089c1cb-64ca-4c64-9908-99e223e3e3a1)

![Screenshot 2025-02-03 at 14 49 46](https://github.com/user-attachments/assets/f864ca12-1d36-4bc9-8a03-1d1950ddca05)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Everything works the same on /insights/routing