### PR TITLE
fix: add org email into ics when hideorganizer email is true

### DIFF
--- a/packages/emails/lib/generateIcsString.test.ts
+++ b/packages/emails/lib/generateIcsString.test.ts
@@ -158,47 +158,4 @@ describe("generateIcsString", () => {
       expect(icsString).toEqual(expect.stringContaining(`LOCATION:${event.location}`));
     });
   });
-
-  describe("hidden organizer email", () => {
-    test("when hideOrganizerEmail is true, organizer email should be omitted", () => {
-      const event = buildCalendarEvent({
-        iCalSequence: 0,
-        attendees: [buildPerson()],
-        hideOrganizerEmail: true,
-      });
-      const status = "CONFIRMED";
-
-      const icsString = generateIcsString({
-        event: event,
-        status,
-      });
-
-      const assertedIcsString = assertHasIcsString(icsString);
-
-      expect(assertedIcsString).toEqual(expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}`));
-      expect(assertedIcsString).not.toEqual(
-        expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}:mailto:`)
-      );
-    });
-
-    test("when hideOrganizerEmail is false, organizer email should be included", () => {
-      const event = buildCalendarEvent({
-        iCalSequence: 0,
-        attendees: [buildPerson()],
-        hideOrganizerEmail: false,
-      });
-      const status = "CONFIRMED";
-
-      const icsString = generateIcsString({
-        event: event,
-        status,
-      });
-
-      const assertedIcsString = assertHasIcsString(icsString);
-
-      expect(assertedIcsString).toEqual(
-        expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}:mailto:${event.organizer.email}`)
-      );
-    });
-  });
 });

--- a/packages/emails/lib/generateIcsString.test.ts
+++ b/packages/emails/lib/generateIcsString.test.ts
@@ -31,14 +31,9 @@ const testIcsStringContains = ({
   // Sometimes the deeply equal stringMatching error appears. Don't want to add flakey tests
   // expect(icsString).toEqual(expect.stringContaining(`SUMMARY:${event.title}`));
   expect(icsString).toEqual(expect.stringContaining(`DTSTART:${DTSTART}`));
-  if (event.hideOrganizerEmail) {
-    expect(icsString).toEqual(expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}`));
-    expect(icsString).not.toEqual(expect.stringContaining(`mailto:${event.organizer.email}`));
-  } else {
-    expect(icsString).toEqual(
-      expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}:mailto:${event.organizer.email}`)
-    );
-  }
+  expect(icsString).toEqual(
+    expect.stringContaining(`ORGANIZER;CN=${event.organizer.name}:mailto:${event.organizer.email}`)
+  );
   expect(icsString).toEqual(expect.stringContaining(`DTEND:${DTEND}`));
   expect(icsString).toEqual(expect.stringContaining(`STATUS:${status}`));
   //   Getting an error expected icsString to deeply equal stringMatching

--- a/packages/emails/lib/generateIcsString.ts
+++ b/packages/emails/lib/generateIcsString.ts
@@ -74,10 +74,7 @@ const generateIcsString = ({
     productId: "calcom/ics",
     title: event.title,
     description: getRichDescription(event, t),
-    organizer: {
-      name: event.organizer.name,
-      ...(event.hideOrganizerEmail ? {} : { email: event.organizer.email }),
-    },
+    organizer: { name: event.organizer.name, email: event.organizer.email },
     ...{ recurrenceRule },
     attendees: [
       ...event.attendees.map((attendee: Person) => ({


### PR DESCRIPTION
## What does this PR do?



## Summary by mrge
Fixed calendar invites to always include the organizer's email in the ICS file, even when hideOrganizerEmail is true. This ensures the organizer's email is present for all events.

<!-- End of auto-generated description by mrge. -->

