### PR TITLE
fix: background of event advanced questions section in dark theme

### DIFF
--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -577,7 +577,7 @@ export const EventAdvancedTab = ({
         />
       )}
 
-      <div className="border-subtle bg-muted rounded-lg border p-1">
+      <div className="border-subtle rounded-lg border p-1">
         <div className="p-5">
           <div className="text-default text-sm font-semibold leading-none ltr:mr-1 rtl:ml-1">
             {t("booking_questions_title")}
@@ -586,7 +586,7 @@ export const EventAdvancedTab = ({
             {t("booking_questions_description")}
           </p>
         </div>
-        <div className="border-subtle rounded-lg border bg-white p-5 dark:bg-black">
+        <div className="border-subtle rounded-lg border p-5">
           <FormBuilder
             showPhoneAndEmailToggle
             title={t("confirmation")}

--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -586,7 +586,7 @@ export const EventAdvancedTab = ({
             {t("booking_questions_description")}
           </p>
         </div>
-        <div className="border-subtle rounded-lg border bg-white p-5">
+        <div className="border-subtle rounded-lg border bg-white p-5 dark:bg-black">
           <FormBuilder
             showPhoneAndEmailToggle
             title={t("confirmation")}

--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -577,7 +577,7 @@ export const EventAdvancedTab = ({
         />
       )}
 
-      <div className="border-subtle rounded-lg border p-1">
+      <div className="border-subtle bg-muted rounded-lg border p-1">
         <div className="p-5">
           <div className="text-default text-sm font-semibold leading-none ltr:mr-1 rtl:ml-1">
             {t("booking_questions_title")}
@@ -586,7 +586,7 @@ export const EventAdvancedTab = ({
             {t("booking_questions_description")}
           </p>
         </div>
-        <div className="border-subtle rounded-lg border p-5">
+        <div className="border-subtle bg-default rounded-lg border p-5">
           <FormBuilder
             showPhoneAndEmailToggle
             title={t("confirmation")}


### PR DESCRIPTION
## What does this PR do?

### Before:

<img width="1263" alt="Screenshot 2025-06-23 at 6 23 24 PM" src="https://github.com/user-attachments/assets/e7e2e24e-969e-4fd6-8082-27231a5a3a8f" />

### After:

<img width="1214" alt="Screenshot 2025-06-23 at 6 23 03 PM" src="https://github.com/user-attachments/assets/e42217a2-45ce-4691-b049-39f1ccae9a5b" />



## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the background color of the event advanced questions section so it displays correctly in dark theme.

<!-- End of auto-generated description by cubic. -->

