### PR TITLE
fix: don't schedule past workflow reminders with tasker

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/providers/emailProvider.ts
+++ b/packages/features/ee/workflows/lib/reminders/providers/emailProvider.ts
@@ -8,11 +8,13 @@ type EmailData = Omit<WorkflowEmailData, "to"> & {
 
 export async function sendOrScheduleWorkflowEmails(mailData: EmailData) {
   if (mailData.sendAt) {
-    const { sendAt, referenceUid, ...taskerData } = mailData;
-    return await tasker.create("sendWorkflowEmails", taskerData, {
-      scheduledAt: sendAt,
-      referenceUid,
-    });
+    if (mailData.sendAt > new Date()) {
+      const { sendAt, referenceUid, ...taskerData } = mailData;
+      return await tasker.create("sendWorkflowEmails", taskerData, {
+        scheduledAt: sendAt,
+        referenceUid,
+      });
+    }
   } else {
     await Promise.all(
       mailData.to.map((to) =>

--- a/packages/features/ee/workflows/lib/reminders/providers/emailProvider.ts
+++ b/packages/features/ee/workflows/lib/reminders/providers/emailProvider.ts
@@ -8,13 +8,12 @@ type EmailData = Omit<WorkflowEmailData, "to"> & {
 
 export async function sendOrScheduleWorkflowEmails(mailData: EmailData) {
   if (mailData.sendAt) {
-    if (mailData.sendAt > new Date()) {
-      const { sendAt, referenceUid, ...taskerData } = mailData;
-      return await tasker.create("sendWorkflowEmails", taskerData, {
-        scheduledAt: sendAt,
-        referenceUid,
-      });
-    }
+    if (mailData.sendAt <= new Date()) return;
+    const { sendAt, referenceUid, ...taskerData } = mailData;
+    return await tasker.create("sendWorkflowEmails", taskerData, {
+      scheduledAt: sendAt,
+      referenceUid,
+    });
   } else {
     await Promise.all(
       mailData.to.map((to) =>

--- a/packages/features/ee/workflows/lib/test/workflows.test.ts
+++ b/packages/features/ee/workflows/lib/test/workflows.test.ts
@@ -642,11 +642,11 @@ describe("scheduleBookingReminders", () => {
           {
             name: "Workflow",
             userId: 101,
-            trigger: "AFTER_EVENT",
+            trigger: "BEFORE_EVENT",
             action: "SMS_NUMBER",
             template: "REMINDER",
             activeOn: [],
-            time: 3,
+            time: 20,
             timeUnit: TimeUnit.HOUR,
             sendTo: "000",
           },
@@ -744,10 +744,10 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-21T12:15:00.000"),
-      new Date("2024-05-21T12:30:00.000Z"),
-      new Date("2024-06-01T08:00:00.000Z"),
-      new Date("2024-06-02T08:00:00.000Z"),
+      new Date("2024-05-20T13:00:00.000"),
+      new Date("2024-05-20T13:15:00.000Z"),
+      new Date("2024-05-31T08:30:00.000Z"),
+      new Date("2024-06-01T08:30:00.000Z"),
     ];
 
     scheduledWorkflowReminders.forEach((reminder, index) => {

--- a/packages/features/ee/workflows/lib/test/workflows.test.ts
+++ b/packages/features/ee/workflows/lib/test/workflows.test.ts
@@ -96,8 +96,8 @@ const mockBookings = [
     eventTypeId: 1,
     userId: 101,
     status: BookingStatus.ACCEPTED,
-    startTime: `2024-05-20T09:00:00.000Z`,
-    endTime: `2024-05-20T09:15:00.000Z`,
+    startTime: `2024-05-21T09:00:00.000Z`,
+    endTime: `2024-05-21T09:15:00.000Z`,
     attendees: [{ email: "attendee@example.com", locale: "en" }],
   },
   {
@@ -105,8 +105,8 @@ const mockBookings = [
     eventTypeId: 1,
     userId: 101,
     status: BookingStatus.ACCEPTED,
-    startTime: `2024-05-20T09:15:00.000Z`,
-    endTime: `2024-05-20T09:30:00.000Z`,
+    startTime: `2024-05-21T09:15:00.000Z`,
+    endTime: `2024-05-21T09:30:00.000Z`,
     attendees: [{ email: "attendee@example.com", locale: "en" }],
   },
   {
@@ -518,8 +518,8 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-20T08:00:00.000"),
-      new Date("2024-05-20T08:15:00.000Z"),
+      new Date("2024-05-21T08:00:00.000"),
+      new Date("2024-05-21T08:15:00.000Z"),
       new Date("2024-06-01T03:30:00.000Z"),
       new Date("2024-06-02T03:30:00.000Z"),
     ];
@@ -604,8 +604,8 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-20T10:15:00.000"),
-      new Date("2024-05-20T10:30:00.000Z"),
+      new Date("2024-05-21T10:15:00.000"),
+      new Date("2024-05-21T10:30:00.000Z"),
       new Date("2024-06-01T06:00:00.000Z"),
       new Date("2024-06-02T06:00:00.000Z"),
     ];
@@ -710,13 +710,13 @@ describe("scheduleBookingReminders", () => {
     expectSMSWorkflowToBeTriggered({
       sms,
       toNumber: "000",
-      includedString: "2024 May 20 at 2:30pm Asia/Kolkata",
+      includedString: "2024 May 21 at 2:30pm Asia/Kolkata",
     });
 
     expectSMSWorkflowToBeTriggered({
       sms,
       toNumber: "000",
-      includedString: "2024 May 20 at 2:45pm Asia/Kolkata",
+      includedString: "2024 May 21 at 2:45pm Asia/Kolkata",
     });
 
     // sms are too far in future
@@ -744,8 +744,8 @@ describe("scheduleBookingReminders", () => {
     );
 
     const expectedScheduledDates = [
-      new Date("2024-05-20T12:15:00.000"),
-      new Date("2024-05-20T12:30:00.000Z"),
+      new Date("2024-05-21T12:15:00.000"),
+      new Date("2024-05-21T12:30:00.000Z"),
       new Date("2024-06-01T08:00:00.000Z"),
       new Date("2024-06-02T08:00:00.000Z"),
     ];


### PR DESCRIPTION
## What does this PR do?

Fix that we don't schedule past reminders with the tasker anymore

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped scheduling workflow reminder emails if the reminder time is in the past.

- **Bug Fixes**
  - Added a check to prevent tasker from creating tasks for past reminders.
  - Added a test to confirm past reminders are not scheduled.

<!-- End of auto-generated description by cubic. -->

