### PR TITLE
fix: returning same booking for already confirmed booking

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
@@ -51,7 +51,7 @@ import {
   CancelBookingInput,
 } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";
-import { EventType, User, Team } from "@calcom/prisma/client";
+import { EventType, User, Team, BookingStatus } from "@calcom/prisma/client";
 
 type CreatedBooking = {
   hosts: { id: number }[];
@@ -723,6 +723,11 @@ export class BookingsService_2024_08_13 {
     const booking = await this.bookingsRepository.getByUid(bookingUid);
     if (!booking) {
       throw new NotFoundException(`Booking with uid=${bookingUid} was not found in the database`);
+    }
+
+    // if booking is already confirmed, return same booking
+    if (booking.status === BookingStatus.ACCEPTED) {
+      return this.getBooking(bookingUid);
     }
 
     const platformClientParams = booking.eventTypeId


### PR DESCRIPTION
## What does this PR do?

- Fixes #20941  (GitHub issue number)
fixes problem: 1

<img width="855" alt="Screenshot 2025-05-09 at 6 41 17 PM" src="https://github.com/user-attachments/assets/9f996db7-1dde-4a47-882e-9ba7643f1024" />

#### after change: 

- no longer throws error, and returns the same booking if already confirmed.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where a new booking was created for already confirmed bookings by returning the existing confirmed booking instead.

<!-- End of auto-generated description by mrge. -->

