### PR TITLE
fix: i18n failed to fetch translations results in api v2 crash

### DIFF
--- a/packages/lib/server/i18n.ts
+++ b/packages/lib/server/i18n.ts
@@ -4,17 +4,25 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 
 const i18nInstanceCache = new Map<string, any>();
 
+async function loadFallbackTranslations() {
+  try {
+    const res = await fetch(`${WEBAPP_URL}/static/locales/en/common.json`);
+    if (res) {
+      return await res.json();
+    }
+  } catch {
+    console.error("Could not fetch fallback translations.");
+  }
+}
+
 async function loadTranslations(locale: string, ns: string) {
   try {
     const url = `${WEBAPP_URL}/static/locales/${locale}/${ns}.json`;
     const response = await fetch(url);
     return await response.json();
   } catch (error) {
-    const res = await fetch(`${WEBAPP_URL}/static/locales/en/common.json`);
-    if (res) {
-      return await res.json();
-    }
-    return {};
+    const fallbackTranslations = await loadFallbackTranslations();
+    return fallbackTranslations ?? {};
   }
 }
 

--- a/packages/lib/server/i18n.ts
+++ b/packages/lib/server/i18n.ts
@@ -13,6 +13,7 @@ async function loadFallbackTranslations() {
   } catch {
     console.error("Could not fetch fallback translations.");
   }
+  return;
 }
 
 async function loadTranslations(locale: string, ns: string) {


### PR DESCRIPTION
## What does this PR do?

if web is not up and running, fetching translations will cause crash

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A - I confirm automated tests are in place that prove my fix is effective or that my feature works.
