### PR TITLE
chore: Remove redundant logging

### DIFF
--- a/apps/api/v2/src/lib/throttler-guard.ts
+++ b/apps/api/v2/src/lib/throttler-guard.ts
@@ -58,12 +58,6 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     const IP = request?.headers?.["cf-connecting-ip"] ?? request?.headers?.["CF-Connecting-IP"] ?? request.ip;
     const response = context.switchToHttp().getResponse<Response>();
     const tracker = await this.getTracker(request);
-    this.logger.verbose(
-      `Tracker "${tracker}" generated based on: Bearer token "${request.get(
-        "Authorization"
-      )}", OAuth client ID "${request.get(X_CAL_CLIENT_ID)}" and IP "${IP}"`
-    );
-
     if (throttleOptions) {
       return this.handleApiEndpointThrottle(tracker, throttleOptions, response);
     }
@@ -104,9 +98,9 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
   private async handleNonApiKeyRequest(tracker: string, response: Response): Promise<boolean> {
     const rateLimit = this.getDefaultRateLimit(tracker);
-    this.logger.verbose(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
+    /*this.logger.verbose(`Tracker "${tracker}" uses default rate limits because it is not tracking api key:
       ${JSON.stringify(rateLimit, null, 2)}
-    `);
+    `);*/
 
     const { isBlocked } = await this.incrementRateLimit(tracker, rateLimit, response);
     if (isBlocked) {
@@ -150,9 +144,9 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
 
     const cachedRateLimits = await this.storageService.redis.get(cacheKey);
     if (cachedRateLimits) {
-      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from redis cache:
+      /*this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from redis cache:
         ${cachedRateLimits}
-      `);
+      `);*/
       return rateLimitsSchema.parse(JSON.parse(cachedRateLimits));
     }
 
@@ -172,15 +166,10 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
       select: { name: true, limit: true, ttl: true, blockDuration: true },
     });
 
-    if (rateLimits) {
-      this.logger.verbose(`Tracker "${tracker}" rate limits retrieved from database:
-        ${JSON.stringify(rateLimits, null, 2)}`);
-    }
-
     if (!rateLimits || rateLimits.length === 0) {
       rateLimits = [this.getDefaultRateLimit(tracker)];
-      this.logger.verbose(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
-        ${JSON.stringify(rateLimits, null, 2)}`);
+      /*this.logger.verbose(`Tracker "${tracker}" rate limits not found in database. Using default rate limits:
+        ${JSON.stringify(rateLimits, null, 2)}`);*/
     }
 
     await this.storageService.redis.set(cacheKey, JSON.stringify(rateLimits), "EX", 3600);
@@ -209,15 +198,15 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     );
     response.setHeader(`X-RateLimit-Reset-${nameFirstUpper}`, timeToBlockExpire || timeToExpire);
 
-    this.logger.verbose(
+    /*this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" incremented. isBlocked ${isBlocked}, totalHits ${totalHits}, timeToExpire ${timeToExpire}, timeToBlockExpire ${timeToBlockExpire}`
-    );
-    this.logger.verbose(
+    );*/
+    /*this.logger.verbose(
       `Tracker "${tracker}" rate limit "${name}" response headers:
         X-RateLimit-Limit-${nameFirstUpper}: ${limit},
         X-RateLimit-Remaining-${nameFirstUpper}: ${timeToBlockExpire ? 0 : Math.max(0, limit - totalHits)},
         X-RateLimit-Reset-${nameFirstUpper}: ${timeToBlockExpire || timeToExpire}`
-    );
+    );*/
 
     return { isBlocked };
   }


### PR DESCRIPTION
## What does this PR do?

Tracking this should be based on context going forward, for now disabling this as redundant - not needed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed verbose logging from the throttler guard to reduce noise in application logs.

<!-- End of auto-generated description by cubic. -->

