### PR TITLE
fix: Added orderBy in the correct place

### DIFF
--- a/packages/features/bookings/lib/get-booking.ts
+++ b/packages/features/bookings/lib/get-booking.ts
@@ -73,6 +73,9 @@ async function getBooking(prisma: PrismaClient, uid: string, isSeatedEvent?: boo
           name: true,
           bookingSeat: true,
         },
+        orderBy: {
+          id: "asc",
+        },
       },
       user: {
         select: {

--- a/packages/prisma/selects/booking.ts
+++ b/packages/prisma/selects/booking.ts
@@ -8,10 +8,6 @@ export const bookingMinimalSelect = Prisma.validator<Prisma.BookingSelect>()({
   customInputs: true,
   startTime: true,
   endTime: true,
-  attendees: {
-    orderBy: {
-      id: "asc",
-    },
-  },
+  attendees: true,
   metadata: true,
 });


### PR DESCRIPTION

## Summary by mrge
Moved the orderBy clause for attendees to the correct place in getBooking to ensure attendee results are sorted by id.

<!-- End of auto-generated description by mrge. -->

