### PR TITLE
fix(slots): set httpOnly & secure flags on uid cookie (fixes #21636)

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/controllers/slots.controller.ts
@@ -52,7 +52,10 @@ export class SlotsController_2024_04_15 {
   ): Promise<ApiResponse<string>> {
     const uid = await this.slotsService.reserveSlot(body, req.cookies?.uid);
 
-    res.cookie("uid", uid);
+    res.cookie("uid", uid, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+    });
     return {
       status: SUCCESS_STATUS,
       data: uid,


### PR DESCRIPTION
Closes #21636.\n\nSets httpOnly and secure flags on the uid cookie in reserveSlot to mitigate XSS-based session hijacking.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set httpOnly and secure flags on the uid cookie in reserveSlot to improve session security and prevent XSS-based attacks.

<!-- End of auto-generated description by cubic. -->

