### PR TITLE
fix: Wrong text EmbedTheme -> Theme

### DIFF
--- a/packages/features/embed/Embed.tsx
+++ b/packages/features/embed/Embed.tsx
@@ -876,8 +876,8 @@ const EmbedTypeCodeAndPreviewDialogContent = ({
 
   const ThemeOptions = [
     { value: EmbedTheme.auto, label: "Auto" },
-    { value: EmbedTheme.dark, label: "Dark EmbedTheme" },
-    { value: EmbedTheme.light, label: "Light EmbedTheme" },
+    { value: EmbedTheme.dark, label: "Dark Theme" },
+    { value: EmbedTheme.light, label: "Light Theme" },
   ];
 
   const layoutOptions = [
@@ -1106,7 +1106,7 @@ const EmbedTypeCodeAndPreviewDialogContent = ({
                   <CollapsibleContent>
                     <div className="text-sm">
                       <Label className="mb-6">
-                        <div className="mb-2">EmbedTheme</div>
+                        <div className="mb-2">Theme</div>
                         <Select
                           className="w-full"
                           defaultValue={ThemeOptions[0]}


### PR DESCRIPTION
It was accidentally done in the PR https://github.com/calcom/cal.com/pull/19489/files, while replacing a variable name

Bug
![image](https://github.com/user-attachments/assets/c15c1358-c691-466f-a61d-6483815df5c5)
