### PR TITLE
feat: convert team member list from infinite to standard pagination

### DIFF
--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -71,23 +71,22 @@ export const AddNewTeamMembersForm = ({ teamId, isOrg }: { teamId: number; isOrg
     }
   );
 
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
-    trpc.viewer.teams.listMembers.useInfiniteQuery(
-      {
-        limit: 10,
-        teamId,
-      },
-      {
-        enabled: !!teamId,
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-        placeholderData: keepPreviousData,
-        refetchOnWindowFocus: true,
-        refetchOnMount: true,
-        staleTime: 0,
-      }
-    );
+  const { data } = trpc.viewer.teams.listMembers.useQuery(
+    {
+      limit: 100, // Use a larger limit since this is for selection
+      offset: 0,
+      teamId,
+    },
+    {
+      enabled: !!teamId,
+      placeholderData: keepPreviousData,
+      refetchOnWindowFocus: true,
+      refetchOnMount: true,
+      staleTime: 0,
+    }
+  );
 
-  const flatData = useMemo(() => data?.pages?.flatMap((page) => page.members) ?? [], [data]) as TeamMember[];
+  const flatData = useMemo(() => data?.members ?? [], [data]) as TeamMember[];
   const totalFetched = flatData.length;
 
   const publishTeamMutation = trpc.viewer.teams.publish.useMutation({
@@ -113,17 +112,6 @@ export const AddNewTeamMembersForm = ({ teamId, isOrg }: { teamId: number; isOrg
             />
           ))}
         </ul>
-        {totalFetched && (
-          <div className="text-default text-center">
-            <Button
-              color="minimal"
-              loading={isFetchingNextPage}
-              disabled={!hasNextPage}
-              onClick={() => fetchNextPage()}>
-              {hasNextPage ? t("load_more_results") : t("no_more_results")}
-            </Button>
-          </div>
-        )}
         <Button
           color="secondary"
           data-testid="new-member-button"

--- a/packages/trpc/server/routers/viewer/teams/listMembers.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/listMembers.schema.ts
@@ -4,7 +4,7 @@ export const ZListMembersInputSchema = z.object({
   teamId: z.number(),
   limit: z.number().default(10),
   searchTerm: z.string().optional(),
-  cursor: z.number().optional().nullable(),
+  offset: z.number().default(0),
 });
 
 export type TListMembersInputSchema = z.infer<typeof ZListMembersInputSchema>;


### PR DESCRIPTION
_PR description is being written. Please check back in a minute._ 

Devin Session: https://app.devin.ai/sessions/7e79cd4bedc940f693931c1d570f73c2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the team member list from infinite scroll to standard pagination for a more consistent and predictable user experience.

- **Refactors**
  - Replaced infinite query logic with offset-based pagination in frontend and backend.
  - Removed infinite scroll code and updated components to use standard pagination controls.

<!-- End of auto-generated description by cubic. -->

