### PR TITLE
test: update flaky tests

### DIFF
--- a/packages/features/insights/__tests__/booking-denormalized.integration-test.ts
+++ b/packages/features/insights/__tests__/booking-denormalized.integration-test.ts
@@ -9,6 +9,7 @@ describe("BookingDenormalized", () => {
   let bookingId: number;
   const randomId = Math.floor(Math.random() * 1000000);
   const email = `booking-denorm-${randomId}@example.com`;
+  const updatedEmail = `updated-${email}`;
 
   beforeEach(async () => {
     // Create test user
@@ -101,7 +102,7 @@ describe("BookingDenormalized", () => {
         where: { id: userId },
         data: {
           name: "Updated User",
-          email: "updated@example.com",
+          email: updatedEmail,
         },
       });
 
@@ -110,7 +111,7 @@ describe("BookingDenormalized", () => {
       });
 
       expect(userUpdatedDenormalizedBooking.userName).toBe("Updated User");
-      expect(userUpdatedDenormalizedBooking.userEmail).toBe("updated@example.com");
+      expect(userUpdatedDenormalizedBooking.userEmail).toBe(updatedEmail);
     });
 
     it("should update denormalized entry when event type is updated", async () => {

--- a/packages/features/insights/__tests__/routing-form-response-denormalized.integration-test.ts
+++ b/packages/features/insights/__tests__/routing-form-response-denormalized.integration-test.ts
@@ -12,14 +12,15 @@ describe("RoutingFormResponseDenormalized", () => {
   let bookingId: number;
   let responseId: number;
   const randomId = Math.floor(Math.random() * 1000000);
-  const email = `booking-denorm-${randomId}@example.com`;
+  const email = `routing-form-response-denorm-${randomId}@example.com`;
+  const updatedEmail = `updated-${email}`;
 
   beforeEach(async () => {
     // Create test user
     const user = await prisma.user.create({
       data: {
         email,
-        username: `booking-denorm-testuser-${randomId}`,
+        username: `routing-form-response-denorm-testuser-${randomId}`,
         name: "Test User",
       },
     });
@@ -96,7 +97,7 @@ describe("RoutingFormResponseDenormalized", () => {
     // Create test booking
     const booking = await prisma.booking.create({
       data: {
-        uid: `booking-denorm-${randomId}`,
+        uid: `routing-form-response-denorm-${randomId}`,
         title: "Test Booking",
         startTime: new Date(),
         endTime: new Date(Date.now() + 60 * 60 * 1000),
@@ -254,7 +255,7 @@ describe("RoutingFormResponseDenormalized", () => {
         where: { id: userId },
         data: {
           name: "Updated User",
-          email: "updated@example.com",
+          email: updatedEmail,
         },
       });
 
@@ -263,7 +264,7 @@ describe("RoutingFormResponseDenormalized", () => {
       });
 
       expect(denormalizedResponse.bookingUserName).toBe("Updated User");
-      expect(denormalizedResponse.bookingUserEmail).toBe("updated@example.com");
+      expect(denormalizedResponse.bookingUserEmail).toBe(updatedEmail);
     });
 
     it("should update denormalized entry when booking is updated", async () => {
@@ -636,7 +637,7 @@ describe("RoutingFormResponseDenormalized", () => {
       // Create a booking with attendees
       const booking = await prisma.booking.create({
         data: {
-          uid: `booking-denorm-${Math.floor(Math.random() * 1000000)}`,
+          uid: `routing-form-response-denorm-${Math.floor(Math.random() * 1000000)}`,
           title: "Test Booking",
           startTime: new Date(),
           endTime: new Date(Date.now() + 60 * 60 * 1000),

--- a/packages/lib/slots.test.ts
+++ b/packages/lib/slots.test.ts
@@ -392,7 +392,7 @@ describe("Tests the slots function performance", () => {
     const endTime = process.hrtime(startTime);
     const executionTimeInMs = endTime[0] * 1000 + endTime[1] / 1000000;
 
-    expect(executionTimeInMs).toBeLessThan(2000); // less than 2 seconds for 2000 date ranges
+    expect(executionTimeInMs).toBeLessThan(3000); // less than 3 seconds for 2000 date ranges
 
     console.log(
       `Performance test completed in ${executionTimeInMs}ms with ${result.length} slots generated from ${dateRanges.length} date ranges`


### PR DESCRIPTION
## What does this PR do?

- We had `updated@example.com` email in the integration tests which sometimes caused issue because of the unique constraint. This PR updates it to be more unique.
- Increasing timeout limit for slot test

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

The integration tests should pass.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated integration tests to use unique email addresses and usernames to prevent failures from duplicate values.

<!-- End of auto-generated description by cubic. -->

