### PR TITLE
fix: typos in docs/

### DIFF
--- a/docs/api-reference/v1/openapi-v1.json
+++ b/docs/api-reference/v1/openapi-v1.json
@@ -3208,7 +3208,7 @@
         "tags": ["Memberships"],
         "responses": {
           "201": {
-            "description": "OK, membership removed successfuly"
+            "description": "OK, membership removed successfully"
           },
           "400": {
             "description": "Bad request. Membership id is invalid."
@@ -4538,7 +4538,7 @@
         "tags": ["Users"],
         "responses": {
           "201": {
-            "description": "OK, user removed successfuly"
+            "description": "OK, user removed successfully"
           },
           "400": {
             "description": "Bad request. User id is invalid."

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -7307,7 +7307,7 @@
           },
           "disableOnPrefill": {
             "type": "boolean",
-            "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if the slug is `language` and options of this select field are ['english', 'italian'] and the URL contains query parameter `&language=italian`,      the 'italian' radio buttom will be selected and the select field will be disabled."
+            "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if the slug is `language` and options of this select field are ['english', 'italian'] and the URL contains query parameter `&language=italian`,      the 'italian' radio button will be selected and the select field will be disabled."
           },
           "hidden": {
             "type": "boolean",
@@ -7915,7 +7915,7 @@
           },
           "beforeEventBuffer": {
             "type": "number",
-            "description": "Time spaces that can be pre-pended before an event to give more time before it."
+            "description": "Time spaces that can be prepended before an event to give more time before it."
           },
           "afterEventBuffer": {
             "type": "number",
@@ -8966,7 +8966,7 @@
           },
           "disableOnPrefill": {
             "type": "boolean",
-            "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if the slug is `language` and options of this select field are ['english', 'italian'] and the URL contains query parameter `&language=italian`,      the 'italian' radio buttom will be selected and the select field will be disabled."
+            "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if the slug is `language` and options of this select field are ['english', 'italian'] and the URL contains query parameter `&language=italian`,      the 'italian' radio button will be selected and the select field will be disabled."
           },
           "hidden": {
             "type": "boolean",
@@ -9607,7 +9607,7 @@
           },
           "beforeEventBuffer": {
             "type": "number",
-            "description": "Time spaces that can be pre-pended before an event to give more time before it."
+            "description": "Time spaces that can be prepended before an event to give more time before it."
           },
           "afterEventBuffer": {
             "type": "number",
@@ -10962,7 +10962,7 @@
           },
           "beforeEventBuffer": {
             "type": "number",
-            "description": "Time spaces that can be pre-pended before an event to give more time before it."
+            "description": "Time spaces that can be prepended before an event to give more time before it."
           },
           "afterEventBuffer": {
             "type": "number",
@@ -11733,7 +11733,7 @@
           },
           "beforeEventBuffer": {
             "type": "number",
-            "description": "Time spaces that can be pre-pended before an event to give more time before it."
+            "description": "Time spaces that can be prepended before an event to give more time before it."
           },
           "afterEventBuffer": {
             "type": "number",
@@ -15259,7 +15259,7 @@
           "externalId": {
             "type": "string",
             "example": "https://caldav.icloud.com/26962146906/calendars/1644422A-1945-4438-BBC0-4F0Q23A57R7S/",
-            "description": "Unique identifier used to represent the specfic calendar, as returned by the /calendars endpoint"
+            "description": "Unique identifier used to represent the specific calendar, as returned by the /calendars endpoint"
           }
         },
         "required": ["integration", "externalId"]

--- a/docs/developing/open-source-contribution/introduction.mdx
+++ b/docs/developing/open-source-contribution/introduction.mdx
@@ -13,7 +13,7 @@ Contributions are what make the open source community such an amazing place to l
 | :-------------------------------------------------------------- | :-------------------------------------------------- |
 | Minor improvements, non-core feature requests                   | <img className="m-0" noZoom src="/images/low-priority.svg" />    |
 | Confusing UX (... but working)                                  | <img className="m-0" noZoom src="/images/medium-priority.svg" /> |
-| Core Features (Booking page, availabilty, timezone calculation) | <img className="m-0" noZoom src="/images/high-priority.svg" />   |
+| Core Features (Booking page, availability, timezone calculation)| <img className="m-0" noZoom src="/images/high-priority.svg" />   |
 | Core Bugs (Login, Booking page, Emails are not working)         | <img className="m-0" noZoom src="/images/urgent-priority.svg" /> |
 
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -43,7 +43,7 @@ If you would like to get right into exploring our core features which are availa
 
 ## Enterprise Features
 
-Cal.com offers a variety of premium features which can be accessed through aquiring the enterprise license. To get an idea of what you get in return for the enterprise license, you can head to our Enterprise Features section:
+Cal.com offers a variety of premium features which can be accessed through acquiring the enterprise license. To get an idea of what you get in return for the enterprise license, you can head to our Enterprise Features section:
 
     <div className="flex">
       <Button size="smb" variant="pill" href="/docs/enterprise-features/teams">

--- a/docs/platform/atoms/apple-calendar-connect.mdx
+++ b/docs/platform/atoms/apple-calendar-connect.mdx
@@ -78,7 +78,7 @@ We offer all kinds of customizations to the Outlook calendar connect via props. 
 | loadingLabel          | No       | Label to display when atom is in loading state                           |
 | onCheckError          | No       | A callback function to handle errors when checking the connection status |
 | initialData           | No       | Initial data to be passed                                                |
-| isMultiCalendar       | No       | Specfies if the button supports integration for multiple users           |
+| isMultiCalendar       | No       | Specifies if the button supports integration for multiple users          |
 | tooltip               | No       | In case user wants to pass external tooltip component                    |
 | tooltipSide           | No       | Specifies what direction the tooltip appears                             |
 | isClickable           | No       | Boolean to disable button or not                                         |

--- a/docs/platform/atoms/event-type.mdx
+++ b/docs/platform/atoms/event-type.mdx
@@ -240,7 +240,7 @@ Below video shows a demonstration of the all the options you get in the advanced
 
 **6. Recurring**
 
-The recurring tab lets you set up a recurring event. You can set up recurring events such as weekly, monthly, yearly, etc for a maximun of events you want it to repeat.
+The recurring tab lets you set up a recurring event. You can set up recurring events such as weekly, monthly, yearly, etc for a maximum of events you want it to repeat.
 
 <img src="/images/Recurring.png" alt="Recurring tab" />
 

--- a/docs/platform/atoms/google-calendar-connect.mdx
+++ b/docs/platform/atoms/google-calendar-connect.mdx
@@ -77,7 +77,7 @@ We offer all kinds of customizations to the Google calendar connect via props. B
 | onCheckError          | No       | A callback function to handle errors when checking the connection status                  |
 | redir                 | No       | A custom redirect URL link where the user gets redirected after successful authentication |
 | initialData           | No       | Initial data to be passed                                                                 |
-| isMultiCalendar       | No       | Specfies if the button supports integration for multiple users                            |
+| isMultiCalendar       | No       | Specifies if the button supports integration for multiple users                           |
 | tooltip               | No       | In case user wants to pass external tooltip component                                     |
 | tooltipSide           | No       | Specifies what direction the tooltip appears                                              |
 | isClickable           | No       | Boolean to disable button or not                                                          |

--- a/docs/platform/atoms/outlook-calendar-connect.mdx
+++ b/docs/platform/atoms/outlook-calendar-connect.mdx
@@ -76,7 +76,7 @@ We offer all kinds of customizations to the Outlook calendar connect via props. 
 | onCheckError       | No       | A callback function to handle errors when checking the connection status                                  |
 | redir              | No       | A custom redirect URL link where the user gets redirected after successful authentication                 |
 | initialData        | No       | Initial data to be passed                                                                                 |
-| isMultiCalendar    | No       | Specfies if the button supports integration for multiple users                                            |
+| isMultiCalendar    | No       | Specifies if the button supports integration for multiple users                                           |
 | tooltip            | No       | In case user wants to pass external tooltip component                                                     |
 | tooltipSide        | No       | Specifies what direction the tooltip appears                                                              |
 | isClickable        | No       | Boolean to disable button or not                                                                          |

--- a/docs/platform/atoms/payment-form.mdx
+++ b/docs/platform/atoms/payment-form.mdx
@@ -69,7 +69,7 @@ export default function EventType(id: number) {
 With this you're all set to accept payments for your bookings.
     </Step>
     <Step title="Use booker atom to access payment uid">
-      The booker atom has a prop called `onCreateBookingSuccess` which is a callback function that gets called at the time of a successful booking creation. This function takes a parameter called `data` which contains the payment uid and another property called paymentRequired which can be used to detect if the booking requres payment or not. You can use the payment uid to access the payment form atom. 
+      The booker atom has a prop called `onCreateBookingSuccess` which is a callback function that gets called at the time of a successful booking creation. This function takes a parameter called `data` which contains the payment uid and another property called paymentRequired which can be used to detect if the booking requires payment or not. You can use the payment uid to access the payment form atom. 
       
       Either store the payment uid in your database, a local state variable or pass it into another page as query parameters.
 

--- a/docs/platform/faq.mdx
+++ b/docs/platform/faq.mdx
@@ -27,7 +27,7 @@ description: Answers to the most common questions about the Platform API and ato
 - An atom is a customizable UI component that handles scheduling on behalf of your user.
 - Everything from the front-end to API calls is being handled by the atom, all you need to is import the atom and drop it in your code.
 
-### 6. What are the minimun setup requirments for using atoms?
+### 6. What are the minimum setup requirements for using atoms?
 - You need to have a project that uses React version 18 and above.
 - At the moment atoms are only supported in React, so there's no way to use them in vanilla js or any other popular framework.
 
@@ -40,7 +40,7 @@ description: Answers to the most common questions about the Platform API and ato
  <html dir="ltr"> ... </html>
  ```
 
-### 9. What are the authentification methods for making calls to the v2 API?
+### 9. What are the authentication methods for making calls to the v2 API?
 Either of the two:
 - Setting `Authorization: Bearer <token>` header where `<token>` is access token of the managed user.
 - Setting `x-cal-client-id: <client-id>` and `x-cal-secret-key: <client-secret>` where `<client-id>` is OAuth client id and `<client-secret>` is OAuth client secret. Both can be copied from the dashboard.

--- a/docs/self-hosting/database-migrations.mdx
+++ b/docs/self-hosting/database-migrations.mdx
@@ -13,7 +13,7 @@ yarn workspace @calcom/prisma db-deploy
 ``` 
 command to update the database.
 
-We use database migrations in order to handle changes to the database schema in a more secure and stable way. This is actually very common. The thing is that when just changing the schema in `schema.prisma` without creating migrations, the update to the newer database schema can damage or delete all data in production mode, since the system sometimes doesn't know how to transform the data from A to B. Using migrations, each step is reproducable, transparent and can be undone in a simple way.
+We use database migrations in order to handle changes to the database schema in a more secure and stable way. This is actually very common. The thing is that when just changing the schema in `schema.prisma` without creating migrations, the update to the newer database schema can damage or delete all data in production mode, since the system sometimes doesn't know how to transform the data from A to B. Using migrations, each step is reproducible, transparent and can be undone in a simple way.
 
 ### Creating migrations
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.svg,./apps/web/public/static/locales" -L afterall,datea,fo,ist,optionel`

## What does this PR do?

Fixes some user and developer facing typos. It also does touch some API code but strictly harmless typo fixes.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

n/a

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't checked if my changes generate no new warnings
