### PR TITLE
fix: switch saveMode for SaveFilterSegmentButton

### DIFF
--- a/packages/features/data-table/DataTableProvider.tsx
+++ b/packages/features/data-table/DataTableProvider.tsx
@@ -158,10 +158,10 @@ export function DataTableProvider({
 
   const setPageSizeAndGoToFirstPage = useCallback(
     (newPageSize: number | null) => {
-      setPageSize(newPageSize === DEFAULT_PAGE_SIZE ? null : newPageSize);
+      setPageSize(newPageSize === defaultPageSize ? null : newPageSize);
       setPageIndex(null);
     },
-    [setPageSize, setPageIndex]
+    [setPageSize, setPageIndex, defaultPageSize]
   );
 
   const { segments, selectedSegment, canSaveSegment, setSegmentIdAndSaveToLocalStorage } = useSegments({

--- a/packages/features/data-table/components/segment/SaveFilterSegmentButton.tsx
+++ b/packages/features/data-table/components/segment/SaveFilterSegmentButton.tsx
@@ -1,5 +1,5 @@
 import { useSession } from "next-auth/react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
@@ -51,11 +51,21 @@ export function SaveFilterSegmentButton() {
     selectedSegment,
     canSaveSegment,
     setSegmentId,
+    pageSize,
   } = useDataTable();
 
   const [saveMode, setSaveMode] = useState<"create" | "update">(() =>
     selectedSegment ? "update" : "create"
   );
+
+  // When the dialog is not open,
+  // switch `saveMode` according to `selectedSegment`
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+    setSaveMode(selectedSegment ? "update" : "create");
+  }, [selectedSegment, isOpen]);
 
   const { data: teams } = trpc.viewer.teams.list.useQuery();
 
@@ -94,7 +104,7 @@ export function SaveFilterSegmentButton() {
       sorting,
       columnVisibility,
       columnSizing,
-      perPage: 10,
+      perPage: pageSize,
     };
 
     if (saveMode === "update") {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `SaveFilterSegmentButton`.

The `saveMode` should change based on whether a filter segment is currently selected. This PR updates the `saveMode` value accordingly.

- Fixes CAL-5398

## Visual Demo (For contributors especially)

Because of this bug, we had this issue:

![Screenshot 2025-04-02 at 10 31 01](https://github.com/user-attachments/assets/d0becb71-2a51-483f-89b1-cef52962d7f6)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to org member list
- Create a filter segment
- Make some changes to enable "Save" button
- Click the "Save" button
- The name `<input>` won't show up (it used to show up occasionally)