### PR TITLE
fix: prevent nested anchor tags in NavigationItem by positioning badge absolutely

### DIFF
--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -3,10 +3,10 @@ import { usePathname } from "next/navigation";
 import React, { Fragment } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { SkeletonText } from "@calcom/ui/components/skeleton";
 import classNames from "@calcom/ui/classNames";
 import { Icon } from "@calcom/ui/components/icon";
 import type { IconName } from "@calcom/ui/components/icon";
+import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import { useShouldDisplayNavigationItem } from "./useShouldDisplayNavigationItem";
@@ -56,46 +56,52 @@ export const NavigationItem: React.FC<{
   return (
     <Fragment>
       <Tooltip side="right" content={t(item.name)} className="lg:hidden">
-        <Link
-          data-test-id={item.name}
-          href={item.href}
-          aria-label={t(item.name)}
-          target={item.target}
-          className={classNames(
-            "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-            item.child ? `[&[aria-current='page']]:!bg-transparent` : `[&[aria-current='page']]:bg-emphasis`,
-            isChild
-              ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
-                  props.index === 0 ? "mt-0" : "mt-px"
-                }`
-              : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
-            isLocaleReady
-              ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-              : ""
+        <div className="relative">
+          <Link
+            data-test-id={item.name}
+            href={item.href}
+            aria-label={t(item.name)}
+            target={item.target}
+            className={classNames(
+              "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
+              item.child
+                ? `[&[aria-current='page']]:!bg-transparent`
+                : `[&[aria-current='page']]:bg-emphasis`,
+              isChild
+                ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
+                    props.index === 0 ? "mt-0" : "mt-px"
+                  }`
+                : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
+              isLocaleReady
+                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+                : ""
+            )}
+            aria-current={current ? "page" : undefined}>
+            {item.icon && (
+              <Icon
+                name={item.isLoading ? "rotate-cw" : item.icon}
+                className={classNames(
+                  "todesktop:!text-blue-500 mr-2 h-4 w-4 flex-shrink-0 rtl:ml-2 md:ltr:mx-auto lg:ltr:mr-2 [&[aria-current='page']]:text-inherit",
+                  item.isLoading && "animate-spin"
+                )}
+                aria-hidden="true"
+                aria-current={current ? "page" : undefined}
+              />
+            )}
+            {isLocaleReady ? (
+              <span
+                className="hidden w-full truncate text-ellipsis lg:flex"
+                data-testid={`${item.name}-test`}>
+                {t(item.name)}
+              </span>
+            ) : (
+              <SkeletonText className="h-[20px] w-full" />
+            )}
+          </Link>
+          {item.badge && (
+            <div className="absolute right-2 top-1/2 hidden -translate-y-1/2 lg:block">{item.badge}</div>
           )}
-          aria-current={current ? "page" : undefined}>
-          {item.icon && (
-            <Icon
-              name={item.isLoading ? "rotate-cw" : item.icon}
-              className={classNames(
-                "todesktop:!text-blue-500 mr-2 h-4 w-4 flex-shrink-0 rtl:ml-2 md:ltr:mx-auto lg:ltr:mr-2 [&[aria-current='page']]:text-inherit",
-                item.isLoading && "animate-spin"
-              )}
-              aria-hidden="true"
-              aria-current={current ? "page" : undefined}
-            />
-          )}
-          {isLocaleReady ? (
-            <span
-              className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-              data-testid={`${item.name}-test`}>
-              {t(item.name)}
-              {item.badge && item.badge}
-            </span>
-          ) : (
-            <SkeletonText className="h-[20px] w-full" />
-          )}
-        </Link>
+        </div>
       </Tooltip>
       {item.child &&
         isCurrent({ pathname, isChild, item }) &&


### PR DESCRIPTION

# Fix: Prevent nested anchor tags in NavigationItem by positioning badge absolutely

## Summary

Resolves the hydration error "In HTML, `<a>` cannot be a descendant of `<a>`" that occurs on the `/event-types` page when the `UnconfirmedBookingBadge` is rendered within the bookings navigation item.

**Root Cause:** The `UnconfirmedBookingBadge` component contains its own `Link` component that links to `/bookings/unconfirmed`, but it was being rendered inside another `Link` component in `NavigationItem` that links to `/bookings/upcoming`, creating nested anchor tags.

**Solution:** Restructured the `NavigationItem` component to use absolute positioning for badges, similar to the existing `MobileNavigationItem` pattern. The badge is now positioned outside the main navigation link while preserving both link destinations and maintaining the visual design.

**Key Changes:**
- Wrapped the navigation `Link` in a relative container
- Positioned the badge absolutely in the top-right area of the container
- Removed the badge from inside the link's span element
- Preserved both navigation functionality (main link → `/bookings/upcoming`, badge → `/bookings/unconfirmed`)

## Review & Testing Checklist for Human

⚠️ **High Priority (5 items)** - Due to limited local testing capability

- [ ] **Visual Verification**: Confirm the badge appears correctly positioned and styled, matching the original design
- [ ] **Functional Testing**: Verify both links work properly (navigation item → `/bookings/upcoming`, badge → `/bookings/unconfirmed`)
- [ ] **Console Check**: Confirm the nested anchor tag hydration error no longer appears in browser console on `/event-types` page
- [ ] **Accessibility Testing**: Test keyboard navigation and screen reader behavior with the repositioned badge
- [ ] **Responsive Testing**: Verify the badge positioning works correctly across different screen sizes (especially the `lg:block` behavior)

**Recommended Test Plan:**
1. Navigate to `/event-types` page when logged in
2. Check browser console for hydration errors
3. Test clicking both the navigation item and the badge
4. Use keyboard navigation to verify tab order
5. Test on mobile/tablet sizes to ensure responsive behavior

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Navigation["Navigation.tsx<br/>(Context)"] --> NavigationItem["NavigationItem.tsx<br/>(Major Edit)"]:::major-edit
    NavigationItem --> Badge["UnconfirmedBookingBadge.tsx<br/>(Context)"]:::context
    
    NavigationItem --> Link1["Main Link<br/>/bookings/upcoming"]
    NavigationItem --> Link2["Badge Link<br/>/bookings/unconfirmed"]
    
    subgraph "Before (Nested)"
        B1["Link (upcoming)"] --> B2["Badge Link (unconfirmed)"]
        B2 --> B3["❌ Nested <a> tags"]
    end
    
    
    subgraph "After (Absolute)"
        A1["Relative Container"] --> A2["Link (upcoming)"]
        A1 --> A3["Absolute Badge (unconfirmed)"]
        A3 --> A4["✅ Separate clickable areas"]
    end
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Pattern Consistency**: This solution follows the same absolute positioning pattern already used in `MobileNavigationItem` within the same file
- **Testing Limitation**: Unable to fully test locally due to development environment authentication issues - human verification is critical
- **Link to Devin run**: https://app.devin.ai/sessions/00a2b74f38234cd5a241429effe57f18
- **Requested by**: @eunjae-lee

