### PR TITLE
fix: Overflowing username placeholder in Signup Form

### DIFF
--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -397,12 +397,18 @@ export default function Signup({
                       data-testid="signup-usernamefield"
                       setPremium={(value) => setPremiumUsername(value)}
                       addOnLeading={
-                        orgSlug
-                          ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
-                              URL_PROTOCOL_REGEX,
-                              ""
-                            )}/`
-                          : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`
+                        <div
+                          className="scrollbar-hide max-w-[120px] overflow-x-auto whitespace-nowrap"
+                          style={{
+                            WebkitOverflowScrolling: "touch",
+                          }}>
+                          {orgSlug
+                            ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
+                                URL_PROTOCOL_REGEX,
+                                ""
+                              )}/`
+                            : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`}
+                        </div>
                       }
                     />
                   ) : null}

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -410,7 +410,7 @@ export default function Signup({
                                 )}/`
                               : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`}
                           </div>
-                          <div className="pointer-events-none absolute right-0 top-0 h-full w-10 bg-gradient-to-l from-black to-transparent" />
+                          <div className="pointer-events-none absolute right-0 top-0 h-full w-10 bg-gradient-to-l from-gray-100 to-transparent dark:from-black" />
                         </div>
                       }
                     />

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -397,17 +397,20 @@ export default function Signup({
                       data-testid="signup-usernamefield"
                       setPremium={(value) => setPremiumUsername(value)}
                       addOnLeading={
-                        <div
-                          className="scrollbar-hide max-w-[120px] overflow-x-auto whitespace-nowrap"
-                          style={{
-                            WebkitOverflowScrolling: "touch",
-                          }}>
-                          {orgSlug
-                            ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
-                                URL_PROTOCOL_REGEX,
-                                ""
-                              )}/`
-                            : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`}
+                        <div className="relative max-w-[120px]">
+                          <div
+                            className="scrollbar-hide overflow-x-auto whitespace-nowrap"
+                            style={{
+                              WebkitOverflowScrolling: "touch",
+                            }}>
+                            {orgSlug
+                              ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
+                                  URL_PROTOCOL_REGEX,
+                                  ""
+                                )}/`
+                              : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`}
+                          </div>
+                          <div className="pointer-events-none absolute right-0 top-0 h-full w-10 bg-gradient-to-l from-black to-transparent" />
                         </div>
                       }
                     />

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -397,21 +397,12 @@ export default function Signup({
                       data-testid="signup-usernamefield"
                       setPremium={(value) => setPremiumUsername(value)}
                       addOnLeading={
-                        <div className="relative max-w-[120px]">
-                          <div
-                            className="scrollbar-hide overflow-x-auto whitespace-nowrap"
-                            style={{
-                              WebkitOverflowScrolling: "touch",
-                            }}>
-                            {orgSlug
-                              ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
-                                  URL_PROTOCOL_REGEX,
-                                  ""
-                                )}/`
-                              : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`}
-                          </div>
-                          <div className="pointer-events-none absolute right-0 top-0 h-full w-10 bg-gradient-to-l from-gray-100 to-transparent dark:from-black" />
-                        </div>
+                        orgSlug
+                          ? `${getOrgFullOrigin(orgSlug, { protocol: true }).replace(
+                              URL_PROTOCOL_REGEX,
+                              ""
+                            )}/`
+                          : `${process.env.NEXT_PUBLIC_WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`
                       }
                     />
                   ) : null}

--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -82,13 +82,13 @@ const Addon = ({ children, className, error, onClickAddon, size = "md", position
       onClickAddon && "pointer-events-auto cursor-pointer disabled:hover:cursor-not-allowed",
       className
     )}>
-    <span
+    <div
       className={classNames(
         "text-sm font-medium leading-none",
         error ? "text-error" : "text-muted peer-disabled:opacity-50"
       )}>
       {children}
-    </span>
+    </div>
   </div>
 );
 

--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -5,6 +5,7 @@ import React, { forwardRef, useId, useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
+import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import { Icon } from "../../icon";
 import { HintsOrErrors } from "./HintOrErrors";
@@ -74,23 +75,34 @@ type AddonProps = {
   position?: "start" | "end";
 };
 
-const Addon = ({ children, className, error, onClickAddon, size = "md", position = "start" }: AddonProps) => (
-  <div
-    onClick={onClickAddon && onClickAddon}
-    className={classNames(
-      "flex flex-shrink-0 items-center justify-center whitespace-nowrap",
-      onClickAddon && "pointer-events-auto cursor-pointer disabled:hover:cursor-not-allowed",
-      className
-    )}>
+const Addon = ({ children, className, error, onClickAddon, size = "md", position = "start" }: AddonProps) => {
+  const tooltipText =
+    typeof children === "string"
+      ? children
+      : React.isValidElement(children) && typeof children.props.children === "string"
+      ? children.props.children
+      : "";
+
+  return (
     <div
+      onClick={onClickAddon && onClickAddon}
       className={classNames(
-        "text-sm font-medium leading-none",
-        error ? "text-error" : "text-muted peer-disabled:opacity-50"
+        "flex flex-shrink-0 items-center justify-center whitespace-nowrap",
+        onClickAddon && "pointer-events-auto cursor-pointer disabled:hover:cursor-not-allowed",
+        className
       )}>
-      {children}
+      <Tooltip content={tooltipText}>
+        <span
+          className={classNames(
+            "inline-block max-w-[150px] overflow-hidden text-ellipsis text-sm font-medium leading-none",
+            error ? "text-error" : "text-muted peer-disabled:opacity-50"
+          )}>
+          {children}
+        </span>
+      </Tooltip>
     </div>
-  </div>
-);
+  );
+};
 
 export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function InputField(props, ref) {
   const id = useId();

--- a/packages/ui/components/form/inputs/input.test.tsx
+++ b/packages/ui/components/form/inputs/input.test.tsx
@@ -30,14 +30,22 @@ describe("Tests for InputField Component", () => {
   });
 
   it("should render with addOnLeading prop", () => {
-    const { getByText } = render(<InputField addOnLeading={<span>Leading</span>} />);
+    const { getByText } = render(
+      <TooltipProvider>
+        <InputField addOnLeading={<span>Leading</span>} />
+      </TooltipProvider>
+    );
 
     const addOnLeadingElement = getByText("Leading");
     expect(addOnLeadingElement).toBeInTheDocument();
   });
 
   it("should render with addOnSuffix prop", () => {
-    const { getByText } = render(<InputField addOnSuffix={<span>Suffix</span>} />);
+    const { getByText } = render(
+      <TooltipProvider>
+        <InputField addOnSuffix={<span>Suffix</span>} />
+      </TooltipProvider>
+    );
 
     const addOnSuffixElement = getByText("Suffix");
     expect(addOnSuffixElement).toBeInTheDocument();
@@ -45,7 +53,9 @@ describe("Tests for InputField Component", () => {
 
   it("should display both addOnLeading and addOnSuffix", () => {
     const { getByText } = render(
-      <InputField addOnLeading={<span>Leading</span>} addOnSuffix={<span>Suffix</span>} />
+      <TooltipProvider>
+        <InputField addOnLeading={<span>Leading</span>} addOnSuffix={<span>Suffix</span>} />
+      </TooltipProvider>
     );
 
     const addOnLeadingElement = getByText("Leading");
@@ -132,7 +142,11 @@ describe("Tests for InputFieldWithSelect Component", () => {
       ],
     } as unknown as typeof UnstyledSelect;
 
-    const { getByText } = render(<InputFieldWithSelect selectProps={selectProps} label="testSelect" />);
+    const { getByText } = render(
+      <TooltipProvider>
+        <InputFieldWithSelect selectProps={selectProps} label="testSelect" />
+      </TooltipProvider>
+    );
 
     const inputElement = getByText("Select...");
     fireEvent.mouseDown(inputElement);
@@ -163,7 +177,11 @@ describe("Tests for NumberInput Component", () => {
 
 describe("Tests for FilterSearchField Component", () => {
   test("Should render correctly with Search icon and input", async () => {
-    const { getByRole, findByTestId } = render(<FilterSearchField name="searchField" />);
+    const { getByRole, findByTestId } = render(
+      <TooltipProvider>
+        <FilterSearchField name="searchField" />
+      </TooltipProvider>
+    );
     const searchInput = getByRole("textbox");
     const searchIcon = await findByTestId("search-icon");
 
@@ -172,7 +190,11 @@ describe("Tests for FilterSearchField Component", () => {
   });
 
   test("Should handle input correctly", () => {
-    const { getByRole } = render(<FilterSearchField name="searchField" onChange={onChangeMock} />);
+    const { getByRole } = render(
+      <TooltipProvider>
+        <FilterSearchField name="searchField" onChange={onChangeMock} />
+      </TooltipProvider>
+    );
     const searchInput = getByRole("textbox") as HTMLInputElement;
 
     fireEvent.change(searchInput, { target: { value: "Test search" } });


### PR DESCRIPTION
## What does this PR do?

This PR improves the UX of the UsernameField by enabling horizontal scrolling for long addOnLeading prefixes (such as Gitpod workspace URLs).
This ensures long prefixes like 3000-calcom-calcom-l7zadcepll3.ws-us120.gitpod.io/ does not overflow due to which users aren't able to see their username being written.

No external dependencies were added.

- Fixes #22372 
- Fixes CAL-6073

## Visual Demo (For contributors especially)

Before

![Screenshot from 2025-07-10 14-48-53](https://github.com/user-attachments/assets/df55f669-3caf-4d60-b91a-43e508a55027)

After changes

[Screencast from 2025-07-12 13-29-17.webm](https://github.com/user-attachments/assets/0ab88ff3-7b63-4022-a57e-dc9e4be9d55f)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if needed – N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works – N/A for this visual UI fix

## How should this be tested?

- Go to the Signup page where UsernameField is rendered.
-  Ensure the app is running in an environment with a long addOnLeading URL (e.g. Gitpod).
- Hover over or scroll the prefix container horizontally, you should see the full  scroll smoothly.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the username field in the signup form so long URL prefixes no longer overflow and can be scrolled horizontally. This makes it easier for users to see and enter their username when a long prefix is present.

- **Bug Fixes**
  - Added horizontal scrolling to the prefix container in the username field.

<!-- End of auto-generated description by cubic. -->

