### PR TITLE
fix: exclude email from replyTo

### DIFF
--- a/packages/emails/templates/attendee-add-guests-email.ts
+++ b/packages/emails/templates/attendee-add-guests-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import generateIcsFile, { GenerateIcsRole } from "../lib/generateIcsFile";
@@ -6,6 +7,8 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeAddGuestsEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -14,7 +17,7 @@ export default class AttendeeAddGuestsEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.t("guests_added_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.team?.name || this.calEvent.organizer.name,

--- a/packages/emails/templates/attendee-add-guests-email.ts
+++ b/packages/emails/templates/attendee-add-guests-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
@@ -7,8 +6,6 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeAddGuestsEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -17,7 +14,7 @@ export default class AttendeeAddGuestsEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.t("guests_added_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.team?.name || this.calEvent.organizer.name,

--- a/packages/emails/templates/attendee-awaiting-payment-email.ts
+++ b/packages/emails/templates/attendee-awaiting-payment-email.ts
@@ -1,14 +1,17 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeAwaitingPaymentEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.attendee.language.translate("complete_your_booking_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-awaiting-payment-email.ts
+++ b/packages/emails/templates/attendee-awaiting-payment-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
@@ -6,12 +5,10 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeAwaitingPaymentEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.attendee.language.translate("complete_your_booking_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-cancelled-email.ts
+++ b/packages/emails/templates/attendee-cancelled-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -8,8 +7,6 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeCancelledEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -18,7 +15,7 @@ export default class AttendeeCancelledEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.t("event_cancelled_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-cancelled-email.ts
+++ b/packages/emails/templates/attendee-cancelled-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -7,6 +8,8 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeCancelledEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -15,7 +18,7 @@ export default class AttendeeCancelledEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.t("event_cancelled_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-cancelled-seat-email.ts
+++ b/packages/emails/templates/attendee-cancelled-seat-email.ts
@@ -1,14 +1,17 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeCancelledSeatEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.t("event_no_longer_attending_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-cancelled-seat-email.ts
+++ b/packages/emails/templates/attendee-cancelled-seat-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
@@ -6,12 +5,10 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeCancelledSeatEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.t("event_no_longer_attending_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-daily-video-download-recording-email.ts
+++ b/packages/emails/templates/attendee-daily-video-download-recording-email.ts
@@ -2,6 +2,7 @@
 import type { TFunction } from "i18next";
 
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -23,15 +24,17 @@ export default class AttendeeDailyVideoDownloadRecordingEmail extends BaseEmail 
     this.t = attendee.language.translate;
   }
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.t("download_recording_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-daily-video-download-recording-email.ts
+++ b/packages/emails/templates/attendee-daily-video-download-recording-email.ts
@@ -1,7 +1,6 @@
 // TODO: We should find a way to keep App specific email templates within the App itself
 import type { TFunction } from "i18next";
 
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
@@ -24,17 +23,13 @@ export default class AttendeeDailyVideoDownloadRecordingEmail extends BaseEmail 
     this.t = attendee.language.translate;
   }
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.t("download_recording_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-daily-video-download-transcript-email.ts
+++ b/packages/emails/templates/attendee-daily-video-download-transcript-email.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next";
 
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -22,6 +23,7 @@ export default class AttendeeDailyVideoDownloadTranscriptEmail extends BaseEmail
     this.t = attendee.language.translate;
   }
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
     const attachments = await Promise.all(
       this.transcriptDownloadLinks.map(async (url, index) => {
         const response = await fetch(url);
@@ -37,12 +39,12 @@ export default class AttendeeDailyVideoDownloadTranscriptEmail extends BaseEmail
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.t("download_transcript_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-daily-video-download-transcript-email.ts
+++ b/packages/emails/templates/attendee-daily-video-download-transcript-email.ts
@@ -1,6 +1,5 @@
 import type { TFunction } from "i18next";
 
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
@@ -23,7 +22,6 @@ export default class AttendeeDailyVideoDownloadTranscriptEmail extends BaseEmail
     this.t = attendee.language.translate;
   }
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
     const attachments = await Promise.all(
       this.transcriptDownloadLinks.map(async (url, index) => {
         const response = await fetch(url);
@@ -39,12 +37,10 @@ export default class AttendeeDailyVideoDownloadTranscriptEmail extends BaseEmail
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.t("download_transcript_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-declined-email.ts
+++ b/packages/emails/templates/attendee-declined-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -7,12 +6,10 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeDeclinedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.t("event_declined_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-declined-email.ts
+++ b/packages/emails/templates/attendee-declined-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -6,10 +7,12 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeDeclinedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.t("event_declined_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-location-change-email.ts
+++ b/packages/emails/templates/attendee-location-change-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import generateIcsFile, { GenerateIcsRole } from "../lib/generateIcsFile";
@@ -6,6 +7,8 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeLocationChangeEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -14,7 +17,7 @@ export default class AttendeeLocationChangeEmail extends AttendeeScheduledEmail 
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.t("location_changed_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.team?.name || this.calEvent.organizer.name,

--- a/packages/emails/templates/attendee-location-change-email.ts
+++ b/packages/emails/templates/attendee-location-change-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
@@ -7,8 +6,6 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeLocationChangeEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -17,7 +14,7 @@ export default class AttendeeLocationChangeEmail extends AttendeeScheduledEmail 
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.t("location_changed_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.team?.name || this.calEvent.organizer.name,

--- a/packages/emails/templates/attendee-request-email.ts
+++ b/packages/emails/templates/attendee-request-email.ts
@@ -1,5 +1,6 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -8,16 +9,17 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class AttendeeRequestEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const toAddresses = this.calEvent.attendees.map((attendee) => attendee.email);
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
 
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.calEvent.attendees[0].language.translate("booking_submitted_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-request-email.ts
+++ b/packages/emails/templates/attendee-request-email.ts
@@ -1,5 +1,4 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -9,17 +8,13 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class AttendeeRequestEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const toAddresses = this.calEvent.attendees.map((attendee) => attendee.email);
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.calEvent.attendees[0].language.translate("booking_submitted_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-rescheduled-email.ts
+++ b/packages/emails/templates/attendee-rescheduled-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -7,6 +8,8 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeRescheduledEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -15,12 +18,12 @@ export default class AttendeeRescheduledEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.attendee.language.translate("event_type_has_been_rescheduled_on_time_date", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-rescheduled-email.ts
+++ b/packages/emails/templates/attendee-rescheduled-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -8,8 +7,6 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeRescheduledEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -18,12 +15,10 @@ export default class AttendeeRescheduledEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.attendee.language.translate("event_type_has_been_rescheduled_on_time_date", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -3,6 +3,7 @@ import { default as cloneDeep } from "lodash/cloneDeep";
 
 import { getRichDescription } from "@calcom/lib/CalEventParser";
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -31,6 +32,7 @@ export default class AttendeeScheduledEmail extends BaseEmail {
 
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const clonedCalEvent = cloneDeep(this.calEvent);
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
 
     return {
       icalEvent: generateIcsFile({
@@ -40,12 +42,12 @@ export default class AttendeeScheduledEmail extends BaseEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.calEvent.title}`,
       html: await this.getHtml(clonedCalEvent, this.attendee),
       text: this.getTextBody(),

--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -2,7 +2,6 @@ import type { TFunction } from "i18next";
 import { default as cloneDeep } from "lodash/cloneDeep";
 
 import { getRichDescription } from "@calcom/lib/CalEventParser";
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
@@ -32,7 +31,6 @@ export default class AttendeeScheduledEmail extends BaseEmail {
 
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const clonedCalEvent = cloneDeep(this.calEvent);
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
 
     return {
       icalEvent: generateIcsFile({
@@ -42,12 +40,10 @@ export default class AttendeeScheduledEmail extends BaseEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.calEvent.title}`,
       html: await this.getHtml(clonedCalEvent, this.attendee),
       text: this.getTextBody(),

--- a/packages/emails/templates/attendee-updated-email.ts
+++ b/packages/emails/templates/attendee-updated-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -7,6 +8,8 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeUpdatedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -15,12 +18,12 @@ export default class AttendeeUpdatedEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: [
+      ...getReplyToHeader(this.calEvent, [
         ...this.calEvent.attendees
           .filter(({ email }) => email !== this.attendee.email)
           .map(({ email }) => email),
-        getReplyToEmail(this.calEvent),
-      ],
+        customReplyToEmail,
+      ]),
       subject: `${this.attendee.language.translate("event_type_has_been_updated", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/attendee-updated-email.ts
+++ b/packages/emails/templates/attendee-updated-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -8,8 +7,6 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 
 export default class AttendeeUpdatedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -18,12 +15,10 @@ export default class AttendeeUpdatedEmail extends AttendeeScheduledEmail {
       }),
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees
-          .filter(({ email }) => email !== this.attendee.email)
-          .map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.filter(({ email }) => email !== this.attendee.email).map(({ email }) => email)
+      ),
       subject: `${this.attendee.language.translate("event_type_has_been_updated", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/no-show-fee-charged-email.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.ts
@@ -1,4 +1,5 @@
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import AttendeeScheduledEmail from "./attendee-scheduled-email";
@@ -6,10 +7,12 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class NoShowFeeChargedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     if (!this.calEvent.paymentInfo?.amount) throw new Error("No payment into");
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
+
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      replyTo: getReplyToEmail(this.calEvent),
+      ...getReplyToHeader(this.calEvent, customReplyToEmail),
       subject: `${this.attendee.language.translate("no_show_fee_charged_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/no-show-fee-charged-email.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.ts
@@ -1,4 +1,3 @@
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
@@ -7,12 +6,10 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class NoShowFeeChargedEmail extends AttendeeScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     if (!this.calEvent.paymentInfo?.amount) throw new Error("No payment into");
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, customReplyToEmail),
+      ...getReplyToHeader(this.calEvent),
       subject: `${this.attendee.language.translate("no_show_fee_charged_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-add-guests-email.ts
+++ b/packages/emails/templates/organizer-add-guests-email.ts
@@ -17,7 +17,10 @@ export default class OrganizerAddGuestsEmail extends OrganizerScheduledEmail {
       }),
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("guests_added_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.attendees[0].name,

--- a/packages/emails/templates/organizer-add-guests-email.ts
+++ b/packages/emails/templates/organizer-add-guests-email.ts
@@ -1,4 +1,5 @@
 import { APP_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import generateIcsFile, { GenerateIcsRole } from "../lib/generateIcsFile";
@@ -16,7 +17,7 @@ export default class OrganizerAddGuestsEmail extends OrganizerScheduledEmail {
       }),
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("guests_added_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.attendees[0].name,

--- a/packages/emails/templates/organizer-daily-video-download-recording-email.ts
+++ b/packages/emails/templates/organizer-daily-video-download-recording-email.ts
@@ -24,7 +24,10 @@ export default class OrganizerDailyVideoDownloadRecordingEmail extends BaseEmail
     return {
       to: `${this.calEvent.organizer.email}>`,
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("download_recording_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-daily-video-download-recording-email.ts
+++ b/packages/emails/templates/organizer-daily-video-download-recording-email.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next";
 
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
@@ -23,7 +24,7 @@ export default class OrganizerDailyVideoDownloadRecordingEmail extends BaseEmail
     return {
       to: `${this.calEvent.organizer.email}>`,
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("download_recording_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-daily-video-download-transcript-email.ts
+++ b/packages/emails/templates/organizer-daily-video-download-transcript-email.ts
@@ -36,7 +36,10 @@ export default class OrganizerDailyVideoDownloadTranscriptEmail extends BaseEmai
     return {
       to: `${this.calEvent.organizer.email}>`,
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("download_transcript_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-daily-video-download-transcript-email.ts
+++ b/packages/emails/templates/organizer-daily-video-download-transcript-email.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next";
 
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
@@ -35,7 +36,7 @@ export default class OrganizerDailyVideoDownloadTranscriptEmail extends BaseEmai
     return {
       to: `${this.calEvent.organizer.email}>`,
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("download_transcript_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-location-change-email.ts
+++ b/packages/emails/templates/organizer-location-change-email.ts
@@ -1,4 +1,5 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import generateIcsFile, { GenerateIcsRole } from "../lib/generateIcsFile";
@@ -16,7 +17,7 @@ export default class OrganizerLocationChangeEmail extends OrganizerScheduledEmai
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("location_changed_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.attendees[0].name,

--- a/packages/emails/templates/organizer-location-change-email.ts
+++ b/packages/emails/templates/organizer-location-change-email.ts
@@ -17,7 +17,10 @@ export default class OrganizerLocationChangeEmail extends OrganizerScheduledEmai
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("location_changed_event_type_subject", {
         eventType: this.calEvent.type,
         name: this.calEvent.attendees[0].name,

--- a/packages/emails/templates/organizer-request-email.ts
+++ b/packages/emails/templates/organizer-request-email.ts
@@ -1,5 +1,6 @@
 import { checkIfUserHasFeatureController } from "@calcom/features/flags/operations/check-if-user-has-feature.controller";
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -21,7 +22,7 @@ export default class OrganizerRequestEmail extends OrganizerScheduledEmail {
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("awaiting_approval")}: ${this.calEvent.title}`,
       html: await this.getHtmlRequestEmail(template, this.calEvent, this.calEvent.organizer),
       text: this.getTextBody("event_awaiting_approval"),

--- a/packages/emails/templates/organizer-request-email.ts
+++ b/packages/emails/templates/organizer-request-email.ts
@@ -22,7 +22,10 @@ export default class OrganizerRequestEmail extends OrganizerScheduledEmail {
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("awaiting_approval")}: ${this.calEvent.title}`,
       html: await this.getHtmlRequestEmail(template, this.calEvent, this.calEvent.organizer),
       text: this.getTextBody("event_awaiting_approval"),

--- a/packages/emails/templates/organizer-request-reminder-email.ts
+++ b/packages/emails/templates/organizer-request-reminder-email.ts
@@ -1,4 +1,5 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import { renderEmail } from "../";
 import OrganizerRequestEmail from "./organizer-request-email";
@@ -10,7 +11,7 @@ export default class OrganizerRequestReminderEmail extends OrganizerRequestEmail
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.t("event_awaiting_approval_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-request-reminder-email.ts
+++ b/packages/emails/templates/organizer-request-reminder-email.ts
@@ -11,7 +11,10 @@ export default class OrganizerRequestReminderEmail extends OrganizerRequestEmail
     return {
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.t("event_awaiting_approval_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-rescheduled-email.ts
+++ b/packages/emails/templates/organizer-rescheduled-email.ts
@@ -1,5 +1,6 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
 import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { renderEmail } from "../";
@@ -9,6 +10,7 @@ import OrganizerScheduledEmail from "./organizer-scheduled-email";
 export default class OrganizerRescheduledEmail extends OrganizerScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
+    const customReplyToEmail = getReplyToEmail(this.calEvent);
 
     return {
       icalEvent: generateIcsFile({
@@ -18,7 +20,10 @@ export default class OrganizerRescheduledEmail extends OrganizerScheduledEmail {
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email), getReplyToEmail(this.calEvent)],
+      ...getReplyToHeader(this.calEvent, [
+        ...this.calEvent.attendees.map(({ email }) => email),
+        customReplyToEmail,
+      ]),
       subject: `${this.calEvent.organizer.language.translate("event_type_has_been_rescheduled_on_time_date", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-rescheduled-email.ts
+++ b/packages/emails/templates/organizer-rescheduled-email.ts
@@ -1,5 +1,4 @@
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
-import { getReplyToEmail } from "@calcom/lib/getReplyToEmail";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -10,8 +9,6 @@ import OrganizerScheduledEmail from "./organizer-scheduled-email";
 export default class OrganizerRescheduledEmail extends OrganizerScheduledEmail {
   protected async getNodeMailerPayload(): Promise<Record<string, unknown>> {
     const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
-    const customReplyToEmail = getReplyToEmail(this.calEvent);
-
     return {
       icalEvent: generateIcsFile({
         calEvent: this.calEvent,
@@ -20,10 +17,10 @@ export default class OrganizerRescheduledEmail extends OrganizerScheduledEmail {
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [
-        ...this.calEvent.attendees.map(({ email }) => email),
-        customReplyToEmail,
-      ]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.calEvent.organizer.language.translate("event_type_has_been_rescheduled_on_time_date", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),

--- a/packages/emails/templates/organizer-scheduled-email.ts
+++ b/packages/emails/templates/organizer-scheduled-email.ts
@@ -50,7 +50,10 @@ export default class OrganizerScheduledEmail extends BaseEmail {
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
+      ...getReplyToHeader(
+        this.calEvent,
+        this.calEvent.attendees.map(({ email }) => email)
+      ),
       subject: `${this.newSeat ? `${this.t("new_attendee")}: ` : ""}${this.calEvent.title}`,
       html: await this.getHtml(
         clonedCalEvent,

--- a/packages/emails/templates/organizer-scheduled-email.ts
+++ b/packages/emails/templates/organizer-scheduled-email.ts
@@ -3,6 +3,7 @@ import { default as cloneDeep } from "lodash/cloneDeep";
 
 import { getRichDescription } from "@calcom/lib/CalEventParser";
 import { EMAIL_FROM_NAME } from "@calcom/lib/constants";
+import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 import { TimeFormat } from "@calcom/lib/timeFormat";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
@@ -49,7 +50,7 @@ export default class OrganizerScheduledEmail extends BaseEmail {
       }),
       from: `${EMAIL_FROM_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
-      replyTo: [...this.calEvent.attendees.map(({ email }) => email)],
+      ...getReplyToHeader(this.calEvent, [...this.calEvent.attendees.map(({ email }) => email)]),
       subject: `${this.newSeat ? `${this.t("new_attendee")}: ` : ""}${this.calEvent.title}`,
       html: await this.getHtml(
         clonedCalEvent,

--- a/packages/emails/templates/workflow-email.ts
+++ b/packages/emails/templates/workflow-email.ts
@@ -14,7 +14,7 @@ export type WorkflowEmailData = {
   to: string;
   subject: string;
   html: string;
-  replyTo: string;
+  replyTo?: string;
   sender?: string | null;
   attachments?: Attachment[];
 };
@@ -31,7 +31,7 @@ export default class WorkflowEmail extends BaseEmail {
     return {
       to: this.mailData.to,
       from: `${this.mailData.sender || SENDER_NAME} <${this.getMailerOptions().from}>`,
-      replyTo: this.mailData.replyTo,
+      ...(this.mailData.replyTo && { replyTo: this.mailData.replyTo }),
       subject: this.mailData.subject,
       html: addHTMLStyles(this.mailData.html),
       attachments: this.mailData.attachments,

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -332,10 +332,12 @@ export async function handler(req: NextRequest) {
               html: emailContent.emailBody,
               batchId: batchId,
               sendAt: dayjs(reminder.scheduledDate).unix(),
-              replyTo:
-                reminder.booking?.eventType?.customReplyToEmail ??
-                reminder.booking?.userPrimaryEmail ??
-                reminder.booking.user?.email,
+              ...(!reminder.booking?.eventType?.hideOrganizerEmail && {
+                replyTo:
+                  reminder.booking?.eventType?.customReplyToEmail ??
+                  reminder.booking?.userPrimaryEmail ??
+                  reminder.booking.user?.email,
+              }),
               attachments: reminder.workflowStep.includeCalendarEvent
                 ? [
                     {
@@ -410,11 +412,13 @@ export async function handler(req: NextRequest) {
               html: emailContent.emailBody,
               batchId: batchId,
               sendAt: dayjs(reminder.scheduledDate).unix(),
-              replyTo:
-                reminder.booking?.eventType?.customReplyToEmail ||
-                reminder.booking?.userPrimaryEmail ||
-                reminder.booking.user?.email,
-              sender: reminder.workflowStep?.sender,
+              ...(!reminder.booking?.eventType?.hideOrganizerEmail && {
+                replyTo:
+                  reminder.booking?.eventType?.customReplyToEmail ||
+                  reminder.booking?.userPrimaryEmail ||
+                  reminder.booking.user?.email,
+                sender: reminder.workflowStep?.sender,
+              }),
             })
           );
 

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -417,8 +417,8 @@ export async function handler(req: NextRequest) {
                   reminder.booking?.eventType?.customReplyToEmail ||
                   reminder.booking?.userPrimaryEmail ||
                   reminder.booking.user?.email,
-                sender: reminder.workflowStep?.sender,
               }),
+              sender: reminder.workflowStep?.sender,
             })
           );
 

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -251,7 +251,7 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
     return {
       subject: emailContent.emailSubject,
       html: emailContent.emailBody,
-      replyTo: evt?.eventType?.customReplyToEmail || evt.organizer.email,
+      ...(!evt.hideOrganizerEmail && { replyTo: evt?.eventType?.customReplyToEmail || evt.organizer.email }),
       attachments,
       sender,
     };

--- a/packages/features/tasker/tasks/sendWorkflowEmails.ts
+++ b/packages/features/tasker/tasks/sendWorkflowEmails.ts
@@ -6,7 +6,7 @@ export const ZSendWorkflowEmailsSchema = z.object({
   to: z.array(z.string()),
   subject: z.string(),
   html: z.string(),
-  replyTo: z.string(),
+  replyTo: z.string().optional(),
   sender: z.string().nullable().optional(),
   attachments: z
     .array(

--- a/packages/lib/getReplyToHeader.ts
+++ b/packages/lib/getReplyToHeader.ts
@@ -1,0 +1,6 @@
+import type { CalendarEvent } from "@calcom/types/Calendar";
+
+export function getReplyToHeader(calEvent: CalendarEvent, replyTo: string | string[]) {
+  if (calEvent.hideOrganizerEmail) return {};
+  return { replyTo };
+}

--- a/packages/lib/getReplyToHeader.ts
+++ b/packages/lib/getReplyToHeader.ts
@@ -1,6 +1,16 @@
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
-export function getReplyToHeader(calEvent: CalendarEvent, replyTo: string | string[]) {
+import { getReplyToEmail } from "./getReplyToEmail";
+
+export function getReplyToHeader(calEvent: CalendarEvent, additionalEmails?: string | string[]) {
   if (calEvent.hideOrganizerEmail) return {};
+
+  const replyToEmail = getReplyToEmail(calEvent);
+  const replyTo = additionalEmails
+    ? Array.isArray(additionalEmails)
+      ? [...additionalEmails, replyToEmail]
+      : [additionalEmails, replyToEmail]
+    : replyToEmail;
+
   return { replyTo };
 }


### PR DESCRIPTION

## Summary by mrge
Updated email templates to exclude the organizer's email from the reply-to field when hideOrganizerEmail is set, preventing unwanted replies.

- **Bug Fixes**
  - Added getReplyToHeader helper to conditionally set reply-to headers in all affected email templates.
  - Updated scheduleEmailReminders to skip reply-to when organizer email is hidden.

<!-- End of auto-generated description by mrge. -->

