### PR TITLE
fix: Don't continue retrying SMS reminders infinitely

### DIFF
--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -38,7 +38,7 @@ export async function handler(req: NextRequest) {
         lte: dayjs().add(2, "hour").toISOString(),
       },
       retryCount: {
-        lte: 3, // Don't continue retrying if it's already failed 3 times
+        lt: 3, // Don't continue retrying if it's already failed 3 times
       },
     },
     select: {

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -37,6 +37,9 @@ export async function handler(req: NextRequest) {
       scheduledDate: {
         lte: dayjs().add(2, "hour").toISOString(),
       },
+      retryCount: {
+        lte: 3, // Don't continue retrying if it's already failed 3 times
+      },
     },
     select: {
       ...select,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stopped SMS reminders from retrying more than 3 times to prevent endless retries.

<!-- End of auto-generated description by cubic. -->

