### PR TITLE
fix: issue #9523 limited scroll range on mobile device

### DIFF
--- a/packages/features/ee/payments/components/PaymentPage.tsx
+++ b/packages/features/ee/payments/components/PaymentPage.tsx
@@ -89,7 +89,7 @@ const PaymentPage: FC<PaymentPageProps> = (props) => {
   return (
     <div className="h-screen">
       <main className="mx-auto max-w-3xl py-24">
-        <div className="fixed inset-0 z-50 overflow-y-auto scroll-auto">
+        <div className="fixed inset-0 z-50">
           <div className="flex min-h-screen items-end justify-center px-4 pb-20 pt-4 text-center sm:block sm:p-0">
             <div className="inset-0 my-4 transition-opacity sm:my-0" aria-hidden="true">
               <span className="hidden sm:inline-block sm:h-screen sm:align-middle" aria-hidden="true">


### PR DESCRIPTION
## What does this PR do? 

Re-opening of [pull/15505](https://github.com/calcom/cal.com/pull/15505) to provide evidence previously requested
> overflow-y-auto and scroll-auto are removed to prevent having a double scroll wheel that causes the users to be unable to scroll through the page as expected unless they begin to click into the form and fill out payment info


- Fixes #9523 
- Fixes [CAL-4156](https://linear.app/calcom/issue/CAL-4156/stripe-app-overflow-y-auto-limits-scroll-range-on-mobile-device) 

#### Evidence
<details>
  <summary>Existing Problem</summary>
  
 https://github.com/user-attachments/assets/22b6b59a-6357-43c1-8c3d-3c81a7acaa3e
</details>

<details>
  <summary>Suggested Fix</summary>
 <img width="400" alt="Image" src="https://github.com/user-attachments/assets/fb13163a-8ff2-4b5d-8600-2bde539f148d" />
 
 https://github.com/user-attachments/assets/d067c195-3a22-4133-82b6-64c9542ea383
</details>

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [n/a] I have added a Docs issue [here](https://github.com/calcom/docs/issues/new) if this PR makes changes that would require a [documentation change](https://docs.cal.com)
- [ n/a] I have added or modified automated tests that prove my fix is effective or that my feature works (PRs might be rejected if logical changes are not properly tested)

## How should this be tested?

Embed it on a webpage and access it through a mobile device (iPhone 12 Pro on my end). When you click to pay and the payment information is displayed, the user won’t be able to see the input section—or it will be very difficult to access.

This fix resolves the issue.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed extra scroll settings from the payment page to fix limited scrolling on mobile devices. Users can now scroll through the payment form as expected.

<!-- End of auto-generated description by cubic. -->

