### PR TITLE
fix: google calendar event creation failure due to invalid timezone

### DIFF
--- a/packages/features/cityTimezones/cityTimezonesHandler.ts
+++ b/packages/features/cityTimezones/cityTimezonesHandler.ts
@@ -23,9 +23,6 @@ export const cityTimezonesHandler = async () => {
   uniqueCities.forEach((city) => {
     if (city.city === "London") city.timezone = "Europe/London";
     if (city.city === "Londonderry") city.city = "London";
-    if (city.timezone === "America/Port_Of_Spain") city.timezone = "America/Port_of_Spain";
-    if (city.timezone === "Africa/Porto-novo") city.timezone = "Africa/Porto-Novo";
-    if (city.timezone === "Africa/Dar_Es_Salaam") city.timezone = "Africa/Dar_es_Salaam";
   });
 
   return uniqueCities;

--- a/packages/features/cityTimezones/cityTimezonesHandler.ts
+++ b/packages/features/cityTimezones/cityTimezonesHandler.ts
@@ -23,6 +23,9 @@ export const cityTimezonesHandler = async () => {
   uniqueCities.forEach((city) => {
     if (city.city === "London") city.timezone = "Europe/London";
     if (city.city === "Londonderry") city.city = "London";
+    if (city.timezone === "America/Port_Of_Spain") city.timezone = "America/Port_of_Spain";
+    if (city.timezone === "Africa/Porto-novo") city.timezone = "Africa/Porto-Novo";
+    if (city.timezone === "Africa/Dar_Es_Salaam") city.timezone = "Africa/Dar_es_Salaam";
   });
 
   return uniqueCities;

--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -127,6 +127,22 @@ export function TimezoneSelectComponent({
       }}
       onInputChange={handleInputChange}
       {...props}
+      onChange={(selectedOption) => {
+        if (!props.onChange) return;
+
+        // Fix inconsistent timezone naming formats
+        const corrections = {
+          "America/Port_Of_Spain": "America/Port_of_Spain",
+          "Africa/Porto-novo": "Africa/Porto-Novo",
+          "Africa/Dar_Es_Salaam": "Africa/Dar_es_Salaam",
+        };
+
+        if (corrections[selectedOption.value]) {
+          selectedOption.value = corrections[selectedOption.value];
+        }
+
+        props.onChange(selectedOption);
+      }}
       formatOptionLabel={(option) => (
         <p className="truncate">{(option as ITimezoneOption).value.replace(/_/g, " ")}</p>
       )}

--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -131,7 +131,7 @@ export function TimezoneSelectComponent({
         if (!props.onChange) return;
 
         // Fix inconsistent timezone naming formats
-        const corrections = {
+        const corrections: Record<string, string> = {
           "America/Port_Of_Spain": "America/Port_of_Spain",
           "Africa/Porto-novo": "Africa/Porto-Novo",
           "Africa/Dar_Es_Salaam": "Africa/Dar_es_Salaam",

--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -130,6 +130,11 @@ export function TimezoneSelectComponent({
       onChange={(selectedOption) => {
         if (!props.onChange) return;
 
+        if (!selectedOption) {
+          props.onChange(selectedOption);
+          return;
+        }
+
         // Fix inconsistent timezone naming formats
         const corrections: Record<string, string> = {
           "America/Port_Of_Spain": "America/Port_of_Spain",
@@ -137,11 +142,8 @@ export function TimezoneSelectComponent({
           "Africa/Dar_Es_Salaam": "Africa/Dar_es_Salaam",
         };
 
-        if (corrections[selectedOption.value]) {
-          selectedOption.value = corrections[selectedOption.value];
-        }
-
-        props.onChange(selectedOption);
+        const correctedValue = corrections[selectedOption.value] || selectedOption.value;
+        props.onChange({ ...selectedOption, value: correctedValue });
       }}
       formatOptionLabel={(option) => (
         <p className="truncate">{(option as ITimezoneOption).value.replace(/_/g, " ")}</p>


### PR DESCRIPTION
## What does this PR do?


Fixed Google Calendar event creation failures by correcting timezone names for Port of Spain, Porto-Novo, and Dar es Salaam.

<!-- End of auto-generated description by cubic. -->

