### PR TITLE
fix: center align dropdown indicator when menu is open

### DIFF
--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -67,12 +67,7 @@ export const Select = <
             innerClassNames?.option
           ),
         placeholder: (state) => cx("text-muted", state.isFocused && variant !== "checkbox" && "hidden"),
-        dropdownIndicator: () =>
-          cx(
-            "text-default",
-            "w-4 h-4",
-            "flex items-center justify-center " // crucial for centering
-          ),
+        dropdownIndicator: () => cx("text-default", "w-4 h-4", "flex items-center justify-center "),
         control: (state) =>
           cx(
             inputStyles({ size }),

--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -67,7 +67,12 @@ export const Select = <
             innerClassNames?.option
           ),
         placeholder: (state) => cx("text-muted", state.isFocused && variant !== "checkbox" && "hidden"),
-        dropdownIndicator: () => cx("text-default w-4 h-4"),
+        dropdownIndicator: () =>
+          cx(
+            "text-default",
+            "w-4 h-4",
+            "flex items-center justify-center " // crucial for centering
+          ),
         control: (state) =>
           cx(
             inputStyles({ size }),
@@ -106,6 +111,7 @@ export const Select = <
           ),
         indicatorsContainer: (state) =>
           cx(
+            "flex items-center justify-center mt-0.5",
             state.selectProps.menuIsOpen
               ? hasMultiLastIcons
                 ? "[&>*:last-child]:rotate-180 [&>*:last-child]:transition-transform [&>*:last-child]:w-4 [&>*:last-child]:h-4"


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where the dropdown indicator in the Select component appears vertically misaligned  when the menu is open

- Fixes #22261 
- Fixes CAL-6043 

## Visual Demo (For contributors especially)

before :

[Screencast from 2025-07-04 15-45-44.webm](https://github.com/user-attachments/assets/db33b171-aada-4cce-a283-82e51636df36)

after:

[Screencast from 2025-07-04 15-48-03.webm](https://github.com/user-attachments/assets/9270b624-320e-4edf-807d-634548be0fa4)




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the dropdown indicator in the Select component so it stays vertically centered when the menu is open.

<!-- End of auto-generated description by cubic. -->

