### PR TITLE
fix: atoms build inferred types

### DIFF
--- a/packages/platform/atoms/src/components/ui/button.tsx
+++ b/packages/platform/atoms/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes } from "react";
 
 import { cn } from "../../lib/utils";
 
@@ -36,12 +37,12 @@ const buttonVariants: buttonVariantsType = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;

--- a/packages/platform/atoms/src/components/ui/button.tsx
+++ b/packages/platform/atoms/src/components/ui/button.tsx
@@ -4,7 +4,12 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-const buttonVariants = cva(
+type buttonVariantsType = (props: {
+  variant: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link" | null | undefined;
+  size: "default" | "sm" | "lg" | "icon" | null | undefined;
+  className: string | undefined;
+}) => string;
+const buttonVariants: buttonVariantsType = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {

--- a/packages/platform/atoms/src/components/ui/toast.tsx
+++ b/packages/platform/atoms/src/components/ui/toast.tsx
@@ -1,6 +1,13 @@
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
+import type {
+  ForwardRefExoticComponent,
+  ElementRef,
+  ComponentPropsWithoutRef,
+  RefAttributes,
+  ReactElement,
+} from "react";
+import { forwardRef } from "react";
 
 import { Icon } from "@calcom/ui/components/icon";
 
@@ -8,9 +15,9 @@ import { cn } from "../../lib/utils";
 
 const ToastProvider = ToastPrimitives.Provider;
 
-const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+const ToastViewport = forwardRef<
+  ElementRef<typeof ToastPrimitives.Viewport>,
+  ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
     ref={ref}
@@ -38,19 +45,20 @@ const toastVariants = cva(
   }
 );
 
-const Toast: React.ForwardRefExoticComponent<
-  ToastPrimitives.ToastProps & React.RefAttributes<HTMLLIElement>
-> = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
->(({ className, variant, ...props }, ref) => {
-  return <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />;
-});
+const Toast: ForwardRefExoticComponent<ToastPrimitives.ToastProps & RefAttributes<HTMLLIElement>> =
+  forwardRef<
+    ElementRef<typeof ToastPrimitives.Root>,
+    ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+  >(({ className, variant, ...props }, ref) => {
+    return (
+      <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />
+    );
+  });
 Toast.displayName = ToastPrimitives.Root.displayName;
 
-const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+const ToastAction = forwardRef<
+  ElementRef<typeof ToastPrimitives.Action>,
+  ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Action
     ref={ref}
@@ -63,9 +71,9 @@ const ToastAction = React.forwardRef<
 ));
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
-const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+const ToastClose = forwardRef<
+  ElementRef<typeof ToastPrimitives.Close>,
+  ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Close
     ref={ref}
@@ -80,25 +88,25 @@ const ToastClose = React.forwardRef<
 ));
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
-const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+const ToastTitle = forwardRef<
+  ElementRef<typeof ToastPrimitives.Title>,
+  ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
 ));
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
-const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+const ToastDescription = forwardRef<
+  ElementRef<typeof ToastPrimitives.Description>,
+  ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description ref={ref} className={cn("text-sm opacity-90", className)} {...props} />
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+type ToastProps = ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>;
+type ToastActionElement = ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,

--- a/packages/platform/atoms/src/components/ui/toast.tsx
+++ b/packages/platform/atoms/src/components/ui/toast.tsx
@@ -38,7 +38,9 @@ const toastVariants = cva(
   }
 );
 
-const Toast = React.forwardRef<
+const Toast: React.ForwardRefExoticComponent<
+  ToastPrimitives.ToastProps & React.RefAttributes<HTMLLIElement>
+> = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {


### PR DESCRIPTION
## What does this PR do?

@calcom/atoms:build: src/components/ui/toast.tsx:41:7 - error TS2742: The inferred type of 'Toast' cannot be named without a reference to '@calcom/ui/node_modules/class-variance-authority/dist/types'. This is likely not portable. A type annotation is necessary.
@calcom/atoms:build: 
@calcom/atoms:build: 41 const Toast = React.forwardRef<
@calcom/atoms:build:          ~~~~~
@calcom/atoms:build: src/components/ui/button.tsx:7:7 - error TS2742: The inferred type of 'buttonVariants' cannot be named without a reference to '@calcom/ui/node_modules/class-variance-authority/dist/types'. This is likely not portable. A type annotation is necessary.
@calcom/atoms:build: 
@calcom/atoms:build: 7 const buttonVariants = cva(
@calcom/atoms:build:         ~~~~~~~~~~~~~~
@calcom/atoms:build: 
@calcom/atoms:build: transforming...

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


