### PR TITLE
feat: Preview booking pages

### DIFF
--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/actions.ts
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateUserBookingPreview({
+  userSlug,
+  eventTypeSlug,
+}: {
+  userSlug: string;
+  eventTypeSlug: string;
+}) {
+  revalidatePath(`/${userSlug}/${eventTypeSlug}/preview`);
+}

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
@@ -1,10 +1,7 @@
 import type { PageProps } from "app/_types";
-import { _generateMetadata } from "app/_utils";
 import { headers, cookies } from "next/headers";
 
-import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
-
-import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getBookingPreviewProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
 
@@ -13,29 +10,14 @@ import { UserBookingPreview } from "./user-booking-preview";
 // Enable ISR - 1 hour cache
 export const revalidate = 3600;
 
-export const generateMetadata = async ({ params, searchParams }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
-  const props = await getBookingPreviewProps(legacyCtx);
-
-  const { eventType, profile, entity } = props;
-
-  const decodedParams = decodeParams(await params);
-  const metadata = await _generateMetadata(
-    () => `${eventType.title} | ${profile.name}`,
-    () => eventType.title,
-    false,
-    getOrgFullOrigin(entity.orgSlug ?? null),
-    `/${decodedParams.user}/${decodedParams.type}/preview`
-  );
-
-  return {
-    ...metadata,
-    robots: {
-      follow: false,
-      index: false,
-    },
-  };
-};
+export const generateMetadata = () => ({
+  title: "User Booking Preview",
+  description: "User Booking Preview",
+  robots: {
+    follow: false,
+    index: false,
+  },
+});
 
 export default async function UserBookingPreviewPage({ params, searchParams }: PageProps) {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
@@ -1,7 +1,10 @@
 import type { PageProps } from "app/_types";
+import { generateMeetingMetadata } from "app/_utils";
 import { headers, cookies } from "next/headers";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
+
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getBookingPreviewProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
 
@@ -10,14 +13,42 @@ import { UserBookingPreview } from "./user-booking-preview";
 // Enable ISR - 1 hour cache
 export const revalidate = 3600;
 
-export const generateMetadata = () => ({
-  title: "User Booking Preview",
-  description: "User Booking Preview",
-  robots: {
-    follow: false,
-    index: false,
-  },
-});
+export const generateMetadata = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getBookingPreviewProps(legacyCtx);
+
+  const { isSEOIndexable, eventData, isBrandingHidden } = props;
+  const profileName = eventData?.profile?.name ?? "";
+  const profileImage = eventData?.profile.image;
+  const title = eventData?.title ?? "";
+  const meeting = {
+    title,
+    profile: { name: profileName, image: profileImage },
+    users: [
+      ...(eventData?.subsetOfUsers || []).map((user) => ({
+        name: `${user.name}`,
+        username: `${user.username}`,
+      })),
+    ],
+  };
+  const decodedParams = decodeParams(await params);
+  const metadata = await generateMeetingMetadata(
+    meeting,
+    () => `${title} | ${profileName}`,
+    () => title,
+    isBrandingHidden,
+    getOrgFullOrigin(eventData?.entity.orgSlug ?? null),
+    `/${decodedParams.user}/${decodedParams.type}`
+  );
+
+  return {
+    ...metadata,
+    robots: {
+      follow: !(eventData?.hidden || !isSEOIndexable),
+      index: !(eventData?.hidden || !isSEOIndexable),
+    },
+  };
+};
 
 export default async function UserBookingPreviewPage({ params, searchParams }: PageProps) {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
@@ -10,6 +10,9 @@ import { getBookingPreviewProps } from "@server/lib/[user]/[type]/getStaticPrevi
 
 import { UserBookingPreview } from "./user-booking-preview";
 
+// Enable ISR - 1 hour cache
+export const revalidate = 3600;
+
 export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
   const props = await getBookingPreviewProps(legacyCtx);

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/page.tsx
@@ -1,0 +1,42 @@
+import type { PageProps } from "app/_types";
+import { _generateMetadata } from "app/_utils";
+import { headers, cookies } from "next/headers";
+
+import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
+
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
+
+import { getBookingPreviewProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
+
+import { UserBookingPreview } from "./user-booking-preview";
+
+export const generateMetadata = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getBookingPreviewProps(legacyCtx);
+
+  const { eventType, profile, entity } = props;
+
+  const decodedParams = decodeParams(await params);
+  const metadata = await _generateMetadata(
+    () => `${eventType.title} | ${profile.name}`,
+    () => eventType.title,
+    false,
+    getOrgFullOrigin(entity.orgSlug ?? null),
+    `/${decodedParams.user}/${decodedParams.type}/preview`
+  );
+
+  return {
+    ...metadata,
+    robots: {
+      follow: false,
+      index: false,
+    },
+  };
+};
+
+export default async function UserBookingPreviewPage({ params, searchParams }: PageProps) {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getBookingPreviewProps(legacyCtx);
+
+  return <UserBookingPreview {...props} />;
+}

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Button } from "@calcom/ui/components/button";
+import { Icon } from "@calcom/ui/components/icon";
+
+interface PreviewBannerProps {
+  bookingUrl: string;
+}
+
+export function PreviewBanner({ bookingUrl }: PreviewBannerProps) {
+  return (
+    <div className="border-attention bg-attention/10 mb-6 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center">
+          <Icon name="eye" className="text-attention mr-2 h-5 w-5" />
+          <div>
+            <p className="text-emphasis font-medium">This is a preview</p>
+            <p className="text-subtle text-sm">This page is optimized for search engines.</p>
+          </div>
+        </div>
+        <Button href={bookingUrl} className="ml-4" size="sm">
+          Book Now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner.tsx
@@ -14,8 +14,7 @@ export function PreviewBanner({ bookingUrl }: PreviewBannerProps) {
         <div className="flex items-center">
           <Icon name="eye" className="text-attention mr-2 h-5 w-5" />
           <div>
-            <p className="text-emphasis font-medium">This is a preview</p>
-            <p className="text-subtle text-sm">This page is optimized for search engines.</p>
+            <p className="text-emphasis font-medium">This is a preview of a booking page</p>
           </div>
         </div>
         <Button href={bookingUrl} className="ml-4" size="sm">

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -5,6 +5,8 @@ import { Icon } from "@calcom/ui/components/icon";
 
 import type { BookingPreviewPageProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
 
+import { PreviewBanner } from "./preview-banner";
+
 export function UserBookingPreview(props: BookingPreviewPageProps) {
   const { eventType, profile, entity } = props;
 
@@ -12,10 +14,14 @@ export function UserBookingPreview(props: BookingPreviewPageProps) {
   useTheme(profile.theme);
 
   const organizationName = entity.name;
+  const bookingUrl = `/${profile.username}/${eventType.slug}`;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-24">
       <main>
+        {/* Preview Banner */}
+        <PreviewBanner bookingUrl={bookingUrl} />
+
         {/* Event Type Header */}
         <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-6">
           {/* User Avatar */}

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useTheme from "@calcom/lib/hooks/useTheme";
+import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
 import { Icon } from "@calcom/ui/components/icon";
 
 import type { BookingPreviewPageProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
@@ -61,7 +62,12 @@ export function UserBookingPreview(props: BookingPreviewPageProps) {
 
           {eventType.description && (
             <div className="text-default text-sm">
-              <p>{eventType.description}</p>
+              <div
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: markdownToSafeHTMLClient(eventType.description),
+                }}
+              />
             </div>
           )}
         </div>

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -8,8 +8,7 @@ import type { BookingPreviewPageProps } from "@server/lib/[user]/[type]/getStati
 import { PreviewBanner } from "./preview-banner";
 
 export function UserBookingPreview(props: BookingPreviewPageProps) {
-  const { eventType, profile, entity } = props;
-  const organizationName = entity.name;
+  const { eventType, profile, organizationName } = props;
   const bookingUrl = `/${profile.username}/${eventType.slug}`;
 
   return (

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import useTheme from "@calcom/lib/hooks/useTheme";
 import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
 import { Icon } from "@calcom/ui/components/icon";
 
@@ -10,10 +9,6 @@ import { PreviewBanner } from "./preview-banner";
 
 export function UserBookingPreview(props: BookingPreviewPageProps) {
   const { eventType, profile, entity } = props;
-
-  // Use theme from profile
-  useTheme(profile.theme);
-
   const organizationName = entity.name;
   const bookingUrl = `/${profile.username}/${eventType.slug}`;
 

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -8,8 +8,11 @@ import type { BookingPreviewPageProps } from "@server/lib/[user]/[type]/getStati
 import { PreviewBanner } from "./preview-banner";
 
 export function UserBookingPreview(props: BookingPreviewPageProps) {
-  const { eventType, profile, organizationName } = props;
-  const bookingUrl = `/${profile.username}/${eventType.slug}`;
+  const { eventType, profile, profiles, organizationName, isDynamicGroup } = props;
+  const bookingUrl =
+    isDynamicGroup && profiles
+      ? `/${profiles.map((p) => p.username).join("+")}/${eventType.slug}`
+      : `/${profile.username}/${eventType.slug}`;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-24">
@@ -19,15 +22,40 @@ export function UserBookingPreview(props: BookingPreviewPageProps) {
 
         {/* Event Type Header */}
         <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-6">
-          {/* User Avatar */}
+          {/* User Avatar(s) */}
           <div className="mb-4">
-            <div className="flex items-center">
-              <img src={profile.image} alt={profile.name} className="h-12 w-12 rounded-full" />
-              <div className="ml-3">
-                <h2 className="text-emphasis font-semibold">{profile.name}</h2>
-                {organizationName && <p className="text-subtle text-sm">{organizationName}</p>}
+            {isDynamicGroup && profiles ? (
+              <div className="flex items-center">
+                <div className="flex -space-x-2">
+                  {profiles.slice(0, 4).map((userProfile, index) => (
+                    <img
+                      key={userProfile.username}
+                      src={userProfile.image}
+                      alt={userProfile.name}
+                      className="h-12 w-12 rounded-full border-2 border-white"
+                      style={{ zIndex: profiles.length - index }}
+                    />
+                  ))}
+                  {profiles.length > 4 && (
+                    <div className="bg-subtle flex h-12 w-12 items-center justify-center rounded-full border-2 border-white text-sm font-medium">
+                      +{profiles.length - 4}
+                    </div>
+                  )}
+                </div>
+                <div className="ml-3">
+                  <h2 className="text-emphasis font-semibold">{profiles.map((p) => p.name).join(", ")}</h2>
+                  {organizationName && <p className="text-subtle text-sm">{organizationName}</p>}
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="flex items-center">
+                <img src={profile.image} alt={profile.name} className="h-12 w-12 rounded-full" />
+                <div className="ml-3">
+                  <h2 className="text-emphasis font-semibold">{profile.name}</h2>
+                  {organizationName && <p className="text-subtle text-sm">{organizationName}</p>}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Event Type Info */}
@@ -50,6 +78,13 @@ export function UserBookingPreview(props: BookingPreviewPageProps) {
               <span className="flex items-center">
                 <Icon name="user-check" className="mr-1 h-4 w-4" />
                 Requires confirmation
+              </span>
+            )}
+
+            {isDynamicGroup && (
+              <span className="flex items-center">
+                <Icon name="users" className="mr-1 h-4 w-4" />
+                Group Meeting
               </span>
             )}
           </div>

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/preview/user-booking-preview.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import useTheme from "@calcom/lib/hooks/useTheme";
+import { Icon } from "@calcom/ui/components/icon";
+
+import type { BookingPreviewPageProps } from "@server/lib/[user]/[type]/getStaticPreviewProps";
+
+export function UserBookingPreview(props: BookingPreviewPageProps) {
+  const { eventType, profile, entity } = props;
+
+  // Use theme from profile
+  useTheme(profile.theme);
+
+  const organizationName = entity.name;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24">
+      <main>
+        {/* Event Type Header */}
+        <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-6">
+          {/* User Avatar */}
+          <div className="mb-4">
+            <div className="flex items-center">
+              <img src={profile.image} alt={profile.name} className="h-12 w-12 rounded-full" />
+              <div className="ml-3">
+                <h2 className="text-emphasis font-semibold">{profile.name}</h2>
+                {organizationName && <p className="text-subtle text-sm">{organizationName}</p>}
+              </div>
+            </div>
+          </div>
+
+          {/* Event Type Info */}
+          <h1 className="font-cal text-emphasis mb-2 text-2xl">{eventType.title}</h1>
+
+          <div className="text-default mb-4 flex items-center space-x-4 text-sm">
+            <span className="flex items-center">
+              <Icon name="clock" className="mr-1 h-4 w-4" />
+              {eventType.length} min
+            </span>
+
+            {eventType.price > 0 && (
+              <span className="flex items-center">
+                <Icon name="credit-card" className="mr-1 h-4 w-4" />
+                {eventType.currency} {eventType.price}
+              </span>
+            )}
+
+            {eventType.requiresConfirmation && (
+              <span className="flex items-center">
+                <Icon name="user-check" className="mr-1 h-4 w-4" />
+                Requires confirmation
+              </span>
+            )}
+          </div>
+
+          {eventType.description && (
+            <div className="text-default text-sm">
+              <p>{eventType.description}</p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/team/[slug]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/team/[slug]/[type]/preview/page.tsx
@@ -1,0 +1,3 @@
+import Page from "app/(booking-page-wrapper)/team/[slug]/[type]/preview/page";
+
+export default Page;

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/actions.ts
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateTeamBookingPreview({
+  teamSlug,
+  eventTypeSlug,
+}: {
+  teamSlug: string;
+  eventTypeSlug: string;
+}) {
+  revalidatePath(`/team/${teamSlug}/${eventTypeSlug}/preview`);
+}

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
@@ -1,10 +1,7 @@
 import type { PageProps } from "app/_types";
-import { _generateMetadata } from "app/_utils";
 import { headers, cookies } from "next/headers";
 
-import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
-
-import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getTeamBookingPreviewProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
 
@@ -13,27 +10,14 @@ import { TeamBookingPreview } from "./team-booking-preview";
 // Enable ISR - 1 hour cache
 export const revalidate = 3600;
 
-export const generateMetadata = async ({ params, searchParams }: PageProps) => {
-  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
-  const props = await getTeamBookingPreviewProps(legacyCtx);
-  const { eventType, team, entity } = props;
-  const decodedParams = decodeParams(await params);
-  const metadata = await _generateMetadata(
-    () => `${eventType.title} | ${team.name}`,
-    () => eventType.title,
-    false,
-    getOrgFullOrigin(entity.orgSlug ?? null),
-    `/team/${decodedParams.slug}/${decodedParams.type}/preview`
-  );
-
-  return {
-    ...metadata,
-    robots: {
-      follow: false,
-      index: false,
-    },
-  };
-};
+export const generateMetadata = () => ({
+  title: "Team Booking Preview",
+  description: "Team Booking Preview",
+  robots: {
+    follow: false,
+    index: false,
+  },
+});
 
 export default async function TeamBookingPreviewPage({ params, searchParams }: PageProps) {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
@@ -1,7 +1,10 @@
 import type { PageProps } from "app/_types";
+import { generateMeetingMetadata } from "app/_utils";
 import { headers, cookies } from "next/headers";
 
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
+
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getTeamBookingPreviewProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
 
@@ -10,14 +13,42 @@ import { TeamBookingPreview } from "./team-booking-preview";
 // Enable ISR - 1 hour cache
 export const revalidate = 3600;
 
-export const generateMetadata = () => ({
-  title: "Team Booking Preview",
-  description: "Team Booking Preview",
-  robots: {
-    follow: false,
-    index: false,
-  },
-});
+export const generateMetadata = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getTeamBookingPreviewProps(legacyCtx);
+  const { isSEOIndexable, eventData, isBrandingHidden } = props;
+
+  const profileName = eventData?.profile?.name ?? "";
+  const profileImage = eventData?.profile.image;
+  const title = eventData?.title ?? "";
+  const meeting = {
+    title,
+    profile: { name: profileName, image: profileImage },
+    users: [
+      ...(eventData?.users || []).map((user) => ({
+        name: `${user.name}`,
+        username: `${user.username}`,
+      })),
+    ],
+  };
+  const decodedParams = decodeParams(await params);
+  const metadata = await generateMeetingMetadata(
+    meeting,
+    () => `${title} | ${profileName}`,
+    () => title,
+    isBrandingHidden,
+    getOrgFullOrigin(eventData.entity.orgSlug ?? null),
+    `/team/${decodedParams.slug}/${decodedParams.type}`
+  );
+
+  return {
+    ...metadata,
+    robots: {
+      follow: !(eventData?.hidden || !isSEOIndexable),
+      index: !(eventData?.hidden || !isSEOIndexable),
+    },
+  };
+};
 
 export default async function TeamBookingPreviewPage({ params, searchParams }: PageProps) {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
@@ -2,11 +2,16 @@ import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { headers, cookies } from "next/headers";
 
+import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
+
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getTeamBookingPreviewProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
 
 import { TeamBookingPreview } from "./team-booking-preview";
+
+// Enable ISR - 1 hour cache
+export const revalidate = 3600;
 
 export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/page.tsx
@@ -1,0 +1,38 @@
+import type { PageProps } from "app/_types";
+import { _generateMetadata } from "app/_utils";
+import { headers, cookies } from "next/headers";
+
+import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
+
+import { getTeamBookingPreviewProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
+
+import { TeamBookingPreview } from "./team-booking-preview";
+
+export const generateMetadata = async ({ params, searchParams }: PageProps) => {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getTeamBookingPreviewProps(legacyCtx);
+  const { eventType, team, entity } = props;
+  const decodedParams = decodeParams(await params);
+  const metadata = await _generateMetadata(
+    () => `${eventType.title} | ${team.name}`,
+    () => eventType.title,
+    false,
+    getOrgFullOrigin(entity.orgSlug ?? null),
+    `/team/${decodedParams.slug}/${decodedParams.type}/preview`
+  );
+
+  return {
+    ...metadata,
+    robots: {
+      follow: false,
+      index: false,
+    },
+  };
+};
+
+export default async function TeamBookingPreviewPage({ params, searchParams }: PageProps) {
+  const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
+  const props = await getTeamBookingPreviewProps(legacyCtx);
+
+  return <TeamBookingPreview {...props} />;
+}

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import useTheme from "@calcom/lib/hooks/useTheme";
+import { Icon } from "@calcom/ui/components/icon";
+
+import type { TeamBookingPreviewPageProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
+
+export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
+  const { eventType, team, entity } = props;
+
+  // Use theme from team
+  useTheme(team.theme);
+
+  const organizationName = entity.name;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24">
+      <main>
+        {/* Event Type Header */}
+        <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-6">
+          {/* Team Logo/Avatar */}
+          <div className="mb-4">
+            <div className="flex items-center">
+              {team.logoUrl ? (
+                <img src={team.logoUrl} alt={team.name} className="h-12 w-12 rounded-lg" />
+              ) : (
+                <div className="bg-emphasis flex h-12 w-12 items-center justify-center rounded-lg">
+                  <Icon name="users" className="h-6 w-6" />
+                </div>
+              )}
+              <div className="ml-3">
+                <h2 className="text-emphasis font-semibold">{team.name}</h2>
+                {organizationName && <p className="text-subtle text-sm">{organizationName}</p>}
+              </div>
+            </div>
+          </div>
+
+          {/* Event Type Info */}
+          <h1 className="font-cal text-emphasis mb-2 text-2xl">{eventType.title}</h1>
+
+          <div className="text-default mb-4 flex items-center space-x-4 text-sm">
+            <span className="flex items-center">
+              <Icon name="clock" className="mr-1 h-4 w-4" />
+              {eventType.length} min
+            </span>
+
+            {eventType.price > 0 && (
+              <span className="flex items-center">
+                <Icon name="credit-card" className="mr-1 h-4 w-4" />
+                {eventType.currency} {eventType.price}
+              </span>
+            )}
+
+            {eventType.requiresConfirmation && (
+              <span className="flex items-center">
+                <Icon name="user-check" className="mr-1 h-4 w-4" />
+                Requires confirmation
+              </span>
+            )}
+
+            {eventType.schedulingType && (
+              <span className="flex items-center">
+                <Icon name="users" className="mr-1 h-4 w-4" />
+                {eventType.schedulingType === "ROUND_ROBIN"
+                  ? "Round Robin"
+                  : eventType.schedulingType === "COLLECTIVE"
+                  ? "Group Meeting"
+                  : "Team Event"}
+              </span>
+            )}
+          </div>
+
+          {eventType.description && (
+            <div className="text-default text-sm">
+              <p>{eventType.description}</p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import useTheme from "@calcom/lib/hooks/useTheme";
 import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
 import { Icon } from "@calcom/ui/components/icon";
 import { PreviewBanner } from "@calcom/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner";
@@ -9,9 +8,6 @@ import type { TeamBookingPreviewPageProps } from "@server/lib/team/[slug]/[type]
 
 export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
   const { eventType, team, organizationName } = props;
-
-  // Use theme from team
-  useTheme(team.theme);
 
   const bookingUrl = `/team/${team.slug}/${eventType.slug}`;
 

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
@@ -8,12 +8,11 @@ import { PreviewBanner } from "@calcom/web/app/(booking-page-wrapper)/[user]/[ty
 import type { TeamBookingPreviewPageProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
 
 export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
-  const { eventType, team, entity } = props;
+  const { eventType, team, organizationName } = props;
 
   // Use theme from team
   useTheme(team.theme);
 
-  const organizationName = entity.name;
   const bookingUrl = `/team/${team.slug}/${eventType.slug}`;
 
   return (

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
@@ -2,6 +2,7 @@
 
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { Icon } from "@calcom/ui/components/icon";
+import { PreviewBanner } from "@calcom/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner";
 
 import type { TeamBookingPreviewPageProps } from "@server/lib/team/[slug]/[type]/getStaticPreviewProps";
 
@@ -12,10 +13,14 @@ export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
   useTheme(team.theme);
 
   const organizationName = entity.name;
+  const bookingUrl = `/team/${team.slug}/${eventType.slug}`;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-24">
       <main>
+        {/* Preview Banner */}
+        <PreviewBanner bookingUrl={bookingUrl} />
+
         {/* Event Type Header */}
         <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-6">
           {/* Team Logo/Avatar */}

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/team-booking-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useTheme from "@calcom/lib/hooks/useTheme";
+import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
 import { Icon } from "@calcom/ui/components/icon";
 import { PreviewBanner } from "@calcom/web/app/(booking-page-wrapper)/[user]/[type]/preview/preview-banner";
 
@@ -69,7 +70,7 @@ export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
                 {eventType.schedulingType === "ROUND_ROBIN"
                   ? "Round Robin"
                   : eventType.schedulingType === "COLLECTIVE"
-                  ? "Group Meeting"
+                  ? "Collective"
                   : "Team Event"}
               </span>
             )}
@@ -77,7 +78,12 @@ export function TeamBookingPreview(props: TeamBookingPreviewPageProps) {
 
           {eventType.description && (
             <div className="text-default text-sm">
-              <p>{eventType.description}</p>
+              <div
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: markdownToSafeHTMLClient(eventType.description),
+                }}
+              />
             </div>
           )}
         </div>

--- a/apps/web/lib/botDetection.ts
+++ b/apps/web/lib/botDetection.ts
@@ -2,34 +2,14 @@ import { userAgent } from "next/server";
 
 interface BotDetectionResult {
   isBot: boolean;
-  source: "vercel" | "nextjs";
   userAgent: string;
 }
 
 export function detectBot(headers: Headers): BotDetectionResult {
   const { isBot, ua } = userAgent({ headers }); // `ua` is the actual user agent string from the request headers
-  const vercelBotHeader = headers.get("x-vercel-bot") === "1";
   const userAgentString = ua ?? "";
-
-  if (vercelBotHeader) {
-    return {
-      isBot: true,
-      source: "vercel",
-      userAgent: userAgentString,
-    };
-  }
-
-  if (isBot) {
-    return {
-      isBot: true,
-      source: "nextjs",
-      userAgent: userAgentString,
-    };
-  }
-
   return {
-    isBot: false,
-    source: "nextjs",
+    isBot,
     userAgent: userAgentString,
   };
 }

--- a/apps/web/lib/botDetection.ts
+++ b/apps/web/lib/botDetection.ts
@@ -1,0 +1,35 @@
+import { userAgent } from "next/server";
+
+interface BotDetectionResult {
+  isBot: boolean;
+  source: "vercel" | "nextjs";
+  userAgent: string;
+}
+
+export function detectBot(headers: Headers): BotDetectionResult {
+  const { isBot, ua } = userAgent({ headers }); // `ua` is the actual user agent string from the request headers
+  const vercelBotHeader = headers.get("x-vercel-bot") === "1";
+  const userAgentString = ua ?? "";
+
+  if (vercelBotHeader) {
+    return {
+      isBot: true,
+      source: "vercel",
+      userAgent: userAgentString,
+    };
+  }
+
+  if (isBot) {
+    return {
+      isBot: true,
+      source: "nextjs",
+      userAgent: userAgentString,
+    };
+  }
+
+  return {
+    isBot: false,
+    source: "nextjs",
+    userAgent: userAgentString,
+  };
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -16,9 +16,8 @@ const safeGet = async <T = any>(key: string): Promise<T | undefined> => {
   }
 };
 
-// Centralized route configuration to prevent sync issues
-// NOTE: If adding dynamic routes (containing ":"), make sure to update
-// the detection logic in isBookingPageRoute function below
+// SUPER IMPORTANT: If adding dynamic routes, make sure to update
+// the detection logic for `isNonBookingRoute` in `isBookingPageRoute` function below
 const MATCHED_ROUTES = {
   nonBooking: [
     // Routes to enforce CSP

--- a/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
@@ -97,7 +97,7 @@ export const getBookingPreviewProps = async (
   });
 
   if (!eventType || eventType.hidden) {
-    log.debug(`Event type not found: ${usernameList[0]}/${eventSlug}`);
+    log.debug("Event type not found");
     return notFound();
   }
 

--- a/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
@@ -39,9 +39,6 @@ export const getBookingPreviewProps = async (
     return notFound();
   }
 
-  const dataFetchStart = Date.now();
-
-  // Lightweight query - only fetch what's needed for preview
   const eventType = await prisma.eventType.findFirst({
     where: {
       slug: eventSlug,
@@ -100,9 +97,6 @@ export const getBookingPreviewProps = async (
     log.debug("Event type not found");
     return notFound();
   }
-
-  const dataFetchEnd = Date.now();
-  log.debug(`Booking preview data fetch took: ${dataFetchEnd - dataFetchStart}ms`);
 
   const owner = eventType.owner;
   if (!owner) {

--- a/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getStaticPreviewProps.ts
@@ -1,0 +1,165 @@
+import type { GetServerSidePropsContext } from "next";
+import { notFound } from "next/navigation";
+
+import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";
+import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
+import { getUsernameList } from "@calcom/lib/defaultEvents";
+import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import logger from "@calcom/lib/logger";
+import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
+import { prisma } from "@calcom/prisma";
+
+const log = logger.getSubLogger({ prefix: ["[[booking-preview]]"] });
+
+export type BookingPreviewPageProps = {
+  eventType: {
+    id: number;
+    title: string;
+    description: string | null;
+    length: number;
+    slug: string;
+    price: number;
+    currency: string;
+    requiresConfirmation: boolean;
+    descriptionAsSafeHTML: string;
+  };
+  profile: {
+    name: string;
+    image: string;
+    theme: string | null;
+    brandColor: string;
+    darkBrandColor: string;
+    organization: any;
+    allowSEOIndexing: boolean;
+    username: string | null;
+  };
+  entity: {
+    logoUrl?: string | null;
+    orgSlug?: string | null;
+    name?: string | null;
+  };
+  isPreviewPage: boolean;
+};
+
+export const getBookingPreviewProps = async (
+  context: GetServerSidePropsContext
+): Promise<BookingPreviewPageProps> => {
+  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
+  const usernameList = getUsernameList(context.query.user as string);
+  const eventSlug = context.query.type as string;
+
+  if (usernameList.length > 1) {
+    // Dynamic groups not supported in preview mode
+    return notFound();
+  }
+
+  const dataFetchStart = Date.now();
+
+  // Lightweight query - get event type and user info without availability data
+  const eventType = await prisma.eventType.findFirst({
+    where: {
+      slug: eventSlug,
+      users: {
+        some: {
+          username: usernameList[0],
+          ...(isValidOrgDomain
+            ? {
+                profiles: {
+                  some: {
+                    organization: {
+                      slug: currentOrgDomain,
+                    },
+                  },
+                },
+              }
+            : {
+                profiles: { none: {} },
+              }),
+        },
+      },
+      // Exclude team events in this handler
+      team: null,
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      length: true,
+      slug: true,
+      price: true,
+      currency: true,
+      requiresConfirmation: true,
+      hidden: true,
+      // Get owner info but avoid heavy user queries
+      owner: {
+        select: {
+          id: true,
+          name: true,
+          username: true,
+          avatarUrl: true,
+          theme: true,
+          brandColor: true,
+          darkBrandColor: true,
+          allowSEOIndexing: true,
+          profiles: {
+            select: {
+              organization: {
+                select: {
+                  slug: true,
+                  name: true,
+                  logoUrl: true,
+                },
+              },
+            },
+            take: 1,
+          },
+        },
+      },
+    },
+  });
+
+  if (!eventType || eventType.hidden) {
+    log.debug(`Event type not found: ${usernameList[0]}/${eventSlug}`);
+    return notFound();
+  }
+
+  const dataFetchEnd = Date.now();
+  log.debug(`Booking preview data fetch took: ${dataFetchEnd - dataFetchStart}ms`);
+
+  const owner = eventType.owner!;
+  const organization = owner.profiles[0]?.organization || null;
+
+  const profile = {
+    name: owner.name || owner.username || "",
+    image: getUserAvatarUrl({
+      avatarUrl: owner.avatarUrl,
+    }),
+    theme: owner.theme,
+    brandColor: owner.brandColor ?? DEFAULT_LIGHT_BRAND_COLOR,
+    darkBrandColor: owner.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
+    allowSEOIndexing: owner.allowSEOIndexing ?? true,
+    username: owner.username,
+    organization,
+  };
+
+  return {
+    eventType: {
+      id: eventType.id,
+      title: eventType.title,
+      description: eventType.description,
+      length: eventType.length,
+      slug: eventType.slug,
+      price: eventType.price,
+      currency: eventType.currency,
+      requiresConfirmation: eventType.requiresConfirmation,
+      descriptionAsSafeHTML: markdownToSafeHTML(eventType.description) || "",
+    },
+    profile,
+    entity: {
+      logoUrl: organization?.logoUrl,
+      orgSlug: currentOrgDomain,
+      name: organization?.name,
+    },
+    isPreviewPage: true,
+  };
+};

--- a/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
@@ -1,0 +1,145 @@
+import type { GetServerSidePropsContext } from "next";
+import { notFound } from "next/navigation";
+
+import { orgDomainConfig, getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
+import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
+import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
+import { prisma } from "@calcom/prisma";
+
+const log = logger.getSubLogger({ prefix: ["[[team-booking-preview]]"] });
+
+export type TeamBookingPreviewPageProps = {
+  eventType: {
+    id: number;
+    title: string;
+    description: string | null;
+    length: number;
+    slug: string;
+    price: number;
+    currency: string;
+    requiresConfirmation: boolean;
+    descriptionAsSafeHTML: string;
+    schedulingType: string | null;
+  };
+  team: {
+    id: number;
+    name: string;
+    slug: string | null;
+    logoUrl: string | null;
+    theme: string | null;
+    brandColor: string;
+    darkBrandColor: string;
+    hideBranding: boolean;
+  };
+  entity: {
+    logoUrl?: string | null;
+    orgSlug?: string | null;
+    name?: string | null;
+  };
+  isPreviewPage: boolean;
+};
+
+export const getTeamBookingPreviewProps = async (
+  context: GetServerSidePropsContext
+): Promise<TeamBookingPreviewPageProps> => {
+  const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
+  const teamSlug = context.query.slug as string;
+  const eventSlug = context.query.type as string;
+
+  const dataFetchStart = Date.now();
+
+  const eventType = await prisma.eventType.findFirst({
+    where: {
+      slug: eventSlug,
+      team: getSlugOrRequestedSlug(teamSlug),
+      ...(isValidOrgDomain && currentOrgDomain
+        ? {
+            team: {
+              parent: {
+                slug: currentOrgDomain,
+              },
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      length: true,
+      slug: true,
+      price: true,
+      currency: true,
+      requiresConfirmation: true,
+      schedulingType: true,
+      hidden: true,
+      team: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          logoUrl: true,
+          theme: true,
+          brandColor: true,
+          darkBrandColor: true,
+          hideBranding: true,
+          parent: {
+            select: {
+              slug: true,
+              name: true,
+              logoUrl: true,
+            },
+          },
+          _count: {
+            select: {
+              members: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!eventType || eventType.hidden || !eventType.team) {
+    log.debug(`Team event type not found: ${teamSlug}/${eventSlug}`);
+    return notFound();
+  }
+
+  const dataFetchEnd = Date.now();
+  log.debug(`Team booking preview data fetch took: ${dataFetchEnd - dataFetchStart}ms`);
+
+  const team = eventType.team;
+  const orgParent = team.parent;
+
+  return {
+    eventType: {
+      id: eventType.id,
+      title: eventType.title,
+      description: eventType.description,
+      length: eventType.length,
+      slug: eventType.slug,
+      price: eventType.price,
+      currency: eventType.currency,
+      requiresConfirmation: eventType.requiresConfirmation,
+      schedulingType: eventType.schedulingType,
+      descriptionAsSafeHTML: markdownToSafeHTML(eventType.description) || "",
+    },
+    team: {
+      id: team.id,
+      name: team.name,
+      slug: team.slug,
+      logoUrl: team.logoUrl,
+      theme: team.theme,
+      brandColor: team.brandColor ?? DEFAULT_LIGHT_BRAND_COLOR,
+      darkBrandColor: team.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
+      hideBranding: team.hideBranding ?? false,
+    },
+    entity: {
+      logoUrl: orgParent?.logoUrl || team.logoUrl,
+      orgSlug: currentOrgDomain,
+      name: orgParent?.name || team.name,
+    },
+    isPreviewPage: true,
+  };
+};

--- a/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
@@ -2,16 +2,13 @@ import type { GetServerSidePropsContext } from "next";
 import { notFound } from "next/navigation";
 
 import { orgDomainConfig, getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
-import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { prisma } from "@calcom/prisma";
 
 const log = logger.getSubLogger({ prefix: ["[[team-booking-preview]]"] });
 
 export type TeamBookingPreviewPageProps = {
   eventType: {
-    id: number;
     title: string;
     description: string | null;
     length: number;
@@ -19,25 +16,15 @@ export type TeamBookingPreviewPageProps = {
     price: number;
     currency: string;
     requiresConfirmation: boolean;
-    descriptionAsSafeHTML: string;
     schedulingType: string | null;
   };
   team: {
-    id: number;
     name: string;
     slug: string | null;
     logoUrl: string | null;
     theme: string | null;
-    brandColor: string;
-    darkBrandColor: string;
-    hideBranding: boolean;
   };
-  entity: {
-    logoUrl?: string | null;
-    orgSlug?: string | null;
-    name?: string | null;
-  };
-  isPreviewPage: boolean;
+  organizationName: string | null;
 };
 
 export const getTeamBookingPreviewProps = async (
@@ -64,7 +51,6 @@ export const getTeamBookingPreviewProps = async (
         : {}),
     },
     select: {
-      id: true,
       title: true,
       description: true,
       length: true,
@@ -76,24 +62,13 @@ export const getTeamBookingPreviewProps = async (
       hidden: true,
       team: {
         select: {
-          id: true,
           name: true,
           slug: true,
           logoUrl: true,
           theme: true,
-          brandColor: true,
-          darkBrandColor: true,
-          hideBranding: true,
           parent: {
             select: {
-              slug: true,
               name: true,
-              logoUrl: true,
-            },
-          },
-          _count: {
-            select: {
-              members: true,
             },
           },
         },
@@ -114,7 +89,6 @@ export const getTeamBookingPreviewProps = async (
 
   return {
     eventType: {
-      id: eventType.id,
       title: eventType.title,
       description: eventType.description,
       length: eventType.length,
@@ -123,23 +97,13 @@ export const getTeamBookingPreviewProps = async (
       currency: eventType.currency,
       requiresConfirmation: eventType.requiresConfirmation,
       schedulingType: eventType.schedulingType,
-      descriptionAsSafeHTML: markdownToSafeHTML(eventType.description) || "",
     },
     team: {
-      id: team.id,
       name: team.name,
       slug: team.slug,
       logoUrl: team.logoUrl,
       theme: team.theme,
-      brandColor: team.brandColor ?? DEFAULT_LIGHT_BRAND_COLOR,
-      darkBrandColor: team.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
-      hideBranding: team.hideBranding ?? false,
     },
-    entity: {
-      logoUrl: orgParent?.logoUrl || team.logoUrl,
-      orgSlug: currentOrgDomain,
-      name: orgParent?.name || team.name,
-    },
-    isPreviewPage: true,
+    organizationName: orgParent?.name || team.name,
   };
 };

--- a/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
@@ -34,8 +34,6 @@ export const getTeamBookingPreviewProps = async (
   const teamSlug = context.query.slug as string;
   const eventSlug = context.query.type as string;
 
-  const dataFetchStart = Date.now();
-
   const eventType = await prisma.eventType.findFirst({
     where: {
       slug: eventSlug,
@@ -80,9 +78,6 @@ export const getTeamBookingPreviewProps = async (
     log.debug(`Team event type not found: ${teamSlug}/${eventSlug}`);
     return notFound();
   }
-
-  const dataFetchEnd = Date.now();
-  log.debug(`Team booking preview data fetch took: ${dataFetchEnd - dataFetchStart}ms`);
 
   const team = eventType.team;
   const orgParent = team.parent;

--- a/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
+++ b/apps/web/server/lib/team/[slug]/[type]/getStaticPreviewProps.ts
@@ -31,6 +31,23 @@ export type TeamBookingPreviewPageProps = {
     theme: string | null;
   };
   organizationName: string | null;
+  isSEOIndexable: boolean;
+  eventData: {
+    title: string;
+    hidden: boolean;
+    profile: {
+      name: string;
+      image: string;
+    };
+    users: Array<{
+      name: string;
+      username: string;
+    }>;
+    entity: {
+      orgSlug: string | null;
+    };
+  };
+  isBrandingHidden: boolean;
 };
 
 export const getTeamBookingPreviewProps = async (
@@ -66,6 +83,16 @@ export const getTeamBookingPreviewProps = async (
       parent: {
         select: {
           name: true,
+          organizationSettings: {
+            select: {
+              allowSEOIndexing: true,
+            },
+          },
+        },
+      },
+      organizationSettings: {
+        select: {
+          allowSEOIndexing: true,
         },
       },
     },
@@ -103,6 +130,12 @@ export const getTeamBookingPreviewProps = async (
 
   const orgParent = team.parent;
 
+  // Determine SEO indexing for teams
+  const allowSEOIndexing =
+    isValidOrgDomain && currentOrgDomain
+      ? orgParent?.organizationSettings?.allowSEOIndexing ?? false
+      : team.organizationSettings?.allowSEOIndexing ?? true; // Default true for non-org teams
+
   return {
     eventType: {
       title: eventType.title,
@@ -121,5 +154,19 @@ export const getTeamBookingPreviewProps = async (
       theme: team.theme,
     },
     organizationName: orgParent?.name || team.name,
+    isSEOIndexable: !!allowSEOIndexing,
+    eventData: {
+      title: eventType.title,
+      hidden: eventType.hidden,
+      profile: {
+        name: team.name,
+        image: team.logoUrl || "",
+      },
+      users: [],
+      entity: {
+        orgSlug: currentOrgDomain,
+      },
+    },
+    isBrandingHidden: false,
   };
 };

--- a/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -140,14 +140,15 @@ const EventTypeWeb = ({ id, ...rest }: EventTypeSetupProps & { id: number }) => 
       // Reset the form with these values as new default values to ensure the correct comparison for dirtyFields eval
       form.reset(currentValues);
       revalidateEventTypeEditPage(eventType.id);
-      if (eventType.team?.id || eventType.parent?.teamId) {
+      const userSlug = eventType.users?.[0]?.username;
+      if (eventType.team?.slug) {
         revalidateTeamBookingPreview({
-          teamSlug: eventType.team?.slug ?? "",
+          teamSlug: eventType.team.slug,
           eventTypeSlug: eventType.slug,
         });
-      } else {
+      } else if (userSlug) {
         revalidateUserBookingPreview({
-          userSlug: eventType.users?.[0]?.username ?? "",
+          userSlug,
           eventTypeSlug: eventType.slug,
         });
       }

--- a/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -20,6 +20,8 @@ import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { showToast } from "@calcom/ui/components/toast";
+import { revalidateUserBookingPreview } from "@calcom/web/app/(booking-page-wrapper)/[user]/[type]/preview/actions";
+import { revalidateTeamBookingPreview } from "@calcom/web/app/(booking-page-wrapper)/team/[slug]/[type]/preview/actions";
 import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/event-types/[type]/actions";
 
 import { TRPCClientError } from "@trpc/react-query";
@@ -138,6 +140,17 @@ const EventTypeWeb = ({ id, ...rest }: EventTypeSetupProps & { id: number }) => 
       // Reset the form with these values as new default values to ensure the correct comparison for dirtyFields eval
       form.reset(currentValues);
       revalidateEventTypeEditPage(eventType.id);
+      if (eventType.team?.id || eventType.parent?.teamId) {
+        revalidateTeamBookingPreview({
+          teamSlug: eventType.team?.slug ?? "",
+          eventTypeSlug: eventType.slug,
+        });
+      } else {
+        revalidateUserBookingPreview({
+          userSlug: eventType.users?.[0]?.username ?? "",
+          eventTypeSlug: eventType.slug,
+        });
+      }
       showToast(t("event_type_updated_successfully", { eventTypeTitle: eventType.title }), "success");
     },
     async onSettled() {


### PR DESCRIPTION
## What does this PR do?

- Added static preview pages for user and team booking links, and updated middleware to detect bots and serve these preview pages automatically.

- **New Features**
  - Created static preview pages for user and team booking routes.
  - Middleware now detects bots and rewrites booking page requests to preview pages.
  - Added bot detection utility for Vercel and Next.js bots.
  
### User Booking Page Preview
<img width="1511" alt="Screenshot 2025-06-17 at 10 01 19 PM" src="https://github.com/user-attachments/assets/f3fabae8-dc26-498d-b983-a8ed6e7ef57b" />

## Team Booking Page Preview
<img width="1512" alt="Screenshot 2025-06-17 at 10 01 26 PM" src="https://github.com/user-attachments/assets/4c6d1a63-afc7-40da-8769-0d0ee6f3a92d" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.
    
