### PR TITLE
chore: Increase workflows/trpc timeout to 800s

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -26,6 +26,9 @@
     }
   ],
   "functions": {
+    "pages/api/trpc/workflows/[trpc].ts": {
+      "maxDuration": 800
+    },
     "pages/api/trpc/highPerf/[trpc].ts": {
       "memory": 3008
     },


### PR DESCRIPTION
## What does this PR do?

Target activateEventType/update so we can process wf updates that take longer to complete due to a larger amount of bookings.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increased the timeout for the workflows TRPC API route to 800 seconds to support processing updates with many bookings.

<!-- End of auto-generated description by cubic. -->

