### PR TITLE
fix: EventTypeSettings atom default schedule title

### DIFF
--- a/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/usePlatformTabsNavigations.tsx
@@ -85,15 +85,15 @@ export const usePlatformTabsNavigations = ({ formMethods, eventType, team, tabs 
         info:
           isManagedEventType || isChildrenManagedEventType
             ? formMethods.getValues("schedule") === null
-              ? "members_default_schedule"
+              ? t("members_default_schedule")
               : isChildrenManagedEventType
               ? `${
                   formMethods.getValues("scheduleName")
                     ? `${formMethods.getValues("scheduleName")} - ${t("managed")}`
-                    : `default_schedule_name`
+                    : t("default_schedule_name")
                 }`
-              : formMethods.getValues("scheduleName") ?? `default_schedule_name`
-            : formMethods.getValues("scheduleName") ?? `default_schedule_name`,
+              : formMethods.getValues("scheduleName") ?? t("default_schedule_name")
+            : formMethods.getValues("scheduleName") ?? t("default_schedule_name"),
         "data-testid": "availability",
       });
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed untranslated schedule title strings in the EventTypeSettings atom component. This ensures default schedule titles are properly translated instead of showing raw translation keys.

**Bug Fixes**
- Wrapped default schedule title strings with translation function (`t()`) to display translated text
- Fixed four instances where raw translation keys were displayed instead of translated content
- Ensured consistent translation handling for default schedule names across different component states

<!-- End of auto-generated description by mrge. -->

Linear [CAL-5444](https://linear.app/calcom/issue/CAL-5444/fix-atoms-translations)