### PR TITLE
fix: select "Your account" for members by default on insights

### DIFF
--- a/packages/features/insights/context/InsightsOrgTeamsProvider.tsx
+++ b/packages/features/insights/context/InsightsOrgTeamsProvider.tsx
@@ -3,6 +3,8 @@
 import { useSession } from "next-auth/react";
 import { createContext, useState } from "react";
 
+import { MembershipRole } from "@calcom/prisma/enums";
+
 import type { OrgTeamsType } from "../filters/OrgTeamsFilter";
 
 export type InsightsOrgTeamsContextType = {
@@ -17,7 +19,11 @@ export const InsightsOrgTeamsContext = createContext<InsightsOrgTeamsContextType
 export function InsightsOrgTeamsProvider({ children }: { children: React.ReactNode }) {
   const session = useSession();
   const currentOrgId = session.data?.user.org?.id;
-  const [orgTeamsType, setOrgTeamsType] = useState<OrgTeamsType>(currentOrgId ? "org" : "yours");
+  const orgRole = session?.data?.user?.org?.role;
+  const isAdminOrOwner = orgRole === MembershipRole.OWNER || orgRole === MembershipRole.ADMIN;
+  const [orgTeamsType, setOrgTeamsType] = useState<OrgTeamsType>(
+    isAdminOrOwner && currentOrgId ? "org" : "yours"
+  );
   const [selectedTeamId, setSelectedTeamId] = useState<number | undefined>();
 
   return (

--- a/packages/features/insights/filters/OrgTeamsFilter.tsx
+++ b/packages/features/insights/filters/OrgTeamsFilter.tsx
@@ -78,6 +78,10 @@ export const OrgTeamsFilter = () => {
       />
     ) : null;
 
+  const teams = (data || [])
+    .filter((team) => !team.isOrg)
+    .filter((team) => team.name?.toLowerCase().includes(query.toLowerCase()));
+
   return (
     <AnimatedPopover text={text} PrefixComponent={PrefixComponent} popoverTriggerClassNames="mb-0">
       <FilterCheckboxFieldsContainer>
@@ -126,35 +130,32 @@ export const OrgTeamsFilter = () => {
           label={t("yours")}
         />
 
-        <Divider />
-        {(data || [])
-          .filter((team) => !team.isOrg)
-          .filter((team) => team.name?.toLowerCase().includes(query.toLowerCase()))
-          .map((team) => {
-            return (
-              <FilterCheckboxField
-                testId="org-teams-filter-item"
-                key={team.id}
-                id={team.name || ""}
-                label={team.name || ""}
-                checked={selectedTeamId === team.id && orgTeamsType === "team"}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    onSelected({ type: "team", teamId: team.id });
-                  } else if (!e.target.checked) {
-                    resetSelection();
-                  }
-                }}
-                icon={
-                  <Avatar
-                    alt={team.name || ""}
-                    imageSrc={getPlaceholderAvatar(team.logoUrl, team.name)}
-                    size="xs"
-                  />
+        {teams.length > 0 && <Divider />}
+        {teams.map((team) => {
+          return (
+            <FilterCheckboxField
+              testId="org-teams-filter-item"
+              key={team.id}
+              id={team.name || ""}
+              label={team.name || ""}
+              checked={selectedTeamId === team.id && orgTeamsType === "team"}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  onSelected({ type: "team", teamId: team.id });
+                } else if (!e.target.checked) {
+                  resetSelection();
                 }
-              />
-            );
-          })}
+              }}
+              icon={
+                <Avatar
+                  alt={team.name || ""}
+                  imageSrc={getPlaceholderAvatar(team.logoUrl, team.name)}
+                  size="xs"
+                />
+              }
+            />
+          );
+        })}
       </FilterCheckboxFieldsContainer>
     </AnimatedPopover>
   );


### PR DESCRIPTION
## What does this PR do?

The new `OrgTeamsFilter` chose "All" wrongly when the user is a member. This PR fixes it.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to /insights or /insights/routing as a member. It should select "Your account" by default.