### PR TITLE
fix: make managedOrganizationSlug parameter optional in getManagedOrganizationBySlug method

### DIFF
--- a/apps/api/v2/src/modules/organizations/organizations/managed-organizations.repository.ts
+++ b/apps/api/v2/src/modules/organizations/organizations/managed-organizations.repository.ts
@@ -25,13 +25,15 @@ export class ManagedOrganizationsRepository {
     });
   }
 
-  async getManagedOrganizationBySlug(managerOrganizationId: number, managedOrganizationSlug: string) {
+  async getManagedOrganizationBySlug(managerOrganizationId: number, managedOrganizationSlug?: string) {
     return this.dbRead.prisma.managedOrganization.findFirst({
       where: {
         managerOrganizationId,
-        managedOrganization: {
-          slug: managedOrganizationSlug,
-        },
+        managedOrganization: managedOrganizationSlug
+          ? {
+              slug: managedOrganizationSlug,
+            }
+          : undefined,
       },
     });
   }


### PR DESCRIPTION
## What does this PR do?
api/v2 breaking after merging #22420, fixes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved organization lookup to allow searching by manager organization ID alone, without requiring a slug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->