### PR TITLE
fix: double end-date parsing when saving availability

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.test.ts
@@ -7,6 +7,7 @@ import { expect, test, beforeEach, vi, describe } from "vitest";
 import "vitest-fetch-mock";
 
 import { CalendarCache } from "@calcom/features/calendar-cache/calendar-cache";
+import { getTimeMin, getTimeMax } from "@calcom/features/calendar-cache/lib/datesForCache";
 import { SelectedCalendarRepository } from "@calcom/lib/server/repository/selectedCalendar";
 import type { CredentialForCalendarServiceWithEmail } from "@calcom/types/Credential";
 
@@ -187,8 +188,8 @@ test("Calendar Cache is being read on cache HIT", async () => {
   await calendarCache.upsertCachedAvailability(
     credentialInDb1.id,
     {
-      timeMin: dateFrom1,
-      timeMax: dateTo1,
+      timeMin: getTimeMin(dateFrom1),
+      timeMax: getTimeMax(dateTo1),
       items: [{ id: testSelectedCalendar.externalId }],
     },
     JSON.parse(

--- a/packages/features/calendar-cache/calendar-cache.repository.ts
+++ b/packages/features/calendar-cache/calendar-cache.repository.ts
@@ -7,7 +7,6 @@ import prisma from "@calcom/prisma";
 import type { Calendar, SelectedCalendarEventTypeIds } from "@calcom/types/Calendar";
 
 import type { ICalendarCacheRepository } from "./calendar-cache.repository.interface";
-import { getTimeMax, getTimeMin } from "./lib/datesForCache";
 
 const log = logger.getSubLogger({ prefix: ["CalendarCacheRepository"] });
 
@@ -19,8 +18,8 @@ function parseKeyForCache(args: FreeBusyArgs): string {
   // Ensure that calendarIds are unique
   const uniqueItems = uniqueBy(args.items, ["id"]);
   const key = JSON.stringify({
-    timeMin: getTimeMin(args.timeMin),
-    timeMax: getTimeMax(args.timeMax),
+    timeMin: args.timeMin,
+    timeMax: args.timeMax,
     items: uniqueItems,
   });
   return key;

--- a/packages/features/calendar-cache/lib/datesForCache.test.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { getTimeMin, getTimeMax } from "./datesForCache";
 
 describe("getTimeMin", () => {
   // Tested on multiple dates
-  // vi.setSystemTime("2030-04-21T00:00:13Z");
+  vi.setSystemTime("2025-04-24T00:00:13Z");
+
   it("should return start of current month when no date is passed", () => {
     const result = getTimeMin();
     const expected = new Date();
@@ -79,5 +80,18 @@ describe("getTimeMax", () => {
     const testDate = "2024-12-24T23:59:59Z";
     const result = getTimeMax(testDate);
     expect(result).toMatchInlineSnapshot(`"2025-02-01T00:00:00.000Z"`);
+  });
+
+  it("should handle next month", () => {
+    const testDate = "2025-05-01T02:59:59.999Z";
+    const result = getTimeMax(testDate);
+    expect(result).toMatchInlineSnapshot(`"2025-06-01T00:00:00.000Z"`);
+  });
+
+  it("should handle special case where timeMax is more than 2 months from now but less than 3 months", () => {
+    vi.setSystemTime("2025-04-24T00:00:13Z");
+    const testDate = "2025-06-02T23:59:59.999Z";
+    const result = getTimeMax(testDate);
+    expect(result).toMatchInlineSnapshot(`"2025-06-01T00:00:00.000Z"`);
   });
 });

--- a/packages/features/calendar-cache/lib/datesForCache.test.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.test.ts
@@ -74,4 +74,10 @@ describe("getTimeMax", () => {
     const result = getTimeMax(testDate);
     expect(result).toMatchInlineSnapshot(`"2024-11-01T00:00:00.000Z"`);
   });
+
+  it("should handle year changes", () => {
+    const testDate = "2024-12-24T23:59:59Z";
+    const result = getTimeMax(testDate);
+    expect(result).toMatchInlineSnapshot(`"2025-02-01T00:00:00.000Z"`);
+  });
 });

--- a/packages/features/calendar-cache/lib/datesForCache.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.ts
@@ -38,14 +38,15 @@ export function getTimeMax(timeMax?: string) {
   let baseYear = currentYear;
   let baseMonth = currentMonth;
 
-  // Check if date is within current month or next month relative to *now*.
-  const isWithinCurrentOrNextMonth =
-    (dateYear === currentYear && dateMonth <= currentMonth + 1) ||
-    (dateYear === currentYear + 1 && currentMonth === 11 && dateMonth === 0);
+  // Check if date is within the current month or the next two months relative to *now*.
+  const isWithinCurrentOrNextTwoMonths =
+    (dateYear === currentYear && dateMonth <= currentMonth + 2) ||
+    (dateYear === currentYear + 1 &&
+      ((currentMonth === 10 && dateMonth === 0) || (currentMonth === 11 && dateMonth <= 1)));
 
-  // If the input date is beyond the next month relative to *now*,
+  // If the input date is beyond the next two months relative to *now*,
   // use the *input date's* month/year as the base.
-  if (!isWithinCurrentOrNextMonth) {
+  if (!isWithinCurrentOrNextTwoMonths) {
     baseYear = dateYear;
     baseMonth = dateMonth;
   }

--- a/packages/features/calendar-cache/lib/datesForCache.ts
+++ b/packages/features/calendar-cache/lib/datesForCache.ts
@@ -23,44 +23,36 @@ export function getTimeMax(timeMax?: string) {
   const currentMonth = now.getUTCMonth();
   const currentYear = now.getUTCFullYear();
 
+  // If no date is passed, return start of the month two months from *now*.
   if (!timeMax) {
-    // If no date passed, return start of the overnext month from current date
     const result = new Date(Date.UTC(currentYear, currentMonth + 2, 1));
     result.setUTCHours(0, 0, 0, 0);
     return result.toISOString();
   }
 
+  // If a date is passed, determine the base month/year for calculation.
   const date = new Date(timeMax);
   const dateMonth = date.getUTCMonth();
   const dateYear = date.getUTCFullYear();
 
-  // If the date is within current month or next month, return start of overnext month
-  // Otherwise, return start of overnext month from the date
-  let targetYear = dateYear;
-  let targetMonth = dateMonth;
+  let baseYear = currentYear;
+  let baseMonth = currentMonth;
 
-  // Check if date is within current month or next month
+  // Check if date is within current month or next month relative to *now*.
   const isWithinCurrentOrNextMonth =
     (dateYear === currentYear && dateMonth <= currentMonth + 1) ||
     (dateYear === currentYear + 1 && currentMonth === 11 && dateMonth === 0);
 
-  if (isWithinCurrentOrNextMonth) {
-    // For dates within current month or next month, return start of overnext month
-    targetMonth = dateMonth + 2;
-    if (targetMonth > 11) {
-      targetMonth = 0;
-      targetYear++;
-    }
-  } else {
-    // For dates beyond overnext month, return start of overnext month from the date
-    targetMonth = dateMonth + 2;
-    if (targetMonth > 11) {
-      targetMonth = 0;
-      targetYear++;
-    }
+  // If the input date is beyond the next month relative to *now*,
+  // use the *input date's* month/year as the base.
+  if (!isWithinCurrentOrNextMonth) {
+    baseYear = dateYear;
+    baseMonth = dateMonth;
   }
+  // Otherwise, the base remains the current year/month.
 
-  const result = new Date(Date.UTC(targetYear, targetMonth, 1));
+  // Calculate the start of the month two months after the determined base date.
+  const result = new Date(Date.UTC(baseYear, baseMonth + 2, 1));
   result.setUTCHours(0, 0, 0, 0);
   return result.toISOString();
 }

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -169,7 +169,7 @@ export const getBusyCalendarTimes = async (
     // Subtract 11 hours from the start date to avoid problems in UTC- time zones.
     const startDate = dayjs(dateFrom).subtract(11, "hours").format();
     // Add 14 hours from the start date to avoid problems in UTC+ time zones.
-    const endDate = dayjs(dateTo).endOf("month").add(14, "hours").format();
+    const endDate = dayjs(dateTo).add(14, "hours").format();
 
     if (includeTimeZone) {
       results = await getCalendarsEventsWithTimezones(withCredentials, startDate, endDate, selectedCalendars);


### PR DESCRIPTION
## What does this PR do?

This pull request introduces improvements to the caching logic for calendar availability and refines date handling in the `GoogleCalendarService` and related modules. The most important changes include expanding cache date ranges to improve cache hit rates, updating date calculation logic for edge cases, and enhancing unit tests for better coverage.

### Improvements to caching logic:

* [`CalendarService.ts`](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L666-R672): Updated `getCachedAvailability` to expand the `timeMin` and `timeMax` parameters to the start and end of the month, respectively, to increase cache hits. [[1]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L666-R672) [[2]](diffhunk://#diff-6bfbaf63c841dc9343dba0c7487e30a546ffe2a63c9d9418379d0dbb88644d27L1058-R1066)
* [`calendar-cache.repository.ts`](diffhunk://#diff-4cf8d3089fad7b6c8fe4172d8d42147f136b65baf30b726e57b9b10d179d4a99L22-R22): Simplified the `parseKeyForCache` function by directly using `args.timeMin` and `args.timeMax` instead of recalculating them.

### Refinements to date handling:

* [`datesForCache.ts`](diffhunk://#diff-394e8011261a8266dcd61e91e2401d8c31708d7a2b8448ca87e2ef9fd5ee8f19R26-R56): Updated the `getTimeMax` function to handle edge cases, such as year transitions and dates beyond the next two months, with clearer logic and comments.
* [`CalendarManager.ts`](diffhunk://#diff-1c8196abc9f4b39046f6f6faea103fbb60ce2d2ac96a409c9a65866234b3fd90L172-R172): Adjusted the `endDate` calculation to remove unnecessary calls to `.endOf("month")`, simplifying the logic.

### Enhancements to test coverage:

* [`datesForCache.test.ts`](diffhunk://#diff-a4f4e261b49f6bc4a915c5d1a8f226a641b3ed9643d801d3fac424bdb4e8acbbR78-R96): Added new test cases for `getTimeMax` to verify behavior during year transitions, next-month scenarios, and special cases where the date range spans more than two months but less than three months.

## How should this be tested?

- I've tested locally with google account
- Cache was hit on current and next month
- Added test cases for parsing
