### PR TITLE
chore: Add workflow to post security advisories to Slack

### DIFF
--- a/.github/workflows/advisories-to-slack.yml
+++ b/.github/workflows/advisories-to-slack.yml
@@ -1,0 +1,23 @@
+name: Notify New Security Advisories
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch advisories and send to Slack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SECURITY_ADVISORIES }}
+        run: |
+          curl -s -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/calcom/cal.com/security-advisories \
+            | jq -r '.[] | select(.state=="published") | "\(.summary)\n\(.url)"' \
+            | while read -r msg; do
+                [ -n "$msg" ] && curl -X POST -H 'Content-type: application/json' \
+                  --data "{\"text\":\"$msg\"}" "$SLACK_WEBHOOK"
+              done


### PR DESCRIPTION
## What does this PR do?

Posts security advisories to our Slack.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a GitHub Actions workflow that posts new published security advisories to Slack every hour. This keeps the team updated on security issues in real time.

<!-- End of auto-generated description by cubic. -->

