### PR TITLE
fix: missing booking reminder reference in cron

### DIFF
--- a/apps/web/app/api/cron/bookingReminder/route.ts
+++ b/apps/web/app/api/cron/bookingReminder/route.ts
@@ -91,7 +91,7 @@ async function postHandler(request: NextRequest) {
       },
     });
 
-    for (const booking of bookings.filter((b) => !reminders.some((r) => r.referenceId == b.id))) {
+    for (const booking of bookingsToRemind.filter((b) => !reminders.some((r) => r.referenceId == b.id))) {
       const { user } = booking;
       const name = user?.name || user?.username;
       if (!user || !name || !user.timeZone) {


### PR DESCRIPTION
## What does this PR do?

Fix filter on bookingsToRemind instead of bookings

this can cause infinite loop of emails 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
