### PR TITLE
fix: use event guest email as last resource for rescheduledby in success page

### DIFF
--- a/apps/web/modules/bookings/hooks/useCurrentEmail.ts
+++ b/apps/web/modules/bookings/hooks/useCurrentEmail.ts
@@ -4,6 +4,7 @@ import type { ZodSchema } from "zod";
 
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
+import { localStorage } from "@calcom/lib/webstorage";
 
 export const useCurrentEmail = (querySchema: ZodSchema) => {
   const { data: session } = useSession();

--- a/apps/web/modules/bookings/hooks/useCurrentEmail.ts
+++ b/apps/web/modules/bookings/hooks/useCurrentEmail.ts
@@ -1,0 +1,28 @@
+import { useSession } from "next-auth/react";
+import { useEffect } from "react";
+import type { ZodSchema } from "zod";
+
+import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
+import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
+
+export const useCurrentEmail = (querySchema: ZodSchema) => {
+  const { data: session } = useSession();
+  const searchParams = useCompatSearchParams();
+  const routerQuery = useRouterQuery();
+
+  const { isSuccessBookingPage, email: routerQueryEmail } = querySchema.parse(routerQuery);
+
+  const paramEmail = searchParams?.get("rescheduledBy") ?? searchParams?.get("cancelledBy");
+
+  useEffect(() => {
+    if (isSuccessBookingPage && routerQueryEmail) {
+      localStorage.setItem("currentEmail", routerQueryEmail);
+    }
+  }, [isSuccessBookingPage, routerQueryEmail]);
+
+  if (paramEmail) return paramEmail;
+  if (session?.user?.email) return session.user.email;
+  if (isSuccessBookingPage) return routerQueryEmail;
+
+  return localStorage.getItem("currentEmail") ?? undefined;
+};

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -182,7 +182,9 @@ export default function Success(props: PageProps) {
     searchParams?.get("rescheduledBy") ??
     searchParams?.get("cancelledBy") ??
     session?.user?.email ??
-    undefined;
+    isSuccessBookingPage
+      ? email
+      : undefined;
 
   const defaultRating = isNaN(parsedRating) ? 3 : parsedRating > 5 ? 5 : parsedRating < 1 ? 1 : parsedRating;
   const [rateValue, setRateValue] = useState<number>(defaultRating);
@@ -556,7 +558,7 @@ export default function Success(props: PageProps) {
                           <>
                             <div className="font-medium">{t("rescheduled_by")}</div>
                             <div className="col-span-2 mb-6 last:mb-0">
-                              <p className="break-words">{previousBooking?.rescheduledBy}</p>
+                              <p className="break-words">{previousBooking?.rescheduledBy ?? t("unknown")}</p>
                               <Link className="text-sm underline" href={`/booking/${previousBooking?.uid}`}>
                                 {t("original_booking")}
                               </Link>

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -59,6 +59,8 @@ import CancelBooking from "@calcom/web/components/booking/CancelBooking";
 import EventReservationSchema from "@calcom/web/components/schemas/EventReservationSchema";
 import { timeZone } from "@calcom/web/lib/clock";
 
+import { useCurrentEmail } from "~/bookings/hooks/useCurrentEmail";
+
 import type { PageProps } from "./bookings-single-view.getServerSideProps";
 
 const stringToBoolean = z
@@ -178,13 +180,8 @@ export default function Success(props: PageProps) {
   const [calculatedDuration, setCalculatedDuration] = useState<number | undefined>(undefined);
   const [comment, setComment] = useState("");
   const parsedRating = rating ? parseInt(rating, 10) : 3;
-  const currentUserEmail =
-    searchParams?.get("rescheduledBy") ??
-    searchParams?.get("cancelledBy") ??
-    session?.user?.email ??
-    isSuccessBookingPage
-      ? email
-      : undefined;
+
+  const currentUserEmail = useCurrentEmail(querySchema);
 
   const defaultRating = isNaN(parsedRating) ? 3 : parsedRating > 5 ? 5 : parsedRating < 1 ? 1 : parsedRating;
   const [rateValue, setRateValue] = useState<number>(defaultRating);

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -7,6 +7,7 @@
   "second_other": "{{count}} seconds",
   "upgrade_now": "Upgrade now",
   "untitled": "Untitled",
+  "unknown": "Unknown",
   "accept_invitation": "Accept Invitation",
   "max_characters": "Max. Characters",
   "min_characters": "Min. Characters",

--- a/apps/web/public/static/locales/fr/common.json
+++ b/apps/web/public/static/locales/fr/common.json
@@ -7,6 +7,7 @@
   "second_other": "{{count}} secondes",
   "upgrade_now": "Mettre à niveau maintenant",
   "untitled": "Sans titre",
+  "unknown": "Inconnu",
   "accept_invitation": "Accepter l'invitation",
   "max_characters": "Caractères max.",
   "min_characters": "Caractères min.",


### PR DESCRIPTION
## What does this PR do?

Completes a fix for #16877 where `rescheduledBy` was not preserved on reschedule redirects (already applied in #16931).  It now also uses the guest's email as default if rescheduled from success page, and stores it in browser storage for further access to the plain booking page without parameters.

The rescheduler email is set based on the following order:

1. If `query.rescheduledBy` or `query.cancelledBy`,
2. else, if `session.user?.email`,
3. else, if `isSuccessBookingPage` then return `query.email`,
4. else, if `localStorage["currentEmail"]`,
5. else `undefined`.

Local storage latest guest email is updated on every new booking success page (single user may use different addresses for different event purposes).

Also added a text default whenever `rescheduledBy` is `undefined`.

- Fixes #16877 (partially fixed by #16931)

## Visual Demo

#### Video Demo (if applicable):

##### Before

https://github.com/user-attachments/assets/79c2553a-df64-412c-8551-ab3c127cece0

##### After

[after-2.webm](https://github.com/user-attachments/assets/8aca8d0e-d5a5-4b17-aa8d-967ec5457d3b)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] ~I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.~ N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set? No.
- What are the minimal test data to have? A single event booking is sufficient.
- What is expected (happy path) to have (input and output)? A rescheduling immediately after making a reservation expects the rescheduler email to be the same as the user who booked in the first place.
- Any other important info that could help to test that PR. No

- Fixes CAL-4431

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Improved how the rescheduler email is set after booking, now using the guest's email from the success page if no other email is available. Added a default "Unknown" label when the rescheduler email is missing.

<!-- End of auto-generated description by mrge. -->

