### PR TITLE
chore(docs): remove AWS Amplify one-click deploy

### DIFF
--- a/docs/self-hosting/deployments/aws.mdx
+++ b/docs/self-hosting/deployments/aws.mdx
@@ -7,12 +7,6 @@ Deploying Cal.com on AWS
 ___
 
 
-## One Click Deployment
-
-<a href="https://console.aws.amazon.com/amplify/home#/deploy?repo=https://github.com/calcom/docker" target="_blank">
-<img src="https://oneclick.amplifyapp.com/button.svg" noZoom alt="Deploy on AWS" />
-</a>
-
 ## Manual Deployment
 <Steps>
   <Step title="Prerequisites">


### PR DESCRIPTION
AWS removed the ability to do one-click deploys a little while back