### PR TITLE
fix-wrong-url-on-auth-error

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -973,7 +973,7 @@ export const getOptions = ({
               return true;
             }
           }
-          return `auth/error?error=wrong-provider&provider=${existingUserWithEmail.identityProvider}`;
+          return `/auth/error?error=wrong-provider&provider=${existingUserWithEmail.identityProvider}`;
         }
 
         // Associate with organization if enabled by flag and idP is Google (for now)


### PR DESCRIPTION
## What does this PR do?

Fx wrong URL when auth error occurs. The path generated was relative and thus the final URL generated was wrong.


Regression from #20582

