### PR TITLE
fix: Updated DateRangePicker in limit future booking

### DIFF
--- a/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -301,6 +301,7 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                         onChange(values);
                       }}
                       strictlyBottom={true}
+                      allowPastDates={true}
                     />
                   )}
                 />

--- a/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
+++ b/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
@@ -33,20 +33,22 @@ export function DatePickerWithRange({
 }: React.HTMLAttributes<HTMLDivElement> & DatePickerWithRangeProps) {
   function handleDayClick(date: Date) {
     if (!dates.startDate) {
-      // If no start date set it as both start and end date
+      // If no start date, set it as both start and end date
       onDatesChange({ startDate: date, endDate: date });
-    } else if (!dates.endDate) {
+    } else if (dates.startDate && !dates.endDate) {
       const startDate = date < dates.startDate ? date : dates.startDate;
       const endDate = date < dates.startDate ? dates.startDate : date;
       onDatesChange({ startDate, endDate });
-    } else {
+    } else if (dates.startDate && dates.endDate) {
       // If both dates exist
-      if (date.getTime() === dates.startDate.getTime() && dates.endDate) {
+      if (date.getTime() === dates.startDate.getTime()) {
         onDatesChange({ startDate: date, endDate: date });
-      } else if (date <= dates.endDate) {
+      } else if (date.getTime() === dates.endDate?.getTime()) {
+        onDatesChange({ startDate: date, endDate: date });
+      } else if (date < dates.startDate) {
         onDatesChange({ startDate: date, endDate: dates.endDate });
-      } else {
-        onDatesChange({ startDate: date, endDate: date });
+      } else if (date > dates.startDate) {
+        onDatesChange({ startDate: dates.startDate, endDate: date });
       }
     }
   }

--- a/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
+++ b/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
@@ -32,21 +32,29 @@ export function DatePickerWithRange({
   strictlyBottom,
 }: React.HTMLAttributes<HTMLDivElement> & DatePickerWithRangeProps) {
   function handleDayClick(date: Date) {
-    if (!dates.startDate) {
-      // If no start date set it as both start and end date
+    if (!dates.startDate || !dates.endDate) {
+      // If no range exists, set clicked date as both start and end
       onDatesChange({ startDate: date, endDate: date });
-    } else if (!dates.endDate) {
-      const startDate = date < dates.startDate ? date : dates.startDate;
-      const endDate = date < dates.startDate ? dates.startDate : date;
-      onDatesChange({ startDate, endDate });
     } else {
-      // If both dates exist
-      if (date.getTime() === dates.startDate.getTime() && dates.endDate) {
+      const startTime = dates.startDate.getTime();
+      const endTime = dates.endDate.getTime();
+      const clickedTime = date.getTime();
+
+      if (clickedTime === startTime || clickedTime === endTime) {
         onDatesChange({ startDate: date, endDate: date });
-      } else if (date <= dates.endDate) {
+      } else if (clickedTime < startTime) {
         onDatesChange({ startDate: date, endDate: dates.endDate });
+      } else if (clickedTime > endTime) {
+        onDatesChange({ startDate: dates.startDate, endDate: date });
       } else {
-        onDatesChange({ startDate: date, endDate: date });
+        // Clicking between start and end adjust the nearer boundary
+        const startDiff = clickedTime - startTime;
+        const endDiff = endTime - clickedTime;
+        if (startDiff < endDiff) {
+          onDatesChange({ startDate: date, endDate: dates.endDate });
+        } else {
+          onDatesChange({ startDate: dates.startDate, endDate: date });
+        }
       }
     }
   }

--- a/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
+++ b/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
@@ -32,29 +32,21 @@ export function DatePickerWithRange({
   strictlyBottom,
 }: React.HTMLAttributes<HTMLDivElement> & DatePickerWithRangeProps) {
   function handleDayClick(date: Date) {
-    if (!dates.startDate || !dates.endDate) {
-      // If no range exists, set clicked date as both start and end
+    if (!dates.startDate) {
+      // If no start date set it as both start and end date
       onDatesChange({ startDate: date, endDate: date });
+    } else if (!dates.endDate) {
+      const startDate = date < dates.startDate ? date : dates.startDate;
+      const endDate = date < dates.startDate ? dates.startDate : date;
+      onDatesChange({ startDate, endDate });
     } else {
-      const startTime = dates.startDate.getTime();
-      const endTime = dates.endDate.getTime();
-      const clickedTime = date.getTime();
-
-      if (clickedTime === startTime || clickedTime === endTime) {
+      // If both dates exist
+      if (date.getTime() === dates.startDate.getTime() && dates.endDate) {
         onDatesChange({ startDate: date, endDate: date });
-      } else if (clickedTime < startTime) {
+      } else if (date <= dates.endDate) {
         onDatesChange({ startDate: date, endDate: dates.endDate });
-      } else if (clickedTime > endTime) {
-        onDatesChange({ startDate: dates.startDate, endDate: date });
       } else {
-        // Clicking between start and end adjust the nearer boundary
-        const startDiff = clickedTime - startTime;
-        const endDiff = endTime - clickedTime;
-        if (startDiff < endDiff) {
-          onDatesChange({ startDate: date, endDate: dates.endDate });
-        } else {
-          onDatesChange({ startDate: dates.startDate, endDate: date });
-        }
+        onDatesChange({ startDate: date, endDate: date });
       }
     }
   }

--- a/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
+++ b/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
@@ -32,20 +32,34 @@ export function DatePickerWithRange({
   strictlyBottom,
 }: React.HTMLAttributes<HTMLDivElement> & DatePickerWithRangeProps) {
   function handleDayClick(date: Date) {
-    if (dates?.endDate) {
-      onDatesChange({ startDate: date, endDate: undefined });
-    } else {
-      const startDate = dates.startDate ? (date < dates.startDate ? date : dates.startDate) : date;
-      const endDate = dates.startDate ? (date < dates.startDate ? dates.startDate : date) : undefined;
+    if (!dates.startDate) {
+      // If no start date set it as both start and end date
+      onDatesChange({ startDate: date, endDate: date });
+    } else if (!dates.endDate) {
+      // If start date exists but no end date and clicked date is before start date set it as both start and end date
+      const startDate = date < dates.startDate ? date : dates.startDate;
+      const endDate = date < dates.startDate ? dates.startDate : date;
       onDatesChange({ startDate, endDate });
+    } else {
+      // If both dates exist
+      if (date.getTime() === dates.startDate.getTime() && dates.endDate) {
+        // If clicking the start date again when there's a range, set it as both start and end
+        onDatesChange({ startDate: date, endDate: date });
+      } else if (date <= dates.endDate) {
+        // If clicking a date before or equal to end date, keep end date and set new start
+        onDatesChange({ startDate: date, endDate: dates.endDate });
+      } else {
+        // If clicking after end date, start new range
+        onDatesChange({ startDate: date, endDate: date });
+      }
     }
   }
+
   const fromDate = minDate ?? new Date();
 
   const calendar = (
     <Calendar
       initialFocus
-      //When explicitly null, we want past dates to be shown as well, otherwise show only dates passed or from current date
       fromDate={minDate === null ? undefined : fromDate}
       toDate={maxDate}
       mode="range"

--- a/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
+++ b/packages/ui/components/form/date-range-picker/DateRangePicker.tsx
@@ -36,20 +36,16 @@ export function DatePickerWithRange({
       // If no start date set it as both start and end date
       onDatesChange({ startDate: date, endDate: date });
     } else if (!dates.endDate) {
-      // If start date exists but no end date and clicked date is before start date set it as both start and end date
       const startDate = date < dates.startDate ? date : dates.startDate;
       const endDate = date < dates.startDate ? dates.startDate : date;
       onDatesChange({ startDate, endDate });
     } else {
       // If both dates exist
       if (date.getTime() === dates.startDate.getTime() && dates.endDate) {
-        // If clicking the start date again when there's a range, set it as both start and end
         onDatesChange({ startDate: date, endDate: date });
       } else if (date <= dates.endDate) {
-        // If clicking a date before or equal to end date, keep end date and set new start
         onDatesChange({ startDate: date, endDate: dates.endDate });
       } else {
-        // If clicking after end date, start new range
         onDatesChange({ startDate: date, endDate: date });
       }
     }


### PR DESCRIPTION
## What does this PR do?

- Fixed date range selection to maintain end date when selecting earlier dates

- Added toggle functionality: clicking start date again converts range to single-day range

- Ensured single date selections automatically set both start and end dates to the same day 

- Updated range behavior: clicking start date in a range (e.g., 2-9) now sets it to single-day range (e.g., 2-2) instead of clearing end date ( it will fix the end date issue ex: start date comes after end date )

Fixes #20464 


## Visual Demo (For contributors especially)


https://github.com/user-attachments/assets/efc56a19-ba93-42cd-8781-de0c0c72f02b


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to Event types > click on any event > go to limit future bookings toggle
- Set an initial range (e.g., April 2nd - April 9th).
- Click on the date picker to open it.
- Select a new start date before the end date (e.g., April 4th).
  - Check that the UI shows the updated start date with the original end date intact (e.g., April 4th - April 9th).
- Click the start date again (e.g., April 4th).
  - Verify it converts to a single-day range (e.g., April 4th - April 4th) instead of clearing the end date.
- Select a single date initially (e.g., April 2nd).
  - Confirm it automatically sets as both start and end date (e.g., April 2nd - April 2nd).
- Set a range again (e.g., April 2nd - April 9th), then pick a start date after the end date (e.g., April 10th).
  - Confirm it starts a new single-day range (e.g., April 10th - April 10th) instead of keeping the old end date.
- Close the date picker and click "Save."
- Refresh the page and verify the saved range matches the last selection.
- Reopen the date picker, pick a new date, close without saving.
  - Ensure the original saved range remains unchanged.
- Save a valid range (e.g., April 4th - April 9th), refresh, and verify the result persists correctly.

