### PR TITLE
fix: case insensitive search on organization member list

### DIFF
--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -93,7 +93,10 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
     teamId: organizationId,
     ...(searchTerm && {
       user: {
-        OR: [{ email: { contains: searchTerm } }, { username: { contains: searchTerm } }],
+        OR: [
+          { email: { contains: searchTerm, mode: "insensitive" } },
+          { username: { contains: searchTerm, mode: "insensitive" } },
+        ],
       },
     }),
   };


### PR DESCRIPTION
## What does this PR do?

This PR updates the search feature to be case-insensitive on organization member list.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

