### PR TITLE
feat: Persist filters across tabs

### DIFF
--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useReactTable, getCoreRowModel, getSortedRowModel, createColumnHelper } from "@tanstack/react-table";
+import { useRouter } from "next/navigation";
 import { useMemo, useRef } from "react";
 
 import { WipeMyCalActionButton } from "@calcom/app-store/wipemycalother/components";
@@ -106,6 +107,7 @@ type RowData =
 function BookingsContent({ status }: BookingsProps) {
   const { t } = useLocale();
   const user = useMeQuery().data;
+  const router = useRouter();
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
   const eventTypeIds = useFilterValue("eventTypeId", ZMultiSelectFilterValue)?.data as number[] | undefined;
@@ -117,6 +119,18 @@ function BookingsContent({ status }: BookingsProps) {
   const bookingUid = useFilterValue("bookingUid", ZTextFilterValue)?.data?.operand as string | undefined;
 
   const { limit, offset } = useDataTable();
+
+  function navigateWithFilters(href: string) {
+    const url = new URL(window.location.href);
+    const activeFilters = url.searchParams.get("activeFilters");
+
+    const newUrl = new URL(href, window.location.origin);
+    if (activeFilters) {
+      newUrl.searchParams.set("activeFilters", activeFilters);
+    }
+
+    router.push(newUrl.toString());
+  }
 
   const query = trpc.viewer.bookings.get.useQuery({
     limit,
@@ -367,6 +381,7 @@ function BookingsContent({ status }: BookingsProps) {
           tabs={tabs.map((tab) => ({
             ...tab,
             name: t(tab.name),
+            onClick: (_name) => navigateWithFilters(tab.href),
           }))}
         />
       </div>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #21696 (GitHub issue number)
- Fixes CAL-5892 (Linear issue number - should be visible at the bottom of the GitHub issue description)


### before: (filters getting lost on navigation)

https://www.loom.com/share/3c3ddc3e943e46da8e6341bb3fe6e3cd?sid=4905a84f-0506-4bca-a154-3f3bb43c7d75


### after:

https://www.loom.com/share/19eab5cdb2944654b20446ca1e09d10f?sid=c64c3d91-29ca-41d6-8969-5302e7d5fb38



## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Filters now stay applied when switching between tabs in the bookings view, so users no longer lose their selected filters during navigation.

<!-- End of auto-generated description by cubic. -->

