### PR TITLE
feat: dry run behaviour for connect atoms

### DIFF
--- a/apps/api/v2/src/ee/calendars/controllers/calendars.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/calendars/controllers/calendars.controller.e2e-spec.ts
@@ -129,7 +129,7 @@ describe("Platform Calendars Endpoints", () => {
 
   it(`/GET/v2/calendars/${GOOGLE_CALENDAR}/connect: it should redirect to auth-url for google calendar OAuth with valid access token `, async () => {
     const response = await request(app.getHttpServer())
-      .get(`/v2/calendars/${GOOGLE_CALENDAR}/connec?redir=https://cal.com&isDryRun=false`)
+      .get(`/v2/calendars/${GOOGLE_CALENDAR}/connect?redir=https://cal.com&isDryRun=false`)
       .set("Authorization", `Bearer ${accessTokenSecret}`)
       .set("Origin", CLIENT_REDIRECT_URI)
       .expect(200);

--- a/apps/api/v2/src/ee/calendars/controllers/calendars.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/calendars/controllers/calendars.controller.e2e-spec.ts
@@ -129,7 +129,7 @@ describe("Platform Calendars Endpoints", () => {
 
   it(`/GET/v2/calendars/${GOOGLE_CALENDAR}/connect: it should redirect to auth-url for google calendar OAuth with valid access token `, async () => {
     const response = await request(app.getHttpServer())
-      .get(`/v2/calendars/${GOOGLE_CALENDAR}/connect`)
+      .get(`/v2/calendars/${GOOGLE_CALENDAR}/connec?redir=https://cal.com&isDryRun=false`)
       .set("Authorization", `Bearer ${accessTokenSecret}`)
       .set("Origin", CLIENT_REDIRECT_URI)
       .expect(200);

--- a/apps/api/v2/src/ee/calendars/services/gcal.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/gcal.service.ts
@@ -39,31 +39,38 @@ export class GoogleCalendarService implements OAuthCalendarApp {
   async connect(
     authorization: string,
     req: Request,
-    redir?: string
+    redir?: string,
+    isDryRun?: boolean
   ): Promise<{ status: typeof SUCCESS_STATUS; data: { authUrl: string } }> {
     const accessToken = authorization.replace("Bearer ", "");
     const origin = req.get("origin") ?? req.get("host");
-    const redirectUrl = await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir);
+    const redirectUrl = await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir, isDryRun);
 
     return { status: SUCCESS_STATUS, data: { authUrl: redirectUrl } };
   }
 
-  async save(code: string, accessToken: string, origin: string, redir?: string): Promise<{ url: string }> {
-    return await this.saveCalendarCredentialsAndRedirect(code, accessToken, origin, redir);
+  async save(
+    code: string,
+    accessToken: string,
+    origin: string,
+    redir?: string,
+    isDryRun?: boolean
+  ): Promise<{ url: string }> {
+    return await this.saveCalendarCredentialsAndRedirect(code, accessToken, origin, redir, isDryRun);
   }
 
   async check(userId: number): Promise<{ status: typeof SUCCESS_STATUS }> {
     return await this.checkIfCalendarConnected(userId);
   }
 
-  async getCalendarRedirectUrl(accessToken: string, origin: string, redir?: string) {
+  async getCalendarRedirectUrl(accessToken: string, origin: string, redir?: string, isDryRun?: boolean) {
     const oAuth2Client = await this.getOAuthClient(this.redirectUri);
 
     const authUrl = oAuth2Client.generateAuthUrl({
       access_type: "offline",
       scope: CALENDAR_SCOPES,
       prompt: "consent",
-      state: `accessToken=${accessToken}&origin=${origin}&redir=${redir ?? ""}`,
+      state: `accessToken=${accessToken}&origin=${origin}&redir=${redir ?? ""}&isDryRun=${isDryRun}`,
     });
 
     return authUrl;
@@ -115,11 +122,17 @@ export class GoogleCalendarService implements OAuthCalendarApp {
     code: string,
     accessToken: string,
     origin: string,
-    redir?: string
+    redir?: string,
+    isDryRun?: boolean
   ) {
     // User chose not to authorize your app or didn't authorize your app
     // redirect directly without oauth code
     if (!code || code === "undefined") {
+      return { url: redir || origin };
+    }
+
+    // if isDryRun is true we know its a dry run so we just redirect straight away
+    if (isDryRun) {
       return { url: redir || origin };
     }
 

--- a/apps/api/v2/src/ee/calendars/services/outlook.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/outlook.service.ts
@@ -38,7 +38,7 @@ export class OutlookService implements OAuthCalendarApp {
   ): Promise<{ status: typeof SUCCESS_STATUS; data: { authUrl: string } }> {
     const accessToken = authorization.replace("Bearer ", "");
     const origin = req.get("origin") ?? req.get("host");
-    const redirectUrl = await await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir, isDryRun);
+    const redirectUrl = await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir, isDryRun);
 
     return { status: SUCCESS_STATUS, data: { authUrl: redirectUrl } };
   }

--- a/apps/api/v2/src/ee/calendars/services/outlook.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/outlook.service.ts
@@ -33,24 +33,31 @@ export class OutlookService implements OAuthCalendarApp {
   async connect(
     authorization: string,
     req: Request,
-    redir?: string
+    redir?: string,
+    isDryRun?: boolean
   ): Promise<{ status: typeof SUCCESS_STATUS; data: { authUrl: string } }> {
     const accessToken = authorization.replace("Bearer ", "");
     const origin = req.get("origin") ?? req.get("host");
-    const redirectUrl = await await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir);
+    const redirectUrl = await await this.getCalendarRedirectUrl(accessToken, origin ?? "", redir, isDryRun);
 
     return { status: SUCCESS_STATUS, data: { authUrl: redirectUrl } };
   }
 
-  async save(code: string, accessToken: string, origin: string, redir?: string): Promise<{ url: string }> {
-    return await this.saveCalendarCredentialsAndRedirect(code, accessToken, origin, redir);
+  async save(
+    code: string,
+    accessToken: string,
+    origin: string,
+    redir?: string,
+    isDryRun?: boolean
+  ): Promise<{ url: string }> {
+    return await this.saveCalendarCredentialsAndRedirect(code, accessToken, origin, redir, isDryRun);
   }
 
   async check(userId: number): Promise<{ status: typeof SUCCESS_STATUS }> {
     return await this.checkIfCalendarConnected(userId);
   }
 
-  async getCalendarRedirectUrl(accessToken: string, origin: string, redir?: string) {
+  async getCalendarRedirectUrl(accessToken: string, origin: string, redir?: string, isDryRun?: boolean) {
     const { client_id } = await this.calendarsService.getAppKeys(OFFICE_365_CALENDAR_ID);
 
     const scopes = ["User.Read", "Calendars.Read", "Calendars.ReadWrite", "offline_access"];
@@ -60,7 +67,7 @@ export class OutlookService implements OAuthCalendarApp {
       client_id,
       prompt: "select_account",
       redirect_uri: this.redirectUri,
-      state: `accessToken=${accessToken}&origin=${origin}&redir=${redir ?? ""}`,
+      state: `accessToken=${accessToken}&origin=${origin}&redir=${redir ?? ""}&isDryRun=${isDryRun}`,
     };
 
     const query = stringify(params);
@@ -148,10 +155,16 @@ export class OutlookService implements OAuthCalendarApp {
     code: string,
     accessToken: string,
     origin: string,
-    redir?: string
+    redir?: string,
+    isDryRun?: boolean
   ) {
     // if code is not defined, user denied to authorize office 365 app, just redirect straight away
     if (!code || code === "undefined") {
+      return { url: redir || origin };
+    }
+
+    // if isDryRun is true we know its a dry run so we just redirect straight away
+    if (isDryRun) {
       return { url: redir || origin };
     }
 

--- a/packages/platform/atoms/connect/OAuthConnect.tsx
+++ b/packages/platform/atoms/connect/OAuthConnect.tsx
@@ -26,6 +26,7 @@ export type OAuthConnectProps = {
   tooltipSide?: "top" | "bottom" | "left" | "right";
   isClickable?: boolean;
   onSuccess?: () => void;
+  isDryRun?: boolean;
 };
 
 export const OAuthConnect: FC<
@@ -46,8 +47,9 @@ export const OAuthConnect: FC<
   tooltipSide = "bottom",
   isClickable,
   onSuccess,
+  isDryRun,
 }) => {
-  const { connect } = useConnect(calendar, redir);
+  const { connect } = useConnect(calendar, redir, isDryRun);
   const { allowConnect, checked } = useCheck({
     onCheckError,
     calendar: calendar,

--- a/packages/platform/atoms/connect/apple/AppleConnect.tsx
+++ b/packages/platform/atoms/connect/apple/AppleConnect.tsx
@@ -38,6 +38,7 @@ export const AppleConnect: FC<Partial<Omit<OAuthConnectProps, "redir">>> = ({
   tooltipSide = "bottom",
   isClickable,
   onSuccess,
+  isDryRun = false,
 }) => {
   const { t } = useLocale();
   const form = useForm({
@@ -134,7 +135,15 @@ export const AppleConnect: FC<Partial<Omit<OAuthConnectProps, "redir">>> = ({
             handleSubmit={async (values) => {
               const { username, password } = values;
 
-              await saveCredentials({ calendar: "apple", username, password });
+              if (isDryRun) {
+                form.reset();
+                setIsDialogOpen(false);
+                toast({
+                  description: "Calendar credentials added successfully",
+                });
+              } else {
+                await saveCredentials({ calendar: "apple", username, password });
+              }
             }}>
             <fieldset
               className="space-y-4"

--- a/packages/platform/atoms/connect/apple/AppleConnect.tsx
+++ b/packages/platform/atoms/connect/apple/AppleConnect.tsx
@@ -139,8 +139,9 @@ export const AppleConnect: FC<Partial<Omit<OAuthConnectProps, "redir">>> = ({
                 form.reset();
                 setIsDialogOpen(false);
                 toast({
-                  description: "Calendar credentials added successfully",
+                  description: "Dry run connection successful (no credentials saved)", // Updated message
                 });
+                onSuccess?.(); // Call onSuccess for dry run as well
               } else {
                 await saveCredentials({ calendar: "apple", username, password });
               }

--- a/packages/platform/atoms/connect/apple/AppleConnect.tsx
+++ b/packages/platform/atoms/connect/apple/AppleConnect.tsx
@@ -139,9 +139,9 @@ export const AppleConnect: FC<Partial<Omit<OAuthConnectProps, "redir">>> = ({
                 form.reset();
                 setIsDialogOpen(false);
                 toast({
-                  description: "Dry run connection successful (no credentials saved)", // Updated message
+                  description: "Calendar credentials added successfully", 
                 });
-                onSuccess?.(); // Call onSuccess for dry run as well
+                onSuccess?.();
               } else {
                 await saveCredentials({ calendar: "apple", username, password });
               }

--- a/packages/platform/atoms/connect/google/GcalConnect.tsx
+++ b/packages/platform/atoms/connect/google/GcalConnect.tsx
@@ -20,6 +20,7 @@ export const GcalConnect: FC<Partial<OAuthConnectProps>> = ({
   tooltipSide,
   tooltip,
   isClickable,
+  isDryRun,
 }) => {
   const { t } = useLocale();
   return (
@@ -36,6 +37,7 @@ export const GcalConnect: FC<Partial<OAuthConnectProps>> = ({
       tooltipSide={tooltipSide}
       tooltip={tooltip}
       isClickable={isClickable}
+      isDryRun={isDryRun}
     />
   );
 };

--- a/packages/platform/atoms/connect/outlook/OutlookConnect.tsx
+++ b/packages/platform/atoms/connect/outlook/OutlookConnect.tsx
@@ -20,6 +20,7 @@ export const OutlookConnect: FC<Partial<OAuthConnectProps>> = ({
   tooltipSide,
   tooltip,
   isClickable,
+  isDryRun,
 }) => {
   const { t } = useLocale();
   return (
@@ -36,6 +37,7 @@ export const OutlookConnect: FC<Partial<OAuthConnectProps>> = ({
       tooltipSide={tooltipSide}
       tooltip={tooltip}
       isClickable={isClickable}
+      isDryRun={isDryRun}
     />
   );
 };

--- a/packages/platform/atoms/hooks/connect/useConnect.ts
+++ b/packages/platform/atoms/hooks/connect/useConnect.ts
@@ -13,7 +13,11 @@ interface IPUpdateOAuthCredentials {
   onError?: (err: ApiErrorResponse) => void;
 }
 
-export const useGetRedirectUrl = (calendar: (typeof CALENDARS)[number], redir?: string) => {
+export const useGetRedirectUrl = (
+  calendar: (typeof CALENDARS)[number],
+  redir?: string,
+  isDryRun?: boolean
+) => {
   const authUrl = useQuery({
     queryKey: getQueryKey(calendar),
     staleTime: Infinity,
@@ -21,7 +25,7 @@ export const useGetRedirectUrl = (calendar: (typeof CALENDARS)[number], redir?: 
     queryFn: () => {
       return http
         ?.get<ApiResponse<{ authUrl: string }>>(
-          `/calendars/${calendar}/connect${redir ? `?redir=${redir}` : ""}`
+          `/calendars/${calendar}/connect?redir=${redir ?? ""}&isDryRun=${isDryRun ?? ""}`
         )
         .then(({ data: responseBody }) => {
           if (responseBody.status === SUCCESS_STATUS) {
@@ -36,8 +40,8 @@ export const useGetRedirectUrl = (calendar: (typeof CALENDARS)[number], redir?: 
   return authUrl;
 };
 
-export const useConnect = (calendar: (typeof CALENDARS)[number], redir?: string) => {
-  const { refetch } = useGetRedirectUrl(calendar, redir);
+export const useConnect = (calendar: (typeof CALENDARS)[number], redir?: string, isDryRun?: boolean) => {
+  const { refetch } = useGetRedirectUrl(calendar, redir, isDryRun);
 
   const connect = async () => {
     const redirectUri = await refetch();


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added dry run functionality to calendar connection components to simulate successful connections without making actual API calls. This feature helps with testing and development by allowing the connection flow to be verified without modifying real data.

**New Features**
- Added `isDryRun` prop to connect atoms that skips actual API calls when enabled
- Updated OAuth connect components to support dry run mode across Google Calendar and Outlook
- Added dry run support to Apple Calendar connection flow
- Modified API endpoints to handle dry run requests by bypassing credential storage

**Refactors**
- Updated calendar service methods to accept and process the dry run parameter
- Modified URL generation to include dry run state in OAuth redirects
- Improved redirect handling to support the dry run workflow

<!-- End of auto-generated description by mrge. -->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
This can be tested in the examples app, just pass isDryRun prop to the atom
