### PR TITLE
fix: Wrong schedule ID set for child managed event

### DIFF
--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -252,7 +252,7 @@ export default async function handleChildrenEventTypes({
           data: {
             ...updatePayloadFiltered,
             hidden: children?.find((ch) => ch.owner.id === userId)?.hidden ?? false,
-            schedule: eventType.scheduleId ? { connect: { id: eventType.scheduleId } } : { disconnect: true },
+            scheduleId: eventType.scheduleId || null,
             hashedLink:
               "multiplePrivateLinks" in unlockedFieldProps
                 ? undefined

--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -252,7 +252,7 @@ export default async function handleChildrenEventTypes({
           data: {
             ...updatePayloadFiltered,
             hidden: children?.find((ch) => ch.owner.id === userId)?.hidden ?? false,
-            ...(eventType.scheduleId ? { schedule: { connect: { id: eventType.scheduleId } } } : {}),
+            schedule: eventType.scheduleId ? { connect: { id: eventType.scheduleId } } : { disconnect: true },
             hashedLink:
               "multiplePrivateLinks" in unlockedFieldProps
                 ? undefined


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug in managed event types where child events were using incorrect schedule IDs, ensuring proper schedule connection or disconnection for child events.

<!-- End of auto-generated description by mrge. -->
