### PR TITLE
revert: "chore: Migration to backfill EventType.userId with B, if null"

### DIFF
--- a/packages/prisma/migrations/20250404225129_backfill_userid_from_user_eventtype/migration.sql
+++ b/packages/prisma/migrations/20250404225129_backfill_userid_from_user_eventtype/migration.sql
@@ -1,6 +1,0 @@
-UPDATE "EventType"
-SET "userId" = "_user_eventtype"."B"
-FROM "_user_eventtype"
-WHERE "EventType"."userId" IS NULL
-AND "EventType"."teamId" IS NULL
-AND "EventType".id = "_user_eventtype"."A";


### PR DESCRIPTION
Reverting due to failed migrations in both QA and Prod. (Omitted actual user ID)


```
ERROR: duplicate key value violates unique constraint "EventType_userId_slug_key"
DETAIL: Key ("userId", slug)=(XXXXX, 15min) already exists.
```

Reverts calcom/cal.com#20562