### PR TITLE
fix: Don't default to ROUND_ROBIN as user bookings don't have it set

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -489,7 +489,7 @@ export async function getBookings({
                 "EventType.disableCancelling",
                 "EventType.disableRescheduling",
                 eb
-                  .cast<SchedulingType>(
+                  .cast<SchedulingType | null>(
                     eb
                       .case()
                       .when("EventType.schedulingType", "=", "roundRobin")
@@ -498,7 +498,7 @@ export async function getBookings({
                       .then(SchedulingType["COLLECTIVE"])
                       .when("EventType.schedulingType", "=", "managed")
                       .then(SchedulingType["MANAGED"])
-                      .else(SchedulingType["ROUND_ROBIN"]) // Ensure ELSE provides a value within SchedulingTypeLiteral for cast safety
+                      .else(null)
                       .end(),
                     "varchar" // Or 'text' - use the actual SQL data type
                   )


### PR DESCRIPTION
Don't default to ROUND_ROBIN. Managed events(children events) have schedulingType as null and it causes those bookings to show 'Reassign' button.