### PR TITLE
fix: /availability - show skeleton only if cached data do not exist

### DIFF
--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -25,9 +25,7 @@ export function AvailabilityList() {
   const { t } = useLocale();
   const [bulkUpdateModal, setBulkUpdateModal] = useState(false);
   const utils = trpc.useUtils();
-  const { data: availabilityData, isFetching: isFetchingAvailabilityData } =
-    trpc.viewer.availability.list.useQuery();
-
+  const { data: availabilityData } = trpc.viewer.availability.list.useQuery();
   const meQuery = trpc.viewer.me.get.useQuery();
 
   const router = useRouter();
@@ -122,7 +120,7 @@ export function AvailabilityList() {
 
   const [animationParentRef] = useAutoAnimate<HTMLUListElement>();
 
-  if (isFetchingAvailabilityData || !availabilityData) {
+  if (!availabilityData) {
     return <SkeletonLoader />;
   }
 


### PR DESCRIPTION
## What does this PR do?

- https://calendso.slack.com/archives/C08B8SYUY02/p1742518457322749?thread_ts=1741629658.798129&cid=C08B8SYUY02

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- I tested already. In /availability, confirm if skeleton doesn't show after initial load
