### PR TITLE
fix: GET Event-Type without username

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -14,19 +14,19 @@ import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import {
-  Controller,
-  UseGuards,
-  Get,
-  Param,
-  Post,
   Body,
-  NotFoundException,
-  Patch,
+  Controller,
+  Delete,
+  Get,
   HttpCode,
   HttpStatus,
-  Delete,
-  Query,
+  NotFoundException,
+  Param,
   ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
@@ -37,10 +37,10 @@ import {
   VERSION_2024_06_14,
 } from "@calcom/platform-constants";
 import {
-  UpdateEventTypeInput_2024_06_14,
-  GetEventTypesQuery_2024_06_14,
   CreateEventTypeInput_2024_06_14,
   EventTypeOutput_2024_06_14,
+  GetEventTypesQuery_2024_06_14,
+  UpdateEventTypeInput_2024_06_14,
 } from "@calcom/platform-types";
 
 @Controller({
@@ -109,11 +109,15 @@ export class EventTypesController_2024_06_14 {
   }
 
   @Get("/")
+  @Permissions([EVENT_TYPE_READ])
+  @UseGuards(ApiAuthGuard)
+  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({ summary: "Get all event types" })
   async getEventTypes(
-    @Query() queryParams: GetEventTypesQuery_2024_06_14
+    @Query() queryParams: GetEventTypesQuery_2024_06_14,
+    @GetUser() user: UserWithProfile
   ): Promise<GetEventTypesOutput_2024_06_14> {
-    const eventTypes = await this.eventTypesService.getEventTypes(queryParams);
+    const eventTypes = await this.eventTypesService.getEventTypes(queryParams, user);
     const eventTypesFormatted = this.eventTypeResponseTransformPipe.transform(eventTypes);
     const eventTypesWithoutHiddenFields = eventTypesFormatted.map((eventType) => {
       return {

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
@@ -181,7 +181,7 @@ export class EventTypesService_2024_06_14 {
     return await getEventTypesPublic(user.id);
   }
 
-  async getEventTypes(queryParams: GetEventTypesQuery_2024_06_14) {
+  async getEventTypes(queryParams: GetEventTypesQuery_2024_06_14, authUser?: UserWithProfile) {
     const { username, eventSlug, usernames, orgSlug, orgId } = queryParams;
     if (username && eventSlug) {
       const eventType = await this.getEventTypeByUsernameAndSlug(username, eventSlug, orgSlug, orgId);
@@ -195,6 +195,10 @@ export class EventTypesService_2024_06_14 {
     if (usernames) {
       const dynamicEventType = await this.getDynamicEventType(usernames, orgSlug, orgId);
       return [dynamicEventType];
+    }
+
+    if (authUser) {
+      return await this.getUserEventTypes(authUser.id);
     }
 
     return [];

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -8342,6 +8342,15 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "value must be `Bearer <token>` where `<token>` is api key prefixed with cal_ or managed user access token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We're able to get event-types based of without the addition of `username` to query parameter in V2 of API, similar to V1 however we would require addition of `api-key` within the header of the request.

- Fixes #18396 (GitHub issue number)
- Fixes CAL-4969 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Try to hit the endpoint below, and test it out if its working locally

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? No
- What are the minimal test data to have? Event-Type created 
- What is expected (happy path) to have (input and output)? Hit the endpoint and receive the response with an event type
- Any other important info that could help to test that PR

```
GET localhost:3004/v2/event-types
Authorization: Bearer cal_80fdb6b64d331fff0362eea8ad3933a9
cal-api-version: 2024-06-14
```

## Checklist

<!-- Remove bullet points below that don't apply to you -->


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
You can now fetch all event types from the v2 API without including a username in the query. The request requires an API key in the Authorization header.

- **Bug Fixes**
  - Updated the GET /v2/event-types endpoint to support requests without a username, using authentication from the API key.

<!-- End of auto-generated description by mrge. -->

