### PR TITLE
Copy of PR #22493: fix: resolve unique constraint violations in listWithTeam integration test

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/listWithTeam.handler.integration-test.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/listWithTeam.handler.integration-test.ts
@@ -18,17 +18,18 @@ let eventType4: EventType;
 describe("listWithTeamHandler", () => {
   beforeAll(async () => {
     // Create users, teams and event types
+    const timestamp = Date.now();
     user1 = await prisma.user.create({
       data: {
-        username: "testuser-lwt-1",
-        email: "testuser-lwt-1@example.com",
+        username: `testuser-lwt-1-${timestamp}`,
+        email: `testuser-lwt-1-${timestamp}@example.com`,
         name: "Test User 1",
       },
     });
     user2 = await prisma.user.create({
       data: {
-        username: "testuser-lwt-2",
-        email: "testuser-lwt-2@example.com",
+        username: `testuser-lwt-2-${timestamp}`,
+        email: `testuser-lwt-2-${timestamp}@example.com`,
         name: "Test User 2",
       },
     });
@@ -36,7 +37,7 @@ describe("listWithTeamHandler", () => {
     team1 = await prisma.team.create({
       data: {
         name: "Team 1 lwt",
-        slug: "team-1-lwt",
+        slug: `team-1-lwt-${timestamp}`,
         members: {
           create: {
             userId: user1.id,
@@ -50,14 +51,14 @@ describe("listWithTeamHandler", () => {
     team2 = await prisma.team.create({
       data: {
         name: "Team 2 lwt",
-        slug: "team-2-lwt",
+        slug: `team-2-lwt-${timestamp}`,
       },
     });
 
     eventType1 = await prisma.eventType.create({
       data: {
         title: "User 1 Event",
-        slug: "user1-event-lwt",
+        slug: `user1-event-lwt-${timestamp}`,
         length: 30,
         userId: user1.id,
       },
@@ -66,7 +67,7 @@ describe("listWithTeamHandler", () => {
     eventType2 = await prisma.eventType.create({
       data: {
         title: "Team 1 Event",
-        slug: "team1-event-lwt",
+        slug: `team1-event-lwt-${timestamp}`,
         length: 30,
         teamId: team1.id,
         userId: user1.id,
@@ -76,7 +77,7 @@ describe("listWithTeamHandler", () => {
     eventType3 = await prisma.eventType.create({
       data: {
         title: "User 2 Event",
-        slug: "user2-event-lwt",
+        slug: `user2-event-lwt-${timestamp}`,
         length: 30,
         userId: user2.id,
       },
@@ -85,7 +86,7 @@ describe("listWithTeamHandler", () => {
     eventType4 = await prisma.eventType.create({
       data: {
         title: "Team 2 Event",
-        slug: "team2-event-lwt",
+        slug: `team2-event-lwt-${timestamp}`,
         length: 30,
         teamId: team2.id,
         userId: user2.id,
@@ -94,27 +95,37 @@ describe("listWithTeamHandler", () => {
   });
 
   afterAll(async () => {
-    await prisma.eventType.deleteMany({
-      where: {
-        id: {
-          in: [eventType1.id, eventType2.id, eventType3.id, eventType4.id],
-        },
-      },
-    });
-    await prisma.team.deleteMany({
-      where: {
-        id: {
-          in: [team1.id, team2.id],
-        },
-      },
-    });
-    await prisma.user.deleteMany({
-      where: {
-        id: {
-          in: [user1.id, user2.id],
-        },
-      },
-    });
+    try {
+      if (eventType1?.id || eventType2?.id || eventType3?.id || eventType4?.id) {
+        await prisma.eventType.deleteMany({
+          where: {
+            id: {
+              in: [eventType1?.id, eventType2?.id, eventType3?.id, eventType4?.id].filter(Boolean),
+            },
+          },
+        });
+      }
+      if (team1?.id || team2?.id) {
+        await prisma.team.deleteMany({
+          where: {
+            id: {
+              in: [team1?.id, team2?.id].filter(Boolean),
+            },
+          },
+        });
+      }
+      if (user1?.id || user2?.id) {
+        await prisma.user.deleteMany({
+          where: {
+            id: {
+              in: [user1?.id, user2?.id].filter(Boolean),
+            },
+          },
+        });
+      }
+    } catch (error) {
+      console.warn("Test cleanup failed:", error);
+    }
   });
 
   it("should return user's own event types and event types of teams they are a member of", async () => {


### PR DESCRIPTION
This is a copy of calcom/cal.com#22493

Originally by: zomars


# fix: resolve unique constraint violations in listWithTeam integration test

## Summary

Fixed a failing integration test in `listWithTeam.handler.integration-test.ts` that was causing unique constraint violations. The test was using hardcoded email addresses and slugs that persisted between test runs, causing failures when the same test data already existed in the database.

**Key changes:**
- Added timestamp-based unique identifiers for usernames, emails, team slugs, and event type slugs
- Implemented robust error handling in test cleanup with null checks and try-catch blocks
- Test success rate improved from 113/114 to 114/114 (100% pass rate)

**Root cause:** The test used static values like `testuser-lwt-1@example.com` and `team-1-lwt` that violated unique constraints on subsequent test runs.

## Review & Testing Checklist for Human

- [ ] **Verify test passes consistently** - Run `TZ=UTC yarn test -- --integrationTestsOnly` multiple times to ensure the fix is robust
- [ ] **Check timestamp uniqueness approach** - Confirm that `Date.now()` provides sufficient uniqueness for concurrent test scenarios
- [ ] **Validate cleanup logic** - Ensure the new error handling in `afterAll` properly cleans up test data without masking real errors
- [ ] **Test multiple rapid runs** - Execute the test suite several times in quick succession to verify no race conditions exist

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Test["packages/trpc/server/routers/viewer/eventTypes/<br/>listWithTeam.handler.integration-test.ts"]:::major-edit
    Handler["listWithTeam.handler"]:::context
    UserModel["User (Prisma Model)"]:::context
    TeamModel["Team (Prisma Model)"]:::context
    EventTypeModel["EventType (Prisma Model)"]:::context
    
    Test --> Handler
    Test --> UserModel
    Test --> TeamModel
    Test --> EventTypeModel
    
    Test -- "creates with unique timestamps" --> UserModel
    Test -- "creates with unique slugs" --> TeamModel
    Test -- "creates with unique slugs" --> EventTypeModel
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This fix addresses the PrismaClientKnownRequestError: Unique constraint failed on the fields: (`email`) that was preventing the integration test suite from achieving 100% pass rate
- The solution maintains test isolation by ensuring each test run creates truly unique database records
- Session requested by @zomars: https://app.devin.ai/sessions/3d62b140e87c424ab80c9ed76ac298ca


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of integration tests by ensuring unique test data and more robust cleanup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->