### PR TITLE
chore: Add id column in CalendarCache

### DIFF
--- a/packages/prisma/migrations/20250407034337_add_id_field_calendar_cache/migration.sql
+++ b/packages/prisma/migrations/20250407034337_add_id_field_calendar_cache/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "CalendarCache" ADD COLUMN     "id" TEXT;
+
+-- Update all historical rows (id) to `gen_random_uuid`
+UPDATE "CalendarCache" SET "id" = gen_random_uuid() WHERE "id" IS NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1457,6 +1457,9 @@ view BookingTimeStatus {
 }
 
 model CalendarCache {
+  // To be made required in a followup
+  id String? @default(uuid())
+
   // The key would be the unique URL that is requested by the user
   key          String
   value        Json


### PR DESCRIPTION
## What does this PR do?

Add optional id field to CalendarCache and backfill it for existing data

This is a preparation to merge https://github.com/calcom/cal.com/pull/18619 which makes `credentialId` optional and thus [credentialId, key] could no longer be a primary index
