### PR TITLE
feat(booking): add rescheduledToUid to model and update logic to link rescheduled bookings

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1382,7 +1382,14 @@ async function handler(
         creationSource: input.bookingData.creationSource,
         tracking: reqBody.tracking,
       });
-
+      if (originalRescheduledBooking && booking && reqBody.rescheduledBy) {
+        await prisma.booking.update({
+          where: { uid: originalRescheduledBooking.uid }, // Original booking UID
+          data: {
+            rescheduledToUid: booking.uid, // Set the rescheduledToUid to the new booking's UID
+          },
+        });
+      }
       if (booking?.userId) {
         const usersRepository = new UsersRepository();
         await usersRepository.updateLastActiveAt(booking.userId);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -766,6 +766,7 @@ model Booking {
   fromReschedule               String?
   recurringEventId             String?
   smsReminderNumber            String?
+  rescheduledToUid             String?                           @db.VarChar(255)
   workflowReminders            WorkflowReminder[]
   scheduledJobs                String[] // scheduledJobs is deprecated, please use scheduledTriggers instead
   seatsReferences              BookingSeat[]


### PR DESCRIPTION
## What does this PR do?

This PR introduces support for tracking when a booking has been rescheduled by:

- ✅ **Adding `rescheduledToUid`** to the `Booking` model in `schema.prisma`.
- ✅ **Updating `handleNewBooking.ts`** logic so that when a booking is rescheduled, the original booking gets updated with the UID of the new one via `rescheduledToUid`.
- 🚫 **Note:** Step 3 (exposing `rescheduledToUid` in the official `/v2/bookings` API response) is not implemented in this PR, as Cal.com's API v2 is part of the closed-source backend.

Instead, for self-hosted users, a **custom API route** can be added to expose the field (example provided below).

No external dependencies were added.

---

## Visual Demo (For contributors especially)

N/A – This is a backend-only feature with no UI changes.

However, testing instructions are provided below for validating the reschedule behavior and optional API exposure.

---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change — **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works — **Manual testing outlined below**

---

## How should this be tested?

### ✅ Reschedule Booking Flow

1. Create a booking via the app.
2. Trigger a **reschedule** through any available path.
3. In the database, check that the **original booking** now has its `rescheduledToUid` field set to the **UID of the new (rescheduled) booking**.

### 🛠 Optional: Add a Custom API Route to Inspect `rescheduledToUid`

If you're self-hosting and want to expose this value:

```ts
// File: apps/web/pages/api/bookings/[uid].ts

import { prisma } from "@calcom/prisma";
import { NextApiRequest, NextApiResponse } from "next";

export default async function handler(req: NextApiRequest, res: NextApiResponse) {
  const { uid } = req.query;
  if (typeof uid !== "string") return res.status(400).json({ message: "Invalid UID" });

  const booking = await prisma.booking.findUnique({
    where: { uid },
    select: {
      uid: true,
      title: true,
      startTime: true,
      endTime: true,
      rescheduledToUid: true,
    },
  });

  if (!booking) return res.status(404).json({ message: "Booking not found" });

  return res.status(200).json(booking);
}
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new rescheduledToUid field to the Booking model and updated booking logic to link original bookings to their rescheduled versions.

- **New Features**
  - Booking records now store the UID of the new booking when rescheduled.

<!-- End of auto-generated description by cubic. -->

