### PR TITLE
feat: persist filters across tabs

### DIFF
--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useReactTable, getCoreRowModel, getSortedRowModel, createColumnHelper } from "@tanstack/react-table";
+import { useSearchParams } from "next/navigation";
 import { useMemo, useRef } from "react";
 
 import { WipeMyCalActionButton } from "@calcom/app-store/wipemycalother/components";
@@ -107,6 +108,8 @@ function BookingsContent({ status }: BookingsProps) {
   const { t } = useLocale();
   const user = useMeQuery().data;
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const searchParams = useSearchParams();
+  const queryString = searchParams.toString();
 
   const eventTypeIds = useFilterValue("eventTypeId", ZMultiSelectFilterValue)?.data as number[] | undefined;
   const teamIds = useFilterValue("teamId", ZMultiSelectFilterValue)?.data as number[] | undefined;
@@ -360,11 +363,17 @@ function BookingsContent({ status }: BookingsProps) {
     getFacetedUniqueValues,
   });
 
+  // tabs include query parameters
+  const tabsWithQuery = tabs.map((tab) => ({
+    ...tab,
+    href: `${tab.href}${queryString ? `?${queryString}` : ""}`,
+  }));
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-row flex-wrap justify-between">
         <HorizontalTabs
-          tabs={tabs.map((tab) => ({
+          tabs={tabsWithQuery.map((tab) => ({
             ...tab,
             name: t(tab.name),
           }))}


### PR DESCRIPTION
## What does this PR do?

- Fixes #21696

## Explanation

- Modified `BookingsContent` in `bookings-listing-view.tsx` to preserve query parameters by appending the current query string to tab `href`s using `useSearchParams`.

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/60b8796f-dc3a-47c1-8c03-95dbcbae61c9


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Tests

  - Verified filter persistence across all tabs with single and multiple filters (e.g., `/bookings/upcoming?activeFilters=...` to `/bookings/unconfirmed?activeFilters=...`).
  - Tested edge cases: clearing filters, modifying filters after switching tabs.
  - Confirmed no impact on existing functionality (e.g., bookings display).

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Tabs in the bookings view now keep any active query parameters, so filters and search settings stay applied when switching tabs.

<!-- End of auto-generated description by cubic. -->

