### PR TITLE
chore: Admin unlocking user, also verify workflow steps

### DIFF
--- a/packages/features/ee/users/components/UsersTable.tsx
+++ b/packages/features/ee/users/components/UsersTable.tsx
@@ -119,6 +119,12 @@ function UsersTableBare() {
     },
   });
 
+  const verifyWorkflows = trpc.viewer.admin.verifyWorkflows.useMutation({
+    onSuccess: () => {
+      showToast("Workflows verified", "success");
+    },
+  });
+
   const handleImpersonateUser = async (username: string | null) => {
     await signIn("impersonation-auth", { username: username, callbackUrl: `${WEBAPP_URL}/event-types` });
   };
@@ -235,6 +241,12 @@ function UsersTableBare() {
                           label: user.locked ? "Unlock User Account" : "Lock User Account",
                           onClick: () => lockUserAccount.mutate({ userId: user.id, locked: !user.locked }),
                           icon: "lock",
+                        },
+                        {
+                          id: "verify-workflows",
+                          label: "Verify workflows",
+                          onClick: () => verifyWorkflows.mutate({ userId: user.id }),
+                          icon: "check",
                         },
                         {
                           id: "impersonation",

--- a/packages/trpc/server/routers/viewer/admin/_router.ts
+++ b/packages/trpc/server/routers/viewer/admin/_router.ts
@@ -7,6 +7,7 @@ import { ZAdminRemoveTwoFactor } from "./removeTwoFactor.schema";
 import { ZAdminPasswordResetSchema } from "./sendPasswordReset.schema";
 import { ZSetSMSLockState } from "./setSMSLockState.schema";
 import { toggleFeatureFlag } from "./toggleFeatureFlag.procedure";
+import { ZAdminVerifyWorkflowsSchema } from "./verifyWorkflows.schema";
 import {
   workspacePlatformCreateSchema,
   workspacePlatformUpdateSchema,
@@ -68,6 +69,13 @@ export const adminRouter = router({
       );
       return handler(opts);
     }),
+  verifyWorkflows: authedAdminProcedure.input(ZAdminVerifyWorkflowsSchema).mutation(async (opts) => {
+    const handler = await importHandler(
+      namespaced("verifyWorkflows"),
+      () => import("./verifyWorkflows.handler")
+    );
+    return handler(opts);
+  }),
   workspacePlatform: router({
     list: authedAdminProcedure.query(async () => {
       const handler = await importHandler(

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
@@ -22,6 +22,21 @@ const lockUserAccountHandler = async ({ input }: GetOptions) => {
     },
   });
 
+  // Verify unlocked user's workflows
+  if (!locked) {
+    await prisma.workflowStep.updateMany({
+      where: {
+        workflow: {
+          userId,
+        },
+        verifiedAt: null,
+      },
+      data: {
+        verifiedAt: new Date(),
+      },
+    });
+  }
+
   if (!user) {
     throw new Error("User not found");
   }

--- a/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/lockUserAccount.handler.ts
@@ -22,21 +22,6 @@ const lockUserAccountHandler = async ({ input }: GetOptions) => {
     },
   });
 
-  // Verify unlocked user's workflows
-  if (!locked) {
-    await prisma.workflowStep.updateMany({
-      where: {
-        workflow: {
-          userId,
-        },
-        verifiedAt: null,
-      },
-      data: {
-        verifiedAt: new Date(),
-      },
-    });
-  }
-
   if (!user) {
     throw new Error("User not found");
   }

--- a/packages/trpc/server/routers/viewer/admin/verifyWorkflows.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/verifyWorkflows.handler.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@calcom/prisma";
+
+import type { TrpcSessionUser } from "../../../types";
+import type { TAdminVerifyWorkflowsSchema } from "./verifyWorkflows.schema";
+
+type GetOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TAdminVerifyWorkflowsSchema;
+};
+
+export const verifyWorkflows = async ({ input }: GetOptions) => {
+  const { userId } = input;
+
+  await prisma.workflowStep.updateMany({
+    where: {
+      workflow: {
+        userId,
+      },
+      verifiedAt: null,
+    },
+    data: {
+      verifiedAt: new Date(),
+    },
+  });
+};
+
+export default verifyWorkflows;

--- a/packages/trpc/server/routers/viewer/admin/verifyWorkflows.schema.ts
+++ b/packages/trpc/server/routers/viewer/admin/verifyWorkflows.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const ZAdminVerifyWorkflowsSchema = z.object({
+  userId: z.number(),
+});
+
+export type TAdminVerifyWorkflowsSchema = z.infer<typeof ZAdminVerifyWorkflowsSchema>;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently when a user is falsely locked due to workflow body spam, we have to manually verify their workflow steps in the DB. This PR aims to auto verify those steps when the user is unlocked via the admin panel.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Lock a user and add a unverified workflow step
- Unlock the user via the admin panel
	- The workflow step should be validated

