### PR TITLE
fix: ESLint Plugin Loading Error with TypeScript 5.0+ Extends Arrays

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@typescript-eslint/parser": "^5.52.0",
     "@typescript-eslint/utils": "^5.52.0",
-    "ts-node": "^10.9.1",
+    "ts-node-maintained": "^10.9.5",
     "typescript": "^5.7.2"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -1,6 +1,6 @@
 // This registers Typescript compiler instance onto node.js.
 // Now it is possible to just require typescript files without any compilation steps in the environment run by node
-require("ts-node").register({
+require("ts-node-maintained").register({
   compilerOptions: {
     module: "commonjs",
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,7 +3052,7 @@ __metadata:
     "@types/eslint": ^8.4.5
     "@typescript-eslint/parser": ^5.52.0
     "@typescript-eslint/utils": ^5.52.0
-    ts-node: ^10.9.1
+    ts-node-maintained: ^10.9.5
     typescript: ^5.7.2
   languageName: unknown
   linkType: soft
@@ -45037,6 +45037,44 @@ __metadata:
     "@ts-morph/common": ~0.26.0
     code-block-writer: ^13.0.3
   checksum: 6370c653824ac5d4cc44571cb6b770d7b6e2a6c5d1910e538012f98f4e26c2e5d3f900d9cdd3c9f65301415e2cb4cd263774de97ec153ea99f4d9ce4b0a1dd37
+  languageName: node
+  linkType: hard
+
+"ts-node-maintained@npm:^10.9.5":
+  version: 10.9.5
+  resolution: "ts-node-maintained@npm:10.9.5"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 7b09bc9bafbd963af5f42508991403c528da3dd8bdfddc496fa8deff9146e28122ba2c51d2c6cea3cb480c0554b030af04a71fa139ae02b260c0521cb4c8f0e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

### Fix ESLint Plugin Loading Error with TypeScript 5.0+ Extends Arrays

**Problem**:
ESLint was failing to load the `@calcom/eslint` plugin with error: `state.conditions.includes is not a function`

**Root Cause**:

- PR #21956 downgraded TypeScript from `^5.8.3` to `^5.7.2`
- This exposed an incompatibility between `ts-node@10.9.1` and TypeScript 5.0+ when using extends arrays in tsconfig.json
- The error occurs in ts-node's `normalizeSlashes` function where it expects `state.conditions` to be an array but receives an object

**Evidence**:

- Git history shows TypeScript downgrade in commit `b381cfe207`
- Web search confirms this is a known issue with ts-node 10.9.1
- `ts-node-maintained` 10.9.5 specifically fixes "issue with extending multiple config files"
- TypeStrong/ts-node#2000: Exact same error with TypeScript 5.0 and extends arrays
- TypeStrong/ts-node#1953: Similar issue with tsconfig extends arrays

**Solution**:

- Upgraded from `ts-node@^10.9.1` to `ts-node-maintained@^10.9.5`
- `ts-node-maintained` is a maintained fork that fixes the extends array compatibility issue
- Updated both package.json dependency and require statement in index.js

**Testing**:

- Verified ESLint plugin loads successfully
- No breaking changes to existing functionality
- Maintains compatibility with current TypeScript version (5.7.2)



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed ESLint plugin loading errors by switching from ts-node to ts-node-maintained, restoring compatibility with TypeScript 5.7.2. 

- **Dependencies**
  - Replaced ts-node with ts-node-maintained@^10.9.5 in package.json and code.

<!-- End of auto-generated description by cubic. -->

