### PR TITLE
fix: UID cookie isn't accessible/created when in embed as it is third party context.

### DIFF
--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.test.ts
@@ -1,0 +1,103 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// We want to test that the UID cookie set by reserveSlotHandler is configured with the correct
+// SameSite and Secure attributes depending on the environment (http vs https).
+// reserveSlotHandler relies on WEBAPP_URL being evaluated at import time, so we need to reset modules
+// between tests after tweaking process.env to simulate different deployment environments.
+//
+// The handler also calls into Prisma and the SelectedSlotsRepository, so we stub those parts out.
+
+// We alias the module path once we know WEBAPP_URL has been configured.
+const dynamicImportHandler = async () => await import("./reserveSlot.handler");
+
+// The repository static method is used to check for an existing reservation by someone else.
+// To keep this unit test isolated from the database layer, we stub this to always resolve falsey.
+vi.mock("@calcom/lib/server/repository/selectedSlots", () => ({
+  SelectedSlotsRepository: {
+    findReservedByOthers: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+// A tiny helper to build a canned handler context with stubbed Prisma methods.
+const buildContext = () => {
+  const prismaStub = {
+    eventType: {
+      // Return a minimal event type that will exercise the happy path.
+      findUnique: vi.fn().mockResolvedValue({ users: [{ id: 1 }], seatsPerTimeSlot: null }),
+    },
+    booking: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    selectedSlots: {
+      upsert: vi.fn().mockResolvedValue(null),
+    },
+  } as unknown as any;
+
+  // Capture header values to assert on.
+  let cookieHeaderValue: string | null = null;
+  const resStub = {
+    setHeader: vi.fn((_name: string, value: string) => {
+      cookieHeaderValue = value;
+    }),
+  };
+
+  const reqStub = {
+    cookies: {},
+  };
+
+  return { prismaStub, resStub, reqStub, getCookieHeader: () => cookieHeaderValue };
+};
+
+describe("reserveSlotHandler cookie settings", () => {
+  const originalWebappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
+
+  afterEach(() => {
+    // Reset the module registry and restore the WEBAPP_URL between tests.
+    vi.resetModules();
+    if (originalWebappUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_WEBAPP_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WEBAPP_URL = originalWebappUrl;
+    }
+  });
+
+  it("sets SameSite=None and Secure when WEBAPP_URL is https", async () => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = "https://example.com";
+    vi.resetModules();
+    const { reserveSlotHandler } = await dynamicImportHandler();
+    const { prismaStub, reqStub, resStub, getCookieHeader } = buildContext();
+    await reserveSlotHandler({
+      ctx: { prisma: prismaStub, req: reqStub, res: resStub },
+      input: {
+        slotUtcStartDate: new Date().toISOString(),
+        slotUtcEndDate: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        eventTypeId: 1,
+        bookingUid: undefined,
+        _isDryRun: false,
+      },
+    });
+    const cookie = getCookieHeader();
+    expect(cookie).toMatch(/SameSite=None/);
+    expect(cookie).toMatch(/Secure/);
+  });
+
+  it("falls back to SameSite=Lax and no Secure for http WEBAPP_URL", async () => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = "http://localhost:3000";
+    vi.resetModules();
+    const { reserveSlotHandler } = await dynamicImportHandler();
+    const { prismaStub, reqStub, resStub, getCookieHeader } = buildContext();
+    await reserveSlotHandler({
+      ctx: { prisma: prismaStub, req: reqStub, res: resStub },
+      input: {
+        slotUtcStartDate: new Date().toISOString(),
+        slotUtcEndDate: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        eventTypeId: 1,
+        bookingUid: undefined,
+        _isDryRun: false,
+      },
+    });
+    const cookie = getCookieHeader();
+    expect(cookie).toMatch(/SameSite=Lax/);
+    expect(cookie).not.toMatch(/Secure/);
+  });
+});

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -1,4 +1,5 @@
 import { serialize } from "cookie";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuid } from "uuid";
 
@@ -99,7 +100,18 @@ export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => 
       });
     }
   }
-  res?.setHeader("Set-Cookie", serialize("uid", uid, { path: "/", sameSite: "lax" }));
+  // We need this cookie to be accessible from embeds where the booking flow is displayed within an iframe on a different origin.
+  // For third‑party iframe contexts (embeds on other sites), browsers require SameSite=None and Secure to make the cookie available.
+  // For local development on http://localhost we fall back to SameSite=Lax to avoid requiring https during development.
+  const useSecureCookies = WEBAPP_URL?.startsWith("https://");
+  res?.setHeader(
+    "Set-Cookie",
+    serialize("uid", uid, {
+      path: "/",
+      sameSite: useSecureCookies ? "none" : "lax",
+      secure: useSecureCookies,
+    })
+  );
   return {
     uid: uid,
   };

--- a/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
+++ b/packages/trpc/server/routers/viewer/slots/reserveSlot.handler.ts
@@ -1,9 +1,9 @@
 import { serialize } from "cookie";
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuid } from "uuid";
 
 import dayjs from "@calcom/dayjs";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import { MINUTES_TO_BOOK } from "@calcom/lib/constants";
 import { SelectedSlotsRepository } from "@calcom/lib/server/repository/selectedSlots";
 import type { PrismaClient } from "@calcom/prisma";
@@ -103,7 +103,7 @@ export const reserveSlotHandler = async ({ ctx, input }: ReserveSlotOptions) => 
   // We need this cookie to be accessible from embeds where the booking flow is displayed within an iframe on a different origin.
   // For third‑party iframe contexts (embeds on other sites), browsers require SameSite=None and Secure to make the cookie available.
   // For local development on http://localhost we fall back to SameSite=Lax to avoid requiring https during development.
-  const useSecureCookies = WEBAPP_URL?.startsWith("https://");
+  const useSecureCookies = WEBAPP_URL.startsWith("https://");
   res?.setHeader(
     "Set-Cookie",
     serialize("uid", uid, {


### PR DESCRIPTION
## What does this PR do?

- **Fixes #19616**
- **Fixes CAL-5240**

We currently use a `uid` cookie to both mark a reserved slot and gate the “Slot no longer available” rollout. On embeds, however, that cookie never gets set because `SameSite=Lax` cookies aren’t sent from `<iframe>`s and other third‑party contexts. This has two side–effects:

* Every slot a user clicks in an embed ends up blocked for everybody else because each `reserveSlot` call gets a fresh `uid` and we never “unlink” the previous provisional selection.
* We can’t roll out “Slot no longer available” on embeds because the feature flag requires the visitor to have a cookie.

This patch sets the `uid` cookie to `SameSite=None; Secure` in production (`WEBAPP_URL` starts with `https://`) and gracefully falls back to `SameSite=Lax` locally so you can still develop on `http://localhost`. Safari will still need special handling, but moving to `SameSite=None` unblocks Chrome and other major browsers.

A small unit test has been added under `packages/trpc/server/routers/viewer/slots` to exercise that the cookie emitted by `reserveSlotHandler` picks up the right security flags for both HTTP and HTTPS environments.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run under an HTTPS `WEBAPP_URL` (or point `NEXT_PUBLIC_WEBAPP_URL` at an HTTPS origin).
2. Embed a booking page in a separate site and select a slot.
3. Open the browser’s cookie inspector inside the iframe: the `uid` cookie should now be present with `SameSite=None` and `Secure` set.
4. Click multiple timeslots – only your last selection should remain blocked for other visitors, and Quick Availability checks can be rolled out to embeds because `uid` is now visible.

For local development (`http://localhost:3000`), cookies continue to be `SameSite=Lax`/non‑secure so you won’t be forced to configure HTTPS.