### PR TITLE
fix: wrong translation value

### DIFF
--- a/apps/web/modules/apps/categories/[category]/category-view.tsx
+++ b/apps/web/modules/apps/categories/[category]/category-view.tsx
@@ -29,7 +29,7 @@ export default function Apps({ apps, category }: CategoryDataProps) {
             </Link>
             {category && (
               <span className="text-default gap-1">
-                <span>{t("slash_separator")}</span>
+                <span>&nbsp;/&nbsp;</span>
                 {t("category_apps", { category: category[0].toUpperCase() + category?.slice(1) })}
               </span>
             )}

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3104,7 +3104,6 @@
   "oauth_client_not_found": "OAuth Client not found.",
   "subscribe_to_platform": "Subscribe to Platform",
   "error_accessing_webhooks": "Error while trying to access webhooks.",
-  "slash_separator": "&nbsp;/&nbsp;",
   "webhook_update_failed": "Failed to update webhook.",
   "webhook_create_failed": "Failed to create webhook.",
   "invalid_link": "Invalid Link",

--- a/packages/features/settings/TimezoneChangeDialog.tsx
+++ b/packages/features/settings/TimezoneChangeDialog.tsx
@@ -55,7 +55,10 @@ const TimezoneChangeDialogContent = () => {
     <>
       <DialogHeader
         title={t("update_timezone_question")}
-        subtitle={t("update_timezone_description", { formattedCurrentTz })}
+        subtitle={t("update_timezone_description", {
+          formattedCurrentTz,
+          interpolation: { escapeValue: false },
+        })}
       />
       {/* todo: save this in db and auto-update when timezone changes (be able to disable??? if yes, /settings)
         <Checkbox description="Always update timezone" />

--- a/packages/features/settings/TimezoneChangeDialog.tsx
+++ b/packages/features/settings/TimezoneChangeDialog.tsx
@@ -28,7 +28,10 @@ const TimezoneChangeDialogContent = () => {
   const formattedCurrentTz = CURRENT_TIMEZONE.replace("_", " ");
 
   const onMutationSuccess = async () => {
-    showToast(t("updated_timezone_to", { formattedCurrentTz }), "success");
+    showToast(
+      t("updated_timezone_to", { formattedCurrentTz, interpolation: { escapeValue: false } }),
+      "success"
+    );
     await utils.viewer.me.invalidate();
   };
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed incorrect translation handling in the UI by removing a hardcoded HTML separator and updating timezone display. These changes improve the display of category navigation and ensure proper escaping of translation values.

**Bug Fixes**
- Replaced translation key with direct HTML for the slash separator in category navigation
- Removed unused translation key "slash_separator" from localization file
- Added proper HTML escaping for timezone update notifications

<!-- End of auto-generated description by mrge. -->



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.