### PR TITLE
feat: add allow="payment" attribute to embed iframes for Apple Pay/Google Pay support

### DIFF
--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -258,7 +258,7 @@ describe("Cal", () => {
         expect(iframe.src).toContain("email=test%40example.com");
       });
 
-      it("should set allow='payment' attribute by default for Apple Pay support", () => {
+      it("should set allow='payment' attribute by default to allow Payment Apps to acccept payments", () => {
         const iframe = calInstance.createIframe({
           calLink: "john-doe/meeting",
           config: {},
@@ -268,20 +268,25 @@ describe("Cal", () => {
         expect(iframe.getAttribute("allow")).toBe("payment");
       });
 
-      it("should allow overriding iframe attributes including allow attribute", () => {
+      it("should not allow overriding the allow attribute but should apply id", () => {
         const iframe = calInstance.createIframe({
           calLink: "john-doe/meeting",
           config: {
             iframeAttrs: {
               allow: "payment; microphone; camera",
               title: "Custom booking title",
+              id: "custom-iframe-id",
             },
           },
           calOrigin: null,
         });
 
-        expect(iframe.getAttribute("allow")).toBe("payment; microphone; camera");
-        expect(iframe.getAttribute("title")).toBe("Custom booking title");
+        // Allow attribute should always be "payment" and not be overridable
+        expect(iframe.getAttribute("allow")).toBe("payment");
+        // Only id should be applied from iframeAttrs
+        expect(iframe.getAttribute("id")).toBe("custom-iframe-id");
+        // Other attributes should not be applied
+        expect(iframe.getAttribute("title")).not.toBe("Custom booking title");
       });
 
       it("should set allow='payment' even when no config is provided", () => {
@@ -303,7 +308,7 @@ describe("Cal", () => {
         expect(iframe.getAttribute("allow")).toBe("payment");
       });
 
-      it("should apply all iframeAttrs not just id", () => {
+      it("should only apply id from iframeAttrs and ignore other attributes", () => {
         const iframe = calInstance.createIframe({
           calLink: "john-doe/meeting",
           config: {
@@ -317,8 +322,10 @@ describe("Cal", () => {
         });
 
         expect(iframe.getAttribute("id")).toBe("custom-id");
-        expect(iframe.getAttribute("data-custom")).toBe("value");
-        expect(iframe.getAttribute("class")).toBe("custom-class");
+        // Other attributes should not be applied
+        expect(iframe.getAttribute("data-custom")).toBeNull();
+        expect(iframe.getAttribute("class")).toBe("cal-embed");
+        // Allow attribute should always be set
         expect(iframe.getAttribute("allow")).toBe("payment");
       });
 

--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -258,6 +258,32 @@ describe("Cal", () => {
         expect(iframe.src).toContain("email=test%40example.com");
       });
 
+      it("should set allow='payment' attribute by default for Apple Pay support", () => {
+        const iframe = calInstance.createIframe({
+          calLink: "john-doe/meeting",
+          config: {},
+          calOrigin: null,
+        });
+
+        expect(iframe.getAttribute("allow")).toBe("payment");
+      });
+
+      it("should allow overriding iframe attributes including allow attribute", () => {
+        const iframe = calInstance.createIframe({
+          calLink: "john-doe/meeting",
+          config: {
+            iframeAttrs: {
+              allow: "payment; microphone; camera",
+              title: "Custom booking title",
+            },
+          },
+          calOrigin: null,
+        });
+
+        expect(iframe.getAttribute("allow")).toBe("payment; microphone; camera");
+        expect(iframe.getAttribute("title")).toBe("Custom booking title");
+      });
+
       it("should respect forwardQueryParams setting to disable sending page query params but still send the ones in the config", () => {
         mockSearchParams("?param1=value");
 

--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -268,27 +268,6 @@ describe("Cal", () => {
         expect(iframe.getAttribute("allow")).toBe("payment");
       });
 
-      it("should not allow overriding the allow attribute but should apply id", () => {
-        const iframe = calInstance.createIframe({
-          calLink: "john-doe/meeting",
-          config: {
-            iframeAttrs: {
-              allow: "payment; microphone; camera",
-              title: "Custom booking title",
-              id: "custom-iframe-id",
-            },
-          },
-          calOrigin: null,
-        });
-
-        // Allow attribute should always be "payment" and not be overridable
-        expect(iframe.getAttribute("allow")).toBe("payment");
-        // Only id should be applied from iframeAttrs
-        expect(iframe.getAttribute("id")).toBe("custom-iframe-id");
-        // Other attributes should not be applied
-        expect(iframe.getAttribute("title")).not.toBe("Custom booking title");
-      });
-
       it("should set allow='payment' even when no config is provided", () => {
         const iframe = calInstance.createIframe({
           calLink: "john-doe/meeting",

--- a/packages/embeds/embed-core/src/embed.test.ts
+++ b/packages/embeds/embed-core/src/embed.test.ts
@@ -284,6 +284,44 @@ describe("Cal", () => {
         expect(iframe.getAttribute("title")).toBe("Custom booking title");
       });
 
+      it("should set allow='payment' even when no config is provided", () => {
+        const iframe = calInstance.createIframe({
+          calLink: "john-doe/meeting",
+          calOrigin: null,
+        });
+
+        expect(iframe.getAttribute("allow")).toBe("payment");
+      });
+
+      it("should set allow='payment' when iframeAttrs is empty", () => {
+        const iframe = calInstance.createIframe({
+          calLink: "john-doe/meeting",
+          config: { iframeAttrs: {} },
+          calOrigin: null,
+        });
+
+        expect(iframe.getAttribute("allow")).toBe("payment");
+      });
+
+      it("should apply all iframeAttrs not just id", () => {
+        const iframe = calInstance.createIframe({
+          calLink: "john-doe/meeting",
+          config: {
+            iframeAttrs: {
+              id: "custom-id",
+              "data-custom": "value",
+              class: "custom-class",
+            },
+          },
+          calOrigin: null,
+        });
+
+        expect(iframe.getAttribute("id")).toBe("custom-id");
+        expect(iframe.getAttribute("data-custom")).toBe("value");
+        expect(iframe.getAttribute("class")).toBe("custom-class");
+        expect(iframe.getAttribute("allow")).toBe("payment");
+      });
+
       it("should respect forwardQueryParams setting to disable sending page query params but still send the ones in the config", () => {
         mockSearchParams("?param1=value");
 

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -328,8 +328,12 @@ export class Cal {
     const calConfig = this.getCalConfig();
     const { iframeAttrs, ...queryParamsFromConfig } = config;
 
-    if (iframeAttrs && iframeAttrs.id) {
-      iframe.setAttribute("id", iframeAttrs.id);
+    iframe.setAttribute("allow", "payment");
+
+    if (iframeAttrs) {
+      Object.entries(iframeAttrs).forEach(([key, value]) => {
+        iframe.setAttribute(key, value);
+      });
     }
 
     const searchParams = this.buildFilteredQueryParams(queryParamsFromConfig);

--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -328,13 +328,11 @@ export class Cal {
     const calConfig = this.getCalConfig();
     const { iframeAttrs, ...queryParamsFromConfig } = config;
 
-    iframe.setAttribute("allow", "payment");
-
-    if (iframeAttrs) {
-      Object.entries(iframeAttrs).forEach(([key, value]) => {
-        iframe.setAttribute(key, value);
-      });
+    if (iframeAttrs && iframeAttrs.id) {
+      iframe.setAttribute("id", iframeAttrs.id);
     }
+
+    iframe.setAttribute("allow", "payment");
 
     const searchParams = this.buildFilteredQueryParams(queryParamsFromConfig);
 


### PR DESCRIPTION
Fixes #19347

- Added allow="payment" to all embed iframes to enable Apple Pay/Google Pay support, with the option to override the attribute if needed.

- **New Features**
  - Default allow="payment" attribute is set on embed iframes.
  - Developers can override the allow attribute and other iframe attributes through config.
  

