### PR TITLE
chore: Experimental CSRF implementation for tRPC non-GET calls

### DIFF
--- a/apps/web/app/_trpc/trpc-client.ts
+++ b/apps/web/app/_trpc/trpc-client.ts
@@ -57,6 +57,11 @@ export const trpcClient = trpc.createClient({
             endpoint,
             httpLink({
               url: `${url}/${endpoint}`,
+              headers() {
+                return {
+                  "x-csrf-token": getCsrfToken(),
+                };
+              },
             })(runtime),
           ])
         );
@@ -69,6 +74,11 @@ export const trpcClient = trpc.createClient({
             endpoint,
             httpBatchLink({
               url: `${url}/${endpoint}`,
+              headers() {
+                return {
+                  "x-csrf-token": getCsrfToken(),
+                };
+              },
             })(runtime),
           ])
         );
@@ -78,3 +88,8 @@ export const trpcClient = trpc.createClient({
   ],
   transformer: superjson,
 });
+
+function getCsrfToken(): string | undefined {
+  if (typeof document === "undefined") return;
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute("content") ?? undefined;
+}

--- a/apps/web/app/api/csrf/route.ts
+++ b/apps/web/app/api/csrf/route.ts
@@ -1,0 +1,17 @@
+import { randomBytes } from "crypto";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const token = randomBytes(32).toString("hex");
+
+  const res = NextResponse.json({ csrfToken: token });
+
+  res.cookies.set("csrf-token", token, {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+  });
+
+  return res;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -101,7 +101,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const cookieStore = await cookies();
   let csrfToken = cookieStore.get("csrf-token")?.value;
   if (!csrfToken) {
-    const res = await fetch("/api/csrf");
+    const res = await fetch("/api/csrf", { cache: "no-store" });
     const data = await res.json();
     csrfToken = data.csrfToken;
   }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -98,6 +98,14 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const h = await headers();
   const nonce = h.get("x-csp") ?? "";
 
+  const cookieStore = await cookies();
+  let csrfToken = cookieStore.get("csrf-token")?.value;
+  if (!csrfToken) {
+    const res = await fetch("/api/csrf");
+    const data = await res.json();
+    csrfToken = data.csrfToken;
+  }
+
   const { locale, direction, isEmbed, embedColorScheme } = await getInitialProps();
 
   const ns = "common";
@@ -113,6 +121,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       suppressHydrationWarning
       data-nextjs-router="app">
       <head nonce={nonce}>
+        <meta name="csrf-token" content={csrfToken ?? ""} />
         <style>{`
           :root {
             --font-inter: ${interFont.style.fontFamily.replace(/\'/g, "")};

--- a/packages/trpc/server/middlewares/validateCSRF.ts
+++ b/packages/trpc/server/middlewares/validateCSRF.ts
@@ -1,0 +1,18 @@
+import { TRPCError } from "@trpc/server";
+
+import { middleware } from "../trpc";
+
+const validateCSRF = middleware(({ ctx, next }) => {
+  const csrfToken = ctx.req?.cookies["csrf-token"];
+  const csrfHeader = ctx.req?.headers["x-csrf-token"];
+  console.table({
+    "CSRF Token (header)": csrfHeader,
+    "CSRF Token (cookie)": csrfToken,
+  });
+  if (ctx.req?.method !== "GET" && (!csrfHeader || csrfToken !== csrfHeader)) {
+    throw new TRPCError({ code: "FORBIDDEN", message: "Invalid CSRF token" });
+  }
+  return next();
+});
+
+export default validateCSRF;

--- a/packages/trpc/server/routers/viewer/availability/schedule/_router.tsx
+++ b/packages/trpc/server/routers/viewer/availability/schedule/_router.tsx
@@ -1,4 +1,7 @@
+import { isAuthed } from "../../../../middlewares/sessionMiddleware";
+import validateCSRF from "../../../../middlewares/validateCSRF";
 import authedProcedure from "../../../../procedures/authedProcedure";
+import publicProcedure from "../../../../procedures/publicProcedure";
 import { router } from "../../../../trpc";
 import { ZBulkUpdateToDefaultAvailabilityInputSchema } from "./bulkUpdateDefaultAvailability.schema";
 import { ZCreateInputSchema } from "./create.schema";
@@ -10,17 +13,7 @@ import { ZGetByEventSlugInputSchema } from "./getScheduleByEventTypeSlug.schema"
 import { ZGetByUserIdInputSchema } from "./getScheduleByUserId.schema";
 import { ZUpdateInputSchema } from "./update.schema";
 
-type ScheduleRouterHandlerCache = {
-  get?: typeof import("./get.handler").getHandler;
-  create?: typeof import("./create.handler").createHandler;
-  delete?: typeof import("./delete.handler").deleteHandler;
-  update?: typeof import("./update.handler").updateHandler;
-  duplicate?: typeof import("./duplicate.handler").duplicateHandler;
-  getScheduleByUserId?: typeof import("./getScheduleByUserId.handler").getScheduleByUserIdHandler;
-  getAllSchedulesByUserId?: typeof import("./getAllSchedulesByUserId.handler").getAllSchedulesByUserIdHandler;
-  getScheduleByEventSlug?: typeof import("./getScheduleByEventTypeSlug.handler").getScheduleByEventSlugHandler;
-  bulkUpdateToDefaultAvailability?: typeof import("./bulkUpdateDefaultAvailability.handler").bulkUpdateToDefaultAvailabilityHandler;
-};
+const protectedMutationProcedure = publicProcedure.use(validateCSRF).use(isAuthed);
 
 export const scheduleRouter = router({
   get: authedProcedure.input(ZGetInputSchema).query(async ({ input, ctx }) => {
@@ -32,7 +25,7 @@ export const scheduleRouter = router({
     });
   }),
 
-  create: authedProcedure.input(ZCreateInputSchema).mutation(async ({ input, ctx }) => {
+  create: protectedMutationProcedure.input(ZCreateInputSchema).mutation(async ({ input, ctx }) => {
     const { createHandler } = await import("./create.handler");
 
     return createHandler({
@@ -41,7 +34,7 @@ export const scheduleRouter = router({
     });
   }),
 
-  delete: authedProcedure.input(ZDeleteInputSchema).mutation(async ({ input, ctx }) => {
+  delete: protectedMutationProcedure.input(ZDeleteInputSchema).mutation(async ({ input, ctx }) => {
     const { deleteHandler } = await import("./delete.handler");
 
     return deleteHandler({
@@ -50,7 +43,7 @@ export const scheduleRouter = router({
     });
   }),
 
-  update: authedProcedure.input(ZUpdateInputSchema).mutation(async ({ input, ctx }) => {
+  update: protectedMutationProcedure.input(ZUpdateInputSchema).mutation(async ({ input, ctx }) => {
     const { updateHandler } = await import("./update.handler");
 
     return updateHandler({
@@ -59,7 +52,7 @@ export const scheduleRouter = router({
     });
   }),
 
-  duplicate: authedProcedure.input(ZScheduleDuplicateSchema).mutation(async ({ input, ctx }) => {
+  duplicate: protectedMutationProcedure.input(ZScheduleDuplicateSchema).mutation(async ({ input, ctx }) => {
     const { duplicateHandler } = await import("./duplicate.handler");
 
     return duplicateHandler({
@@ -94,7 +87,7 @@ export const scheduleRouter = router({
       input,
     });
   }),
-  bulkUpdateToDefaultAvailability: authedProcedure
+  bulkUpdateToDefaultAvailability: protectedMutationProcedure
     .input(ZBulkUpdateToDefaultAvailabilityInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { bulkUpdateToDefaultAvailabilityHandler } = await import(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added experimental CSRF protection for tRPC non-GET calls to improve security.

- **New Features**
  - CSRF tokens are generated and stored in cookies and meta tags.
  - tRPC client sends CSRF tokens in headers for non-GET requests.
  - Server middleware checks CSRF tokens for non-GET tRPC calls.

<!-- End of auto-generated description by cubic. -->

