### PR TITLE
chore: remove /user & /user/type dynamic routes from middleware

### DIFF
--- a/apps/web/app/(use-page-wrapper)/[user]/[type]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/[user]/[type]/page.tsx
@@ -5,7 +5,7 @@ import { headers, cookies } from "next/headers";
 
 import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/[type]/getServerSideProps";
 
@@ -31,12 +31,14 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
       })),
     ],
   };
+  const decodedParams = decodeParams(params);
   const metadata = await generateMeetingMetadata(
     meeting,
     (t) => `${rescheduleUid && !!booking ? t("reschedule") : ""} ${title} | ${profileName}`,
     (t) => `${rescheduleUid ? t("reschedule") : ""} ${title}`,
     isBrandingHidden,
-    getOrgFullOrigin(eventData?.entity.orgSlug ?? null)
+    getOrgFullOrigin(eventData?.entity.orgSlug ?? null),
+    `/${decodedParams.user}/${decodedParams.type}`
   );
 
   return {

--- a/apps/web/app/(use-page-wrapper)/[user]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/[user]/page.tsx
@@ -5,7 +5,7 @@ import { headers, cookies } from "next/headers";
 
 import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/getServerSideProps";
 
@@ -30,7 +30,8 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
     () => profile.name,
     () => markdownStrippedBio,
     false,
-    getOrgFullOrigin(entity.orgSlug ?? null)
+    getOrgFullOrigin(entity.orgSlug ?? null),
+    `/${decodeParams(params).user}`
   );
 
   return {

--- a/apps/web/lib/buildLegacyCtx.tsx
+++ b/apps/web/lib/buildLegacyCtx.tsx
@@ -26,7 +26,7 @@ const buildLegacyCookies = (cookies: ReadonlyRequestCookies) => {
   return createProxifiedObject(cookiesObject);
 };
 
-function decodeParams(params: Params): Params {
+export function decodeParams(params: Params): Params {
   return Object.entries(params).reduce((acc, [key, value]) => {
     // Handle array values
     if (Array.isArray(value)) {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -172,8 +172,6 @@ export const config = {
     "/routing-forms/:path*",
     "/team/:path*",
     "/org/:path*",
-    "/:user/:type/",
-    "/:user/",
   ],
 };
 


### PR DESCRIPTION
## What does this PR do?

- Follow-up of https://github.com/calcom/cal.com/pull/19281
- This PR removes `/[user]` and `/[user]/[type]` dynamic routes from middleware while ensuring that metadata is still being created correctly. For /[user] and /[user]/[type] pages, middleware was needed just for settings two special headers (x-locale and x-pathname), which were used for metadata generation. In this PR, I found a way to generate metadata without needing these two headers

<img width="551" alt="Screenshot 2025-02-14 at 8 45 15 AM" src="https://github.com/user-attachments/assets/b5500c67-11a6-4264-a9fd-8941dfd17e5e" />
<img width="490" alt="Screenshot 2025-02-14 at 8 45 29 AM" src="https://github.com/user-attachments/assets/db2386f3-3d62-40aa-9617-b6e56d9d9272" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Test metadata in /[user] and /[user]/[type] booking pages