### PR TITLE
fix: dynamic links considers '' empty string / nothing as valid username

### DIFF
--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -199,8 +199,10 @@ export const getUsernameList = (users: string | string[] | undefined): string[] 
   // Multiple users can come in case of a team round-robin booking and in that case dynamic link won't be a user.
   // So, even though this code handles even if individual user is dynamic link, that isn't a possibility right now.
   users = arrayCast(users);
-
-  const allUsers = users.map((user) => user.replace(/( |%20|%2b)/gi, "+").split("+")).flat();
+  const allUsers = users
+    .map((user) => user.replace(/( |%20|%2b)/gi, "+").split("+"))
+    .flat()
+    .filter(Boolean);
   return Array.prototype.concat(...allUsers.map((userSlug) => slugify(userSlug)));
 };
 


### PR DESCRIPTION
- due to which random user (probably cal.com test user) shows in case of (username+  or username++othername) cases.

- Fixes #22110  (GitHub issue number)
- Fixes CAL-5998 (Linear issue number - should be visible at the bottom of the GitHub issue description)

### Before:
https://github.com/user-attachments/assets/7a9cf617-faba-4db9-80dd-7c536b7d35c6

### After:
https://github.com/user-attachments/assets/7916b3f1-6f35-4c29-9afe-c8f5ccc38946


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where empty strings were treated as valid usernames in dynamic links, which could show random users in some cases.

- **Bug Fixes**
  - Filters out empty usernames when parsing user lists for dynamic links.

<!-- End of auto-generated description by cubic. -->

