### PR TITLE
fix: Revert "perf: run `ssrInit()` at root layout (#19460)"

### DIFF
--- a/apps/web/app/(booking-page-wrapper)/layout.tsx
+++ b/apps/web/app/(booking-page-wrapper)/layout.tsx
@@ -1,13 +1,24 @@
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
+
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import PageWrapper from "@components/PageWrapperAppDir";
+
+import { ssrInit } from "@server/lib/ssr";
 
 export default async function BookingPageWrapperLayout({ children }: { children: React.ReactNode }) {
   const h = headers();
   const nonce = h.get("x-nonce") ?? undefined;
+  const context = buildLegacyCtx(h, cookies(), {}, {});
+  const ssr = await ssrInit(context);
 
   return (
-    <PageWrapper isBookingPage={true} requiresLicense={false} nonce={nonce} themeBasis={null}>
+    <PageWrapper
+      isBookingPage={true}
+      requiresLicense={false}
+      nonce={nonce}
+      themeBasis={null}
+      dehydratedState={ssr.dehydrate()}>
       {children}
     </PageWrapper>
   );

--- a/apps/web/app/(use-page-wrapper)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/layout.tsx
@@ -1,13 +1,20 @@
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
+
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import PageWrapper from "@components/PageWrapperAppDir";
+
+import { ssrInit } from "@server/lib/ssr";
 
 export default async function PageWrapperLayout({ children }: { children: React.ReactNode }) {
   const h = headers();
   const nonce = h.get("x-nonce") ?? undefined;
 
+  const context = buildLegacyCtx(headers(), cookies(), {}, {});
+  const ssr = await ssrInit(context);
+
   return (
-    <PageWrapper requiresLicense={false} nonce={nonce} themeBasis={null}>
+    <PageWrapper requiresLicense={false} nonce={nonce} themeBasis={null} dehydratedState={ssr.dehydrate()}>
       {children}
     </PageWrapper>
   );

--- a/apps/web/app/_trpc/trpc-provider.tsx
+++ b/apps/web/app/_trpc/trpc-provider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { type DehydratedState, QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { HydrateClient } from "app/_trpc/HydrateClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { trpc } from "app/_trpc/client";
 import { useState } from "react";
 import superjson from "superjson";
@@ -43,10 +42,9 @@ const isTRPCClientError = (cause: unknown): cause is TRPCClientError<AppRouter> 
 
 type Props = {
   children: React.ReactNode;
-  dehydratedState: DehydratedState;
 };
 
-export const TrpcProvider = ({ children, dehydratedState }: Props) => {
+export const TrpcProvider = ({ children }: Props) => {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -128,9 +126,7 @@ export const TrpcProvider = ({ children, dehydratedState }: Props) => {
 
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>
-        <HydrateClient state={dehydratedState}>{children}</HydrateClient>
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </trpc.Provider>
   );
 };

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,10 +7,7 @@ import React from "react";
 import { getLocale } from "@calcom/features/auth/lib/getLocale";
 import { IconSprites } from "@calcom/ui";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { prepareRootMetadata } from "@lib/metadata";
-
-import { ssrInit } from "@server/lib/ssr";
 
 import "../styles/globals.css";
 import { SpeculationRules } from "./SpeculationRules";
@@ -59,7 +56,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     ? getFallbackProps()
     : await getInitialProps(fullUrl);
 
-  const ssr = await ssrInit(buildLegacyCtx(h, cookies(), {}, {}));
   return (
     <html
       lang={locale}
@@ -163,7 +159,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             "/insights",
           ]}
         />
-        <Providers dehydratedState={ssr.dehydrate()}>{children}</Providers>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { type DehydratedState } from "@tanstack/react-query";
 import { TrpcProvider } from "app/_trpc/trpc-provider";
 import { SessionProvider } from "next-auth/react";
 import CacheProvider from "react-inlinesvg/provider";
@@ -8,16 +7,12 @@ import CacheProvider from "react-inlinesvg/provider";
 import useIsBookingPage from "@lib/hooks/useIsBookingPage";
 import PlainChat from "@lib/plain/dynamicProvider";
 
-type ProvidersProps = {
-  children: React.ReactNode;
-  dehydratedState: DehydratedState;
-};
-export function Providers({ children, dehydratedState }: ProvidersProps) {
+export function Providers({ children }: { children: React.ReactNode }) {
   const isBookingPage = useIsBookingPage();
 
   return (
     <SessionProvider>
-      <TrpcProvider dehydratedState={dehydratedState}>
+      <TrpcProvider>
         {!isBookingPage ? <PlainChat /> : null}
         {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
         <CacheProvider>{children}</CacheProvider>

--- a/apps/web/components/PageWrapperAppDir.tsx
+++ b/apps/web/components/PageWrapperAppDir.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type DehydratedState } from "@tanstack/react-query";
 import type { SSRConfig } from "next-i18next";
 // import I18nLanguageHandler from "@components/I18nLanguageHandler";
 import { usePathname } from "next/navigation";
@@ -16,6 +17,7 @@ export type PageWrapperProps = Readonly<{
   requiresLicense: boolean;
   nonce: string | undefined;
   themeBasis: string | null;
+  dehydratedState?: DehydratedState;
   isBookingPage?: boolean;
   i18n?: SSRConfig;
 }>;

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { HydrateClient } from "app/_trpc/HydrateClient";
 import { dir } from "i18next";
 import type { Session } from "next-auth";
 import { useSession } from "next-auth/react";
@@ -280,15 +281,20 @@ const AppProviders = (props: PageWrapperProps) => {
       </CustomI18nextProvider>
     </EventCollectionProvider>
   );
+  const Hydrated = props.dehydratedState ? (
+    <HydrateClient state={props.dehydratedState}>{RemainingProviders}</HydrateClient>
+  ) : (
+    RemainingProviders
+  );
 
   if (props.isBookingPage || isBookingPage) {
-    return RemainingProviders;
+    return Hydrated;
   }
 
   return (
     <>
       <DynamicHelpscoutProvider>
-        <DynamicPostHogProvider>{RemainingProviders}</DynamicPostHogProvider>
+        <DynamicPostHogProvider>{Hydrated}</DynamicPostHogProvider>
       </DynamicHelpscoutProvider>
     </>
   );


### PR DESCRIPTION

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This reverts commit 6ea879f26550e41d0c85443d63a0de1b79342e34. (#19460)
- I found that Root Layout actually re-renders for every page load by design, while nested layout files persist the state. So it's better for `ssrInit` to stay in nested layouts.