### PR TITLE
fix: height of buttons in overrides list

### DIFF
--- a/packages/features/schedules/components/DateOverrideList.tsx
+++ b/packages/features/schedules/components/DateOverrideList.tsx
@@ -106,7 +106,7 @@ const DateOverrideList = ({
                 <DialogTrigger asChild>
                   <Button
                     tooltip={t("edit")}
-                    className="text-default"
+                    className="text-default h-5"
                     color="minimal"
                     variant="icon"
                     StartIcon="pencil"
@@ -116,7 +116,7 @@ const DateOverrideList = ({
             />
             <Tooltip content="Delete">
               <Button
-                className="text-default"
+                className="text-default h-5"
                 data-testid="delete-button"
                 title={t("date_overrides_delete_on_date", {
                   date: new Intl.DateTimeFormat(i18n.language, {


### PR DESCRIPTION
## What does this PR do?

This PR fix the buttons of overrides list in availability.

## Visual Demo (For contributors especially)

- Before 
<img width="703" alt="Screenshot 2025-06-18 at 12 31 48 PM" src="https://github.com/user-attachments/assets/9de90d0c-7f0e-4add-814b-b4b30aa47852" />

- After
<img width="703" alt="Screenshot 2025-06-18 at 1 15 21 PM" src="https://github.com/user-attachments/assets/682a38cf-2d23-4cbc-a5a7-d812c14d0bc4" />


#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the button height in the overrides list to ensure consistent sizing and alignment.

<!-- End of auto-generated description by cubic. -->

