### PR TITLE
fix: Flaky 'OOO records are fetched correctly....' e2e (Final)

### DIFF
--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -771,12 +771,12 @@ test.describe("Out of office", () => {
       //Default filter 'Last 7 Days' when DateRange Filter is selected
       await test.step("Default filter - 'Last 7 Days'", async () => {
         await page.locator('[data-testid="add-filter-button"]').click();
-        await page.locator('[data-testid="add-filter-item-dateRange"]').click();
         const entriesListRespPromise = page.waitForResponse(
           (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
         );
-        await page.locator('[data-testid="add-filter-button"]').click();
+        await page.locator('[data-testid="add-filter-item-dateRange"]').click();
         await entriesListRespPromise;
+        await page.locator('[data-testid="add-filter-button"]').click(); //close popover
 
         //1 OOO record should be visible for member3, end=currentDate-4days
         expect(await page.locator('[data-testid^="table-redirect-"]').count()).toBe(1);
@@ -788,11 +788,10 @@ test.describe("Out of office", () => {
       //Select 'Last 30 Days'
       await test.step("select 'Last 30 Days'", async () => {
         await page.locator('[data-testid="filter-popover-trigger-dateRange"]').click();
-        await page.locator(`[data-testid="date-range-options-t"]`).click();
         const entriesListRespPromise = page.waitForResponse(
           (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
         );
-        await page.locator('[data-testid="filter-popover-trigger-dateRange"]').click();
+        await page.locator(`[data-testid="date-range-options-t"]`).click();
         await entriesListRespPromise;
 
         //2 OOO records should be visible end=currentDate-4days, end=currentDate-12days


### PR DESCRIPTION
follow up PR for https://github.com/calcom/cal.com/pull/20238

actions that exactly triggers trpc, should be placed before await resp