### PR TITLE
fix: New Signup from Google throws error

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -980,8 +980,6 @@ export const getOptions = ({
         const { orgUsername, orgId } = await checkIfUserShouldBelongToOrg(idP, user.email);
 
         try {
-          console.log("------trying to create new user ---------");
-
           const newUser = await prisma.user.create({
             data: {
               // Slugify the incoming name and append a few random characters to

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -1003,9 +1003,9 @@ export const getOptions = ({
           });
 
           const accountData = {
+            ...account,
             userId: newUser.id,
             providerEmail: user.email,
-            ...account,
           };
 
           // Validate account data


### PR DESCRIPTION
## What does this PR do?
fix: New Signup from Google throws error

- Fixes #20616  (GitHub issue number)
- Fixes CAL-5445 (Linear issue number - should be visible at the bottom of the GitHub issue description)

#### context:
- during first time login / signup using Google OAuth it sends `refresh_token_expires_in` field, but our Account model doesn't stores it. 

### What is the issue?
- during object destructuring of account it also passes `refresh_token_expires_in` field.

<img width="716" alt="Screenshot 2025-04-09 at 2 28 29 PM" src="https://github.com/user-attachments/assets/d101d4ff-60d4-4219-8ec9-d867339eaccb" />

### How I fixed?
- parsed the accountData so,
- 1. validates data before passing to adapter.
- 2. **drops any unnecessary fields (`refresh_token_expires_in` in our case)**

### Code:

#### _AccountModel Schema:

- I have used _AccountModel Schema for validation and Omitted `id` as it won't go as input.
 
- why i haven't created new AccountCreationInputSchema ? 
- because i thought it would be better to use _AccountModel as single source of truth for input. 

<img width="466" alt="Screenshot 2025-04-09 at 2 21 40 PM" src="https://github.com/user-attachments/assets/08a86214-c6b9-445a-9961-df142c110c0c" />

<img width="1197" alt="Screenshot 2025-04-09 at 2 22 15 PM" src="https://github.com/user-attachments/assets/3ad9b859-fa57-4476-a138-037bb8511893" />



## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
