### PR TITLE
fix: Include ordered attendees in booking select query

### DIFF
--- a/packages/features/bookings/lib/getUserBooking.ts
+++ b/packages/features/bookings/lib/getUserBooking.ts
@@ -42,6 +42,9 @@ const getUserBooking = async (uid: string) => {
           timeZone: true,
           phoneNumber: true,
         },
+        orderBy: {
+          id: "asc",
+        },
       },
       eventTypeId: true,
       eventType: {

--- a/packages/prisma/selects/booking.ts
+++ b/packages/prisma/selects/booking.ts
@@ -8,6 +8,10 @@ export const bookingMinimalSelect = Prisma.validator<Prisma.BookingSelect>()({
   customInputs: true,
   startTime: true,
   endTime: true,
-  attendees: true,
+  attendees: {
+    orderBy: {
+      id: "asc",
+    },
+  },
   metadata: true,
 });


### PR DESCRIPTION
## What does this PR do?



## Summary by mrge
Updated the booking select query to return attendees in ascending order by ID. This ensures attendee lists are always ordered consistently.

<!-- End of auto-generated description by mrge. -->

