### PR TITLE
fix: correct translation key for host and attendee emails

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -322,12 +322,12 @@ export default function Success(props: PageProps) {
       const attendee = bookingInfo.attendees[0]?.name || bookingInfo.attendees[0]?.email || "Nameless";
       const host = bookingInfo.user.name || bookingInfo.user.email;
       if (isHost) {
-        return t(`${titlePrefix}emailed_host_and_attendees${titleSuffix}`, {
+        return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
           user: attendee,
         });
       }
       if (isAttendee) {
-        return t(`${titlePrefix}emailed_host_and_attendees${titleSuffix}`, {
+        return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
           user: host,
         });
       }
@@ -336,7 +336,7 @@ export default function Success(props: PageProps) {
         attendee,
       });
     }
-    return t(`emailed_host_and_attendees${titleSuffix}`);
+    return t(`emailed_host_and_attendee${titleSuffix}`);
   }
 
   // This is a weird case where the same route can be opened in booking flow as a success page or as a booking detail page from the app


### PR DESCRIPTION
## What does this PR do?
Locale was not updated according to the latest common.json changes so text appeared wrong on the main branch, this PR fixes that.

before:
![image](https://github.com/user-attachments/assets/442fcb23-9d52-41b4-ace2-59122e008192)


after:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/ccafd708-5832-4c0d-bbea-0b57dac4d18f" />
