### PR TITLE
fix: slots.controller sensitive server cookie exposed to the client

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -518,7 +518,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
         expect(uidCookie).toBeDefined();
         if (uidCookie) {
           expect(uidCookie).toContain("HttpOnly"); // This is the key security fix
-          expect(uidCookie).not.toMatch(/SameSite=None(?!;)/); // Should not be permissive without Secure
+          expect(uidCookie).not.toMatch(/SameSite=None(?!.*Secure)/); // Should not be permissive without Secure
         }
 
         // Clean up

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts
@@ -492,7 +492,7 @@ describe("Slots 2024-04-15 Endpoints", () => {
           expect(uidCookie).toContain("HttpOnly"); // Prevents XSS access
           expect(uidCookie).toContain("Path=/"); // Proper scope
           // SameSite will be Lax or none depending on environment
-          expect(uidCookie).toMatch(/SameSite=(Lax|none)/);
+          expect(uidCookie).toMatch(/SameSite=(Lax|None)/i);
         }
 
         // Clean up


### PR DESCRIPTION
## What does this PR do?

Fixes security vulnerability in the slot booking API
/claim https://github.com/calcom/cal.com/issues/21636

- Fixes #21636 (GitHub issue number)
- Fixes [CAL-5880](https://linear.app/calcom/issue/CAL-5880/slotscontroller-sensitive-server-cookie-exposed-to-the-client)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
```
cd apps/api/v2 && yarn test:e2e src/modules/slots/slots-2024-04-15/controllers/slots.controller.e2e-spec.ts --testNamePattern="Cookie Security Tests|routingFormResponseId|should get slots|should reserve a slot|should delete reserved slot"
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Secured the slot booking API by setting the reservation cookie as HttpOnly and Secure, preventing client-side access and exposure.

- **Bug Fixes**
  - Updated cookie settings to use HttpOnly, Secure, and proper SameSite flags.
  - Added tests to verify cookies are not accessible from client-side JavaScript.

<!-- End of auto-generated description by cubic. -->

