### PR TITLE
revert: "fix: lint (#20325)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: ./.github/actions/yarn-install
       - name: Run Lint
         run: yarn lint
-        continue-on-error: false
+        continue-on-error: true


### PR DESCRIPTION
We have other parts of the linting process that need fixed before this can be enabled. Reverting until we can verify those are fixed so we unblock `main` branch merges.