### PR TITLE
chore: Use DBA team for prisma CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /packages/lib/server/getLuckyUser.ts @calcom/Foundation
 /packages/lib/slots.ts @calcom/Foundation
 /packages/platform/**/* @calcom/Platform @calcom/Foundation
-/packages/prisma/**/* @calcom/Foundation
+/packages/prisma/**/* @calcom/DBA
 /packages/trpc/server/routers/viewer/bookings/confirm.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/bookings/get.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/slots/**/* @calcom/Foundation


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated CODEOWNERS to assign the DBA team as code owners for the /packages/prisma directory.

<!-- End of auto-generated description by cubic. -->

