### PR TITLE
fix: Add salesforce query validation in integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "typescript": "^4.9.4",
     "vitest": "^2.1.1",
     "vitest-fetch-mock": "^0.3.0",
-    "vitest-mock-extended": "^2.0.2"
+    "vitest-mock-extended": "^2.0.2",
+    "@jetstreamapp/soql-parser-js": "^6.1.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.59.0",

--- a/packages/app-store/salesforce/lib/CrmService.ts
+++ b/packages/app-store/salesforce/lib/CrmService.ts
@@ -948,7 +948,7 @@ export default class SalesforceCRMService implements CRM {
     log.info("Querying first account matching email domain", safeStringify({ emailDomain }));
     // First check if an account has the same website as the email domain of the attendee
     const accountQuery = await conn.query(
-      `SELECT Id, OwnerId, Owner.Email FROM Account WHERE Website IN (${this.getAllPossibleAccountWebsiteFromEmailDomain(
+      `SELECT Id, OwnerId, Owner.Email, Owner.Website FROM Account WHERE Website IN (${this.getAllPossibleAccountWebsiteFromEmailDomain(
         emailDomain
       )}) LIMIT 1`
     );
@@ -963,7 +963,13 @@ export default class SalesforceCRMService implements CRM {
 
       log.info(
         "Found account matching email domain",
-        safeStringify({ emailDomain, accountWebsite: account.Website, accountId: account.Id })
+        safeStringify({
+          emailDomain,
+          accountWebsite: account.Website,
+          accountOwnerEmail: account.Owner?.Email,
+          accountOwnerId: account.OwnerId,
+          accountId: account.Id,
+        })
       );
 
       return {

--- a/packages/app-store/salesforce/lib/__tests__/salesforceMock.ts
+++ b/packages/app-store/salesforce/lib/__tests__/salesforceMock.ts
@@ -1,3 +1,4 @@
+import { parseQuery, composeQuery } from "@jetstreamapp/soql-parser-js";
 import { vi } from "vitest";
 
 import logger from "@calcom/lib/logger";
@@ -43,7 +44,11 @@ export const createSalesforceMock = () => {
   };
 
   // Query parser and responder
-  const handleQuery = (query: string) => {
+  const handleQuery = (rawQuery: string) => {
+    const parsedQuery = parseQuery(rawQuery);
+    // Validated Query
+    const query = composeQuery(parsedQuery);
+
     // Simple SOQL parser
     console.log({ query });
     const fromMatch = query.match(/FROM\s+(\w+)/i);

--- a/packages/app-store/salesforce/package.json
+++ b/packages/app-store/salesforce/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@calcom/lib": "*",
     "@calcom/prisma": "*",
+    "@jetstreamapp/soql-parser-js": "^6.1.0",
     "@jsforce/jsforce-node": "^3.6.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,6 +3483,7 @@ __metadata:
     "@calcom/lib": "*"
     "@calcom/prisma": "*"
     "@calcom/types": "*"
+    "@jetstreamapp/soql-parser-js": ^6.1.0
     "@jsforce/jsforce-node": ^3.6.3
   languageName: unknown
   linkType: soft
@@ -5751,6 +5752,19 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: a0bcf15dbb0eca6bdd8ce61a3fb055349d40268622a7670a3b2eb3c3dbafe9eb26af59938366d520b86907b9505b0f9b29b85cec11579a9e580694b87cd90fcc
+  languageName: node
+  linkType: hard
+
+"@jetstreamapp/soql-parser-js@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@jetstreamapp/soql-parser-js@npm:6.1.0"
+  dependencies:
+    chevrotain: ^10.5.0
+    commander: ^2.20.3
+    lodash.get: ^4.4.2
+  bin:
+    soql-parser-js: bin/soql-parser-js
+  checksum: 4110e2c19c29ff8ae60efa70bd5ae1f81dca289af0fdc8fd29e8f9e03171c1b5beadfb57d8a39506b8d9e909dd0d3fb21408a06c2238661fc4dd4a9d60fc4142
   languageName: node
   linkType: hard
 
@@ -17543,6 +17557,7 @@ __metadata:
   dependencies:
     "@changesets/cli": ^2.26.1
     "@daily-co/daily-js": ^0.59.0
+    "@jetstreamapp/soql-parser-js": ^6.1.0
     "@next/third-parties": ^14.2.5
     "@playwright/test": ^1.45.3
     "@snaplet/copycat": ^4.1.0
@@ -18534,7 +18549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0, commander@npm:^2.7.1, commander@npm:^2.9.0":
+"commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:^2.7.1, commander@npm:^2.9.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e


### PR DESCRIPTION
## What does this PR do?

Improves integration tests to be able to detect invalid SOQL queries
