### PR TITLE
fix: multi-line formatted correctly for sms

### DIFF
--- a/packages/ui/components/editor/Editor.test.tsx
+++ b/packages/ui/components/editor/Editor.test.tsx
@@ -7,7 +7,7 @@ import type { TextEditorProps } from "./types";
 
 describe("Editor", () => {
   const defaultProps: TextEditorProps = {
-    getText: vi.fn(),
+    getText: vi.fn(() => ""),
     setText: vi.fn(),
     variables: ["name", "email"],
     height: "200px",

--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -370,7 +370,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
       props.setFirstRender(false);
       editor.update(() => {
         const parser = new DOMParser();
-        const content = props.getText().replace(/\n/g, "<br>");
+        const content = props.getText()?.replace(/\n/g, "<br>");
         const dom = parser.parseFromString(content, "text/html");
 
         const nodes = $generateNodesFromDOM(editor, dom);

--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -220,6 +220,7 @@ function getSelectedNode(selection: RangeSelection) {
 }
 
 export default function ToolbarPlugin(props: TextEditorProps) {
+  const isInitialized = useRef(false);
   const [editor] = useLexicalComposerContext();
   const toolbarRef = useRef(null);
   const [blockType, setBlockType] = useState("paragraph");
@@ -364,11 +365,13 @@ export default function ToolbarPlugin(props: TextEditorProps) {
   }, [props.updateTemplate]);
 
   useEffect(() => {
-    if (props.setFirstRender) {
+    if (props.setFirstRender && !isInitialized.current) {
+      isInitialized.current = true;
       props.setFirstRender(false);
       editor.update(() => {
         const parser = new DOMParser();
-        const dom = parser.parseFromString(props.getText(), "text/html");
+        const content = props.getText().replace(/\n/g, "<br>");
+        const dom = parser.parseFromString(content, "text/html");
 
         const nodes = $generateNodesFromDOM(editor, dom);
 


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where the text editor for SMS workflow doesn't persist new lines post saving even though they are recorded in the content.

- Fixes #21679 (GitHub issue number)
- Fixes [CAL-5890](https://linear.app/calcom/issue/CAL-5890/workflow-editor-does-not-keep-the-format-for-sms-workflows-after)

## Visual Demo

![demo](https://github.com/user-attachments/assets/787e5552-b807-4e3b-8389-74cf0c510de8)

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Create a workflow with SMS task
- Save the text with line breaks
- Save the workflow
- Revisit the page or reload
- The line breaks are handled correctly

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where SMS workflow text lost line breaks after saving, so multi-line formatting is now preserved.

<!-- End of auto-generated description by cubic. -->

