### PR TITLE
fix: Add unique constraint to team and slug for attributes

### DIFF
--- a/packages/prisma/migrations/20250709150348_attributes_unique_on_slug_team_id/migration.sql
+++ b/packages/prisma/migrations/20250709150348_attributes_unique_on_slug_team_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[teamId,slug]` on the table `Attribute` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Attribute_slug_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attribute_teamId_slug_key" ON "Attribute"("teamId", "slug");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1999,9 +1999,8 @@ model Attribute {
 
   type AttributeType
 
-  name String
-  slug String @unique
-
+  name    String
+  slug    String
   enabled Boolean @default(true)
 
   usersCanEditRelation Boolean @default(false)
@@ -2012,6 +2011,7 @@ model Attribute {
   isWeightsEnabled Boolean           @default(false)
   isLocked         Boolean           @default(false)
 
+  @@unique([teamId, slug])
   @@index([teamId])
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes the unique constraint for attributes from slug to slug and teamId

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create two attributes of the same slug in two different orgs


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a unique constraint to ensure attribute slugs are only unique within each team, not globally. This allows different teams to use the same slug for their own attributes.

<!-- End of auto-generated description by cubic. -->

