### PR TITLE
fix: generator enums in prisma db

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -26,7 +26,7 @@ generator kysely {
 }
 
 generator enums {
-  provider = "ts-node --transpile-only ./enum-generator"
+  provider = "ts-node --transpile-only ./enum-generator.ts"
 }
 
 enum SchedulingType {


### PR DESCRIPTION
# Fix enum-generator module resolution error in yarn dx

* Fixes #21594
* Fixes CAL-5867

This PR fixes an issue encountered when running `yarn dx` in a freshly cloned `cal.com` repository. Previously, the command failed with the error:

```javascript
Error: Cannot find module './enum-generator'
```

The fix involves explicitly specifying the TypeScript file in the Prisma schema. Specifically, in `packages/prisma/schema/`, the following change was made:

**Before:**
```prisma
generator enums {
  provider = "ts-node --transpile-only ./enum-generator"
}
```

**After:**
```prisma
generator enums {
  provider = "ts-node --transpile-only ./enum-generator.ts"
}
```

This resolves the error and allows `yarn dx` and `yarn test-e2e` to run successfully. Tests now pass and the build completes.

## Visual Demo (For contributors especially)

Image Demo (attached below):
* Side-by-side screenshots have been attached to show:
   * The error before the change.
   * The successful build and tests after the change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

* Clone the `cal.com` repo.
* Run `yarn` and then `yarn dx`.
* The command should now execute successfully without the `Cannot find module './enum-generator'` error.
* Run `yarn test-e2e`.
* All tests should pass.

### Notes:
* No additional environment variables are required.
* No specific test data is needed beyond a standard setup.
* The expected outcome is successful execution of `yarn dx` and `yarn test-e2e`.
![cal-1](https://github.com/user-attachments/assets/1b5a2493-9268-4f37-824c-6cf59a200b68)
![cal-2](https://github.com/user-attachments/assets/6a566184-473c-4cce-b3fe-442f4245f2ff)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a module resolution error in the Prisma enum generator by specifying the .ts file, so running yarn dx and yarn test-e2e now works without errors.

<!-- End of auto-generated description by cubic. -->

