### PR TITLE
chore: Use `createCallerFactory` since `createCaller` method is deprecated

### DIFF
--- a/apps/api/v1/pages/api/invites/_post.ts
+++ b/apps/api/v1/pages/api/invites/_post.ts
@@ -8,6 +8,7 @@ import { createContext } from "@calcom/trpc/server/createContext";
 import { viewerTeamsRouter } from "@calcom/trpc/server/routers/viewer/teams/_router";
 import type { TInviteMemberInputSchema } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/inviteMember.schema";
 import { ZInviteMemberInputSchema } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/inviteMember.schema";
+import { createCallerFactory } from "@calcom/trpc/server/trpc";
 import type { UserProfile } from "@calcom/types/UserProfile";
 
 import { TRPCError } from "@trpc/server";
@@ -38,7 +39,8 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 
   const ctx = await createContext({ req, res }, sessionGetter);
   try {
-    const caller = viewerTeamsRouter.createCaller(ctx);
+    const createCaller = createCallerFactory(viewerTeamsRouter);
+    const caller = createCaller(ctx);
     await caller.inviteMember({
       role: data.role,
       language: data.language,

--- a/apps/api/v1/pages/api/teams/[teamId]/publish.ts
+++ b/apps/api/v1/pages/api/teams/[teamId]/publish.ts
@@ -6,6 +6,7 @@ import { defaultResponder } from "@calcom/lib/server/defaultResponder";
 import { MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
 import { createContext } from "@calcom/trpc/server/createContext";
 import { viewerTeamsRouter } from "@calcom/trpc/server/routers/viewer/teams/_router";
+import { createCallerFactory } from "@calcom/trpc/server/trpc";
 import type { UserProfile } from "@calcom/types/UserProfile";
 
 import { TRPCError } from "@trpc/server";
@@ -39,7 +40,8 @@ const patchHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   /** @see https://trpc.io/docs/server-side-calls */
   const ctx = await createContext({ req, res }, sessionGetter);
   try {
-    const caller = viewerTeamsRouter.createCaller(ctx);
+    const createCaller = createCallerFactory(viewerTeamsRouter);
+    const caller = createCaller(ctx);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return await caller.publish(req.query as any /* Let tRPC handle this */);
   } catch (cause) {

--- a/apps/web/app/api/link/route.ts
+++ b/apps/web/app/api/link/route.ts
@@ -9,6 +9,7 @@ import prisma from "@calcom/prisma";
 import { UserPermissionRole } from "@calcom/prisma/enums";
 import { createContext } from "@calcom/trpc/server/createContext";
 import { bookingsRouter } from "@calcom/trpc/server/routers/viewer/bookings/_router";
+import { createCallerFactory } from "@calcom/trpc/server/trpc";
 import type { UserProfile } from "@calcom/types/UserProfile";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
@@ -83,7 +84,8 @@ async function handler(request: NextRequest) {
     const res = {} as any; // Response is still mocked as it's not used in this context
 
     const ctx = await createContext({ req: legacyReq, res }, sessionGetter);
-    const caller = bookingsRouter.createCaller({
+    const createCaller = createCallerFactory(bookingsRouter);
+    const caller = createCaller({
       ...ctx,
       req: legacyReq,
       res,


### PR DESCRIPTION
## What does this PR do?

<img width="494" alt="Screenshot 2025-03-31 at 7 28 26 PM" src="https://github.com/user-attachments/assets/b8b479d6-fd7c-447f-830d-6a1da57e8eb6" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.