### PR TITLE
fix: changesets memory issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "docker-stop-api": "docker ps --filter 'ancestor=cal-api' -q | xargs docker stop",
     "changesets-add": "yarn changeset add",
     "changesets-version": "yarn changeset version",
-    "changesets-release": "turbo run build --filter=@calcom/atoms && yarn changeset publish"
+    "changesets-release": "NODE_OPTIONS='--max_old_space_size=8192' turbo run build --filter=@calcom/atoms && yarn changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increased the memory limit for the changesets release script to prevent out-of-memory errors during builds.

<!-- End of auto-generated description by cubic. -->

