### PR TITLE
fix: appName interpolation and improve invalid credential message

### DIFF
--- a/packages/lib/server/locales/en/common.json
+++ b/packages/lib/server/locales/en/common.json
@@ -1815,7 +1815,7 @@
   "attendee_email_info": "The person booking's email",
   "booking_uid": "Booking UID",
   "kbar_search_placeholder": "Type a command or search...",
-  "invalid_credential": "It looks like permissions expired or were revoked for {{appName}}.",
+  "invalid_credential": "The app {{appName}} has lost access. Please reinstall the application or reconnect it to continue.",
   "invalid_credential_action": "Reinstall app",
   "reschedule_reason": "Reschedule reason",
   "choose_common_schedule_team_event": "Choose a common schedule",

--- a/packages/ui/components/app-list-card/AppListCard.tsx
+++ b/packages/ui/components/app-list-card/AppListCard.tsx
@@ -74,7 +74,7 @@ export const AppListCard = (props: AppListCardProps & { highlight?: boolean }) =
             <div className="flex gap-x-2 pt-2">
               <Icon name="circle-alert" className="h-8 w-8 text-red-500 sm:h-4 sm:w-4" />
               <ListItemText component="p" className="whitespace-pre-wrap text-red-500">
-                {t("invalid_credential")}
+                {t("invalid_credential", { appName: title })}
               </ListItemText>
             </div>
           )}


### PR DESCRIPTION
## What does this PR do?

- Fixes #22412 

This PR improves the `invalid_credential` warning banner by:

1. ✅ **Fixing placeholder interpolation** – The `{{appName}}` variable was not rendering properly and was shown as plain text.
2. ✅ **Improving clarity** – The message now includes actionable steps for the user to resolve the issue.

---

## Visual Demo (For contributors especially)

#### Image Demo:

| Before | After |
|--------|-------|
| It looks like permissions expired or were revoked for `{{appName}}`. | The app Zoom has lost access. Please reinstall the application or reconnect it to continue. |

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **(N/A)**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **(N/A for i18n fix)**

---

## How should this be tested?

- Navigate to **Integrations** (e.g., Zoom).
- Revoke or expire credentials.
- Try using the integration to trigger the banner.
- ✅ Confirm:
  - The banner message is shown.
  - The app name (e.g., "Zoom") appears properly.
  - The message text comes from:
    `packages/lib/server/locales/en/common.json`
    - Key: `invalid_credential`

---

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **(N/A)**
- [x] My changes generate no new warnings
## What does this PR do?

This PR improves the user-facing `invalid_credential` banner in two ways:

1.  **Fixes variable interpolation:** The `{{appName}}` placeholder in the message was not being rendered properly in the UI. We now interpolate the value dynamically using `t("invalid_credential", { appName: title })`, so the app name (e.g., Zoom) appears correctly.

2.  **Improves the message content:** The original message was vague and didn’t guide users on what to do next. We've updated it to provide clear instructions on reinstalling or reconnecting the integration.

---

###  Old Message (non-functional):
> "It looks like permissions expired or were revoked for {{appName}}."

### ✅ New Message (with working interpolation):
> "The app Zoom has lost access. Please reinstall the application or reconnect it to continue."

---

## Why this change?

- The previous message showed `{{appName}}` literally due to missing interpolation.
- The updated message improves clarity and gives users actionable next steps.
- This change enhances the overall user experience when an integration loses authentication.

---

## Fixes

- Fixes #22412
- Fixes CAL-6082

---

## Visual Demo (For contributors especially)

| Before | After |
|--------|-------|
| "It looks like permissions expired or were revoked for {{appName}}." | "The app Zoom has lost access. Please reinstall the application or reconnect it to continue." |

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the correct usage of the `t()` translation function to fix interpolation
- [x] I have updated the text content in `common.json`
- [x] Documentation change not required (N/A)
- [x] No new tests needed as this is an i18n/UI fix

---

## How should this be tested?

1. Navigate to **Integrations** (like Zoom or Google Calendar).
2. Revoke or expire credentials for that integration.
3. Trigger the invalid credential banner (e.g., try booking through the integration).
4. ✅ Confirm that:
   - The banner message is updated.
   - The app name (e.g., "Zoom") appears correctly.
   - The message is coming from `packages/lib/server/locales/en/common.json` (key: `invalid_credential`).

---

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code where needed (N/A for this case)
- [x] My changes generate no new warnings

