### PR TITLE
fix: Calendar layout breaks on tall screen sizes

### DIFF
--- a/packages/features/calendars/DatePicker.tsx
+++ b/packages/features/calendars/DatePicker.tsx
@@ -240,7 +240,9 @@ const Days = ({
   return (
     <>
       {daysToRenderForTheMonth.map(({ day, disabled, away, emoji }, idx) => (
-        <div key={day === null ? `e-${idx}` : `day-${day.format()}`} className="relative w-full pt-[100%]">
+        <div
+          key={day === null ? `e-${idx}` : `day-${day.format()}`}
+          className="relative aspect-square min-h-[40px] w-full">
           {day === null ? (
             <div key={`e-${idx}`} />
           ) : props.isLoading ? (

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@calcom/tsconfig/base.json",
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ES2020",
+    "types": ["node"]
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext"
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
> Problem:
Calendar dates appear as dots instead of numbers on tall/narrow screens (768×1609), making it impossible to select dates.

#22306 

> Root Cause:
Date cells used pt-[100%] creating 1:1 aspect ratio that becomes too narrow horizontally on tall screens.

> Solution:

Replace pt-[100%] with aspect-square min-h-[40px] to:

Maintain square shape on balanced screens
Ensure minimum readable height on tall screens
Prevent text overflow/dot appearance

> Files Changed:
packages/features/calendars/DatePicker.tsx - Line 243
Testing:

✅ Works on 1024×903 (existing)
✅ Fixed on 768×1609 (previously broken)

> Before: Dates show as dots on tall screens
> After: All dates clearly visible across screen sizes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed calendar date cells showing as dots instead of numbers on tall screens by updating the layout to keep dates readable.

- **Bug Fixes**
  - Replaced pt-[100%] with aspect-square and min-h-[40px] to maintain square cells and prevent text overflow on all screen sizes.

<!-- End of auto-generated description by cubic. -->

