### PR TITLE
perf: don't load ring.mp3 on booking page

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import { getLocale } from "@calcom/features/auth/lib/getLocale";
 import { loadTranslations } from "@calcom/lib/server/i18n";
 import { IconSprites } from "@calcom/ui/components/icon";
-import { NotificationSoundHandler } from "@calcom/web/components/notification-sound-handler";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
@@ -101,6 +100,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   const { locale, direction, isEmbed, embedColorScheme } = await getInitialProps();
 
+  console.log("headers", h);
+
   const ns = "common";
   const translations = await loadTranslations(locale, ns);
 
@@ -152,13 +153,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           ]}
         />
 
-        <Providers>
+        <Providers isEmbed={isEmbed}>
           <AppRouterI18nProvider translations={translations} locale={locale} ns={ns}>
             {children}
           </AppRouterI18nProvider>
         </Providers>
-        {!isEmbed && <NotificationSoundHandler />}
-        <NotificationSoundHandler />
       </body>
     </html>
   );

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -100,8 +100,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   const { locale, direction, isEmbed, embedColorScheme } = await getInitialProps();
 
-  console.log("headers", h);
-
   const ns = "common";
   const translations = await loadTranslations(locale, ns);
 

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -5,20 +5,23 @@ import { SessionProvider } from "next-auth/react";
 import CacheProvider from "react-inlinesvg/provider";
 
 import { WebPushProvider } from "@calcom/features/notifications/WebPushContext";
+import { NotificationSoundHandler } from "@calcom/web/components/notification-sound-handler";
 
 import useIsBookingPage from "@lib/hooks/useIsBookingPage";
 import PlainChat from "@lib/plain/dynamicProvider";
 
 type ProvidersProps = {
+  isEmbed: boolean;
   children: React.ReactNode;
 };
-export function Providers({ children }: ProvidersProps) {
+export function Providers({ isEmbed, children }: ProvidersProps) {
   const isBookingPage = useIsBookingPage();
 
   return (
     <SessionProvider>
       <TrpcProvider>
         {!isBookingPage ? <PlainChat /> : null}
+        {!isEmbed && !isBookingPage && <NotificationSoundHandler />}
         {/* @ts-expect-error FIXME remove this comment when upgrading typescript to v5 */}
         <CacheProvider>
           <WebPushProvider>{children}</WebPushProvider>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes https://github.com/calcom/cal.com/issues/21271 (GitHub issue number)
- Fixes CAL-5758 (Linear issue number - should be visible at the bottom of the GitHub issue description)

NotificationSoundHandler is used to play sound in case of instant meeting push notification and we would have to preload and initialize the audio context with ring.mp3 to play it as soon as push notification is received but we don't need it on public booking pages


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?



    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Stopped loading ring.mp3 and the notification sound handler on the booking page to improve performance.

<!-- End of auto-generated description by mrge. -->

