### PR TITLE
perf: cache TRPC queries in /event-types RSC

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -74,4 +74,3 @@ const Page = async ({ params, searchParams }: PageProps) => {
 };
 
 export default Page;
-export const revalidate = 3600; // 1 hour in seconds

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -30,7 +30,7 @@ const getCachedMe = unstable_cache(
     return await meCaller.get();
   },
   undefined,
-  { revalidate: 3600 }
+  { revalidate: 3600 } // seconds
 );
 
 const getCachedEventGroups = unstable_cache(
@@ -42,7 +42,7 @@ const getCachedEventGroups = unstable_cache(
     return await eventTypesCaller.getUserEventGroups({ filters });
   },
   undefined,
-  { revalidate: 3600 }
+  { revalidate: 3600 } // seconds
 );
 
 const Page = async ({ params, searchParams }: PageProps) => {

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -34,7 +34,15 @@ const getCachedMe = unstable_cache(
 );
 
 const getCachedEventGroups = unstable_cache(
-  async (headers: ReadonlyHeaders, cookies: ReadonlyRequestCookies, filters: any) => {
+  async (
+    headers: ReadonlyHeaders,
+    cookies: ReadonlyRequestCookies,
+    filters?: {
+      teamIds?: number[] | undefined;
+      userIds?: number[] | undefined;
+      upIds?: string[] | undefined;
+    }
+  ) => {
     const eventTypesCaller = await createRouterCaller(
       eventTypesRouter,
       await getTRPCContext(headers, cookies)

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -29,7 +29,7 @@ const getCachedMe = unstable_cache(
     const meCaller = await createRouterCaller(meRouter, await getTRPCContext(headers, cookies));
     return await meCaller.get();
   },
-  undefined,
+  ["viewer.me.get"],
   { revalidate: 3600 } // seconds
 );
 
@@ -41,7 +41,7 @@ const getCachedEventGroups = unstable_cache(
     );
     return await eventTypesCaller.getUserEventGroups({ filters });
   },
-  undefined,
+  ["viewer.eventTypes.getUserEventGroups"],
   { revalidate: 3600 } // seconds
 );
 

--- a/apps/web/app/_trpc/context.ts
+++ b/apps/web/app/_trpc/context.ts
@@ -1,20 +1,22 @@
+import type { ReadonlyHeaders, ReadonlyRequestCookies } from "app/_types";
 import { cookies, headers } from "next/headers";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { createContext } from "@calcom/trpc/server/createContext";
 import { createCallerFactory } from "@calcom/trpc/server/trpc";
+import type { TRPCContext } from "@calcom/trpc/types/server/createContext";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import type { AnyRouter } from "@trpc/server";
 
-const getTRPCContext = async () => {
-  const legacyReq = buildLegacyRequest(await headers(), await cookies());
+export const getTRPCContext = async (_headers?: ReadonlyHeaders, _cookies?: ReadonlyRequestCookies) => {
+  const legacyReq = buildLegacyRequest(_headers ?? (await headers()), _cookies ?? (await cookies()));
   return await createContext({ req: legacyReq, res: {} as any }, getServerSession);
 };
 
-export async function createRouterCaller<TRouter extends AnyRouter>(router: TRouter) {
-  const trpcContext = await getTRPCContext();
+export async function createRouterCaller<TRouter extends AnyRouter>(router: TRouter, context?: TRPCContext) {
+  const trpcContext = context ? context : await getTRPCContext();
   const createCaller = createCallerFactory<TRouter>(router);
   return createCaller(trpcContext);
 }

--- a/apps/web/app/_types.ts
+++ b/apps/web/app/_types.ts
@@ -12,3 +12,6 @@ export type PageProps = {
 };
 
 export type LayoutProps = { params: Promise<Params>; children: React.ReactElement };
+
+export { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
+export { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";


### PR DESCRIPTION
## What does this PR do?

- Caches Server TRPC queries in /event-types RSC to reduce server calls



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Before
- Every time we visit `/event-types`, server TRPC queries run and hence we see the skeleton (rendered from `/event-types/loading.tsx`)

https://github.com/user-attachments/assets/c145a06b-b040-48a3-b5c1-48240c95e050

### After

https://github.com/user-attachments/assets/b7c2e373-943d-41a8-be11-3c7f55b7b62a

#### We already call `revalidateEventTypesList` (which revalidates this RSC page) in places where it's needed, so creating a new event-type or updating an existing event-type overrides cache and hence works as expected:

https://github.com/user-attachments/assets/21358969-dc15-409f-a3cc-40fd17ee6f2f


