### PR TITLE
fix: remove ‘add guests’ from the dropdown if it’s disabled in the booking questions

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -259,7 +259,7 @@ function BookingListItem(booking: BookingItemProps) {
       },
       icon: "map-pin" as const,
     },
-    ...(booking.seatsReferences.length
+    ...(booking.eventType?.disableGuests
       ? []
       : [
           {

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -259,14 +259,18 @@ function BookingListItem(booking: BookingItemProps) {
       },
       icon: "map-pin" as const,
     },
-    {
-      id: "add_members",
-      label: t("additional_guests"),
-      onClick: () => {
-        setIsOpenAddGuestsDialog(true);
-      },
-      icon: "user-plus" as const,
-    },
+    ...(booking.seatsReferences.length
+      ? []
+      : [
+          {
+            id: "add_members",
+            label: t("additional_guests"),
+            onClick: () => {
+              setIsOpenAddGuestsDialog(true);
+            },
+            icon: "user-plus" as const,
+          },
+        ]),
   ];
 
   if (booking.eventType.schedulingType === SchedulingType.ROUND_ROBIN) {

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -92,6 +92,7 @@ export async function getBookings({
         recurringEvent: true,
         currency: true,
         metadata: true,
+        disableGuests: true,
         seatsShowAttendees: true,
         seatsShowAvailabilityCount: true,
         eventTypeColor: true,


### PR DESCRIPTION
## What does this PR do?

- Fixes https://linear.app/calcom/issue/CAL-5229/add-guests-for-seated-events-is-enabled-in-the-upcoming-booking-tab


