### PR TITLE
[POC] Schedule page caching strategy

### DIFF
--- a/packages/prisma/create-performance-test-team.ts
+++ b/packages/prisma/create-performance-test-team.ts
@@ -1,0 +1,281 @@
+import { faker } from "@faker-js/faker";
+import { MembershipRole, Prisma, SchedulingType } from "@prisma/client";
+import { uuid } from "short-uuid";
+
+import dayjs from "@calcom/dayjs";
+import { hashPassword } from "@calcom/features/auth/lib/hashPassword";
+import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
+
+import prisma from ".";
+
+const TEAM_SIZE = 1000;
+const BATCH_SIZE = 50;
+
+async function createLargeTeam() {
+  console.log(`🚀 Starting creation of performance test team with ${TEAM_SIZE} members...`);
+
+  const startTime = Date.now();
+
+  // Step 1: Create the team
+  const teamSlug = `perf-test-${Date.now()}`;
+  const team = await prisma.team.create({
+    data: {
+      name: `Performance Test Team (${TEAM_SIZE} members)`,
+      slug: teamSlug,
+      metadata: {
+        description: `Team created for performance testing with ${TEAM_SIZE} members`,
+      },
+    },
+  });
+
+  console.log(`✅ Team created: ${team.name} (ID: ${team.id})`);
+  console.log(`📍 Team URL: ${process.env.NEXT_PUBLIC_WEBAPP_URL}/team/${teamSlug}`);
+
+  // Step 2: Create team event types
+  const eventTypes = await Promise.all([
+    prisma.eventType.create({
+      data: {
+        title: "15min Quick Call",
+        slug: `${teamSlug}-15min`,
+        length: 15,
+        team: { connect: { id: team.id } },
+        schedulingType: SchedulingType.COLLECTIVE,
+        description: "A quick 15-minute team call",
+      },
+    }),
+    prisma.eventType.create({
+      data: {
+        title: "30min Team Meeting",
+        slug: `${teamSlug}-30min`,
+        length: 30,
+        team: { connect: { id: team.id } },
+        schedulingType: SchedulingType.ROUND_ROBIN,
+        description: "30-minute round-robin team meeting",
+      },
+    }),
+    prisma.eventType.create({
+      data: {
+        title: "60min Strategy Session",
+        slug: `${teamSlug}-60min`,
+        length: 60,
+        team: { connect: { id: team.id } },
+        schedulingType: SchedulingType.COLLECTIVE,
+        description: "60-minute collective strategy session",
+      },
+    }),
+  ]);
+
+  console.log(`✅ Created ${eventTypes.length} team event types`);
+
+  // Step 3: Create users in batches
+  console.log(`\n👥 Creating ${TEAM_SIZE} users in batches of ${BATCH_SIZE}...`);
+
+  const allUsers: Prisma.UserCreateInput[] = [];
+  let processedUsers = 0;
+
+  for (let batch = 0; batch < Math.ceil(TEAM_SIZE / BATCH_SIZE); batch++) {
+    const batchStart = batch * BATCH_SIZE;
+    const batchEnd = Math.min((batch + 1) * BATCH_SIZE, TEAM_SIZE);
+    const batchSize = batchEnd - batchStart;
+
+    console.log(
+      `\n📦 Processing batch ${batch + 1}/${Math.ceil(TEAM_SIZE / BATCH_SIZE)} (users ${
+        batchStart + 1
+      }-${batchEnd})...`
+    );
+
+    // Create user data for this batch
+    const batchUserData: Prisma.UserCreateInput[] = [];
+    for (let i = batchStart; i < batchEnd; i++) {
+      const username = `perf-user-${teamSlug}-${i + 1}`;
+      const email = `${username}@example.com`;
+      const hashedPassword = await hashPassword(username);
+
+      batchUserData.push({
+        email,
+        username,
+        name: faker.person.fullName(),
+        emailVerified: new Date(),
+        completedOnboarding: true,
+        locale: "en",
+        timeZone: faker.helpers.arrayElement([
+          "America/New_York",
+          "America/Chicago",
+          "America/Los_Angeles",
+          "Europe/London",
+          "Europe/Paris",
+          "Asia/Tokyo",
+          "Australia/Sydney",
+        ]),
+      });
+    }
+
+    // Bulk create users
+    await prisma.user.createMany({
+      data: batchUserData,
+    });
+
+    // Fetch created users
+    const createdUsers = await prisma.user.findMany({
+      where: {
+        email: {
+          in: batchUserData.map((u) => u.email),
+        },
+      },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        name: true,
+      },
+    });
+
+    // Create passwords for users
+    await Promise.all(
+      createdUsers.map(async (user) => {
+        await prisma.userPassword.create({
+          data: {
+            userId: user.id,
+            hash: await hashPassword(user.username ?? ""),
+          },
+        });
+      })
+    );
+
+    // Create schedules for users
+    await Promise.all(
+      createdUsers.map(async (user) => {
+        await prisma.schedule.create({
+          data: {
+            name: "Working Hours",
+            userId: user.id,
+            availability: {
+              createMany: {
+                data: getAvailabilityFromSchedule(DEFAULT_SCHEDULE),
+              },
+            },
+          },
+        });
+      })
+    );
+
+    // Create memberships
+    const membershipData = createdUsers.map((user, index) => ({
+      teamId: team.id,
+      userId: user.id,
+      role:
+        index === 0 && batch === 0
+          ? MembershipRole.OWNER
+          : index < 5 && batch === 0
+          ? MembershipRole.ADMIN
+          : MembershipRole.MEMBER,
+      accepted: true,
+      createdAt: new Date(),
+    }));
+
+    await prisma.membership.createMany({
+      data: membershipData,
+    });
+
+    // Connect users to team event types
+    for (const eventType of eventTypes) {
+      await prisma.eventType.update({
+        where: { id: eventType.id },
+        data: {
+          users: {
+            connect: createdUsers.map((user) => ({ id: user.id })),
+          },
+        },
+      });
+    }
+
+    allUsers.push(...createdUsers);
+    processedUsers += batchSize;
+
+    console.log(`✅ Batch ${batch + 1} completed: ${batchSize} users created and added to team`);
+    console.log(
+      `📊 Progress: ${processedUsers}/${TEAM_SIZE} users (${Math.round((processedUsers / TEAM_SIZE) * 100)}%)`
+    );
+  }
+
+  // Step 4: Create some sample bookings for the team events
+  console.log(`\n📅 Creating sample bookings for team events...`);
+
+  const bookingData: Prisma.BookingCreateManyInput[] = [];
+  const numBookings = Math.min(100, TEAM_SIZE / 10); // Create up to 100 bookings
+
+  for (let i = 0; i < numBookings; i++) {
+    const randomUser = allUsers[Math.floor(Math.random() * allUsers.length)];
+    const randomEventType = eventTypes[Math.floor(Math.random() * eventTypes.length)];
+    const startTime = dayjs()
+      .add(Math.floor(Math.random() * 30) + 1, "days")
+      .hour(Math.floor(Math.random() * 8) + 9)
+      .minute(Math.random() > 0.5 ? 0 : 30)
+      .second(0)
+      .toDate();
+
+    bookingData.push({
+      uid: uuid(),
+      title: `${randomEventType.title} - ${faker.company.catchPhrase()}`,
+      startTime,
+      endTime: dayjs(startTime).add(randomEventType.length, "minutes").toDate(),
+      eventTypeId: randomEventType.id,
+      userId: randomUser.id,
+      status: "ACCEPTED",
+      metadata: {},
+      responses: {
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        notes: faker.lorem.sentence(),
+      },
+    });
+  }
+
+  await prisma.booking.createMany({
+    data: bookingData,
+  });
+
+  console.log(`✅ Created ${bookingData.length} sample bookings`);
+
+  // Final stats
+  const endTime = Date.now();
+  const duration = (endTime - startTime) / 1000;
+
+  console.log(`\n🎉 Performance test team creation completed!`);
+  console.log(`📊 Final Statistics:`);
+  console.log(`   - Team: ${team.name} (ID: ${team.id})`);
+  console.log(`   - Team URL: ${process.env.NEXT_PUBLIC_WEBAPP_URL}/team/${teamSlug}`);
+  console.log(`   - Members: ${TEAM_SIZE}`);
+  console.log(`   - Event Types: ${eventTypes.length}`);
+  console.log(`   - Sample Bookings: ${bookingData.length}`);
+  console.log(`   - Total Duration: ${duration.toFixed(2)} seconds`);
+  console.log(`\n📝 Sample user credentials:`);
+  console.log(`   - Username: perf-user-${teamSlug}-1`);
+  console.log(`   - Password: perf-user-${teamSlug}-1`);
+  console.log(`   - Email: perf-user-${teamSlug}-1@example.com`);
+
+  return {
+    team,
+    eventTypes,
+    users: allUsers,
+    stats: {
+      teamId: team.id,
+      teamSlug,
+      memberCount: TEAM_SIZE,
+      eventTypeCount: eventTypes.length,
+      bookingCount: bookingData.length,
+      duration,
+    },
+  };
+}
+
+// Run the script
+createLargeTeam()
+  .then((result) => {
+    console.log("\n✅ Script completed successfully!");
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("\n❌ Error creating performance test team:", error);
+    process.exit(1);
+  });

--- a/packages/trpc/react/trpc.ts
+++ b/packages/trpc/react/trpc.ts
@@ -75,24 +75,24 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext, null> = createTRPC
               process.env.NEXT_PUBLIC_LOGGER_LEVEL >= 0) ||
             (opts.direction === "down" && opts.result instanceof Error),
         }),
-        splitLink({
-          // check for context property `skipBatch`
-          condition: (op) => !!op.context.skipBatch,
-          // when condition is true, use normal request
-          true: (runtime) => {
-            const links = Object.fromEntries(
-              ENDPOINTS.map((endpoint) => [endpoint, httpLink({ url: `${url}/${endpoint}` })(runtime)])
-            );
-            return resolveEndpoint(links);
-          },
-          // when condition is false, use batch request
-          false: (runtime) => {
-            const links = Object.fromEntries(
-              ENDPOINTS.map((endpoint) => [endpoint, httpBatchLink({ url: `${url}/${endpoint}` })(runtime)])
-            );
-            return resolveEndpoint(links);
-          },
-        }),
+        //splitLink({
+        //  // check for context property `skipBatch`
+        //  condition: (op) => !!op.context.skipBatch,
+        //  // when condition is true, use normal request
+        //  true: (runtime) => {
+        //    const links = Object.fromEntries(
+        //      ENDPOINTS.map((endpoint) => [endpoint, httpLink({ url: `${url}/${endpoint}` })(runtime)])
+        //    );
+        //    return resolveEndpoint(links);
+        //  },
+        //  // when condition is false, use batch request
+        //  false: (runtime) => {
+        //    const links = Object.fromEntries(
+        //      ENDPOINTS.map((endpoint) => [endpoint, httpBatchLink({ url: `${url}/${endpoint}` })(runtime)])
+        //    );
+        //    return resolveEndpoint(links);
+        //  },
+        //}),
       ],
       /**
        * @link https://react-query.tanstack.com/reference/QueryClient

--- a/packages/trpc/server/routers/viewer/highPerf/getTeamSchedule.handler.ts
+++ b/packages/trpc/server/routers/viewer/highPerf/getTeamSchedule.handler.ts
@@ -1,4 +1,7 @@
 import type { IncomingMessage } from "http";
+import crypto from "crypto";
+
+import { RedisService } from "@calcom/features/redis/RedisService";
 
 import { getAvailableSlots } from "../slots/util";
 import type { TGetTeamScheduleInputSchema } from "./getTeamSchedule.schema";
@@ -12,6 +15,110 @@ interface ContextForGetSchedule extends Record<string, unknown> {
   req?: (IncomingMessage & { cookies: Partial<{ [key: string]: string }> }) | undefined;
 }
 
+const CACHE_TTL = 300; // 5 minutes cache TTL
+
+function buildCacheKey(input: TGetTeamScheduleInputSchema): string {
+  // Create a stable cache key from input, excluding allowStale
+  const { allowStale, ...cacheableInput } = input;
+  
+  // Sort object keys to ensure stable key generation
+  const sortedInput = Object.keys(cacheableInput)
+    .sort()
+    .reduce((acc, key) => {
+      const value = cacheableInput[key as keyof typeof cacheableInput];
+      if (value !== undefined && value !== null) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {} as Record<string, any>);
+  
+  // Create a hash of the input for a shorter, stable key
+  const inputHash = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(sortedInput))
+    .digest('hex')
+    .substring(0, 16);
+  
+  return `team-schedule:${inputHash}`;
+}
+
 export const getTeamScheduleHandler = async ({ ctx, input }: GetTeamScheduleOptions) => {
-  return await getAvailableSlots({ ctx, input });
+  console.log("getTeamScheduleHandler called with input:", JSON.stringify(input, null, 2));
+  
+  let redisService: RedisService | null = null;
+  
+  try {
+    // Try to initialize RedisService
+    redisService = new RedisService();
+    console.log("RedisService initialized successfully");
+  } catch (error) {
+    // RedisService not configured, proceed without caching
+    console.debug("RedisService not configured, proceeding without cache", error);
+  }
+  
+  // If RedisService is available and allowStale is true, try to serve from cache
+  if (redisService && input.allowStale) {
+    console.log("Attempting to serve from cache (allowStale=true)");
+    try {
+      const cacheKey = buildCacheKey(input);
+      console.log(`Looking for cached result with key: ${cacheKey}`);
+      const cachedResult = await redisService.get<any>(cacheKey);
+      
+      if (cachedResult) {
+        console.log(`Serving team schedule from cache for key: ${cacheKey}`, {
+          resultKeys: Object.keys(cachedResult),
+          inputJson: JSON.stringify(input, null, 2)
+        });
+        return { ...cachedResult, FROM_CACHE: true };
+      } else {
+        console.log(`No cached result found for key: ${cacheKey}`);
+      }
+    } catch (error) {
+      console.error("Error reading from cache:", error, {
+        inputJson: JSON.stringify(input, null, 2)
+      });
+      // Continue to fetch fresh data if cache read fails
+    }
+  } else {
+    console.log("Skipping cache lookup", {
+      hasRedisService: !!redisService,
+      allowStale: input.allowStale,
+      inputJson: JSON.stringify(input, null, 2)
+    });
+  }
+  
+  // Fetch fresh data
+  console.log("Fetching fresh data from getAvailableSlots", {
+    inputJson: JSON.stringify(input, null, 2)
+  });
+  const result = await getAvailableSlots({ ctx, input });
+  console.log("Fresh data fetched successfully", {
+    resultKeys: Object.keys(result),
+    inputJson: JSON.stringify(input, null, 2)
+  });
+  
+  // Store in cache if RedisService is available
+  if (redisService) {
+    console.log("Attempting to cache result");
+    try {
+      const cacheKey = buildCacheKey(input);
+      await redisService.set(cacheKey, result);
+      await redisService.expire(cacheKey, CACHE_TTL);
+      console.log(`Cached team schedule with key: ${cacheKey}`, {
+        ttl: CACHE_TTL,
+        inputJson: JSON.stringify(input, null, 2)
+      });
+    } catch (error) {
+      console.error("Error writing to cache:", error, {
+        inputJson: JSON.stringify(input, null, 2)
+      });
+      // Non-critical error, continue without caching
+    }
+  } else {
+    console.log("Skipping cache storage (no RedisService)", {
+      inputJson: JSON.stringify(input, null, 2)
+    });
+  }
+  
+  return result;
 };

--- a/packages/trpc/server/routers/viewer/highPerf/getTeamSchedule.schema.ts
+++ b/packages/trpc/server/routers/viewer/highPerf/getTeamSchedule.schema.ts
@@ -1,7 +1,9 @@
-import type { z } from "zod";
+import { z } from "zod";
 
 import { getScheduleSchema } from "../slots/types";
 
-export const ZGetTeamScheduleInputSchema = getScheduleSchema;
+export const ZGetTeamScheduleInputSchema = getScheduleSchema.extend({
+  allowStale: z.boolean().optional(),
+});
 
 export type TGetTeamScheduleInputSchema = z.infer<typeof ZGetTeamScheduleInputSchema>;

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -37,20 +37,21 @@ export const getScheduleSchema = z
     queuedFormResponseId: z.string().nullish(),
     email: z.string().nullish(),
   })
-  .transform((val) => {
-    // Need this so we can pass a single username in the query string form public API
-    if (val.usernameList) {
-      val.usernameList = Array.isArray(val.usernameList) ? val.usernameList : [val.usernameList];
-    }
-    if (!val.orgSlug) {
-      val.orgSlug = null;
-    }
-    return val;
-  })
-  .refine(
-    (data) => !!data.eventTypeId || (!!data.usernameList && !!data.eventTypeSlug),
-    "You need to either pass an eventTypeId OR an usernameList/eventTypeSlug combination"
-  );
+  // TODO: this transform part doesn't allow me to extend the schema with other fields, will fix later.
+ //.transform((val) => {
+ //  // Need this so we can pass a single username in the query string form public API
+ //  if (val.usernameList) {
+ //    val.usernameList = Array.isArray(val.usernameList) ? val.usernameList : [val.usernameList];
+ //  }
+ //  if (!val.orgSlug) {
+ //    val.orgSlug = null;
+ //  }
+ //  return val;
+ //})
+ //.refine(
+ //  (data) => !!data.eventTypeId || (!!data.usernameList && !!data.eventTypeSlug),
+ //  "You need to either pass an eventTypeId OR an usernameList/eventTypeSlug combination"
+ //);
 
 export const reserveSlotSchema = z
   .object({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR presents a POC for a caching strategy that could be used in the schedule pages to significantly improve the time until seeing the schedule that the page takes.

At a high level, this PR does something similar to the `stale-while-revalidate` pattern popularized by `react-query`. It enables the `getTeamSchedule` rpc handler to return "stale" data (from cache) on demand, while an additional request is made to retrieve the non-stale data (up to date).

This approach allows to serve a large team schedule from cache in under <500ms, while an additional request is made to get to up-to-date data. 

Is critical to have in mind that this is just a POC, and the high level idea is what should be reviewed, the final implementation will require a significant amount of time and expertise in the codebase that I don't have (_yet_). Another important note is that CDNs/browser have a built-in `stale-while-validate` (well I am not 100% sure CDNs have it), so there may be a better way to implement this. 

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

https://drive.google.com/file/d/1WZdlYULZnlbPeFM_IlT-nNr-EnuKvNXL/view?usp=sharing

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Run the script to generate a team with 1k members (from the root) `cd packages/prisma && yarn run ts-node --transpile-only create-performance-test-team.ts`
- Configure Upstash redis (env vars UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN)
- Login into any of the team member accounts created (password is the username, check in prisma for a valid email)
- Get the team schedule page and go there.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a caching strategy to the team schedule API to improve load times and reduce server load. Also included a script to generate large test teams for performance testing.

- **New Features**
  - Team schedule API now uses Redis caching with a 5-minute TTL and supports serving stale data.
  - Added a script to create a 1000-member team with events and bookings for testing.

- **Refactors**
  - Updated schedule query logic to support fetching from cache and fallback to fresh data.
  - Adjusted schema and types to allow an optional `allowStale` flag for schedule requests.

<!-- End of auto-generated description by cubic. -->

