### PR TITLE
fix: Improve inline embed ID with namespaced values

### DIFF
--- a/packages/embeds/README.md
+++ b/packages/embeds/README.md
@@ -108,7 +108,7 @@ if (!this.iframeReady) {
 Embeds the calendar directly within the page flow:
 ```typescript
 Cal.inline({
-  elementOrSelector: "#my-cal-inline",
+  elementOrSelector: "#my-cal-inline-${namespace}", // Includes namespace for uniqueness
   calLink: "organization/event-type"
 });
 ```

--- a/packages/features/embed/lib/EmbedCodes.tsx
+++ b/packages/features/embed/lib/EmbedCodes.tsx
@@ -244,7 +244,7 @@ export default function Booker( props : BookerProps ) {
       namespace: string;
     }) => {
       return code`${getApiNameForVanillaJsSnippet({ namespace, mainApiName: "Cal" })}("inline", {
-    elementOrSelector:"#my-cal-inline",
+    elementOrSelector:"#my-cal-inline-${namespace}",
     config: ${JSON.stringify(previewState.config)},
     calLink: "${calLink}",
   });

--- a/packages/features/embed/lib/EmbedTabs.tsx
+++ b/packages/features/embed/lib/EmbedTabs.tsx
@@ -14,6 +14,7 @@ import { embedLibUrl, EMBED_PREVIEW_HTML_URL } from "./constants";
 import { getApiNameForReactSnippet, getApiNameForVanillaJsSnippet } from "./getApiName";
 import { getDimension } from "./getDimension";
 import { useEmbedCalOrigin } from "./hooks";
+import { sanitizeHtmlId } from "./utils";
 
 export const enum EmbedTabName {
   HTML = "embed-code",
@@ -41,6 +42,9 @@ export const tabs = [
       if (ref.current && !(ref.current instanceof HTMLTextAreaElement)) {
         return null;
       }
+
+      const safeNamespace = sanitizeHtmlId(namespace);
+
       return (
         <>
           <div>
@@ -59,7 +63,7 @@ export const tabs = [
               embedType === "inline"
                 ? `<div style="width:${getDimension(previewState.inline.width)};height:${getDimension(
                     previewState.inline.height
-                  )};overflow:scroll" id="my-cal-inline-${namespace}"></div>\n`
+                  )};overflow:scroll" id="my-cal-inline-${safeNamespace}"></div>\n`
                 : ""
             }<script type="text/javascript">
   ${embedSnippetString}

--- a/packages/features/embed/lib/EmbedTabs.tsx
+++ b/packages/features/embed/lib/EmbedTabs.tsx
@@ -59,7 +59,7 @@ export const tabs = [
               embedType === "inline"
                 ? `<div style="width:${getDimension(previewState.inline.width)};height:${getDimension(
                     previewState.inline.height
-                  )};overflow:scroll" id="my-cal-inline"></div>\n`
+                  )};overflow:scroll" id="my-cal-inline-${namespace}"></div>\n`
                 : ""
             }<script type="text/javascript">
   ${embedSnippetString}

--- a/packages/features/embed/lib/utils.ts
+++ b/packages/features/embed/lib/utils.ts
@@ -1,0 +1,7 @@
+export const sanitizeHtmlId = (id: string) => {
+  return id
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]/g, "-") // Replace invalid chars with hyphen
+    .replace(/-+/g, "-") // Collapse multiple hyphens
+    .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
+};


### PR DESCRIPTION
## What does this PR do?

Improves inline embed functionality by adding namespace-based unique IDs to prevent conflicts when multiple embeds are placed on the same page.

- Fixes #22111 
- Fixes CAL-5999 

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated inline embed IDs to include a namespace, preventing conflicts when multiple embeds are on the same page.

- **Bug Fixes**
  - Inline embed code and documentation now use unique IDs with namespaces.

<!-- End of auto-generated description by cubic. -->

