### PR TITLE
fix: public team members width on small screens

### DIFF
--- a/apps/web/components/team/screens/Team.tsx
+++ b/apps/web/components/team/screens/Team.tsx
@@ -30,7 +30,7 @@ const Member = ({ member, teamName }: { member: MemberType; teamName: string | n
     <Link
       key={member.id}
       href={{ pathname: `${member.bookerUrl}/${member.username}`, query: queryParamsToForward }}>
-      <div className="sm:min-w-80 sm:max-w-80 bg-default hover:bg-muted border-subtle group flex min-h-full flex-col space-y-2 rounded-md border p-4 transition hover:cursor-pointer">
+      <div className="w-80 bg-default hover:bg-muted border-subtle group flex min-h-full flex-col space-y-2 rounded-md border p-4 transition hover:cursor-pointer">
         <UserAvatar noOrganizationIndicator size="md" user={member} />
         <section className="mt-2 line-clamp-4 w-full space-y-1">
           <p className="text-default font-medium">{member.name}</p>
@@ -61,7 +61,7 @@ const Members = ({ members, teamName }: { members: MemberType[]; teamName: strin
   return (
     <section
       data-testid="team-members-container"
-      className="lg:min-w-lg mx-auto flex min-w-full max-w-5xl flex-wrap justify-center gap-x-6 gap-y-6">
+      className="flex flex-wrap justify-center gap-x-6 gap-y-6 mx-auto">
       {members.map((member) => {
         return member.username !== null && <Member key={member.id} member={member} teamName={teamName} />;
       })}


### PR DESCRIPTION
## What does this PR do?

- Fixes #19657 
- The fix ensures that all cards maintain a uniform width, improving the layout and responsiveness of the public team view.

## Visual Demo

### Before:
![image](https://github.com/user-attachments/assets/baef1217-dca5-456d-aca0-a7806e2cb2b2)

### After:
![image](https://github.com/user-attachments/assets/d2a6aefd-2aeb-4c2e-a9a4-25a6e7131916)

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] I have updated documentation if necessary.
- [x] I confirm automated tests are in place that prove my fix is effective.

## How should this be tested?

1. Open the public team view on a small-screen device or use responsive testing in dev tools.  
2. Ensure that all team member cards maintain a consistent width.

## Checklist

- [x] I have read the contributing guide.
- [x] My code follows the style guidelines of this project.
- [x] I have checked that my changes generate no new warnings.
