### PR TITLE
fix: don't use unpublished org for credit usage

### DIFF
--- a/apps/web/pages/api/twilio/webhook.ts
+++ b/apps/web/pages/api/twilio/webhook.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import * as twilio from "@calcom/features/ee/workflows/lib/reminders/providers/twilioProvider";
 import { IS_SMS_CREDITS_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
-import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
+import { getPublishedOrgIdFromMemberOrTeamId } from "@calcom/lib/getOrgIdFromMemberOrTeamId";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
 import prisma from "@calcom/prisma";
 
@@ -120,7 +120,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (!orgId) {
-    orgId = await getOrgIdFromMemberOrTeamId({
+    orgId = await getPublishedOrgIdFromMemberOrTeamId({
       ...(!parsedTeamId ? { memberId: parsedUserId } : {}),
       teamId: parsedTeamId,
     });

--- a/packages/features/ee/workflows/lib/test/twilioWebhook.test.ts
+++ b/packages/features/ee/workflows/lib/test/twilioWebhook.test.ts
@@ -34,6 +34,11 @@ vi.mock("@calcom/prisma", () => ({
   },
 }));
 
+vi.mock("@calcom/lib/getOrgIdFromMemberOrTeamId", () => ({
+  default: vi.fn().mockResolvedValue(null),
+  getPublishedOrgIdFromMemberOrTeamId: vi.fn().mockResolvedValue(null),
+}));
+
 describe("Twilio Webhook Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -116,10 +121,6 @@ describe("Twilio Webhook Handler", () => {
     test("should create expense log with null credits if userId is not part of a team", async () => {
       mockFindFirst.mockResolvedValue(null);
       const webhookHandler = (await import("../../../../../../apps/web/pages/api/twilio/webhook")).default;
-
-      vi.mock("@calcom/lib/getOrgIdFromMemberOrTeamId", () => ({
-        default: vi.fn().mockResolvedValue(null),
-      }));
 
       const mockRequest = {
         method: "POST",

--- a/packages/lib/getOrgIdFromMemberOrTeamId.ts
+++ b/packages/lib/getOrgIdFromMemberOrTeamId.ts
@@ -1,38 +1,45 @@
 import prisma from "@calcom/prisma";
 
 const getOrgMemberOrTeamWhere = (memberId?: number | null, teamId?: number | null) => {
+  const conditions: Prisma.TeamWhereInput[] = [];
+
+  if (memberId) {
+    conditions.push({
+      AND: [
+        {
+          members: {
+            some: {
+              userId: memberId,
+              accepted: true,
+            },
+          },
+        },
+        {
+          isOrganization: true,
+        },
+      ],
+    });
+  }
+
+  if (teamId) {
+    conditions.push({
+      AND: [
+        {
+          children: {
+            some: {
+              id: teamId,
+            },
+          },
+        },
+        {
+          isOrganization: true,
+        },
+      ],
+    });
+  }
+
   return {
-    OR: [
-      {
-        AND: [
-          {
-            members: {
-              some: {
-                userId: memberId ?? 0,
-                accepted: true,
-              },
-            },
-          },
-          {
-            isOrganization: true,
-          },
-        ],
-      },
-      {
-        AND: [
-          {
-            children: {
-              some: {
-                id: teamId ?? 0,
-              },
-            },
-          },
-          {
-            isOrganization: true,
-          },
-        ],
-      },
-    ],
+    OR: conditions,
   };
 };
 

--- a/packages/lib/getOrgIdFromMemberOrTeamId.ts
+++ b/packages/lib/getOrgIdFromMemberOrTeamId.ts
@@ -1,4 +1,5 @@
 import prisma from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
 
 const getOrgMemberOrTeamWhere = (memberId?: number | null, teamId?: number | null) => {
   const conditions: Prisma.TeamWhereInput[] = [];

--- a/packages/lib/getOrgIdFromMemberOrTeamId.ts
+++ b/packages/lib/getOrgIdFromMemberOrTeamId.ts
@@ -1,45 +1,62 @@
 import prisma from "@calcom/prisma";
 
+const getOrgMemberOrTeamWhere = (memberId?: number | null, teamId?: number | null) => {
+  return {
+    OR: [
+      {
+        AND: [
+          {
+            members: {
+              some: {
+                userId: memberId ?? 0,
+                accepted: true,
+              },
+            },
+          },
+          {
+            isOrganization: true,
+          },
+        ],
+      },
+      {
+        AND: [
+          {
+            children: {
+              some: {
+                id: teamId ?? 0,
+              },
+            },
+          },
+          {
+            isOrganization: true,
+          },
+        ],
+      },
+    ],
+  };
+};
+
 export default async function getOrgIdFromMemberOrTeamId(args: {
   memberId?: number | null;
   teamId?: number | null;
 }) {
-  const userId = args.memberId ?? 0;
-  const teamId = args.teamId ?? 0;
+  const orgId = await prisma.team.findFirst({
+    where: getOrgMemberOrTeamWhere(args.memberId, args.teamId),
+    select: {
+      id: true,
+    },
+  });
+  return orgId?.id;
+}
 
+export async function getPublishedOrgIdFromMemberOrTeamId(args: {
+  memberId?: number | null;
+  teamId?: number | null;
+}) {
   const orgId = await prisma.team.findFirst({
     where: {
-      OR: [
-        {
-          AND: [
-            {
-              members: {
-                some: {
-                  userId,
-                  accepted: true,
-                },
-              },
-            },
-            {
-              isOrganization: true,
-            },
-          ],
-        },
-        {
-          AND: [
-            {
-              children: {
-                some: {
-                  id: teamId,
-                },
-              },
-            },
-            {
-              isOrganization: true,
-            },
-          ],
-        },
-      ],
+      ...getOrgMemberOrTeamWhere(args.memberId, args.teamId),
+      slug: { not: null },
     },
     select: {
       id: true,


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issues that when a user has an unpublished platform Org it uses this org instead of their active team subscription.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed credit usage so that only published organizations are used, preventing unpublished orgs from being selected for team subscriptions.

- **Bug Fixes**
  - Updated logic to select only published orgs when checking credit usage.
  - Added a new function to filter out unpublished organizations.

<!-- End of auto-generated description by cubic. -->

