### PR TITLE
feat: Add loadingStateChildren prop to AvailabilitySettingsPlatformWr…

### DIFF
--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -41,6 +41,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   disableToasts?: boolean;
   isDryRun?: boolean;
   noScheduleChildren?: ReactNode;
+  loadingStateChildren?: ReactNode;
 };
 
 export const AvailabilitySettingsPlatformWrapper = ({
@@ -59,6 +60,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
   disableToasts,
   isDryRun = false,
   noScheduleChildren,
+  loadingStateChildren,
 }: AvailabilitySettingsPlatformWrapperProps) => {
   const { isLoading, data: schedule } = useSchedule(id);
   const { data: schedules } = useSchedules();
@@ -123,7 +125,13 @@ export const AvailabilitySettingsPlatformWrapper = ({
     }
   };
 
-  if (isLoading) return <div className="px-10 py-4 text-xl">Loading...</div>;
+  if (isLoading) {
+    return (
+      <>
+        {loadingStateChildren ? loadingStateChildren : <div className="px-10 py-4 text-xl">Loading...</div>}
+      </>
+    );
+  }
 
   if (!atomSchedule) {
     return noScheduleChildren ? (


### PR DESCRIPTION
## What Does This PR Do?

This PR introduces the `loadingStateChildren` prop to the `AvailabilitySettingsPlatformWrapper` component, providing flexibility for custom loading UIs.

- Fixes #21581

---

## Visual Demo (For Contributors Especially)

---

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in `/docs` if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.
---

## Summary by Cubic

The `AvailabilitySettingsPlatformWrapper` component now supports a `loadingStateChildren` prop, allowing for a custom loading experience.

- **New Features**
    - Users can pass a **custom React node** to the `loadingStateChildren` prop, which will be rendered when the component is in an `isLoading` state.
    - If `loadingStateChildren` is not provided, the component will **automatically fall back to a default "Loading..." UI** including a spinner.
