### PR TITLE
fix: Disable connected forms for any new form or route until further notice

### DIFF
--- a/packages/app-store/routing-forms/components/FormActions.tsx
+++ b/packages/app-store/routing-forms/components/FormActions.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 import { createContext, forwardRef, useContext, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
@@ -23,7 +23,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Form,
-  SettingsToggle,
   showToast,
   Switch,
   TextAreaField,
@@ -126,7 +125,8 @@ function NewFormDialog({
                 placeholder={t("form_description_placeholder")}
               />
             </div>
-            {action === "duplicate" && (
+            {/* Disable this feature for new forms till we get it fully working with Routing Form with Attributes. This isn't much used feature */}
+            {/* {action === "duplicate" && (
               <Controller
                 name="shouldConnect"
                 render={({ field: { value, onChange } }) => {
@@ -142,7 +142,7 @@ function NewFormDialog({
                   );
                 }}
               />
-            )}
+            )} */}
           </div>
           <DialogFooter showDivider className="mt-12">
             <DialogClose />

--- a/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
@@ -952,7 +952,24 @@ const Routes = ({
         };
       }) || [];
 
-  const isConnectedForm = (id: string) => form.connectedForms.map((f) => f.id).includes(id);
+  // const isConnectedForm = (id: string) => form.connectedForms.map((f) => f.id).includes(id);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const routers: any[] = [];
+  /* Disable this feature for new forms till we get it fully working with Routing Form with Attributes. This isn't much used feature */
+  // const routers = availableRouters.map((r) => {
+  //   // Reset disabled state
+  //   r.isDisabled = false;
+
+  //   // Can't select a form as router that is already a connected form. It avoids cyclic dependency
+  //   if (isConnectedForm(r.value)) {
+  //     r.isDisabled = true;
+  //   }
+  //   // A route that's already used, can't be reselected
+  //   if (routes.find((route) => route.id === r.value)) {
+  //     r.isDisabled = true;
+  //   }
+  //   return r;
+  // });
 
   const routerOptions = (
     [
@@ -969,22 +986,7 @@ const Routes = ({
       description: string | null;
       isDisabled?: boolean;
     }[]
-  ).concat(
-    availableRouters.map((r) => {
-      // Reset disabled state
-      r.isDisabled = false;
-
-      // Can't select a form as router that is already a connected form. It avoids cyclic dependency
-      if (isConnectedForm(r.value)) {
-        r.isDisabled = true;
-      }
-      // A route that's already used, can't be reselected
-      if (routes.find((route) => route.id === r.value)) {
-        r.isDisabled = true;
-      }
-      return r;
-    })
-  );
+  ).concat(routers);
 
   const [animationRef] = useAutoAnimate<HTMLDivElement>();
 

--- a/packages/app-store/routing-forms/playwright/tests/basic.e2e.ts
+++ b/packages/app-store/routing-forms/playwright/tests/basic.e2e.ts
@@ -145,7 +145,8 @@ test.describe("Routing Forms", () => {
       await verifyFieldOptionsInRule(options, page);
     });
 
-    test.describe("F1<-F2 Relationship", () => {
+    // This feature is disable till it is fully supported and tested with Routing Form with Attributes.
+    test.describe.skip("F1<-F2 Relationship", () => {
       test("Create relationship by adding F1 as route.Editing F1 should update F2", async ({ page }) => {
         const form1Id = await addForm(page, { name: "F1" });
         await page.goto(`/routing-forms/forms`);


### PR DESCRIPTION
## What does this PR do?

Disable connected forms till we support it with Routing Forms with attributes. We will prioritize that only if this feature is required by good amount of users(maybe)
Existing forms will keep on working. This stops only new forms/new routes from using the feature.

Internal discussion to disable it: https://calendso.slack.com/archives/C08B8SYUY02/p1740102151587659

