### PR TITLE
feat: Salesforce - Fallback to Lead if Contact Isn't Found For Routing

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3044,5 +3044,6 @@
   "could_not_find_slug_to_publish_org": "Could not find slug to publish the organization",
   "picklist": "Picklist",
   "name_or_email": "Name or Email",
+  "salesforce_round_robin_skip_fallback_to_lead_owner": "If no contact is found, fallback to lead owner if it exists",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
+++ b/packages/app-store/salesforce/components/EventTypeAppCardInterface.tsx
@@ -46,6 +46,7 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
   const onBookingWriteToRecord = getAppData("onBookingWriteToRecord") ?? false;
   const onBookingWriteToRecordFields = getAppData("onBookingWriteToRecordFields") ?? {};
   const ignoreGuests = getAppData("ignoreGuests") ?? false;
+  const roundRobinSkipFallbackToLeadOwner = getAppData("roundRobinSkipFallbackToLeadOwner") ?? false;
 
   const { t } = useLocale();
 
@@ -522,6 +523,18 @@ const EventTypeAppCard: EventTypeAppCardComponent = function EventTypeAppCard({ 
                     }}
                   />
                 </div>
+                {checkOwnerSelectedOption.value === SalesforceRecordEnum.CONTACT ? (
+                  <div className="my-4">
+                    <Switch
+                      label={t("salesforce_round_robin_skip_fallback_to_lead_owner")}
+                      labelOnLeading
+                      checked={roundRobinSkipFallbackToLeadOwner}
+                      onCheckedChange={(checked) => {
+                        setAppData("roundRobinSkipFallbackToLeadOwner", checked);
+                      }}
+                    />
+                  </div>
+                ) : null}
                 <div className="my-4">
                   <Switch
                     label={t("salesforce_if_free_email_domain_skip_owner_check")}

--- a/packages/app-store/salesforce/zod.ts
+++ b/packages/app-store/salesforce/zod.ts
@@ -41,6 +41,7 @@ export const appDataSchema = eventTypeAppCardZod.extend({
     .default(SalesforceRecordEnum.CONTACT)
     .optional(),
   ifFreeEmailDomainSkipOwnerCheck: z.boolean().optional(),
+  roundRobinSkipFallbackToLeadOwner: z.boolean().optional(),
   skipContactCreation: z.boolean().optional(),
   createEventOn: z.nativeEnum(SalesforceRecordEnum).default(SalesforceRecordEnum.CONTACT).optional(),
   createNewContactUnderAccount: z.boolean().optional(),


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- For routing based on contact record, add the option to fallback to a lead if it exists

https://www.loom.com/share/eca6d878b6c747aeb745153408cf6e9b

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Enable RR skip based on Contact record in an event type's Salesforce option
- Open the booking page with an email param
- Pass the email of a record that exists as a contact and a lead
	- Should return owner of contact
- Pass the email of a contact
	- Should return owner of contact
- Pass the email of a lead
	- Should return the owner of the lead
