### PR TITLE
fix: unable to change the workflow action

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -485,7 +485,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                               setIsEmailSubjectNeeded(true);
                             }
 
-                            form.unregister(`steps.${step.stepNumber - 1}.sendTo`);
+                            form.setValue(`steps.${step.stepNumber - 1}.sendTo`, null);
                             form.clearErrors(`steps.${step.stepNumber - 1}.sendTo`);
                             form.setValue(`steps.${step.stepNumber - 1}.action`, val.value);
                             setUpdateTemplate(!updateTemplate);


### PR DESCRIPTION
## What does this PR do?

## Summary by mrge
Fixed an issue where users could not change the workflow action in the workflow step editor. Now, selecting a new action updates the field as expected.

<!-- End of auto-generated description by mrge. -->

