### PR TITLE
perf: Remove dynamic imports of Sentry

### DIFF
--- a/apps/web/app/api/defaultResponderForAppDir.ts
+++ b/apps/web/app/api/defaultResponderForAppDir.ts
@@ -1,4 +1,5 @@
 import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import type { Params } from "app/_types";
 import { ApiError } from "next/dist/server/api-utils";
 import type { NextRequest } from "next/server";
@@ -48,7 +49,6 @@ export const defaultResponderForAppDir = <T extends NextResponse | Response = Ne
       // Don't report 400-499 errors to Sentry/console
       if (!(serverError.statusCode >= 400 && serverError.statusCode < 500)) {
         console.error(serverError);
-        const captureException = (await import("@sentry/nextjs")).captureException;
         captureException(error);
       }
 

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -1,3 +1,5 @@
+import { captureException } from "@sentry/nextjs";
+
 import db from "@calcom/prisma";
 
 import type { AppFlags } from "./config";
@@ -9,7 +11,6 @@ export class FeaturesRepository implements IFeaturesRepository {
     try {
       return await getFeatureFlag(db, slug);
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }
@@ -34,7 +35,6 @@ export class FeaturesRepository implements IFeaturesRepository {
       if (userBelongsToTeamWithFeature) return true;
       return false;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }
@@ -61,7 +61,6 @@ export class FeaturesRepository implements IFeaturesRepository {
       if (user) return true;
       return false;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }
@@ -73,7 +72,6 @@ export class FeaturesRepository implements IFeaturesRepository {
       });
       return !!teamFeature;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }

--- a/packages/features/users/users.repository.ts
+++ b/packages/features/users/users.repository.ts
@@ -1,3 +1,5 @@
+import { captureException } from "@sentry/nextjs";
+
 import db from "@calcom/prisma";
 
 import type { IUsersRepository } from "./users.repository.interface";
@@ -11,7 +13,6 @@ export class UsersRepository implements IUsersRepository {
       });
       return user;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }

--- a/packages/features/watchlist/watchlist.repository.ts
+++ b/packages/features/watchlist/watchlist.repository.ts
@@ -90,7 +90,6 @@ export class WatchlistRepository implements IWatchlistRepository {
       });
       return blockedRecords;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }

--- a/packages/features/watchlist/watchlist.repository.ts
+++ b/packages/features/watchlist/watchlist.repository.ts
@@ -1,3 +1,5 @@
+import { captureException } from "@sentry/nextjs";
+
 import db from "@calcom/prisma";
 import { WatchlistType, WatchlistSeverity } from "@calcom/prisma/enums";
 
@@ -18,7 +20,6 @@ export class WatchlistRepository implements IWatchlistRepository {
       });
       return emailInWatchlist;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }
@@ -34,7 +35,6 @@ export class WatchlistRepository implements IWatchlistRepository {
       });
       return domainInWatchWatchlist;
     } catch (err) {
-      const captureException = (await import("@sentry/nextjs")).captureException;
       captureException(err);
       throw err;
     }

--- a/packages/lib/server/defaultResponder.ts
+++ b/packages/lib/server/defaultResponder.ts
@@ -1,4 +1,5 @@
 import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getServerErrorFromUnknown } from "./getServerErrorFromUnknown";
@@ -28,7 +29,6 @@ export function defaultResponder<T>(
       // we don't want to report Bad Request errors to Sentry / console
       if (!(error.statusCode >= 400 && error.statusCode < 500)) {
         console.error(error);
-        const captureException = (await import("@sentry/nextjs")).captureException;
         captureException(error);
       }
       return res

--- a/packages/trpc/server/middlewares/captureErrorsMiddleware.ts
+++ b/packages/trpc/server/middlewares/captureErrorsMiddleware.ts
@@ -1,3 +1,5 @@
+import { captureException } from "@sentry/nextjs";
+
 import { redactError } from "@calcom/lib/redactError";
 
 import { middleware } from "../trpc";
@@ -9,7 +11,6 @@ const captureErrorsMiddleware = middleware(async ({ next }) => {
     if (!cause) {
       return result;
     }
-    const { captureException } = await import("@sentry/nextjs");
     captureException(cause);
     throw redactError(cause);
   }


### PR DESCRIPTION
## What does this PR do?

By doing this, we create perf issues locally where turbopack cannot intelligently keep 1 version of this module around for reuse. Instead, every page you visit causes the app to continue reloading Sentry over and over and over. This screenshot shows a small sample of what I'm talking about. On my machine, I've seen it go upwards of a few hundreds files like this.

I have another bigger #20351  in progress for removing more dynamic imports but running into client-side issues attempting to load the "crypto" module so breaking down into smaller PRs.

<img width="440" alt="Screenshot 2025-04-04 at 8 49 56 AM" src="https://github.com/user-attachments/assets/1e047c94-12fa-44a9-ba26-d581822ebe65" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
