### PR TITLE
perf: remove WithLayout HOC from private booking page and booking embed

### DIFF
--- a/apps/web/app/(use-page-wrapper)/booking/[uid]/embed/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/booking/[uid]/embed/page.tsx
@@ -1,0 +1,21 @@
+import withEmbedSsrAppDir from "app/WithEmbedSSR";
+import type { PageProps as ServerPageProps } from "app/_types";
+import { cookies, headers } from "next/headers";
+
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+
+import OldPage from "~/bookings/views/bookings-single-view";
+import {
+  getServerSideProps,
+  type PageProps as ClientPageProps,
+} from "~/bookings/views/bookings-single-view.getServerSideProps";
+
+const getEmbedData = withEmbedSsrAppDir<ClientPageProps>(getServerSideProps);
+
+const ServerPage = async ({ params, searchParams }: ServerPageProps) => {
+  const context = buildLegacyCtx(headers(), cookies(), params, searchParams);
+  const props = await getEmbedData(context);
+  return <OldPage {...props} />;
+};
+
+export default ServerPage;

--- a/apps/web/app/(use-page-wrapper)/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/d/[link]/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { withAppDirSsr } from "app/WithAppDirSsr";
 import type { PageProps as _PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { WithLayout } from "app/layoutHOC";
 import { cookies, headers } from "next/headers";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
@@ -27,4 +26,11 @@ export const generateMetadata = async ({ params, searchParams }: _PageProps) => 
 };
 
 const getData = withAppDirSsr<PageProps>(getServerSideProps);
-export default WithLayout({ getLayout: null, Page: Type, getData })<"P">;
+const ServerPage = async ({ params, searchParams }: _PageProps) => {
+  const legacyCtx = buildLegacyCtx(headers(), cookies(), params, searchParams);
+  const pageProps = await getData(legacyCtx);
+
+  return <Type {...pageProps} />;
+};
+
+export default ServerPage;

--- a/apps/web/app/booking/[uid]/embed/page.tsx
+++ b/apps/web/app/booking/[uid]/embed/page.tsx
@@ -1,9 +1,0 @@
-import withEmbedSsrAppDir from "app/WithEmbedSSR";
-import { WithLayout } from "app/layoutHOC";
-
-import OldPage from "~/bookings/views/bookings-single-view";
-import { getServerSideProps, type PageProps } from "~/bookings/views/bookings-single-view.getServerSideProps";
-
-const getEmbedData = withEmbedSsrAppDir<PageProps>(getServerSideProps);
-
-export default WithLayout({ getLayout: null, getData: getEmbedData, Page: OldPage });

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -4,7 +4,9 @@ import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 
 export default function useIsBookingPage(): boolean {
   const pathname = usePathname();
-  const isBookingPage = ["/booking/", "/cancel", "/reschedule"].some((route) => pathname?.startsWith(route));
+  const isBookingPage = ["/booking", "/cancel", "/reschedule", "/d"].some((route) =>
+    pathname?.startsWith(route)
+  );
 
   const searchParams = useCompatSearchParams();
   const userParam = Boolean(searchParams?.get("user"));

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -1133,8 +1133,6 @@ const DisplayLocation = ({
     <p className={className}>{locationToDisplay}</p>
   );
 
-Success.isBookingPage = true;
-
 type RecurringBookingsProps = {
   eventType: PageProps["eventType"];
   recurringBookings: PageProps["recurringBookings"];

--- a/apps/web/modules/d/[link]/d-type-view.tsx
+++ b/apps/web/modules/d/[link]/d-type-view.tsx
@@ -33,5 +33,3 @@ export default function Type({
     </main>
   );
 }
-
-Type.isBookingPage = true;


### PR DESCRIPTION
## What does this PR do?

- Remove WithLayout HOC from private booking page and booking embed and move then inside `(use-page-wrapper)` route group. `(use-page-wrapper)/layout.tsx` file serves the same purpose as `WithLayout` HOC

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Test private booking page and booking embed