### PR TITLE
fix: remember last used filter segment

### DIFF
--- a/packages/features/data-table/lib/segments.ts
+++ b/packages/features/data-table/lib/segments.ts
@@ -1,0 +1,156 @@
+import type { SortingState, VisibilityState, ColumnSizingState } from "@tanstack/react-table";
+import { useCallback, useMemo, useEffect } from "react";
+
+import { trpc } from "@calcom/trpc/react";
+
+import { type ActiveFilters, ZSegmentStorage } from "./types";
+
+type UseSegmentsProps = {
+  tableIdentifier: string;
+  activeFilters: ActiveFilters;
+  sorting: SortingState;
+  columnVisibility: VisibilityState;
+  columnSizing: ColumnSizingState;
+  pageSize: number;
+  defaultPageSize: number;
+  segmentId: number;
+  setSegmentId: (segmentId: number | null) => void;
+  setActiveFilters: (activeFilters: ActiveFilters) => void;
+  setSorting: (sorting: SortingState) => void;
+  setColumnVisibility: (columnVisibility: VisibilityState) => void;
+  setColumnSizing: (columnSizing: ColumnSizingState) => void;
+  setPageSize: (pageSize: number) => void;
+  setPageIndex: (pageIndex: number) => void;
+};
+
+export function useSegments({
+  tableIdentifier,
+  activeFilters,
+  sorting,
+  columnVisibility,
+  columnSizing,
+  pageSize,
+  defaultPageSize,
+  segmentId,
+  setSegmentId,
+  setActiveFilters,
+  setSorting,
+  setColumnVisibility,
+  setColumnSizing,
+  setPageSize,
+  setPageIndex,
+}: UseSegmentsProps) {
+  const { data: segments, isFetching: isFetchingSegments } = trpc.viewer.filterSegments.list.useQuery({
+    tableIdentifier,
+  });
+  const selectedSegment = useMemo(
+    () => segments?.find((segment) => segment.id === segmentId),
+    [segments, segmentId]
+  );
+
+  useEffect(() => {
+    if (segments && segmentId > 0 && !isFetchingSegments) {
+      const segment = segments.find((segment) => segment.id === segmentId);
+      if (!segment) {
+        // If segmentId is invalid (or not found), clear the segmentId from the query params,
+        // but we still keep all the other states like activeFilters, etc.
+        // This is useful when someone shares a URL that is inaccessible to someone else.
+        setSegmentId(null);
+      }
+    }
+  }, [segments, segmentId, setSegmentId, isFetchingSegments]);
+
+  useEffect(() => {
+    // this hook doesn't include segmentId in the dependency array
+    // because we want to only run this once, when the component mounts
+    if (segmentId === -1) {
+      const segments = getSegmentsFromLocalStorage();
+      if (segments[tableIdentifier]) {
+        setSegmentId(segments[tableIdentifier].segmentId);
+      }
+    }
+  }, [tableIdentifier, setSegmentId]);
+
+  useEffect(() => {
+    if (selectedSegment) {
+      // segment is selected, so we apply the filters, sorting, etc. from the segment
+      setActiveFilters(selectedSegment.activeFilters);
+      setSorting(selectedSegment.sorting);
+      setColumnVisibility(selectedSegment.columnVisibility);
+      setColumnSizing(selectedSegment.columnSizing);
+      setPageSize(selectedSegment.perPage);
+      setPageIndex(0);
+    }
+  }, [
+    selectedSegment,
+    setActiveFilters,
+    setSorting,
+    setColumnVisibility,
+    setColumnSizing,
+    setPageSize,
+    setPageIndex,
+  ]);
+
+  const canSaveSegment = useMemo(() => {
+    if (!selectedSegment) {
+      // if no segment is selected, we can save the segment if there are any active filters, sorting, etc.
+      return (
+        activeFilters.length > 0 ||
+        sorting.length > 0 ||
+        Object.keys(columnVisibility).length > 0 ||
+        Object.keys(columnSizing).length > 0 ||
+        pageSize !== defaultPageSize
+      );
+    } else {
+      // if a segment is selected, we can save the segment if the active filters, sorting, etc. are different from the segment
+      return (
+        activeFilters !== selectedSegment.activeFilters ||
+        sorting !== selectedSegment.sorting ||
+        columnVisibility !== selectedSegment.columnVisibility ||
+        columnSizing !== selectedSegment.columnSizing ||
+        pageSize !== selectedSegment.perPage
+      );
+    }
+  }, [selectedSegment, activeFilters, sorting, columnVisibility, columnSizing, pageSize, defaultPageSize]);
+
+  const setSegmentIdAndSaveToLocalStorage = useCallback(
+    (segmentId: number | null) => {
+      setSegmentId(segmentId);
+      saveSegmentToLocalStorage({ tableIdentifier, segmentId });
+    },
+    [tableIdentifier, setSegmentId]
+  );
+
+  return {
+    segments: segments ?? [],
+    selectedSegment,
+    canSaveSegment,
+    setSegmentIdAndSaveToLocalStorage,
+  };
+}
+
+const LOCAL_STORAGE_KEY = "data-table:segments";
+
+function getSegmentsFromLocalStorage() {
+  try {
+    return ZSegmentStorage.parse(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "{}"));
+  } catch {
+    return {};
+  }
+}
+
+function saveSegmentToLocalStorage({
+  tableIdentifier,
+  segmentId,
+}: {
+  tableIdentifier: string;
+  segmentId: number | null;
+}) {
+  const segments = getSegmentsFromLocalStorage();
+  if (segmentId) {
+    segments[tableIdentifier] = { segmentId };
+  } else {
+    delete segments[tableIdentifier];
+  }
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(segments));
+}

--- a/packages/features/data-table/lib/types.ts
+++ b/packages/features/data-table/lib/types.ts
@@ -242,3 +242,16 @@ export type FilterSegmentOutput = {
   teamId: number | null;
   team: { id: number; name: string } | null;
 };
+
+export type SegmentStorage = {
+  [tableIdentifier: string]: {
+    segmentId: number;
+  };
+};
+
+export const ZSegmentStorage = z.record(
+  z.string(),
+  z.object({
+    segmentId: z.number(),
+  })
+) satisfies z.ZodType<SegmentStorage>;


### PR DESCRIPTION
## What does this PR do?

This PR improves Filter Segment by remembering last used filter segment and restore it on page load.

This PR also extracts logic related to filter segment from DataTableProvider into a separate file for readability.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### scenario 1


https://github.com/user-attachments/assets/0cd0a53b-7210-46bb-9485-7f3c0493d2f4



1. Go to organization member list.
2. Select a filter segment, and check the browser's url bar to confirm there's `segment=xx` param.
3. Open the same page without `segment=xx` param, and it will automatically restore the same `xx` value.

### scenario 2


https://github.com/user-attachments/assets/9a084f04-3669-49e0-9f00-0450c47866d1



1. Select the same filter again to deselect it, and you will see `segment=xx` param is gone.
2. Now, reload the page again, and it won't attach `segment=` param now.