### PR TITLE
feat: Round robin, when attendee books same timeslot return original booking

### DIFF
--- a/apps/web/playwright/organization/booking.e2e.ts
+++ b/apps/web/playwright/organization/booking.e2e.ts
@@ -333,7 +333,7 @@ test.describe("Bookings", () => {
           // Second booking - should get a different host
           await page.goto(`/org/${org.slug}/${team.slug}/${teamEvent.slug}`);
           await selectFirstAvailableTimeSlotNextMonth(page);
-          await bookTimeSlot(page);
+          await bookTimeSlot(page, { email: "attendee1@test.com" });
           await expect(page.getByTestId("success-page")).toBeVisible();
           const secondHost = await page.getByTestId("booking-host-name").textContent();
           expect(secondHost).not.toBeNull();
@@ -342,7 +342,7 @@ test.describe("Bookings", () => {
           // Third booking - should get a different host
           await page.goto(`/org/${org.slug}/${team.slug}/${teamEvent.slug}`);
           await selectFirstAvailableTimeSlotNextMonth(page);
-          await bookTimeSlot(page);
+          await bookTimeSlot(page, { email: "attendee2@test.com" });
           await expect(page.getByTestId("success-page")).toBeVisible();
           const thirdHost = await page.getByTestId("booking-host-name").textContent();
           expect(thirdHost).not.toBeNull();
@@ -352,7 +352,7 @@ test.describe("Bookings", () => {
           // Fourth booking - should get a different host
           await page.goto(`/org/${org.slug}/${team.slug}/${teamEvent.slug}`);
           await selectFirstAvailableTimeSlotNextMonth(page);
-          await bookTimeSlot(page);
+          await bookTimeSlot(page, { email: "attendee3@test.com" });
           await expect(page.getByTestId("success-page")).toBeVisible();
           const fourthHost = await page.getByTestId("booking-host-name").textContent();
           expect(fourthHost).not.toBeNull();

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -490,15 +490,21 @@ async function handler(
   });
 
   // For unconfirmed bookings or round robin bookings with the same attendee and timeslot, return the original booking
-  let existingBooking = null;
-  if ((!isConfirmedByDefault && !userReschedulingIsOwner) || eventType.schedulingType === "ROUND_ROBIN") {
-    existingBooking = await BookingRepository.getBookingFromEventTypeForAttendee({
+  if (
+    (!isConfirmedByDefault && !userReschedulingIsOwner) ||
+    eventType.schedulingType === SchedulingType.ROUND_ROBIN
+  ) {
+    const booking = await BookingRepository.findBookingByUid({ bookingUid: "MOCKED_UID" });
+    console.log("🚀 ~ file: fresh-booking.test.ts:3351 ~ test ~ booking:", booking);
+
+    const existingBooking = await BookingRepository.getBookingFromEventTypeForAttendee({
       eventTypeId,
       bookerEmail,
       bookerPhoneNumber,
       startTime: new Date(dayjs(reqBody.start).utc().format()),
       filterForUnconfirmed: !isConfirmedByDefault,
     });
+    console.log("🚀 ~ file: handleNewBooking.ts:502 ~ existingBooking:", existingBooking);
 
     if (existingBooking) {
       const bookingResponse = {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -65,6 +65,7 @@ import { getPiiFreeCalendarEvent, getPiiFreeEventType } from "@calcom/lib/piiFre
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { getLuckyUser } from "@calcom/lib/server/getLuckyUser";
 import { getTranslation } from "@calcom/lib/server/i18n";
+import { BookingRepository } from "@calcom/lib/server/repository/booking";
 import { WorkflowRepository } from "@calcom/lib/server/repository/workflow";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import prisma from "@calcom/prisma";
@@ -109,7 +110,6 @@ import type { IEventTypePaymentCredentialType, Invitee, IsFixedAwareUser } from 
 import { validateBookingTimeIsNotOutOfBounds } from "./handleNewBooking/validateBookingTimeIsNotOutOfBounds";
 import { validateEventLength } from "./handleNewBooking/validateEventLength";
 import handleSeats from "./handleSeats/handleSeats";
-import { getBookingRequest } from "./requiresConfirmation/getBookingRequest";
 
 const translator = short();
 const log = logger.getSubLogger({ prefix: ["[api] book:user"] });
@@ -489,20 +489,22 @@ async function handler(
     bookerEmail,
   });
 
-  // If a request already exists for the timeslot, return that request
-  if (!isConfirmedByDefault && !userReschedulingIsOwner) {
-    const requestedBooking = await getBookingRequest({
+  // For unconfirmed bookings or round robin bookings with the same attendee and timeslot, return the original booking
+  let existingBooking = null;
+  if ((!isConfirmedByDefault && !userReschedulingIsOwner) || eventType.schedulingType === "ROUND_ROBIN") {
+    existingBooking = await BookingRepository.getBookingFromEventTypeForAttendee({
       eventTypeId,
       bookerEmail,
       bookerPhoneNumber,
       startTime: new Date(dayjs(reqBody.start).utc().format()),
+      filterForUnconfirmed: !isConfirmedByDefault,
     });
 
-    if (requestedBooking) {
+    if (existingBooking) {
       const bookingResponse = {
-        ...requestedBooking,
+        ...existingBooking,
         user: {
-          ...requestedBooking.user,
+          ...existingBooking.user,
           email: null,
         },
         paymentRequired: false,

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -494,9 +494,6 @@ async function handler(
     (!isConfirmedByDefault && !userReschedulingIsOwner) ||
     eventType.schedulingType === SchedulingType.ROUND_ROBIN
   ) {
-    const booking = await BookingRepository.findBookingByUid({ bookingUid: "MOCKED_UID" });
-    console.log("🚀 ~ file: fresh-booking.test.ts:3351 ~ test ~ booking:", booking);
-
     const existingBooking = await BookingRepository.getBookingFromEventTypeForAttendee({
       eventTypeId,
       bookerEmail,
@@ -504,7 +501,6 @@ async function handler(
       startTime: new Date(dayjs(reqBody.start).utc().format()),
       filterForUnconfirmed: !isConfirmedByDefault,
     });
-    console.log("🚀 ~ file: handleNewBooking.ts:502 ~ existingBooking:", existingBooking);
 
     if (existingBooking) {
       const bookingResponse = {

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -494,7 +494,7 @@ async function handler(
     (!isConfirmedByDefault && !userReschedulingIsOwner) ||
     eventType.schedulingType === SchedulingType.ROUND_ROBIN
   ) {
-    const existingBooking = await BookingRepository.getBookingFromEventTypeForAttendee({
+    const existingBooking = await BookingRepository.getValidBookingFromEventTypeForAttendee({
       eventTypeId,
       bookerEmail,
       bookerPhoneNumber,

--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -58,7 +58,7 @@ import { WEBSITE_URL, WEBAPP_URL } from "@calcom/lib/constants";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import { resetTestEmails } from "@calcom/lib/testEmails";
 import { CreationSource, WatchlistSeverity, WatchlistType } from "@calcom/prisma/enums";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
 export type CustomNextApiRequest = NextApiRequest & Request;
@@ -3277,6 +3277,136 @@ describe("handleNewBooking", () => {
         },
         timeout
       );
+    });
+  });
+
+  describe("Returning original booking", () => {
+    test("Return the original booking if a request is made twice by the same attendee when a booking requires confirmation", async () => {
+      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const booker = getBooker({
+        email: "booker@example.com",
+        name: "Booker",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+
+      const startTime = "2025-05-21T10:00:00.000Z";
+      const endTime = "2025-05-21T10:30:00.000Z";
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          user: organizer.username,
+          eventTypeId: 1,
+          startTime,
+          endTime,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const scenarioData = getScenarioData({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 30,
+            length: 30,
+            requiresConfirmation: true,
+            users: [
+              {
+                id: 101,
+              },
+            ],
+          },
+        ],
+        organizer,
+        apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+      });
+
+      await createBookingScenario(scenarioData);
+
+      const response = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      const secondResponse = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(secondResponse.id).toEqual(response.id);
+    });
+    test("Return the original booking if request is made by the same attendee for a round robin event", async () => {
+      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const booker = getBooker({
+        email: "booker@example.com",
+        name: "Booker",
+      });
+
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+
+      const startTime = "2025-05-21T10:00:00.000Z";
+      const endTime = "2025-05-21T10:30:00.000Z";
+
+      const mockBookingData = getMockRequestDataForBooking({
+        data: {
+          user: organizer.username,
+          eventTypeId: 1,
+          startTime,
+          endTime,
+          responses: {
+            email: booker.email,
+            name: booker.name,
+            location: { optionValue: "", value: "New York" },
+          },
+        },
+      });
+
+      const scenarioData = getScenarioData({
+        eventTypes: [
+          {
+            id: 1,
+            slotInterval: 30,
+            length: 30,
+            requiresConfirmation: true,
+            schedulingType: SchedulingType.ROUND_ROBIN,
+            users: [
+              {
+                id: 101,
+              },
+            ],
+          },
+        ],
+        organizer,
+        apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+      });
+
+      await createBookingScenario(scenarioData);
+
+      const response = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      const secondResponse = await handleNewBooking({
+        bookingData: mockBookingData,
+      });
+
+      expect(secondResponse.id).toEqual(response.id);
     });
   });
 

--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -3297,15 +3297,10 @@ describe("handleNewBooking", () => {
         selectedCalendars: [TestData.selectedCalendars.google],
       });
 
-      const startTime = "2025-05-21T10:00:00.000Z";
-      const endTime = "2025-05-21T10:30:00.000Z";
-
       const mockBookingData = getMockRequestDataForBooking({
         data: {
           user: organizer.username,
           eventTypeId: 1,
-          startTime,
-          endTime,
           responses: {
             email: booker.email,
             name: booker.name,
@@ -3360,15 +3355,10 @@ describe("handleNewBooking", () => {
         selectedCalendars: [TestData.selectedCalendars.google],
       });
 
-      const startTime = "2025-05-21T10:00:00.000Z";
-      const endTime = "2025-05-21T10:30:00.000Z";
-
       const mockBookingData = getMockRequestDataForBooking({
         data: {
           user: organizer.username,
           eventTypeId: 1,
-          startTime,
-          endTime,
           responses: {
             email: booker.email,
             name: booker.name,

--- a/packages/lib/server/repository/booking.ts
+++ b/packages/lib/server/repository/booking.ts
@@ -780,7 +780,7 @@ export class BookingRepository {
     ];
   }
 
-  static async getBookingFromEventTypeForAttendee({
+  static async getValidBookingFromEventTypeForAttendee({
     eventTypeId,
     bookerEmail,
     bookerPhoneNumber,
@@ -803,9 +803,7 @@ export class BookingRepository {
           },
         },
         startTime,
-        ...(filterForUnconfirmed && {
-          status: BookingStatus.PENDING,
-        }),
+        status: filterForUnconfirmed ? BookingStatus.PENDING : BookingStatus.ACCEPTED,
       },
       include: {
         attendees: true,

--- a/packages/lib/server/repository/booking.ts
+++ b/packages/lib/server/repository/booking.ts
@@ -779,4 +779,39 @@ export class BookingRepository {
       ...managedBookings,
     ];
   }
+
+  static async getBookingFromEventTypeForAttendee({
+    eventTypeId,
+    bookerEmail,
+    bookerPhoneNumber,
+    startTime,
+    filterForUnconfirmed,
+  }: {
+    eventTypeId: number;
+    bookerEmail?: string;
+    bookerPhoneNumber?: string;
+    startTime: Date;
+    filterForUnconfirmed?: boolean;
+  }) {
+    return await prisma.booking.findFirst({
+      where: {
+        eventTypeId,
+        attendees: {
+          some: {
+            email: bookerEmail,
+            phoneNumber: bookerPhoneNumber,
+          },
+        },
+        startTime,
+        ...(filterForUnconfirmed && {
+          status: BookingStatus.PENDING,
+        }),
+      },
+      include: {
+        attendees: true,
+        references: true,
+        user: true,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When an attendee books the same timeslot in a round robin event, we return the original booking instead of creating a new one


- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

https://www.loom.com/share/03beff8fc2624e7d83f6fb38e45efb6c

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a round robin event
- Book a time slot
- Book the same timeslot with the same attendee email
	- The original booking should be returned

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
When an attendee books the same timeslot in a round robin event, the system now returns the original booking instead of creating a duplicate.

- **Bug Fixes**
  - Prevents duplicate bookings for the same attendee and timeslot in round robin and unconfirmed events.

<!-- End of auto-generated description by cubic. -->

