### PR TITLE
refactor: filter out admins and owners from platform event types hosts

### DIFF
--- a/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
+++ b/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
@@ -95,7 +95,9 @@ export class EventTypesAtomService {
     }
 
     // note (Lauris): don't show platform owner as one of the people that can be assigned to managed team event type
-    const onlyManagedTeamMembers = eventType.teamMembers.filter((user) => user.isPlatformManaged);
+    const onlyManagedTeamMembers = eventType.teamMembers.filter(
+      (user) => user.isPlatformManaged && user.membership === "MEMBER"
+    );
     eventType.teamMembers = onlyManagedTeamMembers;
 
     return eventType;


### PR DESCRIPTION
Linear [CAL-6042](https://linear.app/calcom/issue/CAL-6042/refactor-filter-out-admins-and-owners-from-platform-event-types-hosts)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated event type host filtering to exclude admins and owners, so only platform-managed team members with "MEMBER" status can be assigned as hosts.

<!-- End of auto-generated description by cubic. -->

