### PR TITLE
chore: enable disable rewrite for apiv2 selfhost

### DIFF
--- a/apps/api/v2/.env.example
+++ b/apps/api/v2/.env.example
@@ -38,3 +38,7 @@ AXIOM_TOKEN=
 # WARN: 2
 # ERROR: 3
 LOGGER_BRIDGE_LOG_LEVEL="1"
+
+# 1: Rewrite /api/v2 to /v2
+# 0: Don't rewrite
+REWRITE_API_V2_PREFIX="1"

--- a/apps/api/v2/src/env.ts
+++ b/apps/api/v2/src/env.ts
@@ -32,6 +32,7 @@ export type Environment = {
   AXIOM_TOKEN: string;
   STRIPE_TEAM_MONTHLY_PRICE_ID: string;
   IS_TEAM_BILLING_ENABLED: boolean;
+  REWRITE_API_V2_PREFIX: string;
 };
 
 export const getEnv = <K extends keyof Environment>(key: K, fallback?: Environment[K]): Environment[K] => {

--- a/apps/api/v2/src/env.ts
+++ b/apps/api/v2/src/env.ts
@@ -32,6 +32,7 @@ export type Environment = {
   AXIOM_TOKEN: string;
   STRIPE_TEAM_MONTHLY_PRICE_ID: string;
   IS_TEAM_BILLING_ENABLED: boolean;
+  // Used to enable/disable the rewrite of /api/v2 to /v2, active by default.
   REWRITE_API_V2_PREFIX: string;
 };
 

--- a/apps/api/v2/src/middleware/app.rewrites.middleware.ts
+++ b/apps/api/v2/src/middleware/app.rewrites.middleware.ts
@@ -1,10 +1,11 @@
+import { getEnv } from "@/env";
 import { Injectable, NestMiddleware } from "@nestjs/common";
 import { Request, Response } from "express";
 
 @Injectable()
 export class RewriterMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: () => void) {
-    if (req.url.startsWith("/api/v2")) {
+    if (getEnv("REWRITE_API_V2_PREFIX", "1") === "1" && req.url.startsWith("/api/v2")) {
       req.url = req.url.replace("/api/v2", "/v2");
     }
     if (req.url.startsWith("/v2/ee")) {

--- a/apps/api/v2/src/middleware/app.rewrites.middleware.ts
+++ b/apps/api/v2/src/middleware/app.rewrites.middleware.ts
@@ -5,7 +5,7 @@ import { Request, Response } from "express";
 @Injectable()
 export class RewriterMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: () => void) {
-    if (getEnv("REWRITE_API_V2_PREFIX", "1") === "1" && req.url.startsWith("/api/v2")) {
+    if (shouldRewriteApiV2Prefix() && req.url.startsWith("/api/v2")) {
       req.url = req.url.replace("/api/v2", "/v2");
     }
     if (req.url.startsWith("/v2/ee")) {
@@ -17,3 +17,12 @@ export class RewriterMiddleware implements NestMiddleware {
     next();
   }
 }
+
+const shouldRewriteApiV2Prefix = () => {
+  try {
+    // rewrite is active even if REWRITE_API_V2_PREFIX is not set
+    return getEnv("REWRITE_API_V2_PREFIX", "1") === "1";
+  } catch (error) {
+    return true;
+  }
+};


### PR DESCRIPTION
## What does this PR do?

ENV variable to disable /api/v2 rewrite in apiV2 middlewares

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


