### PR TITLE
fix: Handle acme.cal.local root path

### DIFF
--- a/apps/web/lib/__tests__/getThemeProviderProps.test.ts
+++ b/apps/web/lib/__tests__/getThemeProviderProps.test.ts
@@ -195,6 +195,11 @@ describe("getUniqueIdentifierForBookingPage", () => {
       const result = getUniqueIdentifierForBookingPage({ pathname: path });
       expect(result).toBe(expected);
     });
+
+    it("should return / for root path", () => {
+      const result = getUniqueIdentifierForBookingPage({ pathname: "/" });
+      expect(result).toBe("/");
+    });
   });
 
   describe("Team Pages", () => {

--- a/apps/web/lib/getThemeProviderProps.ts
+++ b/apps/web/lib/getThemeProviderProps.ts
@@ -16,6 +16,11 @@ const enum ThemeSupport {
  * The theme stays same for same identifier.
  */
 export function getUniqueIdentifierForBookingPage({ pathname }: { pathname: string }) {
+  if (pathname === "/") {
+    // For Org domains, we could have a booking page at root path too, so we use '/' as identifier
+    // As localStorage isn't shared for different org domains, it's safe to use '/' as identifier
+    return "/";
+  }
   const pathTokens = pathname.split("/").slice(1);
 
   // If it is a booking page then it could be one of the following:


### PR DESCRIPTION
https://acme.cal.com/ will be a valid booking page as it is an org domain and it shows Organization profile. 

That page doesn't support customizing theme, because themes are customizable only at Team or User level at the moment, but we fix the namespace for that still to avoid the warning and future support for that.