### PR TITLE
fix: do not force cancellation reason for platform

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -30,7 +30,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.93",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.94",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -184,7 +184,7 @@ async function handler(req: CustomRequest) {
     throw new HttpError({ statusCode: 400, message: "User not found" });
   }
 
-  if (!cancellationReason && req.bookingToDelete.userId == userId) {
+  if (!platformClientId && !cancellationReason && req.bookingToDelete.userId == userId) {
     throw new HttpError({
       statusCode: 400,
       message: "Cancellation reason is required when you are the host",


### PR DESCRIPTION
## What does this PR do?

do not enforce cancellation reason when canceling bookings via platform

platform customers should be able to control enforcing or not the cancellation reason, 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A -  I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

