### PR TITLE
fix: attendee could not reschedule or cancel unconfirmed events directly from the email

### DIFF
--- a/packages/emails/src/templates/AttendeeRequestEmail.tsx
+++ b/packages/emails/src/templates/AttendeeRequestEmail.tsx
@@ -24,7 +24,6 @@ export const AttendeeRequestEmail = (props: React.ComponentProps<typeof Attendee
         title: props.calEvent.title,
         date,
       })}
-      callToAction={null}
       {...props}
     />
   );


### PR DESCRIPTION
## What does this PR do?

Fixed an issue where attendee could not reschedule or cancel unconfirmed events directly from the email.

