### PR TITLE
fix: Hide rescheduled by email if hideOrganizerEmail set to true

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3224,5 +3224,6 @@
   "available_credits": "Available credits",
   "members_affected_by_disabling_delegation_credential": "Affected members",
   "no_members_affected_by_disabling_delegation_credential": "No members affected by disabling delegation credential",
+  "redacted_for_privacy": "<Redacted for privacy>",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3224,6 +3224,6 @@
   "available_credits": "Available credits",
   "members_affected_by_disabling_delegation_credential": "Affected members",
   "no_members_affected_by_disabling_delegation_credential": "No members affected by disabling delegation credential",
-  "redacted_for_privacy": "<Redacted for privacy>",
+  "redacted_for_privacy": "Redacted for privacy",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -109,7 +109,9 @@ export const BaseScheduledEmail = (
         <Info
           label={t("rescheduled_by")}
           description={
-            props.calEvent.hideOrganizerEmail ? t("redacted_for_privacy") : props.calEvent.rescheduledBy
+            props.calEvent.hideOrganizerEmail
+              ? `<${t("redacted_for_privacy")}>`
+              : props.calEvent.rescheduledBy
           }
           withSpacer
         />

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -109,7 +109,8 @@ export const BaseScheduledEmail = (
         <Info
           label={t("rescheduled_by")}
           description={
-            props.calEvent.hideOrganizerEmail
+            props.calEvent.hideOrganizerEmail &&
+            props.calEvent.organizer.email === props.calEvent.rescheduledBy
               ? `<${t("redacted_for_privacy")}>`
               : props.calEvent.rescheduledBy
           }

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -106,7 +106,6 @@ export const BaseScheduledEmail = (
         </>
       )}
       {props.calEvent.rescheduledBy && (
-        //add here
         <Info
           label={t("rescheduled_by")}
           description={

--- a/packages/emails/src/templates/BaseScheduledEmail.tsx
+++ b/packages/emails/src/templates/BaseScheduledEmail.tsx
@@ -106,7 +106,14 @@ export const BaseScheduledEmail = (
         </>
       )}
       {props.calEvent.rescheduledBy && (
-        <Info label={t("rescheduled_by")} description={props.calEvent.rescheduledBy} withSpacer />
+        //add here
+        <Info
+          label={t("rescheduled_by")}
+          description={
+            props.calEvent.hideOrganizerEmail ? t("redacted_for_privacy") : props.calEvent.rescheduledBy
+          }
+          withSpacer
+        />
       )}
       <Info label={t("what")} description={props.calEvent.title} withSpacer />
       <WhenInfo timeFormat={timeFormat} calEvent={props.calEvent} t={t} timeZone={timeZone} locale={locale} />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #21539 
- Fixes CAL-5837

## Visual Demo (For contributors especially)
#### Image Demo (if applicable):

<img width="510" alt="Screenshot 2025-05-27 at 7 54 01 PM" src="https://github.com/user-attachments/assets/21802625-53f8-4be4-aabc-c9f4f9fd080e" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] - N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hides the organizer's email in rescheduled event emails when `hideOrganizerEmail` is true, showing a redacted message instead.

<!-- End of auto-generated description by cubic. -->

