### PR TITLE
fix: preserve columnVisibility from initialState

### DIFF
--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Table as ReactTableType } from "@tanstack/react-table";
+import type { Table as ReactTableType, VisibilityState } from "@tanstack/react-table";
 import { useEffect, useRef } from "react";
 
 import {
@@ -61,11 +61,16 @@ export function DataTableWrapper<TData, TValue>({
   const columnFilters = useColumnFilters();
 
   useEffect(() => {
+    const mergedColumnVisibility = {
+      ...(table.initialState?.columnVisibility || {}),
+      ...columnVisibility,
+    } satisfies VisibilityState;
+
     table.setState((prev) => ({
       ...prev,
       sorting,
       columnFilters,
-      columnVisibility,
+      columnVisibility: mergedColumnVisibility,
     }));
     table.setOptions((prev) => ({
       ...prev,


### PR DESCRIPTION
## What does this PR do?

This PR preserves columnVisibility from initialState.

`initialState.columnVisibility` is only used until `table.setOptions({ ... , columnVisibility })` is called.
Afterwards, `column.getIsVisible()` refers to only `table.options.state`.

So, in this PR, I merge the two, because sometimes we want to keep certain columns hidden.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

At /insights/routing, the first two columns should've been hidden. (Routing Forms, User)

This is the screenshot of the current prod version. They should be hidden in this branch.

![Screenshot 2025-02-20 at 15 41 41](https://github.com/user-attachments/assets/3d77ead8-baca-4f8b-81ee-59d4ee83b9ac)

