### PR TITLE
fix: fixes the crash when empty `users` or `hosts` array is passed to _getDelegationCredentialsMapPerUser

### DIFF
--- a/packages/lib/delegationCredential/server.test.ts
+++ b/packages/lib/delegationCredential/server.test.ts
@@ -399,6 +399,14 @@ describe("enrichUsersWithDelegationCredentials", () => {
       }))
     );
   });
+
+  it("should return empty array when no users is empty", async () => {
+    const result = await enrichUsersWithDelegationCredentials({
+      orgId: 1,
+      users: [],
+    });
+    expect(result).toEqual([]);
+  });
 });
 
 describe("enrichHostsWithDelegationCredentials", () => {
@@ -497,6 +505,14 @@ describe("enrichHostsWithDelegationCredentials", () => {
         },
       }))
     );
+  });
+
+  it("should return empty array when hosts is empty", async () => {
+    const result = await enrichHostsWithDelegationCredentials({
+      orgId: 1,
+      hosts: [],
+    });
+    expect(result).toEqual([]);
   });
 });
 

--- a/packages/lib/delegationCredential/server.test.ts
+++ b/packages/lib/delegationCredential/server.test.ts
@@ -400,7 +400,7 @@ describe("enrichUsersWithDelegationCredentials", () => {
     );
   });
 
-  it("should return empty array when no users is empty", async () => {
+  it("should return empty array when users is empty", async () => {
     const result = await enrichUsersWithDelegationCredentials({
       orgId: 1,
       users: [],

--- a/packages/lib/delegationCredential/server.ts
+++ b/packages/lib/delegationCredential/server.ts
@@ -214,7 +214,13 @@ async function _getDelegationCredentialsMapPerUser({
   if (!organizationId) {
     return emptyMap;
   }
-  const domain = users[0].email.split("@")[1];
+  // We assume that all users in an organization are from the same domain, so first one should be fine.
+  // TODO: There could be multiple domains in an organization(if an organization is migrating maybe from one to another or for some other reason) and we should actually consider all of them, maybe group by domain.
+  const userThatDeterminesDomain = users[0];
+  if (!userThatDeterminesDomain) {
+    return emptyMap;
+  }
+  const domain = userThatDeterminesDomain.email.split("@")[1];
   log.debug("called with", safeStringify({ users }));
   const delegationCredential =
     await DelegationCredentialRepository.findUniqueByOrganizationIdAndDomainIncludeSensitiveServiceAccountKey(


### PR DESCRIPTION
## What does this PR do?

Seeing some errors in sentry where `_getDelegationCredentialsMapPerUser` crash as it gets empty array which Typescript isn't able to inform 

In cases where no users are found, this error could come possibly e.g. it happens in routing form when we reach a route that has no team members matching
