### PR TITLE
fix: local storage in useTheme hook

### DIFF
--- a/packages/lib/hooks/useTheme.tsx
+++ b/packages/lib/hooks/useTheme.tsx
@@ -12,7 +12,9 @@ import { useEmbedTheme } from "@calcom/embed-core/embed-iframe";
 // eslint-disable-next-line @typescript-eslint/ban-types
 export default function useTheme(themeToSet: "system" | (string & {}) | undefined | null, getOnly = false) {
   if (typeof window !== "undefined") {
-    themeToSet = themeToSet || localStorage.getItem("app-theme") || "system";
+    const themeFromLocalStorage =
+      typeof window !== "undefined" && window.localStorage ? localStorage.getItem("app-theme") : null;
+    themeToSet = themeToSet ?? themeFromLocalStorage ?? "system";
   }
   const { resolvedTheme, setTheme, forcedTheme, theme: activeTheme } = useNextTheme();
   const embedTheme = useEmbedTheme();


### PR DESCRIPTION
## What does this PR do?

- Fixed a bug where accessing localStorage in useTheme could cause errors when window is undefined. Now checks for window and localStorage before reading the theme.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



