### PR TITLE
feat: allow custom SMS templates for free users

### DIFF
--- a/apps/web/pages/api/twilio/webhook.ts
+++ b/apps/web/pages/api/twilio/webhook.ts
@@ -76,7 +76,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   const creditService = new CreditService();
 
   if (countryCode === "US" || countryCode === "CA") {
-    // SMS to US and CA are free
+    // SMS to US and CA are free for teams
     let teamIdToCharge = parsedTeamId;
 
     if (!teamIdToCharge && parsedUserId) {
@@ -92,15 +92,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       teamIdToCharge = teamMembership?.teamId;
     }
 
-    await creditService.chargeCredits({
-      teamId: teamIdToCharge,
-      userId: !teamIdToCharge ? parsedUserId : undefined,
-      bookingUid: parsedBookingUid,
-      smsSid,
-      credits: 0,
-    });
+    if (teamIdToCharge) {
+      await creditService.chargeCredits({
+        teamId: teamIdToCharge,
+        bookingUid: parsedBookingUid,
+        smsSid,
+        credits: 0,
+      });
 
-    return res.status(200).send(`SMS to US and CA are free. Credits set to 0`);
+      return res.status(200).send(`SMS to US and CA are free for teams. Credits set to 0`);
+    }
   }
 
   let orgId;

--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -888,9 +888,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   editable={
                     !props.readOnly &&
                     !isWhatsappAction(step.action) &&
-                    (hasActiveTeamPlan ||
-                      (form.getValues(`steps.${step.stepNumber - 1}.template`) === WorkflowTemplates.CUSTOM &&
-                        isSMSAction(step.action)))
+                    (hasActiveTeamPlan || isSMSAction(step.action))
                   }
                   excludedToolbarItems={
                     !isSMSAction(step.action) ? [] : ["blockType", "bold", "italic", "link"]

--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -376,6 +376,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
       label: t(`${step.template.toLowerCase()}`),
       value: step.template,
       needsTeamsUpgrade: false,
+      needsCredits: false, //todo
     };
 
     const canRequirePhoneNumber = (workflowStep: string) => {
@@ -814,10 +815,20 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         }}
                         defaultValue={selectedTemplate}
                         value={selectedTemplate}
-                        options={templateOptions}
+                        options={templateOptions.map((option) => ({
+                          label: option.label,
+                          value: option.value,
+                          needsCredits:
+                            option.needsCreditsOrUpgrade &&
+                            isSMSAction(form.getValues(`steps.${step.stepNumber - 1}.action`)),
+                          needsTeamsUpgrade:
+                            option.needsCreditsOrUpgrade &&
+                            !isSMSAction(form.getValues(`steps.${step.stepNumber - 1}.action`)),
+                        }))}
                         isOptionDisabled={(option: {
                           label: string;
                           value: any;
+                          needsCredits: boolean;
                           needsTeamsUpgrade: boolean;
                         }) => option.needsTeamsUpgrade}
                       />
@@ -860,7 +871,6 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       )}
                   </div>
                 )}
-
                 <div className="mb-2 flex items-center pb-1">
                   <Label className="mb-0 flex-none ">
                     {isEmailSubjectNeeded ? t("email_body") : t("text_message")}
@@ -880,7 +890,13 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   updateTemplate={updateTemplate}
                   firstRender={firstRender}
                   setFirstRender={setFirstRender}
-                  editable={!props.readOnly && !isWhatsappAction(step.action) && hasActiveTeamPlan}
+                  editable={
+                    !props.readOnly &&
+                    !isWhatsappAction(step.action) &&
+                    (hasActiveTeamPlan ||
+                      (form.getValues(`steps.${step.stepNumber - 1}.template`) === WorkflowTemplates.CUSTOM &&
+                        isSMSAction(step.action)))
+                  }
                   excludedToolbarItems={
                     !isSMSAction(step.action) ? [] : ["blockType", "bold", "italic", "link"]
                   }

--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -376,7 +376,6 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
       label: t(`${step.template.toLowerCase()}`),
       value: step.template,
       needsTeamsUpgrade: false,
-      needsCredits: false, //todo
     };
 
     const canRequirePhoneNumber = (workflowStep: string) => {
@@ -818,17 +817,13 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                         options={templateOptions.map((option) => ({
                           label: option.label,
                           value: option.value,
-                          needsCredits:
-                            option.needsCreditsOrUpgrade &&
-                            isSMSAction(form.getValues(`steps.${step.stepNumber - 1}.action`)),
                           needsTeamsUpgrade:
-                            option.needsCreditsOrUpgrade &&
+                            option.needsTeamsUpgrade &&
                             !isSMSAction(form.getValues(`steps.${step.stepNumber - 1}.action`)),
                         }))}
                         isOptionDisabled={(option: {
                           label: string;
                           value: any;
-                          needsCredits: boolean;
                           needsTeamsUpgrade: boolean;
                         }) => option.needsTeamsUpgrade}
                       />
@@ -872,7 +867,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                   </div>
                 )}
                 <div className="mb-2 flex items-center pb-1">
-                  <Label className="mb-0 flex-none ">
+                  <Label className="mb-0 flex-none">
                     {isEmailSubjectNeeded ? t("email_body") : t("text_message")}
                   </Label>
                 </div>

--- a/packages/features/ee/workflows/lib/getOptions.ts
+++ b/packages/features/ee/workflows/lib/getOptions.ts
@@ -54,7 +54,7 @@ export function getWorkflowTemplateOptions(
     return {
       label: t(`${template.toLowerCase()}`),
       value: template,
-      needsCreditsOrUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
+      needsUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
     };
   }) as { label: string; value: any; needsCreditsOrUpgrade: boolean }[];
 }

--- a/packages/features/ee/workflows/lib/getOptions.ts
+++ b/packages/features/ee/workflows/lib/getOptions.ts
@@ -54,7 +54,7 @@ export function getWorkflowTemplateOptions(
     return {
       label: t(`${template.toLowerCase()}`),
       value: template,
-      needsUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
+      needsTeamsUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
     };
-  }) as { label: string; value: any; needsCreditsOrUpgrade: boolean }[];
+  }) as { label: string; value: any; needsTeamsUpgrade: boolean }[];
 }

--- a/packages/features/ee/workflows/lib/getOptions.ts
+++ b/packages/features/ee/workflows/lib/getOptions.ts
@@ -54,7 +54,7 @@ export function getWorkflowTemplateOptions(
     return {
       label: t(`${template.toLowerCase()}`),
       value: template,
-      needsTeamsUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
+      needsCreditsOrUpgrade: !hasPaidPlan && template == WorkflowTemplates.CUSTOM,
     };
-  }) as { label: string; value: any; needsTeamsUpgrade: boolean }[];
+  }) as { label: string; value: any; needsCreditsOrUpgrade: boolean }[];
 }

--- a/packages/features/ee/workflows/lib/test/twilioWebhook.test.ts
+++ b/packages/features/ee/workflows/lib/test/twilioWebhook.test.ts
@@ -1,0 +1,161 @@
+import { describe, beforeEach, vi, test, expect } from "vitest";
+
+vi.mock("@calcom/lib/constants", async () => {
+  const actual = await vi.importActual<typeof import("@calcom/lib/constants")>("@calcom/lib/constants");
+  return {
+    ...actual,
+    IS_SMS_CREDITS_ENABLED: true,
+  };
+});
+
+vi.mock("../reminders/providers/twilioProvider", () => ({
+  validateWebhookRequest: vi.fn().mockResolvedValue(true),
+  getCountryCodeForNumber: vi.fn().mockResolvedValue("US"),
+}));
+
+const mockChargeCredits = vi.fn().mockResolvedValue({ teamId: 1 });
+vi.mock("@calcom/features/ee/billing/credit-service", () => ({
+  CreditService: vi.fn().mockImplementation(() => ({
+    chargeCredits: mockChargeCredits,
+    calculateCreditsFromPrice: vi.fn().mockReturnValue(1),
+  })),
+}));
+
+const mockFindFirst = vi.fn();
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    membership: {
+      findFirst: mockFindFirst,
+    },
+    team: {
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+describe("Twilio Webhook Handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("SMS to US and CA numbers", () => {
+    test("should create expense log with 0 credits with a given teamId", async () => {
+      const webhookHandler = (await import("../../../../../../apps/web/pages/api/twilio/webhook")).default;
+
+      const mockRequest = {
+        method: "POST",
+        headers: {
+          "x-twilio-signature": "valid-signature",
+        },
+        query: {
+          teamId: "1",
+        },
+        body: {
+          MessageStatus: "delivered",
+          To: "+1234567890", // US number
+          SmsSid: "SM123",
+        },
+      };
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+      };
+
+      await webhookHandler(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.send).toHaveBeenCalledWith("SMS to US and CA are free for teams. Credits set to 0");
+      expect(mockChargeCredits).toHaveBeenCalledWith({
+        teamId: 1,
+        bookingUid: undefined,
+        smsSid: "SM123",
+        credits: 0,
+      });
+    });
+
+    test("should create expense log with 0 credits if userId is part of a team", async () => {
+      mockFindFirst.mockResolvedValue({ teamId: 1 });
+      const webhookHandler = (await import("../../../../../../apps/web/pages/api/twilio/webhook")).default;
+
+      const mockRequest = {
+        method: "POST",
+        headers: {
+          "x-twilio-signature": "valid-signature",
+        },
+        query: {
+          userId: "123",
+        },
+        body: {
+          MessageStatus: "delivered",
+          To: "+1234567890", // US number
+          SmsSid: "SM123",
+        },
+      };
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+      };
+
+      await webhookHandler(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.send).toHaveBeenCalledWith("SMS to US and CA are free for teams. Credits set to 0");
+      expect(mockChargeCredits).toHaveBeenCalledWith({
+        teamId: 1,
+        bookingUid: undefined,
+        smsSid: "SM123",
+        credits: 0,
+      });
+    });
+
+    test("should create expense log with null credits if userId is not part of a team", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      const webhookHandler = (await import("../../../../../../apps/web/pages/api/twilio/webhook")).default;
+
+      vi.mock("@calcom/lib/getOrgIdFromMemberOrTeamId", () => ({
+        default: vi.fn().mockResolvedValue(null),
+      }));
+
+      vi.mock("../reminders/providers/twilioProvider", () => ({
+        validateWebhookRequest: vi.fn().mockResolvedValue(true),
+        getCountryCodeForNumber: vi.fn().mockResolvedValue("US"),
+        getPriceForSMS: vi.fn().mockResolvedValue(null),
+      }));
+
+      const mockRequest = {
+        method: "POST",
+        headers: {
+          "x-twilio-signature": "valid-signature",
+        },
+        query: {
+          userId: "123",
+        },
+        body: {
+          MessageStatus: "delivered",
+          To: "+1234567890", // US number
+          SmsSid: "SM123",
+        },
+      };
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+      };
+
+      await webhookHandler(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockChargeCredits).toHaveBeenCalledWith({
+        userId: 123,
+        bookingUid: undefined,
+        smsSid: "SM123",
+        credits: null,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

We now allow custom SMS templates also for free users. With this change, we also have to charge free users for SMS to CA and US.

- Fixes #21392
- Fixes CAL-5788

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Free users can now create custom SMS templates. Free users are now charged for SMS sent to US and Canada.

- **New Features**
  - Enabled custom SMS templates for free users.

- **Billing Changes**
  - Free users are charged credits for SMS to US and Canada.

<!-- End of auto-generated description by cubic. -->

