### PR TITLE
fix: Delegation Credentials - Use Cal Video if set as the default conferencing app

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/getLocationValuesForDb.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getLocationValuesForDb.ts
@@ -15,7 +15,7 @@ const sortUsersByDynamicList = <TUser extends { username: string | null }>(
   });
 };
 
-const _getLocationValuesForDb = <
+export const _getLocationValuesForDb = <
   TUser extends {
     username: string | null;
     metadata: Prisma.JsonValue;
@@ -42,9 +42,17 @@ const _getLocationValuesForDb = <
         credentials: firstDynamicGroupMember.credentials,
       });
 
-    firstDynamicGroupMemberDefaultLocationUrl =
-      firstDynamicGroupMemberMetadata?.defaultConferencingApp?.appLink ||
-      firstDynamicGroupMemberDelegationCredentialConferencingAppLocation;
+    const defaultConferencingApp = firstDynamicGroupMemberMetadata?.defaultConferencingApp;
+
+    const hasMemberSetConferencingPreference =
+      !!defaultConferencingApp?.appSlug || !!defaultConferencingApp?.appLink;
+
+    if (!hasMemberSetConferencingPreference) {
+      firstDynamicGroupMemberDefaultLocationUrl =
+        firstDynamicGroupMemberDelegationCredentialConferencingAppLocation ?? null;
+    } else {
+      firstDynamicGroupMemberDefaultLocationUrl = defaultConferencingApp?.appLink ?? null;
+    }
 
     locationBodyString = firstDynamicGroupMemberDefaultLocationUrl || locationBodyString;
   }

--- a/packages/features/bookings/lib/handleNewBooking/getLocationValuesForDb.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getLocationValuesForDb.ts
@@ -47,12 +47,10 @@ export const _getLocationValuesForDb = <
     const hasMemberSetConferencingPreference =
       !!defaultConferencingApp?.appSlug || !!defaultConferencingApp?.appLink;
 
-    if (!hasMemberSetConferencingPreference) {
-      firstDynamicGroupMemberDefaultLocationUrl =
-        firstDynamicGroupMemberDelegationCredentialConferencingAppLocation ?? null;
-    } else {
-      firstDynamicGroupMemberDefaultLocationUrl = defaultConferencingApp?.appLink ?? null;
-    }
+    firstDynamicGroupMemberDefaultLocationUrl =
+      (hasMemberSetConferencingPreference
+        ? defaultConferencingApp?.appLink
+        : firstDynamicGroupMemberDelegationCredentialConferencingAppLocation) ?? null;
 
     locationBodyString = firstDynamicGroupMemberDefaultLocationUrl || locationBodyString;
   }

--- a/packages/features/bookings/lib/handleNewBooking/test/getLocationValueForDb.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/getLocationValueForDb.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { Prisma } from "@calcom/prisma/client";
+import type { CredentialForCalendarService } from "@calcom/types/Credential";
+
+import { _getLocationValuesForDb } from "../getLocationValuesForDb";
+
+vi.mock("@calcom/prisma/zod-utils", () => ({
+  userMetadata: { parse: (metadata: any) => metadata },
+}));
+
+vi.mock("@calcom/lib/delegationCredential/server", () => ({
+  getFirstDelegationConferencingCredentialAppLocation: ({
+    credentials,
+  }: {
+    credentials: CredentialForCalendarService[];
+  }) => (credentials[0] && (credentials[0] as any).__test__appLink) || null,
+}));
+
+type TestUser = {
+  username: string | null;
+  metadata: Prisma.JsonValue;
+  credentials: CredentialForCalendarService[];
+};
+
+describe("_getLocationValuesForDb", () => {
+  it("returns the provided location for single user bookings", () => {
+    const users: TestUser[] = [
+      {
+        username: "alice",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["alice"],
+      users,
+      location: "https://meet.example.com/alice",
+    });
+    expect(result.locationBodyString).toBe("https://meet.example.com/alice");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBeUndefined();
+  });
+
+  it("uses the first group member's default conferencing appLink if set", () => {
+    const users: TestUser[] = [
+      {
+        username: "bob",
+        metadata: {
+          defaultConferencingApp: {
+            appSlug: "zoom",
+            appLink: "https://zoom.us/bob",
+          },
+        },
+        credentials: [],
+      },
+      {
+        username: "carol",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["bob", "carol"],
+      users,
+      location: "https://meet.example.com/group",
+    });
+    expect(result.locationBodyString).toBe("https://zoom.us/bob");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBe("https://zoom.us/bob");
+  });
+
+  it("uses the first group member's first delegation credential's conferencing app if no preference is set", () => {
+    const users: TestUser[] = [
+      {
+        username: "dave",
+        metadata: {},
+        credentials: [
+          {
+            __test__appLink: "https://meet.google.com/dave",
+          } as unknown as CredentialForCalendarService,
+        ],
+      },
+      {
+        username: "eve",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["dave", "eve"],
+      users,
+      location: "https://meet.example.com/group",
+    });
+    expect(result.locationBodyString).toBe("https://meet.google.com/dave");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBe("https://meet.google.com/dave");
+  });
+
+  it("falls back to provided location if no preferences or credentials are set", () => {
+    const users: TestUser[] = [
+      {
+        username: "frank",
+        metadata: {},
+        credentials: [],
+      },
+      {
+        username: "grace",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["frank", "grace"],
+      users,
+      location: "https://meet.example.com/group",
+    });
+    expect(result.locationBodyString).toBe("https://meet.example.com/group");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBeNull();
+  });
+
+  it("falls back to provided location if preference is set but has no appLink", () => {
+    const users: TestUser[] = [
+      {
+        username: "frank",
+        metadata: {
+          defaultConferencingApp: {
+            appSlug: "daily-video",
+          },
+        },
+        credentials: [],
+      },
+      {
+        username: "grace",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["frank", "grace"],
+      users,
+      location: "https://meet.example.com/group",
+    });
+    expect(result.locationBodyString).toBe("https://meet.example.com/group");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBeNull();
+  });
+
+  it("sorts users according to dynamicUserList before picking the first member", () => {
+    const users: TestUser[] = [
+      {
+        username: "zara",
+        metadata: {
+          defaultConferencingApp: {
+            appSlug: "teams",
+            appLink: "https://teams.microsoft.com/zara",
+          },
+        },
+        credentials: [],
+      },
+      {
+        username: "yanni",
+        metadata: {},
+        credentials: [],
+      },
+    ];
+    // yanni is first in dynamicUserList, but zara is first in users array
+    const result = _getLocationValuesForDb({
+      dynamicUserList: ["yanni", "zara"],
+      users,
+      location: "https://meet.example.com/group",
+    });
+    // After sorting, yanni is first, has no preference, so fallback to location
+    expect(result.locationBodyString).toBe("https://meet.example.com/group");
+    expect(result.organizerOrFirstDynamicGroupMemberDefaultLocationUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where Google Meet was being used as the conferencing location even when a user had set a Default Cal Video preference. Now, if a user has a  Cal Video set as the preference, that  is respected and used as the location for group bookings, rather than falling back to Google Meet from delegation credentials.

- Fixes: Ensures the user's default conferencing app (e.g., Cal Video) is prioritized over Google Meet from delegation credentials. It wasn't working only in the case where a default conferencing app doesn't set any `appLink` which is true for dynamic link conferencing apps.
- Adds: New test coverage in `getLocationValueForDb.test.ts` to verify correct location selection logic.
- Adds: A bookingScenario test in `packages/features/bookings/lib/handleNewBooking/test/delegation-credential.test.ts`

## Visual Demo

N/A (Logic change, covered by automated tests)

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] I have updated/added tests to verify the fix.
- [x] N/A for developer docs (no documentation change required).

## How should this be tested?

- Run the test suite in `packages/features/bookings/lib/handleNewBooking/test/`.
- Ensure that bookings for users with a default conferencing app set use that app as the location.
- Verify that if no default is set, the fallback to delegation credential or provided location works as expected.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes generate no new warnings.
