### PR TITLE
fix: dry run props for `CalendarSettings` atom

### DIFF
--- a/packages/platform/atoms/selected-calendars/wrappers/SelectedCalendarsSettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/selected-calendars/wrappers/SelectedCalendarsSettingsPlatformWrapper.tsx
@@ -333,7 +333,7 @@ const PlatformAdditionalCalendarSelector = ({
         <div>
           <div>
             <Connect.GoogleCalendar
-              // isDryRun={isDryRun}
+              isDryRun={isDryRun}
               isMultiCalendar={true}
               isClickable={true}
               tooltip={<></>}
@@ -346,7 +346,7 @@ const PlatformAdditionalCalendarSelector = ({
           </div>
           <div>
             <Connect.OutlookCalendar
-              // isDryRun={isDryRun}
+              isDryRun={isDryRun}
               isMultiCalendar={true}
               isClickable={true}
               tooltip={<></>}
@@ -359,7 +359,7 @@ const PlatformAdditionalCalendarSelector = ({
           </div>
           <div>
             <AppleConnect
-              // isDryRun={isDryRun}
+              isDryRun={isDryRun}
               onSuccess={refetch}
               isClickable={true}
               isMultiCalendar={true}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Uncommented some props since there were PRs that needed to go before adding those

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] (N/A) I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] (N/A) I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
this can be tested in the web app
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Uncommented the isDryRun prop for Google, Outlook, and Apple calendar components in CalendarSettings to enable dry run functionality during integration.

<!-- End of auto-generated description by mrge. -->

