### PR TITLE
fix: Function return type is illegal, not sure how this passed eslint

### DIFF
--- a/packages/app-store/googlecalendar/lib/__mocks__/googleapis.ts
+++ b/packages/app-store/googlecalendar/lib/__mocks__/googleapis.ts
@@ -51,8 +51,14 @@ export type MockOAuth2Client = {
   type: "oauth2";
   args: [string, string, string];
   setCredentials: typeof setCredentialsMock;
-  refreshToken: Function;
-  isTokenExpiring: Function;
+  refreshToken: () => Promise<{
+    res: {
+      data: typeof MOCK_OAUTH2_TOKEN;
+      status: number;
+      statusText: string;
+    };
+  }>;
+  isTokenExpiring: () => boolean;
 };
 
 export const MOCK_JWT_TOKEN = {


### PR DESCRIPTION
## What does this PR do?

Small type fix to mock files
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed incorrect return types in the googleapis mock to match expected function signatures.

<!-- End of auto-generated description by cubic. -->

