### PR TITLE
fix: add missing ref parameter to SatSymbol forwardRef component

### DIFF
--- a/packages/ui/components/icon/SatSymbol.tsx
+++ b/packages/ui/components/icon/SatSymbol.tsx
@@ -1,8 +1,12 @@
 import React, { forwardRef } from "react";
 
-export const SatSymbol = forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>(function SatSymbol(props) {
+export const SatSymbol = forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>(function SatSymbol(
+  props,
+  ref
+) {
   return (
     <svg
+      ref={ref}
       className={props.className}
       id="Layer_1"
       data-name="Layer 1"


### PR DESCRIPTION

# fix: add missing ref parameter to SatSymbol forwardRef component

## Summary

Fixed a React forwardRef error that was preventing the /event-types page from loading properly. The `SatSymbol` component (used for Bitcoin payment icons) was using `forwardRef` but missing the required `ref` parameter in its render function.

**Error resolved:**
```
forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```

**Changes made:**
- Added missing `ref` parameter to the `SatSymbol` forwardRef render function  
- Forwarded the `ref` to the SVG element to enable proper ref handling

## Review & Testing Checklist for Human

**⚠️ 3 items - Medium Risk (insufficient testing)**

- [x] **Verify the original error is resolved** - Visit `/event-types` page locally and confirm no forwardRef errors appear in console
- [x] **Test Bitcoin payment icons** - Check that Bitcoin payment icons display correctly in event type descriptions and pricing sections
- [x] **Regression testing** - Ensure no new console errors appear when navigating through the application

**Recommended test plan:** Navigate to `/event-types` page → look for event types with Bitcoin payments → verify pricing badges display correctly → check browser console for any forwardRef errors.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["apps/web/modules/event-types/views/<br/>event-types-listing-view.tsx"]:::context
    B["packages/features/eventtypes/components/<br/>EventTypeDescription.tsx"]:::context
    C["packages/features/bookings/components/<br/>event-meta/PriceIcon.tsx"]:::context
    D["packages/ui/components/icon/<br/>SatSymbol.tsx"]:::major-edit
    
    A --> B
    B --> C
    C --> D
    
    A -.->|"forwardRef error<br/>originated here"| D
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The error occurred when Bitcoin payment pricing was displayed, as the `SatSymbol` component is used within the `PriceIcon` component
- TypeScript compilation passed (`yarn type-check:ci`) confirming the fix is type-safe
- **Limited testing:** Could not fully test by visiting the /event-types page due to authentication issues in the local environment
- The fix follows standard React forwardRef patterns and should be safe

---

**Requested by:** @eunjae-lee  
**Devin session:** https://app.devin.ai/sessions/4f8654cc9cc042b3addb5610905f9889
