### PR TITLE
fix: Update org user permissions for admins

### DIFF
--- a/packages/features/pbac/services/__tests__/role-management.factory.test.ts
+++ b/packages/features/pbac/services/__tests__/role-management.factory.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { isOrganisationOwner } from "@calcom/lib/server/queries/organisations";
+import { isOrganisationAdmin } from "@calcom/lib/server/queries/organisations";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 
@@ -24,7 +24,7 @@ vi.mock("@calcom/prisma", () => ({
   },
 }));
 vi.mock("@calcom/lib/server/queries/organisations", () => ({
-  isOrganisationOwner: vi.fn(),
+  isOrganisationAdmin: vi.fn(),
 }));
 
 describe("RoleManagementFactory", () => {
@@ -160,18 +160,18 @@ describe("RoleManagementFactory", () => {
     beforeEach(() => {
       mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(false);
       vi.mocked(prisma.membership.update).mockResolvedValue({});
-      vi.mocked(isOrganisationOwner).mockResolvedValue(false);
+      vi.mocked(isOrganisationAdmin).mockResolvedValue(false);
     });
 
     describe("checkPermissionToChangeRole", () => {
       it("should allow role change when user is owner", async () => {
-        vi.mocked(isOrganisationOwner).mockResolvedValue(true);
+        vi.mocked(isOrganisationAdmin).mockResolvedValue(true);
         const manager = await factory.createRoleManager(organizationId);
         await expect(manager.checkPermissionToChangeRole(userId, organizationId)).resolves.not.toThrow();
       });
 
       it("should throw UNAUTHORIZED when user is not owner", async () => {
-        vi.mocked(isOrganisationOwner).mockResolvedValue(false);
+        vi.mocked(isOrganisationAdmin).mockResolvedValue(false);
         const manager = await factory.createRoleManager(organizationId);
         await expect(manager.checkPermissionToChangeRole(userId, organizationId)).rejects.toThrow(TRPCError);
       });

--- a/packages/features/pbac/services/role-management.factory.ts
+++ b/packages/features/pbac/services/role-management.factory.ts
@@ -1,5 +1,5 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { isOrganisationOwner } from "@calcom/lib/server/queries/organisations";
+import { isOrganisationAdmin } from "@calcom/lib/server/queries/organisations";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 
@@ -73,7 +73,7 @@ class PBACRoleManager implements IRoleManager {
 class LegacyRoleManager implements IRoleManager {
   public isPBACEnabled = false;
   async checkPermissionToChangeRole(userId: number, organizationId: number): Promise<void> {
-    const isUpdaterAnOwner = await isOrganisationOwner(userId, organizationId);
+    const isUpdaterAnOwner = await isOrganisationAdmin(userId, organizationId);
 
     // Only OWNER can update role to OWNER
     if (!isUpdaterAnOwner) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Previously we allowed org admins and owners to update users. Currently the code only checks for owner permissions. This PR fixes that check to include admins again

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed user permission checks so both org admins and owners can update users, not just owners.

<!-- End of auto-generated description by cubic. -->

