### PR TITLE
fix: startdate filter and ui sync on bookings page

### DIFF
--- a/packages/features/bookings/components/FiltersContainer.tsx
+++ b/packages/features/bookings/components/FiltersContainer.tsx
@@ -19,7 +19,9 @@ export function FiltersContainer({ isFiltersVisible }: FiltersContainerProps) {
   const { removeAllQueryParams } = useFilterQuery();
   const { t } = useLocale();
   const searchParams = useSearchParams();
-  const hasQueryString = searchParams.toString().length > 0;
+
+  const validFilterKeys = ["userIds", "eventTypeIds", "upIds", "teamIds", "afterStartDate", "beforeEndDate"];
+  const hasValidQueryParams = Array.from(searchParams.keys()).some((key) => validFilterKeys.includes(key));
 
   return (
     <div ref={animationParentRef}>
@@ -30,7 +32,11 @@ export function FiltersContainer({ isFiltersVisible }: FiltersContainerProps) {
           <TeamsFilter />
           <StartTimeFilters />
           <Tooltip content={t("remove_filters")}>
-            <Button disabled={!hasQueryString} color="secondary" type="button" onClick={removeAllQueryParams}>
+            <Button
+              disabled={!hasValidQueryParams}
+              color="secondary"
+              type="button"
+              onClick={removeAllQueryParams}>
               {t("remove_filters")}
             </Button>
           </Tooltip>

--- a/packages/features/bookings/components/FiltersContainer.tsx
+++ b/packages/features/bookings/components/FiltersContainer.tsx
@@ -1,4 +1,5 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { useSearchParams } from "next/navigation";
 
 import { PeopleFilter } from "@calcom/features/bookings/components/PeopleFilter";
 import { useFilterQuery } from "@calcom/features/bookings/lib/useFilterQuery";
@@ -17,6 +18,8 @@ export function FiltersContainer({ isFiltersVisible }: FiltersContainerProps) {
   const [animationParentRef] = useAutoAnimate<HTMLDivElement>();
   const { removeAllQueryParams } = useFilterQuery();
   const { t } = useLocale();
+  const searchParams = useSearchParams();
+  const hasQueryString = searchParams.toString().length > 0;
 
   return (
     <div ref={animationParentRef}>
@@ -27,12 +30,7 @@ export function FiltersContainer({ isFiltersVisible }: FiltersContainerProps) {
           <TeamsFilter />
           <StartTimeFilters />
           <Tooltip content={t("remove_filters")}>
-            <Button
-              color="secondary"
-              type="button"
-              onClick={() => {
-                removeAllQueryParams();
-              }}>
+            <Button disabled={!hasQueryString} color="secondary" type="button" onClick={removeAllQueryParams}>
               {t("remove_filters")}
             </Button>
           </Tooltip>

--- a/packages/features/filters/components/StartTimeFilters.tsx
+++ b/packages/features/filters/components/StartTimeFilters.tsx
@@ -62,21 +62,19 @@ export const StartTimeFilters = () => {
   }, [query]);
 
   return (
-    <div>
-      <DateRangePicker
-        minDate={null}
-        dates={{ startDate: startValue, endDate: endValue }}
-        onDatesChange={(values) => {
-          const newAfterStartDate = values.startDate ? dayjs(values.startDate) : undefined;
-          const newBeforeEndDate = values.endDate ? dayjs(values.endDate) : undefined;
-          setAfterStartDate(newAfterStartDate);
-          setBeforeEndDate(newBeforeEndDate);
+    <DateRangePicker
+      minDate={null}
+      dates={{ startDate: startValue, endDate: endValue }}
+      onDatesChange={(values) => {
+        const newAfterStartDate = values.startDate ? dayjs(values.startDate) : undefined;
+        const newBeforeEndDate = values.endDate ? dayjs(values.endDate) : undefined;
+        setAfterStartDate(newAfterStartDate);
+        setBeforeEndDate(newBeforeEndDate);
 
-          if (newAfterStartDate && newBeforeEndDate) {
-            updateUrlParams(newAfterStartDate, newBeforeEndDate);
-          }
-        }}
-      />
-    </div>
+        if (newAfterStartDate && newBeforeEndDate) {
+          updateUrlParams(newAfterStartDate, newBeforeEndDate);
+        }
+      }}
+    />
   );
 };

--- a/packages/features/filters/components/StartTimeFilters.tsx
+++ b/packages/features/filters/components/StartTimeFilters.tsx
@@ -50,14 +50,15 @@ export const StartTimeFilters = () => {
       setAfterStartDate(getQueryDate("afterStartDate"));
       setBeforeEndDate(getQueryDate("beforeEndDate"));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
   useEffect(() => {
-    //when clear filter is clicked
-    if (Object.keys(query).length === 1 && afterStartDate && beforeEndDate) {
+    if (Object.keys(query).length === 1 && "status" in query && afterStartDate && beforeEndDate) {
       setAfterStartDate(undefined);
       setBeforeEndDate(undefined);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
   return (


### PR DESCRIPTION
## What does this PR do?

This PR fixes 3 issues with the filters functionality on the _/bookings_ page :

1. **Disabled "Clear All Filters" Button:** The button is now disabled when no filters are selected to prevent unnecessary re-renders and improve performance.

2. **Fixed UI Issue in StartDateFilter:** The date range no longer displays in the StartDateFilter after clearing filters, ensuring the UI matches the current state.

3. **Synced StartDateFilter with URL on Reload:** The StartDateFilter now correctly reflects the date range from the URL when the page is reloaded.

**Now :**
https://www.loom.com/share/8cd9343fc5e44c35a64d217a5a162402?sid=4c072096-61b6-43f7-98a1-bb09fcbb0418
https://www.loom.com/share/ad0fe4992d5348c8ba4d287c8144695d?sid=0057389d-501c-4bd2-b3cb-67b60ce5f7a2

**Proposed Changes :**
https://www.loom.com/share/c04bb0b1282644aeb61a49dad0816029?sid=272f1158-25f9-4c13-b56c-c8182f19a218

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Tested , works fine 🚀
