### PR TITLE
fix: recording button bug

### DIFF
--- a/apps/web/modules/videos/ai/ai-transcribe.tsx
+++ b/apps/web/modules/videos/ai/ai-transcribe.tsx
@@ -144,13 +144,21 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
   const toggleTranscription = async () => {
     if (transcription?.isTranscribing) {
       daily?.updateCustomTrayButtons({
-        recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+        ...(showRecordingButton
+          ? {
+              recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+            }
+          : {}),
         transcription: BUTTONS.WAIT_FOR_TRANSCRIPTION_TO_STOP,
       });
       daily?.stopTranscription();
     } else {
       daily?.updateCustomTrayButtons({
-        recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+        ...(showRecordingButton
+          ? {
+              recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+            }
+          : {}),
         transcription: BUTTONS.WAIT_FOR_TRANSCRIPTION_TO_START,
       });
       daily?.startTranscription();

--- a/apps/web/modules/videos/ai/ai-transcribe.tsx
+++ b/apps/web/modules/videos/ai/ai-transcribe.tsx
@@ -61,7 +61,7 @@ const BUTTONS = {
   },
 };
 
-export const CalAiTranscribe = () => {
+export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: boolean }) => {
   const daily = useDaily();
   const { t } = useLocale();
 
@@ -83,7 +83,11 @@ export const CalAiTranscribe = () => {
 
   useDailyEvent("transcription-started", (ev) => {
     daily?.updateCustomTrayButtons({
-      recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+      ...(showRecordingButton
+        ? {
+            recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+          }
+        : {}),
       transcription: BUTTONS.STOP_TRANSCRIPTION,
     });
   });
@@ -97,7 +101,11 @@ export const CalAiTranscribe = () => {
 
   useDailyEvent("transcription-stopped", (ev) => {
     daily?.updateCustomTrayButtons({
-      recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+      ...(showRecordingButton
+        ? {
+            recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
+          }
+        : {}),
       transcription: BUTTONS.START_TRANSCRIPTION,
     });
   });

--- a/apps/web/modules/videos/ai/ai-transcribe.tsx
+++ b/apps/web/modules/videos/ai/ai-transcribe.tsx
@@ -61,6 +61,15 @@ const BUTTONS = {
   },
 };
 
+export type DailyCustomTrayButtonVisualState = "default" | "sidebar-open" | "active";
+
+export interface DailyCustomTrayButton {
+  iconPath: string;
+  iconPathDarkMode?: string;
+  label: string;
+  tooltip: string;
+  visualState?: DailyCustomTrayButtonVisualState;
+}
 export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: boolean }) => {
   const daily = useDaily();
   const { t } = useLocale();
@@ -73,6 +82,23 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
   const transcription = useTranscription();
   const recording = useRecording();
 
+  const updateCustomTrayButtons = ({
+    recording,
+    transcription,
+  }: {
+    recording: DailyCustomTrayButton;
+    transcription: DailyCustomTrayButton;
+  }) => {
+    daily?.updateCustomTrayButtons({
+      ...(showRecordingButton
+        ? {
+            recording,
+          }
+        : {}),
+      transcription,
+    });
+  };
+
   useDailyEvent(
     "app-message",
     useCallback((ev) => {
@@ -82,36 +108,28 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
   );
 
   useDailyEvent("transcription-started", (ev) => {
-    daily?.updateCustomTrayButtons({
-      ...(showRecordingButton
-        ? {
-            recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
-          }
-        : {}),
+    updateCustomTrayButtons({
+      recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
       transcription: BUTTONS.STOP_TRANSCRIPTION,
     });
   });
 
   useDailyEvent("recording-started", (ev) => {
-    daily?.updateCustomTrayButtons({
+    updateCustomTrayButtons({
       recording: BUTTONS.STOP_RECORDING,
       transcription: transcription?.isTranscribing ? BUTTONS.STOP_TRANSCRIPTION : BUTTONS.START_TRANSCRIPTION,
     });
   });
 
   useDailyEvent("transcription-stopped", (ev) => {
-    daily?.updateCustomTrayButtons({
-      ...(showRecordingButton
-        ? {
-            recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
-          }
-        : {}),
+    updateCustomTrayButtons({
+      recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
       transcription: BUTTONS.START_TRANSCRIPTION,
     });
   });
 
   useDailyEvent("recording-stopped", (ev) => {
-    daily?.updateCustomTrayButtons({
+    updateCustomTrayButtons({
       recording: BUTTONS.START_RECORDING,
       transcription: transcription?.isTranscribing ? BUTTONS.STOP_TRANSCRIPTION : BUTTONS.START_TRANSCRIPTION,
     });
@@ -119,7 +137,7 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
 
   const toggleRecording = async () => {
     if (recording?.isRecording) {
-      daily?.updateCustomTrayButtons({
+      updateCustomTrayButtons({
         recording: BUTTONS.WAIT_FOR_RECORDING_TO_STOP,
         transcription: transcription?.isTranscribing
           ? BUTTONS.STOP_TRANSCRIPTION
@@ -127,7 +145,7 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
       });
       await daily?.stopRecording();
     } else {
-      daily?.updateCustomTrayButtons({
+      updateCustomTrayButtons({
         recording: BUTTONS.WAIT_FOR_RECORDING_TO_START,
         transcription: transcription?.isTranscribing
           ? BUTTONS.STOP_TRANSCRIPTION
@@ -143,24 +161,17 @@ export const CalAiTranscribe = ({ showRecordingButton }: { showRecordingButton: 
 
   const toggleTranscription = async () => {
     if (transcription?.isTranscribing) {
-      daily?.updateCustomTrayButtons({
-        ...(showRecordingButton
-          ? {
-              recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
-            }
-          : {}),
+      updateCustomTrayButtons({
+        recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
         transcription: BUTTONS.WAIT_FOR_TRANSCRIPTION_TO_STOP,
       });
       daily?.stopTranscription();
     } else {
-      daily?.updateCustomTrayButtons({
-        ...(showRecordingButton
-          ? {
-              recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
-            }
-          : {}),
+      updateCustomTrayButtons({
+        recording: recording?.isRecording ? BUTTONS.STOP_RECORDING : BUTTONS.START_RECORDING,
         transcription: BUTTONS.WAIT_FOR_TRANSCRIPTION_TO_START,
       });
+
       daily?.startTranscription();
     }
   };

--- a/apps/web/modules/videos/views/videos-single-view.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.tsx
@@ -106,7 +106,7 @@ export default function JoinCall(props: PageProps) {
       <div
         className="mx-auto hidden sm:block"
         style={{ zIndex: 2, left: "30%", position: "absolute", bottom: 100, width: "auto" }}>
-        <CalAiTranscribe />
+        <CalAiTranscribe showRecordingButton={showRecordingButton} />
       </div>
       <div style={{ zIndex: 2, position: "relative" }}>
         {calVideoLogo ? (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Bug:- If you clicked on cal ai button then recording button was re added because of `daily.updateCustomTrayButtons` function

https://github.com/user-attachments/assets/f2eec3ea-0eba-463f-b65b-542850ed3bb2



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Create an event type and enable toggle to hide recording button from organizer or attendee 
2) Create a meeting and go to cal video link
3) Make sure record button is not visible after click "Cal.ai" or any other button.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the recording button was visible when it should not be during video transcription.

- **Bug Fixes**
  - The recording button now only appears when the showRecordingButton flag is true.

<!-- End of auto-generated description by cubic. -->

