### PR TITLE
chore: TS config - ignore node_modules in subdirectories

### DIFF
--- a/apps/api/v1/tsconfig.json
+++ b/apps/api/v1/tsconfig.json
@@ -18,5 +18,5 @@
     "../../../packages/types/*.d.ts",
     "../../../packages/types/next-auth.d.ts"
   ],
-  "exclude": ["node_modules", "templates", "auth"]
+  "exclude": ["**/node_modules/**", "templates", "auth"]
 }

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/nextjs.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"],
+  "exclude": ["**/node_modules/**"],
   "compilerOptions": {
     "noImplicitAny": false,
     "baseUrl": "."

--- a/apps/swagger/tsconfig.json
+++ b/apps/swagger/tsconfig.json
@@ -13,5 +13,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["**/node_modules/**"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -34,5 +34,5 @@
     "../../packages/features/bookings/lib/getUserBooking.ts",
     "../../packages/features/Segment.tsx"
   ],
-  "exclude": ["node_modules", ".next"]
+  "exclude": ["**/node_modules/**", ".next"]
 }

--- a/example-apps/credential-sync/tsconfig.json
+++ b/example-apps/credential-sync/tsconfig.json
@@ -15,5 +15,5 @@
     "jsx": "preserve"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["**/node_modules/**"]
 }

--- a/packages/app-store/tsconfig.json
+++ b/packages/app-store/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@calcom/tsconfig/react-library.json",
-  "exclude": ["dist", "build", "node_modules"],
+  "exclude": ["dist", "build", "**/node_modules/**"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
@@ -8,7 +8,7 @@
       "@components/*": ["../../apps/web/components/*"],
       /* A `package` should never import from `apps` ↓ */
       "@lib/*": ["../../apps/web/lib/*"],
-      "@prisma/client/*": ["@calcom/prisma/client/*"],
+      "@prisma/client/*": ["@calcom/prisma/client/*"]
     },
     "resolveJsonModule": true,
     "experimentalDecorators": true

--- a/packages/debugging/tsconfig.json
+++ b/packages/debugging/tsconfig.json
@@ -10,5 +10,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/embeds/embed-core/tsconfig.json
+++ b/packages/embeds/embed-core/tsconfig.json
@@ -13,5 +13,5 @@
     }
   },
   "include": ["src", "env.d.ts", "index.ts", "*.ts"],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/embeds/embed-react/tsconfig.json
+++ b/packages/embeds/embed-react/tsconfig.json
@@ -15,5 +15,5 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "env.d.ts", "*.tsx", "*.ts"],
   // Exclude "test" because that has `api.test.ts` which imports @calcom/embed-react which needs it to be built using this tsconfig.json first. Excluding it here prevents type-check from validating test folder
-  "exclude": ["node_modules", "test"]
+  "exclude": ["**/node_modules/**", "test"]
 }

--- a/packages/embeds/embed-snippet/tsconfig.json
+++ b/packages/embeds/embed-snippet/tsconfig.json
@@ -13,5 +13,5 @@
     }
   },
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/features/tsconfig.json
+++ b/packages/features/tsconfig.json
@@ -9,5 +9,5 @@
     "esModuleInterop": true
   },
   "include": [".", "../types/next-auth.d.ts", "../types/tanstack-table.d.ts"],
-  "exclude": ["dist", "build", "**/node_modules**/", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["dist", "build", "**/node_modules/**", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/features/tsconfig.json
+++ b/packages/features/tsconfig.json
@@ -9,5 +9,5 @@
     "esModuleInterop": true
   },
   "include": [".", "../types/next-auth.d.ts", "../types/tanstack-table.d.ts"],
-  "exclude": ["dist", "build", "node_modules", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["dist", "build", "**/node_modules**/", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -6,5 +6,5 @@
     "resolveJsonModule": true
   },
   "include": [".", "../types/next-auth.d.ts", "../types/window.d.ts", "../trpc/types/router.d.ts"],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/platform/atoms/tsconfig.json
+++ b/packages/platform/atoms/tsconfig.json
@@ -45,7 +45,7 @@
   "exclude": [
     "dist",
     "build",
-    "node_modules",
+    "**/node_modules/**",
     "**/*WebWrapper.tsx",
     "**/*.docs.mdx",
     "**/*.stories.tsx",

--- a/packages/platform/constants/tsconfig.json
+++ b/packages/platform/constants/tsconfig.json
@@ -7,5 +7,5 @@
     "outDir": "./dist"
   },
   "include": ["."],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "**/node_modules/**"]
 }

--- a/packages/platform/enums/tsconfig.json
+++ b/packages/platform/enums/tsconfig.json
@@ -8,5 +8,5 @@
     "outDir": "./dist"
   },
   "include": ["."],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "**/node_modules/**"]
 }

--- a/packages/platform/examples/base/tsconfig.json
+++ b/packages/platform/examples/base/tsconfig.json
@@ -19,5 +19,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["**/node_modules/**"]
 }

--- a/packages/platform/libraries/tsconfig.json
+++ b/packages/platform/libraries/tsconfig.json
@@ -14,7 +14,7 @@
   "exclude": [
     "dist",
     "build",
-    "node_modules",
+    "**/node_modules/**",
     "**/*.test.*",
     "**/__mocks__/*",
     "**/__tests__/*",

--- a/packages/platform/types/tsconfig.json
+++ b/packages/platform/types/tsconfig.json
@@ -8,5 +8,5 @@
     "outDir": "dist"
   },
   "include": [".", "../../types/business-days-plugin.d.ts", "../../types/window.d.ts"],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/platform/utils/tsconfig.json
+++ b/packages/platform/utils/tsconfig.json
@@ -9,5 +9,5 @@
     "experimentalDecorators": true
   },
   "include": [".", "./tests", "../../types/business-days-plugin.d.ts", "../../types/window.d.ts"],
-  "exclude": ["dist", "build", "node_modules", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["dist", "build", "**/node_modules/**", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -11,5 +11,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "**/node_modules/**"]
 }


### PR DESCRIPTION
## What does this PR do?

Since we have lots of `tsconfig.json` files all over the monorepo, want to make sure we avoid mismatching includes/excludes for `node_modules`.

We have some packages where the tsconfig.json is in the root package but then there are subpackages that can have `node_modules` and they don't have a dedicated tsconfig.json to exclude it

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
