### PR TITLE
fix: Avoid cross origin XHR for slots/available

### DIFF
--- a/packages/features/schedules/lib/use-schedule/useApiV2AvailableSlots.ts
+++ b/packages/features/schedules/lib/use-schedule/useApiV2AvailableSlots.ts
@@ -32,12 +32,9 @@ export const useApiV2AvailableSlots = ({
     ],
     queryFn: () => {
       return axios
-        .get<ApiResponse<GetAvailableSlotsResponse>>(
-          `${process.env.NEXT_PUBLIC_API_V2_URL}/slots/available`,
-          {
-            params: rest,
-          }
-        )
+        .get<ApiResponse<GetAvailableSlotsResponse>>("/api/v2/slots/available", {
+          params: rest,
+        })
         .then((res) => {
           if (res.data.status === "success") {
             return (res.data as ApiSuccessResponse<GetAvailableSlotsResponse>).data;


### PR DESCRIPTION
## What does this PR do?

Cross origin XHR request fails to initiate if there is a custom request header that is not whitelisted. So, to avoide accidental failure of slots/available request we ensure that it is sent from the same origin.

More Context: [Private Link](https://calendso.slack.com/archives/C08AUBQHM71/p1750769680468679?thread_ts=1750760660.069569&cid=C08AUBQHM71)

#### Video Demo (if applicable):
Demo shows before and after
https://www.loom.com/share/5eafb1976a17424cbcd968a83e1c9184

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.



