### PR TITLE
revert: "fix: prevent background scroll on opening timezone select menu"

### DIFF
--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -178,7 +178,7 @@ export function TimezoneSelectComponent({
         groupHeading: () => "leading-none text-xs uppercase text-default pl-2.5 pt-4 pb-2",
         menuList: (state) =>
           classNames(
-            "scroll-bar h-40 scrollbar-track-w-20 rounded-md",
+            "scroll-bar scrollbar-track-w-20 rounded-md",
             timezoneClassNames?.menuList && timezoneClassNames.menuList(state)
           ),
         indicatorsContainer: (state) =>


### PR DESCRIPTION
Reverts calcom/cal.com#19789
Not good
![Screenshot 2025-03-07 090101](https://github.com/user-attachments/assets/0ad0e849-bbcf-4513-ab94-e3a3d200fcb0)
