### PR TITLE
fix: delete organization user endpoint not working in api v2

### DIFF
--- a/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/organizations-users.repository.ts
@@ -141,7 +141,16 @@ export class OrganizationsUsersRepository {
     return await this.dbWrite.prisma.user.delete({
       where: {
         id: userId,
-        organizationId: orgId,
+        OR: [
+          { organizationId: orgId },
+          {
+            profiles: {
+              some: {
+                organizationId: orgId,
+              },
+            },
+          },
+        ],
       },
       include: {
         profiles: {


### PR DESCRIPTION
## What does this PR do?

 Delete organization user endpoint not working in api v2

- Fixes #21021 (GitHub issue number)
- Fixes CAL-5688 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Follow the instruction to run the API https://cal.com/docs/developing/guides/api/how-to-setup-api-in-a-local-instance
- Find an org ID which already exists and send the following API request to get all the users
```
curl "http://localhost:3001/v2/organizations/{orgId}/users" -H "Authorization: Bearer TOKEN"
```
replace the `orgId` with the ID from step 2 and `TOKEN` with your organization token
- Send the following API request to delete the user
```
curl -X DELETE "http://localhost:3001/v2/organizations/{orgId}/users/{userId}" -H "Authorization: Bearer TOKEN"
```
replace the `orgId` with the ID from step 2, `userId` with any value from previous step and `TOKEN` with your organization token


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed the delete organization user endpoint in API v2 so users can now be removed from organizations as expected.

- **Bug Fixes**
  - Updated the user deletion logic to handle users linked by organization profiles as well as direct organization membership.

<!-- End of auto-generated description by mrge. -->

