### PR TITLE
fix: Convert an error in webhook to info

### DIFF
--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -49,14 +49,13 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
   );
 
   if (!organizationOnboarding) {
-    logger.error(
-      `NonRecoverableError: No onboarding record found for stripe customer id: ${invoice.customer}.`
+    // Invoice Paid is received for all organizations, even those that were created before Organization Onboarding was introduced.
+    logger.info(
+      `No onboarding record found for stripe customer id: ${invoice.customer}, Organization created before Organization Onboarding was introduced, so ignoring the webhook`
     );
 
-    // Don't throw as we don't want to retry.
     return {
-      success: false,
-      error: `No onboarding record found for stripe customer id: ${invoice.customer}.`,
+      success: true,
     };
   }
 

--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -49,14 +49,14 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
   );
 
   if (!organizationOnboarding) {
-    logger.error(
-      `NonRecoverableError: No onboarding record found for stripe customer id: ${invoice.customer}.`
+    // Invoice Paid is received for all organizations, even those that were created before Organization Onboarding was introduced.
+    logger.info(
+      `No onboarding record found for stripe customer id: ${invoice.customer}, Organization created before Organization Onboarding was introduced, so ignoring the webhook`
     );
 
     // Don't throw as we don't want to retry.
     return {
-      success: false,
-      error: `No onboarding record found for stripe customer id: ${invoice.customer}.`,
+      success: true,
     };
   }
 


### PR DESCRIPTION
## Summary by mrge
Changed the webhook handler to log missing onboarding records as info instead of errors and return success, so as to not mark them as errors.