### PR TITLE
fix: flaky 'People filter includes bookings where filtered person is attendee' e2e test

### DIFF
--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -351,11 +351,13 @@ test.describe("Bookings", () => {
     await page.locator('[data-testid="add-filter-item-userId"]').click();
     await page.locator('[data-testid="filter-popover-trigger-userId"]').click();
 
+    const bookingsGetResponse2 = page.waitForResponse((response) =>
+      /\/api\/trpc\/bookings\/get.*/.test(response.url())
+    );
     await page
       .locator(`[data-testid="multi-select-options-userId"] [role="option"]:has-text("${thirdUser.name}")`)
       .click();
-
-    await page.waitForResponse((response) => /\/api\/trpc\/bookings\/get.*/.test(response.url()));
+    await bookingsGetResponse2;
 
     //expect only 3 bookings (out of 4 total) to be shown in list.
     //where ThirdUser is either organizer or attendee


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

follow up for  #20238 

fixes frequently occurring flaky test in bookings-list.e2e
 
<img width="999" alt="Screenshot 2025-03-22 at 12 11 10 PM" src="https://github.com/user-attachments/assets/e692574c-df8e-43c4-9240-04379a7b7e12" />

that is failing exactly at same step every time

<img width="995" alt="Screenshot 2025-03-22 at 12 13 42 PM" src="https://github.com/user-attachments/assets/7ad2634c-d0d0-4fbf-92e6-3948a53d4d3d" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] -N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.