### PR TITLE
fix: require at least 3-letter cancellation reason

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -130,7 +130,7 @@ export default function CancelBooking(props: Props) {
   }, []);
 
   const handleCancelEvent = (value: string) => {
-    if (value.trim().split(/\s+/).filter(Boolean).length < 3) {
+    if (cancellationReason.length < 2) {
       showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -130,7 +130,7 @@ export default function CancelBooking(props: Props) {
   }, []);
 
   const handleCancelEvent = (value: string) => {
-    if (value.length <= 2) {
+    if (value.trim().split(/\s+/).filter(Boolean).length < 3) {
       showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -131,7 +131,7 @@ export default function CancelBooking(props: Props) {
 
   const handleCancelEvent = (value: string) => {
     if (value.length <= 2) {
-      showToast("Enter valid reason", "warning");
+      showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);
   };

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -11,6 +11,7 @@ import type { RecurringEvent } from "@calcom/types/Calendar";
 import { Button } from "@calcom/ui/components/button";
 import { Label, Select, TextArea } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
+import { showToast } from "@calcom/ui/components/toast";
 
 interface InternalNotePresetsSelectProps {
   internalNotePresets: { id: number; name: string }[];
@@ -128,6 +129,13 @@ export default function CancelBooking(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleCancelEvent = (value: string) => {
+    if (value.length <= 2) {
+      showToast("Enter valid reason", "warning");
+      setCancellationReason(value);
+    } else setCancellationReason(value);
+  };
+
   return (
     <>
       {error && (
@@ -175,7 +183,7 @@ export default function CancelBooking(props: Props) {
             ref={cancelBookingRef}
             placeholder={t("cancellation_reason_placeholder")}
             value={cancellationReason}
-            onChange={(e) => setCancellationReason(e.target.value)}
+            onChange={(e) => handleCancelEvent(e.target.value)}
             className="mb-4 mt-2 w-full "
             rows={3}
           />
@@ -199,7 +207,9 @@ export default function CancelBooking(props: Props) {
                 data-testid="confirm_cancel"
                 disabled={
                   props.isHost &&
-                  (!cancellationReason || (props.internalNotePresets.length > 0 && !internalNote?.id))
+                  (!cancellationReason ||
+                    cancellationReason.length < 3 ||
+                    (props.internalNotePresets.length > 0 && !internalNote?.id))
                 }
                 onClick={async () => {
                   setLoading(true);

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1489,6 +1489,7 @@
   "turn_on": "Turn on",
   "cancelled_bookings_cannot_be_rescheduled": "Canceled bookings cannot be rescheduled",
   "settings_updated_successfully": "Settings updated successfully",
+  "enter_valid_reason": "Enter valid reason",
   "error_updating_settings": "Error updating settings",
   "personal_cal_url": "My personal {{appName}} URL",
   "bio_hint": "A few sentences about yourself. this will appear on your personal url page.",


### PR DESCRIPTION
## What does this PR do?

- Fixes #21657  (GitHub issue number)
- Fixes CAL-5884 (Linear issue number)

Added validation to require at least 3 words in cancellation reasons.
Prevents users from submitting vague or incomplete inputs like "no" or "x".

#### Image Demo (if applicable):

![Screenshot 2025-05-31 163009](https://github.com/user-attachments/assets/6efbd961-d114-454f-8207-e21b9deb7899)

![Screenshot 2025-05-31 163901](https://github.com/user-attachments/assets/551d9ef9-e9cf-4ad1-8e53-f641ecc6ec85)


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to the event cancellation.
- Type a very short reason (e.g., "no", "x") in the textarea.
- Submit the button.
- The form submits successfully without any meaningful input.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added validation to require at least 3 words in the cancellation reason when canceling an event. This prevents users from submitting very short or unclear reasons.

<!-- End of auto-generated description by cubic. -->

