### PR TITLE
fix: prevent location input from losing focus after each key stroke

### DIFF
--- a/packages/features/eventtypes/components/Locations.tsx
+++ b/packages/features/eventtypes/components/Locations.tsx
@@ -116,7 +116,6 @@ const LocationInput = (props: {
 }) => {
   const { t } = useLocale();
   const { eventLocationType, index, customClassNames, disableLocationProp, ...remainingProps } = props;
-  console.log("hey", disableLocationProp);
   if (eventLocationType?.organizerInputType === "text") {
     const { defaultValue, ...rest } = remainingProps;
 

--- a/packages/features/eventtypes/components/Locations.tsx
+++ b/packages/features/eventtypes/components/Locations.tsx
@@ -107,6 +107,67 @@ const getLocationInfo = ({
   return { locationAvailable, locationDetails };
 };
 
+const LocationInput = (props: {
+  eventLocationType: EventLocationType;
+  defaultValue?: string;
+  index: number;
+  customClassNames?: LocationInputCustomClassNames;
+  disableLocationProp?: boolean;
+}) => {
+  const { t } = useLocale();
+  const { eventLocationType, index, customClassNames, disableLocationProp, ...remainingProps } = props;
+  console.log("hey", disableLocationProp);
+  if (eventLocationType?.organizerInputType === "text") {
+    const { defaultValue, ...rest } = remainingProps;
+
+    return (
+      <Controller
+        name={`locations.${index}.${eventLocationType.defaultValueVariable}`}
+        defaultValue={defaultValue}
+        render={({ field: { onChange, value } }) => {
+          return (
+            <Input
+              name={`locations[${index}].${eventLocationType.defaultValueVariable}`}
+              placeholder={t(eventLocationType.organizerInputPlaceholder || "")}
+              type="text"
+              required
+              onChange={onChange}
+              value={value}
+              {...(disableLocationProp ? { disabled: true } : {})}
+              className={classNames("my-0", customClassNames?.addressInput)}
+              {...rest}
+            />
+          );
+        }}
+      />
+    );
+  } else if (eventLocationType?.organizerInputType === "phone") {
+    const { defaultValue, ...rest } = remainingProps;
+
+    return (
+      <Controller
+        name={`locations.${index}.${eventLocationType.defaultValueVariable}`}
+        defaultValue={defaultValue}
+        render={({ field: { onChange, value } }) => {
+          return (
+            <PhoneInput
+              required
+              disabled={disableLocationProp}
+              placeholder={t(eventLocationType.organizerInputPlaceholder || "")}
+              name={`locations[${index}].${eventLocationType.defaultValueVariable}`}
+              className={customClassNames?.phoneInput}
+              value={value}
+              onChange={onChange}
+              {...rest}
+            />
+          );
+        }}
+      />
+    );
+  }
+  return null;
+};
+
 const Locations: React.FC<LocationsProps> = ({
   isChildrenManagedEventType,
   disableLocationProp,
@@ -167,64 +228,6 @@ const Locations: React.FC<LocationsProps> = ({
     eventType,
     locationOptions: props.locationOptions,
   });
-
-  const LocationInput = (props: {
-    eventLocationType: EventLocationType;
-    defaultValue?: string;
-    index: number;
-    customClassNames?: LocationInputCustomClassNames;
-  }) => {
-    const { eventLocationType, index, customClassNames, ...remainingProps } = props;
-    if (eventLocationType?.organizerInputType === "text") {
-      const { defaultValue, ...rest } = remainingProps;
-
-      return (
-        <Controller
-          name={`locations.${index}.${eventLocationType.defaultValueVariable}`}
-          defaultValue={defaultValue}
-          render={({ field: { onChange, value } }) => {
-            return (
-              <Input
-                name={`locations[${index}].${eventLocationType.defaultValueVariable}`}
-                placeholder={t(eventLocationType.organizerInputPlaceholder || "")}
-                type="text"
-                required
-                onChange={onChange}
-                value={value}
-                {...(disableLocationProp ? { disabled: true } : {})}
-                className={classNames("my-0", customClassNames?.addressInput)}
-                {...rest}
-              />
-            );
-          }}
-        />
-      );
-    } else if (eventLocationType?.organizerInputType === "phone") {
-      const { defaultValue, ...rest } = remainingProps;
-
-      return (
-        <Controller
-          name={`locations.${index}.${eventLocationType.defaultValueVariable}`}
-          defaultValue={defaultValue}
-          render={({ field: { onChange, value } }) => {
-            return (
-              <PhoneInput
-                required
-                disabled={disableLocationProp}
-                placeholder={t(eventLocationType.organizerInputPlaceholder || "")}
-                name={`locations[${index}].${eventLocationType.defaultValueVariable}`}
-                className={customClassNames?.phoneInput}
-                value={value}
-                onChange={onChange}
-                {...rest}
-              />
-            );
-          }}
-        />
-      );
-    }
-    return null;
-  };
 
   const [showEmptyLocationSelect, setShowEmptyLocationSelect] = useState(false);
   const defaultInitialLocation = defaultValue || null;
@@ -459,6 +462,7 @@ const Locations: React.FC<LocationsProps> = ({
                         eventLocationType={eventLocationType}
                         index={index}
                         customClassNames={customClassNames?.organizerContactInput?.locationInput}
+                        disableLocationProp={disableLocationProp}
                       />
                     </div>
                     <ErrorMessage


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the input field inside the Locations component was losing focus after every keystroke. The root cause was the LocationInput component being redefined on every render, causing React to unmount and remount the input field.

- Fixes #22141(GitHub issue number)
- Fixes CAL-6007 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

before :


[Screencast from 2025-07-01 00-56-16.webm](https://github.com/user-attachments/assets/f2ead95a-19a0-4b26-aa31-274c6363a0a3)

after:

[Screencast from 2025-07-01 00-57-27.webm](https://github.com/user-attachments/assets/23ac7f64-8d84-4b78-979b-cfe519290dfd)

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- go to Event type 
- select a event
- go to setup -> location -> organizer address/ link meeting/ organizer phone
- try typing .

## Checklist

<!-- Remove bullet points below that don't apply to you -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the location input field lost focus after each keystroke in the Locations component.

- **Bug Fixes**
  - Moved the LocationInput component definition outside of the Locations component to prevent unnecessary unmounting and remounting.

<!-- End of auto-generated description by cubic. -->

