### PR TITLE
fix: broken metadata import from platform/types

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -260,7 +260,9 @@ describe("OAuth Client Users Endpoints", () => {
 
       expect(responseBody.status).toEqual(SUCCESS_STATUS);
       expect(responseBody.data).toBeDefined();
-      expect(responseBody.data.user.email).toEqual(getOAuthUserEmail(oAuthClient.id, requestBody.email));
+      expect(responseBody.data.user.email).toEqual(
+        OAuthClientUsersService.getOAuthUserEmail(oAuthClient.id, requestBody.email)
+      );
       expect(responseBody.data.user.timeZone).toEqual(requestBody.timeZone);
       expect(responseBody.data.user.name).toEqual(requestBody.name);
       expect(responseBody.data.user.weekStart).toEqual(requestBody.weekStart);

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -106,7 +106,7 @@ export class OAuthClientUsersService {
     const { offset, limit, emails } = queryParams;
 
     const oAuthEmails = emails?.map((email) =>
-      email.includes(oAuthClientId) ? email : this.getOAuthUserEmail(oAuthClientId, email)
+      email.includes(oAuthClientId) ? email : OAuthClientUsersService.getOAuthUserEmail(oAuthClientId, email)
     );
 
     const managedUsers = await this.userRepository.findManagedUsersByOAuthClientIdAndEmails(

--- a/apps/api/v2/src/modules/organizations/organizations/inputs/create-managed-organization.input.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/inputs/create-managed-organization.input.ts
@@ -2,11 +2,7 @@ import { RefreshApiKeyInput } from "@/modules/api-keys/inputs/refresh-api-key.in
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { IsObject, IsOptional, IsString, Length } from "class-validator";
 
-import {
-  Metadata,
-  METADATA_DOCS,
-  ValidateMetadata,
-} from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import { Metadata, METADATA_DOCS, ValidateMetadata } from "@calcom/platform-types";
 
 export class CreateOrganizationInput extends RefreshApiKeyInput {
   @IsString()

--- a/apps/api/v2/src/modules/organizations/organizations/inputs/update-managed-organization.input.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/inputs/update-managed-organization.input.ts
@@ -1,11 +1,7 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { IsObject, IsOptional, IsString, Length } from "class-validator";
 
-import {
-  Metadata,
-  METADATA_DOCS,
-  ValidateMetadata,
-} from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import { Metadata, METADATA_DOCS, ValidateMetadata } from "@calcom/platform-types";
 
 export class UpdateOrganizationInput {
   @IsString()

--- a/apps/api/v2/src/modules/organizations/organizations/outputs/managed-organization.output.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/outputs/managed-organization.output.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Expose, Transform, Type } from "class-transformer";
 import { IsBoolean, IsInt, IsObject, IsOptional, IsString, Length, ValidateNested } from "class-validator";
 
-import { Metadata } from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import { Metadata } from "@calcom/platform-types";
 
 export class ManagedOrganizationOutput {
   @IsInt()

--- a/apps/api/v2/src/modules/teams/teams/inputs/create-team.input.ts
+++ b/apps/api/v2/src/modules/teams/teams/inputs/create-team.input.ts
@@ -1,11 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { IsBoolean, IsObject, IsOptional, IsString, IsUrl, Length } from "class-validator";
 
-import {
-  Metadata,
-  METADATA_DOCS,
-  ValidateMetadata,
-} from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import { Metadata, METADATA_DOCS, ValidateMetadata } from "@calcom/platform-types";
 
 export class CreateTeamInput {
   @IsString()

--- a/apps/api/v2/src/modules/teams/teams/inputs/update-team.input.ts
+++ b/apps/api/v2/src/modules/teams/teams/inputs/update-team.input.ts
@@ -1,11 +1,7 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { IsBoolean, IsObject, IsOptional, IsString, IsUrl, Length } from "class-validator";
 
-import {
-  Metadata,
-  METADATA_DOCS,
-  ValidateMetadata,
-} from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import { Metadata, METADATA_DOCS, ValidateMetadata } from "@calcom/platform-types";
 
 export class UpdateTeamDto {
   @IsString()

--- a/packages/platform/types/bookings/2024-08-13/inputs/index.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/index.ts
@@ -8,3 +8,4 @@ export * from "./reassign-to-user.input";
 export * from "./reschedule-booking-input.pipe";
 export * from "./cancel-booking-input.pipe";
 export * from "./decline-booking.input";
+export * from "./validators/validate-metadata";

--- a/packages/platform/types/teams/outputs/team.output.ts
+++ b/packages/platform/types/teams/outputs/team.output.ts
@@ -2,7 +2,7 @@ import { ApiProperty as DocsProperty, ApiPropertyOptional } from "@nestjs/swagge
 import { Expose, Transform } from "class-transformer";
 import { IsBoolean, IsInt, IsObject, IsOptional, IsString, IsUrl, Length } from "class-validator";
 
-import type { Metadata } from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata";
+import type { Metadata } from "../../bookings/2024-08-13/inputs/validators/validate-metadata";
 
 export class TeamOutputDto {
   @IsInt()


### PR DESCRIPTION
Broken import from "@calcom/platform-types/bookings/2024-08-13/inputs/validators/validate-metadata"; api-v2 can't import unbuilt code in prod build