### PR TITLE
fix: calendar cache date mismtach

### DIFF
--- a/packages/features/calendar-cache/calendar-cache.repository.ts
+++ b/packages/features/calendar-cache/calendar-cache.repository.ts
@@ -11,28 +11,19 @@ import { getTimeMax, getTimeMin } from "./lib/datesForCache";
 
 const log = logger.getSubLogger({ prefix: ["CalendarCacheRepository"] });
 
-/** Enable or disable the expanded cache. Enabled by default. */
-const ENABLE_EXPANDED_CACHE = process.env.ENABLE_EXPANDED_CACHE !== "0";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ONE_MONTH_IN_MS = 30 * MS_PER_DAY;
 const CACHING_TIME = ONE_MONTH_IN_MS;
 
 export function parseKeyForCache(args: FreeBusyArgs): string {
-  const { timeMin: _timeMin, timeMax: _timeMax, items } = args;
   // Ensure that calendarIds are unique
-  const uniqueItems = uniqueBy(items, ["id"]);
-  const { timeMin, timeMax } = handleMinMax(_timeMin, _timeMax);
-  const key = JSON.stringify({ timeMin, timeMax, items: uniqueItems });
+  const uniqueItems = uniqueBy(args.items, ["id"]);
+  const key = JSON.stringify({
+    timeMin: getTimeMin(args.timeMin),
+    timeMax: getTimeMax(args.timeMax),
+    items: uniqueItems,
+  });
   return key;
-}
-
-/**
- * By expanding the cache to whole months, we can save round trips to the third party APIs.
- * In this case we already have the data in the database, so we can just return it.
- */
-function handleMinMax(min: string, max: string) {
-  if (!ENABLE_EXPANDED_CACHE) return { timeMin: min, timeMax: max };
-  return { timeMin: getTimeMin(min), timeMax: getTimeMax(max) };
 }
 
 type FreeBusyArgs = { timeMin: string; timeMax: string; items: { id: string }[] };

--- a/packages/features/calendar-cache/calendar-cache.repository.ts
+++ b/packages/features/calendar-cache/calendar-cache.repository.ts
@@ -15,7 +15,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ONE_MONTH_IN_MS = 30 * MS_PER_DAY;
 const CACHING_TIME = ONE_MONTH_IN_MS;
 
-export function parseKeyForCache(args: FreeBusyArgs): string {
+function parseKeyForCache(args: FreeBusyArgs): string {
   // Ensure that calendarIds are unique
   const uniqueItems = uniqueBy(args.items, ["id"]);
   const key = JSON.stringify({

--- a/packages/features/calendar-cache/lib/datesForCache.test.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { getTimeMin, getTimeMax } from "./datesForCache";
 
 describe("getTimeMin", () => {
+  // Tested on multiple dates
+  // vi.setSystemTime("2030-04-21T00:00:13Z");
   it("should return start of current month when no date is passed", () => {
     const result = getTimeMin();
     const expected = new Date();
@@ -12,24 +14,18 @@ describe("getTimeMin", () => {
   });
 
   it("should return start of month for a given date", () => {
-    const testDate = "2024-03-15T10:30:00Z";
-    const result = getTimeMin(testDate);
-    const expected = new Date(Date.UTC(2024, 2, 1)); // March is 2 in UTC
-    expect(result).toBe(expected.toISOString());
+    const result = getTimeMin("2025-03-15T10:30:00Z");
+    expect(result).toMatchInlineSnapshot(`"2025-03-01T00:00:00.000Z"`);
   });
 
   it("should handle dates at the start of month", () => {
-    const testDate = "2024-03-01T00:00:00Z";
-    const result = getTimeMin(testDate);
-    const expected = new Date(Date.UTC(2024, 2, 1)); // March is 2 in UTC
-    expect(result).toBe(expected.toISOString());
+    const result = getTimeMin("2026-03-01T00:00:00Z");
+    expect(result).toMatchInlineSnapshot(`"2026-03-01T00:00:00.000Z"`);
   });
 
   it("should handle DST changes", () => {
-    const testDate = "2024-10-27T01:30:00Z"; // DST change in Europe
-    const result = getTimeMin(testDate);
-    const expected = new Date(Date.UTC(2024, 9, 1)); // October is 9 in UTC
-    expect(result).toBe(expected.toISOString());
+    const result = getTimeMin("2024-10-27T01:30:00Z");
+    expect(result).toMatchInlineSnapshot(`"2024-10-01T00:00:00.000Z"`);
   });
 });
 
@@ -46,42 +42,36 @@ describe("getTimeMax", () => {
   it("should return the start of overnext month for dates between start of current month and end of next month", () => {
     const testDate = "2024-03-15T10:30:00Z";
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 4, 1)); // May is 4 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-05-01T00:00:00.000Z"`);
   });
 
   it("should return end of month for dates beyond overnext month", () => {
     const testDate = "2024-05-15T10:30:00Z";
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 6, 1)); // July is 6 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-07-01T00:00:00.000Z"`);
   });
 
   it("should handle dates at the end of month", () => {
     const testDate = "2024-03-31T23:59:59Z";
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 4, 1)); // May is 4 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-05-01T00:00:00.000Z"`);
   });
 
   it("should handle October correctly (31 days)", () => {
     const testDate = "2024-10-15T10:30:00Z";
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 11, 1)); // December is 11 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-12-01T00:00:00.000Z"`);
   });
 
   it("should handle DST changes", () => {
     const testDate = "2024-10-27T01:30:00Z"; // DST change in Europe
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 11, 1)); // December is 11 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-12-01T00:00:00.000Z"`);
   });
 
   it("should handle dates around DST changes in next month", () => {
     const testDate = "2024-09-15T10:30:00Z"; // September, next month includes DST change
     const result = getTimeMax(testDate);
-    const expected = new Date(Date.UTC(2024, 10, 1)); // November is 10 in UTC
-    expect(result).toBe(expected.toISOString());
+    expect(result).toMatchInlineSnapshot(`"2024-11-01T00:00:00.000Z"`);
   });
 });

--- a/packages/features/calendar-cache/lib/datesForCache.test.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { getTimeMin, getTimeMax } from "./datesForCache";
+
+describe("getTimeMin", () => {
+  it("should return start of current month when no date is passed", () => {
+    const result = getTimeMin();
+    const expected = new Date();
+    expected.setUTCDate(1);
+    expected.setUTCHours(0, 0, 0, 0);
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should return start of month for a given date", () => {
+    const testDate = "2024-03-15T10:30:00Z";
+    const result = getTimeMin(testDate);
+    const expected = new Date(Date.UTC(2024, 2, 1)); // March is 2 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle dates at the start of month", () => {
+    const testDate = "2024-03-01T00:00:00Z";
+    const result = getTimeMin(testDate);
+    const expected = new Date(Date.UTC(2024, 2, 1)); // March is 2 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle DST changes", () => {
+    const testDate = "2024-10-27T01:30:00Z"; // DST change in Europe
+    const result = getTimeMin(testDate);
+    const expected = new Date(Date.UTC(2024, 9, 1)); // October is 9 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+});
+
+describe("getTimeMax", () => {
+  it("should return the start of the overnext month when no date is passed", () => {
+    const result = getTimeMax();
+    const expected = new Date();
+    expected.setUTCMonth(expected.getUTCMonth() + 2);
+    expected.setUTCDate(1);
+    expected.setUTCHours(0, 0, 0, 0);
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should return the start of overnext month for dates between start of current month and end of next month", () => {
+    const testDate = "2024-03-15T10:30:00Z";
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 4, 1)); // May is 4 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should return end of month for dates beyond overnext month", () => {
+    const testDate = "2024-05-15T10:30:00Z";
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 6, 1)); // July is 6 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle dates at the end of month", () => {
+    const testDate = "2024-03-31T23:59:59Z";
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 4, 1)); // May is 4 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle October correctly (31 days)", () => {
+    const testDate = "2024-10-15T10:30:00Z";
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 11, 1)); // December is 11 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle DST changes", () => {
+    const testDate = "2024-10-27T01:30:00Z"; // DST change in Europe
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 11, 1)); // December is 11 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+
+  it("should handle dates around DST changes in next month", () => {
+    const testDate = "2024-09-15T10:30:00Z"; // September, next month includes DST change
+    const result = getTimeMax(testDate);
+    const expected = new Date(Date.UTC(2024, 10, 1)); // November is 10 in UTC
+    expect(result).toBe(expected.toISOString());
+  });
+});

--- a/packages/features/calendar-cache/lib/datesForCache.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.ts
@@ -1,16 +1,66 @@
 /** Expand the start date to the beginning of the current month */
 export const getTimeMin = (timeMin?: string) => {
   const date = timeMin ? new Date(timeMin) : new Date();
-  date.setDate(1);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString();
+  // Set to UTC to avoid timezone issues
+  const result = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+  result.setUTCHours(0, 0, 0, 0);
+  return result.toISOString();
 };
 
-/** Expand the end date to the end of the next month */
+/**
+ * Expand the end date to the start of the overnext month if date
+ * is between start of current month and end of next month,
+ * otherwise return start of overnext month from the passed date
+ * @example
+ * Today: March 15, 2024 ▼-------------▼ getTimeMax returns May 1st 00:00:00
+ *                   Mar      Apr      May      Jun
+ *                   ├────────┼────────┼────────┼────────┤
+ * Current Month     █████████|        |        |        |
+ * Next Month        |        █████████|        |        |
+ **/
 export function getTimeMax(timeMax?: string) {
-  const date = timeMax ? new Date(timeMax) : new Date();
-  date.setMonth(date.getMonth() + 1);
-  date.setDate(0);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString();
+  const now = new Date();
+  const currentMonth = now.getUTCMonth();
+  const currentYear = now.getUTCFullYear();
+
+  if (!timeMax) {
+    // If no date passed, return start of the overnext month from current date
+    const result = new Date(Date.UTC(currentYear, currentMonth + 2, 1));
+    result.setUTCHours(0, 0, 0, 0);
+    return result.toISOString();
+  }
+
+  const date = new Date(timeMax);
+  const dateMonth = date.getUTCMonth();
+  const dateYear = date.getUTCFullYear();
+
+  // If the date is within current month or next month, return start of overnext month
+  // Otherwise, return start of overnext month from the date
+  let targetYear = dateYear;
+  let targetMonth = dateMonth;
+
+  // Check if date is within current month or next month
+  const isWithinCurrentOrNextMonth =
+    (dateYear === currentYear && dateMonth <= currentMonth + 1) ||
+    (dateYear === currentYear + 1 && currentMonth === 11 && dateMonth === 0);
+
+  if (isWithinCurrentOrNextMonth) {
+    // For dates within current month or next month, return start of overnext month
+    targetMonth = dateMonth + 2;
+    if (targetMonth > 11) {
+      targetMonth = 0;
+      targetYear++;
+    }
+  } else {
+    // For dates beyond overnext month, return start of overnext month from the date
+    targetMonth = dateMonth + 2;
+    if (targetMonth > 11) {
+      targetMonth = 0;
+      targetYear++;
+    }
+  }
+
+  const result = new Date(Date.UTC(targetYear, targetMonth, 1));
+  result.setUTCHours(0, 0, 0, 0);
+  return result.toISOString();
 }


### PR DESCRIPTION
## What does this PR do?

refs #18052

There was mistmach between the cache key and the [fetched times here](https://github.com/calcom/cal.com/blob/fix/calendar-cache-date-mismatch/packages/app-store/googlecalendar/lib/CalendarService.ts#L1061)
-  Removes the handleMixMac function and uses date helpers directly so it matches the usage [here](https://github.com/calcom/cal.com/blob/fix/calendar-cache-date-mismatch/packages/app-store/googlecalendar/lib/CalendarService.ts#L1061)

<img width="808" alt="imagen" src="https://github.com/user-attachments/assets/cc2df240-e3ac-436b-8720-bef60448fbf4" />



This pull request includes significant changes to the `calendar-cache` feature, primarily focusing on refactoring the handling of time ranges and improving the related test coverage. The most important changes include refactoring the `parseKeyForCache` function to use new utility functions, removing the `handleMinMax` function, and adding comprehensive tests for the new utility functions.

Refactoring and code simplification:

* [`packages/features/calendar-cache/calendar-cache.repository.ts`](diffhunk://#diff-4cf8d3089fad7b6c8fe4172d8d42147f136b65baf30b726e57b9b10d179d4a99L14-L37): Refactored `parseKeyForCache` to use `getTimeMin` and `getTimeMax` functions directly and removed the `handleMinMax` function.
* [`packages/features/calendar-cache/lib/datesForCache.ts`](diffhunk://#diff-394e8011261a8266dcd61e91e2401d8c31708d7a2b8448ca87e2ef9fd5ee8f19L4-R65): Updated `getTimeMin` and `getTimeMax` functions to handle dates more accurately, including edge cases like DST changes.

Test coverage improvements:

* [`packages/features/calendar-cache/lib/datesForCache.test.ts`](diffhunk://#diff-a4f4e261b49f6bc4a915c5d1a8f226a641b3ed9643d801d3fac424bdb4e8acbbR1-R87): Added comprehensive tests for `getTimeMin` and `getTimeMax` functions to ensure they handle various date scenarios correctly, including start of month, end of month, and DST changes.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- yarn tdd packages/features/calendar-cache/lib/datesForCache.test.ts
- With calendar cache enabled the requested time and cache key should match
