### PR TITLE
fix: trigger Lingo.dev for a translation not picked up

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3029,7 +3029,7 @@
   "inactive_team_plan_description": "Your team plan is inactive. Check your subcription or reach out to customer support",
   "limited_access_trial_mode": "Limited access during trial. Feature available after trial ends.",
   "referral_program": "Referral Program",
-  "earn_twenty_percent_referral": "Earn 20% referral",
+  "referral_text": "Earn 20% referral",
   "dub_disabled_error_message": "You need a Dub API Key and Program Id to use this page.",
   "uid": "UID",
   "link": "Link",

--- a/packages/features/shell/useBottomNavItems.ts
+++ b/packages/features/shell/useBottomNavItems.ts
@@ -38,7 +38,7 @@ export function useBottomNavItems({
     },
     IS_DUB_REFERRALS_ENABLED
       ? {
-          name: "earn_twenty_percent_referral",
+          name: "referral_text",
           href: "/refer",
           icon: "gift",
         }


### PR DESCRIPTION
## What does this PR do?

- `"Earn 20% referral"` only exists in `en/common.json`. Seems like this translation isn't picked up by Lingo dev

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

