### PR TITLE
fix: Set a length limit to avatarUrl from google oauth

### DIFF
--- a/packages/app-store/_utils/oauth/updateProfilePhotoGoogle.test.ts
+++ b/packages/app-store/_utils/oauth/updateProfilePhotoGoogle.test.ts
@@ -1,0 +1,91 @@
+import { oauth2_v2 } from "@googleapis/oauth2";
+import type { OAuth2Client } from "googleapis-common";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import logger from "@calcom/lib/logger";
+import { UserRepository } from "@calcom/lib/server/repository/user";
+
+import { updateProfilePhotoGoogle } from "./updateProfilePhotoGoogle";
+
+vi.mock("@googleapis/oauth2", () => ({
+  oauth2_v2: {
+    Oauth2: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/lib/logger", () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/lib/server/repository/user", () => ({
+  UserRepository: {
+    updateAvatar: vi.fn(),
+  },
+}));
+
+describe("updateProfilePhotoGoogle", () => {
+  const mockOAuth2Client = {} as OAuth2Client;
+  const userId = 123;
+  let mockOauth2Instance: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOauth2Instance = {
+      userinfo: {
+        get: vi.fn(),
+      },
+    };
+    (oauth2_v2.Oauth2 as any).mockImplementation(() => mockOauth2Instance);
+  });
+
+  it("should update avatar with valid URL", async () => {
+    const validUrl = "https://example.com/api/avatar.jpg";
+    mockOauth2Instance.userinfo.get.mockResolvedValue({
+      data: { picture: validUrl },
+    });
+
+    await updateProfilePhotoGoogle(mockOAuth2Client, userId);
+
+    expect(UserRepository.updateAvatar).toHaveBeenCalledWith({
+      id: userId,
+      avatarUrl: validUrl,
+    });
+  });
+
+  it("should skip processing for URLs that are too long", async () => {
+    const longUrl = `https://example.com/${"a".repeat(10000)}`;
+    mockOauth2Instance.userinfo.get.mockResolvedValue({
+      data: { picture: longUrl },
+    });
+
+    await updateProfilePhotoGoogle(mockOAuth2Client, userId);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      `Avatar URL too long (${longUrl.length} characters), skipping processing for user ${userId}`
+    );
+    expect(UserRepository.updateAvatar).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when no picture provided", async () => {
+    mockOauth2Instance.userinfo.get.mockResolvedValue({
+      data: {},
+    });
+
+    await updateProfilePhotoGoogle(mockOAuth2Client, userId);
+
+    expect(UserRepository.updateAvatar).not.toHaveBeenCalled();
+  });
+
+  it("should handle errors gracefully", async () => {
+    const error = new Error("OAuth API failed");
+    mockOauth2Instance.userinfo.get.mockRejectedValue(error);
+
+    await updateProfilePhotoGoogle(mockOAuth2Client, userId);
+
+    expect(logger.error).toHaveBeenCalledWith("Error updating avatarUrl from google calendar connect", error);
+    expect(UserRepository.updateAvatar).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-store/_utils/oauth/updateProfilePhotoGoogle.ts
+++ b/packages/app-store/_utils/oauth/updateProfilePhotoGoogle.ts
@@ -4,13 +4,26 @@ import type { OAuth2Client } from "googleapis-common";
 import logger from "@calcom/lib/logger";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 
+const MAX_AVATAR_URL_LENGTH = 10000;
+
 export async function updateProfilePhotoGoogle(oAuth2Client: OAuth2Client, userId: number) {
   try {
     const oauth2 = new oauth2_v2.Oauth2({ auth: oAuth2Client });
     const userDetails = await oauth2.userinfo.get();
-    if (userDetails.data?.picture) {
-      await UserRepository.updateAvatar({ id: userId, avatarUrl: userDetails.data.picture });
+    const avatarUrl = userDetails.data?.picture;
+    if (!avatarUrl) {
+      return;
     }
+
+    // Check avatar URL length before processing
+    if (avatarUrl.length > MAX_AVATAR_URL_LENGTH) {
+      logger.warn(
+        `Avatar URL too long (${avatarUrl.length} characters), skipping processing for user ${userId}`
+      );
+      return;
+    }
+
+    await UserRepository.updateAvatar({ id: userId, avatarUrl });
   } catch (error) {
     logger.error("Error updating avatarUrl from google calendar connect", error);
   }

--- a/packages/app-store/googlecalendar/api/callback.ts
+++ b/packages/app-store/googlecalendar/api/callback.ts
@@ -4,7 +4,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import GoogleCalendarService from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { renewSelectedCalendarCredentialId } from "@calcom/lib/connectedCalendar";
-import { GOOGLE_CALENDAR_SCOPES, WEBAPP_URL, WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  SCOPE_USERINFO_PROFILE,
+  WEBAPP_URL,
+  WEBAPP_URL_FOR_OAUTH,
+} from "@calcom/lib/constants";
 import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { HttpError } from "@calcom/lib/http-error";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
@@ -14,6 +19,7 @@ import { Prisma } from "@calcom/prisma/client";
 
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import { decodeOAuthState } from "../../_utils/oauth/decodeOAuthState";
+import { updateProfilePhotoGoogle } from "../../_utils/oauth/updateProfilePhotoGoogle";
 import { getGoogleAppKeys } from "../lib/getGoogleAppKeys";
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -95,10 +101,9 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // Only attempt to update the user's profile photo if the user has granted the required scope
-    // TODO: Use the avatarUrl when setting the profile picture
-    // if (grantedScopes.includes(SCOPE_USERINFO_PROFILE)) {
-    //   await updateProfilePhotoGoogle(oAuth2Client, req.session.user.id);
-    // }
+    if (grantedScopes.includes(SCOPE_USERINFO_PROFILE)) {
+      await updateProfilePhotoGoogle(oAuth2Client, req.session.user.id);
+    }
 
     const selectedCalendarWhereUnique = {
       userId: req.session.user.id,

--- a/packages/app-store/googlecalendar/api/callback.ts
+++ b/packages/app-store/googlecalendar/api/callback.ts
@@ -4,12 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import GoogleCalendarService from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { renewSelectedCalendarCredentialId } from "@calcom/lib/connectedCalendar";
-import {
-  GOOGLE_CALENDAR_SCOPES,
-  SCOPE_USERINFO_PROFILE,
-  WEBAPP_URL,
-  WEBAPP_URL_FOR_OAUTH,
-} from "@calcom/lib/constants";
+import { GOOGLE_CALENDAR_SCOPES, WEBAPP_URL, WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { HttpError } from "@calcom/lib/http-error";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
@@ -19,7 +14,6 @@ import { Prisma } from "@calcom/prisma/client";
 
 import getInstalledAppPath from "../../_utils/getInstalledAppPath";
 import { decodeOAuthState } from "../../_utils/oauth/decodeOAuthState";
-import { updateProfilePhotoGoogle } from "../../_utils/oauth/updateProfilePhotoGoogle";
 import { getGoogleAppKeys } from "../lib/getGoogleAppKeys";
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -98,11 +92,6 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
           getInstalledAppPath({ variant: "calendar", slug: "google-calendar" })
       );
       return;
-    }
-
-    // Only attempt to update the user's profile photo if the user has granted the required scope
-    if (grantedScopes.includes(SCOPE_USERINFO_PROFILE)) {
-      await updateProfilePhotoGoogle(oAuth2Client, req.session.user.id);
     }
 
     const selectedCalendarWhereUnique = {


### PR DESCRIPTION
## What does this PR do?

- Skips avatar updates if the URL is missing or longer than 10,000 characters

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Added an unit test

