### PR TITLE
chore: run webhookTriggers cron job every minute

### DIFF
--- a/.github/workflows/cron-webhooks-triggers.yml
+++ b/.github/workflows/cron-webhooks-triggers.yml
@@ -4,8 +4,8 @@ on:
   # "Scheduled workflows run on the latest commit on the default or base branch."
   # — https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
   schedule:
-    # Runs “every 5 minutes” (see https://crontab.guru)
-    - cron: "*/5 * * * *"
+    # Runs “every minute” (see https://crontab.guru)
+    - cron: "* * * * *"
 jobs:
   cron-webhookTriggers:
     env:


### PR DESCRIPTION
## What does this PR do?

To make Meeting ended and Meeting started webhook more accurate we want to run the corn job every minute. We will eventually move this to the tasker