### PR TITLE
fix: interpolate appName in invalid_credential message

### DIFF
--- a/packages/ui/components/app-list-card/AppListCard.tsx
+++ b/packages/ui/components/app-list-card/AppListCard.tsx
@@ -74,7 +74,7 @@ export const AppListCard = (props: AppListCardProps & { highlight?: boolean }) =
             <div className="flex gap-x-2 pt-2">
               <Icon name="circle-alert" className="h-8 w-8 text-red-500 sm:h-4 sm:w-4" />
               <ListItemText component="p" className="whitespace-pre-wrap text-red-500">
-                {t("invalid_credential")}
+                {t("invalid_credential", { appName: title })}
               </ListItemText>
             </div>
           )}


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the variable `{{appName}}` was not being interpolated in the `"invalid_credential"` message inside `AppListCard.tsx`.

- Fixes #22412  
- Fixes CAL-6082 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the invalid_credential message in AppListCard to correctly show the app name by interpolating the appName variable.

<!-- End of auto-generated description by cubic. -->

