### PR TITLE
fix: Disable round robin reassignment if reroute is available

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -444,6 +444,7 @@ function BookingListItem(booking: BookingItemProps) {
           setIsOpenDialog={setIsOpenReassignDialog}
           bookingId={booking.id}
           teamId={booking.eventType?.team?.id || 0}
+          bookingFromRoutingForm={isBookingReroutable(parsedBooking)}
         />
       )}
       <EditLocationDialog

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -145,6 +145,7 @@ function BookingListItem(booking: BookingItemProps) {
   const isRecurring = booking.recurringEventId !== null;
   const isTabRecurring = booking.listingStatus === "recurring";
   const isTabUnconfirmed = booking.listingStatus === "unconfirmed";
+  const isBookingFromRoutingForm = isBookingReroutable(parsedBooking);
 
   const paymentAppData = getPaymentAppData(booking.eventType);
 
@@ -237,7 +238,7 @@ function BookingListItem(booking: BookingItemProps) {
             },
           },
         ]),
-    ...(isBookingReroutable(parsedBooking)
+    ...(isBookingFromRoutingForm
       ? [
           {
             id: "reroute",
@@ -444,7 +445,7 @@ function BookingListItem(booking: BookingItemProps) {
           setIsOpenDialog={setIsOpenReassignDialog}
           bookingId={booking.id}
           teamId={booking.eventType?.team?.id || 0}
-          bookingFromRoutingForm={isBookingReroutable(parsedBooking)}
+          bookingFromRoutingForm={isBookingFromRoutingForm}
         />
       )}
       <EditLocationDialog
@@ -692,7 +693,7 @@ function BookingListItem(booking: BookingItemProps) {
         />
       </div>
 
-      {isBookingReroutable(parsedBooking) && (
+      {isBookingFromRoutingForm && (
         <RerouteDialog
           isOpenDialog={rerouteDialogIsOpen}
           setIsOpenDialog={setRerouteDialogIsOpen}

--- a/apps/web/components/dialog/ReassignDialog.tsx
+++ b/apps/web/components/dialog/ReassignDialog.tsx
@@ -32,6 +32,7 @@ type ReassignDialog = {
   setIsOpenDialog: Dispatch<SetStateAction<boolean>>;
   teamId: number;
   bookingId: number;
+  bookingFromRoutingForm: boolean;
 };
 
 type FormValues = {
@@ -57,7 +58,13 @@ interface TeamMemberOption {
   status: string;
 }
 
-export const ReassignDialog = ({ isOpenDialog, setIsOpenDialog, teamId, bookingId }: ReassignDialog) => {
+export const ReassignDialog = ({
+  isOpenDialog,
+  setIsOpenDialog,
+  teamId,
+  bookingId,
+  bookingFromRoutingForm,
+}: ReassignDialog) => {
   const { t } = useLocale();
   const utils = trpc.useUtils();
   const [animationParentRef] = useAutoAnimate<HTMLFormElement>({
@@ -101,7 +108,7 @@ export const ReassignDialog = ({ isOpenDialog, setIsOpenDialog, teamId, bookingI
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      reassignType: "round_robin",
+      reassignType: bookingFromRoutingForm ? "team_member" : "round_robin",
     },
   });
 
@@ -178,14 +185,18 @@ export const ReassignDialog = ({ isOpenDialog, setIsOpenDialog, teamId, bookingI
               onValueChange={(val) => {
                 form.setValue("reassignType", val as "team_member" | "round_robin");
               }}
+              defaultValue={bookingFromRoutingForm ? "team_member" : "round_robin"}
               className="mt-1 flex flex-col gap-4">
-              <RadioArea.Item
-                value="round_robin"
-                className="w-full text-sm"
-                classNames={{ container: "w-full" }}>
-                <strong className="mb-1 block">{t("round_robin")}</strong>
-                <p>{t("round_robin_reassign_description")}</p>
-              </RadioArea.Item>
+              {!bookingFromRoutingForm ? (
+                <RadioArea.Item
+                  value="round_robin"
+                  className="w-full text-sm"
+                  classNames={{ container: "w-full" }}
+                  disabled={bookingFromRoutingForm}>
+                  <strong className="mb-1 block">{t("round_robin")}</strong>
+                  <p>{t("round_robin_reassign_description")}</p>
+                </RadioArea.Item>
+              ) : null}
               <RadioArea.Item value="team_member" className="text-sm" classNames={{ container: "w-full" }}>
                 <strong className="mb-1 block">{t("team_member_round_robin_reassign")}</strong>
                 <p>{t("team_member_round_robin_reassign_description")}</p>

--- a/apps/web/components/dialog/ReassignDialog.tsx
+++ b/apps/web/components/dialog/ReassignDialog.tsx
@@ -27,6 +27,11 @@ import {
   TextAreaField,
 } from "@calcom/ui";
 
+enum ReassignType {
+  ROUND_ROBIN = "round_robin",
+  TEAM_MEMBER = "team_member",
+}
+
 type ReassignDialog = {
   isOpenDialog: boolean;
   setIsOpenDialog: Dispatch<SetStateAction<boolean>>;
@@ -36,13 +41,13 @@ type ReassignDialog = {
 };
 
 type FormValues = {
-  reassignType: "round_robin" | "team_member";
+  reassignType: ReassignType.ROUND_ROBIN | ReassignType.TEAM_MEMBER;
   teamMemberId?: number;
   reassignReason?: string;
 };
 
 const formSchema = z.object({
-  reassignType: z.enum(["round_robin", "team_member"]),
+  reassignType: z.nativeEnum(ReassignType),
   teamMemberId: z.number().optional(),
   reassignReason: z
     .string()
@@ -108,7 +113,7 @@ export const ReassignDialog = ({
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      reassignType: bookingFromRoutingForm ? "team_member" : "round_robin",
+      reassignType: bookingFromRoutingForm ? ReassignType.TEAM_MEMBER : ReassignType.ROUND_ROBIN,
     },
   });
 
@@ -151,7 +156,7 @@ export const ReassignDialog = ({
   });
 
   const handleSubmit = (values: FormValues) => {
-    if (values.reassignType === "round_robin") {
+    if (values.reassignType === ReassignType.ROUND_ROBIN) {
       roundRobinReassignMutation.mutate({ teamId, bookingId });
     } else {
       if (values.teamMemberId) {
@@ -183,13 +188,13 @@ export const ReassignDialog = ({
           <Form form={form} handleSubmit={handleSubmit} ref={animationParentRef}>
             <RadioArea.Group
               onValueChange={(val) => {
-                form.setValue("reassignType", val as "team_member" | "round_robin");
+                form.setValue("reassignType", val as ReasonEnum);
               }}
-              defaultValue={bookingFromRoutingForm ? "team_member" : "round_robin"}
+              defaultValue={bookingFromRoutingForm ? ReassignType.TEAM_MEMBER : ReassignType.ROUND_ROBIN}
               className="mt-1 flex flex-col gap-4">
               {!bookingFromRoutingForm ? (
                 <RadioArea.Item
-                  value="round_robin"
+                  value={ReassignType.ROUND_ROBIN}
                   className="w-full text-sm"
                   classNames={{ container: "w-full" }}
                   disabled={bookingFromRoutingForm}>
@@ -197,13 +202,16 @@ export const ReassignDialog = ({
                   <p>{t("round_robin_reassign_description")}</p>
                 </RadioArea.Item>
               ) : null}
-              <RadioArea.Item value="team_member" className="text-sm" classNames={{ container: "w-full" }}>
+              <RadioArea.Item
+                value={ReassignType.TEAM_MEMBER}
+                className="text-sm"
+                classNames={{ container: "w-full" }}>
                 <strong className="mb-1 block">{t("team_member_round_robin_reassign")}</strong>
                 <p>{t("team_member_round_robin_reassign_description")}</p>
               </RadioArea.Item>
             </RadioArea.Group>
 
-            {watchedReassignType === "team_member" && (
+            {watchedReassignType === ReassignType.TEAM_MEMBER && (
               <div className="mb-2">
                 <Label className="text-emphasis mt-6">{t("select_team_member")}</Label>
                 <div className="mt-2">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Disables the option to reassign a booking if the reroute option is available

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
https://www.loom.com/share/593b6a2539064b7a9283cecf96b0f145?sid=dc5234d5-2e9c-4443-aa5c-ed506a261595

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a round robin booking from a routing form
- Go to reassign the booking
	- The only option should be a manual reassignment
- Create a normal booking of the same event type
	- Both options should be available