### PR TITLE
fix: Skip already completed org onboarding, as webhook request can come when invoice is paid again next month

### DIFF
--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -78,6 +78,15 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
         stripeSubscriptionId: organizationOnboarding.stripeSubscriptionId,
       })
     );
+
+    if (organizationOnboarding.isComplete) {
+      // If the organization is already complete and user is making a repeat payment, we can skip the rest of the flow
+      return {
+        success: true,
+        message: "Onboarding already completed, skipping",
+      };
+    }
+
     const { organization } = await createOrganizationFromOnboarding({
       organizationOnboarding,
       paymentSubscriptionId,


### PR DESCRIPTION
## What does this PR do?

Skip processing if an onboarding is already marked completed. Repeat webhook request will keep on coming for recurring payments