### PR TITLE
fix: create org membership for non-auto-accept emails when inviting to team

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMemberUtils.test.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMemberUtils.test.ts
@@ -560,7 +560,7 @@ describe("Invite Member Utils", () => {
       });
       expect(result).toEqual({
         autoAccept: false,
-        needToCreateOrgMembership: false,
+        needToCreateOrgMembership: true,
         needToCreateProfile: false,
       });
     });

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -576,7 +576,7 @@ export function getAutoJoinStatus({
       autoAccept: isAMemberOfOrg,
       // User is a member of parent organization already - So, no need to create profile and membership with Org
       needToCreateProfile: false,
-      needToCreateOrgMembership: false,
+      needToCreateOrgMembership: !isAMemberOfOrg,
     };
   }
 


### PR DESCRIPTION
# fix: create org membership for non-auto-accept emails when inviting to team

## Summary

Fixed a bug in the team invitation flow where organization memberships were not being created when inviting users whose emails don't match the organization's auto-accept domain. The issue was in the `getAutoJoinStatus` function which incorrectly set `needToCreateOrgMembership: false` for users with pending (unaccepted) organization memberships.

**Key Changes:**
- Modified `getAutoJoinStatus` function to only skip org membership creation when user has an **accepted** org membership
- Changed logic from `needToCreateOrgMembership: false` to `needToCreateOrgMembership: !isAMemberOfOrg`
- Updated corresponding test expectation to reflect the corrected behavior

**Impact:** Users with pending org memberships will now correctly get new org memberships created when invited to teams, ensuring proper access control and membership tracking.

## Review & Testing Checklist for Human

- [ ] **Verify logic correctness**: Confirm that `needToCreateOrgMembership: !isAMemberOfOrg` is the correct fix - we should only skip org membership creation when the user has an accepted org membership
- [ ] **Test invitation flow end-to-end**: Invite a user to a team within an organization where the user's email doesn't match auto-accept domain, verify both team AND org memberships are created
- [ ] **Check for dependent code**: Search codebase for any other logic that might depend on the old behavior of `needToCreateOrgMembership: false` for pending members
- [ ] **Review test changes**: Confirm that updating the test expectation from `needToCreateOrgMembership: false` to `needToCreateOrgMembership: true` is appropriate for the test scenario (user with unaccepted org membership)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["packages/trpc/server/routers/viewer/teams/<br/>inviteMember/utils.ts"]:::major-edit
    B["packages/trpc/server/routers/viewer/teams/<br/>inviteMember/inviteMemberUtils.test.ts"]:::minor-edit
    C["getAutoJoinStatus function"]:::major-edit
    D["createMemberships function"]:::context
    E["Team invitation flow"]:::context
    
    A --> C
    C --> D
    D --> E
    B --> C
    
    C --> |"needToCreateOrgMembership:<br/>!isAMemberOfOrg"| D
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The fix addresses the specific scenario where users with pending org memberships weren't getting new org memberships created during team invitations
- All existing tests pass after updating the one test expectation that was checking for the incorrect behavior
- The change is minimal and focused, affecting only the specific logic that was causing the bug
- This fix ensures consistent behavior: org membership is created unless the user already has an accepted org membership

**Session Info:** Requested by @joeauyeung  
**Link to Devin run:** https://app.devin.ai/sessions/5640ee26980843109fc9a423dfb210b2