### PR TITLE
fix: added new validation for url

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1230,6 +1230,7 @@
   "email_validation_error": "That doesn't look like an email address",
   "emails_must_be_unique_valid": "Emails must be unique and valid",
   "url_validation_error": "That doesn't look like a URL",
+  "url_must_start_with_protocol": "URL must start with http:// or https://",
   "place_where_cal_widget_appear": "Place this code in your HTML where you want your {{appName}} widget to appear.",
   "create_update_react_component": "Create or update an existing React component as shown below.",
   "copy_code": "Copy Code",

--- a/packages/features/form-builder/schema.ts
+++ b/packages/features/form-builder/schema.ts
@@ -403,6 +403,15 @@ export const fieldTypesSchemaMap: Partial<
       const value = response ?? "";
       const urlSchema = z.string().url();
 
+      // Check if URL starts with http:// or https://
+      if (!value.match(/^https?:\/\//)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: m("url_must_start_with_protocol"),
+        });
+        return;
+      }
+
       // Check for malformed protocols (missing second slash test case)
       if (value.match(/^https?:\/[^\/]/)) {
         ctx.addIssue({
@@ -412,22 +421,14 @@ export const fieldTypesSchemaMap: Partial<
         return;
       }
 
-      // 1. Try validating the original value
-      if (urlSchema.safeParse(value).success) {
+      // Validate the URL format
+      if (!urlSchema.safeParse(value).success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: m("url_validation_error"),
+        });
         return;
       }
-
-      // 2. If it failed, try prepending https://
-      const valueWithHttps = `https://${value}`;
-      if (urlSchema.safeParse(valueWithHttps).success) {
-        return;
-      }
-
-      // 3. If all attempts fail, throw err
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: m("url_validation_error"),
-      });
     },
   },
 };


### PR DESCRIPTION
## What does this PR do?

Added new URL validation it will check that is URL starts with http and https

- Fixes #21585 


## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.


#### Image Demo (if applicable):

- Before ( I can add anything as link)
![image](https://github.com/user-attachments/assets/7381dfbd-0e31-4394-8575-ab7cfc7b1a3e)

- After ( It will check whether the added URL starts with http or https)
![image](https://github.com/user-attachments/assets/41dc5c6e-3e4c-4213-a24e-4a0f2a6e4319)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Create a booking using a URL question.  
- Book the slot from the created booking.  
- Add any type of text in that URL question.  
- It will validate whether the added text is a valid URL or not. 



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new URL validation to require URLs to start with http:// or https:// and improved error messages for invalid URLs.

<!-- End of auto-generated description by cubic. -->

