### PR TITLE
fix: decline-booking-reason-missing

### DIFF
--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -68,6 +68,11 @@ export const BaseScheduledEmail = (
           : props.callToAction || <ManageLink attendee={props.attendee} calEvent={props.calEvent} />
       }
       subtitle={props.subtitle || <>{t("emailed_you_and_any_other_attendees")}</>}>
+      {props.calEvent.rejectionReason && (
+        <>
+          <Info label={t("rejection_reason")} description={props.calEvent.rejectionReason} withSpacer />
+        </>
+      )}
       {props.calEvent.cancellationReason && (
         <Info
           label={t(


### PR DESCRIPTION
## What does this PR do?

fix(emails): populate rejection reason in decline emails

- Added conditional rendering of rejection reason in BaseScheduledEmail
- Only displays reason when present in calEvent object

The rejection reason was being properly stored but not displayed in 
attendee decline emails. This change ensures the reason shows when provided.

- Fixes #21132 

#### Image Demo (if applicable):

![Screenshot from 2025-05-07 03-40-37](https://github.com/user-attachments/assets/7eda79f0-3928-42a9-b198-e85b59a6d37b)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Book a slot (as attendee) in an event requiring approval.
- Reject the booking (as organizer), providing a rejection reason.
- Verify the rejection email includes the reason.

- Are there environment variables that should be set? 
No
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Decline emails now show the rejection reason when provided, so attendees can see why their booking was declined.

- **Bug Fixes**
  - Added conditional display of the rejection reason in decline emails.

<!-- End of auto-generated description by mrge. -->

