### PR TITLE
chore: Remove cascade on profile deletion for EventType

### DIFF
--- a/packages/prisma/migrations/20250612210429_remove_profile_cascade_delete_on_eventtype/migration.sql
+++ b/packages/prisma/migrations/20250612210429_remove_profile_cascade_delete_on_eventtype/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "EventType" DROP CONSTRAINT "EventType_profileId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "EventType" ADD CONSTRAINT "EventType_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -101,7 +101,7 @@ model EventType {
   userId            Int?
 
   profileId Int?
-  profile   Profile? @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  profile   Profile? @relation(fields: [profileId], references: [id])
 
   team                               Team?                  @relation(fields: [teamId], references: [id], onDelete: Cascade)
   teamId                             Int?


### PR DESCRIPTION
## What does this PR do?

Removed cascade delete from EventType when a Profile is deleted to prevent accidental removal of related EventTypes. Now, deleting a Profile will set profileId to null in EventType instead of deleting the EventType.

The idea here is that the profile that created the event type may leave the team or organisation at some point; resulting in deletion of all "his" event types.