### PR TITLE
fix: booker atom seated event reservation

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
@@ -21,7 +21,9 @@ export class SlotsService_2024_04_15 {
 
     let shouldReserveSlot = true;
     if (eventType.seatsPerTimeSlot) {
-      const bookingWithAttendees = await this.slotsRepo.getBookingWithAttendees(input.bookingUid);
+      const bookingWithAttendees = input.bookingUid
+        ? await this.slotsRepo.getBookingWithAttendees(input.bookingUid)
+        : undefined;
       const bookingAttendeesLength = bookingWithAttendees?.attendees?.length;
       if (bookingAttendeesLength) {
         const seatsLeft = eventType.seatsPerTimeSlot - bookingAttendeesLength;

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -129,6 +129,7 @@ export type BookerStore = {
   rescheduleUid: string | null;
   rescheduledBy: string | null;
   bookingUid: string | null;
+  setBookingUid: (bookingUid: string | null) => void;
   bookingData: GetBookingType | null;
   setBookingData: (bookingData: GetBookingType | null | undefined) => void;
 
@@ -415,6 +416,7 @@ export const useBookerStore = createWithEqualityFn<BookerStore>((set, get) => ({
   rescheduleUid: null,
   bookingData: null,
   bookingUid: null,
+  setBookingUid: (bookingUid: string | null) => set({ bookingUid }),
   selectedTimeslot: getQueryParam("slot") || null,
   tentativeSelectedTimeslots: [],
   setTentativeSelectedTimeslots: (tentativeSelectedTimeslots: string[]) => {

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -122,21 +122,23 @@ export const BookerPlatformWrapper = (
     };
   }, [onBookerStateChange, getStateValues, debouncedStateChange]);
 
-  const bookingUid = useMemo(() => {
+  const effectiveBookingUid = useMemo(() => {
     if (props.bookingUid) {
-      setBookingUid(props.bookingUid);
       return props.bookingUid;
     }
     if (typeof window !== "undefined") {
       const queryParamsBookingUid = new URLSearchParams(window.location.search).get("bookingUid");
-      setBookingUid(queryParamsBookingUid);
       return queryParamsBookingUid || undefined;
     }
     return undefined;
   }, [props.bookingUid, typeof window !== "undefined" ? window.location.search : ""]);
 
+  useEffect(() => {
+    setBookingUid(effectiveBookingUid || null);
+  }, [effectiveBookingUid, setBookingUid]);
+
   useGetBookingForReschedule({
-    uid: props.rescheduleUid ?? bookingUid ?? "",
+    uid: props.rescheduleUid ?? effectiveBookingUid ?? "",
     onSuccess: (data) => {
       setBookingData(data);
     },
@@ -225,7 +227,7 @@ export const BookerPlatformWrapper = (
     crmOwnerRecordType,
     eventId: event.data?.id,
     rescheduleUid: props.rescheduleUid ?? null,
-    bookingUid: bookingUid ?? null,
+    bookingUid: effectiveBookingUid ?? null,
     layout: layout,
     org: props.entity?.orgSlug,
     username,
@@ -524,7 +526,7 @@ export const BookerPlatformWrapper = (
         }
         rescheduleUid={props.rescheduleUid ?? null}
         rescheduledBy={props.rescheduledBy ?? null}
-        bookingUid={bookingUid ?? null}
+        bookingUid={effectiveBookingUid ?? null}
         isRedirect={false}
         confirmButtonDisabled={confirmButtonDisabled}
         fromUserNameRedirected=""

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -69,6 +69,7 @@ export const BookerPlatformWrapper = (
   const [bookerState, setBookerState] = useBookerStore((state) => [state.state, state.setState], shallow);
   const setSelectedDate = useBookerStore((state) => state.setSelectedDate);
   const setSelectedDuration = useBookerStore((state) => state.setSelectedDuration);
+  const setBookingUid = useBookerStore((state) => state.setBookingUid);
   const setBookingData = useBookerStore((state) => state.setBookingData);
   const setOrg = useBookerStore((state) => state.setOrg);
   const bookingData = useBookerStore((state) => state.bookingData);
@@ -121,8 +122,21 @@ export const BookerPlatformWrapper = (
     };
   }, [onBookerStateChange, getStateValues, debouncedStateChange]);
 
+  const bookingUid = useMemo(() => {
+    if (props.bookingUid) {
+      setBookingUid(props.bookingUid);
+      return props.bookingUid;
+    }
+    if (typeof window !== "undefined") {
+      const queryParamsBookingUid = new URLSearchParams(window.location.search).get("bookingUid");
+      setBookingUid(queryParamsBookingUid);
+      return queryParamsBookingUid || undefined;
+    }
+    return undefined;
+  }, [props.bookingUid, typeof window !== "undefined" ? window.location.search : ""]);
+
   useGetBookingForReschedule({
-    uid: props.rescheduleUid ?? props.bookingUid ?? "",
+    uid: props.rescheduleUid ?? bookingUid ?? "",
     onSuccess: (data) => {
       setBookingData(data);
     },
@@ -211,7 +225,7 @@ export const BookerPlatformWrapper = (
     crmOwnerRecordType,
     eventId: event.data?.id,
     rescheduleUid: props.rescheduleUid ?? null,
-    bookingUid: props.bookingUid ?? null,
+    bookingUid: bookingUid ?? null,
     layout: layout,
     org: props.entity?.orgSlug,
     username,
@@ -510,7 +524,7 @@ export const BookerPlatformWrapper = (
         }
         rescheduleUid={props.rescheduleUid ?? null}
         rescheduledBy={props.rescheduledBy ?? null}
-        bookingUid={props.bookingUid ?? null}
+        bookingUid={bookingUid ?? null}
         isRedirect={false}
         confirmButtonDisabled={confirmButtonDisabled}
         fromUserNameRedirected=""

--- a/packages/platform/atoms/hooks/useReserveSlot.ts
+++ b/packages/platform/atoms/hooks/useReserveSlot.ts
@@ -5,7 +5,7 @@ import type {
   ApiResponse,
   ApiErrorResponse,
   ApiSuccessResponse,
-  ReserveSlotInput,
+  ReserveSlotInput_2024_04_15,
 } from "@calcom/platform-types";
 
 import http from "../lib/http";
@@ -24,8 +24,8 @@ export const useReserveSlot = (
     },
   }
 ) => {
-  const reserveSlot = useMutation<ApiResponse<string>, unknown, ReserveSlotInput>({
-    mutationFn: (props: ReserveSlotInput) => {
+  const reserveSlot = useMutation<ApiResponse<string>, unknown, ReserveSlotInput_2024_04_15>({
+    mutationFn: (props: ReserveSlotInput_2024_04_15) => {
       return http.post<ApiResponse<string>>("/slots/reserve", props).then((res) => {
         if (res.data.status === SUCCESS_STATUS) {
           return res.data;

--- a/packages/platform/atoms/hooks/useSlots.ts
+++ b/packages/platform/atoms/hooks/useSlots.ts
@@ -37,6 +37,7 @@ export const useSlots = (
   }: UseSlotsCallbacks & { isBookingDryRun?: boolean } = {}
 ) => {
   const selectedDuration = useBookerStore((state) => state.selectedDuration);
+  const bookingUid = useBookerStore((state) => state.bookingUid);
   const [selectedTimeslot, setSelectedTimeslot] = useBookerStore(
     (state) => [state.selectedTimeslot, state.setSelectedTimeslot],
     shallow
@@ -78,6 +79,7 @@ export const useSlots = (
           .add(selectedDuration || event.data.length, "minutes")
           .format(),
         _isDryRun: isBookingDryRun,
+        bookingUid: bookingUid || undefined,
       });
     }
   };

--- a/packages/platform/examples/base/src/pages/booking.tsx
+++ b/packages/platform/examples/base/src/pages/booking.tsx
@@ -132,9 +132,9 @@ export default function Bookings(props: { calUsername: string; calEmail: string 
                 : { username: props.calUsername })}
               hostsLimit={3}
               allowUpdatingUrlParams={true}
-              handleSlotReservation={(timeslot) => {
-                console.log("Selected timeslot:", timeslot);
-              }}
+              // handleSlotReservation={(timeslot) => {
+              //   console.log("Selected timeslot:", timeslot);
+              // }}
             />
           </>
         )}


### PR DESCRIPTION
Linear [CAL-5767](https://linear.app/calcom/issue/CAL-5767/fix-booker-atom-seated-events-reserve)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where seated event reservations did not correctly handle the booking UID, causing problems with reserving the first slot.

- **Bug Fixes**
  - Ensured bookingUid is set and passed through all relevant components and API calls for seated events.
  - Updated state management and hooks to support bookingUid.
  - Cleaned up example code to remove unused slot reservation handler.

<!-- End of auto-generated description by mrge. -->

