### PR TITLE
fix: Wrong event details sent to previous host on reschedule RR event

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1602,6 +1602,7 @@ async function handler(
         additionalNotes, // Resets back to the additionalNote input and not the override value
         cancellationReason: `$RCH$${rescheduleReason ? rescheduleReason : ""}`, // Removable code prefix to differentiate cancellation from rescheduling for email
       };
+      const cancelledRRHostEvt = cloneDeep(copyEventAdditionalInfo);
       loggerWithEventDetails.debug("Emails: Sending rescheduled emails for booking confirmation");
 
       /*
@@ -1611,6 +1612,7 @@ async function handler(
       */
       if (eventType.schedulingType === SchedulingType.ROUND_ROBIN) {
         const originalBookingMemberEmails: Person[] = [];
+        const translate = await getTranslation(originalRescheduledBooking.user.locale ?? "en", "common");
 
         for (const user of originalRescheduledBooking.attendees) {
           const translate = await getTranslation(user.locale ?? "en", "common");
@@ -1623,12 +1625,27 @@ async function handler(
           });
         }
         if (originalRescheduledBooking.user) {
-          const translate = await getTranslation(originalRescheduledBooking.user.locale ?? "en", "common");
           originalBookingMemberEmails.push({
             ...originalRescheduledBooking.user,
             name: originalRescheduledBooking.user.name || "",
             language: { translate, locale: originalRescheduledBooking.user.locale ?? "en" },
           });
+        }
+
+        if (changedOrganizer) {
+          const originalOrganizer = originalRescheduledBooking.user;
+
+          cancelledRRHostEvt.title = originalRescheduledBooking.title;
+          cancelledRRHostEvt.startTime =
+            dayjs(originalRescheduledBooking?.startTime).utc().format() || copyEventAdditionalInfo.startTime;
+          cancelledRRHostEvt.endTime =
+            dayjs(originalRescheduledBooking?.endTime).utc().format() || copyEventAdditionalInfo.endTime;
+          cancelledRRHostEvt.organizer = {
+            email: originalOrganizer.email,
+            name: originalOrganizer.name || "",
+            timeZone: originalOrganizer.timeZone,
+            language: { translate, locale: originalOrganizer.locale || "en" },
+          };
         }
 
         const newBookingMemberEmails: Person[] =
@@ -1671,7 +1688,7 @@ async function handler(
             members: newBookedMembers,
             eventTypeMetadata: eventType.metadata,
           });
-          sendRoundRobinCancelledEmailsAndSMS(copyEventAdditionalInfo, cancelledMembers, eventType.metadata);
+          sendRoundRobinCancelledEmailsAndSMS(cancelledRRHostEvt, cancelledMembers, eventType.metadata);
         }
       } else {
         if (!isDryRun) {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1612,7 +1612,6 @@ async function handler(
       */
       if (eventType.schedulingType === SchedulingType.ROUND_ROBIN) {
         const originalBookingMemberEmails: Person[] = [];
-        const translate = await getTranslation(originalRescheduledBooking.user.locale ?? "en", "common");
 
         for (const user of originalRescheduledBooking.attendees) {
           const translate = await getTranslation(user.locale ?? "en", "common");
@@ -1625,27 +1624,29 @@ async function handler(
           });
         }
         if (originalRescheduledBooking.user) {
+          const translate = await getTranslation(originalRescheduledBooking.user.locale ?? "en", "common");
+          const originalOrganizer = originalRescheduledBooking.user;
+
           originalBookingMemberEmails.push({
             ...originalRescheduledBooking.user,
             name: originalRescheduledBooking.user.name || "",
             language: { translate, locale: originalRescheduledBooking.user.locale ?? "en" },
           });
-        }
 
-        if (changedOrganizer) {
-          const originalOrganizer = originalRescheduledBooking.user;
-
-          cancelledRRHostEvt.title = originalRescheduledBooking.title;
-          cancelledRRHostEvt.startTime =
-            dayjs(originalRescheduledBooking?.startTime).utc().format() || copyEventAdditionalInfo.startTime;
-          cancelledRRHostEvt.endTime =
-            dayjs(originalRescheduledBooking?.endTime).utc().format() || copyEventAdditionalInfo.endTime;
-          cancelledRRHostEvt.organizer = {
-            email: originalOrganizer.email,
-            name: originalOrganizer.name || "",
-            timeZone: originalOrganizer.timeZone,
-            language: { translate, locale: originalOrganizer.locale || "en" },
-          };
+          if (changedOrganizer) {
+            cancelledRRHostEvt.title = originalRescheduledBooking.title;
+            cancelledRRHostEvt.startTime =
+              dayjs(originalRescheduledBooking?.startTime).utc().format() ||
+              copyEventAdditionalInfo.startTime;
+            cancelledRRHostEvt.endTime =
+              dayjs(originalRescheduledBooking?.endTime).utc().format() || copyEventAdditionalInfo.endTime;
+            cancelledRRHostEvt.organizer = {
+              email: originalOrganizer.email,
+              name: originalOrganizer.name || "",
+              timeZone: originalOrganizer.timeZone,
+              language: { translate, locale: originalOrganizer.locale || "en" },
+            };
+          }
         }
 
         const newBookingMemberEmails: Person[] =


### PR DESCRIPTION
## What does this PR do?
When a customer reschedules an event originally booked with Consultant A with Consultant B. Consultant A is getting a cancellation notification with the new time and info with Consultant B.

## Summary by cubic
Fixed an issue where the wrong event details were sent to the previous host when a round robin event was rescheduled.

- **Bug Fixes**
  - Ensured the cancellation email to the previous host now includes the correct event title, time, and organizer details.

<!-- End of auto-generated description by cubic. -->

