### PR TITLE
fix: badge dot sizes to be 8x8

### DIFF
--- a/packages/ui/components/badge/Badge.tsx
+++ b/packages/ui/components/badge/Badge.tsx
@@ -86,7 +86,7 @@ export const Badge = function Badge(props: BadgeProps) {
   const Children = () => (
     <>
       {withDot ? (
-        <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor">
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" data-testid="go-primitive-dot">
           <circle cx="4" cy="4" r="4" />
         </svg>
       ) : null}

--- a/packages/ui/components/badge/Badge.tsx
+++ b/packages/ui/components/badge/Badge.tsx
@@ -40,13 +40,16 @@ type IconOrDot =
   | {
       startIcon?: IconName;
       withDot?: never;
+      customDot?: never;
     }
-  | { startIcon?: never; withDot?: true };
+  | { startIcon?: never; withDot?: true; customDot?: never }
+  | { startIcon?: never; withDot?: never; customDot?: React.ReactNode };
 
 export type BadgeBaseProps = InferredBadgeStyles & {
   children: React.ReactNode;
   rounded?: boolean;
   customStartIcon?: React.ReactNode;
+  customDot?: React.ReactNode;
 } & IconOrDot;
 
 export type BadgeProps =
@@ -69,6 +72,7 @@ export const Badge = function Badge(props: BadgeProps) {
     withDot,
     children,
     rounded,
+    customDot,
     ...passThroughProps
   } = props;
   const isButton = "onClick" in passThroughProps && passThroughProps.onClick !== undefined;
@@ -81,10 +85,19 @@ export const Badge = function Badge(props: BadgeProps) {
 
   const Children = () => (
     <>
-      {withDot ? <Icon name="dot" data-testid="go-primitive-dot" className="h-3 w-3 stroke-[3px]" /> : null}
+      {withDot ? (
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor">
+          <circle cx="4" cy="4" r="4" />
+        </svg>
+      ) : null}
       {customStartIcon ||
         (StartIcon ? (
-          <Icon name={StartIcon} data-testid="start-icon" className="h-3 w-3 stroke-[3px]" />
+          <Icon
+            name={StartIcon}
+            data-testid="start-icon"
+            className="stroke-[3px]"
+            style={{ width: 12, height: 12 }}
+          />
         ) : null)}
       {children}
     </>


### PR DESCRIPTION
Fixes dot sizes by using a custom svg instead of our icons because we couldnt increase the size within the bounding-box thw way we wanted

![CleanShot 2025-04-04 at 11 44 45](https://github.com/user-attachments/assets/332628de-1f83-430b-918e-fd6af884a2ce)
![CleanShot 2025-04-04 at 11 45 03](https://github.com/user-attachments/assets/9f988418-3e07-4693-8b90-3b18387ba49b)
