### PR TITLE
fix: iOS Safari scroll-to-timeslots compatibility for iOS < 14

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -41,6 +41,7 @@ import framerFeatures from "./framer-features";
 import { useBookerStore } from "./store";
 import type { BookerProps, WrappedBookerProps } from "./types";
 import { isBookingDryRun } from "./utils/isBookingDryRun";
+import { isSmoothScrollAvailableInUserAgent } from "./utils/isSmoothScrollAvailableInUserAgent";
 import { isTimeSlotAvailable } from "./utils/isTimeslotAvailable";
 
 const BookerComponent = ({
@@ -156,8 +157,13 @@ const BookerComponent = ({
   const scrolledToTimeslotsOnce = useRef(false);
   const scrollToTimeSlots = () => {
     if (isMobile && !scrolledToTimeslotsOnce.current) {
-      // eslint-disable-next-line @calcom/eslint/no-scroll-into-view-embed -- We are allowing it here because scrollToTimeSlots is called on explicit user action where it makes sense to scroll, remember that the goal is to not do auto-scroll on embed load because that ends up scrolling the embedding webpage too
-      timeslotsRef.current?.scrollIntoView({ behavior: "smooth" });
+      if (isSmoothScrollAvailableInUserAgent()) {
+        // eslint-disable-next-line @calcom/eslint/no-scroll-into-view-embed -- We are allowing it here because scrollToTimeSlots is called on explicit user action where it makes sense to scroll, remember that the goal is to not do auto-scroll on embed load because that ends up scrolling the embedding webpage too
+        timeslotsRef.current?.scrollIntoView({ behavior: "smooth" });
+      } else {
+        // eslint-disable-next-line @calcom/eslint/no-scroll-into-view-embed -- We are allowing it here because scrollToTimeSlots is called on explicit user action where it makes sense to scroll, remember that the goal is to not do auto-scroll on embed load because that ends up scrolling the embedding webpage too
+        timeslotsRef.current?.scrollIntoView(true);
+      }
       scrolledToTimeslotsOnce.current = true;
     }
   };

--- a/packages/features/bookings/Booker/utils/isSmoothScrollAvailableInUserAgent.ts
+++ b/packages/features/bookings/Booker/utils/isSmoothScrollAvailableInUserAgent.ts
@@ -1,0 +1,34 @@
+/**
+ * Detects if smooth scrolling behavior is available in the current user agent
+ * Used for feature detection and fallbacks for iOS Safari compatibility
+ *
+ * Safari on iOS versions below 14 does not support scrollIntoView({ behavior: "smooth" })
+ * and will silently ignore the option, so we need to use scrollIntoView(true) as fallback
+ */
+export const isSmoothScrollAvailableInUserAgent = (): boolean => {
+  if (typeof window === "undefined" || typeof navigator === "undefined") {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent;
+
+  const isIOSLegacy = /iPad|iPhone|iPod/.test(userAgent);
+
+  const isIPadOS13Plus = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+
+  const isIOS = isIOSLegacy || isIPadOS13Plus;
+
+  if (!isIOS) {
+    return true;
+  }
+
+  const iosVersionMatch = userAgent.match(/OS (\d+)[._](\d+)/);
+
+  if (!iosVersionMatch) {
+    return false;
+  }
+
+  const majorVersion = parseInt(iosVersionMatch[1], 10);
+
+  return majorVersion >= 14;
+};


### PR DESCRIPTION

# fix: iOS Safari scroll-to-timeslots compatibility for iOS < 14

## Summary

Fixes the scroll-to-timeslots feature not working on iPhone Safari by implementing iOS version detection and using appropriate scrolling methods based on device capabilities.

**Root Cause:** Safari on iOS versions below 14 does not support `scrollIntoView({ behavior: "smooth" })` and silently ignores the option, causing the scroll-to-timeslots feature to fail.

**Solution:** 
- Created `isSmoothScrollAvailableInUserAgent()` utility in the bookings domain following DDD patterns
- Modified `scrollToTimeSlots()` function to use conditional scrolling:
  - iOS < 14: `scrollIntoView(true)` (instant scroll)
  - iOS 14+ and non-iOS: `scrollIntoView({ behavior: "smooth" })` (smooth scroll)

## Review & Testing Checklist for Human

⚠️ **CRITICAL: This PR requires manual testing on actual iOS devices** ⚠️

- [ ] **Test on iOS 13.x device** - Verify that clicking a date scrolls to timeslots instantly (not smoothly)
- [ ] **Test on iOS 14+ device** - Verify that clicking a date scrolls to timeslots smoothly
- [ ] **Test on Android/Desktop** - Ensure smooth scrolling still works and no regression introduced
- [ ] **End-to-end booking flow** - Test the complete booking process on mobile to ensure scrolling feels natural
- [ ] **Edge case testing** - Test on iPad (especially iOS 13+) to verify iPadOS detection works correctly

**Recommended Test Plan:**
1. Open a booking page on iPhone Safari (iOS < 14 if available)
2. Select a date and verify timeslots appear with instant scroll
3. Repeat on iOS 14+ and verify smooth scrolling works
4. Test on Android/Desktop to ensure no regression

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    BookerTsx["packages/features/bookings/Booker/Booker.tsx<br/>Main booking component"]:::major-edit
    ScrollUtil["packages/features/bookings/Booker/utils/<br/>isSmoothScrollAvailableInUserAgent.ts<br/>iOS detection utility"]:::major-edit
    ScrollFunction["scrollToTimeSlots()<br/>Function in Booker.tsx"]:::context
    
    BookerTsx --> ScrollUtil
    ScrollFunction --> ScrollUtil
    ScrollUtil --> IOSDetection["iOS version detection logic<br/>User agent parsing"]:::context
    ScrollFunction --> InstantScroll["scrollIntoView(true)<br/>For iOS < 14"]:::context
    ScrollFunction --> SmoothScroll["scrollIntoView({behavior: 'smooth'})<br/>For iOS 14+ and non-iOS"]:::context

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Link to Devin run:** https://app.devin.ai/sessions/7c512d3333564419bb043b9791cf77d7
- **Requested by:** @hariombalhara
- **Testing limitation:** Could not test on actual iOS devices during development - only verified utility logic on desktop/Android emulation
- **DDD compliance:** Utility placed in `packages/features/bookings/Booker/utils/` following domain-driven design patterns
- **Type safety:** All changes pass TypeScript type checking (`yarn type-check:ci`)

**⚠️ Important:** The effectiveness of this fix depends entirely on manual verification across different iOS versions, as Safari's silent failure behavior cannot be programmatically detected.
