### PR TITLE
fix: Allow reuseFully option to be configurable from outside

### DIFF
--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -167,7 +167,7 @@ For example, if your page is `https.example.com/contact`, you can enable logging
 The prerendering system optimizes the initial load:
 ```typescript
 Cal.prerender({
-  calLink: "organization/event-type",
+  calLink,
   type: "modal"
 });
 ```
@@ -178,24 +178,63 @@ Key aspects:
 - Loads the booking page but doesn't send the slots availability request
 - Tries to reuse whenever it makes sense and do a fresh load otherwise
 
-Iframe Reuse and Reload Conditions. There could be three situations:
+Modal's Iframe Reuse and Reload Conditions. There could be three situations:
 
-1. Reuse
-2. Reuse the iframe but refetch the slots
-3. Do a fresh load in iframe
+1. Show modal as is. No connect and no requests happen - Corresponding action is "noAction"
+2. Connect but don't fetch the slots- Corresponding action is "connect-no-slots-fetch"
+3. Connect and fetch the slots - Corresponding action is "connect"
+4. Do a fresh load in iframe. Corresponding action is "fullReload"
 
-- **Reuse**:
-  - Modal opens when
-    - Modal is not in a failed state
-    - config, params are same as the last time
-    - No threshold violations
+- **Show modal as is**:
+  - Modal is not in a failed state
+  - config, params are same as the last time
+  - No time threshold violations
 
-- **Reuse the iframe but refetch the slots**:
+- **Connect but don't fetch the slots**:
   - Only embed `config` changes (handled via "connect" flow)
   - Query query params changes (handled via "connect" flow)
   - Crossed slots stale time threshold (EMBED_MODAL_IFRAME_SLOT_STALE_TIME)
 
-- **Fresh Reload Conditions**:
+- **Connect and fetch the slots**:
+  - Slots are stale
+  - Crossed slots stale time threshold (EMBED_MODAL_IFRAME_SLOT_STALE_TIME)
+
+- **Do a fresh load in iframe**:
   - Different path being loaded(i.e. /pro vs /free)
   - Modal is in a failed state
   - Time since last render exceeds EMBED_MODAL_IFRAME_FORCE_RELOAD_THRESHOLD_MS
+
+
+#### Prerendering headless router
+
+**Without namespace:**
+Prerender when there are high changes of user clicking the CTA.
+```js
+Cal('prerender', {
+  calLink: "router?formId=123&ATLEAST_ALL_FIELDS_REQUIRED_BY_ROUTING_RULES_SHOULD_BE_PRESENT_HERE",
+  // Prerender right now works only with "modal", so 'element click' embed is able to reuse this prerendered iframe
+  type: "modal"
+  // Shows skeleton loader for a Team Event's booking slots page
+  pageType: "team.event.booking.slots"
+});
+```
+Using the prerendered iframe with a CTA:
+```js
+<button data-cal-link="router?formId=123&ALL_FIELDS_HERE">Demo</button>
+```
+
+**With namespace:**
+Prerender when there are high changes of user clicking the CTA.
+```js
+Cal.ns.myNamespace('prerender', {
+  calLink: "router?formId=123&ATLEAST_ALL_FIELDS_REQUIRED_BY_ROUTING_RULES_SHOULD_BE_PRESENT_HERE",
+  // Prerender right now works only with "modal", so 'element click' embed is able to reuse this prerendered iframe
+  type: "modal"
+  // Shows skeleton loader for a Team Event's booking slots page
+  pageType: "team.event.booking.slots"
+});
+```
+Using the prerendered iframe with a CTA:
+```js
+<button data-cal-namespace="myNamespace" data-cal-link="router?formId=123&ALL_FIELDS_HERE">Demo</button>
+```

--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -213,7 +213,7 @@ Prerender when there are high chances of user clicking the CTA.
 Cal('prerender', {
   calLink: "router?formId=123&ATLEAST_ALL_FIELDS_REQUIRED_BY_ROUTING_RULES_SHOULD_BE_PRESENT_HERE",
   // Prerender right now works only with "modal", so 'element click' embed is able to reuse this prerendered iframe
-  type: "modal"
+  type: "modal",
   // Shows skeleton loader for a Team Event's booking slots page
   pageType: "team.event.booking.slots"
 });

--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -208,7 +208,7 @@ Modal's Iframe Reuse and Reload Conditions. There could be four situations:
 #### Prerendering headless router
 
 **Without namespace:**
-Prerender when there are high changes of user clicking the CTA.
+Prerender when there are high chances of user clicking the CTA.
 ```js
 Cal('prerender', {
   calLink: "router?formId=123&ATLEAST_ALL_FIELDS_REQUIRED_BY_ROUTING_RULES_SHOULD_BE_PRESENT_HERE",

--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -178,7 +178,7 @@ Key aspects:
 - Loads the booking page but doesn't send the slots availability request
 - Tries to reuse whenever it makes sense and do a fresh load otherwise
 
-Modal's Iframe Reuse and Reload Conditions. There could be three situations:
+Modal's Iframe Reuse and Reload Conditions. There could be four situations:
 
 1. Show modal as is. No connect and no requests happen - Corresponding action is "noAction"
 2. Connect but don't fetch the slots- Corresponding action is "connect-no-slots-fetch"

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -999,9 +999,12 @@ class CalApi {
     const containerEl = document.body;
     this.cal.isPrerendering = !!__prerender;
     if (__prerender) {
-      // TODO: Make `reuseFully` a configurable param as well later.
       // If someone's preloading the headless router path, we must reuse the iframe fully as is as Router would redirect to a Booking Page and that should be shown as is
-      this.prerenderOptions = { ...prerenderOptions, reuseFully: isHeadlessRouterPath };
+      this.prerenderOptions = {
+        ...prerenderOptions,
+        // If user has given a preference to reuseFully honour it. Otherwise, if it's a headless router path, we should reuse fully by default
+        reuseFully: prerenderOptions.reuseFully ?? isHeadlessRouterPath,
+      };
       // Add prerender query param
       config.prerender = "true";
 


### PR DESCRIPTION
## What does this PR do?
Allow `reuseFully` option to be configurable from outside
