### PR TITLE
fix: updatedAt routing form response migration

### DIFF
--- a/packages/prisma/migrations/20250409135411_updated_at_routing_form_response/migration.sql
+++ b/packages/prisma/migrations/20250409135411_updated_at_routing_form_response/migration.sql
@@ -5,4 +5,4 @@
 
 */
 -- AlterTable
-ALTER TABLE "App_RoutingForms_FormResponse" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "App_RoutingForms_FormResponse" ADD COLUMN     "updatedAt" TIMESTAMP(3);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1067,7 +1067,7 @@ model App_RoutingForms_FormResponse {
   formId       String
   response     Json
   createdAt    DateTime              @default(now())
-  updatedAt    DateTime              @updatedAt
+  updatedAt    DateTime?             @updatedAt
 
   routedToBookingUid String?  @unique
   // We should not cascade delete the booking, because we want to keep the form response even if the routedToBooking is deleted


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a migration issue by making the updatedAt field optional in routing form responses. This change prevents migration failures since the updatedAt field wasn't required from the beginning.

**Bug Fixes**
- Changed updatedAt field to be nullable in the database migration script
- Updated Prisma schema to mark updatedAt as optional with DateTime? type

**Migration**
- No manual steps required - the fix ensures the migration runs successfully

<!-- End of auto-generated description by mrge. -->

Fix migration failing, making updatedAt optional since we haven't had it from the start