### PR TITLE
feat: dry run behaviour for `AvailabilitySettings` atom

### DIFF
--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -36,6 +36,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   allowDelete?: boolean;
   allowSetToDefault?: boolean;
   disableToasts?: boolean;
+  isDryRun?: boolean;
 };
 
 export const AvailabilitySettingsPlatformWrapper = ({
@@ -51,6 +52,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
   allowDelete,
   allowSetToDefault,
   disableToasts,
+  isDryRun = false,
 }: AvailabilitySettingsPlatformWrapperProps) => {
   const { isLoading, data: schedule } = useSchedule(id);
   const { data: schedules } = useSchedules();
@@ -124,10 +126,26 @@ export const AvailabilitySettingsPlatformWrapper = ({
       <AvailabilitySettings
         disableEditableHeading={disableEditableHeading}
         handleDelete={() => {
-          atomSchedule.id && handleDelete(atomSchedule.id);
+          if (isDryRun) {
+            toast({
+              description: "Schedule deleted successfully",
+            });
+          }
+
+          if (!isDryRun && atomSchedule.id) {
+            handleDelete(atomSchedule.id);
+          }
         }}
         handleSubmit={async (data) => {
-          atomSchedule.id && handleUpdate(atomSchedule.id, data);
+          if (isDryRun) {
+            toast({
+              description: "Schedule updated successfully",
+            });
+          }
+
+          if (!isDryRun && atomSchedule.id) {
+            handleUpdate(atomSchedule.id, data);
+          }
         }}
         weekStart={me?.data?.weekStart || "Sunday"}
         timeFormat={timeFormat}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added a dry run mode to the `AvailabilitySettings` atom that simulates actions without making actual API calls. This feature helps with testing and demonstrations by showing success toasts without modifying real data.

**New Features**
- Added `isDryRun` prop to `AvailabilitySettingsPlatformWrapper` component with a default value of `false`.
- Implemented conditional logic in delete and update handlers to show success toasts in dry run mode.
- Added checks to prevent actual API calls when in dry run mode.

**Refactors**
- Modified handler functions to check the `isDryRun` flag before executing API operations.
- Improved code structure with clear conditional blocks for dry run vs. actual execution paths.

<!-- End of auto-generated description by mrge. -->

## How should this be tested?
This can be tested in the examples app, just pass isDryRun prop to the atom