### PR TITLE
feat: enable schedule restriction on platform

### DIFF
--- a/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
+++ b/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
@@ -813,7 +813,7 @@ const UseTeamEventScheduleSettingsToggle = ({
   ...rest
 }: UseTeamEventScheduleSettingsToggle) => {
   const { t } = useLocale();
-  const isPlatform = useIsPlatform();
+  // const isPlatform = useIsPlatform();
   const { useHostSchedulesForTeamEvent, toggleScheduleState } = useCommonScheduleState(eventType.schedule);
   const { restrictScheduleForHosts, toggleRestrictScheduleState } = useRestrictionScheduleState(
     eventType.restrictionScheduleId
@@ -856,7 +856,7 @@ const UseTeamEventScheduleSettingsToggle = ({
           </div>
         )}
       </div>
-      {!isPlatform && isRestrictionScheduleEnabled ? (
+      {isRestrictionScheduleEnabled ? (
         <div className="border-subtle space-y-6 rounded-lg border p-6">
           <SettingsToggle
             checked={restrictScheduleForHosts}


### PR DESCRIPTION
## What does this PR do?

This PR enables the "Restrict schedule for hosts" feature on the Cal.com platform by passing the required props (`restrictionScheduleQueryData`, `isRestrictionSchedulePending`, `restrictionScheduleRedirectUrl`) into `EventAvailabilityTabPlatformWrapper.tsx`, 
similar to how it's done in `EventAvailabilityTabWebWrapper.tsx.`

Previously, the setting was hidden behind a platform check (`!isPlatform`) as a temporary workaround. With this update, that condition is removed and full functionality is restored for platform users.

- Fixes #21837 
- Fixes CAL-5932 


#### Video Demo (if applicable):

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled the "Restrict schedule for hosts" feature on the platform by passing the needed props and removing the platform check, so platform users can now use schedule restrictions.

<!-- End of auto-generated description by cubic. -->

