### PR TITLE
perf: Add credentialId index to selectedCalendar

### DIFF
--- a/packages/prisma/migrations/20250425220800_add_selected_calendar_credential_id_index/migration.sql
+++ b/packages/prisma/migrations/20250425220800_add_selected_calendar_credential_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "SelectedCalendar_credentialId_idx" ON "SelectedCalendar"("credentialId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -792,6 +792,7 @@ model SelectedCalendar {
   @@index([integration])
   @@index([externalId])
   @@index([eventTypeId])
+  @@index([credentialId])
 }
 
 enum EventTypeCustomInputType {


### PR DESCRIPTION
## What does this PR do?

We run this query to get `selectedCalendar` by credentialId a lot throughout the day. 1.05 times/second in fact, with a latency of 272.22ms and eating up tons of CPU on the DB. This table is also quite heavily written to and has 600,000+ records. Currently we don't have an index on `credentialId` and so this query does a seq scan.

Execution plan shows change from 45ms to 0.027ms

## How should this be tested?

- Make sure the index is successfully created when the migration is run

