### PR TITLE
fix: search on team availiability (for non-org users)

### DIFF
--- a/packages/trpc/server/routers/viewer/availability/team/listTeamAvailability.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/team/listTeamAvailability.handler.ts
@@ -144,15 +144,6 @@ async function getInfoForAllTeams({ ctx, input }: GetOptions) {
     .findMany({
       where: {
         userId: ctx.user.id,
-        ...(searchString
-          ? {
-              OR: [
-                { user: { username: { contains: searchString } } },
-                { user: { name: { contains: searchString } } },
-                { user: { email: { contains: searchString } } },
-              ],
-            }
-          : {}),
       },
       select: {
         id: true,


### PR DESCRIPTION
## What does this PR do?

This PR fixes search on the team availability page for non-org users.

## Visual Demo (For contributors especially)

Search used to fail like this in a certain condition (more details in the code review)

https://github.com/user-attachments/assets/f5136370-d00e-4b90-8d4a-57491cfcc708


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- on `main`, try to search on /availability?type=team (in a non-org account). It should fail with console error.
- on this branch, try the same, and it will work.