### PR TITLE
fix: v2 organization user deletion

### DIFF
--- a/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
@@ -141,7 +141,11 @@ export class OrganizationsUsersRepository {
     return await this.dbWrite.prisma.user.delete({
       where: {
         id: userId,
-        organizationId: orgId,
+        profiles: {
+          some: {
+            organizationId: orgId,
+          },
+        },
       },
       include: {
         profiles: {

--- a/apps/api/v2/src/modules/organizations/users/index/services/organizations-users-service.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/services/organizations-users-service.ts
@@ -1,3 +1,4 @@
+import { Locales } from "@/lib/enums/locales";
 import { EmailService } from "@/modules/email/email.service";
 import { CreateOrganizationUserInput } from "@/modules/organizations/users/index/inputs/create-organization-user.input";
 import { UpdateOrganizationUserInput } from "@/modules/organizations/users/index/inputs/update-organization-user.input";
@@ -89,6 +90,7 @@ export class OrganizationsUsersService {
           autoAccept: userCreateBody.autoAccept,
         },
       },
+      language: userCreateBody.locale ?? Locales.EN,
     });
 
     const createdUser = createdUserCall[0];


### PR DESCRIPTION
Linear [CAL-5688](https://linear.app/calcom/issue/CAL-5688/fix-delete-organization-user-endpoint-not-working-api-v2)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed the organization user deletion endpoint in API v2 so users are now correctly removed from organizations. Also set the default language to English when creating organization users if no locale is provided.

<!-- End of auto-generated description by mrge. -->

