### PR TITLE
fix: offer seats feature is broken 

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
@@ -198,6 +198,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     metadata: rest.metadata === null ? Prisma.DbNull : (rest.metadata as Prisma.InputJsonObject),
     eventTypeColor: eventTypeColor === null ? Prisma.DbNull : (eventTypeColor as Prisma.InputJsonObject),
     disableGuests: guestsField?.hidden ?? false,
+    seatsPerTimeSlot,
   };
   data.locations = locations ?? undefined;
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed the broken seats feature by adding the missing `seatsPerTimeSlot` property to the data object in the event type update handler.

Fixes https://github.com/calcom/cal.com/issues/20756

Regression from here:- https://github.com/calcom/cal.com/pull/19257/
<!-- End of auto-generated description by mrge. -->

