### PR TITLE
feat: add no-show event to Zapier integration [CAL-5107]

### DIFF
--- a/packages/app-store/zapier/README.md
+++ b/packages/app-store/zapier/README.md
@@ -33,7 +33,7 @@ If you run it on localhost, check out the [additional information](https://githu
 
 ## Triggers
 
-Booking created, Booking rescheduled, Booking cancelled, Meeting ended, Out Of Office Created
+Booking created, Booking rescheduled, Booking cancelled, Meeting ended, Out Of Office Created, Booking No-Show Updated
 
 ### Booking created
 
@@ -75,6 +75,25 @@ Create the other triggers (booking rescheduled, booking cancelled and meeting en
    - PerformList: GET `<baseUrl>`/api/integrations/zapier/listOOOEntries
 3. Test your API request
 4. Note: When creating the ZAP you need to remember that data is stored in the { payload: { oooEntry: { ... } } }
+
+### Booking No-Show Updated
+
+1. Settings
+   - Key: booking_no_show_updated
+   - Name: Booking No-Show Updated
+   - Noun: Booking
+   - Description: Triggers when an attendee or host is marked as no-show
+2. API Configuration (apiKey is set automatically, leave it like it is):
+   - Trigger Type: REST Hook
+   - Subscribe: POST `<baseUrl>`/api/integrations/zapier/addSubscription
+     - Request Body
+       - subscriberUrl: {{bundle.targetUrl}}
+       - triggerEvent: BOOKING_NO_SHOW_UPDATED
+   - Unsubscribe: DELETE `<baseUrl>`/api/integrations/zapier/deleteSubscription
+     - URL Params (in addition to apiKey)
+       - id: {{bundle.subscribeData.id}}
+   - PerformList: GET `<baseUrl>`/api/integrations/zapier/listBookings
+3. Test your API request
 
 ### Set ZAPIER_INVITE_LINK
 

--- a/packages/app-store/zapier/components/AppSettingsInterface.tsx
+++ b/packages/app-store/zapier/components/AppSettingsInterface.tsx
@@ -52,6 +52,12 @@ const templates: Template[] = [
     text: "Add new bookings to Google Calendar",
     link: "https://zapier.com/app/editor/template/1083651",
   },
+  {
+    icon: "calendar.svg",
+    app: "Calendar",
+    text: "Handle booking no-show updates",
+    link: "https://zapier.com/app/editor/template/1082074",
+  },
 ];
 
 export default function AppSettings() {


### PR DESCRIPTION
This PR adds the no-show event to the Zapier integration by:

1. Adding the no-show template to the Zapier interface in AppSettingsInterface.tsx
2. Updating the Zapier documentation in README.md

The changes enable users to create automations in Zapier when bookings are marked as no-show.

Closes #18992
/claim #18992