### PR TITLE
fix: Prevent Timing Attacks by Removing await in Password Reset Flow

### DIFF
--- a/apps/web/app/api/auth/forgot-password/route.ts
+++ b/apps/web/app/api/auth/forgot-password/route.ts
@@ -37,10 +37,11 @@ async function handler(req: NextRequest) {
       select: { name: true, email: true, locale: true },
     });
     // Don't leak info about whether the user exists
-    if (user) passwordResetRequest(user);
+    if (user) passwordResetRequest(user).catch(console.error);
     return NextResponse.json({ message: "password_reset_email_sent" }, { status: 201 });
   } catch (reason) {
     console.error(reason);
+    return NextResponse.json({ message: "Unable to create password reset request" }, { status: 500 });
   }
 }
 

--- a/apps/web/app/api/auth/forgot-password/route.ts
+++ b/apps/web/app/api/auth/forgot-password/route.ts
@@ -37,12 +37,10 @@ async function handler(req: NextRequest) {
       select: { name: true, email: true, locale: true },
     });
     // Don't leak info about whether the user exists
-    if (!user) return NextResponse.json({ message: "password_reset_email_sent" }, { status: 201 });
-    await passwordResetRequest(user);
+    if (user) passwordResetRequest(user);
     return NextResponse.json({ message: "password_reset_email_sent" }, { status: 201 });
   } catch (reason) {
     console.error(reason);
-    return NextResponse.json({ message: "Unable to create password reset request" }, { status: 500 });
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

This change removes the await keyword from the passwordResetRequest call to prevent potential timing attacks.

Previously, awaiting the email-sending logic could unintentionally expose whether a user exists, based on response time differences. By removing await, the function is now called asynchronously, ensuring the response time remains consistent regardless of user existence.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed await from the password reset email logic to prevent timing attacks and keep response times consistent.

- **Bug Fixes**
  - Password reset requests now run asynchronously, so attackers cannot infer if a user exists based on response time.

<!-- End of auto-generated description by cubic. -->

