### PR TITLE
fix: Offset is required but not passed everywhere, default to zero.

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.schema.ts
@@ -18,7 +18,7 @@ export const ZGetInputSchema = z.object({
     beforeCreatedDate: z.string().optional(),
   }),
   limit: z.number().min(1).max(100),
-  offset: z.number(),
+  offset: z.number().default(0),
 });
 
 export type TGetInputSchema = z.infer<typeof ZGetInputSchema>;


### PR DESCRIPTION
## What does this PR do?

Fixes error thrown when offset is not passed, default=0 instead.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Set a default value of zero for the offset parameter in the bookings API schema to prevent errors when offset is not provided.

<!-- End of auto-generated description by mrge. -->

