### PR TITLE
fix: missing verifiedAt timestamp

### DIFF
--- a/packages/features/tasker/tasks/scanWorkflowBody.test.ts
+++ b/packages/features/tasker/tasks/scanWorkflowBody.test.ts
@@ -165,7 +165,7 @@ describe("scanWorkflowBody", () => {
     expect(scheduleWorkflowNotifications).toHaveBeenCalledWith({
       activeOn: [1],
       isOrg: false,
-      workflowSteps: [mockWorkflowStep],
+      workflowSteps: [expect.objectContaining(mockWorkflowStep)],
       time: mockWorkflow.time,
       timeUnit: mockWorkflow.timeUnit,
       trigger: mockWorkflow.trigger,

--- a/packages/features/tasker/tasks/scanWorkflowBody.ts
+++ b/packages/features/tasker/tasks/scanWorkflowBody.ts
@@ -151,7 +151,10 @@ export async function scanWorkflowBody(payload: string) {
   await scheduleWorkflowNotifications({
     activeOn: workflow.activeOn.map((activeOn) => activeOn.eventTypeId) ?? [],
     isOrg,
-    workflowSteps,
+    workflowSteps: workflowSteps.map((step) => ({
+      ...step,
+      verifiedAt: new Date(),
+    })),
     time: workflow.time,
     timeUnit: workflow.timeUnit,
     trigger: workflow.trigger,


### PR DESCRIPTION
## What does this PR do?

Add verifiedAt timestamp in when scheudling emails in scanWorkflowBody

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a verifiedAt timestamp to each workflow step when scheduling email notifications to ensure accurate tracking.

<!-- End of auto-generated description by cubic. -->

