### PR TITLE
fix: update profile instead of username. Display p.username

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/getUser.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getUser.handler.ts
@@ -40,6 +40,11 @@ export async function getUserHandler({ input, ctx }: AdminVerifyOptions) {
             name: true,
           },
         },
+        profiles: {
+          select: {
+            username: true,
+          },
+        },
       },
     }),
     // Query on accepted as we don't want the user to be able to get this much info on a user that hasn't accepted the invite
@@ -77,6 +82,8 @@ export async function getUserHandler({ input, ctx }: AdminVerifyOptions) {
 
   const foundUser = {
     ...requestedUser,
+    // Enrich with the users profile for the username or fall back to the username their account was created with.
+    username: requestedUser.profiles[0].username || requestedUser.username,
     teams: teams.map((team) => ({
       ...team.team,
       accepted: team.accepted,

--- a/packages/trpc/server/routers/viewer/organizations/getUser.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getUser.handler.ts
@@ -83,7 +83,7 @@ export async function getUserHandler({ input, ctx }: AdminVerifyOptions) {
   const foundUser = {
     ...requestedUser,
     // Enrich with the users profile for the username or fall back to the username their account was created with.
-    username: requestedUser.profiles[0].username || requestedUser.username,
+    username: requestedUser.profiles[0]?.username || requestedUser.username,
     teams: teams.map((team) => ({
       ...team.team,
       accepted: team.accepted,

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -236,7 +236,7 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
 
       return {
         id: user.id,
-        username: user.profiles[0].username || user.username,
+        username: user.profiles[0]?.username || user.username,
         email: user.email,
         timeZone: user.timeZone,
         role: membership.role,

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -164,6 +164,12 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
         select: {
           id: true,
           username: true,
+          profiles: {
+            select: {
+              organizationId: true,
+              username: true,
+            },
+          },
           email: true,
           avatarUrl: true,
           timeZone: true,
@@ -230,7 +236,7 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
 
       return {
         id: user.id,
-        username: user.username,
+        username: user.profiles[0].username || user.username,
         email: user.email,
         timeZone: user.timeZone,
         role: membership.role,

--- a/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
@@ -111,7 +111,6 @@ export const updateUserHandler = async ({ ctx, input }: UpdateUserOptions) => {
     email: input.email,
     name: input.name,
     timeZone: input.timeZone,
-    username: input.username,
   };
 
   if (input.avatar && input.avatar.startsWith("data:image/png;base64,")) {


### PR DESCRIPTION
## What does this PR do?
When updating a user from organization - we were updating user.username and profile.username for that org. This was causing issues on links and other places around the app. 

Also return the profile.username in replace of the username in the userlist table so we can see the correct link when u.username and p.username dont match. 

## How should this be tested?

Update a user as an org admin. Notice links change but user.username doesnt. Correct links displayed in members table after they have been manually changed. 

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
