### PR TITLE
fix: Do not retrieve already persisted `lastBookingResponse`

### DIFF
--- a/packages/features/bookings/Booker/utils/lastBookingResponse.ts
+++ b/packages/features/bookings/Booker/utils/lastBookingResponse.ts
@@ -1,6 +1,3 @@
-import logger from "@calcom/lib/logger";
-import { localStorage } from "@calcom/lib/webstorage";
-
 // const responsesToStore = ["email", "name"];
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -14,11 +11,12 @@ export const setLastBookingResponse = (responses: Record<string, unknown> | null
 };
 
 export const getLastBookingResponse = () => {
-  const lastBookingResponse = localStorage.getItem("lastBookingResponse");
-  try {
-    return JSON.parse(lastBookingResponse ?? "{}");
-  } catch (err) {
-    logger.error("Error parsing lastBookingResponse: ", err);
-    return {};
-  }
+  return {};
+  // const lastBookingResponse = localStorage.getItem("lastBookingResponse");
+  // try {
+  //   return JSON.parse(lastBookingResponse ?? "{}");
+  // } catch (err) {
+  //   logger.error("Error parsing lastBookingResponse: ", err);
+  //   return {};
+  // }
 };


### PR DESCRIPTION
Follow up of https://github.com/calcom/cal.com/pull/20975

There will be persisted data in localStorage already, we don't want to use that too. This is to ensure that users must always fill the booker form name and email unless
- It is prefilled intentionally through query params
- Or prefilled from session details