### PR TITLE
fix: crash due to lack of input validation in WizardForm

### DIFF
--- a/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
@@ -23,7 +23,7 @@ export const generateMetadata = async () => {
 };
 
 const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
-const stepSchema = z.coerce.number().int().min(1).max(4).default(1);
+const stepSchema = z.enum(["1", "2", "3", "4"]);
 
 const ServerPage = async ({ params, searchParams: _searchParams }: ServerPageProps) => {
   const searchParams = await _searchParams;

--- a/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
@@ -2,6 +2,8 @@ import { withAppDirSsr } from "app/WithAppDirSsr";
 import type { PageProps as ServerPageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { z } from "zod";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
@@ -21,11 +23,18 @@ export const generateMetadata = async () => {
 };
 
 const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
+const stepSchema = z.coerce.number().int().min(1).max(4).default(1);
 
-const ServerPage = async ({ params, searchParams }: ServerPageProps) => {
-  const props = await getData(
-    buildLegacyCtx(await headers(), await cookies(), await params, await searchParams)
-  );
+const ServerPage = async ({ params, searchParams: _searchParams }: ServerPageProps) => {
+  const searchParams = await _searchParams;
+  const stepResult = stepSchema.safeParse(searchParams?.step);
+
+  // If step parameter is invalid, redirect to step 1
+  if (!stepResult.success) {
+    return redirect(`/auth/setup?step=1`);
+  }
+
+  const props = await getData(buildLegacyCtx(await headers(), await cookies(), await params, searchParams));
   return <Setup {...props} />;
 };
 

--- a/packages/ui/components/form/wizard/WizardForm.tsx
+++ b/packages/ui/components/form/wizard/WizardForm.tsx
@@ -5,6 +5,7 @@ import { noop } from "lodash";
 import { useRouter } from "next/navigation";
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
+import { z } from "zod";
 
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import classNames from "@calcom/ui/classNames";
@@ -35,7 +36,8 @@ function WizardForm<T extends DefaultStep>(props: {
   const searchParams = useCompatSearchParams();
   const { href, steps, nextLabel = "Next", finishLabel = "Finish", prevLabel = "Back", stepLabel } = props;
   const router = useRouter();
-  const step = parseInt((searchParams?.get("step") as string) || "1");
+  const stepSchema = z.coerce.number().int().min(1).max(steps.length).default(1);
+  const step = stepSchema.parse(searchParams?.get("step"));
   const currentStep = steps[step - 1];
   const setStep = (newStep: number) => {
     router.replace(`${href}?step=${newStep || 1}`);

--- a/packages/ui/components/form/wizard/WizardForm.tsx
+++ b/packages/ui/components/form/wizard/WizardForm.tsx
@@ -37,7 +37,8 @@ function WizardForm<T extends DefaultStep>(props: {
   const { href, steps, nextLabel = "Next", finishLabel = "Finish", prevLabel = "Back", stepLabel } = props;
   const router = useRouter();
   const stepSchema = z.coerce.number().int().min(1).max(steps.length).default(1);
-  const step = stepSchema.parse(searchParams?.get("step"));
+  const stepResult = stepSchema.safeParse(searchParams?.get("step"));
+  const step = stepResult.success ? stepResult.data : 1;
   const currentStep = steps[step - 1];
   const setStep = (newStep: number) => {
     router.replace(`${href}?step=${newStep || 1}`);


### PR DESCRIPTION
## What does this PR do?

- Fixed a client error in WizardForm by adding both client-side input validation (to WizardForm component) and server-side input validation (to `/auth/setup` RSC)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

`/auth/setup?step=RandomString` led to a crash before. Now it should redirect you to `/auth/setup?step=1`