### PR TITLE
chore: early return for static assets in middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -39,9 +39,20 @@ export function checkPostMethod(req: NextRequest) {
   return null;
 }
 
+export function checkStaticFiles(pathname: string) {
+  const hasFileExtension = /\.(svg|png|jpg|jpeg|gif|webp|ico)$/.test(pathname);
+  // Skip Next.js internal paths (_next) and static assets
+  if (pathname.startsWith("/_next") || hasFileExtension) {
+    return NextResponse.next();
+  }
+}
+
 const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   const postCheckResult = checkPostMethod(req);
   if (postCheckResult) return postCheckResult;
+
+  const isStaticFile = checkStaticFiles(req.nextUrl.pathname);
+  if (isStaticFile) return isStaticFile;
 
   const url = req.nextUrl;
   const requestHeaders = new Headers(req.headers);


### PR DESCRIPTION
## What does this PR do?

- there's no need to process anything for _next files or static assets in middleware 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- E2E tests in place are sufficient