### PR TITLE
perf: Make dynamic imports in tRPC work

### DIFF
--- a/packages/trpc/server/routers/viewer/availability/_router.tsx
+++ b/packages/trpc/server/routers/viewer/availability/_router.tsx
@@ -13,11 +13,19 @@ type AvailabilityRouterHandlerCache = {
 };
 
 const UNSTABLE_HANDLER_CACHE: AvailabilityRouterHandlerCache = {};
+const QUERY_TO_HANDLER_MAP = {
+  list: "./list.handler",
+  user: "./user.handler",
+  listTeam: "./team/listTeamAvailability.handler",
+  calendarOverlay: "./calendarOverlay.handler",
+};
+const handlerContext = require.context("./", false, /\.handler$/);
 
 export const availabilityRouter = router({
   list: authedProcedure.query(async ({ ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.list) {
-      UNSTABLE_HANDLER_CACHE.list = await import("./list.handler").then((mod) => mod.listHandler);
+      UNSTABLE_HANDLER_CACHE.list = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .listHandler;
     }
 
     // Unreachable code but required for type safety
@@ -32,7 +40,8 @@ export const availabilityRouter = router({
 
   user: authedProcedure.input(ZUserInputSchema).query(async ({ ctx, input }) => {
     if (!UNSTABLE_HANDLER_CACHE.user) {
-      UNSTABLE_HANDLER_CACHE.user = await import("./user.handler").then((mod) => mod.userHandler);
+      UNSTABLE_HANDLER_CACHE.user = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .userHandler;
     }
 
     // Unreachable code but required for type safety
@@ -47,9 +56,9 @@ export const availabilityRouter = router({
   }),
   listTeam: authedProcedure.input(ZListTeamAvailaiblityScheme).query(async ({ ctx, input }) => {
     if (!UNSTABLE_HANDLER_CACHE.listTeamAvailability) {
-      UNSTABLE_HANDLER_CACHE.listTeamAvailability = await import("./team/listTeamAvailability.handler").then(
-        (mod) => mod.listTeamAvailabilityHandler
-      );
+      UNSTABLE_HANDLER_CACHE.listTeamAvailability = await handlerContext(
+        QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]
+      ).listTeamAvailabilityHandler;
     }
 
     // Unreachable code but required for type safety
@@ -65,9 +74,8 @@ export const availabilityRouter = router({
   schedule: scheduleRouter,
   calendarOverlay: authedProcedure.input(ZCalendarOverlayInputSchema).query(async ({ ctx, input }) => {
     if (!UNSTABLE_HANDLER_CACHE.calendarOverlay) {
-      UNSTABLE_HANDLER_CACHE.calendarOverlay = await import("./calendarOverlay.handler").then(
-        (mod) => mod.calendarOverlayHandler
-      );
+      UNSTABLE_HANDLER_CACHE.calendarOverlay = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .calendarOverlayHandler;
     }
 
     // Unreachable code but required for type safety

--- a/packages/trpc/server/routers/viewer/availability/schedule/_router.tsx
+++ b/packages/trpc/server/routers/viewer/availability/schedule/_router.tsx
@@ -24,10 +24,23 @@ type ScheduleRouterHandlerCache = {
 
 const UNSTABLE_HANDLER_CACHE: ScheduleRouterHandlerCache = {};
 
+const QUERY_TO_HANDLER_MAP = {
+  "schedule.get": "./get.handler",
+  "schedule.create": "./create.handler",
+  "schedule.delete": "./delete.handler",
+  "schedule.update": "./update.handler",
+  "schedule.duplicate": "./duplicate.handler",
+  "schedule.getScheduleByUserId": "./getScheduleByUserId.handler",
+  "schedule.getAllSchedulesByUserId": "./getAllSchedulesByUserId.handler",
+  "schedule.getScheduleByEventTypeSlug": "./getScheduleByEventTypeSlug.handler",
+  "schedule.bulkUpdateDefaultAvailability": "./bulkUpdateDefaultAvailability.handler",
+};
+const handlerContext = require.context("./", false, /\.handler$/);
+
 export const scheduleRouter = router({
   get: authedProcedure.input(ZGetInputSchema).query(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.get) {
-      UNSTABLE_HANDLER_CACHE.get = await import("./get.handler").then((mod) => mod.getHandler);
+      UNSTABLE_HANDLER_CACHE.get = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]).getHandler;
     }
 
     // Unreachable code but required for type safety
@@ -43,7 +56,8 @@ export const scheduleRouter = router({
 
   create: authedProcedure.input(ZCreateInputSchema).mutation(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.create) {
-      UNSTABLE_HANDLER_CACHE.create = await import("./create.handler").then((mod) => mod.createHandler);
+      UNSTABLE_HANDLER_CACHE.create = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .createHandler;
     }
 
     // Unreachable code but required for type safety
@@ -59,7 +73,8 @@ export const scheduleRouter = router({
 
   delete: authedProcedure.input(ZDeleteInputSchema).mutation(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.delete) {
-      UNSTABLE_HANDLER_CACHE.delete = await import("./delete.handler").then((mod) => mod.deleteHandler);
+      UNSTABLE_HANDLER_CACHE.delete = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .deleteHandler;
     }
 
     // Unreachable code but required for type safety
@@ -75,7 +90,8 @@ export const scheduleRouter = router({
 
   update: authedProcedure.input(ZUpdateInputSchema).mutation(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.update) {
-      UNSTABLE_HANDLER_CACHE.update = await import("./update.handler").then((mod) => mod.updateHandler);
+      UNSTABLE_HANDLER_CACHE.update = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .updateHandler;
     }
 
     // Unreachable code but required for type safety
@@ -91,9 +107,8 @@ export const scheduleRouter = router({
 
   duplicate: authedProcedure.input(ZScheduleDuplicateSchema).mutation(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.duplicate) {
-      UNSTABLE_HANDLER_CACHE.duplicate = await import("./duplicate.handler").then(
-        (mod) => mod.duplicateHandler
-      );
+      UNSTABLE_HANDLER_CACHE.duplicate = await handlerContext(QUERY_TO_HANDLER_MAP[ctx.req.query.trpc])
+        .duplicateHandler;
     }
 
     // Unreachable code but required for type safety
@@ -109,9 +124,9 @@ export const scheduleRouter = router({
 
   getScheduleByUserId: authedProcedure.input(ZGetByUserIdInputSchema).query(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.getScheduleByUserId) {
-      UNSTABLE_HANDLER_CACHE.getScheduleByUserId = await import("./getScheduleByUserId.handler").then(
-        (mod) => mod.getScheduleByUserIdHandler
-      );
+      UNSTABLE_HANDLER_CACHE.getScheduleByUserId = await handlerContext(
+        QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]
+      ).getScheduleByUserIdHandler;
     }
 
     // Unreachable code but required for type safety
@@ -127,9 +142,9 @@ export const scheduleRouter = router({
 
   getAllSchedulesByUserId: authedProcedure.input(ZGetAllByUserIdInputSchema).query(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.getAllSchedulesByUserId) {
-      UNSTABLE_HANDLER_CACHE.getAllSchedulesByUserId = await import("./getAllSchedulesByUserId.handler").then(
-        (mod) => mod.getAllSchedulesByUserIdHandler
-      );
+      UNSTABLE_HANDLER_CACHE.getAllSchedulesByUserId = await handlerContext(
+        QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]
+      ).getAllSchedulesByUserIdHandler;
     }
 
     // Unreachable code but required for type safety
@@ -145,9 +160,9 @@ export const scheduleRouter = router({
 
   getScheduleByEventSlug: authedProcedure.input(ZGetByEventSlugInputSchema).query(async ({ input, ctx }) => {
     if (!UNSTABLE_HANDLER_CACHE.getScheduleByEventSlug) {
-      UNSTABLE_HANDLER_CACHE.getScheduleByEventSlug = await import(
-        "./getScheduleByEventTypeSlug.handler"
-      ).then((mod) => mod.getScheduleByEventSlugHandler);
+      UNSTABLE_HANDLER_CACHE.getScheduleByEventSlug = await handlerContext(
+        QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]
+      ).getScheduleByEventSlugHandler;
     }
 
     // Unreachable code but required for type safety
@@ -164,9 +179,9 @@ export const scheduleRouter = router({
     .input(ZBulkUpdateToDefaultAvailabilityInputSchema)
     .mutation(async ({ ctx, input }) => {
       if (!UNSTABLE_HANDLER_CACHE.bulkUpdateToDefaultAvailability) {
-        UNSTABLE_HANDLER_CACHE.bulkUpdateToDefaultAvailability = await import(
-          "./bulkUpdateDefaultAvailability.handler"
-        ).then((mod) => mod.bulkUpdateToDefaultAvailabilityHandler);
+        UNSTABLE_HANDLER_CACHE.bulkUpdateToDefaultAvailability = await handlerContext(
+          QUERY_TO_HANDLER_MAP[ctx.req.query.trpc]
+        ).bulkUpdateToDefaultAvailabilityHandler;
       }
 
       if (!UNSTABLE_HANDLER_CACHE.bulkUpdateToDefaultAvailability) {


### PR DESCRIPTION
## What does this PR do?

These dynamic imports are pretty much ignored seemingly by webpack and it seems because the import string given to it is hardcoded. When changed to be a value that cannot be determined at compile time (slash runtime because this context is `yarn dev`), it doesn't load all of the dynamic imports that are irrelevant to the tRPC router being called.

Note that these results are based on perf testing this change on top of #19771, which already has a major reduction in modules loaded.
When running locally and calling `http://localhost:3001/api/trpc/availability/schedule.get?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22scheduleId%22%3A4603%7D%7D%2C%221%22%3A%7B%22json%22%3A%7B%22scheduleId%22%3A4630%7D%7D%2C%222%22%3A%7B%22json%22%3A%7B%22scheduleId%22%3A4657%7D%7D%2C%223%22%3A%7B%22json%22%3A%7B%22scheduleId%22%3A4684%7D%7D%7D`:

**Before:**
✓ Compiled /api/trpc/availability/[trpc] in 535ms (619 modules)

**After:**
✓ Compiled /api/trpc/availability/[trpc] in 282ms (247 modules)

The assumption is that if this approach is applied across all of our tRPC routers, we can reduce the number of imports by hundreds if not thousands when full pages are loaded, since many of them call lots of different tRPC routers.

**TBD: Answer the following questions:**
- What impact does this have on webpack's ability to cache these imports? 
- What impact will this have on prod?

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure all tRPC endpoints changed still work properly 
