### PR TITLE
perf: make metadata generation light for event type single page

### DIFF
--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
@@ -2,19 +2,43 @@ import { withAppDirSsr } from "app/WithAppDirSsr";
 import type { PageProps as _PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
+import { z } from "zod";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { EventTypeRepository } from "@calcom/lib/server/repository/eventType";
+
+import { buildLegacyCtx, buildLegacyRequest } from "@lib/buildLegacyCtx";
 import type { PageProps as EventTypePageProps } from "@lib/event-types/[type]/getServerSideProps";
 import { getServerSideProps } from "@lib/event-types/[type]/getServerSideProps";
 
 import EventTypePageWrapper from "~/event-types/views/event-types-single-view";
 
-export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
-  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
-  const { eventType } = await getData(legacyCtx);
+const querySchema = z.object({
+  type: z
+    .string()
+    .refine((val) => !isNaN(Number(val)), {
+      message: "event-type id must be a string that can be cast to a number",
+    })
+    .transform((val) => Number(val)),
+});
+
+export const generateMetadata = async ({ params }: _PageProps) => {
+  const session = await getServerSession({ req: buildLegacyRequest(headers(), cookies()) });
+  const parsed = querySchema.safeParse(params);
+  if (!parsed.success || !session?.user?.id) {
+    return await _generateMetadata(
+      (t) => `${t("event_type")}`,
+      () => ""
+    );
+  }
+
+  const data = await EventTypeRepository.findTitleById({
+    id: parsed.data.type,
+    userId: session?.user?.id,
+  });
 
   return await _generateMetadata(
-    (t) => `${eventType.title} | ${t("event_type")}`,
+    (t) => (data?.title ? `${data.title} | ${t("event_type")}` : `${t("event_type")}`),
     () => ""
   );
 };

--- a/packages/lib/server/repository/eventType.ts
+++ b/packages/lib/server/repository/eventType.ts
@@ -441,6 +441,44 @@ export class EventTypeRepository {
     });
   }
 
+  static async findTitleById({ id, userId }: { id: number; userId: number }) {
+    return await prisma.eventType.findFirst({
+      where: {
+        AND: [
+          {
+            OR: [
+              {
+                users: {
+                  some: {
+                    id: userId,
+                  },
+                },
+              },
+              {
+                team: {
+                  members: {
+                    some: {
+                      userId: userId,
+                    },
+                  },
+                },
+              },
+              {
+                userId: userId,
+              },
+            ],
+          },
+          {
+            id,
+          },
+        ],
+      },
+      select: {
+        title: true,
+      },
+    });
+  }
+
   static async findById({ id, userId }: { id: number; userId: number }) {
     const userSelect = Prisma.validator<Prisma.UserSelect>()({
       name: true,


### PR DESCRIPTION
## What does this PR do?

- Making the metadata generation for /event-type/[type] page lighter by only fetching the title (which is only needed)


### Tested
<img width="459" alt="Screenshot 2025-02-06 at 4 54 07 PM" src="https://github.com/user-attachments/assets/a4f16a6f-1112-4748-ab88-d86e9249e91b" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Visit any `/event-types/[type]` page and check the metadata