### PR TITLE
fix: dont persist last booking response, temporarily

### DIFF
--- a/packages/features/bookings/Booker/utils/lastBookingResponse.test.ts
+++ b/packages/features/bookings/Booker/utils/lastBookingResponse.test.ts
@@ -11,7 +11,7 @@ vi.mock("@calcom/lib/webstorage", () => ({
   },
 }));
 
-describe("Last Booking Response", () => {
+describe.skip("Last Booking Response", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/features/bookings/Booker/utils/lastBookingResponse.ts
+++ b/packages/features/bookings/Booker/utils/lastBookingResponse.ts
@@ -1,15 +1,16 @@
 import logger from "@calcom/lib/logger";
 import { localStorage } from "@calcom/lib/webstorage";
 
-const responsesToStore = ["email", "name"];
+// const responsesToStore = ["email", "name"];
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const setLastBookingResponse = (responses: Record<string, unknown> | null) => {
   return;
-  if (!responses) return;
-  const prevResponse = Object.fromEntries(
-    Object.entries(responses).filter(([key]) => responsesToStore.includes(key))
-  );
-  localStorage.setItem("lastBookingResponse", JSON.stringify(prevResponse));
+  // if (!responses) return;
+  // const prevResponse = Object.fromEntries(
+  //   Object.entries(responses).filter(([key]) => responsesToStore.includes(key))
+  // );
+  // localStorage.setItem("lastBookingResponse", JSON.stringify(prevResponse));
 };
 
 export const getLastBookingResponse = () => {

--- a/packages/features/bookings/Booker/utils/lastBookingResponse.ts
+++ b/packages/features/bookings/Booker/utils/lastBookingResponse.ts
@@ -4,6 +4,7 @@ import { localStorage } from "@calcom/lib/webstorage";
 const responsesToStore = ["email", "name"];
 
 export const setLastBookingResponse = (responses: Record<string, unknown> | null) => {
+  return;
   if (!responses) return;
   const prevResponse = Object.fromEntries(
     Object.entries(responses).filter(([key]) => responsesToStore.includes(key))


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Stopped saving the last booking response in local storage to prevent persisting user data. Disabled related tests.

<!-- End of auto-generated description by mrge. -->

