### PR TITLE
fix: middleware config matcher

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -174,7 +174,7 @@ function responseWithHeaders({ url, res, req }: { url: URL; res: NextResponse; r
 export const config = {
   // Next.js Doesn't support spread operator in config matcher, so, we must list all paths explicitly here.
   // https://github.com/vercel/next.js/discussions/42458
-  // WARNING: DO NOT ADD AN ENDING SLASH "/" TO THE PATHS
+  // WARNING: DO NOT ADD AN ENDING SLASH "/" TO THE PATHS BELOW
   // THIS WILL MAKE THEM NOT MATCH AND HENCE NOT HIT MIDDLEWARE
   matcher: [
     "/403",

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -174,6 +174,8 @@ function responseWithHeaders({ url, res, req }: { url: URL; res: NextResponse; r
 export const config = {
   // Next.js Doesn't support spread operator in config matcher, so, we must list all paths explicitly here.
   // https://github.com/vercel/next.js/discussions/42458
+  // WARNING: DO NOT ADD AN ENDING SLASH "/" TO THE PATHS
+  // THIS WILL MAKE THEM NOT MATCH AND HENCE NOT HIT MIDDLEWARE
   matcher: [
     "/403",
     "/500",
@@ -204,10 +206,16 @@ export const config = {
     "/booking/:path*",
     "/payment/:path*",
     "/routing-forms/:path*",
-    "/team/:path*",
-    "/org/:path*",
-    "/:user/:type/",
-    "/:user/",
+    "/org/:orgSlug/instant-meeting/team/:slug/:type",
+    "/org/:orgSlug/team/:slug/:type",
+    "/org/:orgSlug/team/:slug",
+    "/org/:orgSlug/:user/:type",
+    "/org/:orgSlug/:user",
+    "/org/:orgSlug",
+    "/team/:slug/:type",
+    "/team/:slug",
+    "/:user/:type",
+    "/:user",
   ],
 };
 


### PR DESCRIPTION
## What does this PR do?

- Apparently, in Next.js 15, the ending slash `/` in middleware config.matcher makes the routes NOT go through middleware.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Try adding an ending slash to any route in config.matcher (e.g., `/403`) and logging something in middleware. You will see that it doesn't hit middleware.