### PR TITLE
chore: set x-request-id in response header for exeptions apiv2

### DIFF
--- a/apps/api/v2/src/filters/calendar-service-exception.filter.ts
+++ b/apps/api/v2/src/filters/calendar-service-exception.filter.ts
@@ -36,7 +36,8 @@ export class CalendarServiceExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    const requestId = request.headers["X-Request-Id"];
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
 
     this.logger.error(`Calendar Service Exception Filter: ${exception?.message}`, {
       exception,

--- a/apps/api/v2/src/filters/http-exception.filter.ts
+++ b/apps/api/v2/src/filters/http-exception.filter.ts
@@ -14,8 +14,8 @@ export class HttpExceptionFilter implements ExceptionFilter<HttpException> {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
     const statusCode = exception.getStatus();
-    const requestId = request.headers["X-Request-Id"];
-
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
     this.logger.error(`Http Exception Filter: ${exception?.message}`, {
       exception,
       body: request.body,

--- a/apps/api/v2/src/filters/prisma-exception.filter.ts
+++ b/apps/api/v2/src/filters/prisma-exception.filter.ts
@@ -40,7 +40,8 @@ export class PrismaExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-    const requestId = request.headers["X-Request-Id"];
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
 
     this.logger.error(`PrismaError: ${error.message}`, {
       error,

--- a/apps/api/v2/src/filters/trpc-exception.filter.ts
+++ b/apps/api/v2/src/filters/trpc-exception.filter.ts
@@ -87,7 +87,8 @@ export class TRPCExceptionFilter implements ExceptionFilter {
         break;
     }
 
-    const requestId = request.headers["X-Request-Id"];
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
 
     this.logger.error(`TRPC Exception Filter: ${exception?.message}`, {
       exception,

--- a/apps/api/v2/src/filters/zod-exception.filter.ts
+++ b/apps/api/v2/src/filters/zod-exception.filter.ts
@@ -15,7 +15,8 @@ export class ZodExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-    const requestId = request.headers["X-Request-Id"];
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
 
     this.logger.error(`ZodError: ${error.message}`, {
       error,


### PR DESCRIPTION
## What does this PR do?
Added X-Request-Id header in response of errors within api v2, to ensure easier tracing when communicating with users

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

