### PR TITLE
fix: atoms for local development

### DIFF
--- a/packages/platform/atoms/.gitignore
+++ b/packages/platform/atoms/.gitignore
@@ -1,1 +1,2 @@
 globals.min.css
+cal-atoms-dev.tgz

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -9,7 +9,8 @@
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
     "build": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../../node_modules/.prisma/client/*.d.ts ./dist/packages/prisma-client",
     "publish-npm": "yarn build && npm publish --access public",
-    "test": "jest"
+    "test": "jest",
+    "pack-dev": "yarn build && npm pack && mv calcom-atoms-*.tgz cal-atoms-dev.tgz"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/platform/examples/base/README.md
+++ b/packages/platform/examples/base/README.md
@@ -19,7 +19,7 @@ REDIS_URL="redis://localhost:6379"
 ```
 
 3. Start "apps/api/v2" api using `yarn dev`.
-4. Start "packages/platform/atoms" atoms package with `yarn dev`.
+4. Setup "packages/platform/atoms" by running `yarn pack-dev` in the atoms directory.
 5. Start "apps/web" cal web app using `yarn dx`.
 6. Open your browser at "http://localhost:3000/" and login with admin username `admin@example.com` and password `ADMINadmin2022!`.
 7. In the web app navigate to `http://localhost:3000/settings/organizations/new` and create a sample organization. When asked for phone verification code enter `111111`.

--- a/packages/platform/examples/base/README.md
+++ b/packages/platform/examples/base/README.md
@@ -19,7 +19,7 @@ REDIS_URL="redis://localhost:6379"
 ```
 
 3. Start "apps/api/v2" api using `yarn dev`.
-4. Setup "packages/platform/atoms" by running `yarn pack-dev` in the atoms directory.
+4. Setup "packages/platform/atoms" by running `yarn atoms-dev-on` in the example app directory - it will pack atoms into a dev .tgz and switch the dependency to point to it. When you are done with development, run `yarn atoms-dev-off` to switch back to the published version because otherwise examples app would have entry in the yarn.lock file pointing to the dev .tgz and installation would fail in prod because dev tar file exists only locally.
 5. Start "apps/web" cal web app using `yarn dx`.
 6. Open your browser at "http://localhost:3000/" and login with admin username `admin@example.com` and password `ADMINadmin2022!`.
 7. In the web app navigate to `http://localhost:3000/settings/organizations/new` and create a sample organization. When asked for phone verification code enter `111111`.

--- a/packages/platform/examples/base/atoms-dev-on.sh
+++ b/packages/platform/examples/base/atoms-dev-on.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo "📦 Packing @calcom/atoms into dev .tgz..."
+yarn workspace @calcom/atoms pack-dev
+
+echo "🔧 Switching @calcom/atoms to dev .tgz..."
+
+# Detect platform for sed compatibility
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's|"@calcom/atoms": ".*"|"@calcom/atoms": "file:../../atoms/cal-atoms-dev.tgz"|' package.json
+else
+  sed -i 's|"@calcom/atoms": ".*"|"@calcom/atoms": "file:../../atoms/cal-atoms-dev.tgz"|' package.json
+fi
+
+yarn install
+
+echo "✅ Local atoms .tgz linked. Ready for dev."

--- a/packages/platform/examples/base/package.json
+++ b/packages/platform/examples/base/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@calcom/atoms": "*",
+    "@calcom/atoms": "file:../../atoms/cal-atoms-dev.tgz",
     "@prisma/client": "5.4.2",
     "next": "14.0.4",
     "prisma": "^5.7.1",

--- a/packages/platform/examples/base/package.json
+++ b/packages/platform/examples/base/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "PORT=4321 next dev",
+    "atoms-dev-on": "./atoms-dev-on.sh",
+    "atoms-dev-off": "git checkout -- package.json ../../../../yarn.lock",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
-    "@calcom/atoms": "file:../../atoms/cal-atoms-dev.tgz",
+    "@calcom/atoms": "*",
     "@prisma/client": "5.4.2",
     "next": "14.0.4",
     "prisma": "^5.7.1",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the atoms package and example app to support local development by allowing the atoms package to be packed and used as a local file dependency.

- **Migration**
  - Run `yarn pack-dev` in the atoms directory to generate the local package before starting the example app.

<!-- End of auto-generated description by cubic. -->

