### PR TITLE
feat: Support NEXT_PUBLIC_SINGLE_ORG_SLUG to force that slug similar to x-cal-force-slug(which works in E2E only)

### DIFF
--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -27,6 +27,7 @@ vi.mock("@calcom/lib/constants", () => ({
   IS_PRODUCTION: true,
   WEBAPP_URL: "http://localhost:3000",
   RESERVED_SUBDOMAINS: ["auth", "docs"],
+  SINGLE_ORG_SLUG: "",
 }));
 
 describe("getSchedule", () => {

--- a/apps/web/test/lib/getSchedule/futureLimit.timezone.test.ts
+++ b/apps/web/test/lib/getSchedule/futureLimit.timezone.test.ts
@@ -66,6 +66,7 @@ vi.mock("@calcom/lib/constants", () => ({
   WEBAPP_URL: "http://localhost:3000",
   RESERVED_SUBDOMAINS: ["auth", "docs"],
   ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK: 61,
+  SINGLE_ORG_SLUG: "",
 }));
 
 describe("getSchedule", () => {

--- a/packages/features/ee/organizations/lib/orgDomains.ts
+++ b/packages/features/ee/organizations/lib/orgDomains.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@prisma/client";
 import type { IncomingMessage } from "http";
 
-import { IS_PRODUCTION, WEBSITE_URL } from "@calcom/lib/constants";
+import { IS_PRODUCTION, WEBSITE_URL, SINGLE_ORG_SLUG } from "@calcom/lib/constants";
 import { ALLOWED_HOSTNAMES, RESERVED_SUBDOMAINS, WEBAPP_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import slugify from "@calcom/lib/slugify";
@@ -24,6 +24,12 @@ export function getOrgSlug(hostname: string, forcedSlug?: string) {
     log.debug("Ignoring forcedSlug in non-test mode", {
       forcedSlug,
     });
+  }
+
+  // If SINGLE_ORG_SLUG is set we know that the Cal.com instance is configured to run just one organization, so we can return the slug directly.
+  if (SINGLE_ORG_SLUG) {
+    log.debug("In Single Org Mode, using SINGLE_ORG_SLUG as the Org slug", { SINGLE_ORG_SLUG });
+    return SINGLE_ORG_SLUG;
   }
 
   if (!hostname.includes(".")) {

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -20,6 +20,7 @@ const initialConstants = {
   APP_NAME: "Cal.com",
   BOOKER_NUMBER_OF_DAYS_TO_LOAD: 14,
   PUBLIC_QUICK_AVAILABILITY_ROLLOUT: 100,
+  SINGLE_ORG_SLUG: "",
 } as typeof constants;
 
 export const mockedConstants = { ...initialConstants };

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -7,7 +7,7 @@ export const IS_PRODUCTION = CALCOM_ENV === "production";
 export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === "production";
 export const ORGANIZER_EMAIL_EXEMPT_DOMAINS = process.env.ORGANIZER_EMAIL_EXEMPT_DOMAINS || "";
 const IS_DEV = CALCOM_ENV === "development";
-
+export const SINGLE_ORG_SLUG = process.env.NEXT_PUBLIC_SINGLE_ORG_SLUG;
 /** https://app.cal.com */
 export const WEBAPP_URL =
   process.env.NEXT_PUBLIC_WEBAPP_URL ||


### PR DESCRIPTION
Fixes #21210


`NEXT_PUBLIC_SINGLE_ORG_SLUG`  will force that slug to be used instead of deriving it from the domain. Because it is single organization mode, it makes the most sense and allows any subdomain or any random domain to support an organization instead of hard requirement of having organization slug in the domain name