### PR TITLE
fix: clean up fields columns on /insights/routing

### DIFF
--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -270,7 +270,7 @@ export function RoutingFormResponsesTable() {
 
   const headers = useMemo(() => {
     if (!headersRaw) return;
-    return headersRaw.filter((header) => {
+    const filteredHeaders = headersRaw.filter((header) => {
       if (!header.label || !isValidRoutingFormFieldType(header.type)) {
         return false;
       }
@@ -283,6 +283,19 @@ export function RoutingFormResponsesTable() {
       }
       return true;
     });
+    const ids = new Set<string>();
+    const uniqueHeaders = filteredHeaders.filter((header) => {
+      if (ids.has(header.id)) {
+        return false;
+      }
+      ids.add(header.id);
+      return true;
+    });
+    console.log("💡 test", {
+      h1: filteredHeaders.length,
+      h2: uniqueHeaders.length,
+    });
+    return uniqueHeaders;
   }, [headersRaw]);
 
   const { data: forms } = trpc.viewer.insights.getRoutingFormsForFilters.useQuery({

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -270,7 +270,19 @@ export function RoutingFormResponsesTable() {
 
   const headers = useMemo(() => {
     if (!headersRaw) return;
-    return headersRaw.filter((header) => header.label && isValidRoutingFormFieldType(header.type));
+    return headersRaw.filter((header) => {
+      if (!header.label || !isValidRoutingFormFieldType(header.type)) {
+        return false;
+      }
+      if (
+        (header.type === RoutingFormFieldType.SINGLE_SELECT ||
+          header.type === RoutingFormFieldType.MULTI_SELECT) &&
+        (!header.options || header.options.length === 0)
+      ) {
+        return false;
+      }
+      return true;
+    });
   }, [headersRaw]);
 
   const { data: forms } = trpc.viewer.insights.getRoutingFormsForFilters.useQuery({

--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -29,7 +29,7 @@ import classNames from "@calcom/lib/classNames";
 import { useCopy } from "@calcom/lib/hooks/useCopy";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { BookingStatus } from "@calcom/prisma/enums";
-import { RoutingFormFieldType, isValidRoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
+import { RoutingFormFieldType } from "@calcom/routing-forms/lib/FieldTypes";
 import { trpc, type RouterOutputs } from "@calcom/trpc";
 import {
   Badge,
@@ -258,7 +258,7 @@ export function RoutingFormResponsesTable() {
     useInsightsParameters();
 
   const {
-    data: headersRaw,
+    data: headers,
     isLoading: isHeadersLoading,
     isSuccess: isHeadersSuccess,
   } = trpc.viewer.insights.routingFormResponsesHeaders.useQuery({
@@ -267,36 +267,6 @@ export function RoutingFormResponsesTable() {
     isAll,
     routingFormId,
   });
-
-  const headers = useMemo(() => {
-    if (!headersRaw) return;
-    const filteredHeaders = headersRaw.filter((header) => {
-      if (!header.label || !isValidRoutingFormFieldType(header.type)) {
-        return false;
-      }
-      if (
-        (header.type === RoutingFormFieldType.SINGLE_SELECT ||
-          header.type === RoutingFormFieldType.MULTI_SELECT) &&
-        (!header.options || header.options.length === 0)
-      ) {
-        return false;
-      }
-      return true;
-    });
-    const ids = new Set<string>();
-    const uniqueHeaders = filteredHeaders.filter((header) => {
-      if (ids.has(header.id)) {
-        return false;
-      }
-      ids.add(header.id);
-      return true;
-    });
-    console.log("💡 test", {
-      h1: filteredHeaders.length,
-      h2: uniqueHeaders.length,
-    });
-    return uniqueHeaders;
-  }, [headersRaw]);
 
   const { data: forms } = trpc.viewer.insights.getRoutingFormsForFilters.useQuery({
     userId,


### PR DESCRIPTION
## What does this PR do?

This PR cleans up unnecessary fields columns on /insights/routing.

(follow-up of #19059)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Everything works the same on /insights/routing (but without unnecessary columns)