### PR TITLE
fix: missing key prop in features list

### DIFF
--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -692,7 +692,7 @@ export default function Signup({
             </div>
             <div className="mr-12 mt-8 hidden h-full w-full grid-cols-3 gap-4 overflow-hidden lg:grid">
               {FEATURES.map((feature) => (
-                <>
+                <div key={feature.title}>
                   <div className="max-w-52 mb-8 flex flex-col leading-none sm:mb-0">
                     <div className="text-emphasis items-center">
                       <Icon name={feature.icon} className="mb-1 h-4 w-4" />
@@ -709,7 +709,7 @@ export default function Signup({
                       </p>
                     </div>
                   </div>
-                </>
+                </div>
               ))}
             </div>
           </div>


### PR DESCRIPTION
This PR fixes #21437, I have added the title from the features list as key, some other elements were also using the same approach.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a missing key prop to each feature in the signup view to fix a React warning.

<!-- End of auto-generated description by cubic. -->

