### PR TITLE
fix: Mimic prisma behaviour in Kysely

### DIFF
--- a/packages/kysely/index.ts
+++ b/packages/kysely/index.ts
@@ -7,7 +7,12 @@ export type { DB, Booking };
 
 const connectionString = process.env.DATABASE_URL ?? "postgresql://postgres:@localhost:5450/calendso";
 
-const pool = new Pool({ connectionString });
+const pool = new Pool({
+  connectionString,
+  ssl: {
+    rejectUnauthorized: false,
+  },
+});
 
 // 3. Create the Dialect, passing the configured pool instance
 const dialect = new PostgresDialect({


### PR DESCRIPTION
## What does this PR do?
Updated the Kysely database connection to use SSL with rejectUnauthorized set to false, matching Prisma's default behavior.

