### PR TITLE
fix: timezone input text is now visible in dark mode

### DIFF
--- a/packages/ui/components/form/select/components.tsx
+++ b/packages/ui/components/form/select/components.tsx
@@ -19,7 +19,7 @@ export const InputComponent = <
     <reactSelectComponents.Input
       // disables our default form focus hightlight on the react-select input element
       inputClassName={classNames(
-        "focus:ring-0 focus:ring-offset-0 dark:!text-darkgray-900 !text-emphasis",
+        "focus:ring-0 focus:ring-offset-0 !text-default dark:!text-white",
         inputClassName
       )}
       {...props}


### PR DESCRIPTION
## What does this PR do?

Fixes this:

<img width="519" alt="image" src="https://github.com/user-attachments/assets/15e6b83b-d8f5-4da3-9e2e-61aee8d24867" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
