### PR TITLE
feat: Added optional loadingStateChildren component to render on loading to AvailabilitySettingsPlatformWrapper

### DIFF
--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -4,7 +4,7 @@ import { sortBy } from "lodash";
 import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
 import getApps from "@calcom/app-store/utils";
 import dayjs from "@calcom/dayjs";
-import { getUid } from "@calcom/lib/CalEventPgvarser";
+import { getUid } from "@calcom/lib/CalEventParser";
 import { CalendarAppDelegationCredentialError } from "@calcom/lib/CalendarAppError";
 import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential/clientAndServer";
 import logger from "@calcom/lib/logger";

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -4,7 +4,7 @@ import { sortBy } from "lodash";
 import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
 import getApps from "@calcom/app-store/utils";
 import dayjs from "@calcom/dayjs";
-import { getUid } from "@calcom/lib/CalEventParser";
+import { getUid } from "@calcom/lib/CalEventPgvarser";
 import { CalendarAppDelegationCredentialError } from "@calcom/lib/CalendarAppError";
 import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential/clientAndServer";
 import logger from "@calcom/lib/logger";

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { ScheduleLabelsType } from "@calcom/features/schedules/components/Schedule";
 import type {
   ApiErrorResponse,
@@ -39,7 +37,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   allowSetToDefault?: boolean;
   disableToasts?: boolean;
   isDryRun?: boolean;
-  loadingStateChildren?: React.ReactElement;
+  loadingStateChildren?: React.ReactNode;
 };
 
 export const AvailabilitySettingsPlatformWrapper = ({
@@ -122,10 +120,8 @@ export const AvailabilitySettingsPlatformWrapper = ({
   };
 
   if (isLoading) {
-    if (loadingStateChildren) {
-      return loadingStateChildren;
-    }
-    return <div className="px-10 py-4 text-xl">Loading...</div>;
+    if (loadingStateChildren) return <> {loadingStateChildren} </>;
+    return <div className="px-10 py-4 text-xl"> Loading... </div>;
   }
 
   if (!atomSchedule) return <div className="px-10 py-4 text-xl">No user schedule present</div>;

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import type { ScheduleLabelsType } from "@calcom/features/schedules/components/Schedule";
 import type {
   ApiErrorResponse,
@@ -37,6 +39,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   allowSetToDefault?: boolean;
   disableToasts?: boolean;
   isDryRun?: boolean;
+  loadingStateChildren?: React.ReactElement;
 };
 
 export const AvailabilitySettingsPlatformWrapper = ({
@@ -53,6 +56,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
   allowSetToDefault,
   disableToasts,
   isDryRun = false,
+  loadingStateChildren,
 }: AvailabilitySettingsPlatformWrapperProps) => {
   const { isLoading, data: schedule } = useSchedule(id);
   const { data: schedules } = useSchedules();
@@ -117,7 +121,12 @@ export const AvailabilitySettingsPlatformWrapper = ({
     }
   };
 
-  if (isLoading) return <div className="px-10 py-4 text-xl">Loading...</div>;
+  if (isLoading) {
+    if (loadingStateChildren) {
+      return loadingStateChildren;
+    }
+    return <div className="px-10 py-4 text-xl">Loading...</div>;
+  }
 
   if (!atomSchedule) return <div className="px-10 py-4 text-xl">No user schedule present</div>;
 


### PR DESCRIPTION
## What does this PR do?
 
Fixes #21600 
Added loadingStateChildren optional props in AvailabilitySettingsPlatformWrapper which is rendered when isLoading is true and loadingStateChildren is neither null nor undefined

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an optional loadingStateChildren prop to AvailabilitySettingsPlatformWrapper, allowing custom content to be shown while loading. If not provided, the default loading message is used.

<!-- End of auto-generated description by cubic. -->

