### PR TITLE
fix: improvements for scheduling Email reminders

### DIFF
--- a/packages/features/ee/workflows/lib/getWorkflowReminders.ts
+++ b/packages/features/ee/workflows/lib/getWorkflowReminders.ts
@@ -78,12 +78,15 @@ async function getWorkflowReminders<T extends Prisma.WorkflowReminderSelect>(
   return filteredWorkflowReminders;
 }
 
-type RemindersToDeleteType = { referenceId: string | null };
+type RemindersToDeleteType = { referenceId: string | null; id: number };
 
 export async function getAllRemindersToDelete(): Promise<RemindersToDeleteType[]> {
   const whereFilter: Prisma.WorkflowReminderWhereInput = {
     method: WorkflowMethods.EMAIL,
     cancelled: true,
+    referenceId: {
+      not: null,
+    },
     scheduledDate: {
       lt: dayjs().toISOString(),
     },
@@ -91,6 +94,7 @@ export async function getAllRemindersToDelete(): Promise<RemindersToDeleteType[]
 
   const select = Prisma.validator<Prisma.WorkflowReminderSelect>()({
     referenceId: true,
+    id: true,
   });
 
   const remindersToDelete = await getWorkflowReminders(whereFilter, select);

--- a/packages/trpc/server/routers/viewer/workflows/util.ts
+++ b/packages/trpc/server/routers/viewer/workflows/util.ts
@@ -565,6 +565,9 @@ async function getBookings(activeOn: number[], isOrg: boolean, alreadyScheduledA
         },
       },
       select: bookingSelect,
+      orderBy: {
+        startTime: "asc",
+      },
     });
     return bookingsForReminders;
   } else {
@@ -586,6 +589,9 @@ async function getBookings(activeOn: number[], isOrg: boolean, alreadyScheduledA
         },
       },
       select: bookingSelect,
+      orderBy: {
+        startTime: "asc",
+      },
     });
     return bookingsForReminders;
   }


### PR DESCRIPTION
## What does this PR do?

When we switch to tasker, don't schedule all emails at once instead only schedule for the next two hours. 
