### PR TITLE
fix: Credentials  cron for DelegationCredential not working

### DIFF
--- a/apps/web/app/api/cron/selected-calendars/route.ts
+++ b/apps/web/app/api/cron/selected-calendars/route.ts
@@ -36,8 +36,10 @@ async function handleCreateSelectedCalendars() {
   });
 
   if (!allDelegationUserCredentials.length) {
+    const message = "No delegation credentials found";
+    log.info(message);
     return {
-      message: "No delegation credentials found",
+      message,
       success: 0,
       failures: 0,
     };
@@ -158,17 +160,19 @@ async function handleCreateSelectedCalendars() {
     );
     const successCount = results.filter((r) => r.status === "fulfilled").length;
     const failureCount = results.filter((r) => r.status === "rejected").length;
-
+    log.info(
+      `Processed ${successCount} selected calendars for delegationCredentialId: ${delegationCredentialId} and ${failureCount} failures`
+    );
     totalSuccess += successCount;
     totalFailures += failureCount;
   }
 
   log.info(
-    `Completed processing all selected calendars. Total Success: ${totalSuccess}, Total Failures: ${totalFailures}`
+    `Completed creating selected calendars for all delegation credentials. Total Success: ${totalSuccess}, Total Failures: ${totalFailures}`
   );
 
   return {
-    message: "All selected calendars processed",
+    message: "All selected calendars created",
     executedAt: new Date().toISOString(),
     success: totalSuccess,
     failures: totalFailures,

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -826,7 +826,6 @@ export default class GoogleCalendarService implements Calendar {
       const primaryCalendar = this.filterPrimaryCalendar(cals);
       if (!primaryCalendar) return [];
       return [primaryCalendar.id];
-      return cals.reduce((c, cal) => (cal.id ? [...c, cal.id] : c), [] as string[]);
     };
 
     try {

--- a/packages/features/calendar-cache/calendar-cache.repository.ts
+++ b/packages/features/calendar-cache/calendar-cache.repository.ts
@@ -145,6 +145,8 @@ export class CalendarCacheRepository implements ICalendarCacheRepository {
         },
       },
       update: {
+        // Ensure that on update userId is also set(It handles the case where userId is not set for legacy records)
+        userId,
         value,
         expiresAt: new Date(Date.now() + CACHING_TIME),
       },


### PR DESCRIPTION
## What does this PR do?
Patially fixes PRI-269


- Fix the issue where having one `DelegationCredential` with office365 platform skips the cron for all delegation credentials instead of skipping it just for that `DelegationCredential`
- Fixes the issue where we weren't setting userId on update of CalendarCache. This is important to set so that through Delegation Credential flow, that existing CalendarCache record can be reused.

**Code Improvements**
- Improves the logging for cron
- Removes an unreachable return statement


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.



