### PR TITLE
chore: tech debt clearing — remove BookerSeo from user type booking pages

### DIFF
--- a/apps/web/modules/users/views/users-type-public-view.tsx
+++ b/apps/web/modules/users/views/users-type-public-view.tsx
@@ -5,7 +5,6 @@ import { useSearchParams } from "next/navigation";
 
 import { Booker } from "@calcom/atoms/monorepo";
 import { getBookerWrapperClasses } from "@calcom/features/bookings/Booker/utils/getBookerWrapperClasses";
-import { BookerSeo } from "@calcom/features/bookings/components/BookerSeo";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
 
@@ -23,40 +22,11 @@ export const getMultipleDurationValue = (
   return defaultValue;
 };
 
-function Type({
-  slug,
-  user,
-  isEmbed,
-  booking,
-  isBrandingHidden,
-  isSEOIndexable,
-  rescheduleUid,
-  eventData,
-  orgBannerUrl,
-}: PageProps) {
+function Type({ slug, user, isEmbed, booking, isBrandingHidden, eventData, orgBannerUrl }: PageProps) {
   const searchParams = useSearchParams();
-  const { profile, users, hidden, title } = eventData;
+
   return (
     <main className={getBookerWrapperClasses({ isEmbed: !!isEmbed })}>
-      <BookerSeo
-        username={user}
-        eventSlug={slug}
-        rescheduleUid={rescheduleUid ?? undefined}
-        hideBranding={isBrandingHidden}
-        isSEOIndexable={isSEOIndexable ?? true}
-        eventData={
-          profile && users && title && hidden !== undefined
-            ? {
-                profile,
-                users,
-                title,
-                hidden,
-              }
-            : undefined
-        }
-        entity={eventData.entity}
-        bookingData={booking}
-      />
       <Booker
         username={user}
         eventSlug={slug}


### PR DESCRIPTION
## What does this PR do?

- BookerSeo component is not needed in user type booking client component because user type booking pages are in App Router and hence metadata is handled by App Router natively.
- There are some embeds still in Pages Router that use this client component, but embeds do not need SEO, so this is ok

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Go to a user type booking page and check `header` element to see metadata.