### PR TITLE
feat: Add tablet layout to Booker

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -13,8 +13,11 @@ import TurnstileCaptcha from "@calcom/features/auth/Turnstile";
 import useSkipConfirmStep from "@calcom/features/bookings/Booker/components/hooks/useSkipConfirmStep";
 import { getQueryParam } from "@calcom/features/bookings/Booker/utils/query-param";
 import { useNonEmptyScheduleDays } from "@calcom/features/schedules/lib/use-schedule/useNonEmptyScheduleDays";
-import { PUBLIC_INVALIDATE_AVAILABLE_SLOTS_ON_BOOKING_FORM } from "@calcom/lib/constants";
-import { CLOUDFLARE_SITE_ID, CLOUDFLARE_USE_TURNSTILE_IN_BOOKER } from "@calcom/lib/constants";
+import {
+  CLOUDFLARE_SITE_ID,
+  CLOUDFLARE_USE_TURNSTILE_IN_BOOKER,
+  PUBLIC_INVALIDATE_AVAILABLE_SLOTS_ON_BOOKING_FORM,
+} from "@calcom/lib/constants";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { BookerLayouts } from "@calcom/prisma/zod-utils";
 import classNames from "@calcom/ui/classNames";
@@ -90,6 +93,7 @@ const BookerComponent = ({
     extraDays,
     columnViewExtraDays,
     isMobile,
+    isTablet,
     layout,
     hideEventTypeDetails,
     isEmbed,
@@ -123,12 +127,12 @@ const BookerComponent = ({
   const nextSlots =
     Math.abs(dayjs(selectedDate).diff(availableSlots[availableSlots.length - 1], "day")) + addonDays;
 
-  const animationScope = useBookerResizeAnimation(layout, bookerState);
+  const animationScope = useBookerResizeAnimation(layout, bookerState, isTablet);
 
   const timeslotsRef = useRef<HTMLDivElement>(null);
   const isQuickAvailabilityCheckFeatureEnabled = useIsQuickAvailabilityCheckFeatureEnabled();
 
-  const StickyOnDesktop = isMobile ? "div" : StickyBox;
+  const StickyOnDesktop = isMobile || isTablet ? "div" : StickyBox;
 
   const { bookerFormErrorRef, key, formEmail, bookingForm, errors: formErrors } = bookerForm;
 
@@ -325,7 +329,7 @@ const BookerComponent = ({
           ref={animationScope}
           data-testid="booker-container"
           className={classNames(
-            ...getBookerSizeClassNames(layout, bookerState, hideEventTypeDetails),
+            ...getBookerSizeClassNames(layout, isTablet, bookerState, hideEventTypeDetails),
             `bg-default dark:bg-muted grid max-w-full items-start dark:[color-scheme:dark] sm:transition-[width] sm:duration-300 sm:motion-reduce:transition-none md:flex-row`,
             // We remove border only when the content covers entire viewport. Because in embed, it can almost never be the case that it covers entire viewport, we show the border there
             (layout === BookerLayouts.MONTH_VIEW || isEmbed) && "border-subtle rounded-md",
@@ -381,11 +385,11 @@ const BookerComponent = ({
             <StickyOnDesktop key="meta" className={classNames("relative z-10 flex [grid-area:meta]")}>
               <BookerSection
                 area="meta"
-                className="max-w-screen flex w-full flex-col md:w-[var(--booker-meta-width)]">
+                className="max-w-screen border-subtle flex w-full flex-col md:border-b lg:w-[var(--booker-meta-width)] lg:border-b-0">
                 {!hideEventTypeDetails && orgBannerUrl && (
                   <img
                     loading="eager"
-                    className="-mb-9 h-16 object-cover object-top ltr:rounded-tl-md rtl:rounded-tr-md sm:h-auto"
+                    className="-mb-9 h-16 rounded-t-md object-cover object-top lg:h-auto lg:ltr:rounded-tr-none lg:rtl:rounded-tl-none"
                     alt="org banner"
                     src={orgBannerUrl}
                   />

--- a/packages/features/bookings/Booker/components/hooks/useBookerLayout.ts
+++ b/packages/features/bookings/Booker/components/hooks/useBookerLayout.ts
@@ -19,7 +19,7 @@ export const useBookerLayout = (event: Pick<BookerEvent, "profile"> | undefined 
   const [_layout, setLayout] = useBookerStore((state) => [state.layout, state.setLayout], shallow);
   const isEmbed = useIsEmbed();
   const isMobile = useMediaQuery("(max-width: 768px)");
-  const isTablet = useMediaQuery("(max-width: 1024px)");
+  const isTablet = useMediaQuery("(max-width: 1024px)") && !isMobile;
   const embedUiConfig = useEmbedUiConfig();
   // In Embed we give preference to embed configuration for the layout.If that's not set, we use the App configuration for the event layout
   // But if it's mobile view, there is only one layout supported which is 'mobile'
@@ -63,7 +63,7 @@ export const useBookerLayout = (event: Pick<BookerEvent, "profile"> | undefined 
     // mobile supports showing the Form without Dialog
     mobile: !isEmbed,
     // We don't show Dialog in month_view currently. Can be easily toggled though as it supports no-dialog Form
-    month_view: false,
+    month_view: isTablet, // Show in dialog only on tablet screen size
     // week_view doesn't support no-dialog Form
     // When it's supported, disable it for embed
     week_view: true,


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added tablet layout to the Booker component for improved user experience on medium-sized screens (768px-1024px viewport width).

**UI Improvements**
- Created responsive grid layout specifically for tablet view with optimized content positioning
- Adjusted EventMeta component to display properly in tablet mode with better spacing and organization
- Maintained consistent user experience across mobile, tablet, and desktop layouts

<!-- End of auto-generated description by mrge. -->

## What does this PR do?

Booking page: new tablet view

- Fixes #19698 (GitHub issue number)
- Fixes CAL-5253 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Live Preview:

(resize the viewport to be `768px - 1024px`, click time slots to open the booking form)

- [Before](https://evanliu.dev/cal.com/storybook/)
  - [With Org Banner](https://evanliu.dev/cal.com/storybook/iframe.html?args=&globals=&id=booker--dark-mode)
  - [Without Org Banner](https://evanliu.dev/cal.com/storybook/iframe.html?args=orgBanner:!false&globals=&id=booker--dark-mode)
- [After](https://evanliu.dev/cal.com/pr-4/)
  - [With Org Banner](https://evanliu.dev/cal.com/pr-4/iframe.html?args=&globals=&id=booker--dark-mode)
  - [Without Org Banner](https://evanliu.dev/cal.com/pr-4/iframe.html?args=orgBanner:!false&globals=&id=booker--dark-mode)

![image](https://github.com/user-attachments/assets/cb446ad8-5207-44ea-b244-c50cbee80eed)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
