### PR TITLE
fix: Embed must not wait for getTeamSchedule/getSchedule call to complete before showing the page

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -387,6 +387,15 @@ function isLinkReady() {
 }
 
 function isBookerReady() {
+  // Check if optimistic loading is enabled via URL params
+  const url = new URL(document.URL);
+  const enableOptimisticLoad = url.searchParams.get("cal.enableOptimisticLoad") === "true";
+
+  if (enableOptimisticLoad) {
+    const bookerState = window._embedBookerState;
+    return bookerState && bookerState !== "initializing";
+  }
+
   return window._embedBookerState === "slotsDone";
 }
 
@@ -819,6 +828,35 @@ export function getEmbedBookerState({
 }): EmbedBookerState {
   if (bookerState === "loading") {
     return "initializing";
+  }
+
+  let enableOptimisticLoad = false;
+  try {
+    if (typeof document !== "undefined" && document.URL) {
+      const url = new URL(document.URL);
+      enableOptimisticLoad = url.searchParams.get("cal.enableOptimisticLoad") === "true";
+    }
+  } catch (error) {
+    enableOptimisticLoad = false;
+  }
+
+  if (enableOptimisticLoad) {
+    if (slotsQuery.isLoading) {
+      return "slotsLoading";
+    }
+
+    if (slotsQuery.isPending) {
+      return "slotsPending";
+    }
+
+    if (slotsQuery.isSuccess) {
+      return "slotsDone";
+    }
+    if (slotsQuery.isError) {
+      return "slotsLoadingError";
+    }
+
+    return "slotsPending";
   }
 
   if (slotsQuery.isLoading) {

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -388,12 +388,16 @@ function isLinkReady() {
 
 function isBookerReady() {
   // Check if optimistic loading is enabled via URL params
+  if (typeof document === "undefined") {
+    return false;
+  }
+
   const url = new URL(document.URL);
   const enableOptimisticLoad = url.searchParams.get("cal.enableOptimisticLoad") === "true";
 
   if (enableOptimisticLoad) {
     const bookerState = window._embedBookerState;
-    return bookerState && bookerState !== "initializing";
+    return bookerState !== undefined && bookerState !== "initializing";
   }
 
   return window._embedBookerState === "slotsDone";

--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -965,6 +965,72 @@ describe("Cal", () => {
             expect(calModalBox.getAttribute("data-message")).toBe("Fallback Route Error");
           })();
         });
+
+        it("should handle optimistic loading configuration correctly", () => {
+          const modalArg = buildModalArg({
+            ...baseModalArgs,
+            config: {
+              ...baseModalArgs.config,
+              enableOptimisticLoad: "true",
+            },
+          });
+
+          calInstance.api.modal(modalArg);
+
+          expectCalModalBoxToBeInDocumentWithIframeHavingUrl({
+            expectedModalBoxAttrs: {
+              state: "loading",
+              theme: baseModalArgs.config.theme,
+              layout: baseModalArgs.config.layout,
+              pageType: null,
+            },
+            expectedIframeUrlObject: {
+              pathname: `/${modalArg.calLink}`,
+              searchParams: new URLSearchParams({
+                theme: baseModalArgs.config.theme,
+                layout: baseModalArgs.config.layout,
+                embedType: "modal",
+                enableOptimisticLoad: "true",
+                "cal.enableOptimisticLoad": "true",
+              }),
+              origin: null,
+            },
+          });
+        });
+
+        it("should handle optimistic loading with prerender correctly", () => {
+          const modalArg = buildModalArg({
+            ...baseModalArgs,
+            config: {
+              ...baseModalArgs.config,
+              enableOptimisticLoad: "true",
+            },
+          });
+
+          calInstance.api.modal({ ...modalArg, __prerender: true });
+
+          expectCalModalBoxToBeInDocumentWithIframeHavingUrl({
+            expectedModalBoxAttrs: {
+              state: "prerendering",
+              theme: baseModalArgs.config.theme,
+              layout: baseModalArgs.config.layout,
+              pageType: null,
+            },
+            expectedIframeUrlObject: {
+              pathname: `/${modalArg.calLink}`,
+              searchParams: new URLSearchParams({
+                theme: baseModalArgs.config.theme,
+                layout: baseModalArgs.config.layout,
+                embedType: "modal",
+                enableOptimisticLoad: "true",
+                prerender: "true",
+                "cal.skipSlotsFetch": "true",
+                "cal.enableOptimisticLoad": "true",
+              }),
+              origin: null,
+            },
+          });
+        });
       });
     });
 

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -970,11 +970,16 @@ class CalApi {
       config["cal.skipSlotsFetch"] = "true";
     }
 
+    // Enable optimistic loading for better performance if explicitly requested
+    if (config.enableOptimisticLoad) {
+      config["cal.enableOptimisticLoad"] = "true";
+    }
+
     const configWithGuestKeyAndColorScheme = withColorScheme(
       Cal.ensureGuestKey({
         ...config,
         embedType: "modal",
-      }),
+      } as any),
       containerEl
     );
 
@@ -1395,6 +1400,11 @@ let currentColorScheme: string | null = null;
 
 (function watchAndActOnColorSchemeChange() {
   // TODO: Maybe find a better way to identify change in color-scheme, a mutation observer seems overkill for this. Settle with setInterval for now.
+  // Guard against test environments where document might not be defined
+  if (typeof document === "undefined") {
+    return;
+  }
+
   setInterval(() => {
     const colorScheme = getColorScheme(document.body);
     if (colorScheme && colorScheme !== currentColorScheme) {

--- a/packages/embeds/embed-core/src/types.ts
+++ b/packages/embeds/embed-core/src/types.ts
@@ -67,6 +67,8 @@ export type KnownConfig = {
   // Prefixing with cal.embed because there could be more query params that aren't required by embed and are used for things like prefilling booking form, configuring dry run, and some other params simply to be forwarded to the booking success redirect URL.
   // There are some cal. prefixed query params as well, not meant for embed specifically, but in general for cal.com
   "cal.embed.pageType"?: EmbedPageType;
+  // Enable optimistic loading - allows embed to show immediately while schedule data loads in background
+  enableOptimisticLoad?: boolean;
 };
 
 export type EmbedBookerState =

--- a/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
+++ b/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
@@ -215,8 +215,11 @@ export const AvailableTimeSlots = ({
           !limitHeight && "flex h-full w-full flex-row gap-4",
           `${customClassNames?.availableTimeSlotsContainer}`
         )}>
-        {isLoading && // Shows exact amount of days as skeleton.
+        {/* For optimistic loading, show skeleton when schedule data is loading but page is visible */}
+        {(isLoading || schedule?.isOptimisticLoad) &&
+          (!schedule?.hasEssentialData || !scheduleData?.slots) &&
           Array.from({ length: 1 + (extraDays ?? 0) }).map((_, i) => <AvailableTimesSkeleton key={i} />)}
+        {/* Show slots when data is available, even during optimistic loading */}
         {!isLoading &&
           slotsPerDay.length > 0 &&
           slotsPerDay.map((slots) => (

--- a/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
+++ b/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
@@ -215,11 +215,12 @@ export const AvailableTimeSlots = ({
           !limitHeight && "flex h-full w-full flex-row gap-4",
           `${customClassNames?.availableTimeSlotsContainer}`
         )}>
-        {/* For optimistic loading, show skeleton when schedule data is loading but page is visible */}
-        {(isLoading || schedule?.isOptimisticLoad) &&
-          (!schedule?.hasEssentialData || !scheduleData?.slots) &&
+        {/* Show skeleton ONLY when we don't have essential data OR we're still loading */}
+        {(isLoading || (schedule?.isOptimisticLoad && !schedule?.hasEssentialData)) &&
+          (!scheduleData?.slots || slotsPerDay.length === 0) &&
           Array.from({ length: 1 + (extraDays ?? 0) }).map((_, i) => <AvailableTimesSkeleton key={i} />)}
-        {/* Show slots when data is available, even during optimistic loading */}
+
+        {/* Show actual slots when we have data AND we're not in initial loading state */}
         {!isLoading &&
           slotsPerDay.length > 0 &&
           slotsPerDay.map((slots) => (

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -122,5 +122,7 @@ export const useScheduleForEvent = ({
     isSuccess: schedule?.isSuccess,
     isLoading: schedule?.isLoading,
     invalidate: schedule?.invalidate,
+    isOptimisticLoad: schedule?.isOptimisticLoad,
+    hasEssentialData: schedule?.hasEssentialData,
   };
 };


### PR DESCRIPTION
## What does this PR do?

Fixed embed initialization by improving Cal detection and URL parameter handling.

- Fixes #21208
- Fixes [CAL-5739](https://linear.app/calcom/issue/CAL-5739/embedwithout-skeleton-loader-must-not-wait-for)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Embeds now show the page immediately without waiting for schedule data to load, using an "optimistic loading" mode controlled by a URL parameter.

- **New Features**
  - Added support for optimistic loading in embeds via the `cal.enableOptimisticLoad` URL parameter.
  - Updated UI to display skeleton loaders while schedule data loads in the background.
  - Improved test coverage for the new loading behavior.

<!-- End of auto-generated description by cubic. -->

