### PR TITLE
fix: invisible text on 'Send reset email' hover

### DIFF
--- a/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
+++ b/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
@@ -7,8 +7,8 @@ import type { CSSProperties, SyntheticEvent } from "react";
 import React from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { EmailField } from "@calcom/ui/components/form";
 import { Button } from "@calcom/ui/components/button";
+import { EmailField } from "@calcom/ui/components/form";
 
 import AuthContainer from "@components/ui/AuthContainer";
 
@@ -127,7 +127,7 @@ export default function ForgotPassword(props: PageProps) {
             />
             <div className="space-y-2">
               <Button
-                className="w-full justify-center dark:bg-white dark:text-black"
+                className="w-full justify-center dark:bg-white dark:text-black dark:hover:text-white"
                 type="submit"
                 color="primary"
                 disabled={loading}


### PR DESCRIPTION
## What does this PR do?

This PR fixes [#21334](https://github.com/calcom/cal.com/issues/21334) where the "Send reset email" button text became invisible (black on black) when hovered in dark mode. The issue was caused by conflicting Tailwind classes: dark:bg-white and dark:text-black, which resulted in unreadable text on hover.

- Fixes #21334 
- Fixes CAL-5775  

## Visual Demo (For contributors especially)



#### Video Demo (if applicable):


https://github.com/user-attachments/assets/7ce6b4ac-342e-4216-ade5-fd07aeadfdd3



#### Image Demo (if applicable):

![image](https://github.com/user-attachments/assets/c19497d1-766d-4248-b7d2-7903be0f0b86)


## Mandatory Tasks (DO NOT REMOVE)

- [✓ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ✓] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Go to /auth/forgot-password
Enter an email (e.g. john.doe@example.com)
Hover on the "Send reset email" button


<!-- Remove bullet points below that don't apply to you -->

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the "Send reset email" button text became invisible on hover in dark mode. The button text now stays readable when hovered.

<!-- End of auto-generated description by mrge. -->

