### PR TITLE
Fix: Ensure calendar image is fully visible on home page top

### DIFF
--- a/packages/features/tips/UpgradeTip.tsx
+++ b/packages/features/tips/UpgradeTip.tsx
@@ -45,10 +45,10 @@ export function UpgradeTip({
   return (
     <>
       <div className="relative flex min-h-[295px] w-full items-center justify-between overflow-hidden rounded-lg pb-10">
-        <picture className="absolute min-h-[295px] w-full rounded-lg object-cover">
+        <picture className="absolute min-h-[295px] w-full rounded-lg object-contain">
           <source srcSet={imageSrc} media="(prefers-color-scheme: dark)" />
           <img
-            className="absolute min-h-[295px] w-full select-none rounded-lg object-cover object-left md:object-center"
+            className="absolute min-h-[295px] w-full select-none rounded-lg object-contain object-left md:object-center"
             src={imageSrc}
             loading="lazy"
             alt={title}


### PR DESCRIPTION
The calendar image displayed in the UpgradeTip component (e.g., on the enterprise page) was being cropped because of the `object-cover` Tailwind CSS class. This class was causing the image to fill its container while maintaining aspect ratio, leading to parts of the image being cut off if the aspect ratios didn't match.

I changed `object-cover` to `object-contain` for both the `<picture>` and `<img>` tags within the `UpgradeTip.tsx` component. This ensures that the entire image is displayed within the container, preventing any cropping. Letterboxing may occur if the image and container aspect ratios differ, but this is preferable to a cropped image as per the issue description.

## What does this PR do?

 Fixes an issue where calendar image, specifically on home page using the UpgradeTip component (like the enterprise page), was appearing cut in half.

- Fixes [CAL#21422 ](https://github.com/calcom/cal.com/issues/21422)
- Env: Staging (main branch)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the calendar image on the home page so it is fully visible and no longer cropped in the UpgradeTip component.

<!-- End of auto-generated description by cubic. -->

