### PR TITLE
chore: get oauth client params from event-type hosts

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/booking-fields.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/booking-fields.e2e-spec.ts
@@ -434,7 +434,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     }
 
     describe("get individual booking", () => {
-      it("should should get a seated booking with split name responses", async () => {
+      it("should get a seated booking with split name responses", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings/${bookingWithSplitName.uid}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -457,7 +457,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get a seated booking with split name responses", async () => {
+      it("should get a seated booking with split name responses", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings/${seatedBookingWithSplitName.uid}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/team-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/team-bookings.e2e-spec.ts
@@ -530,7 +530,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     });
 
     describe("get team bookings", () => {
-      it("should should get bookings by teamId", async () => {
+      it("should get bookings by teamId", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?teamId=${team1.id}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -549,7 +549,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by teamId", async () => {
+      it("should get bookings by teamId", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?teamId=${team2.id}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -605,7 +605,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by teamIds", async () => {
+      it("should get bookings by teamIds", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?teamIds=${team1.id},${team2.id}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -627,7 +627,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     });
 
     describe("reschedule", () => {
-      it("should should reschedule phone based booking", async () => {
+      it("should reschedule phone based booking", async () => {
         const body: RescheduleBookingInput_2024_08_13 = {
           start: new Date(Date.UTC(2035, 0, 8, 14, 0, 0)).toISOString(),
           reschedulingReason: "Flying to mars that day",

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/user-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/user-bookings.e2e-spec.ts
@@ -527,7 +527,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     });
 
     describe("get individual booking", () => {
-      it("should should get a booking", async () => {
+      it("should get a booking", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings/${createdBooking.uid}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -562,7 +562,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get a booking with rating", async () => {
+      it("should get a booking with rating", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings/${bookingInThePast.uid}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -586,7 +586,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get 1 recurrence of a recurring booking", async () => {
+      it("should get 1 recurrence of a recurring booking", async () => {
         const recurrenceUid = createdRecurringBooking[0].uid;
         return request(app.getHttpServer())
           .get(`/v2/bookings/${recurrenceUid}`)
@@ -622,7 +622,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get all recurrences of the recurring bookings", async () => {
+      it("should get all recurrences of the recurring bookings", async () => {
         const recurringBookingUid = createdRecurringBooking[0].recurringBookingUid;
         return request(app.getHttpServer())
           .get(`/v2/bookings/${recurringBookingUid}`)
@@ -691,7 +691,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     });
 
     describe("get bookings", () => {
-      it("should should get all bookings", async () => {
+      it("should get all bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -709,7 +709,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should take bookings", async () => {
+      it("should take bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?take=3`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -727,7 +727,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should skip bookings", async () => {
+      it("should skip bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?skip=2`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -745,7 +745,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get upcoming bookings", async () => {
+      it("should get upcoming bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?status=upcoming`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -763,7 +763,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get past bookings", async () => {
+      it("should get past bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?status=past`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -781,7 +781,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get upcoming and past bookings", async () => {
+      it("should get upcoming and past bookings", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?status=upcoming,past`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -799,7 +799,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get recurring booking recurrences", async () => {
+      it("should get recurring booking recurrences", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?status=recurring`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -817,7 +817,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by attendee email", async () => {
+      it("should get bookings by attendee email", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?attendeeEmail=mr_proper@gmail.com`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -835,7 +835,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by attendee name", async () => {
+      it("should get bookings by attendee name", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?attendeeName=Mr Proper Recurring`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -853,7 +853,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by eventTypeId", async () => {
+      it("should get bookings by eventTypeId", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -871,7 +871,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by eventTypeIds", async () => {
+      it("should get bookings by eventTypeIds", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeIds=${eventTypeId},${recurringEventTypeId}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -889,7 +889,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by after specified start time", async () => {
+      it("should get bookings by after specified start time", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?afterStart=${createdRecurringBooking[1].start}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -907,7 +907,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings by before specified end time", async () => {
+      it("should get bookings by before specified end time", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?beforeEnd=${createdRecurringBooking[0].end}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -925,7 +925,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings after specified update time", async () => {
+      it("should get bookings after specified update time", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?afterUpdatedAt=${createdRecurringBooking[1].updatedAt}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -943,7 +943,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings before specified update time", async () => {
+      it("should get bookings before specified update time", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?beforeUpdatedAt=${createdRecurringBooking[0].updatedAt}`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -961,7 +961,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should get bookings in update range", async () => {
+      it("should get bookings in update range", async () => {
         return request(app.getHttpServer())
           .get(
             `/v2/bookings?afterUpdatedAt=${createdRecurringBooking[0].updatedAt}&beforeUpdatedAt=${createdRecurringBooking[2].updatedAt}`
@@ -982,7 +982,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
       });
 
       describe("createdAt filter", () => {
-        it("should should get bookings after specified createdAt time", async () => {
+        it("should get bookings after specified createdAt time", async () => {
           return request(app.getHttpServer())
             .get(`/v2/bookings?afterCreatedAt=${createdRecurringBooking[1].createdAt}`)
             .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1000,7 +1000,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
             });
         });
 
-        it("should should get bookings before specified createdAt time", async () => {
+        it("should get bookings before specified createdAt time", async () => {
           return request(app.getHttpServer())
             .get(`/v2/bookings?beforeCreatedAt=${createdRecurringBooking[0].createdAt}`)
             .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1018,7 +1018,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
             });
         });
 
-        it("should should get bookings in createdAt range", async () => {
+        it("should get bookings in createdAt range", async () => {
           return request(app.getHttpServer())
             .get(
               `/v2/bookings?afterCreatedAt=${createdRecurringBooking[0].createdAt}&beforeCreatedAt=${createdRecurringBooking[1].createdAt}`
@@ -1039,7 +1039,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
         });
       });
 
-      it("should should sort bookings by start in descending order", async () => {
+      it("should sort bookings by start in descending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortStart=desc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1059,7 +1059,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by start in ascending order", async () => {
+      it("should sort bookings by start in ascending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortStart=asc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1079,7 +1079,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by end in descending order", async () => {
+      it("should sort bookings by end in descending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortEnd=desc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1099,7 +1099,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by end in ascending order", async () => {
+      it("should sort bookings by end in ascending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortEnd=asc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1119,7 +1119,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by created in descending order", async () => {
+      it("should sort bookings by created in descending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortCreated=desc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1139,7 +1139,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by created in ascending order", async () => {
+      it("should sort bookings by created in ascending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortCreated=asc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1159,7 +1159,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by updated in descending order", async () => {
+      it("should sort bookings by updated in descending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortUpdatedAt=desc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1179,7 +1179,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
           });
       });
 
-      it("should should sort bookings by updated in ascending order", async () => {
+      it("should sort bookings by updated in ascending order", async () => {
         return request(app.getHttpServer())
           .get(`/v2/bookings?eventTypeId=${eventTypeId}&sortUpdatedAt=asc`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
@@ -1201,7 +1201,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
     });
 
     describe("reschedule bookings", () => {
-      it("should should reschedule normal booking", async () => {
+      it("should reschedule normal booking", async () => {
         const body: RescheduleBookingInput_2024_08_13 = {
           start: new Date(Date.UTC(2035, 0, 8, 14, 0, 0)).toISOString(),
           reschedulingReason: "Flying to mars that day",

--- a/apps/api/v2/src/ee/bookings/shared/platform-bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/shared/platform-bookings.service.ts
@@ -42,6 +42,10 @@ export class PlatformBookingsService {
     } else if (eventType?.teamId) {
       oAuthClient = await this.oAuthClientRepository.getByTeamId(eventType.teamId);
     }
+    // Last resort check the hosts of the event-type
+    if (!oAuthClient && eventType?.teamId) {
+      oAuthClient = await this.oAuthClientRepository.getByEventTypeHosts(eventTypeId);
+    }
 
     if (oAuthClient) {
       return {

--- a/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
+++ b/apps/api/v2/src/modules/oauth-clients/oauth-client.repository.ts
@@ -118,4 +118,19 @@ export class OAuthClientRepository {
       },
     });
   }
+
+  async getByEventTypeHosts(eventTypeId: number) {
+    const hostWithUserPlatformClient = await this.dbRead.prisma.host.findFirst({
+      select: {
+        user: { select: { platformOAuthClients: true } },
+      },
+      where: {
+        eventTypeId: eventTypeId,
+        user: {
+          isPlatformManaged: true,
+        },
+      },
+    });
+    return hostWithUserPlatformClient?.user?.platformOAuthClients?.[0] ?? null;
+  }
 }

--- a/apps/api/v2/src/modules/organizations/teams/bookings/organizations-teams-bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/bookings/organizations-teams-bookings.controller.e2e-spec.ts
@@ -265,7 +265,7 @@ describe("Organizations TeamsBookings Endpoints 2024-08-13", () => {
     });
 
     describe("get team bookings", () => {
-      it("should should get bookings by teamId", async () => {
+      it("should get bookings by teamId", async () => {
         return request(app.getHttpServer())
           .get(`/v2/organizations/${organization.id}/teams/${team1.id}/bookings`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Team event-types for platform, if created with ApiKey instead of oAuthClientId + Secret, resulted in oauth client params not being fetched when booking a meeting, this resulted in emails not being formatted (remove oauth client id) and oauth client settings not being used

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


