### PR TITLE
fix: update trigger function for RoutingFormResponseField

### DIFF
--- a/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
+++ b/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
@@ -97,7 +97,7 @@ BEGIN
                             VALUES (
                                 NEW.id,
                                 field_record->>'id',
-                                (response_field->'value'->0)::text
+                                (response_field->'value'->>0)
                             );
                         ELSIF jsonb_typeof(response_field->'value') = 'string' THEN
                             -- If it's a string, use it directly

--- a/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
+++ b/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
@@ -1,0 +1,143 @@
+CREATE OR REPLACE FUNCTION handle_routing_form_response_fields()
+RETURNS TRIGGER AS $$
+DECLARE
+    form_fields jsonb;
+    field_record jsonb;
+    response_field jsonb;
+    field_type text;
+    response_data jsonb;
+    form_id text;
+BEGIN
+    -- For INSERT trigger on RoutingFormResponseDenormalized, we need to get the response data from App_RoutingForms_FormResponse
+    -- For UPDATE trigger on App_RoutingForms_FormResponse, we can use NEW.response directly
+    IF TG_TABLE_NAME = 'RoutingFormResponseDenormalized' THEN
+        SELECT response, "formId" INTO response_data, form_id
+        FROM "App_RoutingForms_FormResponse"
+        WHERE id = NEW.id;
+    ELSE
+        response_data := NEW.response::jsonb;
+        form_id := NEW."formId";
+    END IF;
+    -- Validate response_data exists and is a valid JSON object
+    IF response_data IS NULL OR jsonb_typeof(response_data) != 'object' THEN
+        RAISE WARNING 'Invalid response data for id %. Type: %', NEW.id, COALESCE(jsonb_typeof(response_data), 'null');
+        RETURN NEW;
+    END IF;
+    -- Get the fields from App_RoutingForms_Form
+    SELECT fields::jsonb INTO form_fields
+    FROM "App_RoutingForms_Form"
+    WHERE id = form_id;
+    -- Delete existing entries for this response
+    DELETE FROM "RoutingFormResponseField"
+    WHERE "responseId" = NEW.id;
+    -- Exit early if form_fields is NULL or not an array
+    IF form_fields IS NULL OR jsonb_typeof(form_fields) != 'array' THEN
+        RAISE WARNING 'form_fields is NULL or not an array for formId %, skipping processing', form_id;
+        RETURN NEW;
+    END IF;
+    -- Iterate through each field in the response
+    FOR field_record IN SELECT * FROM jsonb_array_elements(form_fields)
+    LOOP
+        BEGIN
+            -- Validate field_record has required properties
+            IF field_record->>'id' IS NULL THEN
+                RAISE WARNING 'Field record is missing id property, skipping field';
+                CONTINUE;
+            END IF;
+            IF field_record->>'type' IS NULL THEN
+                RAISE WARNING 'Field record % is missing type property, skipping field', field_record->>'id';
+                CONTINUE;
+            END IF;
+            -- Get the response field object for this field
+            response_field := response_data->(field_record->>'id');
+            -- Skip if no response for this field
+            IF response_field IS NULL THEN
+                CONTINUE;
+            END IF;
+            -- Get field type
+            field_type := field_record->>'type';
+            -- Insert new record based on field type
+            IF field_type = 'multiselect' THEN
+                -- Handle array values for multiselect
+                -- Only insert if value is not null and is a valid JSON array
+                IF response_field->>'value' IS NOT NULL AND jsonb_typeof(response_field->'value') = 'array' THEN
+                    BEGIN
+                        INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueStringArray")
+                        VALUES (
+                            NEW.id,
+                            field_record->>'id',
+                            ARRAY(SELECT jsonb_array_elements_text(response_field->'value'))
+                        );
+                    EXCEPTION WHEN OTHERS THEN
+                        RAISE WARNING 'Failed to insert multiselect values for field %', field_record->>'id';
+                    END;
+                END IF;
+            ELSIF field_type = 'number' THEN
+                -- Handle number values
+                -- Only insert if value is not null and is a valid number
+                IF response_field->>'value' IS NOT NULL AND jsonb_typeof(response_field->'value') = 'number' THEN
+                    BEGIN
+                        INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueNumber")
+                        VALUES (
+                            NEW.id,
+                            field_record->>'id',
+                            (response_field->>'value')::decimal
+                        );
+                    EXCEPTION WHEN OTHERS THEN
+                        RAISE WARNING 'Failed to insert number value for field %', field_record->>'id';
+                    END;
+                END IF;
+            ELSIF field_type = 'select' THEN
+                -- Handle select values - can be either string or array
+                IF response_field->>'value' IS NOT NULL THEN
+                    BEGIN
+                        IF jsonb_typeof(response_field->'value') = 'array' THEN
+                            -- If it's an array, take the first element
+                            INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueString")
+                            VALUES (
+                                NEW.id,
+                                field_record->>'id',
+                                (response_field->'value'->0)::text
+                            );
+                        ELSIF jsonb_typeof(response_field->'value') = 'string' THEN
+                            -- If it's a string, use it directly
+                            INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueString")
+                            VALUES (
+                                NEW.id,
+                                field_record->>'id',
+                                response_field->>'value'
+                            );
+                        END IF;
+                    EXCEPTION WHEN OTHERS THEN
+                        RAISE WARNING 'Failed to insert select value for field %', field_record->>'id';
+                    END;
+                END IF;
+            ELSE
+                -- Handle all other types as strings
+                -- Only insert if value is not null and is a valid string
+                IF response_field->>'value' IS NOT NULL AND jsonb_typeof(response_field->'value') = 'string' THEN
+                    BEGIN
+                        INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueString")
+                        VALUES (
+                            NEW.id,
+                            field_record->>'id',
+                            response_field->>'value'
+                        );
+                    EXCEPTION WHEN OTHERS THEN
+                        RAISE WARNING 'Failed to insert string value for field %', field_record->>'id';
+                    END;
+                END IF;
+            END IF;
+        EXCEPTION WHEN OTHERS THEN
+            -- Log the error and continue processing other fields
+            RAISE WARNING 'Error processing field %', field_record->>'id';
+            CONTINUE;
+        END;
+    END LOOP;
+    RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+    -- Log any unhandled errors and continue
+    RAISE WARNING 'Unhandled error in handle_routing_form_response_fields for response %', NEW.id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
+++ b/packages/prisma/migrations/20250617123959_update_handle_routing_form_response_fields/migration.sql
@@ -71,17 +71,28 @@ BEGIN
                 END IF;
             ELSIF field_type = 'number' THEN
                 -- Handle number values
-                -- Only insert if value is not null and is a valid number
-                IF response_field->>'value' IS NOT NULL AND jsonb_typeof(response_field->'value') = 'number' THEN
+                -- Accept both JSON number values and string values that can be converted to numbers
+                IF response_field->>'value' IS NOT NULL THEN
                     BEGIN
-                        INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueNumber")
-                        VALUES (
-                            response_id,
-                            field_record->>'id',
-                            (response_field->>'value')::decimal
-                        );
+                        IF jsonb_typeof(response_field->'value') = 'number' THEN
+                            -- If it's already a JSON number, use it directly
+                            INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueNumber")
+                            VALUES (
+                                response_id,
+                                field_record->>'id',
+                                (response_field->>'value')::decimal
+                            );
+                        ELSIF jsonb_typeof(response_field->'value') = 'string' THEN
+                            -- If it's a string, try to convert it to a number
+                            INSERT INTO "RoutingFormResponseField" ("responseId", "fieldId", "valueNumber")
+                            VALUES (
+                                response_id,
+                                field_record->>'id',
+                                (response_field->>'value')::decimal
+                            );
+                        END IF;
                     EXCEPTION WHEN OTHERS THEN
-                        RAISE WARNING 'Failed to insert number value for field %', field_record->>'id';
+                        RAISE WARNING 'Failed to insert number value for field % (value: %)', field_record->>'id', response_field->>'value';
                     END;
                 END IF;
             ELSIF field_type = 'select' THEN


### PR DESCRIPTION
## What does this PR do?

This PR fixes the implementation of `handle_routing_form_response_fields` function which is the trigger function to update `RoutingFormResponseField` table. It was missing the implementation for `select` type.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

You trigger the function like this:
```
update "App_RoutingForms_FormResponse" set "updatedAt" = now() where id = 1;
```

and you can check the result with:

```
select * from "RoutingFormResponseField" where "responseId" = 1;
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the trigger function for RoutingFormResponseField to handle select-type fields correctly when updating form responses. This ensures select fields are now processed and stored as expected.

<!-- End of auto-generated description by cubic. -->

