### PR TITLE
revert: "CI: skip draft from releases"

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -44,7 +44,7 @@ jobs:
           git push
 
       - name: Draft release
-        run: gh release create v$VERSION --generate-notes
+        run: gh release create v$VERSION --generate-notes --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.next_version }}


### PR DESCRIPTION
Reverts calcom/cal.com#21932
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restored the creation of draft releases in the CI workflow by adding the --draft flag back to the release command.

<!-- End of auto-generated description by cubic. -->

