### PR TITLE
fix: prevent nested anchor tags in navigation UnconfirmedBookingBadge

### DIFF
--- a/packages/features/bookings/UnconfirmedBookingBadge.tsx
+++ b/packages/features/bookings/UnconfirmedBookingBadge.tsx
@@ -4,19 +4,28 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Badge } from "@calcom/ui/components/badge";
 
-export default function UnconfirmedBookingBadge() {
+interface UnconfirmedBookingBadgeProps {
+  asLink?: boolean;
+}
+
+export default function UnconfirmedBookingBadge({ asLink = true }: UnconfirmedBookingBadgeProps) {
   const { t } = useLocale();
   const { data: unconfirmedBookingCount } = trpc.viewer.me.bookingUnconfirmedCount.useQuery();
   if (!unconfirmedBookingCount) return null;
-  return (
-    <Link href="/bookings/unconfirmed">
-      <Badge
-        rounded
-        title={t("unconfirmed_bookings_tooltip")}
-        variant="orange"
-        className="cursor-pointer hover:bg-orange-800 hover:text-orange-100">
-        {unconfirmedBookingCount}
-      </Badge>
-    </Link>
+
+  const badge = (
+    <Badge
+      rounded
+      title={t("unconfirmed_bookings_tooltip")}
+      variant="orange"
+      className="cursor-pointer hover:bg-orange-800 hover:text-orange-100">
+      {unconfirmedBookingCount}
+    </Badge>
   );
+
+  if (!asLink) {
+    return badge;
+  }
+
+  return <Link href="/bookings/unconfirmed">{badge}</Link>;
 }

--- a/packages/features/bookings/UnconfirmedBookingBadge.tsx
+++ b/packages/features/bookings/UnconfirmedBookingBadge.tsx
@@ -1,19 +1,13 @@
-import Link from "next/link";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Badge } from "@calcom/ui/components/badge";
 
-interface UnconfirmedBookingBadgeProps {
-  asLink?: boolean;
-}
-
-export default function UnconfirmedBookingBadge({ asLink = true }: UnconfirmedBookingBadgeProps) {
+export default function UnconfirmedBookingBadge() {
   const { t } = useLocale();
   const { data: unconfirmedBookingCount } = trpc.viewer.me.bookingUnconfirmedCount.useQuery();
   if (!unconfirmedBookingCount) return null;
 
-  const badge = (
+  return (
     <Badge
       rounded
       title={t("unconfirmed_bookings_tooltip")}
@@ -22,10 +16,4 @@ export default function UnconfirmedBookingBadge({ asLink = true }: UnconfirmedBo
       {unconfirmedBookingCount}
     </Badge>
   );
-
-  if (!asLink) {
-    return badge;
-  }
-
-  return <Link href="/bookings/unconfirmed">{badge}</Link>;
 }

--- a/packages/features/shell/navigation/Navigation.tsx
+++ b/packages/features/shell/navigation/Navigation.tsx
@@ -26,7 +26,7 @@ const getNavigationItems = (orgBranding: OrganizationBranding): NavigationItemTy
     name: "bookings",
     href: "/bookings/upcoming",
     icon: "calendar",
-    badge: <UnconfirmedBookingBadge asLink={false} />,
+    badge: <UnconfirmedBookingBadge />,
     isCurrent: ({ pathname }) => pathname?.startsWith("/bookings") ?? false,
   },
   {

--- a/packages/features/shell/navigation/Navigation.tsx
+++ b/packages/features/shell/navigation/Navigation.tsx
@@ -26,7 +26,7 @@ const getNavigationItems = (orgBranding: OrganizationBranding): NavigationItemTy
     name: "bookings",
     href: "/bookings/upcoming",
     icon: "calendar",
-    badge: <UnconfirmedBookingBadge />,
+    badge: <UnconfirmedBookingBadge asLink={false} />,
     isCurrent: ({ pathname }) => pathname?.startsWith("/bookings") ?? false,
   },
   {


### PR DESCRIPTION

# Fix: Prevent nested anchor tags in navigation UnconfirmedBookingBadge

## Summary

Fixes a hydration error caused by nested `<a>` tags in the navigation sidebar. The issue occurred when `UnconfirmedBookingBadge` rendered its own `<Link>` component inside the navigation item, which was already wrapped in a `<Link>` by the `NavigationItem` component.

**Root cause:** `NavigationItem` → `<Link>` → `UnconfirmedBookingBadge` → `<Link>` = nested `<a>` tags

**Solution:** Added an optional `asLink` prop to `UnconfirmedBookingBadge` that defaults to `true`. When set to `false`, the component renders only the badge without the Link wrapper. Updated navigation usage to pass `asLink={false}`.

## Review & Testing Checklist for Human

- [ ] **Navigate to `/event-types` and verify no hydration errors appear in browser console** (most critical - this was the original issue)
- [ ] **Test unconfirmed booking badge functionality**: Create some unconfirmed bookings and verify the badge appears in navigation with correct count
- [ ] **Verify navigation behavior**: Clicking anywhere on the bookings navigation item (including the badge area) should navigate to `/bookings/upcoming` 
- [ ] **Check standalone usage**: Verify the badge still works as a clickable link in other contexts where it might be used outside navigation
- [ ] **Visual consistency**: Ensure badge styling and hover effects remain the same

**Recommended test plan:** Log into the app locally, create some unconfirmed bookings, navigate to `/event-types`, and verify both the absence of console errors and proper navigation behavior.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Nav["Navigation.tsx<br/>(getNavigationItems)"]:::major-edit
    NavItem["NavigationItem.tsx<br/>(NavigationItem component)"]:::context
    Badge["UnconfirmedBookingBadge.tsx<br/>(UnconfirmedBookingBadge)"]:::major-edit
    
    Nav -->|"badge: <UnconfirmedBookingBadge asLink={false} />"| Badge
    NavItem -->|"wraps in <Link>"| Nav
    Badge -->|"conditional rendering<br/>based on asLink prop"| BadgeOutput["Badge JSX<br/>(with or without Link)"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Performance issue during development**: The local dev server was extremely slow (35+ second page loads), preventing thorough local testing of the fix
- **Backward compatibility**: The `asLink` prop defaults to `true`, so existing usage should remain unchanged
- **Alternative approaches considered**: Could have used React context to detect navigation usage, but the prop-based approach is simpler and more explicit


**Session info:** Requested by @eunjae-lee  
**Devin session:** https://app.devin.ai/sessions/00a2b74f38234cd5a241429effe57f18
