### PR TITLE
fix: logo-sync-issue

### DIFF
--- a/packages/trpc/server/routers/loggedInViewer/teamsAndUserProfilesQuery.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/teamsAndUserProfilesQuery.handler.ts
@@ -2,6 +2,7 @@ import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { withRoleCanCreateEntity } from "@calcom/lib/entityPermissionUtils";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import type { PrismaClient } from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { TrpcSessionUser } from "@calcom/trpc/server/trpc";
 
@@ -83,6 +84,11 @@ export const teamsAndUserProfilesQuery = async ({ ctx, input }: TeamsAndUserProf
       }));
   }
 
+  //For making team logo same as Org logo
+  const ownerTeam = user.teams.find((membership) => membership.role === MembershipRole.OWNER);
+  const ownerLogoUrl = ownerTeam?.team.logoUrl;
+  const ownerName = ownerTeam?.team.name;
+
   return [
     {
       teamId: null,
@@ -97,7 +103,7 @@ export const teamsAndUserProfilesQuery = async ({ ctx, input }: TeamsAndUserProf
       teamId: membership.team.id,
       name: membership.team.name,
       slug: membership.team.slug ? `team/${membership.team.slug}` : null,
-      image: getPlaceholderAvatar(membership.team.logoUrl, membership.team.name),
+      image: ownerLogoUrl ?? getPlaceholderAvatar(membership.team.logoUrl, ownerName),
       role: membership.role,
       readOnly: !withRoleCanCreateEntity(membership.role),
     })),


### PR DESCRIPTION
## What does this PR do?

This PR makes the subteams logo in sync with Org logo at dropdown on `/webhooks` page (like we have on `/event-types `page)

- Fixes : https://github.com/calcom/cal.com/issues/20013

## Visual Demo (For contributors especially)

**Before :** mentioned in the issue

**After :** 

![Screenshot (238)](https://github.com/user-attachments/assets/296b2b01-e38a-46ca-8dff-97f814cfa089)

![Screenshot (237)](https://github.com/user-attachments/assets/6a4b4244-9a7c-48a1-8580-b5055261147e)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

/claim #20013