### PR TITLE
fix: Dry run in prerender flow

### DIFF
--- a/packages/app-store/routing-forms/lib/handleResponse.ts
+++ b/packages/app-store/routing-forms/lib/handleResponse.ts
@@ -179,7 +179,7 @@ const _handleResponse = async ({
       moduleLogger.debug("Dry run mode - Form response not stored and also webhooks and emails not sent");
       if (queueFormResponse) {
         queuedFormResponse = {
-          id: "queued-dry-run-id",
+          id: "00000000-0000-0000-0000-000000000000",
           formId: form.id,
           response,
         };

--- a/packages/app-store/routing-forms/lib/handleResponse.ts
+++ b/packages/app-store/routing-forms/lib/handleResponse.ts
@@ -177,15 +177,23 @@ const _handleResponse = async ({
       }
     } else {
       moduleLogger.debug("Dry run mode - Form response not stored and also webhooks and emails not sent");
-      // Create a mock response for dry run
-      dbFormResponse = {
-        id: 0,
-        formId: form.id,
-        response,
-        chosenRouteId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      if (queueFormResponse) {
+        queuedFormResponse = {
+          id: "queued-dry-run-id",
+          formId: form.id,
+          response,
+        };
+      } else {
+        // Create a mock response for dry run
+        dbFormResponse = {
+          id: 0,
+          formId: form.id,
+          response,
+          chosenRouteId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+      }
     }
     return {
       isPreview: !!isPreview,

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -455,7 +455,9 @@ export const methods = {
 
     // We now record the response to routingFormResponse and connect that with queuedResponse, as the user actually opened the modal which is confirmed by this connect method call
     const newlyRecordedResponseId = await recordResponseIfQueued(params);
-    if (!newlyRecordedResponseId) {
+    // Allow 0 which is for dry run
+    // Negative values are not possible
+    if (typeof newlyRecordedResponseId !== "number") {
       return;
     }
     await ensureRoutingFormResponseIdInUrl({

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -40,7 +40,7 @@ export const recordResponseIfQueued = async (params: Record<string, string | str
     return null;
   }
   // Corresponding dry run value for routingFormResponseId is 0
-  if (queuedFormResponseId === "queued-dry-run-id") {
+  if (queuedFormResponseId === "00000000-0000-0000-0000-000000000000") {
     return 0;
   }
   // form is formId and isn't acutal Form data

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -39,6 +39,10 @@ export const recordResponseIfQueued = async (params: Record<string, string | str
   if (!queuedFormResponseId) {
     return null;
   }
+  // Corresponding dry run value for routingFormResponseId is 0
+  if (queuedFormResponseId === "queued-dry-run-id") {
+    return 0;
+  }
   // form is formId and isn't acutal Form data
   const { form: _1, ...actualFormData } = params;
   const res = await fetch(`/api/routing-forms/queued-response`, {


### PR DESCRIPTION
## What does this PR do?

Fix booking failure in dry-run mode when using prerendering.

The reason for failure was that `routingFormResponseId` wasn't set at all and it is expected to be set as 0 for Dry Run

