### PR TITLE
refactor: v2 automatic team slugs

### DIFF
--- a/apps/api/v2/src/modules/organizations/organizations/inputs/create-managed-organization.input.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/inputs/create-managed-organization.input.ts
@@ -10,6 +10,16 @@ export class CreateOrganizationInput extends RefreshApiKeyInput {
   @ApiProperty({ description: "Name of the organization", example: "CalTeam" })
   readonly name!: string;
 
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      "Organization slug in kebab-case - if not provided will be generated automatically based on name.",
+    example: "cal-tel",
+  })
+  readonly slug?: string;
+
   @ApiPropertyOptional({
     type: Object,
     description: METADATA_DOCS,

--- a/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/organizations-organizations.controller.e2e-spec.ts
@@ -46,6 +46,7 @@ import {
   X_CAL_SECRET_KEY,
 } from "@calcom/platform-constants";
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { slugify } from "@calcom/platform-libraries";
 import { ApiSuccessResponse, CreateOAuthClientInput } from "@calcom/platform-types";
 import { Team } from "@calcom/prisma/client";
 
@@ -176,6 +177,7 @@ describe("Organizations Organizations Endpoints", () => {
         managedOrg = responseBody.data;
         expect(managedOrg?.id).toBeDefined();
         expect(managedOrg?.name).toEqual(body.name);
+        expect(managedOrg?.slug).toEqual(slugify(body.name));
         expect(managedOrg?.metadata).toEqual(body.metadata);
         expect(managedOrg?.apiKey).toBeDefined();
 

--- a/apps/api/v2/src/modules/organizations/organizations/outputs/managed-organization.output.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/outputs/managed-organization.output.ts
@@ -16,6 +16,12 @@ export class ManagedOrganizationOutput {
   @ApiProperty()
   readonly name!: string;
 
+  @IsString()
+  @IsOptional()
+  @Expose()
+  @ApiPropertyOptional()
+  readonly slug?: string;
+
   @ApiPropertyOptional({
     type: Object,
     example: { key: "value" },

--- a/apps/api/v2/src/modules/organizations/organizations/services/managed-organizations.service.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/services/managed-organizations.service.ts
@@ -10,6 +10,8 @@ import { ManagedOrganizationsOutputService } from "@/modules/organizations/organ
 import { ProfilesRepository } from "@/modules/profiles/profiles.repository";
 import { ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 
+import { slugify } from "@calcom/platform-libraries";
+
 @Injectable()
 export class ManagedOrganizationsService {
   constructor(
@@ -35,6 +37,10 @@ export class ManagedOrganizationsService {
     }
 
     const { apiKeyDaysValid, apiKeyNeverExpires, ...organizationData } = organizationInput;
+
+    if (!organizationData.slug) {
+      organizationData.slug = slugify(organizationData.name);
+    }
 
     const organization = await this.managedOrganizationsRepository.createManagedOrganization(
       managerOrganizationId,

--- a/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/index/organizations-teams.controller.e2e-spec.ts
@@ -36,6 +36,7 @@ describe("Organizations Team Endpoints", () => {
     let team2: Team;
     let teamCreatedViaApi: Team;
     let teamCreatedViaApi2: Team;
+    let teamCreatedViaApi3: Team;
 
     const userEmail = `organizations-teams-admin-${randomString()}@api.com`;
     let user: User;
@@ -257,14 +258,14 @@ describe("Organizations Team Endpoints", () => {
         .then(async (response) => {
           const responseBody: ApiSuccessResponse<Team> = response.body;
           expect(responseBody.status).toEqual(SUCCESS_STATUS);
-          teamCreatedViaApi = responseBody.data;
-          expect(teamCreatedViaApi.name).toEqual(teamName);
-          expect(teamCreatedViaApi.slug).toEqual("organizations-teams-automatic-slug");
-          expect(teamCreatedViaApi.bio).toEqual("This is our test team created via API");
-          expect(teamCreatedViaApi.parentId).toEqual(org.id);
+          teamCreatedViaApi3 = responseBody.data;
+          expect(teamCreatedViaApi3.name).toEqual(teamName);
+          expect(teamCreatedViaApi3.slug).toEqual("organizations-teams-automatic-slug");
+          expect(teamCreatedViaApi3.bio).toEqual("This is our test team created via API");
+          expect(teamCreatedViaApi3.parentId).toEqual(org.id);
           const membership = await membershipsRepositoryFixture.getUserMembershipByTeamId(
             user.id,
-            teamCreatedViaApi.id
+            teamCreatedViaApi3.id
           );
           expect(membership?.role ?? "").toEqual("OWNER");
           expect(membership?.accepted).toEqual(true);
@@ -276,6 +277,7 @@ describe("Organizations Team Endpoints", () => {
       await teamsRepositoryFixture.delete(team.id);
       await teamsRepositoryFixture.delete(team2.id);
       await teamsRepositoryFixture.delete(teamCreatedViaApi2.id);
+      await teamsRepositoryFixture.delete(teamCreatedViaApi3.id);
       await teamsRepositoryFixture.delete(org.id);
       await app.close();
     });

--- a/apps/api/v2/src/modules/organizations/teams/index/services/organizations-teams.service.ts
+++ b/apps/api/v2/src/modules/organizations/teams/index/services/organizations-teams.service.ts
@@ -5,6 +5,8 @@ import { OrganizationsTeamsRepository } from "@/modules/organizations/teams/inde
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
 
+import { slugify } from "@calcom/platform-libraries";
+
 @Injectable()
 export class OrganizationsTeamsService {
   constructor(
@@ -40,6 +42,10 @@ export class OrganizationsTeamsService {
   async createOrgTeam(organizationId: number, data: CreateOrgTeamDto, user: UserWithProfile) {
     const { autoAcceptCreator, ...rest } = data;
 
+    if (!rest.slug) {
+      rest.slug = slugify(rest.name);
+    }
+
     const team = await this.organizationsTeamRepository.createOrgTeam(organizationId, rest);
 
     if (user.role !== "ADMIN") {
@@ -55,6 +61,10 @@ export class OrganizationsTeamsService {
     user: UserWithProfile
   ) {
     const { autoAcceptCreator, ...rest } = data;
+
+    if (!rest.slug) {
+      rest.slug = slugify(rest.name);
+    }
 
     const team = await this.organizationsTeamRepository.createPlatformOrgTeam(
       organizationId,

--- a/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.e2e-spec.ts
@@ -20,6 +20,7 @@ import { UserRepositoryFixture } from "test/fixtures/repository/users.repository
 import { randomString } from "test/utils/randomString";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { slugify } from "@calcom/platform-libraries";
 import { TeamOutputDto } from "@calcom/platform-types";
 
 describe("Teams endpoint", () => {
@@ -75,7 +76,7 @@ describe("Teams endpoint", () => {
   describe("User has membership in created team", () => {
     it("should create first team", async () => {
       const body: CreateTeamInput = {
-        name: `teams-dog-${randomString()}`,
+        name: `teams dog ${randomString()}`,
         metadata: {
           teamKey: "teamValue",
         },
@@ -93,6 +94,7 @@ describe("Teams endpoint", () => {
           expect(responseData).toBeDefined();
           expect(responseData.id).toBeDefined();
           expect(responseData.name).toEqual(body.name);
+          expect(responseData.slug).toEqual(slugify(body.name));
           expect(responseData.metadata).toEqual(body.metadata);
           team1 = responseData;
         });

--- a/apps/api/v2/src/modules/teams/teams/inputs/create-team.input.ts
+++ b/apps/api/v2/src/modules/teams/teams/inputs/create-team.input.ts
@@ -11,7 +11,11 @@ export class CreateTeamInput {
 
   @IsOptional()
   @IsString()
-  @ApiPropertyOptional({ type: String, description: "Team slug", example: "caltel" })
+  @ApiPropertyOptional({
+    type: String,
+    description: "Team slug in kebab-case - if not provided will be generated automatically based on name.",
+    example: "caltel",
+  })
   readonly slug?: string;
 
   @IsOptional()

--- a/apps/api/v2/src/modules/teams/teams/services/teams.service.ts
+++ b/apps/api/v2/src/modules/teams/teams/services/teams.service.ts
@@ -6,6 +6,8 @@ import { TeamsRepository } from "@/modules/teams/teams/teams.repository";
 import { BadRequestException, Injectable, InternalServerErrorException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
+import { slugify } from "@calcom/platform-libraries";
+
 @Injectable()
 export class TeamsService {
   private isTeamBillingEnabled = this.configService.get("stripe.isTeamBillingEnabled");
@@ -19,6 +21,9 @@ export class TeamsService {
 
   async createTeam(input: CreateTeamInput, ownerId: number) {
     const { autoAcceptCreator, ...teamData } = input;
+    if (!teamData.slug) {
+      teamData.slug = slugify(teamData.name);
+    }
 
     const existingTeam = await this.teamsMembershipsRepository.findTeamMembershipsByNameAndUser(
       input.name,

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -13337,6 +13337,7 @@
           },
           "enabledLayouts": {
             "type": "array",
+            "description": "Array of valid layouts - month, week or column",
             "items": {
               "type": "string",
               "enum": [
@@ -16153,7 +16154,7 @@
           },
           "slug": {
             "type": "string",
-            "description": "Team slug",
+            "description": "Team slug in kebab-case - if not provided will be generated automatically based on name.",
             "example": "caltel"
           },
           "logoUrl": {
@@ -19352,7 +19353,7 @@
           },
           "slug": {
             "type": "string",
-            "description": "Team slug",
+            "description": "Team slug in kebab-case - if not provided will be generated automatically based on name.",
             "example": "caltel"
           },
           "logoUrl": {
@@ -20265,6 +20266,11 @@
             "description": "Name of the organization",
             "example": "CalTeam"
           },
+          "slug": {
+            "type": "string",
+            "description": "Organization slug in kebab-case - if not provided will be generated automatically based on name.",
+            "example": "cal-tel"
+          },
           "metadata": {
             "type": "object",
             "description": "You can store any additional data you want here.\nMetadata must have at most 50 keys, each key up to 40 characters.\nValues can be strings (up to 500 characters), numbers, or booleans.",
@@ -20286,6 +20292,9 @@
           "name": {
             "type": "string",
             "minLength": 1
+          },
+          "slug": {
+            "type": "string"
           },
           "metadata": {
             "type": "object",
@@ -20332,6 +20341,9 @@
           "name": {
             "type": "string",
             "minLength": 1
+          },
+          "slug": {
+            "type": "string"
           },
           "metadata": {
             "type": "object",
@@ -21103,10 +21115,20 @@
             "description": "The start time of the booking in ISO 8601 format in UTC timezone.",
             "example": "2024-08-13T09:00:00Z"
           },
-          "lengthInMinutes": {
-            "type": "number",
-            "example": 30,
-            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
+          "attendee": {
+            "description": "The attendee's details.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attendee"
+              }
+            ]
+          },
+          "bookingFieldsResponses": {
+            "type": "object",
+            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values for custom booking fields added by you.",
+            "example": {
+              "customField": "customValue"
+            }
           },
           "eventTypeId": {
             "type": "number",
@@ -21132,14 +21154,6 @@
             "type": "string",
             "description": "The organization slug. Optional, only used when booking with eventTypeSlug + username or eventTypeSlug + teamSlug.",
             "example": "acme-corp"
-          },
-          "attendee": {
-            "description": "The attendee's details.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Attendee"
-              }
-            ]
           },
           "guests": {
             "description": "An optional list of guest emails attending the event.",
@@ -21194,12 +21208,10 @@
               "key": "value"
             }
           },
-          "bookingFieldsResponses": {
-            "type": "object",
-            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values.",
-            "example": {
-              "customField": "customValue"
-            }
+          "lengthInMinutes": {
+            "type": "number",
+            "example": 30,
+            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
           }
         },
         "required": [
@@ -21215,10 +21227,20 @@
             "description": "The start time of the booking in ISO 8601 format in UTC timezone.",
             "example": "2024-08-13T09:00:00Z"
           },
-          "lengthInMinutes": {
-            "type": "number",
-            "example": 30,
-            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
+          "attendee": {
+            "description": "The attendee's details.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attendee"
+              }
+            ]
+          },
+          "bookingFieldsResponses": {
+            "type": "object",
+            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values for custom booking fields added by you.",
+            "example": {
+              "customField": "customValue"
+            }
           },
           "eventTypeId": {
             "type": "number",
@@ -21244,14 +21266,6 @@
             "type": "string",
             "description": "The organization slug. Optional, only used when booking with eventTypeSlug + username or eventTypeSlug + teamSlug.",
             "example": "acme-corp"
-          },
-          "attendee": {
-            "description": "The attendee's details.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Attendee"
-              }
-            ]
           },
           "guests": {
             "description": "An optional list of guest emails attending the event.",
@@ -21306,12 +21320,10 @@
               "key": "value"
             }
           },
-          "bookingFieldsResponses": {
-            "type": "object",
-            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values.",
-            "example": {
-              "customField": "customValue"
-            }
+          "lengthInMinutes": {
+            "type": "number",
+            "example": 30,
+            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
           },
           "instant": {
             "type": "boolean",
@@ -21333,10 +21345,20 @@
             "description": "The start time of the booking in ISO 8601 format in UTC timezone.",
             "example": "2024-08-13T09:00:00Z"
           },
-          "lengthInMinutes": {
-            "type": "number",
-            "example": 30,
-            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
+          "attendee": {
+            "description": "The attendee's details.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attendee"
+              }
+            ]
+          },
+          "bookingFieldsResponses": {
+            "type": "object",
+            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values for custom booking fields added by you.",
+            "example": {
+              "customField": "customValue"
+            }
           },
           "eventTypeId": {
             "type": "number",
@@ -21362,14 +21384,6 @@
             "type": "string",
             "description": "The organization slug. Optional, only used when booking with eventTypeSlug + username or eventTypeSlug + teamSlug.",
             "example": "acme-corp"
-          },
-          "attendee": {
-            "description": "The attendee's details.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Attendee"
-              }
-            ]
           },
           "guests": {
             "description": "An optional list of guest emails attending the event.",
@@ -21424,12 +21438,10 @@
               "key": "value"
             }
           },
-          "bookingFieldsResponses": {
-            "type": "object",
-            "description": "Booking field responses consisting of an object with booking field slug as keys and user response as values.",
-            "example": {
-              "customField": "customValue"
-            }
+          "lengthInMinutes": {
+            "type": "number",
+            "example": 30,
+            "description": "If it is an event type that has multiple possible lengths that attendee can pick from, you can pass the desired booking length here.\n    If not provided then event type default length will be used for the booking."
           },
           "recurrenceCount": {
             "type": "number",

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -15023,7 +15023,7 @@
           },
           "slug": {
             "type": "string",
-            "description": "Team slug",
+            "description": "Team slug in kebab-case - if not provided will be generated automatically based on name.",
             "example": "caltel"
           },
           "logoUrl": {
@@ -17750,7 +17750,7 @@
           },
           "slug": {
             "type": "string",
-            "description": "Team slug",
+            "description": "Team slug in kebab-case - if not provided will be generated automatically based on name.",
             "example": "caltel"
           },
           "logoUrl": {
@@ -18545,6 +18545,11 @@
             "description": "Name of the organization",
             "example": "CalTeam"
           },
+          "slug": {
+            "type": "string",
+            "description": "Organization slug in kebab-case - if not provided will be generated automatically based on name.",
+            "example": "cal-tel"
+          },
           "metadata": {
             "type": "object",
             "description": "You can store any additional data you want here.\nMetadata must have at most 50 keys, each key up to 40 characters.\nValues can be strings (up to 500 characters), numbers, or booleans.",
@@ -18564,6 +18569,9 @@
           "name": {
             "type": "string",
             "minLength": 1
+          },
+          "slug": {
+            "type": "string"
           },
           "metadata": {
             "type": "object",
@@ -18600,6 +18608,9 @@
           "name": {
             "type": "string",
             "minLength": 1
+          },
+          "slug": {
+            "type": "string"
           },
           "metadata": {
             "type": "object",


### PR DESCRIPTION
Linear [CAL-5571](https://linear.app/calcom/issue/CAL-5571/fix-ensure-teams-have-slugs)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Team and organization slugs are now generated automatically from the name if not provided, ensuring every team and organization has a valid slug.

- **Refactors**
  - Added automatic slug generation for teams and organizations in API v2.
  - Updated API docs and tests to reflect the new slug behavior.

<!-- End of auto-generated description by mrge. -->

