### PR TITLE
fix: v2 cancelling seated booking as a host

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -232,9 +232,27 @@ export class BookingsController_2024_08_13 {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Cancel a booking",
-    description: `:bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.
-    For seated bookings to cancel one individual booking provide :bookingUid and :seatUid in the request body. For recurring seated bookings it is not possible to cancel all of them with 1 call
-    like with non-seated recurring bookings by providing recurring bookind uid - you have to cancel each recurrence booking by its bookingUid + seatUid.`,
+    description: `Cancel a booking. There are different ways to cancel based on the type of booking and user role:
+    
+      **For NON-SEATED bookings:**
+      - Standard cancellation: Include 'cancellationReason' if you are the host
+      - \`:bookingUid\` can be uid of a normal booking, individual recurrence, or recurring booking to cancel all recurrences
+
+      **For SEATED bookings - Two scenarios:**
+
+      1. **Cancel individual seat (as attendee OR host):**
+        - Include only 'seatUid' in request body
+        - No 'cancellationReason' required
+        - Removes only the specified seat, booking continues for other attendees
+
+      2. **Cancel entire booking (host only):**
+        - Include only 'cancellationReason' in request body  
+        - Do NOT include 'seatUid'
+        - Requires host authentication
+        - Removes ALL seats and cancels the entire booking
+
+      **For recurring seated bookings:**
+      It is not possible to cancel all recurrences with 1 call. You must cancel each recurrence individually using its bookingUid + seatUid.`,
   })
   @ApiBody({
     schema: {

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -100,7 +100,9 @@ async function handler(input: CancelBookingInput) {
     });
   }
 
-  if (!platformClientId && !cancellationReason && bookingToDelete.userId == userId) {
+  // Only require cancellation reason from hosts when cancelling the entire booking (not individual seats)
+  // If seatReferenceUid is provided, this is an individual seat cancellation and doesn't require a reason
+  if (!platformClientId && !cancellationReason && bookingToDelete.userId == userId && !seatReferenceUid) {
     throw new HttpError({
       statusCode: 400,
       message: "Cancellation reason is required when you are the host",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #21743 
- Fixes [CAL-5905](https://linear.app/calcom/issue/CAL-5905/fix-v2-cancelling-seated-booking-as-a-host)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed cancellation logic for seated bookings so hosts can cancel individual seats without a reason, but must provide a reason to cancel the entire booking.

- **Bug Fixes**
  - Hosts can now remove a single seat without a cancellation reason.
  - Cancelling the whole booking as a host now requires a cancellation reason.
  - Added validation to prevent sending both seatUid and cancellationReason together.

<!-- End of auto-generated description by cubic. -->

