### PR TITLE
fix: improve restriction schedule description

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3323,7 +3323,7 @@
   "pbac_desc_manage_team_insights": "Manage team insights",
   "read_permission_auto_enabled_tooltip": "Read permission is automatically enabled when creating, updating, or deleting a resource",
   "choose_restriction_schedule": "Add restriction schedule",
-  "choose_restriction_schedule_description": "Enable this if you want to restrict the availability of hosts for this event type based on a restriction schedule. This only removes the slots that are not in the restriction schedule, it does not add any new slots.",
+  "restriction_schedule_description": "Limit availability of hosts to only display slots that fall within a specified schedule.",
   "use_booker_timezone": "Use booker's timezone",
   "use_booker_timezone_info": "Apply the selected restriction schedule in the booker's timezone",
   "load_balancing_warning": "This will disable Load Balancing on all your Round Robin event types",

--- a/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
+++ b/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
@@ -666,7 +666,7 @@ const TeamMemberSchedule = ({
         {isPlatform && <Icon name="user" className={classNames("h-4 w-4", customClassNames?.labelAvatar)} />}
         <p className={classNames("text-emphasis my-auto ms-3 text-sm", customClassNames?.label)}>{label}</p>
       </div>
-      <div className="flex w-full flex-col pt-2 ">
+      <div className="flex w-full flex-col pt-2">
         {isPending ? (
           <Spinner className="mt-2 h-6 w-6" />
         ) : (
@@ -845,13 +845,13 @@ const UseTeamEventScheduleSettingsToggle = ({
           </div>
         )}
       </div>
-      {!isPlatform && isRestrictionScheduleEnabled ? (
+      {!isPlatform && true ? (
         <div className="border-subtle space-y-6 rounded-lg border p-6">
           <SettingsToggle
             checked={restrictScheduleForHosts}
             onCheckedChange={toggleRestrictScheduleState}
             title={t("choose_restriction_schedule")}
-            description={t("choose_restriction_schedule_description")}>
+            description={t("restriction_schedule_description")}>
             <EventTypeSchedule
               customClassNames={customClassNames?.userAvailability}
               eventType={eventType}

--- a/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
+++ b/packages/features/eventtypes/components/tabs/availability/EventAvailabilityTab.tsx
@@ -845,7 +845,7 @@ const UseTeamEventScheduleSettingsToggle = ({
           </div>
         )}
       </div>
-      {!isPlatform && true ? (
+      {!isPlatform && isRestrictionScheduleEnabled ? (
         <div className="border-subtle space-y-6 rounded-lg border p-6">
           <SettingsToggle
             checked={restrictScheduleForHosts}


### PR DESCRIPTION
## What does this PR do?

Before: 
<img width="994" height="126" alt="Screenshot 2025-07-15 at 11 19 55 AM" src="https://github.com/user-attachments/assets/03d978a8-2fe9-49a9-b31a-65648cb704d2" />


After:
<img width="769" height="118" alt="Screenshot 2025-07-15 at 11 19 48 AM" src="https://github.com/user-attachments/assets/f5794b80-e990-437d-926c-5c234f3954cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Minor cleanup of layout classes for improved code consistency.

* **Documentation**
  * Updated and clarified the description text for the restriction schedule feature in English localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->