### PR TITLE
fix: cal.cache not working

### DIFF
--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -52,7 +52,7 @@ export const useSchedule = ({
     : null;
   const skipContactOwner = searchParams ? searchParams.get("cal.skipContactOwner") === "true" : false;
   const _cacheParam = searchParams?.get("cal.cache");
-  const shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
+  const _shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
   const utils = trpc.useUtils();
   const routingFormResponseIdParam = searchParams?.get("cal.routingFormResponseId");
   const email = searchParams?.get("email");
@@ -80,7 +80,7 @@ export const useSchedule = ({
     teamMemberEmail,
     routedTeamMemberIds,
     skipContactOwner,
-    shouldServeCache,
+    _shouldServeCache,
     routingFormResponseId,
     email,
   };

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -278,7 +278,7 @@ export const BookerPlatformWrapper = (
 
   const [routingParams, setRoutingParams] = useState<{
     routedTeamMemberIds?: number[];
-    shouldServeCache?: boolean;
+    _shouldServeCache?: boolean;
     skipContactOwner?: boolean;
     isBookingDryRun?: boolean;
   }>({});

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -292,14 +292,14 @@ export const BookerPlatformWrapper = (
     const skipContactOwner = searchParams.get("cal.skipContactOwner") === "true";
 
     const _cacheParam = searchParams?.get("cal.cache");
-    const shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
+    const _shouldServeCache = _cacheParam ? _cacheParam === "true" : undefined;
     const isBookingDryRun =
       searchParams?.get("cal.isBookingDryRun")?.toLowerCase() === "true" ||
       searchParams?.get("cal.sandbox")?.toLowerCase() === "true";
     setRoutingParams({
       ...(skipContactOwner ? { skipContactOwner } : {}),
       ...(routedTeamMemberIds ? { routedTeamMemberIds } : {}),
-      ...(shouldServeCache ? { shouldServeCache } : {}),
+      ...(_shouldServeCache ? { _shouldServeCache } : {}),
       ...(isBookingDryRun ? { isBookingDryRun } : {}),
     });
   }, [routingFormSearchParams]);


### PR DESCRIPTION
## What does this PR do?

Fixed an issue where the cal.cache URL parameter was not being passed correctly, so disabling caching for schedule slots per URL did not work.

- **Bug Fixes**
  - Updated parameter naming to use _shouldServeCache, matching backend expectations.

