### PR TITLE
fix: remove disabled on SMS Workflow actions 

### DIFF
--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -168,11 +168,6 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                       options={actionOptions.map((option) => ({
                         ...option,
                       }))}
-                      isOptionDisabled={(option: {
-                        label: string;
-                        value: WorkflowActions;
-                        needsCredits: boolean;
-                      }) => option.needsCredits}
                     />
                   );
                 }}


### PR DESCRIPTION
## What does this PR do?

Fixes that SMS actions were still disabled for free users in the 'Add action' dialog

- Fixes #21360
- Fixes CAL-5781


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed the disabled state from SMS actions in the 'Add action' dialog so free users can select them.

<!-- End of auto-generated description by mrge. -->

