### PR TITLE
feat: add method for getting teamId permissions PBAC

### DIFF
--- a/packages/features/pbac/domain/repositories/IPermissionRepository.ts
+++ b/packages/features/pbac/domain/repositories/IPermissionRepository.ts
@@ -44,4 +44,14 @@ export interface IPermissionRepository {
     teamId: number,
     resource: Resource
   ): Promise<(CrudAction | CustomAction)[]>;
+
+  /**
+   * Gets all team IDs where the user has a specific permission
+   */
+  getTeamIdsWithPermission(userId: number, permission: PermissionString): Promise<number[]>;
+
+  /**
+   * Gets all team IDs where the user has all of the specified permissions
+   */
+  getTeamIdsWithPermissions(userId: number, permissions: PermissionString[]): Promise<number[]>;
 }

--- a/packages/features/pbac/infrastructure/repositories/PermissionRepository.ts
+++ b/packages/features/pbac/infrastructure/repositories/PermissionRepository.ts
@@ -107,6 +107,11 @@ export class PermissionRepository implements IPermissionRepository {
   }
 
   async checkRolePermissions(roleId: string, permissions: PermissionString[]): Promise<boolean> {
+    // Validate that permissions array is not empty to prevent privilege escalation
+    if (permissions.length === 0) {
+      return false;
+    }
+
     const permissionPairs = permissions.map((p) => {
       const [resource, action] = p.split(".");
       return { resource, action };
@@ -179,6 +184,11 @@ export class PermissionRepository implements IPermissionRepository {
   }
 
   async getTeamIdsWithPermissions(userId: number, permissions: PermissionString[]): Promise<number[]> {
+    // Validate that permissions array is not empty to prevent privilege escalation
+    if (permissions.length === 0) {
+      return [];
+    }
+
     const permissionPairs = permissions.map((p) => {
       const [resource, action] = p.split(".");
       return { resource, action };

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -361,6 +361,8 @@ describe("PermissionCheckService", () => {
     });
 
     it("should return empty array when permissions array is empty", async () => {
+      mockRepository.getTeamIdsWithPermissions.mockResolvedValueOnce([]);
+
       const result = await service.getTeamIdsWithPermissions(1, []);
 
       expect(result).toEqual([]);

--- a/packages/features/pbac/services/permission-check.service.ts
+++ b/packages/features/pbac/services/permission-check.service.ts
@@ -225,4 +225,40 @@ export class PermissionCheckService {
   private checkFallbackRoles(userRole: MembershipRole, allowedRoles: MembershipRole[]): boolean {
     return allowedRoles.includes(userRole);
   }
+
+  /**
+   * Gets all team IDs where the user has a specific permission
+   */
+  async getTeamIdsWithPermission(userId: number, permission: PermissionString): Promise<number[]> {
+    try {
+      const validationResult = this.permissionService.validatePermission(permission);
+      if (!validationResult.isValid) {
+        this.logger.error(validationResult.error);
+        return [];
+      }
+
+      return await this.repository.getTeamIdsWithPermission(userId, permission);
+    } catch (error) {
+      this.logger.error(error);
+      return [];
+    }
+  }
+
+  /**
+   * Gets all team IDs where the user has all of the specified permissions
+   */
+  async getTeamIdsWithPermissions(userId: number, permissions: PermissionString[]): Promise<number[]> {
+    try {
+      const validationResult = this.permissionService.validatePermissions(permissions);
+      if (!validationResult.isValid) {
+        this.logger.error(validationResult.error);
+        return [];
+      }
+
+      return await this.repository.getTeamIdsWithPermissions(userId, permissions);
+    } catch (error) {
+      this.logger.error(error);
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
Adds a util for getting all teamIds a user has for a specific permission 

Usage example: 
<img width="3480" height="2172" alt="image" src="https://github.com/user-attachments/assets/991dcc0f-2b87-4966-88de-4bcbd2f42746" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new methods to fetch all team IDs where a user has a specific permission or set of permissions.

- **New Features**
  - Added getTeamIdsWithPermission and getTeamIdsWithPermissions to the permission service and repository.
  - Updated tests to cover these new methods.

<!-- End of auto-generated description by cubic. -->

