### PR TITLE
perf: Refactor `getPublicEvent` to fetch org data using DB index key

### DIFF
--- a/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
+++ b/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
@@ -424,7 +424,10 @@ export class EventTypesAtomService {
         isTeamEvent,
         orgSlug,
         this.dbRead.prisma as unknown as PrismaClient,
-        true
+        true,
+        undefined,
+        false,
+        orgId
       );
 
       if (!event) {

--- a/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/d/[link]/[slug]/getServerSideProps.tsx
@@ -23,7 +23,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
   const { link, slug } = paramsSchema.parse(context.params);
   const { rescheduleUid, duration: queryDuration } = context.query;
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
+  const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
 
   const hashedLink = await prisma.hashedLink.findUnique({
     where: {
@@ -86,7 +86,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       return notFound;
     }
 
-    if (!org) {
+    if (!orgSlug) {
       const redirect = await getTemporaryOrgRedirect({
         slugs: [username],
         redirectType: RedirectType.User,
@@ -103,7 +103,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
 
     const [user] = await UserRepository.findUsersByUsername({
       usernameList: [name],
-      orgSlug: org,
+      orgSlug: orgSlug,
     });
 
     if (!user) {
@@ -128,8 +128,9 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
       username: name,
       eventSlug: slug,
       isTeamEvent,
-      org,
+      orgSlug,
       fromRedirectOfNonOrgLink: context.query.orgRedirection === "true",
+      orgId: session?.user?.org?.id ?? session?.user?.profile?.organizationId ?? undefined,
     },
     session?.user?.id
   );

--- a/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
+++ b/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
@@ -43,8 +43,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     } as const;
   }
 
-  const org = isValidOrgDomain ? currentOrgDomain : null;
-  if (!org) {
+  const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
+  if (!orgSlug) {
     return {
       notFound: true,
     } as const;
@@ -55,8 +55,9 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       username: teamSlug,
       eventSlug: meetingSlug,
       isTeamEvent: true,
-      org,
+      orgSlug,
       fromRedirectOfNonOrgLink: context.query.orgRedirection === "true",
+      orgId: session?.user?.org?.id ?? session?.user?.profile?.organizationId ?? undefined,
     },
     session?.user?.id
   );

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -121,8 +121,8 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
   const { rescheduleUid, bookingUid } = context.query;
   const allowRescheduleForCancelledBooking = context.query.allowRescheduleForCancelledBooking === "true";
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
-  const org = isValidOrgDomain ? currentOrgDomain : null;
-  if (!org) {
+  const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
+  if (!orgSlug) {
     const redirect = await getTemporaryOrgRedirect({
       slugs: usernames,
       redirectType: RedirectType.User,
@@ -155,8 +155,9 @@ async function getDynamicGroupPageProps(context: GetServerSidePropsContext) {
     {
       username: usernames.join("+"),
       eventSlug: slug,
-      org,
+      orgSlug,
       fromRedirectOfNonOrgLink: context.query.orgRedirection === "true",
+      orgId: session?.user?.org?.id ?? session?.user?.profile?.organizationId ?? undefined,
     },
     session?.user?.id
   );
@@ -241,7 +242,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
     } as const;
   }
 
-  const org = isValidOrgDomain ? currentOrgDomain : null;
+  const orgSlug = isValidOrgDomain ? currentOrgDomain : null;
 
   // We use this to both prefetch the query on the server,
   // as well as to check if the event exist, so we can show a 404 otherwise.
@@ -249,7 +250,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
     {
       username,
       eventSlug: slug,
-      org,
+      orgSlug,
       fromRedirectOfNonOrgLink: context.query.orgRedirection === "true",
     },
     session?.user?.id
@@ -261,7 +262,7 @@ async function getUserPageProps(context: GetServerSidePropsContext) {
     } as const;
   }
 
-  const allowSEOIndexing = org
+  const allowSEOIndexing = orgSlug
     ? user?.profile?.organization?.organizationSettings?.allowSEOIndexing
       ? user?.allowSEOIndexing
       : false

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -19,8 +19,8 @@ export type useScheduleForEventReturnType = ReturnType<typeof useScheduleForEven
  * of combining multiple conditional hooks.
  */
 export const useEvent = (props?: { fromRedirectOfNonOrgLink?: boolean; disabled?: boolean }) => {
-  const [username, eventSlug, isTeamEvent, org] = useBookerStore(
-    (state) => [state.username, state.eventSlug, state.isTeamEvent, state.org],
+  const [username, eventSlug, isTeamEvent, orgSlug] = useBookerStore(
+    (state) => [state.username, state.eventSlug, state.isTeamEvent, state.orgSlug],
     shallow
   );
 
@@ -29,7 +29,7 @@ export const useEvent = (props?: { fromRedirectOfNonOrgLink?: boolean; disabled?
       username: username ?? "",
       eventSlug: eventSlug ?? "",
       isTeamEvent,
-      org: org ?? null,
+      orgSlug: orgSlug ?? null,
       fromRedirectOfNonOrgLink: props?.fromRedirectOfNonOrgLink,
     },
     {

--- a/packages/features/bookings/Booker/utils/event.ts
+++ b/packages/features/bookings/Booker/utils/event.ts
@@ -20,7 +20,7 @@ export type useScheduleForEventReturnType = ReturnType<typeof useScheduleForEven
  */
 export const useEvent = (props?: { fromRedirectOfNonOrgLink?: boolean; disabled?: boolean }) => {
   const [username, eventSlug, isTeamEvent, orgSlug] = useBookerStore(
-    (state) => [state.username, state.eventSlug, state.isTeamEvent, state.orgSlug],
+    (state) => [state.username, state.eventSlug, state.isTeamEvent, state.org],
     shallow
   );
 

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -268,28 +268,27 @@ export const getPublicEvent = async (
     const disableBookingTitle = !defaultEvent.isDynamic;
     const unPublishedOrgUser = users.find((user) => user.profile?.organization?.slug === null);
 
-    let orgDetails: Pick<Team, "logoUrl" | "name"> | undefined;
-    if (orgSlug) {
-      orgDetails = orgId
-        ? await prisma.team.findUniqueOrThrow({
-            where: {
-              id: orgId,
-            },
-            select: {
-              logoUrl: true,
-              name: true,
-            },
-          })
-        : await prisma.team.findFirstOrThrow({
-            where: {
-              slug: org,
-            },
-            select: {
-              logoUrl: true,
-              name: true,
-            },
-          });
-    }
+    const orgDetails: Pick<Team, "logoUrl" | "name"> | undefined = orgId
+      ? await prisma.team.findUniqueOrThrow({
+          where: {
+            id: orgId,
+          },
+          select: {
+            logoUrl: true,
+            name: true,
+          },
+        })
+      : orgSlug
+      ? await prisma.team.findFirstOrThrow({
+          where: {
+            slug: orgSlug,
+          },
+          select: {
+            logoUrl: true,
+            name: true,
+          },
+        })
+      : undefined;
 
     return {
       ...defaultEvent,
@@ -448,18 +447,28 @@ export const getPublicEvent = async (
     eventWithUserProfiles.schedule = eventOwnerDefaultSchedule;
   }
 
-  let orgDetails: Pick<Team, "logoUrl" | "name"> | undefined | null;
-  if (orgSlug) {
-    orgDetails = await prisma.team.findUnique({
-      where: {
-        id: orgId,
-      },
-      select: {
-        logoUrl: true,
-        name: true,
-      },
-    });
-  }
+  const orgDetails: Pick<Team, "logoUrl" | "name"> | undefined | null = orgId
+    ? await prisma.team.findUnique({
+        where: {
+          id: orgId,
+        },
+        select: {
+          logoUrl: true,
+          name: true,
+        },
+      })
+    : orgSlug
+    ? await prisma.team.findFirst({
+        where: {
+          slug: orgSlug,
+          parentId: null,
+        },
+        select: {
+          logoUrl: true,
+          name: true,
+        },
+      })
+    : undefined;
 
   let showInstantEventConnectNowModal = eventWithUserProfiles.isInstantEvent;
 

--- a/packages/lib/server/repository/event.ts
+++ b/packages/lib/server/repository/event.ts
@@ -8,10 +8,12 @@ export class EventRepository {
       input.username,
       input.eventSlug,
       input.isTeamEvent,
-      input.org,
+      input.orgSlug,
       prisma,
       input.fromRedirectOfNonOrgLink,
-      userId
+      userId,
+      false,
+      input.orgId
     );
     return event;
   }

--- a/packages/trpc/server/routers/publicViewer/event.schema.ts
+++ b/packages/trpc/server/routers/publicViewer/event.schema.ts
@@ -4,7 +4,8 @@ export const ZEventInputSchema = z.object({
   username: z.string(),
   eventSlug: z.string(),
   isTeamEvent: z.boolean().optional(),
-  org: z.string().nullable(),
+  orgSlug: z.string().nullable(),
+  orgId: z.number().optional(),
   /**
    * Informs that the event request has been sent from a page that was reached by a redirect from non-org link(i.e. app.cal.com/username redirected to acme.cal.com/username)
    * Based on this decision like whether to allow unpublished organization's event to be served or not can be made.


### PR DESCRIPTION
## What does this PR do?

- Improved performance and accuracy of public event fetching by passing both orgSlug and orgId, and updating related function signatures and usage.

- **Refactors**
  - Replaced all org references with orgSlug and added orgId where needed.
  - Updated getPublicEvent and related calls to support the new parameters.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.


