### PR TITLE
fix: nullish check on insights routing

### DIFF
--- a/packages/features/insights/components/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/RoutingFormResponsesTable.tsx
@@ -418,7 +418,7 @@ export function RoutingFormResponsesTable() {
             filter: { type: filterType },
           },
           filterFn: (row, id, filterValue) => {
-            const cellValue = row.original.response[id].value;
+            const cellValue = row.original.response[id]?.value;
             return dataTableFilter(cellValue, filterValue);
           },
         });


### PR DESCRIPTION
## What does this PR do?

`response[id]` can be undefined.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
