### PR TITLE
fix: empty state search messaging event page

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -457,9 +457,9 @@ export const InfiniteEventTypeList = ({
     if (isPending) return <InfiniteSkeletonLoader />;
 
     return group.teamId ? (
-      <EmptyEventTypeList group={group} />
+      <EmptyEventTypeList group={group} searchTerm={debouncedSearchTerm} />
     ) : !group.profile.eventTypesLockedByOrg ? (
-      <CreateFirstEventTypeView slug={group.profile.slug ?? ""} />
+      <CreateFirstEventTypeView slug={group.profile.slug ?? ""} searchTerm={debouncedSearchTerm} />
     ) : (
       <></>
     );
@@ -818,13 +818,13 @@ export const InfiniteEventTypeList = ({
   );
 };
 
-const CreateFirstEventTypeView = ({ slug }: { slug: string }) => {
+const CreateFirstEventTypeView = ({ slug, searchTerm }: { slug: string; searchTerm?: string }) => {
   const { t } = useLocale();
 
   return (
     <EmptyScreen
       Icon="link"
-      headline={t("new_event_type_heading")}
+      headline={searchTerm ? t("no_result_found_for", { searchTerm }) : t("new_event_type_heading")}
       description={t("new_event_type_description")}
       className="mb-16"
       buttonRaw={
@@ -863,12 +863,18 @@ const CTA = ({
   );
 };
 
-const EmptyEventTypeList = ({ group }: { group: EventTypeGroup | InfiniteEventTypeGroup }) => {
+const EmptyEventTypeList = ({
+  group,
+  searchTerm,
+}: {
+  group: EventTypeGroup | InfiniteEventTypeGroup;
+  searchTerm?: string;
+}) => {
   const { t } = useLocale();
   return (
     <>
       <EmptyScreen
-        headline={t("team_no_event_types")}
+        headline={searchTerm ? t("no_result_found_for", { searchTerm }) : t("team_no_event_types")}
         buttonRaw={
           <Button
             href={`?dialog=new&eventPage=${group.profile.slug}&teamId=${group.teamId}`}

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -108,6 +108,7 @@
   "accept_license": "Accept License",
   "still_waiting_for_approval": "An event is still waiting for approval",
   "event_is_still_waiting": "Event request is still waiting: {{attendeeName}} - {{date}} - {{eventType}}",
+  "no_result_found_for": "No result found for \"{{searchTerm}}\"",
   "no_more_results": "No more results",
   "no_results": "No results",
   "load_more_results": "Load more results",

--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -921,7 +921,7 @@ async function main() {
   await createUserAndEventType({
     user: {
       email: "admin@example.com",
-      /** To comply with admin password requirements  */
+      /** To comply with admin password requirements */
       password: "ADMINadmin2022!",
       username: "admin",
       name: "Admin Example",

--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -921,7 +921,7 @@ async function main() {
   await createUserAndEventType({
     user: {
       email: "admin@example.com",
-      /** To comply with admin password requirements */
+      /** To comply with admin password requirements  */
       password: "ADMINadmin2022!",
       username: "admin",
       name: "Admin Example",


### PR DESCRIPTION
## What does this PR do?

This update modifies the message displayed when no event type matches the user's search.
Currently, even if events are present, but the search term doesn't match any event title, the message _"Create your first event type"_ is shown. 
This behavior needs to be changed so that when there are events, but no matches for the search term, the message _"No result found for {searchTerm}"_ is displayed.  
This provides clearer feedback to users.

**Now :**

![Screenshot (25)](https://github.com/user-attachments/assets/47cb5070-fb5f-4217-9c44-9a93cea4905b)

**Proposed change :**

![Screenshot (26)](https://github.com/user-attachments/assets/5838dc17-da0c-44e4-80b3-9f8f61f70aae)

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Tested , everything works well.


