### PR TITLE
chore: improved warning for UNKEY_ROOT_KEY

### DIFF
--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -22,7 +22,7 @@ export function rateLimiter() {
   const { UNKEY_ROOT_KEY } = process.env;
 
   if (!UNKEY_ROOT_KEY) {
-    log.warn("Disabled due to not finding UNKEY_ROOT_KEY env variable");
+    log.warn("Disabled because the UNKEY_ROOT_KEY environment variable was not found.");
     return () => ({ success: true, limit: 10, remaining: 999, reset: 0 } as RatelimitResponse);
   }
   const timeout = {


### PR DESCRIPTION
## What does this PR do?

This PR improves the warning message shown when `UNKEY_ROOT_KEY` is not set.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number — should be visible at the bottom of the GitHub issue description)
<!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
Improved the warning message shown when the UNKEY_ROOT_KEY environment variable is missing to make it clearer.

<!-- End of auto-generated description by mrge. -->

