### PR TITLE
perf: Remove slots router from publicViewer

### DIFF
--- a/packages/features/bookings/Booker/components/hooks/useSlots.ts
+++ b/packages/features/bookings/Booker/components/hooks/useSlots.ts
@@ -92,7 +92,7 @@ export const useSlots = (event: { data?: Pick<BookerEvent, "id" | "length"> | nu
       shallow
     );
   const [slotReservationId, setSlotReservationId] = useSlotReservationId();
-  const reserveSlotMutation = trpc.viewer.public.slots.reserveSlot.useMutation({
+  const reserveSlotMutation = trpc.viewer.slots.reserveSlot.useMutation({
     trpc: {
       context: {
         skipBatch: true,
@@ -102,7 +102,7 @@ export const useSlots = (event: { data?: Pick<BookerEvent, "id" | "length"> | nu
       setSlotReservationId(data.uid);
     },
   });
-  const removeSelectedSlot = trpc.viewer.public.slots.removeSelectedSlotMark.useMutation({
+  const removeSelectedSlot = trpc.viewer.slots.removeSelectedSlotMark.useMutation({
     trpc: { context: { skipBatch: true } },
   });
 

--- a/packages/features/schedules/lib/use-schedule/types.ts
+++ b/packages/features/schedules/lib/use-schedule/types.ts
@@ -1,7 +1,7 @@
 import type { RouterOutputs } from "@calcom/trpc/react";
 
-export type Slots = RouterOutputs["viewer"]["public"]["slots"]["getSchedule"]["slots"];
+export type Slots = RouterOutputs["viewer"]["slots"]["getSchedule"]["slots"];
 
 export type Slot = Slots[string][number] & { showConfirmButton?: boolean };
 
-export type GetSchedule = RouterOutputs["viewer"]["public"]["slots"]["getSchedule"];
+export type GetSchedule = RouterOutputs["viewer"]["slots"]["getSchedule"];

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -109,7 +109,7 @@ export const useSchedule = ({
   if (isTeamEvent) {
     schedule = trpc.viewer.highPerf.getTeamSchedule.useQuery(input, options);
   } else {
-    schedule = trpc.viewer.public.slots.getSchedule.useQuery(input, options);
+    schedule = trpc.viewer.slots.getSchedule.useQuery(input, options);
   }
   return {
     ...schedule,
@@ -117,7 +117,7 @@ export const useSchedule = ({
      * Invalidates the request and resends it regardless of any other configuration including staleTime
      */
     invalidate: () => {
-      return utils.viewer.public.slots.getSchedule.invalidate(input);
+      return utils.viewer.slots.getSchedule.invalidate(input);
     },
   };
 };

--- a/packages/trpc/server/routers/publicViewer/_router.tsx
+++ b/packages/trpc/server/routers/publicViewer/_router.tsx
@@ -1,6 +1,5 @@
 import publicProcedure from "../../procedures/publicProcedure";
 import { importHandler, router } from "../../trpc";
-import { slotsRouter } from "../viewer/slots/_router";
 import { ZUserEmailVerificationRequiredSchema } from "./checkIfUserEmailVerificationRequired.schema";
 import { ZMarkHostAsNoShowInputSchema } from "./markHostAsNoShow.schema";
 import { event } from "./procedures/event";
@@ -45,8 +44,6 @@ export const publicViewerRouter = router({
     );
     return handler(opts);
   }),
-  // REVIEW: This router is part of both the public and private viewer router?
-  slots: slotsRouter,
   event,
   ssoConnections: publicProcedure.query(async () => {
     const handler = await importHandler(


### PR DESCRIPTION
## What does this PR do?

Loading slots pulls in loads of dependencies, which being on the `publicViewer` means that for any of those tRPC calls, we were compiling loads of things we may have never used.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Ensure all tests pass
- Ensure loading booking pages to get slots works fine.
