### PR TITLE
fix: add httpOnly and secure flags to uid cookie to prevent XSS

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
@@ -52,7 +52,13 @@ export class SlotsController_2024_04_15 {
   ): Promise<ApiResponse<string>> {
     const uid = await this.slotsService.reserveSlot(body, req.cookies?.uid);
 
-    res.cookie("uid", uid);
+    res.cookie("uid", uid, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production", 
+      sameSite: "strict",                            
+      maxAge: 1000 * 60 * 60 * 24 * 7,             
+    });
+
     return {
       status: SUCCESS_STATUS,
       data: uid,


### PR DESCRIPTION
## What does this PR do?

This PR fixes a **security vulnerability** in the slot booking API (`slots.controller.ts`) by securely configuring the cookie used for user identification (`uid`). The update ensures the cookie is no longer exposed to client-side JavaScript or transmitted over insecure HTTP connections.

---

###  What was updated?

**Before:**

```ts
res.cookie("uid", uid);
```

**After:**

```ts
res.cookie("uid", uid, {
  httpOnly: true,            // Prevents client-side JavaScript access (mitigates XSS)
  secure: isProduction,      // Ensures cookie is only sent over HTTPS in production
  sameSite: 'strict'           // Stricter CSRF protection
  maxAge: 1000 * 60 * 60 * 24 * 7,        // 7 days
});
```

---

- Fixes - #21636
- /claim #21636 
- Fixes CAL - #5880

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Secured the uid cookie in the slot booking API by adding httpOnly, secure, and sameSite flags to prevent XSS and CSRF attacks. The cookie now also has a 7-day expiration.

<!-- End of auto-generated description by cubic. -->

