### PR TITLE
hotfix: Embed - Sometimes hidden mostly for acme.cal.local/team1 page

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -14,6 +14,7 @@ const enum EMBED_IFRAME_STATE {
   NOT_INITIALIZED,
   INITIALIZED,
 }
+
 /**
  * All types of config that are critical to be processed as soon as possible are provided as query params to the iframe
  */
@@ -333,7 +334,13 @@ export const useEmbedType = () => {
 };
 
 function unhideBody() {
-  document.body.style.visibility = "visible";
+  // Ensure that it stays visible and not reverted by React
+  runAsap(() => {
+    if (document.body.style.visibility !== "visible") {
+      document.body.style.visibility = "visible";
+    }
+    unhideBody();
+  });
 }
 
 // It is a map of methods that can be called by parent using doInIframe({method: "methodName", arg: "argument"})


### PR DESCRIPTION
## What does this PR do?

- Fixes the issue where embed is hidden sometimes completely breaking booking page
- It should also fix the organization checkly tests that are failing inconsistently

Root cause seems to be that with App Router(or maybe something else but started happening after App Router migration), for apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/embed/page.tsx the style prop gets reapplied and reverts the visibility:visible added by embed-iframe.

Now, I am enforcing the visibility using setInterval

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Visit http://acme.cal.local:3000/team1/team1-event-1/embed and http://acme.cal.local:3000/team1/embed and make sure that they load and are not hidden.

