### PR TITLE
feat: v2 bookings count endpoint

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.258",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -15,7 +15,6 @@ import { API_KEY_OR_ACCESS_TOKEN_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
-import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { UsersService } from "@/modules/users/services/users.service";
@@ -267,12 +266,12 @@ export class BookingsController_2024_08_13 {
   @ApiOperation({
     summary: "Cancel a booking",
     description: `:bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.
-    
+
     \nCancelling seated bookings:
     It is possible to cancel specific seat within a booking as an attendee or all of the seats as the host.
     \n1. As an attendee - provide :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and seatUid in the request body \`{"seatUid": "123-123-123"}\` . This will remove this particular attendance from the booking.
     \n2. As the host - host can cancel booking for all attendees aka for every seat. Provide :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and cancellationReason in the request body \`{"cancellationReason": "Will travel"}\` and \`Authorization: Bearer token\` request header where token is event type owner (host) credential. This will cancel the booking for all attendees.
-    
+
     \nCancelling recurring seated bookings:
     For recurring seated bookings it is not possible to cancel all of them with 1 call
     like with non-seated recurring bookings by providing recurring bookind uid - you have to cancel each recurrence booking by its bookingUid + seatUid.`,

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/bookings.service.ts
@@ -610,6 +610,39 @@ export class BookingsService_2024_08_13 {
     };
   }
 
+  async getBookingsCount(
+    queryParams: GetBookingsInput_2024_08_13,
+    user: { email: string; id: number; orgId?: number },
+    userIds?: number[]
+  ) {
+    if (queryParams.attendeeEmail) {
+      queryParams.attendeeEmail = await this.getAttendeeEmail(queryParams.attendeeEmail, user);
+    }
+
+    const skip = 0;
+    // note(Lauris): initialize take to null to take all bookings matching the filters
+    const take = null;
+
+    const fetchedBookings: { totalCount: number } = await getAllUserBookings({
+      bookingListingByStatus: queryParams.status || [],
+      skip,
+      take,
+      filters: {
+        ...this.inputService.transformGetBookingsFilters(queryParams),
+        ...(userIds?.length ? { userIds } : {}),
+      },
+      ctx: {
+        user,
+        prisma: this.prismaReadService.prisma as unknown as PrismaClient,
+        kysely: this.kyselyReadService.kysely,
+      },
+    });
+
+    return {
+      count: fetchedBookings.totalCount,
+    };
+  }
+
   async getAttendeeEmail(queryParamsAttendeeEmail: string, user: { id: number }) {
     // note(Lauris): this is to handle attendees that are managed users - in attendee table their email is one of managed users e.g
     // urdasdqinm+clxyyy21o0003sbk7yw5z6tzg@example.com but if attendeeEmail is passed as urdasdqinm@example.com then we check if user whose

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.e2e-spec.ts
@@ -529,7 +529,7 @@ describe("Organizations Bookings Endpoints 2024-08-13", () => {
 
       it("should get bookings count by organizationId", async () => {
         return request(app.getHttpServer())
-          .get(`/v2/organizations/${organization.id}/bookings/count`)
+          .get(`/v2/organizations/${organization.id}/bookings/statistics`)
           .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
           .set(X_CAL_CLIENT_ID, oAuthClient.id)
           .set(X_CAL_SECRET_KEY, oAuthClient.secret)

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.e2e-spec.ts
@@ -34,6 +34,7 @@ import {
   RecurringBookingOutput_2024_08_13,
   GetBookingsOutput_2024_08_13,
   GetSeatedBookingOutput_2024_08_13,
+  GetBookingsCountOutput_2024_08_13,
 } from "@calcom/platform-types";
 import { PlatformOAuthClient, Team } from "@calcom/prisma/client";
 
@@ -523,6 +524,21 @@ describe("Organizations Bookings Endpoints 2024-08-13", () => {
             expect(data.map((booking) => booking.eventTypeId).sort()).toEqual(
               [orgEventTypeId, orgEventTypeId2, nonOrgEventTypeId, nonOrgEventTypeId].sort()
             );
+          });
+      });
+
+      it("should get bookings count by organizationId", async () => {
+        return request(app.getHttpServer())
+          .get(`/v2/organizations/${organization.id}/bookings/count`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_08_13)
+          .set(X_CAL_CLIENT_ID, oAuthClient.id)
+          .set(X_CAL_SECRET_KEY, oAuthClient.secret)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: GetBookingsCountOutput_2024_08_13 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data).toBeDefined();
+            expect(responseBody.data.count).toEqual(4);
           });
       });
 

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
@@ -63,7 +63,7 @@ export class OrganizationsBookingsController {
     };
   }
 
-  @Get("/count")
+  @Get("/statistics")
   @ApiOperation({
     summary: "Get organization bookings count",
     description: "Feel free to also use available query parameters to narrow down the results.",

--- a/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
+++ b/apps/api/v2/src/modules/organizations/bookings/organizations-bookings.controller.ts
@@ -19,7 +19,12 @@ import { Controller, UseGuards, Get, Param, ParseIntPipe, Query, HttpStatus, Htt
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import { GetBookingsOutput_2024_08_13, GetOrganizationsBookingsInput } from "@calcom/platform-types";
+import {
+  GetBookingsCountOutput_2024_08_13,
+  GetBookingsOutput_2024_08_13,
+  GetOrganizationsBookingsCountInput,
+  GetOrganizationsBookingsInput,
+} from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/organizations/:orgId/bookings",
@@ -55,6 +60,32 @@ export class OrganizationsBookingsController {
       status: SUCCESS_STATUS,
       data: bookings,
       pagination,
+    };
+  }
+
+  @Get("/count")
+  @ApiOperation({
+    summary: "Get organization bookings count",
+    description: "Feel free to also use available query parameters to narrow down the results.",
+  })
+  @Roles("ORG_ADMIN")
+  @HttpCode(HttpStatus.OK)
+  async getAllOrgTeamBookingsCount(
+    @Query() queryParams: GetOrganizationsBookingsCountInput,
+    @Param("orgId", ParseIntPipe) orgId: number,
+    @GetUser() user: UserWithProfile
+  ): Promise<GetBookingsCountOutput_2024_08_13> {
+    const { userIds, ...restParams } = queryParams;
+
+    const count = await this.bookingsService.getBookingsCount(
+      { ...restParams },
+      { email: user.email, id: user.id, orgId },
+      userIds
+    );
+
+    return {
+      status: SUCCESS_STATUS,
+      data: count,
     };
   }
 }

--- a/packages/lib/bookings/getAllUserBookings.ts
+++ b/packages/lib/bookings/getAllUserBookings.ts
@@ -19,7 +19,7 @@ type GetOptions = {
     kysely: Kysely<DB>;
   };
   bookingListingByStatus: InputByStatus[];
-  take: number;
+  take: number | null;
   skip: number;
   filters: {
     status?: InputByStatus;

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/platform-libraries",
-  "version": "0.0.0",
+  "version": "9.9.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/platform/types/bookings/2024-08-13/inputs/get-bookings.input.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/get-bookings.input.ts
@@ -283,3 +283,191 @@ export class GetBookingsInput_2024_08_13 {
   @IsOptional()
   skip?: number;
 }
+
+export class GetBookingsCountInput_2024_08_13 {
+  // note(Lauris): filters
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === "string") {
+      return value.split(",").map((status: string) => status.trim());
+    }
+    return value;
+  })
+  @ArrayNotEmpty({ message: "status cannot be empty." })
+  @IsEnum(Status, {
+    each: true,
+    message: "Invalid status. Allowed are upcoming, recurring, past, cancelled, unconfirmed",
+  })
+  @ApiProperty({
+    required: false,
+    description:
+      "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma.",
+    example: "?status=upcoming,past",
+    enum: Status,
+    isArray: true,
+  })
+  status?: StatusType[];
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by the attendee's email address.",
+    example: "example@domain.com",
+  })
+  @Transform(({ value }) => {
+    if (typeof value === "string") {
+      // note(Lauris): we replace inner white spaces with "+" because managed user emails have "+" in them but if they are not URL encoded
+      // when making request "+" becomes empty space " ".
+      return value.trim().replace(/\s+/g, "+");
+    }
+    return value;
+  })
+  attendeeEmail?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by the attendee's name.",
+    example: "John Doe",
+  })
+  attendeeName?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by the booking Uid.",
+    example: "2NtaeaVcKfpmSZ4CthFdfk",
+  })
+  bookingUid?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === "string") {
+      return value.split(",").map((eventTypeId: string) => parseInt(eventTypeId));
+    }
+    if (Array.isArray(value)) {
+      return value.map((eventTypeId: string | number) => +eventTypeId);
+    }
+    return value;
+  })
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @ArrayMinSize(1, { message: "eventTypeIds must contain at least 1 event type id" })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Filter bookings by event type ids belonging to the user. Event type ids must be separated by a comma.",
+    example: "?eventTypeIds=100,200",
+  })
+  eventTypeIds?: number[];
+
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by event type id belonging to the user.",
+    example: "?eventTypeId=100",
+  })
+  eventTypeId?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === "string") {
+      return value.split(",").map((teamId: string) => parseInt(teamId));
+    }
+    if (Array.isArray(value)) {
+      return value.map((teamId: string | number) => +teamId);
+    }
+    return value;
+  })
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @ArrayMinSize(1, { message: "teamIds must contain at least 1 team id" })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by team ids that user is part of. Team ids must be separated by a comma.",
+    example: "?teamIds=50,60",
+  })
+  teamsIds?: number[];
+
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by team id that user is part of",
+    example: "?teamId=50",
+  })
+  teamId?: number;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "fromDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings with start after this date string.",
+    example: "?afterStart=2025-03-07T10:00:00.000Z",
+  })
+  afterStart?: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "toDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings with end before this date string.",
+    example: "?beforeEnd=2025-03-07T11:00:00.000Z",
+  })
+  beforeEnd?: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "fromDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings that have been created after this date string.",
+    example: "?afterCreatedAt=2025-03-07T10:00:00.000Z",
+  })
+  afterCreatedAt?: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "toDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings that have been created before this date string.",
+    example: "?beforeCreatedAt=2025-03-14T11:00:00.000Z",
+  })
+  beforeCreatedAt?: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "fromDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings that have been updated after this date string.",
+    example: "?afterUpdatedAt=2025-03-07T10:00:00.000Z",
+  })
+  afterUpdatedAt?: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true }, { message: "toDate must be a valid ISO 8601 date." })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings that have been updated before this date string.",
+    example: "?beforeUpdatedAt=2025-03-14T11:00:00.000Z",
+  })
+  beforeUpdatedAt?: string;
+}

--- a/packages/platform/types/bookings/2024-08-13/outputs/get-bookings.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/get-bookings.output.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiExtraModels, getSchemaPath } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsEnum, ValidateNested } from "class-validator";
+import { IsEnum, IsNumber, ValidateNested } from "class-validator";
 
 import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
 import {
@@ -47,4 +47,21 @@ export class GetBookingsOutput_2024_08_13 {
   @Type(() => PaginationMetaDto)
   @ValidateNested()
   pagination!: PaginationMetaDto;
+}
+
+class BookingsCount {
+  @IsNumber()
+  @ApiProperty({ example: 10 })
+  count!: number;
+}
+
+export class GetBookingsCountOutput_2024_08_13 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({ type: () => BookingsCount })
+  @Type(() => BookingsCount)
+  @ValidateNested()
+  data!: BookingsCount;
 }

--- a/packages/platform/types/organizations/bookings/get-org-bookings.input.ts
+++ b/packages/platform/types/organizations/bookings/get-org-bookings.input.ts
@@ -2,9 +2,32 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Transform } from "class-transformer";
 import { ArrayMinSize, IsArray, IsNumber, IsOptional } from "class-validator";
 
-import { GetBookingsInput_2024_08_13 } from "@calcom/platform-types";
+import { GetBookingsInput_2024_08_13, GetBookingsCountInput_2024_08_13 } from "@calcom/platform-types";
 
 export class GetOrganizationsBookingsInput extends GetBookingsInput_2024_08_13 {
+  @IsArray()
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === "string") {
+      return value.split(",").map((userId: string) => parseInt(userId));
+    }
+    if (Array.isArray(value)) {
+      return value.map((userId: string | number) => +userId);
+    }
+    return value;
+  })
+  @IsNumber({}, { each: true })
+  @ArrayMinSize(1, { message: "userIds must contain at least 1 user id" })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Filter bookings by ids of users within your organization.",
+    example: "?userIds=100,200",
+  })
+  userIds?: number[];
+}
+
+export class GetOrganizationsBookingsCountInput extends GetBookingsCountInput_2024_08_13 {
   @IsArray()
   @IsOptional()
   @Transform(({ value }) => {

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -80,7 +80,7 @@ type GetBookingsProps = {
     sortCreated?: "asc" | "desc";
     sortUpdated?: "asc" | "desc";
   };
-  take: number;
+  take: number | null;
   skip: number;
 };
 


### PR DESCRIPTION
Linear [CAL-6091](https://linear.app/calcom/issue/CAL-6091/feat-bookings-statistics-endpoint)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new v2 endpoint to get the count of bookings for an organization, with support for filtering by user, status, date, and other parameters.

- **New Features**
  - Introduced `/v2/organizations/:orgId/bookings/count` endpoint to return the total number of bookings matching query filters.
  - Added input and output types for bookings count queries.
  - Updated service and handler logic to efficiently compute booking counts without fetching full booking data.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve the count of bookings for an organization, supporting various filters.
  * Introduced input and output types for bookings count queries and responses.
  * Added support for additional date range filters when querying bookings.
  * Implemented a method to fetch only the total count of bookings matching specified criteria.

* **Tests**
  * Added an end-to-end test verifying the bookings count endpoint for organizations.

* **Refactor**
  * Improved query construction for bookings retrieval and counting, enhancing modularity and filter support.

* **Chores**
  * Updated dependency and package versions.
  * Removed unused imports and cleaned up API documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->