### PR TITLE
fix: prevent background scroll on opening timezone select menu

### DIFF
--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -178,7 +178,7 @@ export function TimezoneSelectComponent({
         groupHeading: () => "leading-none text-xs uppercase text-default pl-2.5 pt-4 pb-2",
         menuList: (state) =>
           classNames(
-            "scroll-bar scrollbar-track-w-20 rounded-md",
+            "scroll-bar h-40 scrollbar-track-w-20 rounded-md",
             timezoneClassNames?.menuList && timezoneClassNames.menuList(state)
           ),
         indicatorsContainer: (state) =>


### PR DESCRIPTION
## What does this PR do?

- Fixes #19622 
- Prevents background scrolling when the Timezone Select dropdown is open.
- Ensures the last timezone remains fully visible.
- Adds `h-40` to limit dropdown height and prevent content overflow.

## Visual Demo (For contributors especially)

### Before:
- Background would scroll when the dropdown was opened.

### After:
- The dropdown has a fixed height and does not cause background scrolling.

#### Video Demo:

https://github.com/user-attachments/assets/26cab3db-034c-4e62-8cda-1fb589c33184


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated documentation if necessary.
- [x] I confirm automated tests are in place that prove my fix is effective.

## How should this be tested?

1. Open the Timezone Select dropdown.
2. Verify that the background does **not** scroll.
3. Scroll to the bottom and ensure the last timezone is fully visible.

## Checklist

- [x] I have read the contributing guide.
- [x] My code follows the style guidelines of this project.
- [x] I have checked that my changes generate no new warnings.
