### PR TITLE
fix: try to fix the docs api v2

### DIFF
--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -2410,7 +2410,7 @@
             "name": "teamIds",
             "required": false,
             "in": "query",
-            "description": "Filter by teamIds. Team ids must be separated by a comma.",
+            "description": "Filter by teamIds. Team IDs must be separated by a comma.",
             "example": "?teamIds=100,200",
             "schema": {
               "type": "array",

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -2410,7 +2410,8 @@
             "name": "teamIds",
             "required": false,
             "in": "query",
-            "description": "Filter by teamIds",
+            "description": "Filter by teamIds. Team ids must be separated by a comma.",
+            "example": "?teamIds=100,200",
             "schema": {
               "type": "array",
               "items": {

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -2310,7 +2310,7 @@
             "name": "teamIds",
             "required": false,
             "in": "query",
-            "description": "Filter by teamIds. Team ids must be separated by a comma.",
+            "description": "Filter by teamIds. Team IDs must be separated by a comma.",
             "example": "?teamIds=100,200",
             "schema": {
               "type": "array",

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -2310,7 +2310,8 @@
             "name": "teamIds",
             "required": false,
             "in": "query",
-            "description": "Filter by teamIds",
+            "description": "Filter by teamIds. Team ids must be separated by a comma.",
+            "example": "?teamIds=100,200",
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Improved API v2 documentation by enhancing the teamIds parameter description and adding usage examples. This clarifies how to properly format team IDs when filtering API requests.

**Bug Fixes**
- Updated the teamIds parameter description to specify that IDs must be separated by commas.
- Added an example query parameter format to show the correct syntax for filtering by multiple team IDs.

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Try to fix api v2 docs