### PR TITLE
fix: Dsync group table formatting

### DIFF
--- a/packages/features/ee/dsync/components/GroupNameCell.tsx
+++ b/packages/features/ee/dsync/components/GroupNameCell.tsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { Badge } from "@calcom/ui/components/badge";
-import { Icon } from "@calcom/ui/components/icon";
-import { TextField } from "@calcom/ui/components/form";
 import classNames from "@calcom/ui/classNames";
+import { Badge } from "@calcom/ui/components/badge";
+import { TextField } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 
 interface GroupNameCellProps {
@@ -72,18 +72,21 @@ const GroupNameCell = ({ groupNames, teamId, directoryId }: GroupNameCellProps) 
   };
 
   return (
-    <div className="flex items-center space-x-4">
+    <div className="flex flex-wrap items-center gap-2 space-x-4">
       {groupNames.map((name) => (
-        <Badge variant="gray" size="lg" key={name} className="h-8 py-4">
-          <div className="flex items-center space-x-2 ">
-            <p>{name}</p>
-            <div className="hover:bg-emphasis rounded p-1">
+        <Badge variant="gray" size="lg" key={name} className="min-h-8 h-auto py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="min-w-0 break-words">{name}</p>
+            <div className="hover:bg-emphasis shrink-0 rounded p-1">
               <Icon name="x" className="h-4 w-4 stroke-[3px]" onClick={() => removeGroupName(name)} />
             </div>
           </div>
         </Badge>
       ))}
-      <Badge variant="gray" size="lg" className={classNames(!showTextInput && "hover:bg-emphasis")}>
+      <Badge
+        variant="gray"
+        size="lg"
+        className={classNames(!showTextInput && "hover:bg-emphasis", "min-h-8 h-auto py-2")}>
         <div
           className="flex items-center space-x-1"
           onClick={() => {

--- a/packages/features/ee/dsync/components/GroupTeamMappingTable.tsx
+++ b/packages/features/ee/dsync/components/GroupTeamMappingTable.tsx
@@ -40,7 +40,7 @@ const GroupTeamMappingTable = () => {
     {
       id: "group",
       header: t("group_name"),
-      size: 200,
+      size: 500,
       enableHiding: false,
       enableSorting: false,
       cell: ({ row }) => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Before
Notice group names get cut off
![image](https://github.com/user-attachments/assets/a2978f9a-dfc3-4ff9-b2c4-d066b97f28db)


## After
![image](https://github.com/user-attachments/assets/3a3330a5-3b85-4376-b163-54fb8148d402)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

