### PR TITLE
perf: settings to main page transition from back button

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
@@ -255,7 +255,7 @@ const useTabs = ({ isDelegationCredentialEnabled }: { isDelegationCredentialEnab
 const BackButtonInSidebar = ({ name }: { name: string }) => {
   return (
     <Link
-      href="/"
+      href="/event-types"
       className="hover:bg-subtle todesktop:mt-10 [&[aria-current='page']]:bg-emphasis [&[aria-current='page']]:text-emphasis group-hover:text-default text-emphasis group my-6 flex h-6 max-h-6 w-full flex-row items-center rounded-md px-3 py-2 text-sm font-medium leading-4 transition"
       data-testid={`vertical-tab-${name}`}>
       <Icon


### PR DESCRIPTION
## What does this PR do?

- Updated the settings sidebar back button to go directly to the event types page, improving navigation speed.

<img width="561" alt="Screenshot 2025-04-23 at 4 37 04 PM" src="https://github.com/user-attachments/assets/0be75f70-223c-4138-a823-39affa5aabe0" />

this used to route us to `/` which redirects us to `/event-types`

let's just go straight to `/event-types`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

