### PR TITLE
feat: improved auto-fill of "Identifier" with lowercase only and replace space " " with "_"

### DIFF
--- a/packages/app-store/routing-forms/lib/__tests__/getDefaultIdentifierFromLabel.test.ts
+++ b/packages/app-store/routing-forms/lib/__tests__/getDefaultIdentifierFromLabel.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+import { getDefaultIdentifierFromLabel } from "../getDefaultIdentifierFromLabel";
+
+describe("getDefaultIdentifierFromLabel", () => {
+  it("should convert spaces to underscores and lowercase", () => {
+    expect(getDefaultIdentifierFromLabel("My Label")).toBe("my_label");
+  });
+
+  it("should handle multiple spaces", () => {
+    expect(getDefaultIdentifierFromLabel("My   Label")).toBe("my_label");
+  });
+
+  it("should handle leading and trailing spaces", () => {
+    expect(getDefaultIdentifierFromLabel("  My Label  ")).toBe("my_label");
+  });
+
+  it("should handle all spaces", () => {
+    expect(getDefaultIdentifierFromLabel("   ")).toBe("");
+  });
+
+  it("should handle empty string", () => {
+    expect(getDefaultIdentifierFromLabel("")).toBe("");
+  });
+
+  it("should handle mixed case", () => {
+    expect(getDefaultIdentifierFromLabel("My LABEL")).toBe("my_label");
+  });
+});

--- a/packages/app-store/routing-forms/lib/getDefaultIdentifierFromLabel.ts
+++ b/packages/app-store/routing-forms/lib/getDefaultIdentifierFromLabel.ts
@@ -1,0 +1,5 @@
+export function getDefaultIdentifierFromLabel(label: string) {
+  return label.trim().replace(/\s+/g, "_").toLowerCase().replace(/_+$/g, "");
+}
+
+export default getDefaultIdentifierFromLabel;

--- a/packages/app-store/routing-forms/pages/form-edit/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/form-edit/[...appPages].tsx
@@ -21,6 +21,7 @@ import SingleForm, {
   getServerSidePropsForSingleFormView as getServerSideProps,
 } from "../../components/SingleForm";
 import { FieldTypes } from "../../lib/FieldTypes";
+import { getDefaultIdentifierFromLabel } from "../../lib/getDefaultIdentifierFromLabel";
 import type { RoutingFormWithResponseCount } from "../../types/types";
 
 export { getServerSideProps };
@@ -215,7 +216,13 @@ function Field({
               //This change has the same effects that already existed in relation to this field,
               // but written in a different way.
               // The identifier field will have the same value as the label field until it is changed
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
+              value={
+                identifier ||
+                routerField?.identifier ||
+                getDefaultIdentifierFromLabel(label) ||
+                routerField?.label ||
+                ""
+              }
               onChange={(e) => {
                 hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value, { shouldDirty: true });
               }}

--- a/packages/app-store/routing-forms/pages/form-edit/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/form-edit/[...appPages].tsx
@@ -216,13 +216,7 @@ function Field({
               //This change has the same effects that already existed in relation to this field,
               // but written in a different way.
               // The identifier field will have the same value as the label field until it is changed
-              value={
-                identifier ||
-                routerField?.identifier ||
-                getDefaultIdentifierFromLabel(label) ||
-                routerField?.label ||
-                ""
-              }
+              value={ identifier || routerField?.identifier || getDefaultIdentifierFromLabel(label) || routerField?.label || "" }
               onChange={(e) => {
                 hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value, { shouldDirty: true });
               }}


### PR DESCRIPTION

## What does this PR do?
improves auto-fill of "Identifier" with lowercase only and replace space " " with "_"

#### what we want to do?


- Fixes #19640  (GitHub issue number)
- Fixes CAL-5245 (Linear issue number - should be visible at the bottom of the GitHub issue description)
/claim #19640 

##### Before:
- Identifier Value was Directly getting replaced by Label value by Default. (can see in PR video)

### Result After Adding Feature:

🎥 [After Adding Feature](https://www.loom.com/embed/04440ce2090a4290a05a437a737b6be2?sid=0a066feb-2d5f-4c88-9529-ce41e0eefa20)


#### How I Added This Feature:
- created an function which transforms Label value before placing them into Identifier Field. 
- written test for this function.
- called this function before replacing the identifier value with Label value.

**NOTE**: Code Changes are pretty straightforward. let me know if i need to explain changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- On dashboard go to Routing Section. and test as described in video above.

<img width="1512" alt="Screenshot 2025-04-07 at 1 52 27 AM" src="https://github.com/user-attachments/assets/3629346c-fc7f-4ee3-be0c-7aba26ec46fb" />

