### PR TITLE
fix: event description duplication

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -354,7 +354,14 @@ export default function ToolbarPlugin(props: TextEditorProps) {
             const nodes = $generateNodesFromDOM(editor, dom);
             root.clear();
             root.select();
-            $insertNodes(nodes);
+            try {
+              $insertNodes(nodes);
+            } catch (_e) {
+              // Fallback for cases where top-level insertion is not allowed.
+              const paragraphNode = $createParagraphNode();
+              nodes.forEach((n) => paragraphNode.append(n));
+              root.append(paragraphNode);
+            }
           });
         }
       });

--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -352,9 +352,8 @@ export default function ToolbarPlugin(props: TextEditorProps) {
             const dom = parser.parseFromString(props.getText(), "text/html");
 
             const nodes = $generateNodesFromDOM(editor, dom);
-            const paragraph = $createParagraphNode();
-            root.clear().append(paragraph);
-            paragraph.select();
+            root.clear();
+            root.select();
             $insertNodes(nodes);
           });
         }
@@ -372,7 +371,9 @@ export default function ToolbarPlugin(props: TextEditorProps) {
 
         const nodes = $generateNodesFromDOM(editor, dom);
 
-        $getRoot().select();
+        const root = $getRoot();
+        root.clear();
+        root.select();
         try {
           $insertNodes(nodes);
         } catch (e: unknown) {
@@ -380,7 +381,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
           // @see https://stackoverflow.com/questions/73094258/setting-editor-from-html
           const paragraphNode = $createParagraphNode();
           nodes.forEach((n) => paragraphNode.append(n));
-          $getRoot().append(paragraphNode);
+          root.append(paragraphNode);
         }
 
         editor.registerUpdateListener(({ editorState, prevEditorState }) => {


### PR DESCRIPTION
## What does this PR do?

When opening event type settings, the description field would display duplicated text. For example, a description "A quick video meeting." would show as "A quick video meeting.A quick video meeting." - sometimes with extra line breaks.
This PR fixes that bug.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

Before:

https://cap.link/8n65y45r5g1a2ne

After:

https://cap.link/grtzntt9348zc50

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the event description field showed duplicated text in event type settings.

- **Bug Fixes**
 - The description now displays correctly without repeated content.

<!-- End of auto-generated description by cubic. -->

