### PR TITLE
fix: empty hosts array in filterHostsByLeadThreshold 

### DIFF
--- a/packages/lib/bookings/filterHostsByLeadThreshold.ts
+++ b/packages/lib/bookings/filterHostsByLeadThreshold.ts
@@ -103,7 +103,7 @@ export const filterHostsByLeadThreshold = async <T extends BaseHost<BaseUser>>({
   if (maxLeadThreshold === 0) {
     throw new Error(errorCodes.MAX_LEAD_THRESHOLD_FALSY);
   }
-  if (maxLeadThreshold === null) {
+  if (maxLeadThreshold === null || !hosts.length) {
     return hosts; // don't apply filter.
   }
 

--- a/packages/lib/bookings/filterHostsByLeadThreshold.ts
+++ b/packages/lib/bookings/filterHostsByLeadThreshold.ts
@@ -103,7 +103,7 @@ export const filterHostsByLeadThreshold = async <T extends BaseHost<BaseUser>>({
   if (maxLeadThreshold === 0) {
     throw new Error(errorCodes.MAX_LEAD_THRESHOLD_FALSY);
   }
-  if (maxLeadThreshold === null || !hosts.length) {
+  if (maxLeadThreshold === null || hosts.length < 1) {
     return hosts; // don't apply filter.
   }
 


### PR DESCRIPTION
## What does this PR do?

fix `Cannot read properties of undefined (reading 'user') ` error when a round robin event with fairness enabled has only fixed hosts.