### PR TITLE
fix: ensure failed apiv2 slots workers are terminated

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
@@ -32,7 +32,7 @@ interface WorkerResult {
 
 @Injectable()
 export class SlotsWorkerService_2024_04_15 implements OnModuleDestroy {
-  private readonly logger = new Logger(SlotsWorkerService_2024_04_15.name);
+  private readonly logger = new Logger("SlotsWorkerService_2024_04_15");
   private readonly workerPool: Worker[] = [];
   private readonly maxWorkers: number;
   private readonly taskQueue: Array<{
@@ -94,8 +94,22 @@ export class SlotsWorkerService_2024_04_15 implements OnModuleDestroy {
    */
   private handleWorkerFailure(failedWorker: Worker): void {
     // Remove the failed worker from both pools
+    this.logger.error(`Handling Worker ${failedWorker.threadId} failure`);
     this.workerPool.splice(this.workerPool.indexOf(failedWorker), 1);
     this.availableWorkers = this.availableWorkers.filter((w) => w !== failedWorker);
+
+    try {
+      failedWorker
+        .terminate()
+        .then(() => {
+          this.logger.log(`Terminated failed worker ${failedWorker.threadId}`);
+        })
+        .catch((err) => {
+          this.logger.error(`Error terminating failed worker ${failedWorker.threadId}: ${err?.message}`);
+        });
+    } catch {
+      this.logger.error(`Cannot invoke terminate method on failed worker ${failedWorker.threadId}`);
+    }
 
     // Attempt to create a new worker to replace the failed one
     try {

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
@@ -107,8 +107,12 @@ export class SlotsWorkerService_2024_04_15 implements OnModuleDestroy {
         .catch((err) => {
           this.logger.error(`Error terminating failed worker ${failedWorker.threadId}: ${err?.message}`);
         });
-    } catch {
-      this.logger.error(`Cannot invoke terminate method on failed worker ${failedWorker.threadId}`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to invoke terminate method on failed worker ${failedWorker.threadId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
 
     // Attempt to create a new worker to replace the failed one


### PR DESCRIPTION

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where failed API v2 slots workers were not being properly terminated, preventing resource leaks.

- **Bug Fixes**
  - Ensured failed workers are always terminated and logged on failure.

<!-- End of auto-generated description by cubic. -->

