### PR TITLE
fix: self hosted feature check

### DIFF
--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -54,9 +54,8 @@ export const CONSOLE_URL =
   process.env.NODE_ENV !== "production"
     ? `https://console.cal.dev`
     : `https://console.cal.com`;
-export const IS_SELF_HOSTED = !(
-  new URL(WEBAPP_URL).hostname.endsWith(".cal.dev") || new URL(WEBAPP_URL).hostname.endsWith(".cal.com")
-);
+const CAL_DOMAINS = [".cal.com", ".cal.dev", ".cal.eu", ".cal.qa"];
+export const IS_SELF_HOSTED = !CAL_DOMAINS.some((domain) => new URL(WEBAPP_URL).hostname.endsWith(domain));
 export const EMBED_LIB_URL = process.env.NEXT_PUBLIC_EMBED_LIB_URL || `${WEBAPP_URL}/embed/embed.js`;
 export const TRIAL_LIMIT_DAYS = 14;
 export const MAX_SEATS_PER_TIME_SLOT = 1000;

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -55,7 +55,8 @@ export const CONSOLE_URL =
     ? `https://console.cal.dev`
     : `https://console.cal.com`;
 const CAL_DOMAINS = [".cal.com", ".cal.dev", ".cal.eu", ".cal.qa"];
-export const IS_SELF_HOSTED = !CAL_DOMAINS.some((domain) => new URL(WEBAPP_URL).hostname.endsWith(domain));
+const WEBAPP_HOSTNAME = new URL(WEBAPP_URL).hostname;
+export const IS_SELF_HOSTED = !CAL_DOMAINS.some((domain) => WEBAPP_HOSTNAME.endsWith(domain));
 export const EMBED_LIB_URL = process.env.NEXT_PUBLIC_EMBED_LIB_URL || `${WEBAPP_URL}/embed/embed.js`;
 export const TRIAL_LIMIT_DAYS = 14;
 export const MAX_SEATS_PER_TIME_SLOT = 1000;


### PR DESCRIPTION
## What does this PR do?

This pull request refactors the logic for determining if the application is self-hosted by introducing a centralized list of supported domains. This change improves maintainability and makes it easier to add or update domains in the future.

### Refactoring for maintainability:
* [`packages/lib/constants.ts`](diffhunk://#diff-84a559b7431271bcf747be80243751e28f9e17100616987cb5776afffe63e1a6L57-R58): Replaced the inline logic for determining `IS_SELF_HOSTED` with a new `CAL_DOMAINS` array. The `IS_SELF_HOSTED` constant now checks if the hostname of `WEBAPP_URL` ends with any domain in `CAL_DOMAINS`. This simplifies the code and allows for easier updates to the list of supported domains.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the self-hosted feature check to correctly detect all Cal domains, including .cal.com, .cal.dev, .cal.eu, and .cal.qa.

<!-- End of auto-generated description by cubic. -->

