### PR TITLE
fix: 500 error on missing response id. Should be 400

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -456,6 +456,10 @@ async function handler(
   let routingFormResponse = null;
 
   if (routedTeamMemberIds) {
+    //routingFormResponseId could be 0 for dry run. So, we just avoid undefined value
+    if (routingFormResponseId === undefined) {
+      throw new HttpError({ statusCode: 400, message: "Missing routingFormResponseId" });
+    }
     routingFormResponse = await prisma.app_RoutingForms_FormResponse.findUnique({
       where: {
         id: routingFormResponseId,

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -2638,6 +2638,7 @@ describe("handleNewBooking", () => {
               start: `${plus1DateString}T04:00:00.000Z`,
               end: `${plus1DateString}T04:15:00.000Z`,
               routedTeamMemberIds: [101],
+              routingFormResponseId: 12323,
               responses: {
                 email: booker.email,
                 name: booker.name,


### PR DESCRIPTION
## What does this PR do?

Change unintentended 500 error to 400 when routingFormResponseId isn't provided