### PR TITLE
fix: ensure correct dymanic values are passed in getTitle()

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -310,12 +310,18 @@ export default function Success(props: PageProps) {
       const host = bookingInfo.user.name || bookingInfo.user.email;
 
       if (isHost || isAttendee) {
-        return t(`round_robin_emailed_you_and_attendees${titleSuffix}`, {
-          user: isHost ? attendee : host,
-        });
+        if (titlePrefix) {
+          return t(`${titlePrefix}emailed_you_and_attendees${titleSuffix}`, {
+            user: isHost ? attendee : host,
+          });
+        } else {
+          return t(`round_robin_emailed_you_and_attendees${titleSuffix}`, {
+            user: isHost ? attendee : host,
+          });
+        }
       }
 
-      return t(`round_robin_emailed_host_and_attendee${titleSuffix}`, {
+      return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
         host,
         attendee,
       });

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -308,19 +308,14 @@ export default function Success(props: PageProps) {
       const isAttendee = bookingInfo.attendees.find((attendee) => attendee.email === session?.user?.email);
       const attendee = bookingInfo.attendees[0]?.name || bookingInfo.attendees[0]?.email || "Nameless";
       const host = bookingInfo.user.name || bookingInfo.user.email;
-      if (isHost) {
-        return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
-          host,
-          attendee,
+
+      if (isHost || isAttendee) {
+        return t(`round_robin_emailed_you_and_attendees${titleSuffix}`, {
+          user: isHost ? attendee : host,
         });
       }
-      if (isAttendee) {
-        return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
-          host,
-          attendee,
-        });
-      }
-      return t(`${titlePrefix}emailed_host_and_attendee${titleSuffix}`, {
+
+      return t(`round_robin_emailed_host_and_attendee${titleSuffix}`, {
         host,
         attendee,
       });


### PR DESCRIPTION
## What does this PR do?

- For personalized messages, use the "round_robin_emailed_you_and_attendees" key with the 'user' property set appropriately
- For third-party views, pass both 'host' and 'attendee' as expected by the locale string



Basically addresses this concern after the last [change](https://github.com/calcom/cal.com/commit/a7247c594b82c5c96951e12c9c0d93036559dde8):
<img width="377" alt="image" src="https://github.com/user-attachments/assets/ca4235ae-f6cb-4540-b2a9-5f48f2b42aa6" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
