### PR TITLE
fix: add link to /help/billing-and-usage/messaging-credits

### DIFF
--- a/apps/web/modules/settings/billing/components/BillingCredits.tsx
+++ b/apps/web/modules/settings/billing/components/BillingCredits.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { ProgressBar } from "@tremor/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
+import ServerTrans from "@calcom/lib/components/ServerTrans";
 import { IS_SMS_CREDITS_ENABLED } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useParamsWithFallback } from "@calcom/lib/hooks/useParamsWithFallback";
@@ -61,7 +63,19 @@ export default function BillingCredits() {
     <div className="border-subtle mt-8 space-y-6 rounded-lg border px-6 py-6 pb-6 text-sm sm:space-y-8">
       <div>
         <h2 className="text-base font-semibold">{t("credits")}</h2>
-        <p>{t("view_and_manage_credits_description")}</p>
+        <ServerTrans
+          t={t}
+          i18nKey="view_and_manage_credits_description"
+          components={[
+            <Link
+              key="Credit System"
+              className="underline underline-offset-2"
+              target="_blank"
+              href="https://cal.com/help/billing-and-usage/messaging-credits">
+              Learn more
+            </Link>,
+          ]}
+        />
         <div className="-mx-6 mt-6">
           <hr className="border-subtle" />
         </div>
@@ -90,7 +104,6 @@ export default function BillingCredits() {
           ) : (
             <></>
           )}
-
           <Label>
             {creditsData.credits.totalMonthlyCredits ? t("additional_credits") : t("available_credits")}
           </Label>

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3024,7 +3024,7 @@
   "buy_credits": "Buy Credits",
   "credits": "Credits",
   "view_and_manage_credits": "View and manage credits",
-  "view_and_manage_credits_description": "View and manage credits for sending SMS messages. One credit is worth 1¢ (USD)",
+  "view_and_manage_credits_description": "View and manage credits for sending SMS messages. One credit is worth 1¢ (USD). <0>Learn more</0>",
   "buy_additional_credits": "Buy additional credits ($0.01 per credit)",
   "overview": "Overview",
   "organization_slug_taken": "Organization slug is already taken",


### PR DESCRIPTION
## What does this PR do?
Adds 'Learn more' with link to https://cal.com/help/billing-and-usage/messaging-credits
![Screenshot 2025-05-15 at 12 40 10 PM](https://github.com/user-attachments/assets/cf7a4500-28b0-44ba-aa4a-0120b9022ea7)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a "Learn more" link to the messaging credits section in billing, directing users to the help page for more information.

<!-- End of auto-generated description by mrge. -->

