### PR TITLE
fix: emtpy availability heading issue

### DIFF
--- a/packages/ui/components/editable-heading/EditableHeading.tsx
+++ b/packages/ui/components/editable-heading/EditableHeading.tsx
@@ -21,23 +21,33 @@ export const EditableHeading = function EditableHeading({
   const [initialValue] = useState(value);
   const enableEditing = () => setIsEditing(!disabled);
 
+  const validateAndUpdateValue = (inputValue: string) => {
+    if (!inputValue || !inputValue.trim()) {
+      onChange(initialValue);
+      return;
+    }
+    onChange(inputValue.trim());
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    passThroughProps.onKeyDown?.(e);
     if (e.key === "Enter") {
-      const inputValue = e.currentTarget.value;
-      if (!inputValue || !inputValue.trim()) {
-        onChange(initialValue);
-      }
+      e.preventDefault();
+      validateAndUpdateValue(e.currentTarget.value);
       setIsEditing(false);
     }
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value;
-    if (!inputValue || !inputValue.trim()) {
-      onChange(initialValue);
-    }
+    validateAndUpdateValue(e.target.value);
     setIsEditing(false);
     passThroughProps.onBlur && passThroughProps.onBlur(e);
+  };
+
+  const handleChange = (newValue: string) => {
+    if (onChange) {
+      onChange(newValue);
+    }
   };
 
   return (
@@ -63,7 +73,7 @@ export const EditableHeading = function EditableHeading({
               passThroughProps.onFocus && passThroughProps.onFocus(e);
             }}
             onBlur={handleBlur}
-            onChange={(e) => onChange && onChange(e.target.value)}
+            onChange={(e) => handleChange(e.target.value)}
           />
           {!isEditing && isReady && !disabled && (
             <Icon name="pencil" className="text-subtle group-hover:text-subtle -mt-px ml-1 inline h-3 w-3" />

--- a/packages/ui/components/editable-heading/EditableHeading.tsx
+++ b/packages/ui/components/editable-heading/EditableHeading.tsx
@@ -18,7 +18,28 @@ export const EditableHeading = function EditableHeading({
 } & Omit<JSX.IntrinsicElements["input"], "name" | "onChange"> &
   ControllerRenderProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const [initialValue] = useState(value);
   const enableEditing = () => setIsEditing(!disabled);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      const inputValue = e.currentTarget.value;
+      if (!inputValue || !inputValue.trim()) {
+        onChange(initialValue);
+      }
+      setIsEditing(false);
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    if (!inputValue || !inputValue.trim()) {
+      onChange(initialValue);
+    }
+    setIsEditing(false);
+    passThroughProps.onBlur && passThroughProps.onBlur(e);
+  };
+
   return (
     <div className="group pointer-events-auto relative truncate" onClick={enableEditing}>
       <div className={classNames(!disabled && "cursor-pointer", "flex items-center")}>
@@ -36,18 +57,16 @@ export const EditableHeading = function EditableHeading({
               "text-emphasis absolute left-0 top-0 w-full truncate border-none bg-transparent p-0 align-top text-xl ",
               passThroughProps.className
             )}
+            onKeyDown={handleKeyDown}
             onFocus={(e) => {
               setIsEditing(!disabled);
               passThroughProps.onFocus && passThroughProps.onFocus(e);
             }}
-            onBlur={(e) => {
-              setIsEditing(false);
-              passThroughProps.onBlur && passThroughProps.onBlur(e);
-            }}
+            onBlur={handleBlur}
             onChange={(e) => onChange && onChange(e.target.value)}
           />
           {!isEditing && isReady && !disabled && (
-            <Icon name="pencil" className="text-subtle group-hover:text-subtle -mt-px ml-1 inline  h-3 w-3" />
+            <Icon name="pencil" className="text-subtle group-hover:text-subtle -mt-px ml-1 inline h-3 w-3" />
           )}
         </label>
       </div>


### PR DESCRIPTION
## What does this PR do?

Fixed empty space issue in availability heading now user cant save the empty heading.

- Fixes #21709 

## Visual Demo (For contributors especially)

- Before

https://github.com/user-attachments/assets/29b03cd0-e674-40ee-a26d-6b76120486d2

- After

https://github.com/user-attachments/assets/8de3901b-11de-479b-a758-7796d3c80c98



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to Availability  > click on any availability  > click on edit heading > set heading as empty > click on save




    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where users could save an empty availability heading. Now, empty headings are not allowed and the previous value is restored if left blank.

<!-- End of auto-generated description by cubic. -->

