### PR TITLE
fix: don't setup auto accept for free emails

### DIFF
--- a/packages/lib/server/repository/organization.ts
+++ b/packages/lib/server/repository/organization.ts
@@ -4,6 +4,7 @@ import { getOrgUsernameFromEmail } from "@calcom/features/auth/signup/utils/getO
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { prisma } from "@calcom/prisma";
+import type { BillingPeriod, OrganizationSettings } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
@@ -29,11 +30,11 @@ export class OrganizationRepository {
       slug: string | null;
       isOrganizationConfigured: boolean;
       isOrganizationAdminReviewed: boolean;
-      autoAcceptEmail: string;
+      autoAcceptEmail: OrganizationSettings["orgAutoAcceptEmail"];
       seats: number | null;
       pricePerSeat: number | null;
       isPlatform: boolean;
-      billingPeriod?: "MONTHLY" | "ANNUALLY";
+      billingPeriod?: BillingPeriod;
       logoUrl: string | null;
       bio: string | null;
       requestedSlug?: string | null;
@@ -76,9 +77,9 @@ export class OrganizationRepository {
       slug: string;
       isOrganizationConfigured: boolean;
       isOrganizationAdminReviewed: boolean;
-      autoAcceptEmail: string;
+      autoAcceptEmail: OrganizationSettings["orgAutoAcceptEmail"];
       seats: number | null;
-      billingPeriod?: "MONTHLY" | "ANNUALLY";
+      billingPeriod?: BillingPeriod;
       pricePerSeat: number | null;
       isPlatform: boolean;
       logoUrl: string | null;
@@ -123,9 +124,9 @@ export class OrganizationRepository {
     slug: string | null;
     isOrganizationConfigured: boolean;
     isOrganizationAdminReviewed: boolean;
-    autoAcceptEmail: string;
+    autoAcceptEmail: OrganizationSettings["orgAutoAcceptEmail"];
     seats: number | null;
-    billingPeriod?: "MONTHLY" | "ANNUALLY";
+    billingPeriod?: BillingPeriod;
     pricePerSeat: number | null;
     isPlatform: boolean;
     logoUrl: string | null;

--- a/packages/prisma/migrations/20250424151830_make_org_auto_accept_email_optional/migration.sql
+++ b/packages/prisma/migrations/20250424151830_make_org_auto_accept_email_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "OrganizationSettings" ALTER COLUMN "orgAutoAcceptEmail" DROP NOT NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -518,7 +518,7 @@ model OrganizationSettings {
   isOrganizationVerified              Boolean    @default(false)
   // It is a domain e.g "acme.com". Any email with this domain might be auto-accepted
   // Also, it is the domain to which the organization profile is redirected.
-  orgAutoAcceptEmail                  String
+  orgAutoAcceptEmail                  String?
   lockEventTypeCreationForUsers       Boolean    @default(false)
   adminGetsNoSlotsNotification        Boolean    @default(false)
   // It decides if instance ADMIN has reviewed the organization or not.


### PR DESCRIPTION
## What does this PR do?

Stopped setting auto-accept email domains for organizations created with free email addresses. This prevents auto-accept rules from being set for generic domains like Gmail.

- **Bug Fixes**
  - Made the orgAutoAcceptEmail field optional in the database.
  - Updated organization creation to skip auto-accept setup for free email domains.

