### PR TITLE
chore: Use fixed mintlify version for builds

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: docs
         run: |
           export NODE_OPTIONS="--max_old_space_size=8192"
-          npm install -g mintlify
+          npm install -g mintlify@4.0.436
           mintlify dev &
           sleep 5 # Let it run for 5 seconds
           kill $!


### PR DESCRIPTION
## What does this PR do?

The newer version of `mintlify` causes `Maximum call stack size exceeded` errors. Pinning to this version for stability.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
