### PR TITLE
fix: ensure desktop layout renders correctly in constrained Canva con…

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -442,78 +442,109 @@ const messageParent = (data: CustomEvent["detail"]) => {
 
 function keepParentInformedAboutDimensionChanges() {
   let knownIframeHeight: number | null = null;
-  let knownIframeWidth: number | null = null;
+  let knownIframeWidth: null | number = null;
   let isFirstTime = true;
   let isWindowLoadComplete = false;
+
+  // Add container dimension detection
+  const getContainerDimensions = () => {
+    const container = window.frameElement?.parentElement;
+    if (container) {
+      const containerStyles = window.getComputedStyle(container);
+      return {
+        width: parseInt(containerStyles.width),
+        height: parseInt(containerStyles.height),
+      };
+    }
+    return null;
+  };
+
   runAsap(function informAboutScroll() {
     if (document.readyState !== "complete") {
-      // Wait for window to load to correctly calculate the initial scroll height.
       runAsap(informAboutScroll);
       return;
     }
+
     if (!isWindowLoadComplete) {
-      // On Safari, even though document.readyState is complete, still the page is not rendered and we can't compute documentElement.scrollHeight correctly
-      // Postponing to just next cycle allow us to fix this.
       setTimeout(() => {
         isWindowLoadComplete = true;
         informAboutScroll();
       }, 100);
       return;
     }
+
     if (!embedStore.windowLoadEventFired) {
       sdkActionManager?.fire("__windowLoadComplete", {});
     }
+
     embedStore.windowLoadEventFired = true;
-    // Use the dimensions of main element as in most places there is max-width restriction on it and we just want to show the main content.
-    // It avoids the unwanted padding outside main tag.
+
     const mainElement =
       document.getElementsByClassName("main")[0] ||
       document.getElementsByTagName("main")[0] ||
       document.documentElement;
-    const documentScrollHeight = document.documentElement.scrollHeight;
-    const documentScrollWidth = document.documentElement.scrollWidth;
 
     if (!(mainElement instanceof HTMLElement)) {
       throw new Error("Main element should be an HTMLElement");
     }
 
     const mainElementStyles = getComputedStyle(mainElement);
-    // Use, .height as that gives more accurate value in floating point. Also, do a ceil on the total sum so that whatever happens there is enough iframe size to avoid scroll.
-    const contentHeight = Math.ceil(
-      parseFloat(mainElementStyles.height) +
-        parseFloat(mainElementStyles.marginTop) +
-        parseFloat(mainElementStyles.marginBottom)
-    );
+    const containerDimensions = getContainerDimensions();
+
+    // Calculate optimal width based on container and content
+    const desktopMinWidth = 768; // minimum width for desktop view
+    const containerWidth = containerDimensions?.width || window.innerWidth;
+
+    // Determine if we should force desktop view
+    const shouldForceDesktop =
+      embedStore.uiConfig?.forceDesktop ||
+      window.location.href.includes("embed=true") ||
+      containerWidth >= desktopMinWidth;
+
+    // Calculate content dimensions
     const contentWidth = Math.ceil(
       parseFloat(mainElementStyles.width) +
         parseFloat(mainElementStyles.marginLeft) +
         parseFloat(mainElementStyles.marginRight)
     );
 
-    // During first render let iframe tell parent that how much is the expected height to avoid scroll.
-    // Parent would set the same value as the height of iframe which would prevent scroll.
-    // On subsequent renders, consider html height as the height of the iframe. If we don't do this, then if iframe gets bigger in height, it would never shrink
-    const iframeHeight = isFirstTime ? documentScrollHeight : contentHeight;
-    const iframeWidth = isFirstTime ? documentScrollWidth : contentWidth;
+    const contentHeight = Math.ceil(
+      parseFloat(mainElementStyles.height) +
+        parseFloat(mainElementStyles.marginTop) +
+        parseFloat(mainElementStyles.marginBottom)
+    );
+
+    // Set appropriate dimensions
+    const iframeWidth = shouldForceDesktop ? Math.max(desktopMinWidth, contentWidth) : contentWidth;
+
+    const iframeHeight = isFirstTime ? document.documentElement.scrollHeight : contentHeight;
+
     embedStore.parentInformedAboutContentHeight = true;
+
     if (!iframeHeight || !iframeWidth) {
       runAsap(informAboutScroll);
       return;
     }
+
+    // Only update if dimensions have changed
     if (knownIframeHeight !== iframeHeight || knownIframeWidth !== iframeWidth) {
       knownIframeHeight = iframeHeight;
       knownIframeWidth = iframeWidth;
-      // FIXME: This event shouldn't be subscribable by the user. Only by the SDK.
+
       sdkActionManager?.fire("__dimensionChanged", {
         iframeHeight,
         iframeWidth,
         isFirstTime,
+        shouldForceDesktop,
       });
+
+      // Add data attribute for CSS targeting
+      if (window.frameElement) {
+        window.frameElement.setAttribute("data-force-desktop", String(shouldForceDesktop));
+      }
     }
+
     isFirstTime = false;
-    // Parent Counterpart would change the dimension of iframe and thus page's dimension would be impacted which is recursive.
-    // It should stop ideally by reaching a hiddenHeight value of 0.
-    // FIXME: If 0 can't be reached we need to just abandon our quest for perfect iframe and let scroll be there. Such case can be logged in the wild and fixed later on.
     runAsap(informAboutScroll);
   });
 }
@@ -526,10 +557,16 @@ function main() {
   const url = new URL(document.URL);
   embedStore.theme = window?.getEmbedTheme?.();
 
+  // Check for explicit view parameters
+  const isDesktopView =
+    url.searchParams.get("view") === "desktop" || url.searchParams.get("isMobile") === "false";
+
   embedStore.uiConfig = {
     // TODO: Add theme as well here
     colorScheme: url.searchParams.get("ui.color-scheme"),
-    layout: url.searchParams.get("layout") as BookerLayouts,
+    layout: (url.searchParams.get("layout") || "week_view") as BookerLayouts,
+    // Force desktop layout in embed context unless explicitly set otherwise
+    forceDesktop: window?.isEmbed?.() || isDesktopView,
   };
 
   actOnColorScheme(embedStore.uiConfig.colorScheme);

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -504,8 +504,8 @@ function keepParentInformedAboutDimensionChanges() {
     const containerWidth = containerDimensions?.width || window.innerWidth;
 
     // Determine if we should force desktop view
-    const shouldForceDesktop =
-      embedStore.uiConfig?.forceDesktop ||
+    const shouldForceDesktop: boolean =
+      !!embedStore.uiConfig?.forceDesktop ||
       window.location.href.includes("embed=true") ||
       containerWidth >= desktopMinWidth;
 
@@ -576,13 +576,13 @@ function main() {
 
   embedStore.uiConfig = {
     // TODO: Add theme as well here
-    colorScheme: url.searchParams.get("ui.color-scheme"),
+    colorScheme: url.searchParams.get("ui.color-scheme") as string | null,
     layout: (url.searchParams.get("layout") || "week_view") as BookerLayouts,
     // Force desktop layout in embed context unless explicitly set otherwise
     forceDesktop: window?.isEmbed?.() || isDesktopView,
   };
 
-  actOnColorScheme(embedStore.uiConfig.colorScheme);
+  actOnColorScheme(embedStore.uiConfig.colorScheme as string | null | undefined);
   // If embed link is opened in top, and not in iframe. Let the page be visible.
   if (top === window) {
     unhideBody();

--- a/packages/embeds/embed-core/src/embed.css
+++ b/packages/embeds/embed-core/src/embed.css
@@ -2,6 +2,10 @@
  These styles are applied to the entire page, so the selectors need to be specific
 */
 
+:root {
+  --cal-embed-desktop-min-width: 768px;
+}
+
 .cal-embed {
   border: 0;
   min-height: 300px;
@@ -14,7 +18,7 @@
 
 /* Desktop view styles */
 .cal-embed[data-force-desktop="true"] {
-  min-width: 768px;
+  min-width: var(--cal-embed-desktop-min-width);
   width: 100%;
   max-width: 100%;
 }
@@ -54,10 +58,10 @@
 }
 
 /* Fallback for iframe containers (like Canva) with limited width */
-@media (max-width: 768px) {
+@media (max-width: var(--cal-embed-desktop-min-width)) {
   .cal-embed[data-force-desktop="true"] {
-    min-width: 768px;
-    width: 768px; /* ensure horizontal scroll works */
+    min-width: var(--cal-embed-desktop-min-width);
+    width: var(--cal-embed-desktop-min-width); /* ensure horizontal scroll works */
   }
 
   .cal-embed-container {

--- a/packages/embeds/embed-core/src/embed.css
+++ b/packages/embeds/embed-core/src/embed.css
@@ -1,9 +1,66 @@
 /**
  These styles are applied to the entire page, so the selectors need to be specific
 */
+
 .cal-embed {
-  border: 0px;
+  border: 0;
   min-height: 300px;
   margin: 0 auto;
   width: 100%;
+  transition: width 0.3s ease-in-out;
+  display: block;
+  box-sizing: border-box;
+}
+
+/* Desktop view styles */
+.cal-embed[data-force-desktop="true"] {
+  min-width: 768px;
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Mobile view styles */
+.cal-embed[data-force-desktop="false"] {
+  min-width: unset;
+  width: 100%;
+}
+
+/* Container styles */
+.cal-embed-container {
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
+}
+
+/* Custom scrollbar for better UX */
+.cal-embed-container::-webkit-scrollbar {
+  height: 8px;
+}
+
+.cal-embed-container::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.cal-embed-container::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 4px;
+}
+
+.cal-embed-container::-webkit-scrollbar-thumb:hover {
+  background: #666;
+}
+
+/* Fallback for iframe containers (like Canva) with limited width */
+@media (max-width: 768px) {
+  .cal-embed[data-force-desktop="true"] {
+    min-width: 768px;
+    width: 768px; /* ensure horizontal scroll works */
+  }
+
+  .cal-embed-container {
+    overflow-x: auto;
+  }
 }

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -846,7 +846,7 @@ class CalApi {
   }
 
   ui(uiConfig: UiConfig) {
-    validate(uiConfig, {
+    validate(uiConfig as Record<string, unknown>, {
       required: true,
       props: {
         theme: {

--- a/packages/embeds/embed-core/src/sdk-action-manager.ts
+++ b/packages/embeds/embed-core/src/sdk-action-manager.ts
@@ -106,6 +106,7 @@ export type EventDataMap = {
     iframeHeight: number;
     iframeWidth: number;
     isFirstTime: boolean;
+    shouldForceDesktop: boolean;
   };
 };
 

--- a/packages/embeds/embed-core/src/types.ts
+++ b/packages/embeds/embed-core/src/types.ts
@@ -32,6 +32,7 @@ export interface UiConfig {
   layout?: BookerLayouts;
   colorScheme?: string | null;
   forceDesktop?: boolean;
+  [key: string]: unknown;
 }
 
 declare global {

--- a/packages/embeds/embed-core/src/types.ts
+++ b/packages/embeds/embed-core/src/types.ts
@@ -22,7 +22,7 @@ export interface EmbedNonStylesConfig {
   };
 }
 
-export type UiConfig = {
+export interface UiConfig {
   hideEventTypeDetails?: boolean;
   // If theme not provided we would get null
   theme?: EmbedThemeConfig | null;
@@ -31,7 +31,8 @@ export type UiConfig = {
   cssVarsPerTheme?: Record<Theme, Record<string, string>>;
   layout?: BookerLayouts;
   colorScheme?: string | null;
-};
+  forceDesktop?: boolean;
+}
 
 declare global {
   interface Window {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug where Cal.com's embedded calendar appeared in mobile layout when embedded in Canva. The calendar now correctly renders in desktop layout within constrained containers like Canva's Embed app.

**Bug Fixes**
- Fixed incorrect mobile layout detection in Canva and similar embedding environments
- Added container dimension detection to properly determine when to use desktop layout
- Ensured horizontal scrolling works properly in narrow containers

**Refactors**
- Improved iframe dimension calculation logic for better layout decisions
- Added data attributes to control CSS behavior based on container context
- Enhanced CSS with better container handling and scrollbar styling

**Migration**
- No migration steps needed - changes are backward compatible

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #20680 
- This PR resolves a bug where the Cal.com embedded calendar appeared in mobile layout when embedded in Canva via their Embed app. The issue was caused by embed.css within Canva’s embedding container, which led the calendar to incorrectly infer a mobile environment in canva.

## Visual Demo (For contributors especially)
Before : 
![image](https://github.com/user-attachments/assets/420a7255-ce91-4c97-831d-4719b7c4eafb)
After : 
![Screenshot 2025-04-14 131054](https://github.com/user-attachments/assets/06c994af-daf2-4c0c-b83b-c2f5d81198d9)


## Mandatory Tasks (DO NOT REMOVE)

- ✅ I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- ✅ I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

✅ How should this be tested?
🧪 Manual Testing via test-containers.html 
To test the fix and verify that the embed behaves correctly inside a Canva-like container, follow the steps below:
1) make a test-container.html file inside the directory -> packages\embeds\embed-core
and paste the code -> 
`
<!DOCTYPE html>
<html>
<head>
    <title>Cal.com Embed Container Tests</title>
    <style>
        /* Base page styles */
        body {
            font-family: Arial, sans-serif;
            padding: 20px;
            margin: 0;
        }

        .test-section {
            margin-bottom: 40px;
            border: 1px solid #ccc;
            padding: 20px;
        }

        /* Canva-like container */
        .canva-container {
            width: 800px;
            background: #f5f5f5;
            padding: 15px;
            border-radius: 8px;
            position: relative;
        }

        .container-info {
            margin-bottom: 10px;
            color: #666;
        }

        /**
         * 👇 Styles from updated embed.css
         */
        .cal-embed {
            border: 0;
            min-height: 300px;
            margin: 0 auto;
            width: 100%;
            transition: width 0.3s ease-in-out;
        }

        .cal-embed[data-force-desktop="true"] {
            min-width: 768px;
            width: 100%;
            max-width: 100%;
        }

        .cal-embed[data-force-desktop="false"] {
            min-width: unset;
            width: 100%;
        }

        .cal-embed-container {
            position: relative;
            width: 100%;
            overflow-x: auto;
            -webkit-overflow-scrolling: touch;
        }

        .cal-embed-container::-webkit-scrollbar {
            height: 8px;
        }

        .cal-embed-container::-webkit-scrollbar-track {
            background: #f1f1f1;
            border-radius: 4px;
        }

        .cal-embed-container::-webkit-scrollbar-thumb {
            background: #888;
            border-radius: 4px;
        }

        .cal-embed-container::-webkit-scrollbar-thumb:hover {
            background: #666;
        }

        /* Inline calendar styling */
        #my-cal-inline {
            width: 100%;
            height: 100%;
            min-height: 600px;
        }

        @media (max-width: 768px) {
            .canva-container {
                width: 100%;
                max-width: 800px;
                margin: 0 auto;
                overflow-x: auto;
            }

            #my-cal-inline {
                min-width: 768px; /* Ensures desktop layout is respected */
            }
        }
    </style>
</head>
<body>
    <h1>Cal.com Embed Container Tests (Your calender Embedding Link) </h1>

    <div class="test-section">
        <h2>Canva-like Container (800px)</h2>
        <div class="container-info">Simulates Canva embed environment (small-width container)</div>
        <div class="canva-container">
            <!-- Cal inline embed code begins -->
            <div class="cal-embed-container">
                <div id="my-cal-inline" class="cal-embed"></div>
            </div>
            <script type="text/javascript">
                (function (C, A, L) {
                    let p = function (a, ar) { a.q.push(ar); };
                    let d = C.document;
                    C.Cal = C.Cal || function () {
                        let cal = C.Cal;
                        let ar = arguments;
                        if (!cal.loaded) {
                            cal.ns = {};
                            cal.q = cal.q || [];
                            d.head.appendChild(d.createElement("script")).src = A;
                            cal.loaded = true;
                        }
                        if (ar[0] === L) {
                            const api = function () { p(api, arguments); };
                            const namespace = ar[1];
                            api.q = api.q || [];
                            if (typeof namespace === "string") {
                                cal.ns[namespace] = cal.ns[namespace] || api;
                                p(cal.ns[namespace], ar);
                                p(cal, ["initNamespace", namespace]);
                            } else p(cal, ar);
                            return;
                        }
                        p(cal, ar);
                    };
                })(window, "http://localhost:3000/embed/embed.js", "init");

                Cal("init", "30min", {
                    origin: "http://localhost:3000",
                    debug: true
                });

                Cal.ns["30min"]("inline", {
                    elementOrSelector: "#my-cal-inline",
                    config: {
                        layout: "month_view",
                        forceDesktop: true
                    },
                    calLink:    ###"/30min"
                });

                Cal.ns["30min"]("ui", {
                    layout: "month_view",
                    styles: {
                        body: {
                            background: "transparent"
                        }
                    }
                });
            </script>
            <!-- Cal inline embed code ends -->
        </div>
    </div>
</body>
</html>

`
Navigate to the embed test container directory:  
   ```bash
   2. yarn run dev
   3. then go to the another terminal
   cd packages\embeds\embed-core\
   npx http-server
   Go to the URL : localhost:8080\test-containers.html
