### PR TITLE
fix: Errors seen in some cases when organization is created through w…

### DIFF
--- a/packages/lib/createAProfileForAnExistingUser.ts
+++ b/packages/lib/createAProfileForAnExistingUser.ts
@@ -25,6 +25,16 @@ export const createAProfileForAnExistingUser = async ({
   if (!org) {
     throw new Error(`Organization with id ${organizationId} not found`);
   }
+
+  const existingProfile = await ProfileRepository.findByUserIdAndOrgId({
+    userId: user.id,
+    organizationId,
+  });
+
+  if (existingProfile) {
+    return existingProfile;
+  }
+
   const usernameInOrg = getOrgUsernameFromEmail(
     user.email,
     org.organizationSettings?.orgAutoAcceptEmail ?? null

--- a/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/createTeams.handler.ts
@@ -243,6 +243,9 @@ async function moveTeam({
       language: "en",
       inviterName: null,
       teamId: org.id,
+      // This is important so that if we re-invite existing users accidentally, we don't endup erroring out.
+      // Because this is a bulk action that could be taken from organization payment webhook, we could have cases where a user was just invited through another team migration in parallel.
+      isDirectUserAction: false,
     });
   }
 

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -141,16 +141,20 @@ export const inviteMembersWithNoInviterPermissionCheck = async (
       role: MembershipRole;
     }[];
     creationSource: CreationSource;
+    /**
+     * Whether invitation is a direct user action or not i.e. we need to show them User based errors like inviting existing users or not.
+     */
+    isDirectUserAction?: boolean;
   } & TargetTeam
 ) => {
-  const { inviterName, orgSlug, invitations, language, creationSource } = data;
+  const { inviterName, orgSlug, invitations, language, creationSource, isDirectUserAction = true } = data;
   const myLog = log.getSubLogger({ prefix: ["inviteMembers"] });
   const translation = await getTranslation(language ?? "en", "common");
   const team = "team" in data ? data.team : await getTeamOrThrow(data.teamId);
   const isTeamAnOrg = team.isOrganization;
 
   const uniqueInvitations = await getUniqueInvitationsOrThrowIfEmpty(invitations);
-  const beSilentAboutErrors = shouldBeSilentAboutErrors(uniqueInvitations);
+  const beSilentAboutErrors = shouldBeSilentAboutErrors(uniqueInvitations) || !isDirectUserAction;
   const existingUsersToBeInvited = await findUsersWithInviteStatus({
     invitations: uniqueInvitations,
     team,


### PR DESCRIPTION
## What does this PR do?

Fixes two errors:
1. When a team member is part of two teams and both teams are selected for migration. Because teams are migrated in parallel, we can't determine easily before hand if a that user has been already migrated along with the team or not. That causes an error in the end, where we try to create a profile again and that errors because profile already exists
2. Because webhook is retried due to the above error, team-1 which had that as the only member is attempted to be re-migrated and throws error that 'user is already a member'

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

