### PR TITLE
fix: Resending team invites now updates token expiry date

### DIFF
--- a/packages/lib/server/repository/verificationToken.ts
+++ b/packages/lib/server/repository/verificationToken.ts
@@ -10,7 +10,7 @@ export class VerificationTokenRepository {
     teamId: number;
     expiresInDays: number;
   }) {
-    const expires = new Date(new Date().setHours(expiresInDays * 24));
+    const expires = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
     return prisma.verificationToken.updateMany({
       where: {
         identifier: email,

--- a/packages/lib/server/repository/verificationToken.ts
+++ b/packages/lib/server/repository/verificationToken.ts
@@ -11,12 +11,13 @@ export class VerificationTokenRepository {
     expiresInDays: number;
   }) {
     const expires = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
-    return prisma.verificationToken.updateMany({
+    const results = await prisma.verificationToken.updateMany({
       where: {
         identifier: email,
         teamId,
       },
       data: { expires },
     });
+    return results[0];
   }
 }

--- a/packages/lib/server/repository/verificationToken.ts
+++ b/packages/lib/server/repository/verificationToken.ts
@@ -11,13 +11,23 @@ export class VerificationTokenRepository {
     expiresInDays: number;
   }) {
     const expires = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
-    const results = await prisma.verificationToken.updateMany({
+
+    const token = await prisma.verificationToken.findFirst({
       where: {
         identifier: email,
         teamId,
       },
+    });
+
+    await prisma.verificationToken.update({
+      where: {
+        identifier: email,
+        teamId,
+        token: token?.token,
+      },
       data: { expires },
     });
-    return results[0];
+
+    return { ...token, expires };
   }
 }

--- a/packages/lib/server/repository/verificationToken.ts
+++ b/packages/lib/server/repository/verificationToken.ts
@@ -1,0 +1,22 @@
+import prisma from "@calcom/prisma";
+
+export class VerificationTokenRepository {
+  static async updateTeamInviteTokenExpirationDate({
+    email,
+    teamId,
+    expiresInDays,
+  }: {
+    email: string;
+    teamId: number;
+    expiresInDays: number;
+  }) {
+    const expires = new Date(new Date().setHours(expiresInDays * 24));
+    return prisma.verificationToken.update({
+      where: {
+        identifier: email,
+        teamId,
+      },
+      data: { expires },
+    });
+  }
+}

--- a/packages/lib/server/repository/verificationToken.ts
+++ b/packages/lib/server/repository/verificationToken.ts
@@ -11,7 +11,7 @@ export class VerificationTokenRepository {
     expiresInDays: number;
   }) {
     const expires = new Date(new Date().setHours(expiresInDays * 24));
-    return prisma.verificationToken.update({
+    return prisma.verificationToken.updateMany({
       where: {
         identifier: email,
         teamId,

--- a/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
@@ -1,7 +1,6 @@
 import { sendTeamInviteEmail } from "@calcom/emails";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getTranslation } from "@calcom/lib/server/i18n";
-import { prisma } from "@calcom/prisma";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 import { ensureAtleastAdminPermissions, getTeamOrThrow } from "./inviteMember/utils";
@@ -24,14 +23,10 @@ export const resendInvitationHandler = async ({ ctx, input }: InviteMemberOption
     isOrg: input.isOrg,
   });
 
-  const verificationToken = await prisma.verificationToken.findFirst({
-    where: {
-      identifier: input.email,
-      teamId: input.teamId,
-    },
-    select: {
-      token: true,
-    },
+  const verificationToken = await VerificationTokenRepository.updateTeamInviteTokenExpirationDate({
+    email: input.email,
+    teamId: input.teamId,
+    expiresInDays: 7,
   });
 
   const inviteTeamOptions = {

--- a/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
@@ -33,7 +33,7 @@ export const resendInvitationHandler = async ({ ctx, input }: InviteMemberOption
       expiresInDays: 7,
     });
   } catch (error) {
-    console.error("[resendInvitationHandler]Error updating verification token:", error);
+    console.error("[resendInvitationHandler] Error updating verification token: ", error);
   }
 
   const inviteTeamOptions = {

--- a/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
@@ -23,11 +23,17 @@ export const resendInvitationHandler = async ({ ctx, input }: InviteMemberOption
     isOrg: input.isOrg,
   });
 
-  const verificationToken = await VerificationTokenRepository.updateTeamInviteTokenExpirationDate({
-    email: input.email,
-    teamId: input.teamId,
-    expiresInDays: 7,
-  });
+  let verificationToken;
+
+  try {
+    verificationToken = await VerificationTokenRepository.updateTeamInviteTokenExpirationDate({
+      email: input.email,
+      teamId: input.teamId,
+      expiresInDays: 7,
+    });
+  } catch (error) {
+    console.error("[resendInvitationHandler]Error updating verification token:", error);
+  }
 
   const inviteTeamOptions = {
     joinLink: `${WEBAPP_URL}/auth/login?callbackUrl=/settings/teams`,

--- a/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/resendInvitation.handler.ts
@@ -1,6 +1,7 @@
 import { sendTeamInviteEmail } from "@calcom/emails";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getTranslation } from "@calcom/lib/server/i18n";
+import { VerificationTokenRepository } from "@calcom/lib/server/repository/verificationToken";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 import { ensureAtleastAdminPermissions, getTeamOrThrow } from "./inviteMember/utils";


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously when a team invite expires, resending the invite didn't update the token expiry date. This PR now updates the token to 7 more days from the time of resending the invite.

https://www.loom.com/share/3d96179f53244b5c8fc24243a1a6c8f5

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Send a team invite
- Change the expiry date of the token in the DB
- Resend the invite. The expiry date should now be refreshed

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Resending a team invite now refreshes the token expiry date, giving the invitee 7 more days to accept.

- **Bug Fixes**
  - Updated the invite token to extend its expiry when an invite is resent.

<!-- End of auto-generated description by cubic. -->

