### PR TITLE
chore: update i18n workflow to use Node.js 20

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -17,6 +17,10 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
       - uses: lingodotdev/lingo.dev@main
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

The Run i18n AI automation action was crashing because the BuildJet runner only ships with Node 18, while one of Lingo.dev’s dependencies (ink@6) requires Node 20. This PR ensures the job uses Node 20.

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the i18n workflow to use Node.js 20 to fix crashes caused by incompatible dependencies.

<!-- End of auto-generated description by cubic. -->

