### PR TITLE
feat: ✨add eye icon in event types page

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -47,7 +47,6 @@ import {
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 import { Label } from "@calcom/ui/components/form";
 import { TextField } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { HorizontalTabs } from "@calcom/ui/components/navigation";
 import { Skeleton } from "@calcom/ui/components/skeleton";
@@ -530,14 +529,17 @@ export const InfiniteEventTypeList = ({
                                   type.hidden ? t("show_eventtype_on_profile") : t("hide_from_profile")
                                 }>
                                 <div className="self-center rounded-md p-2">
-                                  <Switch
-                                    name="Hidden"
-                                    disabled={lockedByOrg}
-                                    checked={!type.hidden}
-                                    onCheckedChange={() => {
+                                  <button
+                                    className="text-emphasis h-9"
+                                    onClick={() => {
                                       setHiddenMutation.mutate({ id: type.id, hidden: !type.hidden });
-                                    }}
-                                  />
+                                    }}>
+                                    {type.hidden ? (
+                                      <Icon name="eye-off" className="h-4 w-4 stroke-[2.5px]" />
+                                    ) : (
+                                      <Icon name="eye" className="h-4 w-4 stroke-[2.5px]" />
+                                    )}
+                                  </button>
                                 </div>
                               </Tooltip>
                             </>
@@ -765,14 +767,17 @@ export const InfiniteEventTypeList = ({
                                 className="mt-2 inline cursor-pointer self-center pr-2 ">
                                 {type.hidden ? t("show_eventtype_on_profile") : t("hide_from_profile")}
                               </Skeleton>
-                              <Switch
-                                id="hiddenSwitch"
-                                name="Hidden"
-                                checked={!type.hidden}
-                                onCheckedChange={() => {
+                              <button
+                                className="text-emphasis h-9"
+                                onClick={() => {
                                   setHiddenMutation.mutate({ id: type.id, hidden: !type.hidden });
-                                }}
-                              />
+                                }}>
+                                {type.hidden ? (
+                                  <Icon name="eye-off" className="h-4 w-4 stroke-[2.5px]" />
+                                ) : (
+                                  <Icon name="eye" className="h-4 w-4 stroke-[2.5px]" />
+                                )}
+                              </button>
                             </div>
                           )}
                         </DropdownMenuContent>

--- a/packages/features/eventtypes/components/EventTypeLayout.tsx
+++ b/packages/features/eventtypes/components/EventTypeLayout.tsx
@@ -21,7 +21,6 @@ import {
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
 import { Label } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { HorizontalTabs, VerticalTabs } from "@calcom/ui/components/navigation";
 import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
@@ -125,14 +124,17 @@ function EventTypeSingleLayout({
                   }
                   side="bottom">
                   <div className="self-center rounded-md p-2">
-                    <Switch
-                      id="hiddenSwitch"
-                      disabled={eventTypesLockedByOrg}
-                      checked={!formMethods.watch("hidden")}
-                      onCheckedChange={(e) => {
-                        formMethods.setValue("hidden", !e, { shouldDirty: true });
-                      }}
-                    />
+                    <button
+                      className="text-emphasis h-9"
+                      onClick={() => {
+                        formMethods.setValue("hidden", !formMethods.watch("hidden"), { shouldDirty: true });
+                      }}>
+                      {formMethods.watch("hidden") ? (
+                        <Icon name="eye-off" className="h-4 w-4 stroke-[2.5px]" />
+                      ) : (
+                        <Icon name="eye" className="h-4 w-4 stroke-[2.5px]" />
+                      )}
+                    </button>
                   </div>
                 </Tooltip>
               </div>
@@ -250,13 +252,17 @@ function EventTypeSingleLayout({
                   className="mt-2 inline cursor-pointer self-center pr-2 ">
                   {formMethods.watch("hidden") ? t("show_eventtype_on_profile") : t("hide_from_profile")}
                 </Skeleton>
-                <Switch
-                  id="hiddenSwitch"
-                  checked={!formMethods.watch("hidden")}
-                  onCheckedChange={(e) => {
-                    formMethods.setValue("hidden", !e, { shouldDirty: true });
-                  }}
-                />
+                <button
+                  className="text-emphasis h-9"
+                  onClick={() => {
+                    formMethods.setValue("hidden", !formMethods.watch("hidden"), { shouldDirty: true });
+                  }}>
+                  {formMethods.watch("hidden") ? (
+                    <Icon name="eye-off" className="h-4 w-4 stroke-[2.5px]" />
+                  ) : (
+                    <Icon name="eye" className="h-4 w-4 stroke-[2.5px]" />
+                  )}
+                </button>
               </div>
             </DropdownMenuContent>
           </Dropdown>


### PR DESCRIPTION
## What does this PR do?

Removes the slider for "hidden event types" and uses eye icon instead.

- Fixes #21014  (GitHub issue number)
- Fixes CAL-5681(Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/db4a04c7-c920-4a4d-a9d0-25265f2d83cb


#### Image Demo (if applicable):

Before--
![Screenshot 2025-06-07 at 12 42 34 PM](https://github.com/user-attachments/assets/5d0e4088-e901-4ad4-bdad-2aee6d053538)

After--
![Screenshot 2025-06-07 at 12 44 24 PM](https://github.com/user-attachments/assets/f9526174-d3c8-4631-8440-6151bb4b07c4)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the slider for hiding event types with an eye icon button on the event types page for a clearer and more intuitive UI.

<!-- End of auto-generated description by cubic. -->

