### PR TITLE
chore: Add proton.me to email provider list

### DIFF
--- a/packages/features/ee/organizations/lib/server/orgCreationUtils.ts
+++ b/packages/features/ee/organizations/lib/server/orgCreationUtils.ts
@@ -31,6 +31,7 @@ function isNotACompanyEmail(email: string) {
     "icloud.com",
     "mail.com",
     "protonmail.com",
+    "proton.me",
     "zoho.com",
     "yandex.com",
     "gmx.com",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added proton.me to the list of recognized email providers for organization creation checks.

<!-- End of auto-generated description by mrge. -->

