### PR TITLE
fix: Salesforce Stricter Website querying to prevent wrong account match during contact owner check

### DIFF
--- a/packages/app-store/salesforce/lib/CrmService.test.ts
+++ b/packages/app-store/salesforce/lib/CrmService.test.ts
@@ -511,4 +511,13 @@ describe("SalesforceCRMService", () => {
       });
     });
   });
+
+  describe("getAllPossibleAccountWebsiteFromEmailDomain", () => {
+    it("should return all possible account websites from email domain", () => {
+      const result = service.getAllPossibleAccountWebsiteFromEmailDomain("example.com");
+      expect(result).toEqual(
+        "example.com, www.example.com, http://www.example.com, http://example.com, https://www.example.com, https://example.com"
+      );
+    });
+  });
 });

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -883,6 +883,17 @@ export default class SalesforceCRMService implements CRM {
       });
   }
 
+  private getAllPossibleAccountWebsiteFromEmailDomain(emailDomain: string) {
+    return [
+      emailDomain,
+      `www.${emailDomain}`,
+      `http://www.${emailDomain}`,
+      `http://${emailDomain}`,
+      `https://www.${emailDomain}`,
+      `https://${emailDomain}`,
+    ].join(", ");
+  }
+
   private async getAccountIdBasedOnEmailDomainOfContacts(email: string) {
     const conn = await this.conn;
     const emailDomain = email.split("@")[1];
@@ -890,13 +901,16 @@ export default class SalesforceCRMService implements CRM {
     log.info("getAccountIdBasedOnEmailDomainOfContacts", safeStringify({ email, emailDomain }));
     // First check if an account has the same website as the email domain of the attendee
     const accountQuery = await conn.query(
-      `SELECT Id, Website FROM Account WHERE Website IN ('${emailDomain}', 'www.${emailDomain}', 
-                      'http://www.${emailDomain}', 'http://${emailDomain}',
-                      'https://www.${emailDomain}', 'https://${emailDomain}') LIMIT 1`
+      `SELECT Id, Website FROM Account WHERE Website IN (${this.getAllPossibleAccountWebsiteFromEmailDomain(
+        emailDomain
+      )}) LIMIT 1`
     );
     if (accountQuery.records.length > 0) {
-      const account = accountQuery.records[0] as { Id: string };
-      log.info("Found account based on email domain", safeStringify({ accountId: account.Id }));
+      const account = accountQuery.records[0] as { Id: string; Website: string };
+      log.info(
+        "Found account based on email domain",
+        safeStringify({ emailDomain, accountWebsite: account.Website, accountId: account.Id })
+      );
       return account.Id;
     }
 
@@ -923,13 +937,26 @@ export default class SalesforceCRMService implements CRM {
     log.info("Querying first account matching email domain", safeStringify({ emailDomain }));
     // First check if an account has the same website as the email domain of the attendee
     const accountQuery = await conn.query(
-      `SELECT Id, OwnerId, Owner.Email FROM Account WHERE Website LIKE '%${emailDomain}%' LIMIT 1`
+      `SELECT Id, OwnerId, Owner.Email FROM Account WHERE Website IN (${this.getAllPossibleAccountWebsiteFromEmailDomain(
+        emailDomain
+      )}) LIMIT 1`
     );
 
     if (accountQuery.records.length > 0) {
-      log.info("Found account matching email domain", safeStringify({ emailDomain }));
+      const account = accountQuery.records[0] as {
+        Id?: string;
+        OwnerId?: string;
+        Owner?: { Email?: string };
+        Website?: string;
+      };
+
+      log.info(
+        "Found account matching email domain",
+        safeStringify({ emailDomain, accountWebsite: account.Website, accountId: account.Id })
+      );
+
       return {
-        ...(accountQuery.records[0] as { Id?: string; OwnerId?: string; Owner?: { Email?: string } }),
+        ...account,
         Email: undefined,
       };
     }

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -883,7 +883,7 @@ export default class SalesforceCRMService implements CRM {
       });
   }
 
-  private getAllPossibleAccountWebsiteFromEmailDomain(emailDomain: string) {
+  public getAllPossibleAccountWebsiteFromEmailDomain(emailDomain: string) {
     return [
       emailDomain,
       `www.${emailDomain}`,

--- a/packages/app-store/salesforce/lib/__tests__/CrmService.integration.test.ts
+++ b/packages/app-store/salesforce/lib/__tests__/CrmService.integration.test.ts
@@ -178,8 +178,8 @@ describe("SalesforceCRMService", () => {
 
       it("(Lookup-3) should fallback to account having most number of contacts matched by emailDomain when Lookup-1 and Lookup-2 fails", async () => {
         const crmService = new SalesforceCRMService(credential, appOptions);
-        const account1OwnerEmail = "contact-account-owner1@example.com";
-        const account2OwnerEmail = "contact-account-owner2@example.com";
+        const account1OwnerEmail = "account1-owner@example.com";
+        const account2OwnerEmail = "account2-owner@example.com";
         const emailDomain = "example.com";
         const lookingForEmail = `test@${emailDomain}`;
         const account1 = salesforceMock.addAccount({

--- a/packages/app-store/salesforce/lib/__tests__/salesforceMock.ts
+++ b/packages/app-store/salesforce/lib/__tests__/salesforceMock.ts
@@ -45,6 +45,7 @@ export const createSalesforceMock = () => {
   // Query parser and responder
   const handleQuery = (query: string) => {
     // Simple SOQL parser
+    console.log({ query });
     const fromMatch = query.match(/FROM\s+(\w+)/i);
     const whereMatch = query.match(/WHERE\s+(.+?)(?:\s+LIMIT|\s+ORDER|\s*$)/i);
     const limitMatch = query.match(/LIMIT\s+(\d+)/i);
@@ -77,6 +78,7 @@ export const createSalesforceMock = () => {
         return { records: [] };
     }
 
+    console.log({ whereClause });
     // Apply where clause filtering (basic implementation)
     if (whereClause) {
       if (whereClause.includes("Email =")) {
@@ -131,6 +133,14 @@ export const createSalesforceMock = () => {
         if (websiteLikeMatch) {
           const websitePart = websiteLikeMatch[1];
           result = result.filter((r) => r.Website && r.Website.includes(websitePart));
+        }
+      }
+
+      if (whereClause.includes("Website IN")) {
+        const websitesMatch = whereClause.match(/Website IN \((.+)\)/i);
+        if (websitesMatch) {
+          const websites = websitesMatch[1].split(",").map((w) => w.trim());
+          result = result.filter((r) => websites.includes(r.Website));
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

Followup of https://github.com/calcom/cal.com/pull/19799
