### PR TITLE
feat: dry run behaviour for event type atoms

### DIFF
--- a/packages/platform/atoms/event-types/wrappers/CreateEventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/CreateEventTypePlatformWrapper.tsx
@@ -27,6 +27,7 @@ type CreateEventTypeProps = {
     buttons?: ActionButtonsClassNames;
   };
   onCancel?: () => void;
+  isDryRun?: boolean;
 };
 
 const ActionButtons = ({
@@ -67,6 +68,7 @@ export const CreateEventTypePlatformWrapper = ({
   onError,
   customClassNames,
   onCancel,
+  isDryRun = false,
 }: CreateEventTypeProps) => {
   const { form, isManagedEventType } = useCreateEventTypeForm();
   const createEventTypeQuery = useCreateEventType({ onSuccess, onError });
@@ -86,15 +88,16 @@ export const CreateEventTypePlatformWrapper = ({
         form={form}
         isManagedEventType={isManagedEventType}
         handleSubmit={(values) => {
-          createTeamEventTypeQuery.mutate({
-            lengthInMinutes: values.length,
-            title: values.title,
-            slug: values.slug,
-            description: values.description ?? "",
-            schedulingType: values.schedulingType ?? "COLLECTIVE",
-            hosts: [],
-            teamId,
-          });
+          !isDryRun &&
+            createTeamEventTypeQuery.mutate({
+              lengthInMinutes: values.length,
+              title: values.title,
+              slug: values.slug,
+              description: values.description ?? "",
+              schedulingType: values.schedulingType ?? "COLLECTIVE",
+              hosts: [],
+              teamId,
+            });
         }}
         SubmitButton={(isPending) =>
           ActionButtons({
@@ -115,12 +118,13 @@ export const CreateEventTypePlatformWrapper = ({
         form={form}
         isManagedEventType={isManagedEventType}
         handleSubmit={(values) => {
-          createEventTypeQuery.mutate({
-            lengthInMinutes: values.length,
-            title: values.title,
-            slug: values.slug,
-            description: values.description ?? "",
-          });
+          !isDryRun &&
+            createEventTypeQuery.mutate({
+              lengthInMinutes: values.length,
+              title: values.title,
+              slug: values.slug,
+              description: values.description ?? "",
+            });
         }}
         SubmitButton={(isPending) =>
           ActionButtons({

--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -56,6 +56,7 @@ export type EventTypePlatformWrapperProps = {
   allowDelete: boolean;
   customClassNames?: EventTypeCustomClassNames;
   disableToasts?: boolean;
+  isDryRun?: boolean;
 };
 
 const EventType = ({
@@ -68,6 +69,7 @@ const EventType = ({
   allowDelete = true,
   customClassNames,
   disableToasts = false,
+  isDryRun = false,
   ...props
 }: EventTypeSetupProps & EventTypePlatformWrapperProps) => {
   const { t } = useLocale();
@@ -141,7 +143,13 @@ const EventType = ({
 
   const { form, handleSubmit } = useEventTypeForm({
     eventType,
-    onSubmit: (data) => updateMutation.mutate(data),
+    onSubmit: (data) => {
+      if (!isDryRun) {
+        updateMutation.mutate(data);
+      } else {
+        toast({ description: t("event_type_updated_successfully", { eventTypeTitle: eventType.title }) });
+      }
+    },
   });
   const slug = form.watch("slug") ?? eventType.slug;
 
@@ -244,11 +252,15 @@ const EventType = ({
   });
 
   const onDelete = () => {
-    if (allowDelete) {
+    if (allowDelete && !isDryRun) {
       isTeamEventTypeDeleted.current = true;
       team?.id
         ? deleteTeamEventTypeMutation.mutate({ eventTypeId: id, teamId: team.id })
         : deleteMutation.mutate(id);
+    }
+
+    if (isDryRun) {
+      handleDeleteSuccess();
     }
   };
 
@@ -307,6 +319,7 @@ export const EventTypePlatformWrapper = ({
   onDeleteError,
   allowDelete = true,
   customClassNames,
+  isDryRun,
 }: EventTypePlatformWrapperProps) => {
   const { data: eventTypeQueryData } = useAtomsEventTypeById(id);
   const queryClient = useQueryClient();
@@ -338,6 +351,7 @@ export const EventTypePlatformWrapper = ({
       onDeleteError={onDeleteError}
       allowDelete={allowDelete}
       customClassNames={customClassNames}
+      isDryRun={isDryRun}
     />
   );
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added a dry run mode for event type atoms to simulate behavior without making actual API calls. This feature helps with testing and development by allowing components to function normally without triggering backend operations.

**New Features**
- Added `isDryRun` prop to event type atoms that prevents API calls when enabled
- Implemented mock success responses for dry run mode in event type updates
- Added support for simulating event type deletion without actual deletion
- Created toast notifications that still appear during dry run operations

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
This can be tested in the examples app, just pass isDryRun prop to the atom