### PR TITLE
fix: don't fetch calendar credentials for top banner

### DIFF
--- a/packages/trpc/server/routers/viewer/me/getUserTopBanners.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/getUserTopBanners.handler.ts
@@ -40,20 +40,20 @@ export const getUserTopBannersHandler = async ({ ctx }: Props) => {
   const upgradeableTeamMememberships = getUpgradeableHandler({ userId: ctx.user.id });
   const upgradeableOrgMememberships = checkIfOrgNeedsUpgradeHandler({ ctx });
   const shouldEmailVerify = shouldVerifyEmailHandler({ ctx });
-  const isInvalidCalendarCredential = checkInvalidGoogleCalendarCredentials({ ctx });
+  // const isInvalidCalendarCredential = checkInvalidGoogleCalendarCredentials({ ctx });
   const appsWithInavlidCredentials = checkInvalidAppCredentials({ ctx });
 
   const [
     teamUpgradeBanner,
     orgUpgradeBanner,
     verifyEmailBanner,
-    calendarCredentialBanner,
+    // calendarCredentialBanner,
     invalidAppCredentialBanners,
   ] = await Promise.allSettled([
     upgradeableTeamMememberships,
     upgradeableOrgMememberships,
     shouldEmailVerify,
-    isInvalidCalendarCredential,
+    // isInvalidCalendarCredential,
     appsWithInavlidCredentials,
   ]);
 
@@ -61,8 +61,7 @@ export const getUserTopBannersHandler = async ({ ctx }: Props) => {
     teamUpgradeBanner: teamUpgradeBanner.status === "fulfilled" ? teamUpgradeBanner.value : [],
     orgUpgradeBanner: orgUpgradeBanner.status === "fulfilled" ? orgUpgradeBanner.value : [],
     verifyEmailBanner: verifyEmailBanner.status === "fulfilled" ? !verifyEmailBanner.value.isVerified : false,
-    calendarCredentialBanner:
-      calendarCredentialBanner.status === "fulfilled" ? calendarCredentialBanner.value : false,
+    calendarCredentialBanner: false,
     invalidAppCredentialBanners:
       invalidAppCredentialBanners.status === "fulfilled" ? invalidAppCredentialBanners.value : [],
   };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

Hide the Invalid Calendar credential top banner to prevent sending too many API requests to google calendar API.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

