### PR TITLE
chore: replaced submit to continue

### DIFF
--- a/packages/app-store/routing-forms/pages/routing-link/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/routing-link/[...appPages].tsx
@@ -183,7 +183,7 @@ function RoutingForm({ form, profile, ...restProps }: Props) {
                         loading={responseMutation.isPending}
                         type="submit"
                         color="primary">
-                        {t("submit")}
+                        {t("continue")}
                       </Button>
                     </div>
                   </form>


### PR DESCRIPTION
since we pretty much always require action after submitting (book a time, or similar) we hsould show "conutnue"

![CleanShot 2025-03-01 at 14 47 04@2x](https://github.com/user-attachments/assets/def7a420-db52-45e8-9def-83e69c7ad1c9)