### PR TITLE
chore: only use event api v2 call if route is in env

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -21,6 +21,10 @@ const paramsSchema = z.object({
   slug: z.string().transform((s) => slugify(s)),
 });
 
+function hasApiV2RouteInEnv() {
+  return Boolean(process.env.NEXT_PUBLIC_API_V2_URL);
+}
+
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const { req, params, query } = context;
   const session = await getServerSession({ req });
@@ -115,7 +119,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const allowSEOIndexing = organizationSettings?.allowSEOIndexing ?? false;
 
   const featureRepo = new FeaturesRepository();
-  const useApiV2 = await featureRepo.checkIfTeamHasFeature(team.id, "use-api-v2-for-team-slots");
+  const teamHasApiV2Route = await featureRepo.checkIfTeamHasFeature(team.id, "use-api-v2-for-team-slots");
+  const useApiV2 = teamHasApiV2Route && hasApiV2RouteInEnv();
 
   return {
     props: {


### PR DESCRIPTION
Only call event types via api v2 route if the env var is set 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The event API v2 route is now only called if the related environment variable is set, preventing unwanted API calls.

<!-- End of auto-generated description by cubic. -->

