### PR TITLE
refactor: Salesforce - account query based on website

### DIFF
--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -895,9 +895,9 @@ export default class SalesforceCRMService implements CRM {
                       'https://www.${emailDomain}', 'https://${emailDomain}') LIMIT 1`
     );
     if (accountQuery.records.length > 0) {
-      const accountId = accountQuery.records[0] as { Id: string };
-      log.info("Found account based on email domain", safeStringify({ accountId }));
-      return accountId;
+      const account = accountQuery.records[0] as { Id: string };
+      log.info("Found account based on email domain", safeStringify({ accountId: account.Id }));
+      return account.Id;
     }
 
     // Fallback to querying which account the majority of contacts are under

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -890,12 +890,14 @@ export default class SalesforceCRMService implements CRM {
     log.info("getAccountIdBasedOnEmailDomainOfContacts", safeStringify({ email, emailDomain }));
     // First check if an account has the same website as the email domain of the attendee
     const accountQuery = await conn.query(
-      `SELECT Id, Website FROM Account WHERE Website LIKE '%${emailDomain}%' LIMIT 1`
+      `SELECT Id, Website FROM Account WHERE Website IN ('${emailDomain}', 'www.${emailDomain}', 
+                      'http://www.${emailDomain}', 'http://${emailDomain}',
+                      'https://www.${emailDomain}', 'https://${emailDomain}') LIMIT 1`
     );
-
     if (accountQuery.records.length > 0) {
-      const account = accountQuery.records[0] as { Id: string };
-      return account.Id;
+      const accountId = accountQuery.records[0] as { Id: string };
+      log.info("Found account based on email domain", safeStringify({ accountId }));
+      return accountId;
     }
 
     // Fallback to querying which account the majority of contacts are under
@@ -903,7 +905,15 @@ export default class SalesforceCRMService implements CRM {
       `SELECT Id, Email, AccountId FROM Contact WHERE Email LIKE '%@${emailDomain}' AND AccountId != null`
     );
 
-    return this.getDominantAccountId(response.records as { AccountId: string }[]);
+    const accountId = this.getDominantAccountId(response.records as { AccountId: string }[]);
+
+    if (accountId) {
+      log.info("Found account based on other contacts", safeStringify({ accountId }));
+    } else {
+      log.info("No account found");
+    }
+
+    return accountId;
   }
 
   private async getAccountBasedOnEmailDomainOfContacts(email: string) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When querying a Salesforce account associated with the email domain of an attendee, instead of using double wildcards to match the account website, instead we'll use strict matches with different variations of URL prefixes

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Tested with the following attendee email test@accountdomain.com

Account websites tested
- acconutdomain.com ✅ 
- 1accountdomain.com ❌ 
- accountdomain.co ❌ 
- www.accountdomain.com ✅ 
- http://accountdomain.com ✅ 
- https://accountdomain.com ✅ 
- http://www.accountdomain.com ✅ 
- https://www.accountdomain.com ✅ 
 