### PR TITLE
refactor: Handle API v2 team slots in useSchedule hook

### DIFF
--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -97,7 +97,7 @@ export const useScheduleForEvent = ({
   const searchParams = useCompatSearchParams();
   const rescheduleUid = searchParams?.get("rescheduleUid");
 
-  const scheduleUsingApiV2 = useSchedule({
+  const schedule = useSchedule({
     username: usernameFromStore ?? username,
     eventSlug: eventSlugFromStore ?? eventSlug,
     eventId,
@@ -114,29 +114,6 @@ export const useScheduleForEvent = ({
     teamMemberEmail,
     useApiV2: useApiV2,
   });
-
-  const scheduleNotUsingApiV2 = useSchedule({
-    username: usernameFromStore ?? username,
-    eventSlug: eventSlugFromStore ?? eventSlug,
-    eventId,
-    timezone,
-    selectedDate,
-    prefetchNextMonth,
-    monthCount,
-    dayCount,
-    rescheduleUid,
-    month: monthFromStore ?? month,
-    duration: durationFromStore ?? duration,
-    isTeamEvent,
-    orgSlug,
-    teamMemberEmail,
-    useApiV2: false,
-    // only run this query if the one using Api v2 fails
-    // Network error does not trigger `isError` flag, so we are instead using `failureReason` here
-    enabled: isTeamEvent && !!scheduleUsingApiV2?.failureReason,
-  });
-
-  const schedule = scheduleUsingApiV2?.isSuccess ? scheduleUsingApiV2 : scheduleNotUsingApiV2;
 
   return {
     data: schedule?.data,

--- a/packages/features/schedules/lib/use-schedule/useSchedule.ts
+++ b/packages/features/schedules/lib/use-schedule/useSchedule.ts
@@ -122,7 +122,9 @@ export const useSchedule = ({
   };
 
   const isCallingApiV2Slots = useApiV2 && Boolean(isTeamEvent) && options.enabled;
-  const teamSchedule = useApiV2AvailableSlots({
+
+  // API V2 query for team events
+  const teamScheduleV2 = useApiV2AvailableSlots({
     ...input,
     enabled: isCallingApiV2Slots,
     duration: input.duration ? Number(input.duration) : undefined,
@@ -131,25 +133,30 @@ export const useSchedule = ({
     eventTypeId: eventId ?? undefined,
   });
 
-  if (isCallingApiV2Slots) {
+  const schedule = isTeamEvent
+    ? trpc.viewer.highPerf.getTeamSchedule.useQuery(input, {
+        ...options,
+        // Only enable if we're not using API V2 or if API V2 failed
+        enabled: options.enabled && (!isCallingApiV2Slots || !!teamScheduleV2.failureReason),
+      })
+    : trpc.viewer.slots.getSchedule.useQuery(input, options);
+
+  if (isCallingApiV2Slots && !teamScheduleV2.failureReason) {
     updateEmbedBookerState({
       bookerState,
-      slotsQuery: teamSchedule,
+      slotsQuery: teamScheduleV2,
     });
+
     return {
-      ...teamSchedule,
+      ...teamScheduleV2,
       /**
        * Invalidates the request and resends it regardless of any other configuration including staleTime
        */
       invalidate: () => {
-        return teamSchedule.refetch();
+        return teamScheduleV2.refetch();
       },
     };
   }
-
-  const schedule = isTeamEvent
-    ? trpc.viewer.highPerf.getTeamSchedule.useQuery(input, options)
-    : trpc.viewer.slots.getSchedule.useQuery(input, options);
 
   updateEmbedBookerState({
     bookerState,


### PR DESCRIPTION
## What does this PR do?

- Refactored the `useSchedule` hook and the `useScheduleForEvent` hook to handle API v2 fetching inside `useSchedule` hook

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- E2E tests in place are enough (but I still manually tested if fallbacks to trpc query work on team events—works)
![Screenshot 2025-05-14 at 11 26 30 AM](https://github.com/user-attachments/assets/db491ad2-fb32-4aca-b142-426b8236a170)
