### PR TITLE
fix: don't schedule reminder from the past

### DIFF
--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -35,6 +35,7 @@ export async function handler(req: NextRequest) {
       method: WorkflowMethods.SMS,
       scheduled: false,
       scheduledDate: {
+        gte: dayjs().toISOString(),
         lte: dayjs().add(2, "hour").toISOString(),
       },
       retryCount: {

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -35,7 +35,7 @@ export async function handler(req: NextRequest) {
       method: WorkflowMethods.SMS,
       scheduled: false,
       scheduledDate: {
-        gte: dayjs().toISOString(),
+        gte: new Date(),
         lte: dayjs().add(2, "hour").toISOString(),
       },
       retryCount: {

--- a/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
@@ -24,23 +24,17 @@ export async function handler(req: NextRequest) {
     return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
   }
 
-  //delete all scheduled whatsapp reminders where scheduled date is past current date
-  await prisma.workflowReminder.deleteMany({
-    where: {
-      method: WorkflowMethods.WHATSAPP,
-      scheduledDate: {
-        lte: dayjs().toISOString(),
-      },
-    },
-  });
-
   //find all unscheduled WHATSAPP reminders
   const unscheduledReminders = (await prisma.workflowReminder.findMany({
     where: {
       method: WorkflowMethods.WHATSAPP,
       scheduled: false,
       scheduledDate: {
+        gte: dayjs().toISOString(),
         lte: dayjs().add(2, "hour").toISOString(),
+      },
+      retryCount: {
+        lt: 3, // Don't continue retrying if it's already failed 3 times
       },
     },
     select,

--- a/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
@@ -30,7 +30,7 @@ export async function handler(req: NextRequest) {
       method: WorkflowMethods.WHATSAPP,
       scheduled: false,
       scheduledDate: {
-        gte: dayjs().toISOString(),
+        gte: new Date(),
         lte: dayjs().add(2, "hour").toISOString(),
       },
       retryCount: {

--- a/packages/features/ee/workflows/lib/getWorkflowReminders.ts
+++ b/packages/features/ee/workflows/lib/getWorkflowReminders.ts
@@ -206,7 +206,11 @@ export async function getAllUnscheduledReminders(): Promise<PartialWorkflowRemin
     method: WorkflowMethods.EMAIL,
     scheduled: false,
     scheduledDate: {
+      gte: dayjs().toISOString(),
       lte: dayjs().add(2, "hour").toISOString(),
+    },
+    retryCount: {
+      lt: 3, // Don't continue retrying if it's already failed 3 times
     },
     OR: [{ cancelled: false }, { cancelled: null }],
   };

--- a/packages/features/ee/workflows/lib/getWorkflowReminders.ts
+++ b/packages/features/ee/workflows/lib/getWorkflowReminders.ts
@@ -206,7 +206,7 @@ export async function getAllUnscheduledReminders(): Promise<PartialWorkflowRemin
     method: WorkflowMethods.EMAIL,
     scheduled: false,
     scheduledDate: {
-      gte: dayjs().toISOString(),
+      gte: new Date(),
       lte: dayjs().add(2, "hour").toISOString(),
     },
     retryCount: {


### PR DESCRIPTION
## What does this PR do?

Don't try to schedule workflow reminders that are already in the past. Also don't continue retrying if it's already failed 3 times 

- Fixes #22327
- Fixes CAL-6062

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reminders are now only scheduled if their date is in the future, and failed reminders will not be retried more than three times.

- **Bug Fixes**
  - Prevented scheduling of reminders with past dates.
  - Stopped retries for reminders that have already failed three times.

<!-- End of auto-generated description by cubic. -->

