### PR TITLE
fix: failing tests during DST transition

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/complex-schedules.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/complex-schedules.test.ts
@@ -56,18 +56,34 @@ describe("handleNewBooking", () => {
         });
 
         // Using .endOf("day") here to ensure our date doesn't change when we set the time zone
-        const startDateTimeOrganizerTz = dayjs(plus1DateString)
+        let startDateTimeOrganizerTz = dayjs(plus1DateString)
           .endOf("day")
           .tz(newYorkTimeZone)
           .hour(23)
           .minute(0)
           .second(0);
 
-        const endDateTimeOrganizerTz = dayjs(plus1DateString)
+        let endDateTimeOrganizerTz = dayjs(plus1DateString)
           .endOf("day")
           .tz(newYorkTimeZone)
           .startOf("day")
           .add(1, "day");
+
+        const endUtcOffset = Math.abs(endDateTimeOrganizerTz.utcOffset());
+        const startUtcOffset = Math.abs(startDateTimeOrganizerTz.utcOffset());
+        //on DST transition day the utc offsets are unequal
+        if (startUtcOffset !== endUtcOffset) {
+          if (endUtcOffset > startUtcOffset) {
+            // -5:00 to -4:00 transition
+            endDateTimeOrganizerTz = endDateTimeOrganizerTz.subtract(
+              endUtcOffset - startUtcOffset,
+              "minutes"
+            );
+          } else {
+            // -4:00 to -5:00 transition
+            startDateTimeOrganizerTz = startDateTimeOrganizerTz.add(startUtcOffset - endUtcOffset, "minutes");
+          }
+        }
 
         const schedule = {
           name: "4:00PM to 11:59PM in New York",

--- a/packages/features/bookings/lib/handleNewBooking/test/date-overrides.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/date-overrides.test.ts
@@ -221,18 +221,34 @@ describe("handleNewBooking", () => {
         });
 
         // Using .endOf("day") here to ensure our date doesn't change when we set the time zone
-        const startDateTimeOrganizerTz = dayjs(plus1DateString)
+        let startDateTimeOrganizerTz = dayjs(plus1DateString)
           .endOf("day")
           .tz(newYorkTimeZone)
           .hour(23)
           .minute(0)
           .second(0);
 
-        const endDateTimeOrganizerTz = dayjs(plus1DateString)
+        let endDateTimeOrganizerTz = dayjs(plus1DateString)
           .endOf("day")
           .tz(newYorkTimeZone)
           .startOf("day")
           .add(1, "day");
+
+        const endUtcOffset = Math.abs(endDateTimeOrganizerTz.utcOffset());
+        const startUtcOffset = Math.abs(startDateTimeOrganizerTz.utcOffset());
+        //on DST transition day the utc offsets are unequal
+        if (startUtcOffset !== endUtcOffset) {
+          if (endUtcOffset > startUtcOffset) {
+            // -5:00 to -4:00 transition
+            endDateTimeOrganizerTz = endDateTimeOrganizerTz.subtract(
+              endUtcOffset - startUtcOffset,
+              "minutes"
+            );
+          } else {
+            // -4:00 to -5:00 transition
+            startDateTimeOrganizerTz = startDateTimeOrganizerTz.add(startUtcOffset - endUtcOffset, "minutes");
+          }
+        }
 
         const overrideSchedule = {
           name: "11:00PM to 11:59PM in New York",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #19863 
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Root Cause

https://github.com/calcom/cal.com/blob/ae659b517602dbfc50bb46023b8ca4d4f58b662c/packages/features/bookings/lib/handleNewBooking/test/complex-schedules.test.ts#L59-L70

On DST Transition days , the utcOffsets or the timezones of startTime and endTime are different.
On Mar9, 2025 , the endTime is in timezone of -5:00
while the startTime is in -4:00 timezone

Example: For today
plus1DateString = 2025-03-09
startDateTimeOrganizerTz = 2025-03-09T23:00:00 **-04:00**
endDateTimeOrganizerTz = 2025-03-10T00:00:00 **-05:00**
The time interval is intended to be 60mins , but because of different timezones of -4:00 and -5:00 , the time diff or interval is 120mins

Due to this the interval is calculated as 120mins instead of 60mins.
Hence it does not match the eventType length, in this function
https://github.com/calcom/cal.com/blob/ae659b517602dbfc50bb46023b8ca4d4f58b662c/packages/features/bookings/lib/handleNewBooking/validateEventLength.ts#L14-L25


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] - N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
