### PR TITLE
fix: Use setTimeout instead of requestAnimationFrame which is more reliable and support calOrigin in prerender

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -102,7 +102,7 @@ export const embedStore = {
           // Avoid unnecessary history push
           window.history.replaceState({}, "", currentUrl.toString());
         }
-        requestAnimationFrame(updateIfNeeded);
+        runAsap(updateIfNeeded);
         return {
           hasChanged,
         };
@@ -167,11 +167,8 @@ if (isBrowser) {
 }
 
 function runAsap(fn: (...arg: unknown[]) => void) {
-  if (isSafariBrowser) {
-    // https://adpiler.com/blog/the-full-solution-why-do-animations-run-slower-in-safari/
-    return setTimeout(fn, 50);
-  }
-  return requestAnimationFrame(fn);
+  // We don't use rAF because it runs slower in Safari plus doesn't run if the iframe is hidden sometimes
+  return setTimeout(fn, 50);
 }
 
 function log(...args: unknown[]) {

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -1159,6 +1159,7 @@ class CalApi {
     type,
     options = {},
     pageType,
+    calOrigin,
   }: {
     calLink: string;
     type?: "modal" | "floatingButton";
@@ -1166,6 +1167,7 @@ class CalApi {
       prerenderIframe?: boolean;
     };
     pageType?: EmbedPageType;
+    calOrigin?: string;
   }) {
     // eslint-disable-next-line prefer-rest-params
     validate(arguments[0], {
@@ -1210,7 +1212,7 @@ class CalApi {
         this.cal.isPrerendering = true;
         this.modal({
           calLink,
-          calOrigin: config.calOrigin,
+          calOrigin: calOrigin || config.calOrigin,
           __prerender: true,
           ...(pageType ? { config: { "cal.embed.pageType": pageType } } : {}),
         });
@@ -1227,15 +1229,18 @@ class CalApi {
     calLink,
     type,
     pageType,
+    calOrigin,
   }: {
     calLink: string;
     type: "modal" | "floatingButton";
     pageType?: EmbedPageType;
+    calOrigin?: string;
   }) {
     this.preload({
       calLink,
       type,
       pageType,
+      calOrigin,
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #21205
## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR



