### PR TITLE
fix: hidden cancel button for past bookings

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -369,7 +369,8 @@ function BookingListItem(booking: BookingItemProps) {
     bookedActions = bookedActions.filter((action) => action.id !== "edit_booking");
   }
 
-  if (isDisabledCancelling || (isBookingInPast && isPending && !isConfirmed)) {
+  // Remove cancel option if cancellation is disabled or booking has already ended
+  if (isDisabledCancelling || isBookingInPast) {
     bookedActions = bookedActions.filter((action) => action.id !== "cancel");
   }
 

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -379,7 +379,8 @@ export default function Success(props: PageProps) {
   const canCancelOrReschedule = !eventType?.disableCancelling || !eventType?.disableRescheduling;
   const canCancelAndReschedule = !eventType?.disableCancelling && !eventType?.disableRescheduling;
 
-  const canCancel = !eventType?.disableCancelling;
+  // Allow cancellation only if it's not disabled and the booking hasn't ended yet
+  const canCancel = !eventType?.disableCancelling && !isBookingInPast;
   const canReschedule = !eventType?.disableRescheduling;
 
   const successPageHeadline = (() => {

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -120,6 +120,14 @@ async function handler(input: CancelBookingInput) {
     });
   }
 
+  // Prevent canceling past bookings
+  if (bookingToDelete.endTime && dayjs(bookingToDelete.endTime).isBefore(dayjs())) {
+    throw new HttpError({
+      statusCode: 400,
+      message: "This booking has already ended and cannot be cancelled",
+    });
+  }
+
   // If the booking is a seated event and there is no seatReferenceUid we should validate that logged in user is host
   if (bookingToDelete.eventType?.seatsPerTimeSlot && !seatReferenceUid) {
     const userIsHost = bookingToDelete.eventType.hosts.find((host) => {


### PR DESCRIPTION
## What does this PR do?

- Fixes: #22370 
- Fixes: CAL-6072

This PR prevents users from canceling bookings that have already ended by implementing both UI and API-level protections. The solution ensures that past bookings cannot be canceled through either the user interface or direct API calls, maintaining data integrity and preventing unintended booking modifications.

**Key Changes:**
- Hide cancel buttons in the UI for bookings that have already ended
- Add server-side validation to prevent API bypass attempts
- Maintain existing functionality for future bookings
- Preserve all current cancellation logic and user experience for valid use cases

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Visual Demo (For contributors especially)

Before Fix:

https://github.com/user-attachments/assets/e6aa8bab-aee8-49c4-bb1f-fae841820f78

After Fix:

https://github.com/user-attachments/assets/1e6cea6f-3717-4953-b31b-83033891ba01

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write **N/A** here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Test Environment Setup:
- No specific environment variables required
- Standard Cal.com development setup is sufficient

## Checklist

<!-- Remove bullet points below that don't apply to you -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking cancellation rules to prevent users from canceling bookings that have already ended.
  * Updated the interface to consistently disable the cancel option for past bookings.
  
* **New Features**
  * Users will now only see the cancel option for upcoming or ongoing bookings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->