### PR TITLE
fix: changesets atoms size

### DIFF
--- a/.changeset/five-zebras-tease.md
+++ b/.changeset/five-zebras-tease.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": patch
+---
+
+ignore this test log

--- a/packages/platform/atoms/README.md
+++ b/packages/platform/atoms/README.md
@@ -13,6 +13,6 @@ Currently supports React 18, React 19, Next 14 and Next 15.
 3. Some of the versions are suffixed e.g. `1.0.102-framer` and are intended for isolated use cases, so you most probably
 want to use version without any suffix e.g. `1.0.103`.
 
-### Documentation
+### Documentation 
 Documentation on how to get started with platform solution is [here](https://cal.com/docs/platform/quickstart) and list of atoms can be viewed
 [here](https://cal.com/docs/platform/atoms/cal-provider)

--- a/turbo.json
+++ b/turbo.json
@@ -68,6 +68,9 @@
       "cache": false,
       "dependsOn": []
     },
+    "@calcom/atoms#build": {
+      "outputs": ["dist/**", "globals.min.css"]
+    },
     "@calcom/api-v2#build": {
       "dependsOn": ["^build"],
       "env": [


### PR DESCRIPTION
Linear [CAL-6003](https://linear.app/calcom/issue/CAL-6003/fix-changesets-atoms-size)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the build configuration for the @calcom/atoms package to ensure correct output files and reduce npm package size.

<!-- End of auto-generated description by cubic. -->

