### PR TITLE
fix: incorrect managed user username format on update

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.e2e-spec.ts
@@ -26,6 +26,7 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 import { randomString } from "test/utils/randomString";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { slugify } from "@calcom/platform-libraries";
 import { ApiSuccessResponse } from "@calcom/platform-types";
 
 const CLIENT_REDIRECT_URI = "http://localhost:4321";
@@ -228,6 +229,9 @@ describe("OAuth Client Users Endpoints", () => {
       expect(responseBody.data.user.timeFormat).toEqual(requestBody.timeFormat);
       expect(responseBody.data.user.locale).toEqual(requestBody.locale);
       expect(responseBody.data.user.avatarUrl).toEqual(requestBody.avatarUrl);
+      const [emailUser, emailDomain] = responseBody.data.user.email.split("@");
+      const [domainName, TLD] = emailDomain.split(".");
+      expect(responseBody.data.user.username).toEqual(slugify(`${emailUser}-${domainName}-${TLD}`));
       expect(responseBody.data.accessToken).toBeDefined();
       expect(responseBody.data.refreshToken).toBeDefined();
 
@@ -546,6 +550,9 @@ describe("OAuth Client Users Endpoints", () => {
       expect(responseBody.data.email).toEqual(
         OAuthClientUsersService.getOAuthUserEmail(oAuthClient.id, userUpdatedEmail)
       );
+      const [emailUser, emailDomain] = responseBody.data.email.split("@");
+      const [domainName, TLD] = emailDomain.split(".");
+      expect(responseBody.data.username).toEqual(slugify(`${emailUser}-${domainName}-${TLD}`));
       expect(responseBody.data.locale).toEqual(Locales.PT_BR);
     });
 

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -123,7 +123,9 @@ export class OAuthClientUsersService {
     if (body.email) {
       const emailWithOAuthId = OAuthClientUsersService.getOAuthUserEmail(oAuthClientId, body.email);
       body.email = emailWithOAuthId;
-      const newUsername = slugify(emailWithOAuthId);
+      const [emailUser, emailDomain] = emailWithOAuthId.split("@");
+      const [domainName, TLD] = emailDomain.split(".");
+      const newUsername = slugify(`${emailUser}-${domainName}-${TLD}`);
       await this.userRepository.updateUsername(userId, newUsername);
     }
 


### PR DESCRIPTION
## What does this PR do?

Managed user username was not following the same pattern on create / update

this pr rectifies that and ensures the format is always 

username-oauthClientId-EmailTld

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

