### PR TITLE
fix: make uuid of App_RoutingForms_FormResponse nullable

### DIFF
--- a/packages/prisma/migrations/20250626092518_app_routing_forms_form_response_uuid_nullable/migration.sql
+++ b/packages/prisma/migrations/20250626092518_app_routing_forms_form_response_uuid_nullable/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX IF EXISTS "App_RoutingForms_FormResponse_uuid_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "RoutingFormResponseDenormalized_uuid_key";
+
+-- AlterTable
+ALTER TABLE "App_RoutingForms_FormResponse" ALTER COLUMN "uuid" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "RoutingFormResponseDenormalized" ALTER COLUMN "uuid" DROP NOT NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1159,7 +1159,7 @@ model App_RoutingForms_Form {
 
 model App_RoutingForms_FormResponse {
   id           Int                   @id @default(autoincrement())
-  uuid         String                @unique @default(uuid())
+  uuid         String?               @default(uuid())
   formFillerId String                @default(cuid())
   form         App_RoutingForms_Form @relation(fields: [formId], references: [id], onDelete: Cascade)
   formId       String
@@ -1240,7 +1240,7 @@ view RoutingFormResponse {
 
 model RoutingFormResponseDenormalized {
   id                      Int                           @id
-  uuid                    String                        @unique
+  uuid                    String?
   formId                  String
   formName                String
   formTeamId              Int?


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes the non-null constraints of App_RoutingForms_FormResponse's uuid column (and the corresponding RoutingFormResponseDenormalized table)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
