### PR TITLE
fix: disable Google Translate from HTML

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -119,6 +119,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   return (
     <html
+      className="notranslate"
+      translate="no"
       lang={locale}
       dir={direction}
       style={embedColorScheme ? { colorScheme: embedColorScheme as string } : undefined}

--- a/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
+++ b/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
@@ -152,7 +152,7 @@ test.describe("Popup Tests", () => {
         }
         const html = embedIframe.locator("html");
         // Expect "light" theme as configured in App for pro user.
-        await expect(html).toHaveClass("light");
+        await expect(html).toHaveClass(/light/);
         const { uid: bookingId } = await bookFirstEvent("pro", embedIframe, page);
         const booking = await getBooking(bookingId);
         expect(booking.attendees.length).toBe(3);
@@ -187,7 +187,8 @@ test.describe("Popup Tests", () => {
           return window.matchMedia("(prefers-color-scheme: dark)").matches;
         });
         // Detect browser preference and expect accordingly
-        await expect(html).toHaveClass(prefersDarkScheme ? "dark" : "light");
+
+        prefersDarkScheme ? await expect(html).toHaveClass(/dark/) : await expect(html).toHaveClass(/light/);
       });
 
       test("should open embed iframe(Booker Profile Page) with dark theme when configured with dark theme using Embed API", async ({
@@ -210,7 +211,7 @@ test.describe("Popup Tests", () => {
         }
 
         const html = embedIframe.locator("html");
-        await expect(html).toHaveClass("dark");
+        await expect(html).toHaveClass(/dark/);
       });
 
       test("should open embed iframe(Event Booking Page) with dark theme when configured with dark theme using Embed API", async ({
@@ -233,7 +234,7 @@ test.describe("Popup Tests", () => {
         }
 
         const html = embedIframe.locator("html");
-        await expect(html).toHaveClass("dark");
+        await expect(html).toHaveClass(/dark/);
       });
     });
   });

--- a/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
+++ b/packages/embeds/embed-core/playwright/tests/action-based.e2e.ts
@@ -152,7 +152,7 @@ test.describe("Popup Tests", () => {
         }
         const html = embedIframe.locator("html");
         // Expect "light" theme as configured in App for pro user.
-        await expect(html).toHaveAttribute("class", "light");
+        await expect(html).toHaveClass("light");
         const { uid: bookingId } = await bookFirstEvent("pro", embedIframe, page);
         const booking = await getBooking(bookingId);
         expect(booking.attendees.length).toBe(3);
@@ -187,7 +187,7 @@ test.describe("Popup Tests", () => {
           return window.matchMedia("(prefers-color-scheme: dark)").matches;
         });
         // Detect browser preference and expect accordingly
-        await expect(html).toHaveAttribute("class", prefersDarkScheme ? "dark" : "light");
+        await expect(html).toHaveClass(prefersDarkScheme ? "dark" : "light");
       });
 
       test("should open embed iframe(Booker Profile Page) with dark theme when configured with dark theme using Embed API", async ({
@@ -210,7 +210,7 @@ test.describe("Popup Tests", () => {
         }
 
         const html = embedIframe.locator("html");
-        await expect(html).toHaveAttribute("class", "dark");
+        await expect(html).toHaveClass("dark");
       });
 
       test("should open embed iframe(Event Booking Page) with dark theme when configured with dark theme using Embed API", async ({
@@ -233,7 +233,7 @@ test.describe("Popup Tests", () => {
         }
 
         const html = embedIframe.locator("html");
-        await expect(html).toHaveAttribute("class", "dark");
+        await expect(html).toHaveClass("dark");
       });
     });
   });


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added HTML attributes to prevent automatic translation of the application. This ensures consistent user experience by disabling browser translation features.

**Bug Fixes**
- Added `notranslate` class to the HTML element to prevent automatic translation.
- Added `translate="no"` attribute to explicitly disable browser translation features.

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

- Potential fix for NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.