### PR TITLE
fix: Routing Form - Crash due to an invalid state of connected field that was deleted in main form

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1987,7 +1987,7 @@
   "a_routing_form": "A Routing Form",
   "form_description_placeholder": "Form Description",
   "keep_me_connected_with_form": "Keep me connected with the form",
-  "fields_in_form_duplicated": "Any changes in Router and Fields of the form being duplicated, would reflect in the duplicate.",
+  "fields_in_form_duplicated": "Any changes made to the router or fields of the form being duplicated will be reflected in the duplicate. However, deleting a field will not remove it from the duplicate.",
   "form_deleted": "Form deleted",
   "delete_form": "Are you sure you want to delete this form?",
   "delete_form_action": "Yes, delete Form",

--- a/packages/app-store/routing-forms/components/FormInputFields.tsx
+++ b/packages/app-store/routing-forms/components/FormInputFields.tsx
@@ -37,7 +37,10 @@ export default function FormInputFields(props: FormInputFieldsProps) {
       {form.fields?.map((field) => {
         if (isRouterLinkedField(field)) {
           // @ts-expect-error FIXME @hariombalhara
-          field = field.routerField;
+          const routerField = field.routerField;
+          // A field that has been deleted from the main form would still be there in the duplicate form but disconnected
+          // In that case, it could mistakenly be categorized as RouterLinkedField, so if routerField is nullish, we use the field itself
+          field = routerField ?? field;
         }
         const widget = formFieldsQueryBuilderConfig.widgets[field.type];
         if (!("factory" in widget)) {

--- a/packages/app-store/routing-forms/lib/isRouterLinkedField.ts
+++ b/packages/app-store/routing-forms/lib/isRouterLinkedField.ts
@@ -2,6 +2,9 @@ import type { z } from "zod";
 
 import type { zodFieldView, zodField, zodRouterField, zodRouterFieldView } from "../zod";
 
+/**
+ * It has been seen that the field had routerId but not routerField, which could be considered an invalid state. We need to analyze why rotuerId is still set in that case and infact should have been cleanedup.
+ */
 export default function isRouterLinkedField(
   field: z.infer<typeof zodFieldView> | z.infer<typeof zodField>
 ): field is z.infer<typeof zodRouterField> | z.infer<typeof zodRouterFieldView> {


### PR DESCRIPTION
## What does this PR do?

As reported over email by a customer

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Duplicate an existing form(with 2-3 fields) but tick 'Keep me connected with form'
- Now in the original(i.e. main) form delete one of the fields.
- Now, try to submit a response for the duplicate form and notice that it crashes.(It won't crash after the fix and instead will still render the deleted field in the duplicate form as the field got disconnected on deletion)
