### PR TITLE
chore: deprecate `requiresLicense = true`

### DIFF
--- a/apps/web/app/(use-page-wrapper)/connect-and-join/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/connect-and-join/page.tsx
@@ -1,5 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 
+import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
+
 import LegacyPage from "~/connect-and-join/connect-and-join-view";
 
 export const generateMetadata = async () => {
@@ -9,4 +11,11 @@ export const generateMetadata = async () => {
   );
 };
 
-export default LegacyPage;
+const ServerPage = async () => {
+  return (
+    <LicenseRequired>
+      <LegacyPage />
+    </LicenseRequired>
+  );
+};
+export default ServerPage;

--- a/apps/web/modules/connect-and-join/connect-and-join-view.tsx
+++ b/apps/web/modules/connect-and-join/connect-and-join-view.tsx
@@ -85,6 +85,4 @@ function ConnectAndJoin() {
   );
 }
 
-ConnectAndJoin.requiresLicense = true;
-
 export default ConnectAndJoin;


### PR DESCRIPTION
## What does this PR do?

- `Component.requiresLicense = true` is deprecated
- Connect and join route still has this

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

