### PR TITLE
chore: Loosen Platform CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /packages/lib/getUserAvailability.ts @calcom/Foundation
 /packages/lib/server/getLuckyUser.ts @calcom/Foundation
 /packages/lib/slots.ts @calcom/Foundation
+/packages/platform/atoms/**/*WebWrapper.tsx @calcom/Consumer
 /packages/platform/**/* @calcom/Platform @calcom/Foundation
 /packages/prisma/**/* @calcom/DBA
 /packages/trpc/server/routers/viewer/bookings/confirm.handler.ts @calcom/Foundation


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated CODEOWNERS to assign the Consumer team to all WebWrapper files in the platform atoms package, making ownership more specific.

<!-- End of auto-generated description by cubic. -->

