### PR TITLE
fix: increase memory requirement for building atoms

### DIFF
--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.52",
   "scripts": {
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
-    "build": "yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
+    "build": "NODE_OPTIONS='--max_old_space_size=8192' yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
     "publish": "rm -rf dist && yarn build && npm publish --access public",
     "test": "jest"
   },

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.52",
   "scripts": {
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
-    "build": "NODE_OPTIONS='--max_old_space_size=8192' yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
+    "build": "NODE_OPTIONS='--max_old_space_size=16384' yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
     "publish": "rm -rf dist && yarn build && npm publish --access public",
     "test": "jest"
   },


### PR DESCRIPTION
## What does this PR do?

This pull request includes a change to the `packages/platform/atoms/package.json` file to enhance the build process by increasing the maximum old space size for Node.js.

* [`packages/platform/atoms/package.json`](diffhunk://#diff-551250ebb001eea815ae02e5eb86432d97849bac825ad417230da66ed41a39a4L10-R10): Added the `NODE_OPTIONS='--max_old_space_size=8192'` environment variable to the `build` script to increase the memory limit for Node.js during the build process.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
