### PR TITLE
fix: Dismiss toast on click

### DIFF
--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import type { ToastT } from "sonner";
+import type { ExternalToast } from "sonner";
 import { toast } from "sonner";
 
 import { Icon } from "../icon";
@@ -72,9 +72,9 @@ export function showToast(
   message: string,
   variant: ToastVariants,
   // Options or duration (duration for backwards compatibility reasons)
-  options: number | ToastT = TOAST_VISIBLE_DURATION
+  options: number | ExternalToast = TOAST_VISIBLE_DURATION
 ) {
-  const _options: ToastT = typeof options === "number" ? { duration: options, id: "" } : options;
+  const _options: ExternalToast = typeof options === "number" ? { duration: options } : options;
   if (!_options.duration) _options.duration = TOAST_VISIBLE_DURATION;
   if (!_options.position) _options.position = "bottom-center";
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

@anikdhabal This is a follow-up to PR #19342 , ensuring that toast messages can be dismissed when clicked. Previously, clicking on the toast did not remove it. Now, the toast will disappear upon user interaction.

Let me know if any further adjustments are needed! 🚀

## Visual Demo (For contributors especially)
After: 
https://github.com/user-attachments/assets/cadd3be3-881f-4820-9ca5-4f9f558fc594

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
