### PR TITLE
fix: gap between reschedule label and user on mobile screen

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -546,7 +546,7 @@ export default function Success(props: PageProps) {
                           </h4>
                         )}
 
-                      <div className="border-subtle text-default mt-8 grid grid-cols-3 border-t pt-8 text-left rtl:text-right">
+                      <div className="border-subtle text-default mt-8 grid grid-cols-3 gap-x-4 border-t pt-8 text-left rtl:text-right sm:gap-x-0">
                         {(isCancelled || reschedule) && cancellationReason && (
                           <>
                             <div className="font-medium">


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where there is no gap between rescheduled by label and the user on the /bookings/<booking-id> page on mobile devices.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before (No Gap between Rescheduled By and user):

<img width="313" alt="image" src="https://github.com/user-attachments/assets/fede4f4c-e67a-4c54-8a67-77398ce74f40" />

After (Sufficient gap between rescheduled by label and user):

<img width="313" alt="image" src="https://github.com/user-attachments/assets/67994aa5-2362-40c7-987a-2390787535b5" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the missing gap between the "rescheduled by" label and the user on mobile booking pages.

<!-- End of auto-generated description by cubic. -->

