### PR TITLE
fix: attendees not visible for hosts in a seated team booking

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -152,28 +152,6 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     slug: eventType.team?.slug || eventType.users[0]?.username || null,
   };
 
-  if (bookingInfo !== null && eventType.seatsPerTimeSlot) {
-    await handleSeatsEventTypeOnBooking(
-      eventType,
-      bookingInfo,
-      seatReferenceUid,
-      session?.user.id === eventType.userId
-    );
-  }
-
-  const payment = await prisma.payment.findFirst({
-    where: {
-      bookingId: bookingInfo.id,
-    },
-    select: {
-      success: true,
-      refunded: true,
-      currency: true,
-      amount: true,
-      paymentOption: true,
-    },
-  });
-
   const userId = session?.user?.id;
 
   const checkIfUserIsHost = (userId?: number | null) => {
@@ -193,6 +171,23 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   };
 
   const isLoggedInUserHost = checkIfUserIsHost(userId);
+
+  if (bookingInfo !== null && eventType.seatsPerTimeSlot) {
+    await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
+  }
+
+  const payment = await prisma.payment.findFirst({
+    where: {
+      bookingId: bookingInfo.id,
+    },
+    select: {
+      success: true,
+      refunded: true,
+      currency: true,
+      amount: true,
+      paymentOption: true,
+    },
+  });
 
   if (!isLoggedInUserHost) {
     // Removing hidden fields from responses


### PR DESCRIPTION
## What does this PR do?

## Summary by mrge
Fixed an issue where hosts could not see attendees in seated team bookings. Hosts now have full visibility of attendee information during these bookings.

<!-- End of auto-generated description by mrge. -->

