### PR TITLE
fix: use correct organizer info when admin accepts team booking requiring confirmation

### DIFF
--- a/apps/web/playwright/webhook.e2e.ts
+++ b/apps/web/playwright/webhook.e2e.ts
@@ -191,7 +191,7 @@ test.describe("BOOKING_REJECTED", async () => {
         endTime: "[redacted/dynamic]",
         organizer: {
           id: "[redacted/dynamic]",
-          name: "Unnamed",
+          name: "Nameless",
           email: "[redacted/dynamic]",
           timeZone: "[redacted/dynamic]",
           language: "[redacted/dynamic]",


### PR DESCRIPTION
## What does this PR do?

Use correct attendee info when admin accepts team booking requiring confirmation.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A-I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A-I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

