### PR TITLE
fix: Private links in orgs when profile username isnt cal.com username

### DIFF
--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -37,6 +37,13 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
           users: {
             select: {
               username: true,
+              profiles: {
+                select: {
+                  id: true,
+                  organizationId: true,
+                  username: true,
+                },
+              },
             },
           },
           team: {
@@ -61,13 +68,13 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   if (!hashedLink) {
     return notFound;
   }
+  const username = hashedLink.eventType.users[0]?.username;
+  const profileUsername = hashedLink.eventType.users[0]?.profiles[0]?.username;
 
   if (hashedLink.eventType.team) {
     name = hashedLink.eventType.team.slug || "";
     hideBranding = hashedLink.eventType.team.hideBranding;
   } else {
-    const username = hashedLink.eventType.users[0]?.username;
-
     if (!username) {
       return notFound;
     }
@@ -85,8 +92,10 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       }
     }
 
+    name = profileUsername || username;
+
     const [user] = await UserRepository.findUsersByUsername({
-      usernameList: [username],
+      usernameList: [name],
       orgSlug: org,
     });
 
@@ -94,7 +103,6 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       return notFound;
     }
 
-    name = username;
     hideBranding = user.hideBranding;
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes private links when a user is in an organization when their profile username !== their cal.com username. 

## How should this be tested?
Two options - create a new account and org where their profile username !== cal.com username. Or simpily seed DB. 

1) Login as user -> If using seeded use owner1-acme@example.com
2) Create a private link on a personal event type. 
3) visit personal event type -> Workes as expected 

1) Login as a normal user
2) create private link
3) Ensure it works as expected

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
