### PR TITLE
fix: rewrite /en/* paths to /*

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -187,11 +187,6 @@ const nextConfig = {
     optimizePackageImports: ["@calcom/ui"],
     turbo: {},
   },
-  i18n: {
-    defaultLocale: "en",
-    locales: ["en"],
-    localeDetection: false,
-  },
   productionBrowserSourceMaps: process.env.SENTRY_DISABLE_CLIENT_SOURCE_MAPS === "0",
   /* We already do type check on GH actions */
   typescript: {
@@ -293,6 +288,10 @@ const nextConfig = {
   async rewrites() {
     const { orgSlug } = nextJsOrgRewriteConfig;
     const beforeFiles = [
+      {
+        source: "/en/:path*",
+        destination: "/:path*",
+      },
       {
         source: "/forms/:formQuery*",
         destination: "/apps/routing-forms/routing-link/:formQuery*",

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -187,6 +187,10 @@ const nextConfig = {
     optimizePackageImports: ["@calcom/ui"],
     turbo: {},
   },
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en"],
+  },
   productionBrowserSourceMaps: process.env.SENTRY_DISABLE_CLIENT_SOURCE_MAPS === "0",
   /* We already do type check on GH actions */
   typescript: {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -190,6 +190,7 @@ const nextConfig = {
   i18n: {
     defaultLocale: "en",
     locales: ["en"],
+    localeDetection: false,
   },
   productionBrowserSourceMaps: process.env.SENTRY_DISABLE_CLIENT_SOURCE_MAPS === "0",
   /* We already do type check on GH actions */

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -289,6 +289,7 @@ const nextConfig = {
     const { orgSlug } = nextJsOrgRewriteConfig;
     const beforeFiles = [
       {
+        // This should be the first item in `beforeFiles` to take precedence over other rewrites
         source: "/en/:path*",
         destination: "/:path*",
       },

--- a/apps/web/playwright/i18n-routing.e2e.ts
+++ b/apps/web/playwright/i18n-routing.e2e.ts
@@ -1,0 +1,27 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+
+test.describe("/en/* pages must not 404", () => {
+  test("/en/login shouldn't 404", async ({ page }) => {
+    const response = await page.goto(`/en/login`);
+    expect(response?.status()).not.toBe(404);
+  });
+
+  test("/en/auth/login shouldn't 404", async ({ page }) => {
+    const response = await page.goto(`/en/auth/login`);
+    expect(response?.status()).not.toBe(404);
+  });
+
+  test("/en/[user] page shouldn't 404", async ({ page, users }) => {
+    const user = await users.create();
+    const response = await page.goto(`/en/${user.username}`);
+    expect(response?.status()).not.toBe(404);
+  });
+
+  test("/en/[user]/[type] page shouldn't 404", async ({ page, users }) => {
+    const user = await users.create();
+    const response = await page.goto(`/en/${user.username}/30-min`);
+    expect(response?.status()).not.toBe(404);
+  });
+});

--- a/apps/web/playwright/unpublished.e2e.ts
+++ b/apps/web/playwright/unpublished.e2e.ts
@@ -14,16 +14,24 @@ test.afterEach(async ({ users }) => {
   await users.deleteAll();
 });
 
+const assertChecks = async (page: any, entityName: string, entityType: string) => {
+  await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
+  await expect(page.locator(`h2:has-text("${title(entityName)}")`)).toHaveCount(1);
+  await expect(page.locator(`div:text("${description(entityType)}")`)).toHaveCount(1);
+  await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+};
+
 test.describe("Unpublished", () => {
   test("Regular team profile", async ({ page, users }) => {
     const owner = await users.create(undefined, { hasTeam: true, isUnpublished: true });
     const { team } = await owner.getFirstTeamMembership();
     const { requestedSlug } = team.metadata as { requestedSlug: string };
-    await page.goto(`/team/${requestedSlug}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(team.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("team")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/team/${requestedSlug}`);
+      await assertChecks(page, team.name, "team");
+    }
   });
 
   test("Regular team event type", async ({ page, users }) => {
@@ -35,22 +43,24 @@ test.describe("Unpublished", () => {
     const { team } = await owner.getFirstTeamMembership();
     const { requestedSlug } = team.metadata as { requestedSlug: string };
     const { slug: teamEventSlug } = await owner.getFirstTeamEvent(team.id);
-    await page.goto(`/team/${requestedSlug}/${teamEventSlug}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(team.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("team")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/team/${requestedSlug}/${teamEventSlug}`);
+      await assertChecks(page, team.name, "team");
+    }
   });
 
   test("Organization profile", async ({ users, page }) => {
     const owner = await users.create(undefined, { hasTeam: true, isUnpublished: true, isOrg: true });
     const { team: org } = await owner.getOrgMembership();
     const { requestedSlug } = org.metadata as { requestedSlug: string };
-    await page.goto(`/org/${requestedSlug}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(org.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("organization")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/org/${requestedSlug}`);
+      await assertChecks(page, org.name, "organization");
+    }
   });
 
   test("Organization sub-team", async ({ users, page }) => {
@@ -63,11 +73,12 @@ test.describe("Unpublished", () => {
     const { team: org } = await owner.getOrgMembership();
     const { requestedSlug } = org.metadata as { requestedSlug: string };
     const [{ slug: subteamSlug }] = org.children as { slug: string }[];
-    await page.goto(`/org/${requestedSlug}/team/${subteamSlug}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(org.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("organization")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/org/${requestedSlug}/team/${subteamSlug}`);
+      await assertChecks(page, org.name, "organization");
+    }
   });
 
   test("Organization sub-team event-type", async ({ users, page }) => {
@@ -81,23 +92,24 @@ test.describe("Unpublished", () => {
     const { requestedSlug } = org.metadata as { requestedSlug: string };
     const [{ slug: subteamSlug, id: subteamId }] = org.children as { slug: string; id: number }[];
     const { slug: subteamEventSlug } = await owner.getFirstTeamEvent(subteamId);
-    await page.goto(`/org/${requestedSlug}/team/${subteamSlug}/${subteamEventSlug}`);
+    const prefixes = ["", "/en"];
 
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(org.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("organization")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/org/${requestedSlug}/team/${subteamSlug}/${subteamEventSlug}`);
+      await assertChecks(page, org.name, "organization");
+    }
   });
 
   test("Organization user", async ({ users, page }) => {
     const owner = await users.create(undefined, { hasTeam: true, isUnpublished: true, isOrg: true });
     const { team: org } = await owner.getOrgMembership();
     const { requestedSlug } = org.metadata as { requestedSlug: string };
-    await page.goto(`/org/${requestedSlug}/${owner.username}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(org.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("organization")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/org/${requestedSlug}/${owner.username}`);
+      await assertChecks(page, org.name, "organization");
+    }
   });
 
   test("Organization user event-type", async ({ users, page }) => {
@@ -105,10 +117,11 @@ test.describe("Unpublished", () => {
     const { team: org } = await owner.getOrgMembership();
     const { requestedSlug } = org.metadata as { requestedSlug: string };
     const [{ slug: ownerEventType }] = owner.eventTypes;
-    await page.goto(`/org/${requestedSlug}/${owner.username}/${ownerEventType}`);
-    await expect(page.locator('[data-testid="empty-screen"]')).toHaveCount(1);
-    await expect(page.locator(`h2:has-text("${title(org.name)}")`)).toHaveCount(1);
-    await expect(page.locator(`div:text("${description("organization")}")`)).toHaveCount(1);
-    await expect(page.locator(`img`)).toHaveAttribute("src", /.*/);
+    const prefixes = ["", "/en"];
+
+    for (const prefix of prefixes) {
+      await page.goto(`${prefix}/org/${requestedSlug}/${owner.username}/${ownerEventType}`);
+      await assertChecks(page, org.name, "organization");
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Discussion: https://calendso.slack.com/archives/C08BBD6QAR2/p1742795448562089?thread_ts=1742781884.770979&cid=C08BBD6QAR2

Both are renderings of  `/en/event-types`

### Before

<img width="1244" alt="Screenshot 2025-03-24 at 1 41 34 AM" src="https://github.com/user-attachments/assets/2c18a2bb-40c9-43f6-aa6c-515a2457b134" />


### After

<img width="868" alt="Screenshot 2025-03-24 at 1 43 25 AM" src="https://github.com/user-attachments/assets/9568c05b-2df7-4582-8059-667fa3b7e104" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- I added e2e tests
- but let's still test booking pages (team, org, user booking pages) with `/en` prefix in QA before releasing to Prod @keithwillcode @zomars @emrysal 