### PR TITLE
fix: apply transaction to public methods of CreditService

### DIFF
--- a/packages/features/ee/billing/credit-service.test.ts
+++ b/packages/features/ee/billing/credit-service.test.ts
@@ -6,11 +6,22 @@ import * as EmailManager from "@calcom/emails/email-manager";
 import { CreditsRepository } from "@calcom/lib/server/repository/credits";
 import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import { TeamRepository } from "@calcom/lib/server/repository/team";
+import prisma from "@calcom/prisma";
 import { CreditType } from "@calcom/prisma/enums";
 
-import { CreditService } from "./credit-service";
+import { CreditService as OriginalCreditService } from "./credit-service";
 import { StripeBillingService } from "./stripe-billling-service";
 import { InternalTeamBilling } from "./teams/internal-team-billing";
+
+const MOCK_TX = prisma;
+
+vi.mock("@calcom/prisma", () => {
+  return {
+    default: {
+      $transaction: vi.fn((fn) => fn(MOCK_TX)),
+    },
+  };
+});
 
 vi.mock("stripe");
 
@@ -40,6 +51,39 @@ vi.mock("@calcom/emails/email-manager");
 vi.mock("../workflows/lib/reminders/reminderScheduler", () => ({
   cancelScheduledMessagesAndScheduleEmails: vi.fn(),
 }));
+
+// Create a testable version of CreditService that exposes protected methods
+class CreditService extends OriginalCreditService {
+  public async _getTeamWithAvailableCredits(
+    params: Parameters<OriginalCreditService["_getTeamWithAvailableCredits"]>[0]
+  ) {
+    return super._getTeamWithAvailableCredits(params);
+  }
+
+  public async _getUserOrTeamToCharge(
+    params: Parameters<OriginalCreditService["_getUserOrTeamToCharge"]>[0]
+  ) {
+    return super._getUserOrTeamToCharge(params);
+  }
+
+  public async _createExpenseLog(props: Parameters<OriginalCreditService["_createExpenseLog"]>[0]) {
+    return super._createExpenseLog(props);
+  }
+
+  public async _handleLowCreditBalance(
+    params: Parameters<OriginalCreditService["_handleLowCreditBalance"]>[0]
+  ) {
+    return super._handleLowCreditBalance(params);
+  }
+
+  public async _getAllCreditsForTeam(params: Parameters<OriginalCreditService["_getAllCreditsForTeam"]>[0]) {
+    return super._getAllCreditsForTeam(params);
+  }
+
+  public async _getAllCredits(params: Parameters<OriginalCreditService["_getAllCredits"]>[0]) {
+    return super._getAllCredits(params);
+  }
+}
 
 describe("CreditService", () => {
   let creditService: CreditService;
@@ -182,11 +226,11 @@ describe("CreditService", () => {
           user: null,
         });
 
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
         vi.spyOn(EmailManager, "sendCreditBalanceLowWarningEmails").mockResolvedValue();
 
-        vi.spyOn(CreditService.prototype, "getAllCreditsForTeam").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCreditsForTeam").mockResolvedValue({
           totalMonthlyCredits: 500,
           totalRemainingMonthlyCredits: 20,
           additionalCredits: 60,
@@ -206,7 +250,8 @@ describe("CreditService", () => {
             creditType: CreditType.MONTHLY,
             credits: 5,
             smsSid: "sms-123",
-          })
+          }),
+          MOCK_TX
         );
 
         expect(EmailManager.sendCreditBalanceLowWarningEmails).toHaveBeenCalled();
@@ -243,7 +288,7 @@ describe("CreditService", () => {
 
         vi.spyOn(EmailManager, "sendCreditBalanceLimitReachedEmails").mockResolvedValue();
 
-        vi.spyOn(CreditService.prototype, "getAllCreditsForTeam").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCreditsForTeam").mockResolvedValue({
           totalMonthlyCredits: 500,
           totalRemainingMonthlyCredits: -1,
           additionalCredits: 0,
@@ -263,7 +308,8 @@ describe("CreditService", () => {
             creditType: CreditType.ADDITIONAL,
             credits: 5,
             smsSid: "sms-123",
-          })
+          }),
+          MOCK_TX
         );
 
         expect(EmailManager.sendCreditBalanceLimitReachedEmails).toHaveBeenCalled();
@@ -272,7 +318,7 @@ describe("CreditService", () => {
 
     describe("getUserOrTeamToCharge", () => {
       it("should return team with remaining credits when teamId is provided", async () => {
-        vi.spyOn(CreditService.prototype, "getAllCreditsForTeam").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCreditsForTeam").mockResolvedValue({
           totalMonthlyCredits: 500,
           totalRemainingMonthlyCredits: 100,
           additionalCredits: 50,
@@ -291,7 +337,7 @@ describe("CreditService", () => {
       });
 
       it("should use additional credits when monthly credits are out", async () => {
-        vi.spyOn(CreditService.prototype, "getAllCreditsForTeam").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCreditsForTeam").mockResolvedValue({
           totalMonthlyCredits: 500,
           totalRemainingMonthlyCredits: 0,
           additionalCredits: 50,
@@ -319,7 +365,7 @@ describe("CreditService", () => {
           warningSentAt: null,
         });
 
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue({
           teamId: 1,
           availableCredits: 150,
           creditType: CreditType.MONTHLY,
@@ -429,7 +475,7 @@ describe("CreditService", () => {
           limitReachedAt: null,
           warningSentAt: null,
         });
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
         const hasAvailableCredits = await creditService.hasAvailableCredits({ userId: 1 });
         expect(hasAvailableCredits).toBe(true);
@@ -445,7 +491,7 @@ describe("CreditService", () => {
           warningSentAt: null,
         });
 
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
         const result = await creditService.hasAvailableCredits({ userId: 1 });
         expect(result).toBe(false);
@@ -475,11 +521,11 @@ describe("CreditService", () => {
           team: null,
         });
 
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
         vi.spyOn(EmailManager, "sendCreditBalanceLowWarningEmails").mockResolvedValue();
 
-        vi.spyOn(CreditService.prototype, "getAllCredits").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCredits").mockResolvedValue({
           totalMonthlyCredits: 0,
           totalRemainingMonthlyCredits: 0,
           additionalCredits: 10,
@@ -499,7 +545,8 @@ describe("CreditService", () => {
             creditType: CreditType.ADDITIONAL,
             credits: 5,
             smsSid: "sms-123",
-          })
+          }),
+          MOCK_TX
         );
 
         expect(EmailManager.sendCreditBalanceLowWarningEmails).toHaveBeenCalled();
@@ -537,9 +584,9 @@ describe("CreditService", () => {
 
         vi.spyOn(EmailManager, "sendCreditBalanceLimitReachedEmails").mockResolvedValue();
 
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
-        vi.spyOn(CreditService.prototype, "getAllCredits").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCredits").mockResolvedValue({
           totalMonthlyCredits: 0,
           totalRemainingMonthlyCredits: 0,
           additionalCredits: 2,
@@ -559,7 +606,8 @@ describe("CreditService", () => {
             creditType: CreditType.ADDITIONAL,
             credits: 5,
             smsSid: "sms-123",
-          })
+          }),
+          MOCK_TX
         );
 
         expect(EmailManager.sendCreditBalanceLimitReachedEmails).toHaveBeenCalled();
@@ -568,9 +616,9 @@ describe("CreditService", () => {
 
     describe("getUserOrTeamToCharge", () => {
       it("should return user with remaining credits when userId is provided", async () => {
-        vi.spyOn(CreditService.prototype, "getTeamWithAvailableCredits").mockResolvedValue(null);
+        vi.spyOn(CreditService.prototype, "_getTeamWithAvailableCredits").mockResolvedValue(null);
 
-        vi.spyOn(CreditService.prototype, "getAllCredits").mockResolvedValue({
+        vi.spyOn(CreditService.prototype, "_getAllCredits").mockResolvedValue({
           totalMonthlyCredits: 0,
           totalRemainingMonthlyCredits: 0,
           additionalCredits: 10,

--- a/packages/features/ee/billing/credit-service.ts
+++ b/packages/features/ee/billing/credit-service.ts
@@ -179,7 +179,7 @@ export class CreditService {
     });
   }
 
-  private async _getTeamWithAvailableCredits({ userId, tx }: { userId: number; tx: PrismaTransaction }) {
+  protected async _getTeamWithAvailableCredits({ userId, tx }: { userId: number; tx: PrismaTransaction }) {
     const memberships = await MembershipRepository.findAllAcceptedMemberships(userId, tx);
 
     if (memberships.length === 0) {
@@ -243,7 +243,7 @@ export class CreditService {
     });
   }
 
-  private async _getUserOrTeamToCharge({
+  protected async _getUserOrTeamToCharge({
     credits,
     userId,
     teamId,
@@ -282,7 +282,7 @@ export class CreditService {
     return null;
   }
 
-  private async _createExpenseLog(props: {
+  protected async _createExpenseLog(props: {
     bookingUid?: string;
     smsSid?: string;
     teamId?: number;
@@ -344,7 +344,7 @@ export class CreditService {
   - Sends limit reached email
   - cancels all already scheduled SMS (from the next two hours)
   */
-  private async _handleLowCreditBalance({
+  protected async _handleLowCreditBalance({
     teamId,
     userId,
     remainingCredits,
@@ -555,7 +555,7 @@ export class CreditService {
     });
   }
 
-  private async _getAllCredits({
+  protected async _getAllCredits({
     userId,
     teamId,
     tx,
@@ -591,7 +591,7 @@ export class CreditService {
     });
   }
 
-  private async _getAllCreditsForTeam({ teamId, tx }: { teamId: number; tx: PrismaTransaction }) {
+  protected async _getAllCreditsForTeam({ teamId, tx }: { teamId: number; tx: PrismaTransaction }) {
     const creditBalance = await CreditsRepository.findCreditBalanceWithExpenseLogs({ teamId }, tx);
 
     const totalMonthlyCredits = await this.getMonthlyCredits(teamId);

--- a/packages/features/ee/billing/credit-service.ts
+++ b/packages/features/ee/billing/credit-service.ts
@@ -25,14 +25,14 @@ type LowCreditBalanceResultBase = {
     name: string;
     adminAndOwners: {
       id: number;
-      name: string;
+      name: string | null;
       email: string;
       t: TFunction;
     }[];
   };
   user?: {
     id: number;
-    name: string;
+    name: string | null;
     email: string;
     t: TFunction;
   };
@@ -40,8 +40,8 @@ type LowCreditBalanceResultBase = {
 
 type LowCreditBalanceLimitReachedResult = LowCreditBalanceResultBase & {
   type: "LIMIT_REACHED";
-  teamId?: number;
-  userId?: number;
+  teamId?: number | null;
+  userId?: number | null;
 };
 
 type LowCreditBalanceWarningResult = LowCreditBalanceResultBase & {

--- a/packages/features/ee/billing/credit-service.ts
+++ b/packages/features/ee/billing/credit-service.ts
@@ -118,7 +118,7 @@ export class CreditService {
       .then(async (result) => {
         if (result?.lowCreditBalanceResult) {
           // send emails after transaction is successfully committed
-          await this.handleLowCreditBalanceResult(result.lowCreditBalanceResult);
+          await this._handleLowCreditBalanceResult(result.lowCreditBalanceResult);
         }
         return {
           teamId: result?.teamId,
@@ -465,7 +465,7 @@ export class CreditService {
     return null;
   }
 
-  private async handleLowCreditBalanceResult(result: LowCreditBalanceResult) {
+  private async _handleLowCreditBalanceResult(result: LowCreditBalanceResult) {
     if (!result) return;
 
     try {
@@ -513,7 +513,7 @@ export class CreditService {
         return result;
       })
       .then(async (result) => {
-        await this.handleLowCreditBalanceResult(result);
+        await this._handleLowCreditBalanceResult(result);
       });
   }
 

--- a/packages/lib/server/repository/credits.ts
+++ b/packages/lib/server/repository/credits.ts
@@ -1,10 +1,14 @@
 import dayjs from "@calcom/dayjs";
-import prisma from "@calcom/prisma";
-import type { Prisma } from "@calcom/prisma/client";
+import prisma, { type PrismaTransaction } from "@calcom/prisma";
 import { CreditType } from "@calcom/prisma/enums";
 
 export class CreditsRepository {
-  static async findCreditBalance({ teamId, userId }: { teamId?: number; userId?: number }) {
+  static async findCreditBalance(
+    { teamId, userId }: { teamId?: number; userId?: number },
+    tx?: PrismaTransaction
+  ) {
+    const prismaClient = tx ?? prisma;
+
     const select = {
       id: true,
       additionalCredits: true,
@@ -13,7 +17,7 @@ export class CreditsRepository {
     };
 
     if (teamId) {
-      return await prisma.creditBalance.findUnique({
+      return await prismaClient.creditBalance.findUnique({
         where: {
           teamId,
         },
@@ -22,20 +26,25 @@ export class CreditsRepository {
     }
 
     if (userId) {
-      return await prisma.creditBalance.findUnique({
+      return await prismaClient.creditBalance.findUnique({
         where: { userId },
         select,
       });
     }
   }
 
-  static async findCreditBalanceWithTeamOrUser({
-    teamId,
-    userId,
-  }: {
-    teamId?: number | null;
-    userId?: number | null;
-  }) {
+  static async findCreditBalanceWithTeamOrUser(
+    {
+      teamId,
+      userId,
+    }: {
+      teamId?: number | null;
+      userId?: number | null;
+    },
+    tx?: PrismaTransaction
+  ) {
+    const prismaClient = tx ?? prisma;
+
     const select = {
       id: true,
       additionalCredits: true,
@@ -69,7 +78,7 @@ export class CreditsRepository {
       },
     };
     if (teamId) {
-      return await prisma.creditBalance.findUnique({
+      return await prismaClient.creditBalance.findUnique({
         where: {
           teamId,
         },
@@ -78,15 +87,17 @@ export class CreditsRepository {
     }
 
     if (userId) {
-      return await prisma.creditBalance.findUnique({
+      return await prismaClient.creditBalance.findUnique({
         where: { userId },
         select,
       });
     }
   }
 
-  static async findCreditBalanceWithExpenseLogs({ teamId }: { teamId: number }) {
-    return await prisma.creditBalance.findUnique({
+  static async findCreditBalanceWithExpenseLogs({ teamId }: { teamId: number }, tx?: PrismaTransaction) {
+    const prismaClient = tx ?? prisma;
+
+    return await prismaClient.creditBalance.findUnique({
       where: {
         teamId,
       },
@@ -109,33 +120,37 @@ export class CreditsRepository {
     });
   }
 
-  static async updateCreditBalance({
-    id,
-    teamId,
-    userId,
-    data,
-  }: {
-    id?: string;
-    teamId?: number | null;
-    userId?: number | null;
-    data: Prisma.CreditBalanceUncheckedUpdateInput;
-  }) {
+  static async updateCreditBalance(
+    {
+      id,
+      teamId,
+      userId,
+      data,
+    }: {
+      id?: string;
+      teamId?: number | null;
+      userId?: number | null;
+      data: Prisma.CreditBalanceUncheckedUpdateInput;
+    },
+    tx?: PrismaTransaction
+  ) {
+    const prismaClient = tx ?? prisma;
     if (id) {
-      return prisma.creditBalance.update({
+      return prismaClient.creditBalance.update({
         where: { id },
         data,
       });
     }
 
     if (teamId) {
-      return prisma.creditBalance.update({
+      return prismaClient.creditBalance.update({
         where: { teamId },
         data,
       });
     }
 
     if (userId) {
-      return prisma.creditBalance.update({
+      return prismaClient.creditBalance.update({
         where: { userId },
         data,
       });
@@ -144,14 +159,17 @@ export class CreditsRepository {
     return null;
   }
 
-  static async createCreditBalance(data: Prisma.CreditBalanceUncheckedCreateInput) {
-    return prisma.creditBalance.create({
+  static async createCreditBalance(data: Prisma.CreditBalanceUncheckedCreateInput, tx?: PrismaTransaction) {
+    return (tx ?? prisma).creditBalance.create({
       data,
     });
   }
 
-  static async createCreditExpenseLog(data: Prisma.CreditExpenseLogUncheckedCreateInput) {
-    return prisma.creditExpenseLog.create({
+  static async createCreditExpenseLog(
+    data: Prisma.CreditExpenseLogUncheckedCreateInput,
+    tx?: PrismaTransaction
+  ) {
+    return (tx ?? prisma).creditExpenseLog.create({
       data,
     });
   }

--- a/packages/lib/server/repository/credits.ts
+++ b/packages/lib/server/repository/credits.ts
@@ -1,5 +1,6 @@
 import dayjs from "@calcom/dayjs";
 import prisma, { type PrismaTransaction } from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
 import { CreditType } from "@calcom/prisma/enums";
 
 export class CreditsRepository {

--- a/packages/lib/server/repository/membership.ts
+++ b/packages/lib/server/repository/membership.ts
@@ -1,4 +1,4 @@
-import { availabilityUserSelect, prisma } from "@calcom/prisma";
+import { availabilityUserSelect, prisma, type PrismaTransaction } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -310,8 +310,8 @@ export class MembershipRepository {
       },
     });
   }
-  static async findAllAcceptedMemberships(userId: number) {
-    return prisma.membership.findMany({
+  static async findAllAcceptedMemberships(userId: number, tx?: PrismaTransaction) {
+    return (tx ?? prisma).membership.findMany({
       where: {
         userId,
         accepted: true,


### PR DESCRIPTION
## What does this PR do?

This PR applies $transaction to public methods of CreditService.

- Fixes CAL-5791

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Existing test cases should work.

<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Wrapped all public methods in CreditService with database transactions to ensure data consistency and atomic updates.

- **Refactors**
  - Updated repository methods to accept an optional transaction object.
  - Moved side effects like sending emails to run after successful transaction commits.

<!-- End of auto-generated description by mrge. -->

---

Enable this for better diff.

![Screenshot 2025-05-19 at 16 35 17](https://github.com/user-attachments/assets/ea812da7-301a-4ce4-a241-24357b7a6753)

