### PR TITLE
fix: calendar connect atoms

### DIFF
--- a/apps/api/v2/src/ee/calendars/controllers/calendars.controller.ts
+++ b/apps/api/v2/src/ee/calendars/controllers/calendars.controller.ts
@@ -150,7 +150,7 @@ export class CalendarsController {
     @Headers("Authorization") authorization: string,
     @Param("calendar") calendar: string,
     @Query("redir") redir?: string | null,
-    @Query("isDryRun", ParseBoolPipe) isDryRun?: boolean
+    @Query("isDryRun", new ParseBoolPipe({ optional: true })) isDryRun?: boolean
   ): Promise<ApiResponse<{ authUrl: string }>> {
     switch (calendar) {
       case OFFICE_365_CALENDAR:


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed an issue where the calendar connect endpoint did not handle missing isDryRun query parameters correctly.

<!-- End of auto-generated description by mrge. -->

Linear [CAL-5539](https://linear.app/calcom/issue/CAL-5539/fix-connect-atoms-not-working)