### PR TITLE
fix: flaky ooo e2e test

### DIFF
--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -686,10 +686,7 @@ test.describe("Out of office", () => {
       await expect(page.locator('[data-testid="date-range-options-c"]')).toBeVisible(); //Custom
     });
 
-    test("OOO records are fetched correctly w.r.t their end dates matching the date range filter selected.", async ({
-      page,
-      users,
-    }) => {
+    test("Default - No date range filter selected.", async ({ page, users }) => {
       const member1Name = `member-1-${Date.now()}`;
       const member2Name = `member-2-${Date.now()}`;
       const member3Name = `member-3-${Date.now()}`;
@@ -721,22 +718,39 @@ test.describe("Out of office", () => {
         },
       });
 
-      //create OOO for member3, start:currentDate-12Days, end:currentDate-10days (for Last 30 Days)
-      await prisma.outOfOfficeEntry.create({
-        data: {
-          start: dayjs().startOf("day").subtract(12, "days").toDate(),
-          end: dayjs().startOf("day").subtract(10, "days").toDate(),
-          uuid: uuidv4(),
-          user: { connect: { id: member3User?.id } },
-          toUser: { connect: { id: member1User?.id } },
-          createdAt: new Date(),
-          reason: {
-            connect: {
-              id: 2,
-            },
-          },
-        },
-      });
+      await member3User?.apiLogin();
+      const entriesListRespPromise = page.waitForResponse(
+        (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
+      );
+      await page.goto("/settings/my-account/out-of-office");
+      await entriesListRespPromise;
+      await page.waitForLoadState("domcontentloaded");
+
+      //By Default future OOO will be displayed
+      //1 OOO record should be visible for member3, end=currentDate+4days
+      const oooEntries = page.locator('[data-testid="ooo-actions"]');
+      await oooEntries.waitFor({ state: "visible" });
+      const oooEntriesCount = await oooEntries.count();
+
+      expect(oooEntriesCount).toBe(1);
+      await expect(page.locator(`data-testid=table-redirect-n-a`).nth(0)).toBeVisible();
+    });
+
+    test("Date range filter selected - 'Last 7 Days' (default filter).", async ({ page, users }) => {
+      const member1Name = `member-1-${Date.now()}`;
+      const member2Name = `member-2-${Date.now()}`;
+      const member3Name = `member-3-${Date.now()}`;
+      const teamMatesObj = [{ name: member1Name }, { name: member2Name }];
+      const member3User = await users.create(
+        { name: member3Name },
+        {
+          hasTeam: true,
+          teamRole: MembershipRole.MEMBER,
+          teammates: teamMatesObj,
+        }
+      );
+      const member1User = users.get().find((user) => user.name === member1Name);
+      const member2User = users.get().find((user) => user.name === member2Name);
 
       //create OOO for member3, start:currentDate-2Days, end:currentDate-4days (for Last 7 Days)
       await prisma.outOfOfficeEntry.create({
@@ -763,14 +777,6 @@ test.describe("Out of office", () => {
       await entriesListRespPromise;
       await page.waitForLoadState("domcontentloaded");
 
-      //By Default future OOO will be displayed
-      //1 OOO record should be visible for member3, end=currentDate+4days
-      const oooEntries = page.locator('[data-testid="ooo-actions"]');
-      const oooEntriesCount = await oooEntries.count();
-
-      expect(oooEntriesCount).toBe(1);
-      await expect(page.locator(`data-testid=table-redirect-n-a`).nth(0)).toBeVisible();
-
       //Default filter 'Last 7 Days' when DateRange Filter is selected
       await test.step("Default filter - 'Last 7 Days'", async () => {
         await page.locator('[data-testid="add-filter-button"]').click();
@@ -781,29 +787,79 @@ test.describe("Out of office", () => {
         await entriesListRespPromise;
 
         //1 OOO record should be visible for member3, end=currentDate-4days
-        expect(await page.locator('[data-testid^="table-redirect-"]').count()).toBe(1);
+        const oooEntries = page.locator('[data-testid="ooo-actions"]');
+        await oooEntries.waitFor({ state: "visible" });
+        const oooEntriesCount = await oooEntries.count();
+
+        expect(oooEntriesCount).toBe(1);
         await expect(
           page.locator(`data-testid=table-redirect-${member2User?.username}`).nth(0)
         ).toBeVisible();
       });
+    });
+
+    test("Date range filter selected - 'Last 30 Days'.", async ({ page, users }) => {
+      const member1Name = `member-1-${Date.now()}`;
+      const member2Name = `member-2-${Date.now()}`;
+      const member3Name = `member-3-${Date.now()}`;
+      const teamMatesObj = [{ name: member1Name }, { name: member2Name }];
+      const member3User = await users.create(
+        { name: member3Name },
+        {
+          hasTeam: true,
+          teamRole: MembershipRole.MEMBER,
+          teammates: teamMatesObj,
+        }
+      );
+      const member1User = users.get().find((user) => user.name === member1Name);
+      const member2User = users.get().find((user) => user.name === member2Name);
+
+      //create OOO for member3, start:currentDate-12Days, end:currentDate-10days (for Last 30 Days)
+      await prisma.outOfOfficeEntry.create({
+        data: {
+          start: dayjs().startOf("day").subtract(12, "days").toDate(),
+          end: dayjs().startOf("day").subtract(10, "days").toDate(),
+          uuid: uuidv4(),
+          user: { connect: { id: member3User?.id } },
+          toUser: { connect: { id: member1User?.id } },
+          createdAt: new Date(),
+          reason: {
+            connect: {
+              id: 2,
+            },
+          },
+        },
+      });
+
+      await member3User?.apiLogin();
+      const entriesListRespPromise = page.waitForResponse(
+        (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
+      );
+      await page.goto("/settings/my-account/out-of-office");
+      await entriesListRespPromise;
+      await page.waitForLoadState("domcontentloaded");
 
       //Select 'Last 30 Days'
       await test.step("select 'Last 30 Days'", async () => {
-        await page.locator('[data-testid="filter-popover-trigger-dateRange"]').click();
-        const entriesListRespPromise = page.waitForResponse(
+        await page.locator('[data-testid="add-filter-button"]').click();
+        const entriesListRespPromise1 = page.waitForResponse(
           (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
         );
-        await page.locator(`[data-testid="date-range-options-t"]`).click();
-        await entriesListRespPromise;
+        await page.locator('[data-testid="add-filter-item-dateRange"]').click();
+        await entriesListRespPromise1;
 
-        //2 OOO records should be visible end=currentDate-4days, end=currentDate-12days
+        await page.locator('[data-testid="filter-popover-trigger-dateRange"]').click();
+        const entriesListRespPromise2 = page.waitForResponse(
+          (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
+        );
+        await page.locator(`[data-testid="date-range-options-t"]`).click(); //Last 30 Days
+        await entriesListRespPromise2;
+
+        //1 OOO record should be visible end=currentDate-12days
         const oooEntries = page.locator('[data-testid="ooo-actions"]');
         const oooEntriesCount = await oooEntries.count();
 
-        expect(oooEntriesCount).toBe(2);
-        await expect(
-          page.locator(`data-testid=table-redirect-${member2User?.username}`).nth(0)
-        ).toBeVisible();
+        expect(oooEntriesCount).toBe(1);
         await expect(
           page.locator(`data-testid=table-redirect-${member1User?.username}`).nth(0)
         ).toBeVisible();

--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -857,6 +857,7 @@ test.describe("Out of office", () => {
 
         //1 OOO record should be visible end=currentDate-12days
         const oooEntries = page.locator('[data-testid="ooo-actions"]');
+        await oooEntries.waitFor({ state: "visible" });
         const oooEntriesCount = await oooEntries.count();
 
         expect(oooEntriesCount).toBe(1);


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed flaky out-of-office end-to-end tests by splitting a large test into three smaller, focused tests. This approach improves test reliability by isolating different date range filter scenarios.

**Refactors**
- Split one large test into three separate tests for better isolation:
  - Default test with no date range filter
  - Test with "Last 7 Days" date range filter
  - Test with "Last 30 Days" date range filter
- Improved test structure with clearer test steps and assertions
- Added proper waiting for API responses to reduce timing issues

**Bug Fixes**
- Fixed flaky test behavior by isolating test scenarios that were previously combined
- Added explicit element waiting to ensure components are visible before assertions

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

follow up for https://github.com/calcom/cal.com/pull/19596#issuecomment-2788284204

Have Split this bigger test to small 3 separate tests.
This should hopefully reduce the flakiness.
Tested and verified.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
