### PR TITLE
fix: platformPlanGuard per active users plan

### DIFF
--- a/apps/api/v2/src/modules/auth/guards/billing/platform-plan.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/billing/platform-plan.guard.ts
@@ -1,6 +1,6 @@
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
-import { PlatformPlanType } from "@/modules/billing/types";
+import { PlatformPlanType, orderedPlans } from "@/modules/billing/types";
 import { OrganizationsRepository } from "@/modules/organizations/index/organizations.repository";
 import { RedisService } from "@/modules/redis/redis.service";
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from "@nestjs/common";
@@ -61,7 +61,7 @@ export class PlatformPlanGuard implements CanActivate {
       !hasMinimumPlan({
         currentPlan: organization.platformBilling?.plan as PlatformPlanType,
         minimumPlan: minimumPlan,
-        plans: ["FREE", "STARTER", "ESSENTIALS", "SCALE", "PER_ACTIVE_USER", "ENTERPRISE"],
+        plans: orderedPlans,
       })
     ) {
       throw new ForbiddenException(
@@ -79,7 +79,7 @@ export class PlatformPlanGuard implements CanActivate {
 type HasMinimumPlanProp = {
   currentPlan: PlatformPlanType;
   minimumPlan: PlatformPlanType;
-  plans: PlatformPlanType[];
+  plans: readonly PlatformPlanType[];
 };
 
 export function hasMinimumPlan(props: HasMinimumPlanProp): boolean {

--- a/apps/api/v2/src/modules/auth/guards/billing/platform-plan.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/billing/platform-plan.guard.ts
@@ -61,7 +61,7 @@ export class PlatformPlanGuard implements CanActivate {
       !hasMinimumPlan({
         currentPlan: organization.platformBilling?.plan as PlatformPlanType,
         minimumPlan: minimumPlan,
-        plans: ["FREE", "STARTER", "ESSENTIALS", "SCALE", "ENTERPRISE"],
+        plans: ["FREE", "STARTER", "ESSENTIALS", "SCALE", "PER_ACTIVE_USER", "ENTERPRISE"],
       })
     ) {
       throw new ForbiddenException(
@@ -87,7 +87,7 @@ export function hasMinimumPlan(props: HasMinimumPlanProp): boolean {
   const minimumPlanIndex = props.plans.indexOf(props.minimumPlan);
 
   if (currentPlanIndex === -1 || minimumPlanIndex === -1) {
-    throw new Error(
+    throw new ForbiddenException(
       `PlatformPlanGuard - Invalid platform billing plan provided. Current plan: ${props.currentPlan}, Minimum plan: ${props.minimumPlan}`
     );
   }

--- a/apps/api/v2/src/modules/billing/types.ts
+++ b/apps/api/v2/src/modules/billing/types.ts
@@ -7,4 +7,13 @@ export enum PlatformPlan {
   PER_ACTIVE_USER = "PER_ACTIVE_USER",
 }
 
-export type PlatformPlanType = "FREE" | "STARTER" | "ESSENTIALS" | "SCALE" | "ENTERPRISE" | "PER_ACTIVE_USER";
+export const orderedPlans = [
+  "FREE",
+  "STARTER",
+  "ESSENTIALS",
+  "SCALE",
+  "PER_ACTIVE_USER",
+  "ENTERPRISE",
+] as const;
+
+export type PlatformPlanType = (typeof orderedPlans)[number];


### PR DESCRIPTION


## Summary by cubic
Updated the platform plan guard to support the "PER_ACTIVE_USER" plan and improved error handling for invalid plans.

- **Bug Fixes**
  - Added "PER_ACTIVE_USER" to the list of valid plans.
  - Changed invalid plan errors to return a forbidden exception.

<!-- End of auto-generated description by cubic. -->

