### PR TITLE
fix: failing e2e test

### DIFF
--- a/apps/web/playwright/organization/organization-settings.e2e.ts
+++ b/apps/web/playwright/organization/organization-settings.e2e.ts
@@ -66,7 +66,8 @@ async function verifyRobotsMetaTag({ page, orgSlug, urls, expectedContent }: Ver
   await doOnOrgDomain({ orgSlug, page }, async ({ page, goToUrlWithErrorHandling }) => {
     for (const relativeUrl of urls) {
       const { url } = await goToUrlWithErrorHandling(relativeUrl);
-      const metaTag = await page.locator('head > meta[name="robots"]');
+      const metaTag = page.locator('head > meta[name="robots"]');
+      await expect(metaTag).toBeAttached();
       const metaTagValue = await metaTag.getAttribute("content");
       expect(metaTagValue).not.toBeNull();
       expect(


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed failing E2E test by ensuring the robots meta tag is attached to the DOM before checking its attributes.

