### PR TITLE
fix: remove deprecated fields from retell ai

### DIFF
--- a/packages/features/ee/cal-ai-phone/retellAIService.ts
+++ b/packages/features/ee/cal-ai-phone/retellAIService.ts
@@ -1,4 +1,3 @@
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { fetcher } from "@calcom/lib/retellAIFetcher";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -77,7 +76,6 @@ class CreateRetellLLMCommand implements Command<TCreateRetellLLMSchema> {
         body: JSON.stringify({
           general_prompt: this.props.generalPrompt,
           begin_message: this.props.beginMessage,
-          inbound_dynamic_variables_webhook_url: `${WEBAPP_URL}/api/get-inbound-dynamic-variables`,
           general_tools: [
             {
               type: "end_call",
@@ -101,13 +99,6 @@ class CreateRetellLLMCommand implements Command<TCreateRetellLLMSchema> {
           ],
         }),
       }).then(ZCreateRetellLLMSchema.parse);
-
-      const llmWebSocketUrlToBeUpdated = createdRetellLLM.inbound_dynamic_variables_webhook_url;
-      await updateAgentWebsocketUrl(
-        this.props.yourPhoneNumber,
-        llmWebSocketUrlToBeUpdated,
-        createdRetellLLM.llm_id
-      );
 
       return createdRetellLLM;
     } catch (error) {
@@ -141,16 +132,8 @@ class UpdateRetellLLMCommand implements Command<TGetRetellLLMSchema> {
         body: JSON.stringify({
           general_prompt: this.props.generalPrompt,
           begin_message: this.props.beginMessage,
-          inbound_dynamic_variables_webhook_url: `${WEBAPP_URL}/api/get-inbound-dynamic-variables`,
         }),
       }).then(ZGetRetellLLMSchema.parse);
-
-      const llmWebSocketUrlToBeUpdated = updatedRetellLLM.inbound_dynamic_variables_webhook_url;
-      await updateAgentWebsocketUrl(
-        this.props.yourPhoneNumber,
-        llmWebSocketUrlToBeUpdated,
-        updatedRetellLLM.llm_id
-      );
 
       return updatedRetellLLM;
     } catch (err) {

--- a/packages/features/ee/cal-ai-phone/zod-utils.ts
+++ b/packages/features/ee/cal-ai-phone/zod-utils.ts
@@ -123,7 +123,7 @@ export const ZCreateRetellLLMSchema = z
   .object({
     llm_id: z.string(),
     llm_websocket_url: z.string().optional(),
-    inbound_dynamic_variables_webhook_url: z.string(),
+    inbound_dynamic_variables_webhook_url: z.string().optional(),
   })
   .passthrough();
 
@@ -135,7 +135,7 @@ export const ZGetRetellLLMSchema = z
     begin_message: z.string().nullable().optional(),
     llm_id: z.string(),
     llm_websocket_url: z.string().optional(),
-    inbound_dynamic_variables_webhook_url: z.string(),
+    inbound_dynamic_variables_webhook_url: z.string().optional(),
     general_tools: z.array(
       z
         .object({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

The propery `inbound_dynamic_variables_webhook_url` can only be used during creating/importing/updating phone number.

https://docs.retellai.com/deprecation-notice/5-30



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


