### PR TITLE
fix: 404 for embed.js in single domain-single org self hosting setup

### DIFF
--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -52,15 +52,22 @@ function getRegExpMatchingAllReservedRoutes(suffix) {
   // Following routes don't exist but they work by doing rewrite. Thus they need to be excluded from matching the orgRewrite patterns
   // Make sure to keep it upto date as more nonExistingRouteRewrites are added.
   const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel"];
+  // Most files/dirs in public dir must not be rewritten to org pages. Ideally it should be all the content of public dir, but that can be done later
+  // It is important to exclude the embed pages separately here because with SINGLE_ORG_SLUG enabled, the entire domain is eligible for rewrite vs just the org subdomain otherwise
+  const staticAssets = ["embed"];
+  // FIXME: I am not sure why public is needed here, an asset 'test' in public isn't accessible through "/public/test" but only through "/test"
+  // We should infact scan through all files in public and exclude them instead.
   const nextJsSpecialPaths = ["_next", "public"];
 
-  let beforeRewriteExcludePages = pages.concat(otherNonExistingRoutePrefixes).concat(nextJsSpecialPaths);
+  let beforeRewriteExcludePages = pages
+    .concat(otherNonExistingRoutePrefixes)
+    .concat(nextJsSpecialPaths)
+    .concat(staticAssets);
   return beforeRewriteExcludePages.join(`${suffix}|`) + suffix;
 }
 
 // To handle /something
 exports.orgUserRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes("/?$")})[a-zA-Z0-9\-_]+)`;
-
 // To handle /something/somethingelse
 exports.orgUserTypeRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes(
   "/"

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -92,7 +92,7 @@ describe("next.config.js - Org Rewrite", () => {
   });
 
   describe("Rewrite", () => {
-    it("booking pages", () => {
+    it("Booking pages", () => {
       expect(orgUserTypeRouteMatch("/user/type")?.params).toEqual({
         user: "user",
         type: "type",
@@ -137,6 +137,9 @@ describe("next.config.js - Org Rewrite", () => {
     it("Non booking pages", () => {
       expect(orgUserTypeRouteMatch("/_next/def")).toEqual(false);
       expect(orgUserTypeRouteMatch("/public/def")).toEqual(false);
+      expect(orgUserRouteMatch("/embed.js")).toEqual(false);
+      expect(orgUserTypeRouteMatch("/embed/embed.js")).toEqual(false);
+      expect(orgUserTypeRouteMatch("/embed/preview.html")).toEqual(false);
 
       expect(orgUserRouteMatch("/_next/")).toEqual(false);
       expect(orgUserRouteMatch("/public/")).toEqual(false);


### PR DESCRIPTION
## What does this PR do?


Fixes #20160 
Fixes CAL-5324
In [Single org mode](https://github.com/calcom/cal.com/blob/fix-404-single-org-embed/README.md?plain=1#L489), app.cal.local:3000 rewrites embed/embed.js as well(thinking it as a user-type booking page). This is excluded now.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Setup Single Org Mode, as linked in README
- Verify that app.cal.local:3000/embed/embed.js loads correctly.

