### PR TITLE
fix: Zoom missing property schedule_meeting sometimes

### DIFF
--- a/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/zoomvideo/lib/VideoApiAdapter.ts
@@ -63,12 +63,16 @@ export type ZoomUserSettings = z.infer<typeof zoomUserSettingsSchema>;
 
 /** @link https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/userSettings */
 export const zoomUserSettingsSchema = z.object({
-  recording: z.object({
-    auto_recording: z.string(),
-  }),
-  schedule_meeting: z.object({
-    default_password_for_scheduled_meetings: z.string(),
-  }),
+  recording: z
+    .object({
+      auto_recording: z.string(),
+    })
+    .nullish(),
+  schedule_meeting: z
+    .object({
+      default_password_for_scheduled_meetings: z.string(),
+    })
+    .nullish(),
 });
 
 // https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/userSettings


### PR DESCRIPTION
Make the props optional in `users/me/settings`