### PR TITLE
fix: hide organizer email in cal video sidebar

### DIFF
--- a/apps/web/modules/videos/views/videos-single-view.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.tsx
@@ -225,8 +225,12 @@ export function VideoMeetingInfo(props: VideoMeetingInfo) {
 
           <h3>{t("who")}:</h3>
           <p>
-            {booking?.user?.name} - {t("organizer")}:{" "}
-            <a href={`mailto:${booking?.user?.email}`}>{booking?.user?.email}</a>
+            {booking?.user?.name} - {t("organizer")}
+            {!booking?.eventType?.hideOrganizerEmail && (
+              <>
+                : <a href={`mailto:${booking?.user?.email}`}>{booking?.user?.email}</a>
+              </>
+            )}
           </p>
 
           {booking.attendees.length

--- a/packages/lib/server/repository/booking.ts
+++ b/packages/lib/server/repository/booking.ts
@@ -371,6 +371,11 @@ export class BookingRepository {
         uid: true,
         description: true,
         isRecorded: true,
+        eventType: {
+          select: {
+            hideOrganizerEmail: true,
+          },
+        },
         user: {
           select: {
             id: true,


### PR DESCRIPTION
## Summary by mrge
Hid the organizer's email in the video meeting sidebar when the event type is set to hide it.

<!-- End of auto-generated description by mrge. -->

