### PR TITLE
fix: Padding issue in text fields and dropdown

### DIFF
--- a/apps/web/components/settings/CustomEmailTextField.tsx
+++ b/apps/web/components/settings/CustomEmailTextField.tsx
@@ -49,7 +49,7 @@ const CustomEmailTextField = ({
         }`}>
         <input
           {...formMethods.register(formMethodFieldName)}
-          className="flex-1 bg-transparent px-3 py-1 text-sm outline-none"
+          className="flex-1 bg-transparent px-3 py-1.5 text-sm outline-none"
           data-testid={dataTestId}
           onFocus={() => setInputFocus(true)}
           onBlur={() => setInputFocus(false)}

--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -153,7 +153,7 @@ export function TimezoneSelectComponent({
                 : "px-3 h-fit"
               : size === "sm"
               ? "h-7 px-2"
-              : "h-9 px-3",
+              : "h-9 py-0 px-3",
             props.isDisabled && "bg-subtle",
             "rounded-[10px]",
             timezoneClassNames?.control && timezoneClassNames.control(state)


### PR DESCRIPTION
## What does this PR do?

Added extra padding in email text field and removed unnecessary padding from timezone dropdown

- Fixes #20286 

## Visual Demo (For contributors especially)

### Before
![image](https://github.com/user-attachments/assets/bd6ec4a3-22e8-43d8-8abd-2e038bd19831)

![image](https://github.com/user-attachments/assets/80511f41-e1c3-452d-8e11-f44b618fcb30)

### After
![image](https://github.com/user-attachments/assets/0ab57b90-628f-43eb-af87-cfbf9a4e9d55)

![image](https://github.com/user-attachments/assets/50ae2220-ac1d-41aa-bede-080d5a450c5a)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

