### PR TITLE
fix: 'handles OOO correctly' test fail in non-UTC servertime

### DIFF
--- a/packages/lib/date-ranges.test.ts
+++ b/packages/lib/date-ranges.test.ts
@@ -545,13 +545,13 @@ describe("buildDateRanges", () => {
     });
 
     expect(dateRanges[0]).toEqual({
-      start: dayjs("2023-06-13T14:00:00Z").tz(timeZone),
-      end: dayjs("2023-06-13T19:00:00Z").tz(timeZone),
+      start: dayjs.utc("2023-06-13T14:00:00Z").tz(timeZone),
+      end: dayjs.utc("2023-06-13T19:00:00Z").tz(timeZone),
     });
 
     expect(dateRanges[1]).toEqual({
-      start: dayjs("2023-06-14T12:00:00Z").tz(timeZone),
-      end: dayjs("2023-06-14T21:00:00Z").tz(timeZone),
+      start: dayjs.utc("2023-06-14T12:00:00Z").tz(timeZone),
+      end: dayjs.utc("2023-06-14T21:00:00Z").tz(timeZone),
     });
     expect(oooExcludedDateRanges.length).toBe(1);
     expect(oooExcludedDateRanges[0]).toEqual({

--- a/packages/lib/date-ranges.ts
+++ b/packages/lib/date-ranges.ts
@@ -132,12 +132,9 @@ export function processDateOverride({
   };
 }
 
+// This function processes out-of-office dates and returns a date range for each OOO date.
 function processOOO(outOfOffice: Dayjs, timeZone: string) {
-  const utcOffset = outOfOffice.tz(timeZone).utcOffset();
-  const utcDate = outOfOffice.subtract(utcOffset, "minute");
-
-  const OOOdate = utcDate.tz(timeZone);
-
+  const OOOdate = outOfOffice.tz(timeZone, true);
   return {
     start: OOOdate,
     end: OOOdate,
@@ -171,7 +168,7 @@ export function buildDateRanges({
     }, [])
   );
   const OOOdates = outOfOffice
-    ? Object.keys(outOfOffice).map((outOfOffice) => processOOO(dayjs(outOfOffice), timeZone))
+    ? Object.keys(outOfOffice).map((outOfOffice) => processOOO(dayjs.utc(outOfOffice), timeZone))
     : [];
 
   const groupedOOO = groupByDate(OOOdates);


### PR DESCRIPTION
## What does this PR do?
Fixed the "handles OOO correctly" test to work with non-UTC server times by updating date handling logic.

- **Bug Fixes**
  - Ensured out-of-office date ranges are processed in UTC before applying time zone conversions.

Self review done.