### PR TITLE
fix: flaky e2e test

### DIFF
--- a/apps/web/playwright/organization/organization-settings.e2e.ts
+++ b/apps/web/playwright/organization/organization-settings.e2e.ts
@@ -87,7 +87,7 @@ async function verifyRobotsMetaTag({ page, orgSlug, urls, expectedContent }: Ver
 
 test.describe("Organization Settings", () => {
   // Skip these tests for now since the meta tag is being placed in the body instead of the head
-  test.describe.skip("Setting - 'Allow search engine indexing' inside Org profile settings", async () => {
+  test.describe("Setting - 'Allow search engine indexing' inside Org profile settings", async () => {
     let ctx: TestContext;
 
     test.beforeEach(async ({ users }) => {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed flaky end-to-end tests by adding fallback values to SEO indexing settings across booking page components.

**Bug Fixes**
- Added `|| false` fallback to all `robots` metadata settings to ensure consistent behavior when values are undefined.

<!-- End of auto-generated description by mrge. -->



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.