### PR TITLE
fix: tanstack getRight error, focus in user impersonation, missing space after input fields, border in my-profile email

### DIFF
--- a/apps/web/components/settings/CustomEmailTextField.tsx
+++ b/apps/web/components/settings/CustomEmailTextField.tsx
@@ -4,7 +4,6 @@ import type { UseFormReturn } from "react-hook-form";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import {
   Badge,
-  TextField,
   Dropdown,
   DropdownItem,
   DropdownMenuContent,
@@ -48,11 +47,9 @@ const CustomEmailTextField = ({
         className={`border-default mt-2 flex w-full items-center rounded-[10px] border ${
           inputFocus ? "ring-brand-default border-neutral-300 ring-2" : ""
         }`}>
-        <TextField
+        <input
           {...formMethods.register(formMethodFieldName)}
-          label=""
-          containerClassName="flex flex-1 items-center"
-          className="mb-0 border-none outline-none focus:ring-0"
+          className="flex-1 bg-transparent px-3 py-1 text-sm outline-none"
           data-testid={dataTestId}
           onFocus={() => setInputFocus(true)}
           onBlur={() => setInputFocus(false)}

--- a/apps/web/modules/settings/admin/impersonation-view.tsx
+++ b/apps/web/modules/settings/admin/impersonation-view.tsx
@@ -38,7 +38,7 @@ const ImpersonationView = () => {
       }}>
       <div className="flex items-center space-x-2 rtl:space-x-reverse">
         <TextField
-          containerClassName="w-full"
+          containerClassName="w-full [&_input:-webkit-autofill]:!shadow-[0_0_0_1000px_white_inset]"
           name={t("user_impersonation_heading")}
           addOnLeading={<>{process.env.NEXT_PUBLIC_WEBSITE_URL}/</>}
           ref={usernameRef}

--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -153,7 +153,7 @@ export function DataTable<TData, TValue>({
                         key={header.id}
                         style={{
                           ...(column.getIsPinned() === "left" && { left: `${column.getStart("left")}px` }),
-                          ...(column.getIsPinned() === "right" && { right: `${column.getAfter("right")}px` }),
+                          ...(column.getIsPinned() === "right" && { right: `${column.getStart("right")}px` }),
                           width: `var(--header-${kebabCase(header?.id)}-size)`,
                         }}
                         className={classNames(
@@ -271,7 +271,7 @@ function DataTableBody<TData>({
                     key={cell.id}
                     style={{
                       ...(column.getIsPinned() === "left" && { left: `${column.getStart("left")}px` }),
-                      ...(column.getIsPinned() === "right" && { right: `${column.getAfter("right")}px` }),
+                      ...(column.getIsPinned() === "right" && { right: `${column.getStart("right")}px` }),
                       width: `var(--col-${kebabCase(cell.column.id)}-size)`,
                     }}
                     className={classNames(

--- a/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
+++ b/packages/features/users/components/UserTable/EditSheet/EditUserForm.tsx
@@ -195,10 +195,10 @@ export function EditForm({
             />
           </div>
           <Divider />
-          <TextField label={t("name")} {...form.register("name")} />
-          <TextField label={t("username")} {...form.register("username")} />
-          <TextAreaField label={t("about")} {...form.register("bio")} className="min-h-24" />
-          <div>
+          <TextField label={t("name")} {...form.register("name")} className="mb-6" />
+          <TextField label={t("username")} {...form.register("username")} className="mb-6" />
+          <TextAreaField label={t("about")} {...form.register("bio")} className="min-h-24 mb-6" />
+          <div className="mb-6">
             <Label>{t("role")}</Label>
             <ToggleGroup
               isFullWidth
@@ -210,7 +210,7 @@ export function EditForm({
               }}
             />
           </div>
-          <div className="mb-4">
+          <div className="mb-6">
             <Label>{t("timezone")}</Label>
             <TimezoneSelect value={watchTimezone ?? "America/Los_Angeles"} />
           </div>


### PR DESCRIPTION
## What does this PR do?
[fix: shadow after email and before the primary label](https://github.com/calcom/cal.com/commit/16ea97cfddcf55945d98fd5fcd27a42add2f6280)

[fix: autofill input shadow in impersonation view](https://github.com/calcom/cal.com/commit/41764ff41a9c471983c3a58859e30787a152150c)

[fix: improve spacing and layout in EditUserForm](https://github.com/calcom/cal.com/commit/b33ee38dbc00a441964182429fd917b340fb69e5)

[fix: tanstack error due to getAfter](https://github.com/calcom/cal.com/commit/c70dae22aa66f81310004bcf8d4f4ff983e3841c)

### Before:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/712820b5-8429-43ae-84e9-4516a6c65cc4" />

<img width="502" alt="image" src="https://github.com/user-attachments/assets/ed5b876c-44a4-41da-9d5a-f7e55752c4b9" />

![image](https://github.com/user-attachments/assets/dc657c91-84c5-4d5a-b89a-7e4167260330)

### After:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/d981072d-cde6-4c33-9c81-2b3bcce59149" />

<img width="474" alt="image" src="https://github.com/user-attachments/assets/b8ab66bb-7d24-4f95-a0d8-54c5f48123f2" />

<img width="797" alt="image" src="https://github.com/user-attachments/assets/96672d08-4f03-4e37-970e-c6540b58e474" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
