### PR TITLE
fix: revalidations for attributes are missing in some places

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/organizations/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/members/page.tsx
@@ -20,8 +20,8 @@ const getCachedAttributes = unstable_cache(
   async (orgId: number) => {
     return await AttributeRepository.findAllByOrgIdWithOptions({ orgId });
   },
-  ["viewer.attributes.list"],
-  { revalidate: 3600 } // Cache for 1 hour
+  undefined,
+  { revalidate: 3600, tags: ["viewer.attributes.list"] } // Cache for 1 hour
 );
 
 const Page = async () => {

--- a/packages/features/ee/organizations/pages/settings/attributes/attributes-create-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/attributes/attributes-create-view.tsx
@@ -7,8 +7,9 @@ import { z } from "zod";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { showToast } from "@calcom/ui/components/toast";
 import { Button } from "@calcom/ui/components/button";
+import { showToast } from "@calcom/ui/components/toast";
+import { revalidateAttributesList } from "@calcom/web/app/(use-page-wrapper)/settings/organizations/members/actions";
 
 import { AttributeForm } from "./AttributesForm";
 
@@ -26,6 +27,7 @@ function CreateAttributesPage() {
   const mutation = trpc.viewer.attributes.create.useMutation({
     onSuccess: () => {
       showToast("Attribute created successfully", "success");
+      revalidateAttributesList();
       router.push("/settings/organizations/attributes");
     },
     onError: (err) => {

--- a/packages/features/ee/organizations/pages/settings/attributes/attributes-list-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/attributes/attributes-list-view.tsx
@@ -19,6 +19,7 @@ import {
 import { Switch } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
+import { revalidateAttributesList } from "@calcom/web/app/(use-page-wrapper)/settings/organizations/members/actions";
 
 import { DeleteAttributeModal } from "./DeleteAttributeModal";
 import { ListSkeleton } from "./ListSkeleton";
@@ -44,6 +45,7 @@ function AttributeItem({
   const mutation = trpc.viewer.attributes.toggleActive.useMutation({
     onSuccess: () => {
       showToast(t("attribute_updated_successfully"), "success");
+      revalidateAttributesList();
     },
     onError: (err) => {
       showToast(err.message, "error");


### PR DESCRIPTION
## What does this PR do?

- Fixed attribute list revalidation so changes to organization attributes now update the list right away. This prevents stale data after creating or updating attributes.
- Follow up of #21552

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- I already tested. To test, create/update/delete attributes and check if data is not stale in /settings/organizations/members and /settings/organizations/[id]/members