### PR TITLE
fix: make 'Send reset email' button text visible on hover (#21334)

### DIFF
--- a/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
+++ b/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
@@ -127,7 +127,7 @@ export default function ForgotPassword(props: PageProps) {
             />
             <div className="space-y-2">
               <Button
-                className="w-full justify-center dark:bg-white dark:text-black enabled:hover:text-white" 
+                className="w-full justify-center bg-white hover:bg-black hover:text-white"
                 type="submit"
                 color="primary"
                 disabled={loading}

--- a/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
+++ b/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
@@ -127,7 +127,7 @@ export default function ForgotPassword(props: PageProps) {
             />
             <div className="space-y-2">
               <Button
-                className="w-full justify-center dark:bg-white dark:text-black"
+                className="w-full justify-center dark:bg-white dark:text-black enabled:hover:text-white" 
                 type="submit"
                 color="primary"
                 disabled={loading}

--- a/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
+++ b/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
@@ -112,7 +112,7 @@ export default function ForgotPassword(props: PageProps) {
               {
                 "--cal-brand": "#111827",
                 "--cal-brand-emphasis": "#101010",
-                "--cal-brand-text": "white",
+                "--cal-brand-text": "Black",
                 "--cal-brand-subtle": "#9CA3AF",
               } as CSSProperties
             }>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -247,7 +247,7 @@
   /* Brand */
   --cal-brand: hsla(0, 0%, 100%, 1); /* white */
   --cal-brand-emphasis: hsla(218, 11%, 65%, 1); /* Keeping existing brand emphasis */
-  --cal-brand-text: hsla(0, 0%, 0%, 1); /* black */
+  --cal-brand-text: rgb(0, 0, 0); /* Black */
 }
 
 @layer base {

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -150,7 +150,7 @@
   /* Brand */
   --cal-brand: hsla(221, 39%, 11%, 1); /* Keeping existing brand color */
   --cal-brand-emphasis: hsla(0, 0%, 6%, 1); /* Keeping existing brand emphasis */
-  --cal-brand-text: hsla(0, 0%, 100%, 1); /* white */
+  --cal-brand-text: rgb(0, 0, 0); /* Black */
 }
 .dark {
   /* Background Standard */

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -150,7 +150,7 @@
   /* Brand */
   --cal-brand: hsla(221, 39%, 11%, 1); /* Keeping existing brand color */
   --cal-brand-emphasis: hsla(0, 0%, 6%, 1); /* Keeping existing brand emphasis */
-  --cal-brand-text: rgb(0, 0, 0); /* Black */
+  --cal-brand-text: hsla(0, 0%, 100%, 1); /* white */
 }
 .dark {
   /* Background Standard */
@@ -247,7 +247,7 @@
   /* Brand */
   --cal-brand: hsla(0, 0%, 100%, 1); /* white */
   --cal-brand-emphasis: hsla(218, 11%, 65%, 1); /* Keeping existing brand emphasis */
-  --cal-brand-text: rgb(0, 0, 0); /* Black */
+  --cal-brand-text: hsla(0, 0%, 0%, 1); /* black */
 }
 
 @layer base {


### PR DESCRIPTION
Before: Button text turned black on hover, blending with the dark background.  
After: Added 'enabled:hover:text-white' to maintain readability.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes a visual bug where the **"Send reset email"** button text became invisible on hover due to dark-mode styling.  
The `dark:text-black` class caused the text to disappear against the dark background.

- Fixes #21334
- Fixes [CAL-5775 "Send reset email' button text becomes invisible on hover](https://linear.app/calcom/issue/CAL-5775/send-reset-email-button-text-becomes-invisible-on-hover)

## Visual Demo (For contributors especially)

#### Image Demo:

| Before Hover (Text visible) | After Hover (Text invisible) | Fix Applied (Text visible) |
|-----------------------------|------------------------------|-----------------------------|
| ![before](https://github.com/user-attachments/assets/a31a9244-307f-4770-b9b5-0b009ee24a89) | ![hover](https://github.com/user-attachments/assets/17cdf366-b536-4443-9f2d-a6aabaf4559e) | ![after](https://github.com/user-attachments/assets/3caf05d1-6b88-4bee-b230-415097614dfe) | 


https://github.com/user-attachments/assets/7e1ac561-e2fc-463c-a52f-00a847cab165

## I’ve made the required updates:

-  Set the default text color to black by using `bg-white` (which renders black text).
-  Applied `hover:bg-black hover:text-white` so the background turns black and the text turns white **only on hover**.
-  Updated the theme config: changed `"--cal-brand-text": "white"` to `"--cal-brand-text": "black"`.

I've used the following Tailwind classes:
```tsx
bg-white hover:bg-black hover:text-white
```

## Mandatory Tasks (DO NOT REMOVE)
 - [x] I have self-reviewed the code.
- [x] N/A – No need to update developer docs for this minor style fix.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.  
  **(Not applicable - minor UI change)**
  
## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Navigate to `/auth/forgot-password`
- Enter a valid email
- Hover on the "Send reset email" button
- Confirm the text remains **readable/white on hover**


## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code where necessary
- I have checked that my changes generate no new warnings


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the "Send reset email" button text became invisible on hover in dark mode by ensuring the text stays white for better readability.

<!-- End of auto-generated description by mrge. -->

