### PR TITLE
fix: don’t let the booking page crash on invalid metadata

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -87,7 +87,9 @@ function buildParsedBooking(booking: BookingItemProps) {
       >)
     : null;
 
-  const bookingMetadata = bookingMetadataSchema.parse(booking.metadata ?? null);
+  const parsedMetadata = bookingMetadataSchema.safeParse(booking.metadata ?? null);
+  const bookingMetadata = parsedMetadata.success ? parsedMetadata.data : null;
+
   return {
     ...booking,
     eventType: bookingEventType,

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -129,7 +129,9 @@ export default function Success(props: PageProps) {
     rescheduleLocation = bookingInfo.responses.location.optionValue;
   }
 
-  const parsedBookingMetadata = bookingMetadataSchema.parse(bookingInfo?.metadata || {});
+  const parsed = bookingMetadataSchema.safeParse(bookingInfo?.metadata ?? null);
+  const parsedBookingMetadata = parsed.success ? parsed.data : null;
+
   const bookingWithParsedMetadata = {
     ...bookingInfo,
     metadata: parsedBookingMetadata,

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -390,7 +390,7 @@ export const bookingMetadataSchema = z
   .object({
     videoCallUrl: z.string().optional(),
   })
-  .and(z.record(z.unknown()))
+  .and(z.record(z.string()))
   .nullable()
   .describe("BookingMetadata");
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -390,7 +390,7 @@ export const bookingMetadataSchema = z
   .object({
     videoCallUrl: z.string().optional(),
   })
-  .catchall(z.unknown())
+  .and(z.record(z.unknown()))
   .nullable()
   .describe("BookingMetadata");
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -390,7 +390,7 @@ export const bookingMetadataSchema = z
   .object({
     videoCallUrl: z.string().optional(),
   })
-  .and(z.record(z.string()))
+  .passthrough()
   .nullable()
   .describe("BookingMetadata");
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -390,7 +390,7 @@ export const bookingMetadataSchema = z
   .object({
     videoCallUrl: z.string().optional(),
   })
-  .passthrough()
+  .catchall(z.unknown())
   .nullable()
   .describe("BookingMetadata");
 


### PR DESCRIPTION
## What does this PR do?

![screenshot_2025-05-20_at_11 00 50](https://github.com/user-attachments/assets/5b7dee1b-3777-45a8-a9c6-d1af9a394665)


<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a crash on the booking page caused by invalid metadata, so the page now handles unexpected fields without breaking.

<!-- End of auto-generated description by cubic. -->

