### PR TITLE
Fix UI url input comp adjusted

### DIFF
--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -162,10 +162,10 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
             type={type}
             placeholder={placeholder}
             className={classNames(
-              "w-full min-w-0 truncate border-0 bg-transparent focus:outline-none focus:ring-0",
-              "text-default rounded-lg text-sm font-medium leading-none",
+              "-ml-1 w-full min-w-0 truncate border-0 bg-transparent focus:outline-none focus:ring-0",
+              "text-default text-sm font-medium leading-none",
               "placeholder:text-muted disabled:cursor-not-allowed disabled:bg-transparent",
-              addOnLeading && "pl-0.5 pr-0",
+              addOnLeading && "pl-0 pr-0",
               addOnSuffix && "pl-0",
               className
             )}

--- a/t margin on transcription button input"
+++ b/t margin on transcription button input"
@@ -1,0 +1,12 @@
+[1mdiff --git a/packages/ui/components/form/inputs/TextField.tsx b/packages/ui/components/form/inputs/TextField.tsx[m
+[1mindex e7361a06f6..5b1fa07879 100644[m
+[1m--- a/packages/ui/components/form/inputs/TextField.tsx[m
+[1m+++ b/packages/ui/components/form/inputs/TextField.tsx[m
+[36m@@ -160,6 +160,7 @@[m [mexport const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function[m
+             data-testid={dataTestid ? `${dataTestid}-input` : "input-field"}[m
+             id={id}[m
+             type={type}[m
+[32m+[m
+             placeholder={placeholder}[m
+             className={classNames([m
+               "-ml-1 w-full min-w-0 truncate border-0 bg-transparent focus:outline-none focus:ring-0",[m


### PR DESCRIPTION
## When we enter the url text there is a little space this commit address that 

<!-- 
removed rounde-lg and added -ml-1
 --> 

![Screenshot 2025-06-13 110800](https://github.com/user-attachments/assets/4e314a86-f4ac-4940-ac21-51a605b781f8)
![Screenshot 2025-06-13 110857](https://github.com/user-attachments/assets/2769d71f-f3d9-4558-b54f-fd60c84f99a5)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. open webpage 
2 .click on new button on the right corner
3. try typing title, observe what happens to the url input

## Checklist
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed spacing in the URL input field so text aligns correctly and removes extra space. This improves the appearance and usability of the input.

<!-- End of auto-generated description by cubic. -->

