### PR TITLE
chore: redirect immediately when visiting /upgrade

### DIFF
--- a/apps/web/modules/upgrade/upgrade-view.tsx
+++ b/apps/web/modules/upgrade/upgrade-view.tsx
@@ -29,9 +29,12 @@ export default function UpgradePage() {
 
   const doesUserHaveOrgToUpgrade = trpc.viewer.organizations.checkIfOrgNeedsUpgrade.useQuery();
 
+  // Automatically trigger upgrade when user visits the page and has an org to upgrade
   useEffect(() => {
-    doesUserHaveOrgToUpgrade.data && publishOrgMutation.mutate();
-  }, [doesUserHaveOrgToUpgrade.data, publishOrgMutation]);
+    if (doesUserHaveOrgToUpgrade.data) {
+      publishOrgMutation.mutate();
+    }
+  }, [doesUserHaveOrgToUpgrade.data]);
 
   return (
     <Shell withoutSeo={true}>

--- a/apps/web/modules/upgrade/upgrade-view.tsx
+++ b/apps/web/modules/upgrade/upgrade-view.tsx
@@ -27,11 +27,11 @@ export default function UpgradePage() {
     },
   });
 
-  useEffect(() => {
-    publishOrgMutation.mutate();
-  }, [publishOrgMutation]);
-
   const doesUserHaveOrgToUpgrade = trpc.viewer.organizations.checkIfOrgNeedsUpgrade.useQuery();
+
+  useEffect(() => {
+    doesUserHaveOrgToUpgrade.data && publishOrgMutation.mutate();
+  }, [doesUserHaveOrgToUpgrade.data, publishOrgMutation]);
 
   return (
     <Shell withoutSeo={true}>

--- a/apps/web/modules/upgrade/upgrade-view.tsx
+++ b/apps/web/modules/upgrade/upgrade-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 import Shell from "@calcom/features/shell/Shell";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -25,6 +26,10 @@ export default function UpgradePage() {
       showToast(error.message, "error");
     },
   });
+
+  useEffect(() => {
+    publishOrgMutation.mutate();
+  }, [publishOrgMutation]);
 
   const doesUserHaveOrgToUpgrade = trpc.viewer.organizations.checkIfOrgNeedsUpgrade.useQuery();
 


### PR DESCRIPTION
right now, when organizations are unpublished (unpaid or stopped paying) we ask people go to https://app.cal.com/upgrade

i want this page to immediately go to stripe

not sure if this works, havent tested