### PR TITLE
fix: members page crash with pbac feature flag

### DIFF
--- a/packages/features/pbac/infrastructure/mappers/RoleOutputMapper.ts
+++ b/packages/features/pbac/infrastructure/mappers/RoleOutputMapper.ts
@@ -11,7 +11,7 @@ export class RoleOutputMapper {
       description: prismaRole.description || undefined,
       teamId: prismaRole.teamId || undefined,
       type: prismaRole.type,
-      permissions: prismaRole.permissions.map(this.toDomainPermission),
+      permissions: prismaRole.permissions.map(RoleOutputMapper.toDomainPermission),
       createdAt: prismaRole.createdAt,
       updatedAt: prismaRole.updatedAt,
     };
@@ -28,6 +28,6 @@ export class RoleOutputMapper {
   }
 
   static toDomainList(prismaRoles: (PrismaRole & { permissions: PrismaRolePermission[] })[]): Role[] {
-    return prismaRoles.map(this.toDomain);
+    return prismaRoles.map(RoleOutputMapper.toDomain);
   }
 }


### PR DESCRIPTION
Fixes a crash on members page when pbac feature flag is enabled
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a crash on the members page that occurred when the pbac feature flag was enabled.

<!-- End of auto-generated description by cubic. -->

