### PR TITLE
fix: timezone-fix

### DIFF
--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -127,10 +127,11 @@ export function TimezoneSelectComponent({
       }}
       onInputChange={handleInputChange}
       {...props}
-      formatOptionLabel={(option) => (
-        <p className="truncate">{(option as ITimezoneOption).value.replace(/_/g, " ")}</p>
-      )}
-      getOptionLabel={(option) => handleOptionLabel(option as ITimezoneOption, additionalTimezones)}
+      formatOptionLabel={(option) => {
+        const label = handleOptionLabel(option as ITimezoneOption);
+        return <p className="truncate">{label}</p>;
+      }}
+      getOptionLabel={(option) => handleOptionLabel(option as ITimezoneOption)}
       classNames={{
         ...timezoneClassNames,
         input: (state) =>

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -27,12 +27,37 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
 const formatOffset = (offset: string) =>
   offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
 
-export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
-  const offsetUnit = option.label.split("-")[0].substring(1);
-  const cityName = option.label.split(") ")[1];
+export const handleOptionLabel = (option: ITimezoneOption) => {
+  const ianaValue = option.value;
+  let displayCityName = "";
 
-  const timezoneValue = ` ${offsetUnit} ${formatOffset(dayjs.tz(undefined, option.value).format("Z"))}`;
-  return timezones.length > 0
-    ? `${cityName}${timezoneValue}`
-    : `${option.value.replace(/_/g, " ")}${timezoneValue}`;
+  if (option.label) {
+    const parts = option.label.split(") ");
+    if (parts.length > 1) {
+      displayCityName = parts[1];
+    } else {
+      const parts2 = option.label.split(" (GMT");
+      if (parts2.length > 0) {
+        displayCityName = parts2[0];
+      }
+    }
+  }
+
+  if (!displayCityName) {
+    displayCityName = ianaValue.includes("/")
+      ? ianaValue.split("/")[1].replace(/_/g, " ")
+      : ianaValue.replace(/_/g, " ");
+  }
+
+  let offsetString = "";
+  try {
+    offsetString = dayjs.tz(undefined, ianaValue).format("Z");
+  } catch (e) {
+    console.error(`Error getting offset for ${ianaValue} using dayjs:`, e);
+    offsetString = "ERR";
+  }
+
+  const displayOffset = `GMT${offsetString}`;
+
+  return `${displayCityName} (${displayOffset})`;
 };


### PR DESCRIPTION
## Fixes the Timezone change for Kazakhstan and other inconsistencies

- Fixes #14437  (GitHub issue number)

## Problem:

### Problem 1:
So currently, what we have when we click on the dropdown, it shows a weirdly formatted location, eg. : Almaty GMT+6:00) Almaty +5:00 (has two timezones +6 and +5) 

<img width="312" alt="Screenshot 2025-05-13 at 9 34 34 PM" src="https://github.com/user-attachments/assets/2d74e78c-770a-4d6f-beba-bc90de65a6c9" />

### Problem 2:
Using the dropdown gives different names for the location compared to using the search bar

<img width="216" alt="Screenshot 2025-05-13 at 9 35 30 PM" src="https://github.com/user-attachments/assets/0abe667b-9443-476e-bcad-92ccb03a4d04" />

<img width="226" alt="Screenshot 2025-05-14 at 1 20 58 AM" src="https://github.com/user-attachments/assets/41dd8420-38e9-4381-a0e1-274907b66b82" />

### Now:
<img width="174" alt="Screenshot 2025-05-13 at 10 12 17 PM" src="https://github.com/user-attachments/assets/b7fc08e7-333e-4113-993d-505d9a5dacd0" />

<img width="173" alt="Screenshot 2025-05-13 at 10 12 25 PM" src="https://github.com/user-attachments/assets/8d682758-2dc8-4f91-9301-8d2bc102f40d" />

### Approach:
As it showed two timezones (Almaty GMT+6:00) Almaty +5:00), the left one which shows the older timezone would be the dayjs as we were using an older dayjs version as it says in the yarn.lock file:
```
"@calcom/dayjs@*, @calcom/dayjs@workspace:packages/dayjs":
  version: 0.0.0-use.local
  resolution: "@calcom/dayjs@workspace:packages/dayjs"
  dependencies:
    dayjs: 1.11.2
```
which was released 3 years ago also some were patched to use 1.11.4 which was also released 3 years ago.

which had this in their package.json:
```
"moment-timezone": "0.5.31"
```
while according to moment-timezone/changelog.md we see that "v0.5.45" was when they updated data to IANA TZDB 2024a which included the Kazakhstan timezone change.

but surprisingly, the issue was due to browser's default, which shouldnt be the case as I tried on multiple latest versions of browsers.

This is how I confirmed when i removed the component using the browser's Intl API was causing trouble:
<img width="184" alt="Screenshot 2025-05-13 at 9 35 11 PM" src="https://github.com/user-attachments/assets/82306fa1-54cc-4899-a3a4-024770545085" />


### Other Issues:
- Still using the older versions of dayjs and moment-timezone
- Also can someone pinpoint me the issue, why even with older dayjs, it works fine (has that something to do with the patch)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed incorrect and inconsistent timezone labels for Kazakhstan and other locations in the timezone dropdown and search.

- **Bug Fixes**
  - Updated label formatting to show the correct city name and GMT offset.
  - Ensured dropdown and search results now display matching timezone names.

<!-- End of auto-generated description by mrge. -->

