### PR TITLE
feat: OnformChange on Availability Settings Atom

### DIFF
--- a/docs/platform/atoms/availability-settings.mdx
+++ b/docs/platform/atoms/availability-settings.mdx
@@ -26,7 +26,7 @@ export default function Availability() {
             console.log("Deleted schedule successfully");
           }}
           onFormStateChange={(formState) => {
-            console.log("Form state changed:", formState);
+            console.log("Form state updated");
             // Access form data: formState.name, formState.schedule, formState.timeZone, etc.
           }}
        />

--- a/docs/platform/atoms/availability-settings.mdx
+++ b/docs/platform/atoms/availability-settings.mdx
@@ -25,6 +25,10 @@ export default function Availability() {
           onDeleteSuccess={() => {
             console.log("Deleted schedule successfully");
           }}
+          onFormStateChange={(formState) => {
+            console.log("Form state changed:", formState);
+            // Access form data: formState.name, formState.schedule, formState.timeZone, etc.
+          }}
        />
     </>
   )
@@ -63,6 +67,10 @@ export default function Availability() {
           onDeleteSuccess={() => {
             console.log("Deleted schedule successfully");
           }}
+          onFormStateChange={(formState) => {
+            console.log("Form state changed:", formState);
+            // Access form data including dateOverrides: formState.dateOverrides
+          }}
        />
     </>
   )
@@ -99,6 +107,7 @@ Below is a list of props that can be passed to the availability settings atom.
 | onUpdateError      | No       | A callback function that gets triggered when the user availability fails to update                        |
 | onDeleteSuccess    | No       | A callback function that gets triggered when the user availability is deleted successfully                |
 | onDeleteError      | No       | A callback function that gets triggered when the user availability fails to delete                        |
+| onFormStateChange  | No       | A callback function that gets triggered whenever the form state changes, providing real-time access to form data |
 | enableOverrides    | No       | Allows user to enable or disable date overrides display in the atom; defaults to disabled                 |
 | disableEditableHeading    | No       | Prevents users from editing the heading               |
 | allowDelete      | No       | When set to false, this prop hides the delete button                        |

--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { SetStateAction, Dispatch } from "react";
-import { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { Controller, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
 
 import dayjs from "@calcom/dayjs";
@@ -103,6 +103,7 @@ type AvailabilitySettingsProps = {
   customClassNames?: CustomClassNames;
   disableEditableHeading?: boolean;
   enableOverrides?: boolean;
+  onFormStateChange?: (formState: AvailabilityFormValues) => void;
   bulkUpdateModalProps?: {
     isOpen: boolean;
     setIsOpen: Dispatch<SetStateAction<boolean>>;
@@ -275,6 +276,7 @@ export function AvailabilitySettings({
   customClassNames,
   disableEditableHeading = false,
   enableOverrides = false,
+  onFormStateChange,
   bulkUpdateModalProps,
   allowSetToDefault = true,
   allowDelete = true,
@@ -288,6 +290,17 @@ export function AvailabilitySettings({
       schedule: schedule.availability || [],
     },
   });
+
+  const watchedValues = useWatch({
+    control: form.control,
+  });
+
+  // Trigger callback whenever the form state changes
+  useEffect(() => {
+    if (onFormStateChange && watchedValues) {
+      onFormStateChange(watchedValues as AvailabilityFormValues);
+    }
+  }, [watchedValues, onFormStateChange]);
 
   const [Shell, Schedule, TimezoneSelect] = useMemo(() => {
     return isPlatform

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -33,6 +33,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   disableEditableHeading?: boolean;
   enableOverrides?: boolean;
   onBeforeUpdate?: (updateBody: UpdateScheduleInput_2024_06_11) => boolean | Promise<boolean>;
+  onFormStateChange?: (formState: AvailabilityFormValues) => void;
   allowDelete?: boolean;
   allowSetToDefault?: boolean;
   disableToasts?: boolean;
@@ -49,6 +50,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
   disableEditableHeading = false,
   enableOverrides = false,
   onBeforeUpdate,
+  onFormStateChange,
   allowDelete,
   allowSetToDefault,
   disableToasts,
@@ -176,6 +178,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
         customClassNames={customClassNames}
         allowDelete={allowDelete}
         allowSetToDefault={allowSetToDefault}
+        onFormStateChange={onFormStateChange}
       />
     </AtomsWrapper>
   );


### PR DESCRIPTION
## What does this PR do?
Adds an `onFormStateChange` callback prop to the AvailabilitySettings atom component, enabling real-time monitoring of form state changes.

- Fixes #21528 (GitHub issue number)
- Fixes [CAL-5831](https://linear.app/calcom/issue/CAL-5831/cal-5830-atoms-add-onformstatechange-callback-on) 

#### Video Demo:
[Loom video for demo](https://www.loom.com/share/f2a3418c4493469ab88bd723eac45375?sid=628d10ac-5a4c-42d8-8405-7196ce27edf5)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an onFormStateChange callback prop to the AvailabilitySettings atom, allowing real-time tracking of form state changes.

- **New Features**
  - Triggers the callback with updated form data whenever the form changes.
  - Updated docs with usage examples and prop details.

<!-- End of auto-generated description by cubic. -->

