### PR TITLE
chore: remove WithLayout from not-found route

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,5 +1,5 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
-import { WithLayout } from "app/layoutHOC";
+import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { headers } from "next/headers";
 import Link from "next/link";
 
@@ -9,6 +9,8 @@ import {
 } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { DOCS_URL, IS_CALCOM, WEBSITE_URL } from "@calcom/lib/constants";
 import { Icon } from "@calcom/ui";
+
+import PageWrapper from "@components/PageWrapperAppDir";
 
 enum PageType {
   ORG = "ORG",
@@ -46,11 +48,9 @@ function getPageInfo(pathname: string, host: string) {
   }
 }
 
-async function NotFound() {
-  const t = await getTranslate();
-  const headersList = headers();
-  const host = headersList.get("x-forwarded-host") ?? "";
-  const pathname = headersList.get("x-pathname") ?? "";
+function NotFound({ t, headers }: { t: any; headers: ReadonlyHeaders }) {
+  const host = headers.get("x-forwarded-host") ?? "";
+  const pathname = headers.get("x-pathname") ?? "";
 
   // This makes more sense after full migration to App Router
   // if (!pathname) {
@@ -241,6 +241,14 @@ export const generateMetadata = async () => {
   };
 };
 
-export default WithLayout({
-  ServerPage: NotFound,
-});
+const ServerPage = async () => {
+  const t = await getTranslate();
+  const h = headers();
+  const nonce = h.get("x-nonce") ?? undefined;
+  return (
+    <PageWrapper requiresLicense={false} nonce={nonce} themeBasis={null}>
+      <NotFound t={t} headers={h} />
+    </PageWrapper>
+  );
+};
+export default ServerPage;


### PR DESCRIPTION
## What does this PR do?

- Step towards removing usage of `WithLayout` and hence `layoutHOC.tsx`.

### Tested

<img width="1512" alt="Screenshot 2025-02-18 at 5 37 21 AM" src="https://github.com/user-attachments/assets/288080be-cd0f-408f-88ab-6ab1a709ba19" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Test not-found route by visiting invalid routes like http://localhost:3000/19314