### PR TITLE
perf: do not use dynamic imports for settings layouts

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/layout.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import { cookies, headers } from "next/headers";
 import React from "react";
 
@@ -8,10 +7,7 @@ import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import SettingsLayoutAppDir from "../(settings-layout)/layout";
 import type { AdminLayoutProps } from "./AdminLayoutAppDirClient";
-
-const AdminLayoutAppDirClient = dynamic(() => import("./AdminLayoutAppDirClient"), {
-  ssr: false,
-});
+import AdminLayoutAppDirClient from "./AdminLayoutAppDirClient";
 
 type AdminLayoutAppDirProps = Omit<AdminLayoutProps, "userRole">;
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import { cookies, headers } from "next/headers";
 import React from "react";
 
@@ -8,10 +7,7 @@ import { OrganizationRepository } from "@calcom/lib/server/repository/organizati
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import type { SettingsLayoutProps } from "./SettingsLayoutAppDirClient";
-
-const SettingsLayoutAppDirClient = dynamic(() => import("./SettingsLayoutAppDirClient"), {
-  ssr: false,
-});
+import SettingsLayoutAppDirClient from "./SettingsLayoutAppDirClient";
 
 type SettingsLayoutAppDirProps = Omit<SettingsLayoutProps, "currentOrg" | "otherTeams">;
 


### PR DESCRIPTION
## What does this PR do?

- No need to use dynamic imports. `SettingsLayoutAppDirClient` and `AdminLayoutAppDirClient` need to be immediately rendered.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.