### PR TITLE
fix: booking creation error when users[0] is undefined

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -800,7 +800,7 @@ async function handler(
 
         const userIdsSet = new Set(users.map((user) => user.id));
         const firstUserOrgId = await getOrgIdFromMemberOrTeamId({
-          memberId: eventTypeWithUsers.users[0].id ?? null,
+          memberId: eventTypeWithUsers.users[0]?.id ?? null,
           teamId: eventType.teamId,
         });
         const newLuckyUser = await getLuckyUser({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #21504
- Fixes CAL-5823

Guard against an empty `users` array in the v1 booking handler by replacing `eventTypeWithUsers.users[0].id` with `eventTypeWithUsers.users[0]?.id ?? null`. This prevents the runtime “Cannot read properties of undefined (reading ‘id’)” error and correctly falls back to using the team ID when no primary user exists.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a booking creation error that occurred when the users array was empty, preventing a crash if users[0] is undefined.

<!-- End of auto-generated description by cubic. -->

