### PR TITLE
refactor: `getCalendarBusyTimesOfInterval` use `Promise.allSettled`

### DIFF
--- a/packages/lib/server/getLuckyUser.ts
+++ b/packages/lib/server/getLuckyUser.ts
@@ -415,10 +415,18 @@ async function getCalendarBusyTimesOfInterval(
         user.userLevelSelectedCalendars,
         true,
         true
-      ).then((busyTimes) => ({
-        userId: user.id,
-        busyTimes,
-      }))
+      )
+        .then((busyTimes) => ({
+          userId: user.id,
+          busyTimes,
+        }))
+        .catch((error) => {
+          log.error(
+            "getCalendarBusyTimesOfInterval",
+            `Error getting busy calendar times for ${user.id}`,
+            safeStringify(error)
+          );
+        })
     )
   );
 }

--- a/packages/lib/server/getLuckyUser.ts
+++ b/packages/lib/server/getLuckyUser.ts
@@ -618,7 +618,7 @@ async function fetchAllDataNeededForCalculations<
       interval
     ).then((results) => {
       return results.reduce((fulfilledPromises, result) => {
-        if (result.status === "fulfilled") {
+        if (result.status === "fulfilled" && result.value) {
           fulfilledPromises.push(result.value);
         }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- In `getCalendarBusyTimesOfInterval` instead of using `Promise.all` we use `Promise.allSettled` so if one member throws an error it doesn't stop execution for other members

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create calendar busy time for a RR host
- Book an RR event with that host
- `userBusyTimesOfInterval` should have the calendar busy times
