### PR TITLE
fix: typos in apps/api/v2

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/emails/confirm-emails.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/emails/confirm-emails.e2e-spec.ts
@@ -385,7 +385,7 @@ describe("Bookings Endpoints 2024-08-13 confirm emails", () => {
               emailsEnabledSetup.createdBookingUid = responseBody.data.uid;
             } else {
               throw new Error(
-                "Invalid response data - expected booking but received array of possibily recurring bookings"
+                "Invalid response data - expected booking but received array of possibly recurring bookings"
               );
             }
           });
@@ -430,7 +430,7 @@ describe("Bookings Endpoints 2024-08-13 confirm emails", () => {
                 emailsEnabledSetup.rescheduledBookingUid = responseBody.data.uid;
               } else {
                 throw new Error(
-                  "Invalid response data - expected booking but received array of possibily recurring bookings"
+                  "Invalid response data - expected booking but received array of possibly recurring bookings"
                 );
               }
             });
@@ -459,7 +459,7 @@ describe("Bookings Endpoints 2024-08-13 confirm emails", () => {
                 emailsEnabledSetup.rescheduledBookingUid = responseBody.data.uid;
               } else {
                 throw new Error(
-                  "Invalid response data - expected booking but received array of possibily recurring bookings"
+                  "Invalid response data - expected booking but received array of possibly recurring bookings"
                 );
               }
             });
@@ -502,7 +502,7 @@ describe("Bookings Endpoints 2024-08-13 confirm emails", () => {
               emailsEnabledSetup.createdBookingUid = responseBody.data.uid;
             } else {
               throw new Error(
-                "Invalid response data - expected booking but received array of possibily recurring bookings"
+                "Invalid response data - expected booking but received array of possibly recurring bookings"
               );
             }
           });

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/user-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/e2e/user-bookings.e2e-spec.ts
@@ -583,7 +583,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
               expect(data.rating).toEqual(bookingInThePast.rating);
             } else {
               throw new Error(
-                "Invalid response data - expected booking but received array of possibily recurring bookings"
+                "Invalid response data - expected booking but received array of possibly recurring bookings"
               );
             }
           });
@@ -642,7 +642,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
               await bookingsRepositoryFixture.deleteById(mockBooking.id);
             } else {
               throw new Error(
-                "Invalid response data - expected booking but received array of possibily recurring bookings"
+                "Invalid response data - expected booking but received array of possibly recurring bookings"
               );
             }
           });

--- a/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
@@ -38,7 +38,7 @@ export class OrganizationsUsersRepository {
         member: {
           teamId: orgId,
           ...(teamIds && { user: { teams: { some: { teamId: { in: teamIds } } } } }),
-          // Filter to only get users which have ALL of the assigned attribue options
+          // Filter to only get users which have ALL of the assigned attribute options
           ...(attributeQueryOperator === "AND" && {
             AND: assignedOptionIds.map((optionId) => ({
               AttributeToUser: { some: { attributeOptionId: optionId } },
@@ -46,11 +46,11 @@ export class OrganizationsUsersRepository {
           }),
         },
         ...(emailArray && emailArray.length ? { email: { in: emailArray } } : {}),
-        // Filter to get users which have AT LEAST ONE of the assigned attribue options
+        // Filter to get users which have AT LEAST ONE of the assigned attribute options
         ...(attributeQueryOperator === "OR" && {
           attributeOption: { id: { in: assignedOptionIds } },
         }),
-        // Filter to  get users that have NONE the assigned attribue options
+        // Filter to  get users that have NONE the assigned attribute options
         ...(attributeQueryOperator === "NONE" && {
           NOT: {
             attributeOption: { id: { in: assignedOptionIds } },

--- a/apps/api/v2/src/modules/tokens/tokens.repository.ts
+++ b/apps/api/v2/src/modules/tokens/tokens.repository.ts
@@ -149,7 +149,7 @@ export class TokensRepository {
       this.dbWrite.prisma.refreshToken.create({
         data: {
           // note(Lauris): I am leaving userId because it was before adding ownerId to standardize payload like in the createOAuthTokens function for
-          // backwards compatability.
+          // backwards compatibility.
           secret: this.jwtService.signRefreshToken({
             clientId,
             ownerId: tokenUserId,


### PR DESCRIPTION
## What does this PR do?

Fixes typos in apps/api/v2 directory

Found via `codespell -q 3 -S "*.svg,./apps/web/public/static/locales,./packages/app-store/stripepayment/lib/currencyOptions.ts,./packages/lib/freeEmailDomainCheck/freeEmailDomains.ts" -L afterall,atleast,datea,fo,incase,ist,nam,notin,optionel,perview,reccuring`

Closes #21104

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

n/a

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed typos in comments and error messages in the apps/api/v2 directory to improve code clarity.

<!-- End of auto-generated description by mrge. -->

