### PR TITLE
feat: Add loadingStateChildren prop to AvailabilitySettingsPlatformWrapper

### DIFF
--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -41,6 +41,7 @@ type AvailabilitySettingsPlatformWrapperProps = {
   disableToasts?: boolean;
   isDryRun?: boolean;
   noScheduleChildren?: ReactNode;
+  loadingStateChildren?: ReactNode;
 };
 
 export const AvailabilitySettingsPlatformWrapper = ({
@@ -123,7 +124,13 @@ export const AvailabilitySettingsPlatformWrapper = ({
     }
   };
 
-  if (isLoading) return <div className="px-10 py-4 text-xl">Loading...</div>;
+  if (isLoading) {
+    return loadingStateChildren ? (
+      <>{loadingStateChildren}</>
+    ) : (
+      <div className="px-10 py-4 text-xl">Loading...</div>
+    );
+  }
 
   if (!atomSchedule) {
     return noScheduleChildren ? (

--- a/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
+++ b/packages/platform/atoms/availability/wrappers/AvailabilitySettingsPlatformWrapper.tsx
@@ -60,6 +60,7 @@ export const AvailabilitySettingsPlatformWrapper = ({
   disableToasts,
   isDryRun = false,
   noScheduleChildren,
+  loadingStateChildren,
 }: AvailabilitySettingsPlatformWrapperProps) => {
   const { isLoading, data: schedule } = useSchedule(id);
   const { data: schedules } = useSchedules();


### PR DESCRIPTION
## What does this PR do?

Add loadingStateChildren prop to AvailabilitySettingsPlatformWrapper

<img width="531" alt="Screenshot 2025-06-01 at 1 08 54 PM" src="https://github.com/user-attachments/assets/feb28691-3cde-4f83-99a5-33dd4a9e6287" />

- Fixes #21569  (GitHub issue number)


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a loadingStateChildren prop to AvailabilitySettingsPlatformWrapper so custom loading content can be shown while data is loading.

<!-- End of auto-generated description by cubic. -->

