### PR TITLE
fix: full page reload on routing forms

### DIFF
--- a/packages/app-store/routing-forms/components/RoutingNavBar.tsx
+++ b/packages/app-store/routing-forms/components/RoutingNavBar.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation";
 import type { Dispatch, SetStateAction } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
@@ -19,6 +20,7 @@ export default function RoutingNavBar({
   hookForm: UseFormReturn<RoutingFormWithResponseCount>;
   setShowInfoLostDialog: Dispatch<SetStateAction<boolean>>;
 }) {
+  const router = useRouter();
   const { data } = trpc.viewer.appRoutingForms.getIncompleteBookingSettings.useQuery({
     formId: form.id,
   });
@@ -39,7 +41,7 @@ export default function RoutingNavBar({
         if (hookForm.formState.isDirty) {
           setShowInfoLostDialog(true);
         } else {
-          window.location.href = `${appUrl}/route-builder/${form?.id}`;
+          router.push(`${appUrl}/route-builder/${form?.id}`);
         }
       },
     },


### PR DESCRIPTION
Fixes full page reload on routing forms tab navigation

![CleanShot 2025-04-09 at 09 52 59](https://github.com/user-attachments/assets/f1f9dd21-a891-4d39-91e4-dded4b7cc438)
