### PR TITLE
chore: use correct import path for AppRouter

### DIFF
--- a/apps/web/components/apps/MultiDisconnectIntegration.tsx
+++ b/apps/web/components/apps/MultiDisconnectIntegration.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import type { AppRouter } from "@calcom/trpc/server/routers/_app";
+import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 import { Button } from "@calcom/ui/components/button";
 import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
 import {


### PR DESCRIPTION
## What does this PR do?

We're supposed to import AppRouter from the generated `types` folder instead of the source file.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the import path for AppRouter to use the generated types folder instead of the source file.

<!-- End of auto-generated description by cubic. -->

