### PR TITLE
fix: Show loading indicator in button when delete account API is in progress

### DIFF
--- a/apps/web/modules/settings/my-account/profile-view.tsx
+++ b/apps/web/modules/settings/my-account/profile-view.tsx
@@ -362,7 +362,8 @@ const ProfileView = () => {
               <Button
                 color="primary"
                 data-testid="delete-account-confirm"
-                onClick={(e) => onConfirmButton(e)}>
+                onClick={(e) => onConfirmButton(e)}
+                loading={deleteMeMutation.isPending}>
                 {t("delete_my_account")}
               </Button>
             </DialogFooter>


### PR DESCRIPTION
## What does this PR do?

Show loading indicator in button when delete account API is in progress

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Login and navigate to `/settings/my-account/profile`
- Click on `Delete account` which opens the popup
- Click `Delete my account` button

