### PR TITLE
revert: "perf: add p-limit to _getUsersAvailability to limit concurre…

### DIFF
--- a/packages/lib/getUserAvailability.ts
+++ b/packages/lib/getUserAvailability.ts
@@ -7,7 +7,6 @@ import type {
   EventType as PrismaEventType,
 } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
-import pLimit from "p-limit";
 import { z } from "zod";
 
 import type { Dayjs } from "@calcom/dayjs";
@@ -700,26 +699,22 @@ type GetUsersAvailabilityProps = {
 };
 
 const _getUsersAvailability = async ({ users, query, initialData }: GetUsersAvailabilityProps) => {
-  const limit = pLimit(10);
-
   return await Promise.all(
     users.map((user) =>
-      limit(() =>
-        _getUserAvailability(
-          {
-            ...query,
-            userId: user.id,
-            username: user.username || "",
-          },
-          initialData
-            ? {
-                ...initialData,
-                user,
-                currentBookings: user.currentBookings,
-                outOfOfficeDays: user.outOfOfficeDays,
-              }
-            : undefined
-        )
+      _getUserAvailability(
+        {
+          ...query,
+          userId: user.id,
+          username: user.username || "",
+        },
+        initialData
+          ? {
+              ...initialData,
+              user,
+              currentBookings: user.currentBookings,
+              outOfOfficeDays: user.outOfOfficeDays,
+            }
+          : undefined
       )
     )
   );


### PR DESCRIPTION
This is causing things to break in API v2 after the platform-libraries were updated. Reverting until we can figure that out.
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the p-limit concurrency control from _getUsersAvailability, so all user availability checks now run in parallel without a limit.

<!-- End of auto-generated description by cubic. -->

