### PR TITLE
fix: Double skeleton apps page

### DIFF
--- a/packages/app-store/components.tsx
+++ b/packages/app-store/components.tsx
@@ -1,20 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
 
 import type { UseAddAppMutationOptions } from "@calcom/app-store/_utils/useAddAppMutation";
 import useAddAppMutation from "@calcom/app-store/_utils/useAddAppMutation";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { deriveAppDictKeyFromType } from "@calcom/lib/deriveAppDictKeyFromType";
-import { useHasTeamPlan } from "@calcom/lib/hooks/useHasPaidPlan";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import type { App } from "@calcom/types/App";
-import { Icon } from "@calcom/ui/components/icon";
 import classNames from "@calcom/ui/classNames";
+import { Icon } from "@calcom/ui/components/icon";
 
 import { InstallAppButtonMap } from "./apps.browser.generated";
 import type { InstallAppButtonProps } from "./types";
@@ -59,44 +55,8 @@ export const InstallAppButton = (
     disableInstall?: boolean;
   } & InstallAppButtonProps
 ) => {
-  const { isPending: isUserLoading, data: user } = trpc.viewer.me.get.useQuery();
-  const router = useRouter();
-  const proProtectionElementRef = useRef<HTMLDivElement | null>(null);
-  const { isPending: isTeamPlanStatusLoading, hasTeamPlan } = useHasTeamPlan();
-
-  useEffect(() => {
-    const el = proProtectionElementRef.current;
-    if (!el) {
-      return;
-    }
-    el.addEventListener(
-      "click",
-      (e) => {
-        if (!user) {
-          router.push(
-            `${WEBAPP_URL}/auth/login?callbackUrl=${WEBAPP_URL + location.pathname + location.search}`
-          );
-          e.stopPropagation();
-          return;
-        }
-
-        if (props.teamsPlanRequired && !hasTeamPlan) {
-          // TODO: I think we should show the UpgradeTip in a Dialog here. This would solve the problem of no way to go back to the App page from the UpgradeTip page(except browser's back button)
-          router.push(props.teamsPlanRequired.upgradeUrl);
-          e.stopPropagation();
-          return;
-        }
-      },
-      true
-    );
-  }, [isUserLoading, user, router, hasTeamPlan, props.teamsPlanRequired]);
-
-  if (isUserLoading || isTeamPlanStatusLoading) {
-    return null;
-  }
-
   return (
-    <div ref={proProtectionElementRef} className={props.wrapperClassName}>
+    <div className={props.wrapperClassName}>
       <InstallAppButtonWithoutPlanCheck {...props} />
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

Fix double skeleton loading screen on apps

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

**BEFORE**

[Screencast from 2025-06-23 00-27-36.webm](https://github.com/user-attachments/assets/79b364fc-bfe8-45a3-851f-ad651b3e96ee)

**AFTER**

[Screencast from 2025-06-23 00-49-11.webm](https://github.com/user-attachments/assets/9ceabacc-a6e9-43a2-902c-63091f97bc05)



#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the apps page showed two skeleton loading screens instead of one.

- **Bug Fixes**
  - Removed duplicate loading logic to prevent double skeleton display.

<!-- End of auto-generated description by cubic. -->

