### PR TITLE
feat: v2 return team event type hosts username

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
@@ -89,11 +89,13 @@ describe("Organizations Event Types Endpoints", () => {
       teammate1 = await userRepositoryFixture.create({
         email: teammate1Email,
         username: teammate1Email,
+        name: "alice",
       });
 
       teammate2 = await userRepositoryFixture.create({
         email: teammate2Email,
         username: teammate2Email,
+        name: "bob",
       });
 
       falseTestUser = await userRepositoryFixture.create({
@@ -432,6 +434,21 @@ describe("Organizations Event Types Endpoints", () => {
 
           const responseTeamEvent = responseBody.data.find((event) => event.teamId === team.id);
           expect(responseTeamEvent).toBeDefined();
+          expect(responseTeamEvent?.hosts).toEqual([
+            {
+              userId: teammate1.id,
+              name: teammate1.name,
+              username: teammate1.username,
+              avatarUrl: teammate1.avatarUrl,
+            },
+            {
+              userId: teammate2.id,
+              name: teammate2.name,
+              username: teammate2.username,
+              avatarUrl: teammate2.avatarUrl,
+            },
+          ]);
+
           if (!responseTeamEvent) {
             throw new Error("Team event not found");
           }

--- a/apps/api/v2/src/modules/organizations/event-types/services/output.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/output.service.ts
@@ -93,7 +93,7 @@ export class OutputOrganizationsEventTypesService {
     const hosts =
       databaseEventType.schedulingType === "MANAGED"
         ? await this.getManagedEventTypeHosts(databaseEventType.id)
-        : await this.transformHosts(databaseEventType.hosts, databaseEventType.schedulingType);
+        : await this.getNonManagedEventTypeHosts(databaseEventType.hosts, databaseEventType.schedulingType);
 
     return {
       ...rest,
@@ -138,13 +138,18 @@ export class OutputOrganizationsEventTypesService {
     for (const child of children) {
       if (child.userId) {
         const user = await this.usersRepository.findById(child.userId);
-        transformedHosts.push({ userId: child.userId, name: user?.name || "" });
+        transformedHosts.push({
+          userId: child.userId,
+          name: user?.name || "",
+          username: user?.username || "",
+          avatarUrl: user?.avatarUrl,
+        });
       }
     }
     return transformedHosts;
   }
 
-  async transformHosts(
+  async getNonManagedEventTypeHosts(
     databaseHosts: Host[],
     schedulingType: SchedulingType | null
   ): Promise<TeamEventTypeResponseHost[]> {
@@ -160,6 +165,7 @@ export class OutputOrganizationsEventTypesService {
         transformedHosts.push({
           userId: databaseHost.userId,
           name: databaseUser?.name || "",
+          username: databaseUser?.username || "",
           mandatory: !!databaseHost.isFixed,
           priority: getPriorityLabel(databaseHost.priority || 2),
           avatarUrl: databaseUser?.avatarUrl,
@@ -168,6 +174,7 @@ export class OutputOrganizationsEventTypesService {
         transformedHosts.push({
           userId: databaseHost.userId,
           name: databaseUser?.name || "",
+          username: databaseUser?.username || "",
           avatarUrl: databaseUser?.avatarUrl,
         });
       }

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
@@ -85,11 +85,13 @@ describe("Organizations Event Types Endpoints", () => {
       teamMember1 = await userRepositoryFixture.create({
         email: teammate1Email,
         username: teammate1Email,
+        name: "alice",
       });
 
       teamMember2 = await userRepositoryFixture.create({
         email: teammate2Email,
         username: teammate2Email,
+        name: "bob",
       });
 
       falseTestUser = await userRepositoryFixture.create({
@@ -403,6 +405,21 @@ describe("Organizations Event Types Endpoints", () => {
 
           const responseTeamEvent = responseBody.data.find((event) => event.teamId === team.id);
           expect(responseTeamEvent).toBeDefined();
+          expect(responseTeamEvent?.hosts).toEqual([
+            {
+              userId: teamMember1.id,
+              name: teamMember1.name,
+              username: teamMember1.username,
+              avatarUrl: teamMember1.avatarUrl,
+            },
+            {
+              userId: teamMember2.id,
+              name: teamMember2.name,
+              username: teamMember2.username,
+              avatarUrl: teamMember2.avatarUrl,
+            },
+          ]);
+
           if (!responseTeamEvent) {
             throw new Error("Team event not found");
           }

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -19060,6 +19060,10 @@
             "type": "string",
             "example": "John Doe"
           },
+          "username": {
+            "type": "string",
+            "example": "john-doe"
+          },
           "avatarUrl": {
             "type": "string",
             "nullable": true,
@@ -19068,7 +19072,8 @@
         },
         "required": [
           "userId",
-          "name"
+          "name",
+          "username"
         ]
       },
       "EventTypeTeam": {

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -17679,13 +17679,17 @@
             "type": "string",
             "example": "John Doe"
           },
+          "username": {
+            "type": "string",
+            "example": "john-doe"
+          },
           "avatarUrl": {
             "type": "string",
             "nullable": true,
             "example": "https://cal.com/api/avatar/d95949bc-ccb1-400f-acf6-045c51a16856.png"
           }
         },
-        "required": ["userId", "name"]
+        "required": ["userId", "name", "username"]
       },
       "EventTypeTeam": {
         "type": "object",

--- a/packages/platform/types/event-types/event-types_2024_06_14/outputs/event-type.output.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/outputs/event-type.output.ts
@@ -437,6 +437,10 @@ export class TeamEventTypeResponseHost extends TeamEventTypeHostInput {
   name!: string;
 
   @IsString()
+  @DocsProperty({ example: "john-doe" })
+  username!: string;
+
+  @IsString()
   @IsOptional()
   @ApiPropertyOptional({
     example: "https://cal.com/api/avatar/d95949bc-ccb1-400f-acf6-045c51a16856.png",


### PR DESCRIPTION
Linear [CAL-5864](https://linear.app/calcom/issue/CAL-5864/feat-v2-return-managed-event-child-event)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Team event type API responses now include the username for each host.

- **API Changes**
  - Added the username field to hosts in team event type responses.
  - Updated OpenAPI docs and tests to cover the new field.

<!-- End of auto-generated description by cubic. -->

