### PR TITLE
ci: enable auto-merge of release PRs

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # Run daily at midnight
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions: {} # remove permissions and set explicitly under "permissions:" below
@@ -35,3 +37,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Enable auto-merge for release PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.changesets.outputs.pullRequestNumber }}
+          merge-method: squash


### PR DESCRIPTION
## What does this PR do?
This PR adds the **`peter-evans/enable-pull-request-automerge`** GitHub Action step to automatically enable auto-merge on the release pull request created by the Changesets action.

---

#### Why `peter-evans/enable-pull-request-automerge`?

* This Action allows us to **programmatically enable GitHub’s auto-merge feature** on PRs.

#### Is version `v3` latest?

* Yes, `v3` is the latest major stable version of this Action as per the [official GitHub Marketplace page](https://github.com/marketplace/actions/enable-pull-request-automerge).

#### Why use `merge-method: squash`?

* The **squash merge** method combines all commits in the PR into a **single clean commit** on the base branch.

#### How is the pull request number obtained?

* The `changesets/action@v1` step outputs the pull request number it creates as `pullRequestNumber`.
* We access it dynamically using:

  ```yaml
  ${{ steps.changesets.outputs.pullRequestNumber }}
  ```
* This allows the auto-merge Action to target the **exact PR** generated in the previous step.

---

- Fixes #22161
- [CAL-6016 feat: release atoms daily using changesets](https://linear.app/calcom/issue/CAL-6016/feat-release-atoms-daily-using-changesets)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## How did you test this?

I set up a local test repository, created a changeset, and verified that the pull request was generated and auto-merged successfully without any issues.
    
<img width="1261" alt="Screenshot 2025-07-01 at 11 02 06 PM" src="https://github.com/user-attachments/assets/f0e97320-2ca9-4946-a710-0f1565cb18b0" />

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a step to the release workflow to automatically enable auto-merge with squash for release PRs created by Changesets.

- **Dependencies**
  - Uses peter-evans/enable-pull-request-automerge@v3 to set up auto-merge on the generated PR.

<!-- End of auto-generated description by cubic. -->

