### PR TITLE
fix: api v2 routing form responses flaky tests

### DIFF
--- a/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms-responses.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/routing-forms/controllers/organizations-routing-forms-responses.controller.e2e-spec.ts
@@ -126,36 +126,6 @@ describe("OrganizationsRoutingFormsResponsesController", () => {
     await app.init();
   });
 
-  afterAll(async () => {
-    await prismaWriteService.prisma.app_RoutingForms_FormResponse.deleteMany({
-      where: {
-        formId: routingForm.id,
-      },
-    });
-    await prismaWriteService.prisma.app_RoutingForms_Form.deleteMany({
-      where: {
-        teamId: org.id,
-      },
-    });
-    await prismaWriteService.prisma.apiKey.deleteMany({
-      where: {
-        teamId: org.id,
-      },
-    });
-    await prismaWriteService.prisma.team.delete({
-      where: {
-        id: team.id,
-      },
-    });
-    await prismaWriteService.prisma.team.delete({
-      where: {
-        id: org.id,
-      },
-    });
-
-    await app.close();
-  });
-
   describe(`GET /v2/organizations/:orgId/routing-forms/:routingFormId/responses`, () => {
     it("should not get routing form responses for non existing org", async () => {
       return request(app.getHttpServer())
@@ -260,5 +230,45 @@ describe("OrganizationsRoutingFormsResponsesController", () => {
           expect(data.response).toEqual(updatedResponse);
         });
     });
+  });
+
+  afterAll(async () => {
+    await prismaWriteService.prisma.app_RoutingForms_FormResponse.delete({
+      where: {
+        id: routingFormResponse.id,
+      },
+    });
+    await prismaWriteService.prisma.app_RoutingForms_FormResponse.delete({
+      where: {
+        id: routingFormResponse2.id,
+      },
+    });
+    await prismaWriteService.prisma.app_RoutingForms_Form.deleteMany({
+      where: {
+        teamId: org.id,
+      },
+    });
+    await prismaWriteService.prisma.apiKey.deleteMany({
+      where: {
+        teamId: org.id,
+      },
+    });
+    await prismaWriteService.prisma.team.delete({
+      where: {
+        id: team.id,
+      },
+    });
+    await prismaWriteService.prisma.team.delete({
+      where: {
+        id: org.id,
+      },
+    });
+    await prismaWriteService.prisma.user.delete({
+      where: {
+        id: user.id,
+      },
+    });
+
+    await app.close();
   });
 });

--- a/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/routing-forms/controllers/organizations-teams-routing-forms-responses.controller.e2e-spec.ts
@@ -35,7 +35,7 @@ describe("Organizations Teams Routing Forms Responses", () => {
 
   let org: Team;
   let orgTeam: Team;
-  let routingFormResponseId: string;
+  let routingFormResponseId: number;
   const authEmail = `organizations-teams-routing-forms-responses-user-${randomString()}@api.com`;
   let user: User;
   let apiKeyString: string;
@@ -43,8 +43,7 @@ describe("Organizations Teams Routing Forms Responses", () => {
   let routingFormId: string;
   const routingFormResponses = [
     {
-      id: 1,
-      formFillerId: "cm78tvkvd0001kh8jq0tu5iq9",
+      formFillerId: `${randomString()}`,
       response: {
         "participant-field": {
           label: "participant",
@@ -184,7 +183,6 @@ describe("Organizations Teams Routing Forms Responses", () => {
         const responseData = responseBody.data;
         expect(responseData).toBeDefined();
         expect(responseData.length).toEqual(1);
-        expect(responseData[0].id).toEqual(routingFormResponses[0].id);
         expect(responseData[0].response).toEqual(routingFormResponses[0].response);
         expect(responseData[0].formFillerId).toEqual(routingFormResponses[0].formFillerId);
         expect(responseData[0].createdAt).toEqual(routingFormResponses[0].createdAt.toISOString());
@@ -248,6 +246,8 @@ describe("Organizations Teams Routing Forms Responses", () => {
   });
 
   afterAll(async () => {
+    await routingFormsRepositoryFixture.deleteResponse(routingFormResponseId);
+    await routingFormsRepositoryFixture.delete(routingFormId);
     await userRepositoryFixture.deleteByEmail(user.email);
     await organizationsRepositoryFixture.delete(org.id);
     await app.close();

--- a/apps/api/v2/test/fixtures/repository/routing-forms.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/routing-forms.repository.fixture.ts
@@ -1,7 +1,7 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { TestingModule } from "@nestjs/testing";
-import { Prisma, App_RoutingForms_Form } from "@prisma/client";
+import { Prisma, App_RoutingForms_Form, App_RoutingForms_FormResponse } from "@prisma/client";
 
 export class RoutingFormsRepositoryFixture {
   private prismaReadClient: PrismaReadService["prisma"];
@@ -22,5 +22,11 @@ export class RoutingFormsRepositoryFixture {
 
   async delete(routingFormId: App_RoutingForms_Form["id"]) {
     return this.prismaWriteClient.app_RoutingForms_Form.delete({ where: { id: routingFormId } });
+  }
+
+  async deleteResponse(routingFormResponseId: App_RoutingForms_FormResponse["id"]) {
+    return this.prismaWriteClient.app_RoutingForms_FormResponse.delete({
+      where: { id: routingFormResponseId },
+    });
   }
 }

--- a/packages/platform/types/routing-forms/responses/routing-form-response.output.ts
+++ b/packages/platform/types/routing-forms/responses/routing-form-response.output.ts
@@ -23,7 +23,7 @@ export class RoutingFormResponseOutput {
   @ApiProperty()
   @IsInt()
   @Expose()
-  id!: string;
+  id!: number;
 
   @ApiProperty()
   @IsInt()


### PR DESCRIPTION
## What does this PR do?

Fix flaky routing form response controllers test api v2

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed flaky tests in API v2 routing form response controllers by improving test cleanup and correcting response ID types.

- **Bug Fixes**
  - Updated test teardown to fully clean up test data.
  - Changed response ID fields from string to number for consistency.

<!-- End of auto-generated description by mrge. -->

