### PR TITLE
fix: Remove hard dependency on NEXT_PUBLIC_API_V2_URL

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -331,12 +331,6 @@ const nextConfig = {
     ].filter(Boolean);
 
     let afterFiles = [
-      ...(Boolean(process.env.NEXT_PUBLIC_API_V2_URL)
-        ? {
-            source: "/api/v2/:path*",
-            destination: `${process.env.NEXT_PUBLIC_API_V2_URL}/:path*`,
-          }
-        : {}),
       {
         source: "/org/:slug",
         destination: "/team/:slug",
@@ -372,6 +366,13 @@ const nextConfig = {
         destination: process.env.NEXT_PUBLIC_EMBED_LIB_URL?,
       }, */
     ];
+
+    if (Boolean(process.env.NEXT_PUBLIC_API_V2_URL)) {
+      afterFiles.push({
+        source: "/api/v2/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_V2_URL}/:path*`,
+      });
+    }
 
     return {
       beforeFiles,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -48,10 +48,6 @@ if (!process.env.EMAIL_FROM) {
 
 if (!process.env.NEXTAUTH_URL) throw new Error("Please set NEXTAUTH_URL");
 
-if (!process.env.NEXT_PUBLIC_API_V2_URL) {
-  console.error("Please set NEXT_PUBLIC_API_V2_URL");
-}
-
 const getHttpsUrl = (url) => {
   if (!url) return url;
   if (url.startsWith("http://")) {
@@ -335,10 +331,12 @@ const nextConfig = {
     ].filter(Boolean);
 
     let afterFiles = [
-      {
-        source: "/api/v2/:path*",
-        destination: `${process.env.NEXT_PUBLIC_API_V2_URL}/:path*`,
-      },
+      ...(Boolean(process.env.NEXT_PUBLIC_API_V2_URL)
+        ? {
+            source: "/api/v2/:path*",
+            destination: `${process.env.NEXT_PUBLIC_API_V2_URL}/:path*`,
+          }
+        : {}),
       {
         source: "/org/:slug",
         destination: "/team/:slug",


### PR DESCRIPTION
## What does this PR do?

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the hard requirement for NEXT_PUBLIC_API_V2_URL to prevent crashes when the variable is missing. Now, the app works even if this environment variable is not set.

<!-- End of auto-generated description by cubic. -->

