### PR TITLE
fix: the word on confirm booking button in japanese

### DIFF
--- a/apps/web/public/static/locales/ja/common.json
+++ b/apps/web/public/static/locales/ja/common.json
@@ -709,7 +709,7 @@
   "apply": "適用",
   "cancel_event": "このイベントをキャンセル",
   "continue": "続行",
-  "confirm": "確認",
+  "confirm": "確定",
   "confirm_all": "すべて確認",
   "disband_team": "チームを解散する",
   "disband_team_confirmation_message": "このチームを解散しますか？ あなたがこのチームのリンクを共有した人は、それを使って予約することができなくなります。",


### PR DESCRIPTION
## What does this PR do?
This PR fixes the word on the confirm button in Japanese.

- Fixes #19116 (GitHub issue number)
- Fixes CAL-5130 (Linear issue number - should be visible at the bottom of the GitHub issue description)

![Screenshot 2025-02-11 081515](https://github.com/user-attachments/assets/9ced087b-95b0-4e77-8eeb-9dd4a96e583f)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Check the word on the confirm button in Japanese.

## Checklist

