### PR TITLE
fix: show icon button when one item in array

### DIFF
--- a/packages/ui/components/card/FormCard.tsx
+++ b/packages/ui/components/card/FormCard.tsx
@@ -44,6 +44,23 @@ const FormCardActions = ({ deleteField, duplicateField }: FormCardActionsProps) 
 
   if (actions.length === 0) return null;
 
+  // If only one action, show a single icon button
+  if (actions.length === 1) {
+    const action = actions[0];
+    return (
+      <Button
+        type="button"
+        variant="icon"
+        color={action.color || "minimal"}
+        className="ml-2"
+        onClick={action.onClick}
+        StartIcon={action.icon}
+        title={action.label}
+      />
+    );
+  }
+
+  // If multiple actions, show dropdown
   return (
     <Dropdown>
       <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## What does this PR do?
![image](https://github.com/user-attachments/assets/1c6f5e4c-3f52-4d2b-ad7b-fcff86fccabb)
When form actions is a single item - use a single icon button instead of a elipsis dropdown 

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
When there is only one form action, show a single icon button instead of a dropdown menu. This makes the UI simpler and easier to use.

<!-- End of auto-generated description by cubic. -->

