### PR TITLE
fix: fixed type mismatch

### DIFF
--- a/packages/prisma/seed.ts
+++ b/packages/prisma/seed.ts
@@ -309,10 +309,14 @@ async function createOrganizationAndAddMembersAndTeams({
 
       const batchResults = await Promise.all(
         batch.map(async (member) => {
+          const { theme, ...restMemberData } = member.memberData;
+          const hash = member.memberData.password.create?.hash;
+          if (!hash) throw new Error(`Password hash is missing for user: ${member.memberData.username}`);
           const newUser = await createUserAndEventType({
             user: {
-              ...member.memberData,
-              password: member.memberData.password.create?.hash,
+              ...restMemberData,
+              ...(theme != null ? { theme: theme as "dark" | "light" } : {}),
+              password: hash,
             },
             eventTypes: [
               {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In the file `packages/prisma/seed.ts`  lines 314-315, there was an error for the password property:
`member.memberData.password.create?.hash`

the error was: 

```
Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
```
The fix included checking if the hash was undefined.

- Fixes #21879 (GitHub issue number)
- Fixes CAL-5950 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a type mismatch in seed.ts by ensuring the password hash is always a string and throwing an error if it is missing.

<!-- End of auto-generated description by cubic. -->

