### PR TITLE
fix: corrected path for cron in documentation

### DIFF
--- a/docs/developing/local-development.mdx
+++ b/docs/developing/local-development.mdx
@@ -123,7 +123,7 @@ yarn dx
 
 There are a few features which require cron job setup. At cal.com, the cron jobs are found in the following directory:
 ```bash
-/apps/web/pages/api/cron
+/apps/web/app/api/cron
 ```
 
 

--- a/docs/self-hosting/installation.mdx
+++ b/docs/self-hosting/installation.mdx
@@ -76,7 +76,7 @@ For instance, if you are hosting on Vercel, you would need to set up cron jobs b
 
 At cal.com, the cron jobs are found in the following directory:
 ```
-/apps/web/pages/api/cron
+/apps/web/app/api/cron
 ```
 
 


### PR DESCRIPTION
## This PR fixes the path of cron in the documentation

Had wrong path in the documentation

## Visual Demo (For contributors especially)

Path to cron folder:
<img width="211" alt="Screenshot 2025-05-13 at 6 49 27 PM" src="https://github.com/user-attachments/assets/c3278dda-d42c-45f0-b290-535778e5b593" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed the cron job path in the installation documentation to point to the correct directory.

<!-- End of auto-generated description by mrge. -->

