### PR TITLE
fix: can save an event type without a slug

### DIFF
--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -228,7 +228,11 @@ export type IntervalLimitsType = IntervalLimit | null;
 
 export { intervalLimitsType } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 
-export const eventTypeSlug = z.string().transform((val) => slugify(val.trim()));
+export const eventTypeSlug = z
+  .string()
+  .trim()
+  .min(1)
+  .transform((val) => slugify(val));
 
 export const stringToDate = z.string().transform((a) => new Date(a));
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -231,8 +231,10 @@ export { intervalLimitsType } from "@calcom/lib/intervalLimits/intervalLimitSche
 export const eventTypeSlug = z
   .string()
   .trim()
-  .min(1)
-  .transform((val) => slugify(val));
+  .transform((val) => slugify(val))
+  .refine((val) => val.length >= 1, {
+    message: "Please enter at least one character",
+  });
 
 export const stringToDate = z.string().transform((a) => new Date(a));
 


### PR DESCRIPTION
## What does this PR do?

Fixed an issue where event types could be saved without a slug by requiring the slug field to have at least one character. Also i can sabe the slug with any special character for eg:- "!!!"

<!-- End of auto-generated description by cubic. -->

