### PR TITLE
fix: Revert "fix: Make event type title visible in mobile view (

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
@@ -19,18 +19,22 @@ export function ShellMainAppDir(props: LayoutProps) {
             <header
               className={classNames(props.large && "py-8", "flex w-full max-w-full items-center truncate")}>
               {props.HeadingLeftIcon && <div className="ltr:mr-4">{props.HeadingLeftIcon}</div>}
-              <div className={classNames("w-full truncate ltr:mr-4 rtl:ml-4", props.headerClassName)}>
+              <div
+                className={classNames(
+                  "hidden w-full truncate ltr:mr-4 rtl:ml-4 md:block",
+                  props.headerClassName
+                )}>
                 {props.heading && (
                   <h3
                     className={classNames(
-                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 truncate text-lg font-semibold tracking-wide sm:text-xl xl:max-w-full",
+                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 inline truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
                       props.smallHeading ? "text-base" : "text-xl"
                     )}>
                     {props.heading}
                   </h3>
                 )}
                 {props.subtitle && (
-                  <p className="text-default text-sm" data-testid="subtitle">
+                  <p className="text-default hidden text-sm md:block" data-testid="subtitle">
                     {props.subtitle}
                   </p>
                 )}

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -158,7 +158,7 @@ export function ShellMain(props: LayoutProps) {
                 {props.heading && (
                   <h3
                     className={classNames(
-                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 truncate text-lg font-semibold tracking-wide sm:text-xl xl:max-w-full",
+                      "font-cal text-emphasis max-w-28 sm:max-w-72 md:max-w-80 hidden truncate text-lg font-semibold tracking-wide sm:text-xl md:block xl:max-w-full",
                       props.smallHeading ? "text-base" : "text-xl"
                     )}>
                     {!isLocaleReady ? <SkeletonText invisible /> : props.heading}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Reverted a previous fix that made event type titles visible in mobile view. This change restores the original responsive behavior where certain UI elements are hidden on mobile devices.

**Bug Fixes**
- Fixed responsive design issues by hiding certain header elements on mobile screens
- Restored original display behavior with proper `md:block` and `hidden` class combinations
- Updated class names in both ShellMainAppDir and Shell components for consistency

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

- Fixes CAL-[FILL IN]

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.