### PR TITLE
fix: don't allow double reserving already reserved slot

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -454,9 +454,6 @@ describe("Slots 2024-09-04 Endpoints", () => {
       expect(responseReservedSlot.eventTypeId).toEqual(eventTypeId);
       expect(responseReservedSlot.slotStart).toEqual(slotStartTime);
       expect(responseReservedSlot.slotDuration).toEqual(eventTypeLength);
-      console.log("asap responseReservedSlot.slotStart", responseReservedSlot.slotStart);
-      console.log("asap responseReservedSlot.slotDuration", responseReservedSlot.slotDuration);
-      console.log("asap responseReservedSlot.slotEnd", responseReservedSlot.slotEnd);
       expect(responseReservedSlot.slotEnd).toEqual(
         DateTime.fromISO(slotStartTime, { zone: "UTC" }).plus({ minutes: eventTypeLength }).toISO()
       );

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -507,8 +507,8 @@ describe("Slots 2024-09-04 Endpoints", () => {
     });
 
     describe("overlapping slot reservations", () => {
-      it("user-event-type-slots-overlap-starts-during-${randomString()}", async () => {
-        // Try to reserve 10:15-10:45 when 10:00-10:30 is taken
+      it("start of request slot overlaps already existing reserved slot", async () => {
+        // Try to reserve 10:15-11:15 when 10:00-11:00 is taken (60 min event)
         const newSlotStart = DateTime.fromISO(reservedSlot.slotStart).plus({ minutes: 15 }).toISO();
 
         await request(app.getHttpServer())
@@ -526,8 +526,8 @@ describe("Slots 2024-09-04 Endpoints", () => {
           });
       });
 
-      it("user-event-type-slots-overlap-ends-during-${randomString()}", async () => {
-        // Try to reserve 9:45-10:15 when 10:00-10:30 is taken
+      it("end of request slot overlaps already existing reserved slot", async () => {
+        // Try to reserve 9:45-10:45 when 10:00-11:00 is taken (60 min event)
         const newSlotStart = DateTime.fromISO(reservedSlot.slotStart).minus({ minutes: 15 }).toISO();
 
         await request(app.getHttpServer())
@@ -545,8 +545,8 @@ describe("Slots 2024-09-04 Endpoints", () => {
           });
       });
 
-      it("user-event-type-slots-overlap-inside-${randomString()}", async () => {
-        // Try to reserve 10:10-10:20 when 10:00-10:30 is taken
+      it("request slot is inside already existing reserved slot", async () => {
+        // Try to reserve 10:10-11:10 when 10:00-11:00 is taken (60 min event)
         const newSlotStart = DateTime.fromISO(reservedSlot.slotStart).plus({ minutes: 10 }).toISO();
 
         await request(app.getHttpServer())
@@ -1410,8 +1410,8 @@ describe("Slots 2024-09-04 Endpoints", () => {
         clear();
       });
 
-      it("user-event-type-slots-overlap-contains-${randomString()}", async () => {
-        // Try to reserve 9:45-12:45 when 10:00-10:30 is taken
+      it("request slot contains already existing reserved slot", async () => {
+        // Try to reserve 9:45-12:45 when 10:00-11:00 is taken
         const newSlotStart = DateTime.fromISO(responseReservedVariableSlot.slotStart)
           .minus({ minutes: 15 })
           .toISO();

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
@@ -124,17 +124,7 @@ export class SlotsService_2024_09_04 {
 
     const reservationDuration = input.reservationDuration ?? DEFAULT_RESERVATION_DURATION;
 
-    const overlappingReservation = await this.slotsRepository.getOverlappingSlotReservation(
-      input.eventTypeId,
-      startDate.toISO(),
-      endDate.toISO()
-    );
-
-    if (overlappingReservation) {
-      throw new UnprocessableEntityException(
-        `This time slot is already reserved by another user. Please choose a different time.`
-      );
-    }
+    await this.checkSlotOverlap(input.eventTypeId, startDate.toISO(), endDate.toISO());
 
     if (eventType.userId) {
       const slot = await this.slotsRepository.createSlot(
@@ -163,6 +153,20 @@ export class SlotsService_2024_09_04 {
     );
 
     return this.slotsOutputService.getReservationSlotCreated(slot, reservationDuration);
+  }
+
+  private async checkSlotOverlap(eventTypeId: number, startDate: string, endDate: string) {
+    const overlappingReservation = await this.slotsRepository.getOverlappingSlotReservation(
+      eventTypeId,
+      startDate,
+      endDate
+    );
+
+    if (overlappingReservation) {
+      throw new UnprocessableEntityException(
+        `This time slot is already reserved by another user. Please choose a different time.`
+      );
+    }
   }
 
   validateSlotDuration(eventType: EventType, inputSlotDuration: number) {
@@ -268,6 +272,8 @@ export class SlotsService_2024_09_04 {
     }
 
     const reservationDuration = input.reservationDuration ?? DEFAULT_RESERVATION_DURATION;
+
+    await this.checkSlotOverlap(input.eventTypeId, startDate.toISO(), endDate.toISO());
 
     const slot = await this.slotsRepository.updateSlot(
       eventType.id,

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/services/slots.service.ts
@@ -124,6 +124,18 @@ export class SlotsService_2024_09_04 {
 
     const reservationDuration = input.reservationDuration ?? DEFAULT_RESERVATION_DURATION;
 
+    const overlappingReservation = await this.slotsRepository.getOverlappingSlotReservation(
+      input.eventTypeId,
+      startDate.toISO(),
+      endDate.toISO()
+    );
+
+    if (overlappingReservation) {
+      throw new UnprocessableEntityException(
+        `This time slot is already reserved by another user. Please choose a different time.`
+      );
+    }
+
     if (eventType.userId) {
       const slot = await this.slotsRepository.createSlot(
         eventType.userId,

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/slots.repository.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/slots.repository.ts
@@ -37,7 +37,7 @@ export class SlotsRepository_2024_09_04 {
             ],
           },
           // Only consider non-expired reservations
-          { releaseAt: { gt: new Date() } },
+          { releaseAt: { gt: DateTime.utc().toJSDate() } },
         ],
       },
     });


### PR DESCRIPTION
Linear [CAL-5721](https://linear.app/calcom/issue/CAL-5721/fix-dont-allow-conflict-for-reserved-slots)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Prevented users from reserving a time slot that overlaps with an already reserved slot.

- **Bug Fixes**
  - Added checks to block double booking of overlapping slots.
  - Updated tests to cover overlapping reservation scenarios.

<!-- End of auto-generated description by mrge. -->

