### PR TITLE
fix: fix request reschedule - not allowing reschedule of cancelled booking

### DIFF
--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -117,7 +117,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // A booking that has been rescheduled to a new booking will also have a status of CANCELLED
   const isDisabledRescheduling = booking.eventType?.disableRescheduling;
   // This comes from query param and thus is considered forced
-  const canRescheduleCancelledBooking = booking.eventType?.allowReschedulingCancelledBookings;
+  const canBookThroughCancelledBookingRescheduleLink = booking.eventType?.allowReschedulingCancelledBookings;
   const isNonRescheduleableBooking =
     booking.status === BookingStatus.CANCELLED || booking.status === BookingStatus.REJECTED;
 
@@ -131,7 +131,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   }
 
   if (isNonRescheduleableBooking && !isForcedRescheduleForCancelledBooking) {
-    const canReschedule = booking.status === BookingStatus.CANCELLED && canRescheduleCancelledBooking;
+    const canReschedule =
+      booking.status === BookingStatus.CANCELLED && canBookThroughCancelledBookingRescheduleLink;
     return {
       redirect: {
         destination: canReschedule ? eventUrl : `/booking/${uid}`,

--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -117,8 +117,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // A booking that has been rescheduled to a new booking will also have a status of CANCELLED
   const isDisabledRescheduling = booking.eventType?.disableRescheduling;
   // This comes from query param and thus is considered forced
-  const canRescheduleCancelledBooking =
-    isForcedRescheduleForCancelledBooking || booking.eventType?.allowReschedulingCancelledBookings;
+  const canRescheduleCancelledBooking = booking.eventType?.allowReschedulingCancelledBookings;
   const isNonRescheduleableBooking =
     booking.status === BookingStatus.CANCELLED || booking.status === BookingStatus.REJECTED;
 
@@ -131,7 +130,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     };
   }
 
-  if (isNonRescheduleableBooking) {
+  if (isNonRescheduleableBooking && !isForcedRescheduleForCancelledBooking) {
     const canReschedule = booking.status === BookingStatus.CANCELLED && canRescheduleCancelledBooking;
     return {
       redirect: {


### PR DESCRIPTION
## What does this PR do?

Fixed the request reschedule feature so users can now reschedule the cancelled booking itself(instead of asking them to create a new booking) when allowed by event settings.
