### PR TITLE
fix: allow hosts to cancel bookings when disableCancelling is enabled

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -106,7 +106,14 @@ async function handler(input: CancelBookingInput) {
     throw new HttpError({ statusCode: 400, message: "User not found" });
   }
 
-  if (bookingToDelete.eventType?.disableCancelling) {
+  // Check if user is host or owner
+  const userIsHost = bookingToDelete.eventType?.hosts?.find((host) => host.user.id === userId);
+  const userIsOwnerOfEventType = bookingToDelete.eventType?.owner?.id === userId;
+  const userIsBookingOwner = bookingToDelete.userId === userId;
+  const isHostOrOwner = userIsHost || userIsOwnerOfEventType || userIsBookingOwner;
+
+  // Only block cancellation for attendees (not hosts/owners) when disableCancelling is enabled
+  if (bookingToDelete.eventType?.disableCancelling && !isHostOrOwner) {
     throw new HttpError({
       statusCode: 400,
       message: "This event type does not allow cancellations",


### PR DESCRIPTION
>> What does this PR do?

- > Fixes issue where the "Disable Cancelling" feature incorrectly prevented hosts from canceling their own bookings. Now only attendees are blocked from canceling when this setting is enabled, while hosts/owners retain the ability to cancel bookings.

Fixes #22271

> How should this be tested?

- Create an event type with "Disable Cancelling" enabled
- Book an appointment as an attendee
- Try to cancel as the host/owner - should succeed
- Try to cancel as the attendee - should be blocked
- Test with team event types to verify host permissions work correctly

- Expected: Hosts can always cancel, attendees cannot when feature is disabled.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hosts can now cancel bookings even when "Disable Cancelling" is enabled. Only attendees are blocked from cancelling in this mode.

<!-- End of auto-generated description by cubic. -->

