### PR TITLE
fix: caching for sprite.svg

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -498,7 +498,7 @@ const nextConfig = {
           headers: [CORP_CROSS_ORIGIN_HEADER],
         },
         {
-          source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-]+)?",
+          source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-\\.]+)?",
           headers: [
             CORP_CROSS_ORIGIN_HEADER,
             ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -498,8 +498,15 @@ const nextConfig = {
           headers: [CORP_CROSS_ORIGIN_HEADER],
         },
         {
-          source: "/icons/sprite.svg",
-          headers: [CORP_CROSS_ORIGIN_HEADER, ACCESS_CONTROL_ALLOW_ORIGIN_HEADER],
+          source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-]+)?",
+          headers: [
+            CORP_CROSS_ORIGIN_HEADER,
+            ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
+            {
+              key: "Cache-Control",
+              value: "public, max-age=31536000, immutable",
+            },
+          ],
         },
       ],
       ...(isOrganizationsEnabled


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #20825 
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Currently cache-control in response header is "public, max-age=0, must-revalidate" for sprite.svg .
must-revalidate is disabling cache.
Updated the header rules for sprite.svg with regex for version to immutable

## Visual Demo (For contributors especially)
#### Image Demo (if applicable):

**Before:**
<img width="779" alt="Screenshot 2025-04-23 at 9 28 15 AM" src="https://github.com/user-attachments/assets/9517fc58-0b9b-4a53-baec-d3f13b0f0c5a" />

**After**

<img width="818" alt="Screenshot 2025-04-23 at 8 58 50 AM" src="https://github.com/user-attachments/assets/c89594fc-9c28-42f2-9623-3af2372fbea7" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the cache-control header for sprite.svg to allow browsers to cache it for one year, improving load times and reducing network requests.

<!-- End of auto-generated description by mrge. -->

