### PR TITLE
chore: format calendar events to remove oauthClientIds

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.176",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.178",
     "@calcom/platform-libraries-0.0.2": "npm:@calcom/platform-libraries@0.0.2",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -8,6 +8,7 @@ import {
   CalendarAppDelegationCredentialConfigurationError,
 } from "@calcom/lib/CalendarAppError";
 import { handleErrorsJson, handleErrorsRaw } from "@calcom/lib/errors";
+import { formatCalEvent } from "@calcom/lib/formatCalendarEvent";
 import logger from "@calcom/lib/logger";
 import type { BufferedBusyTime } from "@calcom/types/BufferedBusyTime";
 import type {
@@ -249,9 +250,10 @@ export default class Office365CalendarService implements Calendar {
         ? `${await this.getUserEndpoint()}/calendars/${mainHostDestinationCalendar?.externalId}/events`
         : `${await this.getUserEndpoint()}/calendar/events`;
 
+      const formattedEvent = formatCalEvent(event);
       const response = await this.fetcher(eventsUrl, {
         method: "POST",
-        body: JSON.stringify(this.translateEvent(event)),
+        body: JSON.stringify(this.translateEvent(formattedEvent)),
       });
 
       const responseJson = await handleErrorsJson<NewCalendarEventType & { iCalUId: string }>(response);

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -32,6 +32,7 @@ import type { CredentialPayload } from "@calcom/types/Credential";
 
 import { getLocation, getRichDescription } from "./CalEventParser";
 import { symmetricDecrypt } from "./crypto";
+import { formatCalEvent } from "./formatCalendarEvent";
 import logger from "./logger";
 
 const TIMEZONE_FORMAT = "YYYY-MM-DDTHH:mm:ss[Z]";
@@ -139,10 +140,10 @@ export default abstract class BaseCalendarService implements Calendar {
     return attendees;
   }
 
-  async createEvent(event: CalendarEvent, credentialId: number): Promise<NewCalendarEventType> {
+  async createEvent(eventRaw: CalendarEvent, credentialId: number): Promise<NewCalendarEventType> {
     try {
-      const calendars = await this.listCalendars(event);
-
+      const calendars = await this.listCalendars(eventRaw);
+      const event = formatCalEvent(eventRaw);
       const uid = uuidv4();
 
       // We create local ICS files


### PR DESCRIPTION
## What does this PR do?

Format calendar events before creating them on outlook and apple calendar in order to remove oauth client ids from organizer emails and attendee emails 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Calendar events are now formatted to remove oauthClientIds from organizer and attendee emails before creating events on Outlook and Apple Calendar.

- **Dependencies**
  - Updated @calcom/platform-libraries to version 0.0.178.

<!-- End of auto-generated description by mrge. -->

