### PR TITLE
fix: Added onFormStateChange callback on EventSettings atom

### DIFF
--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import type { AvailabilityFormValues } from "availability/types";
 import { useRef, useState, useEffect } from "react";
 
 import type { ChildrenEventType } from "@calcom/features/eventtypes/components/ChildrenEventTypeSelect";
@@ -57,6 +58,7 @@ export type EventTypePlatformWrapperProps = {
   customClassNames?: EventTypeCustomClassNames;
   disableToasts?: boolean;
   isDryRun?: boolean;
+  onFormStateChange?: (formState: AvailabilityFormValues) => void;
 };
 
 const EventType = ({
@@ -320,6 +322,7 @@ export const EventTypePlatformWrapper = ({
   allowDelete = true,
   customClassNames,
   isDryRun,
+  onFormStateChange,
 }: EventTypePlatformWrapperProps) => {
   const { data: eventTypeQueryData } = useAtomsEventTypeById(id);
   const queryClient = useQueryClient();
@@ -352,6 +355,7 @@ export const EventTypePlatformWrapper = ({
       allowDelete={allowDelete}
       customClassNames={customClassNames}
       isDryRun={isDryRun}
+      onFormStateChange={onFormStateChange}
     />
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Fixes #21577
- Fixes [CAL-5856 [Atoms] Add onFormStateChange callback on EventTypeSettings atom](https://linear.app/calcom/issue/CAL-5856/atoms-add-onformstatechange-callback-on-eventtypesettings-atom)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).  N/A.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an onFormStateChange callback prop to the EventSettings atom to allow external components to track form state changes.

<!-- End of auto-generated description by cubic. -->

