### PR TITLE
fix: use triggering user's email/name in draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,7 +27,17 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+          # Get user information from GitHub API
+          USER_EMAIL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/users/${{ github.actor }}" | \
+            jq -r '.email // empty')
+          
+          # Fallback to a team-friendly email if user email is private/null
+          if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
+            USER_EMAIL="${{ github.actor }}@users.noreply.github.com"
+          fi
+          
+          git config --local user.email "$USER_EMAIL"
           git config --local user.name "${{ github.actor }}"
 
       - uses: ./.github/actions/yarn-install

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,15 +27,18 @@ jobs:
 
       - name: Configure git
         run: |
-          # Get user information from GitHub API
-          USER_EMAIL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/users/${{ github.actor }}" | \
-            jq -r '.email // empty')
+          # Define authorized users and their emails using organization secret
+          # Expected format: JSON object with username -> email mapping
+          USER_EMAILS='${{ secrets.RELEASE_USER_EMAILS }}'
           
-          # Fail if user email is private/null - no fallback allowed
+          # Extract email for the triggering user
+          USER_EMAIL=$(echo "$USER_EMAILS" | jq -r --arg user "${{ github.actor }}" '.[$user] // empty')
+          
+          # Fail if user is not authorized or not in mapping
           if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
-            echo "Error: User ${{ github.actor }} has no public email address."
-            echo "Please make your email address public in your GitHub profile settings."
+            echo "Error: User '${{ github.actor }}' is not authorized to run the release workflow."
+            echo "Only authorized team members can trigger releases."
+            echo "Contact your administrator to be added to the authorized users list."
             exit 1
           fi
           

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           # Define authorized users and their emails using organization secret
           # Expected format: JSON object with username -> email mapping
+          # Example: {"zomars": "zomars@cal.com", "peer": "peer@cal.com", "username3": "email3@cal.com"}
           USER_EMAILS='${{ secrets.RELEASE_USER_EMAILS }}'
           
           # Extract email for the triggering user

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -32,9 +32,11 @@ jobs:
             "https://api.github.com/users/${{ github.actor }}" | \
             jq -r '.email // empty')
           
-          # Fallback to a team-friendly email if user email is private/null
+          # Fail if user email is private/null - no fallback allowed
           if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
-            USER_EMAIL="${{ github.actor }}@users.noreply.github.com"
+            echo "Error: User ${{ github.actor }} has no public email address."
+            echo "Please make your email address public in your GitHub profile settings."
+            exit 1
           fi
           
           git config --local user.email "$USER_EMAIL"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,8 +27,18 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --local user.email "github-actions@github.com"
-          git config --local user.name "GitHub Actions"
+          # Get user information from GitHub API
+          USER_EMAIL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/users/${{ github.actor }}" | \
+            jq -r '.email // empty')
+          
+          # Fallback to a team-friendly email if user email is private/null
+          if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
+            USER_EMAIL="${{ github.actor }}@users.noreply.github.com"
+          fi
+          
+          git config --local user.email "$USER_EMAIL"
+          git config --local user.name "${{ github.actor }}"
 
       - uses: ./.github/actions/yarn-install
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,17 +27,7 @@ jobs:
 
       - name: Configure git
         run: |
-          # Get user information from GitHub API
-          USER_EMAIL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/users/${{ github.actor }}" | \
-            jq -r '.email // empty')
-          
-          # Fallback to a team-friendly email if user email is private/null
-          if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
-            USER_EMAIL="${{ github.actor }}@users.noreply.github.com"
-          fi
-          
-          git config --local user.email "$USER_EMAIL"
+          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
           git config --local user.name "${{ github.actor }}"
 
       - uses: ./.github/actions/yarn-install


### PR DESCRIPTION

# fix: use triggering user's email/name in draft-release workflow

## Summary

Replaces hardcoded GitHub Actions email (`github-actions@github.com`) with a custom organization secrets approach that maps authorized usernames to their actual email addresses. This resolves the Vercel deployment issue where commits show "by invalid-email-address" because the GitHub Actions email doesn't belong to the team.

**Key Changes:**
- **Breaking change**: Only authorized users can now trigger the release workflow
- Uses `RELEASE_USER_EMAILS` organization secret with JSON username->email mapping
- Workflow fails explicitly if user is not in the authorized mapping
- Removes all API dependencies and privacy concerns
- Provides clear error messages for unauthorized access

**Before:**
```yaml
git config --local user.email "github-actions@github.com"
git config --local user.name "GitHub Actions"
```

**After:**
```yaml
# Define authorized users and their emails using organization secret
USER_EMAILS='${{ secrets.RELEASE_USER_EMAILS }}'

# Extract email for the triggering user
USER_EMAIL=$(echo "$USER_EMAILS" | jq -r --arg user "${{ github.actor }}" '.[$user] // empty')

# Fail if user is not authorized or not in mapping
if [ -z "$USER_EMAIL" ] || [ "$USER_EMAIL" = "null" ]; then
  echo "Error: User '${{ github.actor }}' is not authorized to run the release workflow."
  exit 1
fi

git config --local user.email "$USER_EMAIL"
git config --local user.name "${{ github.actor }}"
```

## Review & Testing Checklist for Human

- [ ] **Create the organization secret** - Add `RELEASE_USER_EMAILS` secret with JSON format: `{"username1": "email1@cal.com", "username2": "email2@cal.com"}`
- [ ] **Test end-to-end workflow** - Trigger the draft release workflow with an authorized user and verify commit author is correct
- [ ] **Test unauthorized access** - Try triggering with a user not in the mapping to ensure it fails with proper error message
- [ ] **Verify JSON parsing** - Ensure the secret JSON format is valid and jq parsing works correctly
- [ ] **Test Vercel deployment** - Confirm Vercel deployments now show actual user instead of "by invalid-email-address"

**Recommended Test Plan:**
1. Add the organization secret with 4-5 authorized users
2. Trigger the workflow from Actions tab with an authorized user
3. Check commit author: `git log --oneline -1`
4. Test with unauthorized user to verify failure
5. Verify Vercel deployment shows correct author

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["draft-release.yml"]:::major-edit --> B["Organization Secret"]:::context
    A --> C["Shell Script Logic"]:::major-edit
    B --> D["RELEASE_USER_EMAILS"]:::context
    C --> E["JSON Parsing (jq)"]:::major-edit
    E --> F["Authorization Check"]:::major-edit
    F --> G["Git Config"]:::context
    G --> H["Commit Author"]:::context
    H --> I["Vercel Deployment"]:::context
    I --> J["Fixed: No more invalid-email-address"]:::context
    
    K["Unauthorized User"]:::context --> F
    F --> L["Workflow Failure"]:::context
    
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Risk Assessment:** High risk due to untested workflow execution, dependency on external configuration, and breaking change in access control. The shell script logic with JSON parsing needs careful verification.

**Breaking Change Warning:** This workflow will now fail for users not in the authorized mapping. The organization secret `RELEASE_USER_EMAILS` must be created before this can work.

**Session Info:** 
- Link to Devin run: https://app.devin.ai/sessions/ce60bff42a264c5a9600b209131f180e
- Requested by: @zomars
