### PR TITLE
fix: add missing 'add' in profile username tip (#21049)

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3066,7 +3066,7 @@
   "link": "Link",
   "rows_per_page": "rows per page",
   "pagination_status": "{{currentRange}} of {{totalItems}}",
-  "tip_username_plus": "Tip: You can a '+' between usernames: cal.com/anna+brian to make a dynamic group meeting",
+  "tip_username_plus": "Tip: You can add a '+' between usernames: cal.com/anna+brian to make a dynamic group meeting",
   "user_has_no_team_yet": "You don't have a team yet",
   "no_team_members": "You don't have team members yet",
   "recurring_event_doesnt_support_seats": "Recurring event doesn't support seats feature. Make it non-recurring to enable seats.",


### PR DESCRIPTION
fixed the missing add a in the profile username tip
![Screenshot from 2025-05-03 22-37-59](https://github.com/user-attachments/assets/7ee6dcac-0578-4657-96da-35d502d2f0bd)

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a typo in the profile username tip by adding the missing word "add" for clearer instructions.

<!-- End of auto-generated description by mrge. -->

