### PR TITLE
fix: make installed apps spacing consistent with event types

### DIFF
--- a/apps/web/components/apps/layouts/InstalledAppsLayout.tsx
+++ b/apps/web/components/apps/layouts/InstalledAppsLayout.tsx
@@ -10,7 +10,14 @@ export default function InstalledAppsLayout({
 }: { children: React.ReactNode } & ComponentProps<typeof Shell>) {
   return (
     <Shell {...rest} title="Installed Apps" description="Manage your installed apps or change settings">
-      <AppCategoryNavigation baseURL="/apps/installed" containerClassname="min-w-0 w-full">
+      <AppCategoryNavigation
+        baseURL="/apps/installed"
+        classNames={{
+          root: "flex flex-col gap-x-6 md:p-0 xl:flex-row",
+          container: "min-w-0 w-full ltr:mr-2 rtl:ml-2",
+          verticalTabsItem:
+            "w-48 [&[aria-current='page']]:bg-emphasis [&[aria-current='page']]:text-emphasis",
+        }}>
         {children}
       </AppCategoryNavigation>
     </Shell>


### PR DESCRIPTION
## What does this PR do?

The issue:
<img width="635" alt="image" src="https://github.com/user-attachments/assets/5e20eef4-cd20-40f7-aebe-f57396b5f8be" />


After:
<img width="1608" alt="image" src="https://github.com/user-attachments/assets/6b43a6f4-9241-4219-8243-9ed618c7c663" />
