### PR TITLE
feat: set organizers default confrencing app only for team-events

### DIFF
--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -138,9 +138,9 @@ export async function getLocationGroupedOptions(
 
   const filteredDefaultLocations = defaultLocations.filter((l) => {
     if (l.type == OrganizerDefaultConferencingAppType && "teamId" in userOrTeamId) {
-      return true;
+      return false;
     }
-    return false;
+    return true;
   });
 
   filteredDefaultLocations.forEach((l) => {

--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -11,7 +11,7 @@ import { prisma } from "@calcom/prisma";
 import { AppCategories } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
-import { defaultLocations } from "./locations";
+import { defaultLocations, OrganizerDefaultConferencingAppType } from "./locations";
 
 export async function getLocationGroupedOptions(
   userOrTeamId: { userId: number } | { teamId: number },
@@ -136,7 +136,14 @@ export async function getLocationGroupedOptions(
     }
   });
 
-  defaultLocations.forEach((l) => {
+  const filteredDefaultLocations = defaultLocations.filter((l) => {
+    if (l.type == OrganizerDefaultConferencingAppType && "teamId" in userOrTeamId) {
+      return true;
+    }
+    return false;
+  });
+
+  filteredDefaultLocations.forEach((l) => {
     const category = l.category;
     if (apps[category]) {
       apps[category] = [


### PR DESCRIPTION
## What does this PR do?
This PR implements `organizers default conferencing` only be visible for team-events

- Fixes #21249  (GitHub issue number)
- Fixes CAL-5752 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

N/A

#### Video Demo (if applicable):
N/A

#### Image Demo (if applicable):
N/A
## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
The organizer's default conferencing app option now only appears for team events.

- **Bug Fixes**
 - Hides the default conferencing app for individual events.

<!-- End of auto-generated description by mrge. -->

