### PR TITLE
chore: figure out `isBookingPage` server-side, making it needless to pass props from client components

### DIFF
--- a/apps/web/app/(use-page-wrapper)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/layout.tsx
@@ -1,3 +1,4 @@
+import { checkIfBookingPage } from "app/_utils";
 import { cookies, headers } from "next/headers";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
@@ -9,11 +10,17 @@ import { ssrInit } from "@server/lib/ssr";
 export default async function PageWrapperLayout({ children }: { children: React.ReactNode }) {
   const h = headers();
   const nonce = h.get("x-nonce") ?? undefined;
+  const isBookingPage = checkIfBookingPage();
   const context = buildLegacyCtx(headers(), cookies(), {}, {});
   const ssr = await ssrInit(context);
 
   return (
-    <PageWrapper requiresLicense={false} nonce={nonce} themeBasis={null} dehydratedState={ssr.dehydrate()}>
+    <PageWrapper
+      isBookingPage={isBookingPage}
+      requiresLicense={false}
+      nonce={nonce}
+      themeBasis={null}
+      dehydratedState={ssr.dehydrate()}>
       {children}
     </PageWrapper>
   );

--- a/apps/web/app/_utils.tsx
+++ b/apps/web/app/_utils.tsx
@@ -146,7 +146,8 @@ export const generateAppMetadata = async (
 
 export function checkIfBookingPage(): boolean {
   const headersList = headers();
-  const matchedPath = headersList.get("x-matched-path"); // Exists only in Staging and Prod
+  // This special header exists only in Staging and Production
+  const matchedPath = headersList.get("x-matched-path");
 
   const routes = [
     "/booking",

--- a/apps/web/app/_utils.tsx
+++ b/apps/web/app/_utils.tsx
@@ -143,3 +143,26 @@ export const generateAppMetadata = async (
     },
   };
 };
+
+export function checkIfBookingPage(): boolean {
+  const headersList = headers();
+  const matchedPath = headersList.get("x-matched-path"); // Exists only in Staging and Prod
+
+  const routes = [
+    "/booking",
+    "/cancel",
+    "/reschedule",
+    "/d", // Private Link of booking page
+    "/apps/routing-forms/routing-link", // Routing Form page
+    "/forms/", // Rewrites to /apps/routing-forms/routing-link
+    "/team", // Team Booking Pages
+    "/[user]", // User Booking page,
+    "/[user]/[type]", // User Booking Type page,
+    "/org/[orgSlug]/team", // Org Team Booking page,
+    "/org/[orgSlug]/[user]", // Org User Booking page,
+    "/org/[orgSlug]/[user]/[type]", // Org User Booking Type page,
+    "/org/[orgSlug]/instant-meeting", // Org Instant Meeting page,
+  ];
+
+  return routes.some((route) => matchedPath?.startsWith(route));
+}

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -287,7 +287,7 @@ const AppProviders = (props: PageWrapperProps) => {
     RemainingProviders
   );
 
-  if (isBookingPage) {
+  if (props.isBookingPage || isBookingPage) {
     return Hydrated;
   }
 


### PR DESCRIPTION
## What does this PR do?

- Because booking pages are dynamic routes, e.g., `/[user]`, `/[user]/[type]`, we currently lack a way of knowing if the currently rendered page is a booking page. We can solve this by checking `x-matched-path` special header because it shows the naked urls like `/[user]` or `/[user]/[type]`.
- After we merge this, we can remove `Page.isBookingPage = true` from all client components

<img width="701" alt="Screenshot 2025-02-18 at 4 43 56 AM" src="https://github.com/user-attachments/assets/6e41ae9a-4112-4204-a59b-38884120b5b9" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- We can only test this in QA because `x-matched-path` header only exists in Staging / Prod environments. This PR doesn't include any deletion but only addition, so it's safe to merge.