### PR TITLE
chore: Trigger Docker release on publish

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -4,6 +4,7 @@ on: # yamllint disable-line rule:truthy
   release:
     types:
       - created
+      - published
   # in case manual trigger is needed
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What does this PR do?

Our new release process wasn't trigger this anymore since we draft and then publish releases.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A -  I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Use our new release process and ensure this workflow is triggered
