### PR TITLE
feat: move pbac to prisma

### DIFF
--- a/packages/features/pbac/domain/repositories/IPermissionRepository.ts
+++ b/packages/features/pbac/domain/repositories/IPermissionRepository.ts
@@ -1,3 +1,5 @@
+import type { PrismaTransaction, PrismaClient as PrismaClientWithExtensions } from "@calcom/prisma";
+
 import type { TeamPermissions } from "../models/Permission";
 import type { PermissionString, Resource, CrudAction, CustomAction } from "../types/permission-registry";
 
@@ -44,4 +46,6 @@ export interface IPermissionRepository {
     teamId: number,
     resource: Resource
   ): Promise<(CrudAction | CustomAction)[]>;
+
+  setTransaction(trx: PrismaClientWithExtensions | PrismaTransaction): void;
 }

--- a/packages/features/pbac/domain/repositories/IRoleRepository.ts
+++ b/packages/features/pbac/domain/repositories/IRoleRepository.ts
@@ -1,6 +1,4 @@
-import type { Transaction } from "kysely";
-
-import type { DB } from "@calcom/kysely";
+import type { PrismaTransaction, PrismaClient as PrismaClientWithExtensions } from "@calcom/prisma";
 
 import type { Role, CreateRoleData } from "../models/Role";
 import type { PermissionString } from "../types/permission-registry";
@@ -21,5 +19,5 @@ export interface IRoleRepository {
       description?: string;
     }
   ): Promise<Role>;
-  transaction<T>(callback: (repository: IRoleRepository, trx: Transaction<DB>) => Promise<T>): Promise<T>;
+  setTransaction(trx: PrismaClientWithExtensions | PrismaTransaction): void;
 }

--- a/packages/features/pbac/infrastructure/repositories/RoleRepository.ts
+++ b/packages/features/pbac/infrastructure/repositories/RoleRepository.ts
@@ -1,9 +1,7 @@
-import type { Transaction } from "kysely";
-import { jsonArrayFrom } from "kysely/helpers/postgres";
 import { v4 as uuidv4 } from "uuid";
 
-import type { DB } from "@calcom/kysely";
-import kysely from "@calcom/kysely";
+import db from "@calcom/prisma";
+import type { PrismaClient as PrismaClientWithExtensions, PrismaTransaction } from "@calcom/prisma";
 
 import { RoleMapper } from "../../domain/mappers/RoleMapper";
 import { RoleType } from "../../domain/models/Role";
@@ -11,125 +9,96 @@ import type { CreateRoleData } from "../../domain/models/Role";
 import type { IRoleRepository } from "../../domain/repositories/IRoleRepository";
 import type { PermissionString } from "../../domain/types/permission-registry";
 
-type KyselyRole = {
-  id: string;
-  name: string;
-  color: string | null;
-  description: string | null;
-  teamId: number | null;
-  type: RoleType;
-  createdAt: Date;
-  updatedAt: Date;
-  permissions: Array<{
-    id: string;
-    resource: string;
-    action: string;
-  }>;
-};
-
 export class RoleRepository implements IRoleRepository {
-  private getRoleSelect() {
-    return [
-      "Role.id",
-      "Role.name",
-      "Role.description",
-      "Role.teamId",
-      "Role.type",
-      "Role.color",
-      "Role.createdAt",
-      "Role.updatedAt",
-      (eb: any) =>
-        jsonArrayFrom(
-          eb
-            .selectFrom("RolePermission")
-            .select(["id", "resource", "action"])
-            .whereRef("RolePermission.roleId", "=", "Role.id")
-        ).as("permissions"),
-    ] as const;
+  private client: PrismaClientWithExtensions | PrismaTransaction;
+
+  constructor(client: PrismaClientWithExtensions | PrismaTransaction = db) {
+    this.client = client;
+  }
+
+  setTransaction(trx: PrismaClientWithExtensions | PrismaTransaction) {
+    this.client = trx;
   }
 
   async findByName(name: string, teamId?: number) {
-    const role = await kysely
-      .selectFrom("Role")
-      .select(this.getRoleSelect())
-      .where("name", "=", name)
-      .where((eb) => (teamId ? eb("teamId", "=", teamId) : eb("teamId", "is", null)))
-      .executeTakeFirst();
-
-    return role ? RoleMapper.toDomain(role as KyselyRole) : null;
+    const role = await this.client.role.findFirst({
+      where: {
+        name,
+        teamId: teamId ?? null,
+      },
+      include: {
+        permissions: true,
+      },
+    });
+    return role
+      ? RoleMapper.toDomain({ ...role, permissions: role.permissions, color: role.color ?? null })
+      : null;
   }
 
   async findById(id: string) {
-    const role = await kysely
-      .selectFrom("Role")
-      .select(this.getRoleSelect())
-      .where("id", "=", id)
-      .executeTakeFirst();
-
-    return role ? RoleMapper.toDomain(role as KyselyRole) : null;
+    const role = await this.client.role.findUnique({
+      where: { id },
+      include: {
+        permissions: true,
+      },
+    });
+    return role
+      ? RoleMapper.toDomain({ ...role, permissions: role.permissions, color: role.color ?? null })
+      : null;
   }
 
   async findByTeamId(teamId: number) {
-    const roles = await kysely
-      .selectFrom("Role")
-      .select(this.getRoleSelect())
-      .where((eb) => eb.or([eb("Role.teamId", "=", teamId), eb("Role.type", "=", RoleType.SYSTEM)]))
-      .execute();
-
-    return roles.map((role) => RoleMapper.toDomain(role as KyselyRole));
+    const roles = await this.client.role.findMany({
+      where: {
+        OR: [{ teamId }, { type: RoleType.SYSTEM }],
+      },
+      include: {
+        permissions: true,
+      },
+    });
+    return roles.map((role) =>
+      RoleMapper.toDomain({ ...role, permissions: role.permissions, color: role.color ?? null })
+    );
   }
 
   async create(data: CreateRoleData) {
     const roleId = uuidv4();
-
-    await kysely.transaction().execute(async (trx) => {
-      // Create role
-      await trx
-        .insertInto("Role")
-        .values({
-          id: roleId,
-          name: data.name,
-          description: data.description || null,
-          teamId: data.teamId || null,
-          type: data.type || RoleType.CUSTOM,
-          color: data.color || null,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .execute();
-
-      // Create permissions only if there are any
-      if (data.permissions.length > 0) {
-        const permissionData = data.permissions.map((permission) => {
-          const [resource, action] = permission.split(".");
-          return {
-            id: uuidv4(),
-            roleId,
-            resource,
-            action,
-          };
-        });
-
-        await trx.insertInto("RolePermission").values(permissionData).execute();
-      }
-
-      return roleId;
+    const now = new Date();
+    // Create role
+    await this.client.role.create({
+      data: {
+        id: roleId,
+        name: data.name,
+        description: data.description || null,
+        teamId: data.teamId || null,
+        type: data.type || RoleType.CUSTOM,
+        color: data.color || null,
+        createdAt: now,
+        updatedAt: now,
+      },
     });
-
+    // Create permissions only if there are any
+    if (data.permissions.length > 0) {
+      const permissionData = data.permissions.map((permission) => {
+        const [resource, action] = permission.split(".");
+        return {
+          id: uuidv4(),
+          roleId,
+          resource,
+          action,
+        };
+      });
+      await this.client.rolePermission.createMany({ data: permissionData });
+    }
     // Fetch complete role with permissions
     const completeRole = await this.findById(roleId);
-
-    // This should never happen
     if (!completeRole) throw new Error("Failed to create role");
-
     return completeRole;
   }
 
   async delete(id: string) {
-    await kysely.transaction().execute(async (trx) => {
-      await trx.deleteFrom("RolePermission").where("roleId", "=", id).execute();
-      await trx.deleteFrom("Role").where("id", "=", id).execute();
-    });
+    await this.client.rolePermission.deleteMany({ where: { roleId: id } });
+    await this.client.role.delete({ where: { id } });
   }
 
   async update(
@@ -141,64 +110,37 @@ export class RoleRepository implements IRoleRepository {
       description?: string;
     }
   ) {
-    await kysely.transaction().execute(async (trx) => {
-      // Update role metadata if provided
-      if (updates) {
-        const updateData: Partial<Pick<KyselyRole, "name" | "color" | "description">> = {};
-
-        if (updates.color !== undefined) {
-          updateData.color = updates.color || null;
-        }
-        if (updates.name !== undefined) {
-          updateData.name = updates.name;
-        }
-        if (updates.description !== undefined) {
-          updateData.description = updates.description || null;
-        }
-
-        await trx.updateTable("Role").set(updateData).where("id", "=", roleId).execute();
+    // Update role metadata if provided
+    if (updates) {
+      const updateData: Record<string, any> = {};
+      if (updates.color !== undefined) {
+        updateData.color = updates.color || null;
       }
-
-      // Delete existing permissions
-      await trx.deleteFrom("RolePermission").where("roleId", "=", roleId).execute();
-
-      // Create new permissions
-      const permissionData = permissions.map((permission) => {
-        const [resource, action] = permission.split(".");
-        return {
-          id: uuidv4(),
-          roleId,
-          resource,
-          action,
-        };
-      });
-
-      await trx.insertInto("RolePermission").values(permissionData).execute();
-
-      return roleId;
+      if (updates.name !== undefined) {
+        updateData.name = updates.name;
+      }
+      if (updates.description !== undefined) {
+        updateData.description = updates.description || null;
+      }
+      await this.client.role.update({ where: { id: roleId }, data: updateData });
+    }
+    // Delete existing permissions
+    await this.client.rolePermission.deleteMany({ where: { roleId } });
+    // Create new permissions
+    const permissionData = permissions.map((permission) => {
+      const [resource, action] = permission.split(".");
+      return {
+        id: uuidv4(),
+        roleId,
+        resource,
+        action,
+      };
     });
-
+    await this.client.rolePermission.createMany({ data: permissionData });
     // Fetch updated role
-    const updatedRole = await kysely
-      .selectFrom("Role")
-      .select(this.getRoleSelect())
-      .where("id", "=", roleId)
-      .executeTakeFirst();
-
+    const updatedRole = await this.findById(roleId);
     if (!updatedRole) throw new Error("Failed to update role permissions");
-
-    return RoleMapper.toDomain(updatedRole as KyselyRole);
-  }
-
-  async transaction<T>(
-    callback: (repository: IRoleRepository, trx: Transaction<DB>) => Promise<T>
-  ): Promise<T> {
-    return kysely.transaction().execute(async (trx) => {
-      // Create a new repository instance with the transaction connection
-      const transactionRepo = new RoleRepository();
-      // Pass both the repository and the transaction connection
-      return callback(transactionRepo, trx);
-    });
+    return updatedRole;
   }
 
   async roleBelongsToTeam(roleId: string, teamId: number) {


### PR DESCRIPTION
This PR moves PBAC from kysley to prisma while also providing a cleaner implementation of handling the transaction instance using DI within the repos
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved PBAC repositories from Kysely to Prisma for database access, and updated transaction handling to use dependency injection for cleaner code.

- **Refactors**
  - Replaced Kysely queries with Prisma in PBAC repositories.
  - Updated services and tests to use the new Prisma-based implementation and transaction pattern.

<!-- End of auto-generated description by cubic. -->

