### PR TITLE
feat: filter team members by MEMBER role in EventTeamAssignmentTabPla…

### DIFF
--- a/packages/platform/atoms/event-types/wrappers/EventTeamAssignmentTabPlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTeamAssignmentTabPlatformWrapper.tsx
@@ -2,17 +2,12 @@ import {
   EventTeamAssignmentTab,
   type EventTeamAssignmentTabBaseProps,
 } from "@calcom/features/eventtypes/components/tabs/assignment/EventTeamAssignmentTab";
-import { MembershipRole } from "@calcom/prisma/enums";
 
 const EventTeamAssignmentTabPlatformWrapper = (
   props: Omit<EventTeamAssignmentTabBaseProps, "isSegmentApplicable">
 ) => {
-  // Filter team members to only include those with MEMBER role
-  const filteredTeamMembers = props.teamMembers.filter(
-    (member) => member.membership === MembershipRole.MEMBER
-  );
-
-  return <EventTeamAssignmentTab {...props} teamMembers={filteredTeamMembers} isSegmentApplicable={false} />;
+  // todo: implement attributes for platform orgs for segment
+  return <EventTeamAssignmentTab {...props} isSegmentApplicable={false} />;
 };
 
 export default EventTeamAssignmentTabPlatformWrapper;

--- a/packages/platform/atoms/event-types/wrappers/EventTeamAssignmentTabPlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTeamAssignmentTabPlatformWrapper.tsx
@@ -2,12 +2,17 @@ import {
   EventTeamAssignmentTab,
   type EventTeamAssignmentTabBaseProps,
 } from "@calcom/features/eventtypes/components/tabs/assignment/EventTeamAssignmentTab";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 const EventTeamAssignmentTabPlatformWrapper = (
   props: Omit<EventTeamAssignmentTabBaseProps, "isSegmentApplicable">
 ) => {
-  // todo: implement attributes for platform orgs for segment
-  return <EventTeamAssignmentTab {...props} isSegmentApplicable={false} />;
+  // Filter team members to only include those with MEMBER role
+  const filteredTeamMembers = props.teamMembers.filter(
+    (member) => member.membership === MembershipRole.MEMBER
+  );
+
+  return <EventTeamAssignmentTab {...props} teamMembers={filteredTeamMembers} isSegmentApplicable={false} />;
 };
 
 export default EventTeamAssignmentTabPlatformWrapper;


### PR DESCRIPTION
…tformWrapper

## What does this PR do?

filters out member roles from admin roles. 

- Fixes #22257
- Fixes CAL-6042
## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Team member filtering now only shows users with the MEMBER role in the EventTeamAssignmentTabPlatformWrapper. This prevents admins and other roles from appearing in team assignments.

<!-- End of auto-generated description by cubic. -->

