### PR TITLE
fix: user primary email not updating on reassignment

### DIFF
--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -244,6 +244,7 @@ export const roundRobinReassignment = async ({
       },
       data: {
         userId: reassignedRRHost.id,
+        userPrimaryEmail: reassignedRRHost.email,
         title: newBookingTitle,
       },
       select: bookingSelect,


### PR DESCRIPTION
## What does this PR do?

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where a user's primary email was not updated when a booking was reassigned in round-robin scheduling.

<!-- End of auto-generated description by mrge. -->

