### PR TITLE
fix: Downgrades typescript to 5.7.2

### DIFF
--- a/apps/api/v1/package.json
+++ b/apps/api/v1/package.json
@@ -38,7 +38,7 @@
     "next-axiom": "^0.17.0",
     "next-swagger-doc": "^0.3.6",
     "next-validations": "^0.2.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "tzdata": "^1.0.30",
     "uuid": "^8.3.2",
     "zod": "^3.22.4"

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -108,7 +108,7 @@
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   },
   "prisma": {
     "schema": "../../../packages/prisma/schema.prisma"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -194,7 +194,7 @@
     "tailwindcss": "^3.3.3",
     "tailwindcss-animate": "^1.0.6",
     "ts-node": "^10.9.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   },
   "nextBundleAnalysis": {
     "budget": 358400,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "prismock": "^1.33.4",
     "resize-observer-polyfill": "^1.5.1",
     "tsc-absolute": "^1.0.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vitest": "^2.1.1",
     "vitest-fetch-mock": "^0.3.0",
     "vitest-mock-extended": "^2.0.2"

--- a/packages/app-store-cli/package.json
+++ b/packages/app-store-cli/package.json
@@ -31,6 +31,6 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -33,6 +33,6 @@
     "prettier-plugin-tailwindcss": "^0.2.5",
     "tailwind-scrollbar": "^2.0.1",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -54,7 +54,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.18",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vite": "^4.1.2",
     "vite-plugin-environment": "^1.1.3"
   }

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -50,7 +50,7 @@
     "@vitejs/plugin-react": "^2.2.0",
     "eslint": "^8.34.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vite": "^4.5.2"
   },
   "dependencies": {

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -25,7 +25,7 @@
   ],
   "types": "./dist/index.d.ts",
   "devDependencies": {
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vite": "^4.1.2"
   },
   "dependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,7 +8,7 @@
     "@typescript-eslint/parser": "^5.52.0",
     "@typescript-eslint/utils": "^5.52.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   },
   "devDependencies": {
     "@types/eslint": "^8.4.5"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,6 +34,6 @@
     "@calcom/tsconfig": "*",
     "@calcom/types": "*",
     "@faker-js/faker": "^7.3.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -27,7 +27,7 @@
     "postcss-prefixwrap": "1.46.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vite": "^5.0.10",
     "vite-plugin-dts": "^3.7.3",
     "vite-plugin-inspect": "^0.8.4",

--- a/packages/platform/examples/base/package.json
+++ b/packages/platform/examples/base/package.json
@@ -26,6 +26,6 @@
     "eslint-config-next": "14.0.4",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/node": "^20.3.1",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.8.3",
+    "typescript": "^5.7.2",
     "vite": "^5.0.12",
     "vite-plugin-dts": "^3.7.2",
     "vite-plugin-environment": "^1.1.3"

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -22,6 +22,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -112,6 +112,6 @@
     "fs-extra": "^11.2.0",
     "lucide-static": "^0.424.0",
     "node-html-parser": "^6.1.13",
-    "typescript": "^5.8.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,7 +2584,7 @@ __metadata:
     ts-loader: ^9.4.3
     ts-node: ^10.9.1
     tsconfig-paths: ^4.1.0
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     uuid: ^8.3.2
     winston: ^3.13.0
     winston-transport: ^4.7.0
@@ -2614,7 +2614,7 @@ __metadata:
     next-swagger-doc: ^0.3.6
     next-validations: ^0.2.0
     node-mocks-http: ^1.11.0
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     tzdata: ^1.0.30
     uuid: ^8.3.2
     zod: ^3.22.4
@@ -2636,7 +2636,7 @@ __metadata:
     meow: ^9.0.0
     react: ^18.2.0
     ts-node: ^10.9.1
-    typescript: ^5.8.3
+    typescript: ^5.7.2
   bin:
     app-store-cli: dist/cli.js
   languageName: unknown
@@ -2705,7 +2705,7 @@ __metadata:
     tailwindcss: ^3.3.3
     tailwindcss-animate: ^1.0.6
     ts-jest: ^29.1.2
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vite: ^5.0.10
     vite-plugin-dts: ^3.7.3
     vite-plugin-inspect: ^0.8.4
@@ -2763,7 +2763,7 @@ __metadata:
     react-dom: ^18
     react-select: ^5.8.0
     tailwindcss: ^3.3.0
-    typescript: ^5.8.3
+    typescript: ^5.7.2
   languageName: unknown
   linkType: soft
 
@@ -2859,7 +2859,7 @@ __metadata:
     prettier-plugin-tailwindcss: ^0.2.5
     tailwind-scrollbar: ^2.0.1
     tailwindcss: ^3.3.3
-    typescript: ^5.8.3
+    typescript: ^5.7.2
   languageName: unknown
   linkType: soft
 
@@ -3011,7 +3011,7 @@ __metadata:
     npm-run-all: ^4.1.5
     postcss: ^8.4.18
     tailwindcss: ^3.3.3
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vite: ^4.1.2
     vite-plugin-environment: ^1.1.3
   languageName: unknown
@@ -3029,7 +3029,7 @@ __metadata:
     "@vitejs/plugin-react": ^2.2.0
     eslint: ^8.34.0
     npm-run-all: ^4.1.5
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vite: ^4.5.2
   peerDependencies:
     react: ^18.2.0 || ^19.0.0
@@ -3042,7 +3042,7 @@ __metadata:
   resolution: "@calcom/embed-snippet@workspace:packages/embeds/embed-snippet"
   dependencies:
     "@calcom/embed-core": "workspace:*"
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vite: ^4.1.2
   languageName: unknown
   linkType: soft
@@ -3055,7 +3055,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.52.0
     "@typescript-eslint/utils": ^5.52.0
     ts-node: ^10.9.1
-    typescript: ^5.8.3
+    typescript: ^5.7.2
   languageName: unknown
   linkType: soft
 
@@ -3391,7 +3391,7 @@ __metadata:
     sonner: ^1.7.4
     tsdav: 2.0.3
     tslog: ^4.9.2
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -3595,7 +3595,7 @@ __metadata:
     "@calcom/lib": "*"
     "@types/node": ^20.3.1
     "@vitejs/plugin-react": ^4.2.1
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vite: ^5.0.12
     vite-plugin-dts: ^3.7.2
     vite-plugin-environment: ^1.1.3
@@ -3900,7 +3900,7 @@ __metadata:
     "@trpc/react-query": 11.0.0-next-beta.222
     "@trpc/server": 11.0.0-next-beta.222
     superjson: 1.9.1
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     zod: ^3.22.4
   languageName: unknown
   linkType: soft
@@ -3972,7 +3972,7 @@ __metadata:
     react-inlinesvg: ^4.1.3
     react-select: ^5.7.0
     tailwind-merge: ^1.13.2
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     uuid: ^11.1.0
   languageName: unknown
   linkType: soft
@@ -4180,7 +4180,7 @@ __metadata:
     tailwindcss-radix: ^2.6.0
     ts-node: ^10.9.1
     turndown: ^7.1.3
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     uuid: ^8.3.2
     zod: ^3.22.4
   languageName: unknown
@@ -21853,7 +21853,7 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     tsc-absolute: ^1.0.0
     turbo: ^1.10.1
-    typescript: ^5.8.3
+    typescript: ^5.7.2
     vitest: ^2.1.1
     vitest-fetch-mock: ^0.3.0
     vitest-mock-extended: ^2.0.2
@@ -45875,7 +45875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2, typescript@npm:^5.8.3":
+"typescript@npm:^5.2.2":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -45915,7 +45915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.8.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=1f5320"
   bin:


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #21955 

**Testing Methodology:**

1. **Reproduction**: Consistently reproducible on TypeScript 5.8.3 with Cal.com codebase
2. **Isolation**: Verified same codebase works perfectly with TypeScript 5.8.2
3. **Workaround**: Downgrading to 5.8.2 immediately resolves the issue
4. **Command Output**:

**Failed with TypeScript 5.8.3:**

<img width="522" alt="Image" src="https://github.com/user-attachments/assets/0e40cbcd-91d7-4de1-bceb-9e5e0e8d3563" />

**Successful with TypeScript 5.8.2:**

<img width="657" alt="Image" src="https://github.com/user-attachments/assets/6137a1d6-105d-4e85-aa76-5ceb8ba4dcc7" />

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Locally, run `yarn type-check --filter=@calcom/web --force`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Downgraded TypeScript from 5.8.3 to 5.7.2 across all packages to resolve compatibility issues.

<!-- End of auto-generated description by cubic. -->

