### PR TITLE
perf: Better perf by going event type first w/o booking

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -447,7 +447,7 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
           workflowId,
           eventTypeId,
         },
-      ].concat(userEventType.children.map((ch) => ({ workflowId, eventTypeId: ch.id }))),
+      ].concat(eventType.children.map((ch) => ({ workflowId, eventTypeId: ch.id }))),
     });
     const requiresAttendeeNumber = (action: WorkflowActions) =>
       action === WorkflowActions.SMS_ATTENDEE || action === WorkflowActions.WHATSAPP_ATTENDEE;

--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -161,7 +161,7 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
     await prisma.workflowsOnEventTypes.deleteMany({
       where: {
         workflowId,
-        eventTypeId: { in: [eventTypeId].concat(eventType.children.map((ch) => ch.id)) },
+        eventTypeId: { in: activeOn },
       },
     });
 
@@ -228,15 +228,11 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
       eventTypeWorkflow.trigger == WorkflowTriggerEvents.BEFORE_EVENT ||
       eventTypeWorkflow.trigger == WorkflowTriggerEvents.AFTER_EVENT
     ) {
-      // we used to OR by eventType.parentId - but if so the eventTypeId
-      // would be a child of the current event type. So instead we have a list
-      // of the current event type and all its children
-      const eventTypeIds = [eventTypeId].concat(eventType.children.map((ch) => ch.id));
       // activate workflow and schedule reminders for existing bookings
       const bookingsForReminders = await prisma.booking.findMany({
         where: {
           eventTypeId: {
-            in: eventTypeIds,
+            in: activeOn,
           },
           status: BookingStatus.ACCEPTED,
           startTime: {

--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -147,7 +147,9 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
 
   const activeOnEventTypes = new Map<number, typeof eventType>([
     [eventType.id, eventType],
-    ...(eventType.children?.map((child) => [child.id, child]) ?? []),
+    ...(eventType.children
+      ? eventType.children.map((child) => [child.id, child] as [number, typeof eventType])
+      : []),
   ]);
 
   if (isActive) {
@@ -292,7 +294,8 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
       const bookerUrl = await getBookerBaseUrl(ctx.user.organizationId ?? null);
 
       for (const booking of bookingsForReminders) {
-        const bookingEventType = activeOnEventTypes.get(booking.eventTypeId);
+        // eventTypeId is technically nullable but we know it will be there
+        const bookingEventType = activeOnEventTypes.get(booking.eventTypeId!);
         const defaultLocale = "en";
         const bookingInfo = {
           uid: booking.uid,

--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -228,17 +228,16 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
       eventTypeWorkflow.trigger == WorkflowTriggerEvents.BEFORE_EVENT ||
       eventTypeWorkflow.trigger == WorkflowTriggerEvents.AFTER_EVENT
     ) {
+      // we used to OR by eventType.parentId - but if so the eventTypeId
+      // would be a child of the current event type. So instead we have a list
+      // of the current event type and all its children
+      const eventTypeIds = [eventTypeId].concat(eventType.children.map((ch) => ch.id));
       // activate workflow and schedule reminders for existing bookings
       const bookingsForReminders = await prisma.booking.findMany({
         where: {
-          OR: [
-            { eventTypeId },
-            {
-              eventType: {
-                parentId: eventTypeId,
-              },
-            },
-          ],
+          eventTypeId: {
+            in: eventTypeIds,
+          },
           status: BookingStatus.ACCEPTED,
           startTime: {
             gte: new Date(),

--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -469,7 +469,10 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
     }
 
     await prisma.workflowsOnEventTypes.createMany({
-      data: Array.from(activeOnEventTypes).map((ch) => ({ workflowId, eventTypeId: ch.id })),
+      data: Array.from(activeOnEventTypes).map(([eventTypeId]) => ({
+        workflowId,
+        eventTypeId,
+      })),
     });
     const requiresAttendeeNumber = (action: WorkflowActions) =>
       action === WorkflowActions.SMS_ATTENDEE || action === WorkflowActions.WHATSAPP_ATTENDEE;


### PR DESCRIPTION
## What does this PR do?

By making the hosts join query part of the booking.findMany, we end up fetching all hosts for each individual booking. This is a huge issue for big teams where there may be thousands of bookings with thousands of hosts; there's no way this will ever not time-out.

Huge database impact also.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Improved performance in the activateEventType handler by fetching event type and host data up front, avoiding repeated host queries for each booking.

- **Performance**
  - Reduced database load by removing nested host lookups inside booking queries.
  - Now fetches hosts once per event type instead of once per booking.

<!-- End of auto-generated description by mrge. -->

