### PR TITLE
fix: insecure uid cookie by setting httpOnly and secure flags

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
@@ -52,7 +52,18 @@ export class SlotsController_2024_04_15 {
   ): Promise<ApiResponse<string>> {
     const uid = await this.slotsService.reserveSlot(body, req.cookies?.uid);
 
-    res.cookie("uid", uid);
+    const onProd = process.env.NODE_ENV === "production";
+
+    if (onProd) {
+      res.cookie("uid", uid, {
+        httpOnly: true,
+        secure: onProd,
+        sameSite: "lax",
+        maxAge: 1000 * 60 * 60 * 24 * 10,
+        path: "/",
+      });
+    }
+
     return {
       status: SUCCESS_STATUS,
       data: uid,
@@ -158,19 +169,19 @@ export class SlotsController_2024_04_15 {
     @Req() req: ExpressRequest
   ): Promise<ApiResponse<{ slots: TimeSlots["slots"] | RangeSlots["slots"] }>> {
     try {
-    const isTeamEvent =
-      query.isTeamEvent === undefined
-        ? await this.slotsService.checkIfIsTeamEvent(query.eventTypeId)
-        : query.isTeamEvent;
-    const availableSlots = await getAvailableSlots({
-      input: {
-        ...query,
-        isTeamEvent,
-      },
-      ctx: {
-        req,
-      },
-    });
+      const isTeamEvent =
+        query.isTeamEvent === undefined
+          ? await this.slotsService.checkIfIsTeamEvent(query.eventTypeId)
+          : query.isTeamEvent;
+      const availableSlots = await getAvailableSlots({
+        input: {
+          ...query,
+          isTeamEvent,
+        },
+        ctx: {
+          req,
+        },
+      });
 
       const { slots } = await this.slotsOutputService.getOutputSlots(
         availableSlots,

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
@@ -52,16 +52,14 @@ export class SlotsController_2024_04_15 {
   ): Promise<ApiResponse<string>> {
     const uid = await this.slotsService.reserveSlot(body, req.cookies?.uid);
 
-    const onProd = process.env.NODE_ENV === "production";
+    const isSecure = req.secure || req.headers["x-forwarded-proto"] === "https";
 
-    if (onProd) {
-      res.cookie("uid", uid, {
-        httpOnly: true,
-        secure: onProd,
-        sameSite: "lax",
-        path: "/",
-      });
-    }
+    res.cookie("uid", uid, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: "lax",
+      path: "/",
+    });
 
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
@@ -59,7 +59,6 @@ export class SlotsController_2024_04_15 {
         httpOnly: true,
         secure: onProd,
         sameSite: "lax",
-        maxAge: 1000 * 60 * 60 * 24 * 10,
         path: "/",
       });
     }

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -130,7 +130,7 @@ export default function CancelBooking(props: Props) {
   }, []);
 
   const handleCancelEvent = (value: string) => {
-    if (value.trim().split(/\s+/).filter(Boolean).length < 3) {
+    if (cancellationReason.length < 2) {
       showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -130,7 +130,7 @@ export default function CancelBooking(props: Props) {
   }, []);
 
   const handleCancelEvent = (value: string) => {
-    if (value.length <= 2) {
+    if (value.trim().split(/\s+/).filter(Boolean).length < 3) {
       showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -131,7 +131,7 @@ export default function CancelBooking(props: Props) {
 
   const handleCancelEvent = (value: string) => {
     if (value.length <= 2) {
-      showToast("Enter valid reason", "warning");
+      showToast(t("enter_valid_reason"), "warning");
       setCancellationReason(value);
     } else setCancellationReason(value);
   };

--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -11,6 +11,7 @@ import type { RecurringEvent } from "@calcom/types/Calendar";
 import { Button } from "@calcom/ui/components/button";
 import { Label, Select, TextArea } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
+import { showToast } from "@calcom/ui/components/toast";
 
 interface InternalNotePresetsSelectProps {
   internalNotePresets: { id: number; name: string }[];
@@ -128,6 +129,13 @@ export default function CancelBooking(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleCancelEvent = (value: string) => {
+    if (value.length <= 2) {
+      showToast("Enter valid reason", "warning");
+      setCancellationReason(value);
+    } else setCancellationReason(value);
+  };
+
   return (
     <>
       {error && (
@@ -175,7 +183,7 @@ export default function CancelBooking(props: Props) {
             ref={cancelBookingRef}
             placeholder={t("cancellation_reason_placeholder")}
             value={cancellationReason}
-            onChange={(e) => setCancellationReason(e.target.value)}
+            onChange={(e) => handleCancelEvent(e.target.value)}
             className="mb-4 mt-2 w-full "
             rows={3}
           />
@@ -199,7 +207,9 @@ export default function CancelBooking(props: Props) {
                 data-testid="confirm_cancel"
                 disabled={
                   props.isHost &&
-                  (!cancellationReason || (props.internalNotePresets.length > 0 && !internalNote?.id))
+                  (!cancellationReason ||
+                    cancellationReason.length < 3 ||
+                    (props.internalNotePresets.length > 0 && !internalNote?.id))
                 }
                 onClick={async () => {
                   setLoading(true);

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1489,6 +1489,7 @@
   "turn_on": "Turn on",
   "cancelled_bookings_cannot_be_rescheduled": "Canceled bookings cannot be rescheduled",
   "settings_updated_successfully": "Settings updated successfully",
+  "enter_valid_reason": "Enter valid reason",
   "error_updating_settings": "Error updating settings",
   "personal_cal_url": "My personal {{appName}} URL",
   "bio_hint": "A few sentences about yourself. this will appear on your personal url page.",


### PR DESCRIPTION
## What does this PR do?

This PR improves slot booking API security by setting the uid cookie with httpOnly and secure flags in slots.controller.ts, preventing session theft via XSS.

- /claim #21636 
- Fixes #21636  (GitHub issue number)
- Fixes CAL-5880 (Linear issue number)


## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

![Screenshot 2025-05-31 210817](https://github.com/user-attachments/assets/c55fdadd-c6fe-4bae-b629-91aa0692567c)


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A 
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Use Network Tab to Inspect Cookies on Requests

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved slot booking API security by setting the uid cookie with httpOnly and secure flags. Added better validation and user feedback for cancellation reasons in the booking UI.

- **Bug Fixes**
  - Set httpOnly and secure flags on the uid cookie to prevent session theft.
  - Show a warning toast if the cancellation reason is too short.
  - Updated button logic to require a valid cancellation reason.

<!-- End of auto-generated description by cubic. -->

