### PR TITLE
fix: advanced text filters getBookings with kysely

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -424,7 +424,6 @@ export async function getBookings({
           "Booking.endTime",
           "Booking.metadata",
           "Booking.uid",
-
           eb
             .cast<Prisma.JsonValue>( // Target TypeScript type
               eb.ref("Booking.responses"), // Source column
@@ -928,7 +927,7 @@ function addAdvancedAttendeeWhereClause(
   isAttendeeTableJoined: boolean
 ) {
   let fullQuery = query.$if(!isAttendeeTableJoined, (eb) =>
-    eb.innerJoin("Attendee", "Attendee.id", "Booking.id")
+    eb.innerJoin("Attendee", "Attendee.bookingId", "Booking.id")
   ) as SelectQueryBuilder<
     DB,
     "Booking" | "Attendee",


### PR DESCRIPTION
## What does this PR do?

Fix inner join mistake on attendee table when using advanced text filters

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A -  I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an inner join error on the attendee table in advanced text filters for getBookings, ensuring correct booking and attendee matching.

<!-- End of auto-generated description by mrge. -->

