### PR TITLE
fix: session-middleware-types

### DIFF
--- a/packages/trpc/server/middlewares/sessionMiddleware.ts
+++ b/packages/trpc/server/middlewares/sessionMiddleware.ts
@@ -56,7 +56,9 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
 
   const locale = user?.locale ?? ctx.locale;
   const { members = [], ..._organization } = user.profile?.organization || {};
-  const isOrgAdmin = members.some((member: any) => ["OWNER", "ADMIN"].includes(member.role));
+  // TODO: Update this if we ever enable multi-orgs
+  const singleOrgMemebrship = members[0];
+  const isOrgAdmin = ["ADMIN", "OWNER"].includes(singleOrgMemebrship.role);
 
   if (isOrgAdmin) {
     logger.debug("User is an org admin", safeStringify({ userId: user.id }));
@@ -67,6 +69,7 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
     ..._organization,
     id: user.profile?.organization?.id ?? null,
     isOrgAdmin,
+    role: singleOrgMemebrship.role,
     metadata: orgMetadata,
     requestedSlug: orgMetadata?.requestedSlug ?? null,
   };


### PR DESCRIPTION
<img width="2460" height="3072" alt="image" src="https://github.com/user-attachments/assets/11262c94-f4d2-4454-b000-72ad77066a56" />
Adds back the role to organization value in session like the types expected. Usage of user.org.role was failing 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The user's organization information now includes a visible role property.

* **Bug Fixes**
  * Improved accuracy in determining if a user is an organization admin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->