### PR TITLE
chore: Add consent message when SMS workflows are related

### DIFF
--- a/apps/web/playwright/organization/organization-settings.e2e.ts
+++ b/apps/web/playwright/organization/organization-settings.e2e.ts
@@ -97,7 +97,7 @@ test.describe("Organization Settings", () => {
       await users.deleteAll();
     });
 
-    test.skip("Disabling SEO indexing updates settings and meta tags", async ({ page }) => {
+    test("Disabling SEO indexing updates settings and meta tags", async ({ page }) => {
       await test.step("Disable 'Allow search engine indexing' for organization", async () => {
         await page.goto(`/settings/organizations/profile`);
         const seoSwitch = await page.getByTestId(`${ctx.org.id}-seo-indexing-switch`);
@@ -120,7 +120,7 @@ test.describe("Organization Settings", () => {
       });
     });
 
-    test.skip("Enabling SEO indexing updates settings and meta tags", async ({ page }) => {
+    test("Enabling SEO indexing updates settings and meta tags", async ({ page }) => {
       await test.step("Enable 'Allow search engine indexing' for organization", async () => {
         await page.goto(`/settings/organizations/profile`);
         await toggleSeoSwitch({

--- a/apps/web/playwright/organization/organization-settings.e2e.ts
+++ b/apps/web/playwright/organization/organization-settings.e2e.ts
@@ -97,7 +97,7 @@ test.describe("Organization Settings", () => {
       await users.deleteAll();
     });
 
-    test("Disabling SEO indexing updates settings and meta tags", async ({ page }) => {
+    test.skip("Disabling SEO indexing updates settings and meta tags", async ({ page }) => {
       await test.step("Disable 'Allow search engine indexing' for organization", async () => {
         await page.goto(`/settings/organizations/profile`);
         const seoSwitch = await page.getByTestId(`${ctx.org.id}-seo-indexing-switch`);
@@ -120,7 +120,7 @@ test.describe("Organization Settings", () => {
       });
     });
 
-    test("Enabling SEO indexing updates settings and meta tags", async ({ page }) => {
+    test.skip("Enabling SEO indexing updates settings and meta tags", async ({ page }) => {
       await test.step("Enable 'Allow search engine indexing' for organization", async () => {
         await page.goto(`/settings/organizations/profile`);
         await toggleSeoSwitch({

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3140,5 +3140,6 @@
   "reschedule_cta_short": "Reschedule here.",
   "you_and_conjunction": "You &",
   "email_survey_triggered_by_workflow": "This survey was triggered by a Workflow in Cal.",
+  "sms_workflow_consent": "By entering your phone number you consent to receive SMS messages for this event. SMS rates may apply.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/form-builder/FormBuilderField.tsx
+++ b/packages/features/form-builder/FormBuilderField.tsx
@@ -164,6 +164,9 @@ const WithLabel = ({
             </div>
           )}
       {children}
+      {field.name === "smsReminderNumber" && (
+        <div className="text-sm text-gray-500">{t("sms_workflow_consent")}</div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added a consent message for SMS workflows that informs users about potential SMS rates when they enter their phone number for event notifications.

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds a consent message under the SMS workflow input on the booking page

## Visual Demo (For contributors especially)

![CleanShot 2025-04-16 at 21 27 04@2x](https://github.com/user-attachments/assets/e5d42eb7-d073-4a2f-802c-fafa13a64a9b)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

