### PR TITLE
Revert "fix: multi-line formatted correctly for sms"

### DIFF
--- a/packages/ui/components/editor/Editor.test.tsx
+++ b/packages/ui/components/editor/Editor.test.tsx
@@ -7,7 +7,7 @@ import type { TextEditorProps } from "./types";
 
 describe("Editor", () => {
   const defaultProps: TextEditorProps = {
-    getText: vi.fn(() => ""),
+    getText: vi.fn(),
     setText: vi.fn(),
     variables: ["name", "email"],
     height: "200px",

--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -220,7 +220,6 @@ function getSelectedNode(selection: RangeSelection) {
 }
 
 export default function ToolbarPlugin(props: TextEditorProps) {
-  const isInitialized = useRef(false);
   const [editor] = useLexicalComposerContext();
   const toolbarRef = useRef(null);
   const [blockType, setBlockType] = useState("paragraph");
@@ -365,13 +364,11 @@ export default function ToolbarPlugin(props: TextEditorProps) {
   }, [props.updateTemplate]);
 
   useEffect(() => {
-    if (props.setFirstRender && !isInitialized.current) {
-      isInitialized.current = true;
+    if (props.setFirstRender) {
       props.setFirstRender(false);
       editor.update(() => {
         const parser = new DOMParser();
-        const content = props.getText()?.replace(/\n/g, "<br>");
-        const dom = parser.parseFromString(content, "text/html");
+        const dom = parser.parseFromString(props.getText(), "text/html");
 
         const nodes = $generateNodesFromDOM(editor, dom);
 


### PR DESCRIPTION
Reverts calcom/cal.com#21779

The PR calcom/cal.com#21779 is causing a weird formatting issue in the event description
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted the recent fix for multi-line formatting in SMS templates to restore previous editor behavior. This undoes changes to how newlines are handled in the editor toolbar plugin and related tests.

<!-- End of auto-generated description by cubic. -->

