### PR TITLE
fix: Updated Send Reset Email Button Visibility

### DIFF
--- a/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
+++ b/apps/web/modules/auth/forgot-password/forgot-password-view.tsx
@@ -7,8 +7,8 @@ import type { CSSProperties, SyntheticEvent } from "react";
 import React from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { EmailField } from "@calcom/ui/components/form";
 import { Button } from "@calcom/ui/components/button";
+import { EmailField } from "@calcom/ui/components/form";
 
 import AuthContainer from "@components/ui/AuthContainer";
 
@@ -127,7 +127,7 @@ export default function ForgotPassword(props: PageProps) {
             />
             <div className="space-y-2">
               <Button
-                className="w-full justify-center dark:bg-white dark:text-black"
+                className="w-full justify-center dark:bg-white dark:text-black hover:dark:text-white"
                 type="submit"
                 color="primary"
                 disabled={loading}


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the "Send reset email" button was not visible when the email field was filled.
Minor UI update in the forgot-password-view.tsx file to improve user experience during password reset.

- Fixes #21334 
- Fixes CAL-5775

#### Image Demo:
<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b8a76d96-e729-41f7-8c72-466525679c6c" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/29d8b2da-abdb-45c6-a3d2-f1f580c69838" width="400"/></td>
  </tr>
</table>


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to the Forgot Password page(/auth/forgot-password).
- Enter a valid email in the input field.
- Ensure the "Send reset email" button becomes visible.
- Confirm that the button is disabled when the email field is empty.
- No additional environment variables are required.
- No database or backend changes were made, only frontend behavior.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the "Send reset email" button was not visible when the email field was filled on the Forgot Password page. The button now appears as expected, improving the password reset experience.

<!-- End of auto-generated description by mrge. -->

