### PR TITLE
fix: add api.bodyParser.sizeLimit of 5mb for image uploads

### DIFF
--- a/apps/web/pages/api/trpc/organizations/[trpc].ts
+++ b/apps/web/pages/api/trpc/organizations/[trpc].ts
@@ -2,3 +2,11 @@ import { createNextApiHandler } from "@calcom/trpc/server/createNextApiHandler";
 import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/organizations/_router";
 
 export default createNextApiHandler(viewerOrganizationsRouter);
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "5mb", // default body size limit of 1MB is not enough for images
+    },
+  },
+};


### PR DESCRIPTION
## What does this PR do?

I added a config to the organizations trpc. Setting `api.bodyParser.sizeLimit` to 5mb for image uploads.
No changes to dependencies required for this change.

- Fixes #21895 (GitHub issue number)
- Fixes CAL-5954 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
  - N/A 
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Upload an image or banner of less then 1mb, b/w 1 and 5mb, and more than 5mb. It works now with images up to 5mb in size (which is quite common).

- Are there environment variables that should be set?
  + No 
- What are the minimal test data to have?
  + Three images of size < 1mb, b/w 1 and 5mb and > 5mb 
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

I've covered all 4 items from the checklist, and hence removed them. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increased the image upload size limit to 5MB for organization API routes to support larger image files.

- **Bug Fixes**
  - Updated body parser config to allow image uploads up to 5MB.

<!-- End of auto-generated description by cubic. -->

