### PR TITLE
fix: Dry Run for non-pre-render scenario 

### DIFF
--- a/packages/app-store/routing-forms/pages/routing-link/getUrlSearchParamsToForward.test.ts
+++ b/packages/app-store/routing-forms/pages/routing-link/getUrlSearchParamsToForward.test.ts
@@ -328,4 +328,26 @@ describe("getUrlSearchParamsToForward", () => {
     });
     expect(fromEntriesWithDuplicateKeys(result.entries())).toEqual(expectedParams);
   });
+
+  describe("Dry Run", () => {
+    it("should add cal.routingFormResponseId=0 when formResponseId is 0", () => {
+      const searchParams = new URLSearchParams("?query1=value1&query2=value2");
+      const expectedParams = {
+        "cal.routingFormResponseId": "0",
+        query1: "value1",
+        query2: "value2",
+      };
+
+      const result = getUrlSearchParamsToForward({
+        formResponse: {},
+        fields: [],
+        searchParams,
+        teamMembersMatchingAttributeLogic: null,
+        formResponseId: 0,
+        queuedFormResponseId: null,
+        attributeRoutingConfig: null,
+      });
+      expect(fromEntriesWithDuplicateKeys(result.entries())).toEqual(expectedParams);
+    });
+  });
 });

--- a/packages/app-store/routing-forms/pages/routing-link/getUrlSearchParamsToForward.ts
+++ b/packages/app-store/routing-forms/pages/routing-link/getUrlSearchParamsToForward.ts
@@ -124,7 +124,9 @@ export function getUrlSearchParamsToForward({
     ...(teamMembersMatchingAttributeLogic
       ? { ["cal.routedTeamMemberIds"]: teamMembersMatchingAttributeLogic.join(",") }
       : null),
-    ...(formResponseId ? { [ROUTING_FORM_RESPONSE_ID_QUERY_STRING]: String(formResponseId) } : null),
+    ...(typeof formResponseId === "number"
+      ? { [ROUTING_FORM_RESPONSE_ID_QUERY_STRING]: String(formResponseId) }
+      : null),
     ...(queuedFormResponseId ? { ["cal.queuedFormResponseId"]: queuedFormResponseId } : null),
     ...attributeRoutingConfigParams,
     ...(reroutingFormResponses

--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -156,6 +156,11 @@ Cal.config = Cal.config || {};
 Cal.config.forwardQueryParams=true
 ```
 
+#### Enabling Logging
+You can enable logging for the embed by adding the `cal.embed.logging=1` query parameter to the URL of the page where the embed is placed. This is useful for debugging issues with the embed. It will log all important things in parent as well as in the iframe(i.e. child)
+
+For example, if your page is `https.example.com/contact`, you can enable logging by visiting `https.example.com/contact?cal.embed.logging=1`.
+
 ### Advanced Features
 
 #### Routing Prerendering System

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -349,8 +349,10 @@ export class Cal {
 
     urlInstance.searchParams.set("embed", this.namespace);
 
-    if (calConfig.debug) {
-      urlInstance.searchParams.set("debug", `${calConfig.debug}`);
+    const pageParams = this.getQueryParamsFromPage();
+    // cal.embed.logging=1 enabled logging in parent and by setting debug=true in iframe, it enables logging in iframe(child) as well
+    if (calConfig.debug || pageParams["cal.embed.logging"] === "1") {
+      urlInstance.searchParams.set("debug", "true");
     }
 
     // Keep iframe invisible, till the embedded calLink sets its color-scheme. This is so that there is no flash of non-transparent(white/black) background


### PR DESCRIPTION
- Ensure that 0 which is falsy is passed as "0" for cal.routingFormResponseId
- Also, made a small improvement to enable logging through `cal.embed.logging=1` query param