### PR TITLE
chore: Back down @calcom/Consumer CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,5 @@
 /**/package.json @calcom/Foundation
 /apps/api/**/* @calcom/Platform @calcom/Foundation
-/apps/ui-playground/**/* @calcom/Consumer @calcom/Foundation
-/apps/web/components/**/* @calcom/Consumer @calcom/Foundation
-/apps/web/modules/**/* @calcom/Consumer @calcom/Foundation
 /apps/web/**/layout.tsx @calcom/Consumer @calcom/Foundation
 /apps/web/lib/**/* @calcom/Foundation
 /apps/web/middleware.ts @calcom/Foundation


### PR DESCRIPTION
    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Removed @calcom/Consumer as CODEOWNER from several web and UI directories to update code review responsibilities.

<!-- End of auto-generated description by mrge. -->

Main reason for this is because we were blocking too many PRs for simple changes. We will monitor consumer-related changes moving forward and add back any high-risk files when needed.

