### PR TITLE
chore: Update CODEOWNERS to have @calcom/Foundation on Platform line items

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-/apps/api/**/* @calcom/Platform
+/apps/api/**/* @calcom/Platform @calcom/Foundation
 /deploy/**/* @calcom/Foundation
 /infra/**/* @calcom/Foundation
 /packages/app-store/applecalendar/**/* @calcom/Foundation
@@ -17,6 +17,6 @@
 /packages/lib/getUserAvailability.ts @calcom/Foundation
 /packages/lib/server/getLuckyUser.ts @calcom/Foundation
 /packages/lib/slots.ts @calcom/Foundation
-/packages/platform/**/* @calcom/Platform
+/packages/platform/**/* @calcom/Platform @calcom/Foundation
 /packages/prisma/**/* @calcom/Foundation
 /packages/trpc/server/routers/viewer/slots/**/* @calcom/Foundation


### PR DESCRIPTION
## What does this PR do?

Adding @calcom/Foundation team to platform line items so we have more coverage of availability to approve and merge.

When using multiple teams, anyone from any team suffices for the approval.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection