### PR TITLE
fix: plain z index

### DIFF
--- a/apps/web/lib/plain/plainChat.tsx
+++ b/apps/web/lib/plain/plainChat.tsx
@@ -69,6 +69,7 @@ interface PlainChatConfig {
     launcherIconColor: string;
   };
   position: {
+    zIndex: string;
     bottom: string;
     right: string;
   };
@@ -232,6 +233,7 @@ const PlainChat = () => {
           launcherIconColor: "#FFFFFF",
         },
         position: {
+          zIndex: "1",
           bottom: "20px",
           right: "20px",
         },


### PR DESCRIPTION
## What does this PR do?

A fix on the plain chatbot message icon covering items when in dialog. We simply added in a z index which puts the chatbot behind the dialog shadow at all times (refer to the ss below). 

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.
BEFORE:
![cleanshot_2025-02-26_at_18 19 51_2x_360_360](https://github.com/user-attachments/assets/f2c650b7-4f11-4fc2-b5d3-cfa78338bea5)

AFTER:
<img width="512" alt="Screenshot 2025-03-05 at 10 45 15 AM" src="https://github.com/user-attachments/assets/c774b01e-126f-4e86-894b-15030f3369b4" />

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Open a dialog and see if the chatbot is behind it. 
