### PR TITLE
refactor: Add DomainEventBus and WorkflowBookingListener

### DIFF
--- a/packages/features/bookings/lib/bookingDomainEvents.ts
+++ b/packages/features/bookings/lib/bookingDomainEvents.ts
@@ -1,0 +1,49 @@
+import { type DomainEvent } from "@calcom/lib/domainEvent/domainEvent";
+import { type SchedulingType } from "@calcom/prisma/enums";
+import { type EventTypeMetadata } from "@calcom/prisma/zod-utils";
+import { type CalendarEvent } from "@calcom/types/Calendar";
+
+export interface EventType {
+  id: number;
+  teamId: number | null;
+  parentId: number | null;
+
+  slug: string;
+  schedulingType: SchedulingType | null;
+  hosts: Array<{ user: { email: string; destinationCalendar?: { primaryEmail: string | null } | null } }>;
+  owner: { hideBranding: boolean } | null;
+
+  metadata: EventTypeMetadata;
+}
+
+export interface Booking {
+  id: number;
+  user: { id: number };
+  eventType: EventType;
+  calendarEvent: CalendarEvent;
+
+  bookerUrl: string;
+  videoCallUrl?: string | null;
+  smsReminderNumber?: string | null;
+  rescheduleUid?: string | null;
+  rescheduleReason?: string | null;
+  isRecurring?: boolean;
+  isFirstRecurringEvent?: boolean;
+
+  requiresConfirmation: boolean;
+  isNotConfirmed: boolean;
+
+  isDryRun?: boolean;
+}
+
+/**
+ * Domain event emitted when a regular booking is created.
+ */
+export class BookingCreated implements DomainEvent {
+  constructor(
+    public readonly booking: Booking & {
+      noEmail?: boolean;
+      platformClientId?: string;
+    }
+  ) {}
+}

--- a/packages/features/bookings/lib/handleNewBooking/test/delegation-credential.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/delegation-credential.test.ts
@@ -162,6 +162,7 @@ describe("handleNewBooking", () => {
         const createdBooking = await handleNewBooking({
           bookingData: mockBookingData,
         });
+        await new Promise(setImmediate); // Flush domain event handlers
 
         expect(createdBooking.responses).toEqual(
           expect.objectContaining({

--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -650,6 +650,7 @@ describe("handleNewBooking", () => {
           const createdBooking = await handleNewBooking({
             bookingData: mockBookingData,
           });
+          await new Promise(setImmediate); // Flush domain event handlers
           expect(createdBooking.responses).toEqual(
             expect.objectContaining({
               email: booker.email,
@@ -2760,6 +2761,7 @@ describe("handleNewBooking", () => {
         const createdBooking = await handleNewBooking({
           bookingData: mockBookingData,
         });
+        await new Promise(setImmediate); // Flush domain event handlers
         expect(createdBooking.responses).toEqual(
           expect.objectContaining({
             email: booker.email,

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -185,6 +185,7 @@ describe("handleNewBooking", () => {
           const createdBooking = await handleNewBooking({
             bookingData: mockBookingData,
           });
+          await new Promise(setImmediate); // Flush domain event handlers
 
           const previousBooking = await prismaMock.booking.findUnique({
             where: {
@@ -812,6 +813,7 @@ describe("handleNewBooking", () => {
             const createdBooking = await handleNewBooking({
               bookingData: mockBookingData,
             });
+            await new Promise(setImmediate); // Flush domain event handlers
             expect(createdBooking.responses).toEqual(
               expect.objectContaining({
                 email: booker.email,
@@ -1292,6 +1294,7 @@ describe("handleNewBooking", () => {
               // Fake the request to be from organizer
               userId: organizer.id,
             });
+            await new Promise(setImmediate); // Flush domain event handlers
 
             /**
              *  Booking Time should be new time

--- a/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
@@ -135,7 +135,7 @@ describe("handleNewBooking", () => {
         await handleNewBooking({
           bookingData: mockBookingData,
         });
-
+        await new Promise(setImmediate); // Flush domain event handlers
         expectSMSWorkflowToBeTriggered({
           sms,
           toNumber: "000",
@@ -231,6 +231,7 @@ describe("handleNewBooking", () => {
         await handleNewBooking({
           bookingData: mockBookingData,
         });
+        await new Promise(setImmediate); // Flush domain event handlers
 
         expectSMSWorkflowToBeNotTriggered({
           sms,
@@ -375,6 +376,7 @@ describe("handleNewBooking", () => {
         await handleNewBooking({
           bookingData: mockBookingData,
         });
+        await new Promise(setImmediate); // Flush domain event handlers
 
         expectSMSWorkflowToBeTriggered({
           sms,
@@ -517,6 +519,7 @@ describe("handleNewBooking", () => {
         await handleNewBooking({
           bookingData: mockBookingData,
         });
+        await new Promise(setImmediate); // Flush domain event handlers
 
         expectSMSWorkflowToBeNotTriggered({
           sms,
@@ -634,6 +637,7 @@ describe("handleNewBooking", () => {
       await handleNewBooking({
         bookingData: mockBookingData,
       });
+      await new Promise(setImmediate); // Flush domain event handlers
 
       expectWorkflowToBeTriggered({
         emailsToReceive: ["booker@example.com"],
@@ -747,6 +751,7 @@ describe("handleNewBooking", () => {
       await handleNewBooking({
         bookingData: mockBookingData,
       });
+      await new Promise(setImmediate); // Flush domain event handlers
 
       expectSMSWorkflowToBeTriggered({
         sms,

--- a/packages/features/ee/.prettierrc.js
+++ b/packages/features/ee/.prettierrc.js
@@ -1,0 +1,7 @@
+const rootConfig = require("../../config/prettier-preset");
+
+module.exports = {
+  ...rootConfig,
+  importOrder: ["^./instrument", ...rootConfig.importOrder],
+  importOrderParserPlugins: ["typescript", "decorators-legacy"],
+};

--- a/packages/features/ee/workflows/lib/domainEventListeners/workflowBookingListener.test.ts
+++ b/packages/features/ee/workflows/lib/domainEventListeners/workflowBookingListener.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type Booking, BookingCreated } from "@calcom/features/bookings/lib/bookingDomainEvents";
+import * as getOrgIdUtils from "@calcom/lib/getOrgIdFromMemberOrTeamId";
+import * as getTeamIdUtils from "@calcom/lib/getTeamIdFromEventType";
+
+import * as reminderScheduler from "../reminders/reminderScheduler";
+import * as mandatoryReminder from "../reminders/scheduleMandatoryReminder";
+import { workflowRepository } from "../repository/workflowRepository";
+import type { Workflow } from "../types";
+import { WorkflowBookingListener } from "./workflowBookingListener";
+
+const baseBooking: Booking = {
+  id: 1,
+  user: { id: 123 },
+  eventType: { id: 1, metadata: {}, owner: {}, teamId: 1 },
+  calendarEvent: { attendeeSeatId: 456 },
+  bookerUrl: "https://example.com",
+  requiresConfirmation: false,
+  isNotConfirmed: false,
+};
+
+const bookingCreated = (params?: Partial<Parameters<typeof BookingCreated>[0]>) =>
+  new BookingCreated({ ...baseBooking, ...params });
+
+const workflow = (id: number) => ({ id } as Workflow);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+
+  vi.spyOn(getOrgIdUtils, "default").mockResolvedValue(null);
+  vi.spyOn(getTeamIdUtils, "getTeamIdFromEventType").mockResolvedValue(baseBooking.eventType.teamId);
+
+  vi.spyOn(workflowRepository, "getWorkflowsActiveOnEventType").mockResolvedValue([]);
+  vi.spyOn(workflowRepository, "getTeamWorkflows").mockResolvedValue([]);
+  vi.spyOn(workflowRepository, "getUserWorkflows").mockResolvedValue([]);
+  vi.spyOn(workflowRepository, "getWorkflowsActiveOnTeam").mockResolvedValue([]);
+  vi.spyOn(workflowRepository, "getWorkflowsActiveOnTeamMember").mockResolvedValue([]);
+
+  vi.spyOn(reminderScheduler, "scheduleWorkflowReminders").mockResolvedValue();
+  vi.spyOn(mandatoryReminder, "scheduleMandatoryReminder").mockResolvedValue();
+});
+
+describe("WorkflowBookingListener", () => {
+  it("should correctly handle skipping and scheduling logic", async () => {
+    const listener = new WorkflowBookingListener();
+
+    await listener.onBookingCreated(bookingCreated({ isDryRun: true }));
+    expect(mandatoryReminder.scheduleMandatoryReminder).not.toHaveBeenCalled();
+    expect(reminderScheduler.scheduleWorkflowReminders).not.toHaveBeenCalled();
+
+    await listener.onBookingCreated(
+      bookingCreated({ eventType: { metadata: { disableStandardEmails: { all: { attendee: true } } } } })
+    );
+    expect(mandatoryReminder.scheduleMandatoryReminder).toHaveBeenCalledTimes(0);
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledTimes(1);
+
+    await listener.onBookingCreated(bookingCreated());
+    expect(mandatoryReminder.scheduleMandatoryReminder).toHaveBeenCalledTimes(1);
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledTimes(2);
+  });
+
+  it("should pass correct flags to mandatoryReminder", async () => {
+    await new WorkflowBookingListener().onBookingCreated(
+      bookingCreated({
+        noEmail: true,
+        platformClientId: 999,
+        eventType: { owner: { hideBranding: true } },
+        requiresConfirmation: true,
+        calendarEvent: { attendeeSeatId: 789 },
+      })
+    );
+
+    expect(mandatoryReminder.scheduleMandatoryReminder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isPlatformNoEmail: true,
+        hideBranding: true,
+        requiresConfirmation: true,
+        seatReferenceUid: 789,
+      })
+    );
+  });
+
+  it("should load workflows correctly based on eventType locking", async () => {
+    const listener = new WorkflowBookingListener();
+
+    // Managed And Locked
+    vi.spyOn(getTeamIdUtils, "getTeamIdFromEventType").mockResolvedValue(1);
+    await listener.onBookingCreated(bookingCreated({ eventType: { parentId: 2 } }));
+    expect(workflowRepository.getUserWorkflows).not.toHaveBeenCalled();
+
+    // Managed And unlocked
+    await listener.onBookingCreated(
+      bookingCreated({
+        eventType: { parentId: 2, metadata: { managedEventConfig: { unlockedFields: { workflows: true } } } },
+      })
+    );
+    expect(workflowRepository.getUserWorkflows).toHaveBeenCalledTimes(1);
+
+    // Not managed
+    await listener.onBookingCreated(bookingCreated());
+    expect(workflowRepository.getUserWorkflows).toHaveBeenCalledTimes(2);
+
+    vi.spyOn(getTeamIdUtils, "getTeamIdFromEventType").mockResolvedValue(null);
+    await listener.onBookingCreated(bookingCreated({ eventType: { parentId: 2 } }));
+    expect(workflowRepository.getUserWorkflows).toHaveBeenCalledTimes(3);
+
+    vi.spyOn(workflowRepository, "getUserWorkflows").mockResolvedValue([workflow(111)]);
+    await listener.onBookingCreated(bookingCreated());
+    expect(workflowRepository.getUserWorkflows).toHaveBeenCalled();
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledWith(
+      expect.objectContaining({ workflows: [workflow(111)] })
+    );
+  });
+
+  it("should load organization workflows if orgId exists", async () => {
+    vi.spyOn(getOrgIdUtils, "default").mockResolvedValue(555);
+    vi.spyOn(workflowRepository, "getTeamWorkflows").mockResolvedValue([workflow(222)]);
+
+    await new WorkflowBookingListener().onBookingCreated(bookingCreated());
+
+    expect(mandatoryReminder.scheduleMandatoryReminder).toHaveBeenCalledWith(
+      expect.objectContaining({ workflows: [workflow(222)] })
+    );
+  });
+
+  it("should pass isFirstRecurringEvent correctly", async () => {
+    const listener = new WorkflowBookingListener();
+
+    await listener.onBookingCreated(bookingCreated({ isRecurring: true, isFirstRecurringEvent: false }));
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledWith(
+      expect.objectContaining({ isFirstRecurringEvent: false })
+    );
+
+    await listener.onBookingCreated(bookingCreated({ isRecurring: true, isFirstRecurringEvent: true }));
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledWith(
+      expect.objectContaining({ isFirstRecurringEvent: true })
+    );
+  });
+
+  it("should handle missing workflows gracefully", async () => {
+    await new WorkflowBookingListener().onBookingCreated(bookingCreated());
+
+    expect(mandatoryReminder.scheduleMandatoryReminder).toHaveBeenCalledWith(
+      expect.objectContaining({ workflows: [] })
+    );
+    expect(reminderScheduler.scheduleWorkflowReminders).toHaveBeenCalledWith(
+      expect.objectContaining({ workflows: [] })
+    );
+  });
+});

--- a/packages/features/ee/workflows/lib/domainEventListeners/workflowBookingListener.ts
+++ b/packages/features/ee/workflows/lib/domainEventListeners/workflowBookingListener.ts
@@ -1,0 +1,106 @@
+import { BookingCreated, type EventType } from "@calcom/features/bookings/lib/bookingDomainEvents";
+import type { DomainEventListener } from "@calcom/lib/domainEvent/domainEvent";
+import { onDomainEvent } from "@calcom/lib/domainEvent/onDomainEvent";
+import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
+import { getTeamIdFromEventType } from "@calcom/lib/getTeamIdFromEventType";
+
+import { type ExtendedCalendarEvent, scheduleWorkflowReminders } from "../reminders/reminderScheduler";
+import { scheduleMandatoryReminder } from "../reminders/scheduleMandatoryReminder";
+import { workflowRepository } from "../repository/workflowRepository";
+import { type Workflow } from "../types";
+
+export class WorkflowBookingListener implements DomainEventListener {
+  @onDomainEvent(BookingCreated)
+  async onBookingCreated({ booking }: BookingCreated): Promise<void> {
+    if (booking.isDryRun) return;
+
+    const workflows = await this.getWorkflows(booking.eventType, booking.user.id);
+
+    const calendarEvent: ExtendedCalendarEvent = {
+      ...booking.calendarEvent,
+      rescheduleReason: booking.rescheduleReason,
+      metadata: booking.videoCallUrl ? { videoCallUrl: booking.videoCallUrl } : undefined,
+      eventType: booking.eventType,
+      bookerUrl: booking.bookerUrl,
+    };
+    await Promise.all([
+      !booking.eventType.metadata?.disableStandardEmails?.all?.attendee &&
+        scheduleMandatoryReminder({
+          workflows,
+          evt: calendarEvent,
+          requiresConfirmation: booking.requiresConfirmation,
+          hideBranding: !!booking.eventType.owner?.hideBranding,
+          seatReferenceUid: booking.calendarEvent.attendeeSeatId,
+          isPlatformNoEmail: booking.noEmail && Boolean(booking.platformClientId),
+          isDryRun: booking.isDryRun,
+        }),
+
+      scheduleWorkflowReminders({
+        workflows,
+        calendarEvent,
+        smsReminderNumber: booking.smsReminderNumber || null,
+        isNotConfirmed: booking.isNotConfirmed,
+        isRescheduleEvent: !!booking.rescheduleUid,
+        isFirstRecurringEvent: !booking.isRecurring || booking.isFirstRecurringEvent,
+        hideBranding: !!booking.eventType.owner?.hideBranding,
+        seatReferenceUid: calendarEvent.attendeeSeatId,
+        isDryRun: booking.isDryRun,
+      }),
+    ]);
+  }
+
+  private async getWorkflows(eventType: EventType, userId: number): Promise<Workflow[]> {
+    const loaders = [] as Array<Promise<void>>;
+    const workflowSet = new WorkflowSet();
+    const load = (promise: Promise<Workflow[]>) => loaders.push(promise.then((x) => workflowSet.add(x)));
+
+    load(workflowRepository.getWorkflowsActiveOnEventType(eventType.id));
+
+    const teamId = await getTeamIdFromEventType({
+      eventType: { team: { id: eventType.teamId }, parentId: eventType.parentId },
+    });
+    if (teamId) {
+      load(workflowRepository.getTeamWorkflows(teamId, { isActiveOnAll: true }));
+    }
+
+    if (userId && !this.workflowsLockedForUser(eventType, teamId)) {
+      load(workflowRepository.getUserWorkflows(userId, { isActiveOnAll: true, teamId: null }));
+    }
+
+    const orgId = await getOrgIdFromMemberOrTeamId({ teamId, memberId: userId });
+    if (orgId) {
+      if (teamId) {
+        load(workflowRepository.getWorkflowsActiveOnTeam(teamId));
+      } else if (userId) {
+        load(workflowRepository.getWorkflowsActiveOnTeamMember(userId));
+      }
+      load(workflowRepository.getTeamWorkflows(orgId, { isActiveOnAll: true }));
+    }
+
+    await Promise.all(loaders);
+    return workflowSet.getValues();
+  }
+
+  private workflowsLockedForUser(eventType: EventType, teamId?: number | null): boolean {
+    if (!teamId || !eventType.parentId) return false; // Not managed event type
+    return !eventType.metadata?.managedEventConfig?.unlockedFields?.workflows;
+  }
+}
+
+class WorkflowSet {
+  private values: Workflow[] = [];
+  private idSet = new Set<number>();
+
+  add(workflows: Workflow[]): void {
+    workflows.forEach((workflow) => {
+      if (!this.idSet.has(workflow.id)) {
+        this.idSet.add(workflow.id);
+        this.values.push(workflow);
+      }
+    });
+  }
+
+  getValues(): Workflow[] {
+    return this.values;
+  }
+}

--- a/packages/features/ee/workflows/lib/repository/workflowRepository.ts
+++ b/packages/features/ee/workflows/lib/repository/workflowRepository.ts
@@ -1,0 +1,82 @@
+import { type PrismaClient, readonlyPrisma } from "@calcom/prisma";
+
+import type { Workflow, WorkflowStep } from "../types";
+
+type FieldSelect = true | { select: Record<string, FieldSelect> };
+
+const stepsSelect = {
+  action: true,
+  sendTo: true,
+  template: true,
+  reminderBody: true,
+  emailSubject: true,
+  id: true,
+  sender: true,
+  includeCalendarEvent: true,
+  numberVerificationPending: true,
+  numberRequired: true,
+  verifiedAt: true,
+} satisfies Record<keyof WorkflowStep, FieldSelect>;
+
+const workflowSelect = {
+  id: true,
+  name: true,
+  trigger: true,
+  time: true,
+  timeUnit: true,
+  userId: true,
+  teamId: true,
+  steps: { select: stepsSelect },
+} satisfies Record<keyof Workflow, FieldSelect>;
+
+export class WorkflowRepository {
+  constructor(private readonly dbRead: PrismaClient) {}
+
+  getTeamWorkflows(teamId: number, where?: { isActiveOnAll?: boolean }): Promise<Workflow[]> {
+    return this.dbRead.workflow.findMany({
+      where: { teamId, ...where },
+      select: workflowSelect,
+    });
+  }
+
+  getUserWorkflows(
+    userId: number,
+    where?: { isActiveOnAll?: boolean; teamId?: number | null }
+  ): Promise<Workflow[]> {
+    return this.dbRead.workflow.findMany({
+      where: { userId, ...where },
+      select: workflowSelect,
+    });
+  }
+
+  getWorkflowsActiveOnEventType(eventTypeId: number): Promise<Workflow[]> {
+    return this.dbRead.workflow.findMany({
+      where: { activeOn: { some: { eventTypeId } } },
+      select: workflowSelect,
+    });
+  }
+
+  getWorkflowsActiveOnTeam(teamId: number): Promise<Workflow[]> {
+    return this.dbRead.workflow.findMany({
+      where: { activeOnTeams: { some: { teamId } } },
+      select: workflowSelect,
+    });
+  }
+
+  getWorkflowsActiveOnTeamMember(userId: number): Promise<Workflow[]> {
+    return this.dbRead.workflow.findMany({
+      where: {
+        activeOnTeams: {
+          some: {
+            team: {
+              members: { some: { userId, accepted: true } },
+            },
+          },
+        },
+      },
+      select: workflowSelect,
+    });
+  }
+}
+
+export const workflowRepository = new WorkflowRepository(readonlyPrisma);

--- a/packages/features/tsconfig.json
+++ b/packages/features/tsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "~/*": ["/*"]
     },
+    "experimentalDecorators": true,
     "resolveJsonModule": true,
     "esModuleInterop": true
   },

--- a/packages/lib/.prettierrc.js
+++ b/packages/lib/.prettierrc.js
@@ -1,0 +1,7 @@
+const rootConfig = require("../../packages/config/prettier-preset");
+
+module.exports = {
+  ...rootConfig,
+  importOrder: ["^./instrument", ...rootConfig.importOrder],
+  importOrderParserPlugins: ["typescript", "decorators-legacy"],
+};

--- a/packages/lib/domainEvent/domainEvent.ts
+++ b/packages/lib/domainEvent/domainEvent.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+/*
+ * Domain events let parts of the system react to changes elsewhere without tight coupling.
+ *
+ * Example: Creating a Booking
+ *
+ *     Upstream                 Core Domain               Downstream
+ *     ========                 ===========               ==========
+ *                         ┌════════════════════┐
+ *                         ║                    ║
+ * EventType ───────────▶  ║      Booking       ║ -------------▶ Workflow
+ *                         ║   (Core Domain)    ║   (BookingCreated)
+ * Availability ────────▶  ║                    ║
+ *                         ║                    ║
+ *   Routing ───────────▶  ║                    ║
+ *                         └════════════════════┘
+ *
+ * - Booking depends on `EventType`, `Availability`, and `Routing` during creation.
+ * - Booking emits `BookingCreated` and other lifecycle events.
+ * - Subscribers (e.g., `Workflow`) listen and react — e.g. send notifications.
+ */
+
+/**
+ * Marker interface for domain events.
+ * Domain events are plain objects published to the `DomainEventBus`.
+ *
+ * The event name used for routing is determined by:
+ * 1. The static `eventName` property on the event class (if present)
+ * 2. The constructor name of the event class (fallback)
+ *
+ * @example ```
+ * // Using constructor name as event name
+ * class BookingCreated implements DomainEvent {
+ *   constructor (public readonly bookingId: string) {}
+ * }
+ *
+ * // Using custom event name
+ * class BookingRescheduled implements DomainEvent {
+ *   static eventName = "booking.rescheduled";
+ *   constructor (public readonly bookingId: string) {}
+ * }
+ * ```
+ */
+export interface DomainEvent {}
+
+/** Constructor type for domain events. */
+export interface DomainEventCtor {
+  /** The constructor name, used as event name by default. */
+  name: string;
+  /** The event name, to override the default constructor name. */
+  eventName?: string;
+}
+
+/**
+ * Marker interface for domain event listeners.
+ * A DomainEventListener groups related domain event handlers into a single class
+ * so they can be colocated and registered together in the `DomainEventBus`.
+ *
+ * @example ```
+ * class WorkflowBookingListener implements DomainEventListener {
+ *   @onDomainEvent(BookingCreated)
+ *   async onBookingCreated(event: BookingCreated) {
+ *     // Trigger workflows when booking is created
+ *   }
+ *   @onDomainEvent(BookingCancelled)
+ *   async onBookingCancelled(event: BookingCancelled) {
+ *     // Trigger workflows when booking is cancelled
+ *   }
+ * }
+ * ```
+ */
+export interface DomainEventListener {}
+
+/** Constructor type for domain event listeners. */
+export interface DomainEventListenerCtor {
+  new (): DomainEventListener;
+}
+
+/** DomainEventListener methods with `@onDomainEvent()` decorator. */
+export interface DomainEventHandler<T extends DomainEvent = DomainEvent> {
+  (event: T, timestamp: Date): void | Promise<void>;
+}
+
+/** Options for domain event handlers */
+export interface DomainEventHandlerOptions {
+  /** Whether the handler should block execution until completed */
+  blocking?: boolean;
+}

--- a/packages/lib/domainEvent/domainEventBus.test.ts
+++ b/packages/lib/domainEvent/domainEventBus.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DomainEvent, DomainEventListener } from "./domainEvent";
+import { DomainEventBus } from "./domainEventBus";
+import { onDomainEvent } from "./onDomainEvent";
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+class TestDomainEvent implements DomainEvent {}
+
+class AnotherDomainEvent implements DomainEvent {}
+
+class TestListener implements DomainEventListener {
+  @onDomainEvent(TestDomainEvent)
+  onTestDomainEvent() {}
+
+  @onDomainEvent(AnotherDomainEvent)
+  onAnotherDomainEvent() {}
+
+  @onDomainEvent(TestDomainEvent, { blocking: true })
+  onTestDomainEventBlocking() {}
+
+  @onDomainEvent(TestDomainEvent)
+  onTestDomainEvent2() {}
+}
+
+describe("DomainEventBus", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("dispatch()", () => {
+    it("should invoke a registered listener for an event", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      domainEventBus.addListener(listener);
+
+      vi.spyOn(listener, "onTestDomainEvent");
+
+      const event = new TestDomainEvent();
+      const timestamp = new Date();
+      await domainEventBus.dispatch(event, timestamp);
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalledWith(event, timestamp);
+    });
+
+    it("should invoke multiple handlers registered for the same event", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      domainEventBus.addListener(listener);
+
+      vi.spyOn(listener, "onTestDomainEvent");
+      vi.spyOn(listener, "onTestDomainEvent2");
+
+      await domainEventBus.dispatch(new TestDomainEvent());
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalled();
+      expect(listener.onTestDomainEvent2).toHaveBeenCalled();
+    });
+
+    it("should allow one method to handle multiple event types", async () => {
+      class MultiEventListener implements DomainEventListener {
+        handled: string[] = [];
+
+        @onDomainEvent(TestDomainEvent)
+        @onDomainEvent(AnotherDomainEvent)
+        onAnyEvent(e: DomainEvent) {
+          this.handled.push(e.constructor.name);
+        }
+      }
+
+      const domainEventBus = new DomainEventBus();
+      const listener = new MultiEventListener();
+      domainEventBus.addListener(listener);
+
+      await domainEventBus.dispatch(new TestDomainEvent());
+      await domainEventBus.dispatch(new AnotherDomainEvent());
+
+      expect(listener.handled).toEqual(["TestDomainEvent", "AnotherDomainEvent"]);
+    });
+
+    it("should wait for blocking handlers before non-blocking", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      domainEventBus.addListener(listener);
+
+      const logs: string[] = [];
+      let resolveBlocking!: () => void;
+      const blockingPromise = new Promise<void>((resolve) => {
+        resolveBlocking = () => {
+          logs.push("blocking resolved");
+          resolve();
+        };
+      });
+      vi.spyOn(listener, "onTestDomainEventBlocking").mockImplementation(() => {
+        logs.push("blocking start");
+        return blockingPromise;
+      });
+      vi.spyOn(listener, "onTestDomainEvent").mockImplementation(() => {
+        logs.push("non-blocking start");
+      });
+
+      const dispatchPromise = domainEventBus.dispatch(new TestDomainEvent());
+
+      await Promise.resolve(); // flush microtasks
+
+      // Non-blocking should not run yet
+      expect(logs).toEqual(["blocking start"]);
+
+      resolveBlocking();
+      await dispatchPromise;
+
+      expect(logs).toEqual(["blocking start", "blocking resolved", "non-blocking start"]);
+    });
+
+    it("should do nothing if no handlers are registered for the event", async () => {
+      const domainEventBus = new DomainEventBus();
+      const event = new TestDomainEvent();
+      await expect(domainEventBus.dispatch(event)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("addListener()", () => {
+    it("should register listener instance correctly", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      vi.spyOn(listener, "onTestDomainEvent");
+
+      domainEventBus.addListener(listener);
+      await domainEventBus.dispatch(new TestDomainEvent());
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalled();
+    });
+
+    it("should register listener class correctly", async () => {
+      class TestListenerType implements DomainEventListener {
+        static lastInstance: TestListenerType;
+        constructor() {
+          TestListenerType.lastInstance = this;
+        }
+        @onDomainEvent(TestDomainEvent)
+        onTestDomainEvent() {}
+      }
+
+      const domainEventBus = new DomainEventBus();
+      domainEventBus.addListener(TestListenerType);
+      expect(TestListenerType.lastInstance).toBeDefined();
+
+      vi.spyOn(TestListenerType.lastInstance, "onTestDomainEvent");
+
+      await domainEventBus.dispatch(new TestDomainEvent());
+      expect(TestListenerType.lastInstance.onTestDomainEvent).toHaveBeenCalled();
+    });
+
+    it("should not register the same listener twice", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      vi.spyOn(listener, "onTestDomainEvent");
+
+      domainEventBus.addListener(listener);
+      domainEventBus.addListener(listener);
+
+      await domainEventBus.dispatch(new TestDomainEvent());
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not register the same handler twice for the same event", async () => {
+      class DuplicateHandlerListener implements DomainEventListener {
+        calls = 0;
+
+        @onDomainEvent(TestDomainEvent)
+        @onDomainEvent(TestDomainEvent)
+        onTest() {
+          this.calls++;
+        }
+      }
+
+      const domainEventBus = new DomainEventBus();
+      const listener = new DuplicateHandlerListener();
+      domainEventBus.addListener(listener);
+
+      await domainEventBus.dispatch(new TestDomainEvent());
+      expect(listener.calls).toBe(1);
+    });
+  });
+
+  describe("addListeners()", () => {
+    it("should register multiple listeners", async () => {
+      class TestListener2 implements DomainEventListener {
+        @onDomainEvent(TestDomainEvent)
+        onTestDomainEvent() {}
+      }
+
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      const listener2 = new TestListener2();
+      vi.spyOn(listener, "onTestDomainEvent");
+      vi.spyOn(listener2, "onTestDomainEvent");
+
+      domainEventBus.addListeners([listener, listener2]);
+      await domainEventBus.dispatch(new TestDomainEvent());
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalled();
+      expect(listener2.onTestDomainEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should continue processing events when handler throws", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      vi.spyOn(listener, "onTestDomainEvent").mockImplementation(() => Promise.reject("Test error"));
+      vi.spyOn(listener, "onTestDomainEvent2");
+
+      domainEventBus.addListener(listener);
+      await domainEventBus.dispatch(new TestDomainEvent());
+
+      expect(listener.onTestDomainEvent2).toHaveBeenCalled();
+    });
+  });
+
+  describe("multiple event types", () => {
+    it("should handle different event types independently", async () => {
+      const domainEventBus = new DomainEventBus();
+      const listener = new TestListener();
+      vi.spyOn(listener, "onTestDomainEvent");
+      vi.spyOn(listener, "onAnotherDomainEvent");
+
+      domainEventBus.addListener(listener);
+      await domainEventBus.dispatch(new TestDomainEvent());
+      await domainEventBus.dispatch(new AnotherDomainEvent());
+
+      expect(listener.onTestDomainEvent).toHaveBeenCalled();
+      expect(listener.onAnotherDomainEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe("custom event names", () => {
+    it("should use eventName property instead of constructor name when available", async () => {
+      class EventWithCustomName implements DomainEvent {
+        static eventName = "testing.customEvent";
+      }
+
+      class BothNamesListener implements DomainEventListener {
+        @onDomainEvent("testing.customEvent")
+        onOverriddenEvent() {}
+
+        @onDomainEvent(EventWithCustomName)
+        onEventByClass() {}
+      }
+
+      const domainEventBus = new DomainEventBus();
+      const listener = new BothNamesListener();
+      vi.spyOn(listener, "onOverriddenEvent");
+      vi.spyOn(listener, "onEventByClass");
+
+      domainEventBus.addListener(listener);
+      await domainEventBus.dispatch(new EventWithCustomName());
+
+      expect(listener.onOverriddenEvent).toHaveBeenCalled();
+      expect(listener.onEventByClass).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/lib/domainEvent/domainEventBus.ts
+++ b/packages/lib/domainEvent/domainEventBus.ts
@@ -1,0 +1,110 @@
+import { WorkflowBookingListener } from "@calcom/ee/workflows/lib/domainEventListeners/workflowBookingListener";
+
+import logger from "../logger";
+import type {
+  DomainEvent,
+  DomainEventCtor,
+  DomainEventHandler,
+  DomainEventListener,
+  DomainEventListenerCtor,
+} from "./domainEvent";
+import { listenerRegistry } from "./listenerRegistry";
+
+const log = logger.getSubLogger({ prefix: ["[domainEvents]"] });
+
+/**
+ * Central event bus for dispatching and handling domain events.
+ * Supports both blocking and non-blocking (default) handlers.
+ */
+export class DomainEventBus {
+  private listeners = new Set<DomainEventListenerCtor>();
+  private handlersByEvent = new Map<
+    string, // DomainEvent name
+    { blocking: DomainEventHandler[]; nonBlocking: DomainEventHandler[] }
+  >();
+
+  /**
+   * Dispatches a domain event to all registered handlers.
+   * @note It is an async function and should be awaited.
+   */
+  async dispatch(event: DomainEvent, timestamp = new Date()): Promise<void> {
+    const eventCtor = event?.constructor as DomainEventCtor;
+    const eventName = eventCtor?.eventName || eventCtor?.name;
+    const handlers = this.handlersByEvent.get(eventName);
+    if (handlers?.blocking.length) {
+      await Promise.all(handlers.blocking.map((handler) => handler(event, timestamp)));
+    }
+    if (handlers?.nonBlocking?.length) {
+      queueMicrotask(() => handlers.nonBlocking.forEach((handler) => handler(event, timestamp)));
+    }
+  }
+
+  /** Registers multiple listeners with the event bus */
+  addListeners(listeners: Array<DomainEventListener | DomainEventListenerCtor>): void {
+    listeners.forEach((listener) => this.addListener(listener));
+  }
+
+  /** Registers a single DomainEventListener with the event bus */
+  addListener(target: DomainEventListener | DomainEventListenerCtor): void {
+    let listener: DomainEventListener;
+    let ListenerCtor: DomainEventListenerCtor;
+    if (typeof target === "function" && target.prototype?.constructor === target) {
+      ListenerCtor = target as DomainEventListenerCtor;
+      listener = new ListenerCtor();
+    } else {
+      listener = target as DomainEventListener;
+      ListenerCtor = target.constructor as DomainEventListenerCtor;
+    }
+
+    if (this.listeners.has(ListenerCtor)) {
+      log.warn(`DomainEventListener ${ListenerCtor.name} is already added.`);
+      return;
+    }
+
+    this.listeners.add(ListenerCtor);
+
+    const self = listener as Record<string, DomainEventHandler>;
+    const listenerHandlers = listenerRegistry.getHandlers(listener.constructor.prototype);
+    listenerHandlers?.forEach(({ domainEventName, method, options }) => {
+      const handler: DomainEventHandler = async (event, timestamp) => {
+        try {
+          await self[method](event, timestamp);
+        } catch (err) {
+          log.error(`${ListenerCtor.name}.${method}()`, err);
+        }
+      };
+      let handlers = this.handlersByEvent.get(domainEventName);
+      if (!handlers) {
+        handlers = { blocking: [], nonBlocking: [] };
+        this.handlersByEvent.set(domainEventName, handlers);
+      }
+      if (options?.blocking) {
+        handlers.blocking.push(handler);
+      } else {
+        handlers.nonBlocking.push(handler);
+      }
+    });
+  }
+}
+
+/** Global DomainEventBus instance */
+export const domainEventBus = new DomainEventBus();
+
+/**
+ * Temporary solution for initializing domain event listeners in Next.js web app and api/v1.
+ * Current implementation:
+ * - Ensures listeners are registered before any events are dispatched
+ * - Adds listeners when domainEventBus is first imported
+ *
+ * Future improvements:
+ * 1. Centralize event handling in api/v2:
+ *    - Create event dispatch endpoint
+ *    - Web app and api/v1 to forward events to this endpoint
+ * 2. Implement distributed event broker:
+ *    - Handle events across multiple services
+ *    - Improve scalability and reliability
+ */
+domainEventBus.addListeners([
+  WorkflowBookingListener,
+  // Register other domain event listeners here
+]);

--- a/packages/lib/domainEvent/listenerRegistry.ts
+++ b/packages/lib/domainEvent/listenerRegistry.ts
@@ -1,0 +1,40 @@
+import logger from "../logger";
+import type { DomainEventHandlerOptions } from "./domainEvent";
+
+const log = logger.getSubLogger({ prefix: ["[domainEvents]"] });
+
+interface ListenerHandlerEntry {
+  domainEventName: string;
+  method: string;
+  options?: DomainEventHandlerOptions;
+}
+
+// Registry for storing `@onDomainEvent()` handlers on specific listeners.
+// This avoids using reflect-metadata, which is not supported in upcoming ECMAScript decorators.
+// This makes migration to ECMAScript decorators easier when upgrading to TypeScript 5+.
+class ListenerRegistry {
+  /* eslint-disable @typescript-eslint/ban-types */
+  private handlersByListenerPrototype = new Map<Object, ListenerHandlerEntry[]>();
+
+  getHandlers(listenerPrototype: Object): ListenerHandlerEntry[] | undefined {
+    return this.handlersByListenerPrototype.get(listenerPrototype);
+  }
+
+  addHandler(listenerPrototype: Object, handler: ListenerHandlerEntry): void {
+    const handlers = this.handlersByListenerPrototype.get(listenerPrototype);
+    if (!handlers) {
+      this.handlersByListenerPrototype.set(listenerPrototype, [handler]);
+      return;
+    }
+
+    const { domainEventName, method } = handler;
+    const exists = handlers.some((x) => x.domainEventName === domainEventName && x.method === method);
+    if (exists) {
+      log.warn(`${listenerPrototype.constructor.name}.${method} already added for ${domainEventName}`);
+    } else {
+      handlers.push(handler);
+    }
+  }
+}
+
+export const listenerRegistry = new ListenerRegistry();

--- a/packages/lib/domainEvent/onDomainEvent.ts
+++ b/packages/lib/domainEvent/onDomainEvent.ts
@@ -1,0 +1,17 @@
+import type { DomainEventCtor, DomainEventHandlerOptions } from "./domainEvent";
+import { listenerRegistry } from "./listenerRegistry";
+
+/**
+ * Decorator for marking methods as domain event handlers.
+ * @param domainEvent - The domain event class or name to handle
+ * @param options - Optional configuration for the handler
+ */
+export function onDomainEvent(
+  domainEvent: string | DomainEventCtor,
+  options?: DomainEventHandlerOptions
+): MethodDecorator {
+  const domainEventName =
+    typeof domainEvent === "string" ? domainEvent : domainEvent.eventName || domainEvent.name;
+  return (target, propertyKey) =>
+    listenerRegistry.addHandler(target, { domainEventName, method: String(propertyKey), options });
+}

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es5",
     "jsx": "preserve",
+    "experimentalDecorators": true,
     "resolveJsonModule": true
   },
   "include": [".", "../types/next-auth.d.ts", "../types/window.d.ts", "../trpc/types/router.d.ts"],

--- a/tests/libs/__mocks__/prismaMock.ts
+++ b/tests/libs/__mocks__/prismaMock.ts
@@ -6,6 +6,7 @@ import type { PrismaClient } from "@calcom/prisma";
 vi.mock("@calcom/prisma", () => ({
   default: prisma,
   prisma,
+  readonlyPrisma: prisma,
   availabilityUserSelect: vi.fn(),
   userSelect: vi.fn(),
 }));


### PR DESCRIPTION
## What does this PR do?

- Related to #18671  
- Related to CAL-5026  

> Abstracts logic from handleNewBooking when a booking is created.

This PR introduces a `BookingCreated` domain event to decouple side-effects (e.g., triggering workflows) from the booking creation flow.  
Rather than adding a service layer, it uses event listeners to improve separation of concerns.

Currently a WIP — looking for early feedback to confirm if this is the right direction.

## Why domain events?

- Cleanly separates side-effects (like workflows) from core booking logic  
- Domain event handlers run non-blocking by default — improves response time  
- Enhances testability, readability, and extensibility  
- `DomainEvent` naming avoids confusion with `CalendarEvent`  

## Next steps (if this direction is approved)

- Remove workflow logic from `handleNewBooking()`  
- Move workflow query + trigger to `WorkflowBookingListener.onBookingCreated()`  
- Add more listeners for additional `BookingCreated` concerns  
- Open follow-up PRs for other domain events (`BookingRescheduled`, `BookingCancelled`, etc.)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a DomainEventBus system and @onDomainEvent() decorator to decouple side-effects from booking creation using domain events.

- **New Features**
  - Introduced a DomainEventBus for dispatching domain events.
  - Added the BookingCreated event and a sample WorkflowBookingListener.
  - Implemented the @onDomainEvent() decorator for event handler methods.
  - Updated handleNewBooking to emit a BookingCreated event after booking creation.
  - Added tests for the DomainEventBus and event handling.

<!-- End of auto-generated description by mrge. -->

