### PR TITLE
fix: changesets release

### DIFF
--- a/.changeset/spicy-things-act.md
+++ b/.changeset/spicy-things-act.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": patch
+---
+
+testing changesets - can ignore this

--- a/package.json
+++ b/package.json
@@ -80,8 +80,9 @@
     "docker-build-api": "docker build -t cal-api -f ./infra/docker/api/Dockerfile .",
     "docker-run-api": "docker run -p 80:80 cal-api",
     "docker-stop-api": "docker ps --filter 'ancestor=cal-api' -q | xargs docker stop",
+    "changesets-add": "yarn changeset add",
     "changesets-version": "yarn changeset version",
-    "changesets-release": "turbo run build && yarn changeset publish"
+    "changesets-release": "turbo run build --filter=@calcom/atoms && yarn changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",

--- a/packages/platform/atoms/README.md
+++ b/packages/platform/atoms/README.md
@@ -3,7 +3,7 @@ Customizable UI components to integrate scheduling into your services.
 ### Support
 Currently supports React 18, React 19, Next 14 and Next 15.
 
-### Changelog
+### Changelog 
 1. Changelog can be viewed [here](https://github.com/calcom/cal.com/blob/main/packages/platform/atoms/CHANGELOG.md).
 2. For upcoming changes in the next release click [here](https://github.com/calcom/cal.com/pulls?q=is%3Apr+is%3Aopen+%22chore%3A+version+packages%22+in%3Atitle) to see a pull request titled `chore: version packages` containing next release changes.
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the changesets release script to only build the @calcom/atoms package before publishing, making releases faster and more targeted. Also added a changeset entry and made a minor README formatting fix.

<!-- End of auto-generated description by cubic. -->

