### PR TITLE
fix: indicate hidden columns on filter dropdown

### DIFF
--- a/packages/features/data-table/components/filters/AddFilterButton.tsx
+++ b/packages/features/data-table/components/filters/AddFilterButton.tsx
@@ -58,14 +58,16 @@ function AddFilterButtonComponent<TData>(
             <CommandList>
               <CommandEmpty>{t("no_columns_found")}</CommandEmpty>
               {filterableColumns.map((column) => {
+                const isVisible = table.getColumn(column.id).getIsVisible();
                 if (activeFilters?.some((filter) => filter.f === column.id)) return null;
                 return (
                   <CommandItem
                     key={column.id}
                     onSelect={() => handleAddFilter(column.id)}
-                    className="px-4 py-2"
+                    className="flex items-center justify-between px-4 py-2"
                     data-testid={`add-filter-item-${column.id}`}>
-                    {startCase(column.title)}
+                    <span>{startCase(column.title)}</span>
+                    {!isVisible && <Icon name="eye-off" className="h-4 w-4 opacity-50" />}
                   </CommandItem>
                 );
               })}

--- a/packages/features/data-table/components/filters/AddFilterButton.tsx
+++ b/packages/features/data-table/components/filters/AddFilterButton.tsx
@@ -58,7 +58,7 @@ function AddFilterButtonComponent<TData>(
             <CommandList>
               <CommandEmpty>{t("no_columns_found")}</CommandEmpty>
               {filterableColumns.map((column) => {
-                const isVisible = table.getColumn(column.id).getIsVisible();
+                const isVisible = table.getColumn(column.id)?.getIsVisible();
                 if (activeFilters?.some((filter) => filter.f === column.id)) return null;
                 return (
                   <CommandItem


### PR DESCRIPTION
## What does this PR do?

- Fixes CAL-5159

Even if you hide columns, you can still filter based on those columns. However, it'd be nicer to have an indicator that the column is currently hidden.

https://github.com/user-attachments/assets/3604d221-6d55-4606-8e86-15ca74408c43


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
