### PR TITLE
fix: update delegation credentials api-v2

### DIFF
--- a/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.repository.ts
+++ b/apps/api/v2/src/modules/organizations/delegation-credentials/organizations-delegation-credential.repository.ts
@@ -1,11 +1,12 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { Injectable } from "@nestjs/common";
 
 import { Prisma } from "@calcom/prisma/client";
 
 @Injectable()
 export class OrganizationsDelegationCredentialRepository {
-  constructor(private readonly dbRead: PrismaReadService) {}
+  constructor(private readonly dbRead: PrismaReadService, private readonly dbWrite: PrismaWriteService) {}
 
   async findById(delegationCredentialId: string) {
     return this.dbRead.prisma.delegationCredential.findUnique({ where: { id: delegationCredentialId } });
@@ -22,7 +23,7 @@ export class OrganizationsDelegationCredentialRepository {
     delegationCredentialId: string,
     data: Prisma.DelegationCredentialUncheckedUpdateInput
   ) {
-    return this.dbRead.prisma.delegationCredential.update({
+    return this.dbWrite.prisma.delegationCredential.update({
       where: { id: delegationCredentialId },
       data,
       include: { workspacePlatform: true },


### PR DESCRIPTION
This change ensures that when Delegation Credential is disabled and then re-enabled, the system properly validates the new credentials. Previously, invalid credentials could be accepted, leading to a state where Delegation Credential was enabled but unusable, and updates required disablingthe *original* (correct) credentials. Now, only valid credentials will be accepted upon re-enablement.



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


