### PR TITLE
fix: the custom icon at out of office empty view

### DIFF
--- a/packages/features/settings/outOfOffice/OutOfOfficeEntriesList.tsx
+++ b/packages/features/settings/outOfOffice/OutOfOfficeEntriesList.tsx
@@ -382,9 +382,11 @@ function OutOfOfficeEntriesListContent() {
                       <div className="w-12" />
                     </div>
                     <div className="dark:bg-darkgray-50 text-inverted relative z-0 flex h-[70px] w-[70px] items-center justify-center rounded-3xl border-2 border-[#e5e7eb] bg-white">
-                      <Icon name="clock" size={28} />
+                      <Icon name="clock" size={28} className="text-black" />
                       <div className="dark:bg-darkgray-50 absolute right-4 top-5 h-[12px] w-[12px] rotate-[56deg] bg-white text-lg font-bold" />
-                      <span className="absolute right-4 top-3 font-sans text-sm font-extrabold">z</span>
+                      <span className="absolute right-4 top-3 font-sans text-sm font-extrabold text-black">
+                        z
+                      </span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the visibility issue where the icon in the "Out of Office" empty state view appears white and is not visible on the light theme background. 

- Fixes #22207 (GitHub issue number)
- Fixes CAL-6023 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)


A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

before:

![Screenshot from 2025-07-02 16-46-31](https://github.com/user-attachments/assets/85be8828-b024-4cc2-aa17-84c8a0d06e24)

after:

![Screenshot from 2025-07-02 16-50-30](https://github.com/user-attachments/assets/702f9281-dde9-473b-9f6f-8aed2f4b39e0)

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the "Out of Office" empty state icon so it is now visible on light backgrounds. The icon and label now use black text for better contrast.

<!-- End of auto-generated description by cubic. -->

