### PR TITLE
refactor: filter out managed users when resolving platform owner

### DIFF
--- a/apps/api/v2/src/modules/profiles/profiles.repository.ts
+++ b/apps/api/v2/src/modules/profiles/profiles.repository.ts
@@ -10,6 +10,9 @@ export class ProfilesRepository {
     const profile = await this.dbRead.prisma.profile.findFirst({
       where: {
         organizationId,
+        user:{
+          isPlatformManaged: false
+        },
       },
       orderBy: {
         createdAt: "asc",


### PR DESCRIPTION
## What does this PR do?

- Fixes CAL-6090 (Linear issue)

- Refactors the logic used to determine the platform owner in the getPlatformOwnerUserId function

- Prevents mistakenly assigning platform ownership to managed users if the original owner is deleted

- Adds a filter to ensure only real (non-managed) users are considered as owners

- Fixes #22466 (GitHub issue number)
- Fixes CAL-6090 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)
```ts
   async getPlatformOwnerUserId(organizationId: number) {
    const profile = await this.dbRead.prisma.profile.findFirst({
      where: {
        organizationId,
        user:{
          isPlatformManaged: false
        },
      },
      orderBy: {
        createdAt: "asc",
      },
    });

    return profile?.userId;
  }
```
--
## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. -> N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Call any endpoint that authenticates via x-cal-client-id / x-cal-secret headers (OAuth strategy)

- Ensure that the platform owner (userId) returned is not a managed user (isPlatformManaged: false)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated platform owner resolution to exclude managed users, ensuring only real users can be assigned as owners if the original owner is deleted.

<!-- End of auto-generated description by cubic. -->

