### PR TITLE
fix: uncheck requires Confirmation for FreeEmail when uncheck requires confirmation

### DIFF
--- a/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
@@ -104,7 +104,7 @@ export default function RequiresConfirmationController({
               LockedIcon={requiresConfirmationLockedProps.LockedIcon}
               onCheckedChange={(val) => {
                 formMethods.setValue("requiresConfirmation", val, { shouldDirty: true });
-                // If we uncheck requires confirmation, we also uncheck these checkbox
+                // If we uncheck requires confirmation, we also uncheck these checkboxes
                 if (!val) {
                   formMethods.setValue("requiresConfirmationWillBlockSlot", false, { shouldDirty: true });
                   formMethods.setValue("requiresConfirmationForFreeEmail", false, { shouldDirty: true });

--- a/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
@@ -104,9 +104,10 @@ export default function RequiresConfirmationController({
               LockedIcon={requiresConfirmationLockedProps.LockedIcon}
               onCheckedChange={(val) => {
                 formMethods.setValue("requiresConfirmation", val, { shouldDirty: true });
-                // If we uncheck requires confirmation, we also uncheck the "will block slot" checkbox
+                // If we uncheck requires confirmation, we also uncheck these checkbox
                 if (!val) {
                   formMethods.setValue("requiresConfirmationWillBlockSlot", false, { shouldDirty: true });
+                  formMethods.setValue("requiresConfirmationForFreeEmail", false, { shouldDirty: true });
                 }
                 onRequiresConfirmation(val);
               }}>


### PR DESCRIPTION
## What does this PR do?

uncheck requires Confirmation for FreeEmail when uncheck requires confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unchecking the "Requires Confirmation" option now also resets the "Requires Confirmation For Free Email" setting, ensuring both related checkboxes are cleared as expected.

* **Documentation**
  * Updated in-app comments to clarify that multiple checkboxes are reset when "Requires Confirmation" is unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->