### PR TITLE
feat: add 2FA status column to organization members table

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -156,7 +156,7 @@ jobs:
   integration-test:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -155,7 +155,7 @@ jobs:
 
   integration-test:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    needs: [changes, check-label, deps]
     if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -155,8 +155,8 @@ jobs:
 
   integration-test:
     name: Tests
-    needs: [changes, check-label, deps]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -421,7 +421,7 @@ function UserListTableContent({ org, attributes, teams, facetedTeamValues }: Use
         id: "twoFactorEnabled",
         accessorKey: "twoFactorEnabled",
         header: t("2fa"),
-        enableHiding: true,
+        enableHiding: adminOrOwner,
         enableSorting: false,
         enableColumnFilter: false,
         size: 80,

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -77,6 +77,7 @@ const initalColumnVisibility = {
   teams: true,
   createdAt: false,
   updatedAt: false,
+  twoFactorEnabled: false,
   actions: true,
 };
 
@@ -415,6 +416,26 @@ function UserListTableContent({ org, attributes, teams, facetedTeamValues }: Use
           },
         },
         cell: ({ row }) => <div>{row.original.updatedAt || ""}</div>,
+      },
+      {
+        id: "twoFactorEnabled",
+        accessorKey: "twoFactorEnabled",
+        header: t("2fa"),
+        enableHiding: true,
+        enableSorting: false,
+        enableColumnFilter: false,
+        size: 80,
+        cell: ({ row }) => {
+          const { twoFactorEnabled } = row.original;
+          if (!adminOrOwner || twoFactorEnabled === undefined) {
+            return null;
+          }
+          return (
+            <Badge variant={twoFactorEnabled ? "green" : "gray"}>
+              {twoFactorEnabled ? t("enabled") : t("disabled")}
+            </Badge>
+          );
+        },
       },
       {
         id: "actions",

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -225,6 +225,7 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
           disableImpersonation: true,
           completedOnboarding: true,
           lastActiveAt: true,
+          ...(ctx.user.organization.isOrgAdmin && { twoFactorEnabled: true }),
           teams: {
             select: {
               team: {
@@ -311,6 +312,7 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
               .toLowerCase()
           : null,
         avatarUrl: user.avatarUrl,
+        ...(ctx.user.organization.isOrgAdmin && { twoFactorEnabled: user.twoFactorEnabled }),
         teams: user.teams
           .filter((team) => team.team.id !== organizationId) // In this context we dont want to return the org team
           .map((team) => {


### PR DESCRIPTION
# Add 2FA status column to organization members table with admin-only visibility

## Summary

Implements a new 2FA status column in the organization members table that shows whether each user has two-factor authentication enabled. The column is hidden by default and only accessible to organization admins for security reasons.

**Key changes:**
- Added `twoFactorEnabled` column to UserListTable with green/gray badges for enabled/disabled status
- Modified backend to conditionally include 2FA data only for admin users via `ctx.user.organization.isOrgAdmin` check
- Implemented permission-based column visibility - non-admins cannot see the 2FA column in display options
- Fixed CI workflow dependency issue by reverting integration-test job dependencies and adding conditional logic
- Column is hidden by default and requires manual toggling by admins to view

## Review & Testing Checklist for Human

**⚠️ Critical Security Testing Required (5 items)**

- [ ] **Admin vs Non-Admin Access**: Test with both admin and non-admin organization accounts to verify only admins can see and toggle the 2FA column
- [ ] **API Security Verification**: Use browser dev tools to verify that non-admin API calls to listMembers do NOT include the `twoFactorEnabled` field in responses
- [ ] **Column Visibility Controls**: Confirm non-admin users cannot see "2FA" option in the column display/visibility dropdown menu
- [ ] **End-to-End Badge Display**: Test that 2FA badges show correct enabled/disabled status for various users when viewed by admins
- [ ] **CI Workflow Impact**: Monitor that the workflow changes don't break CI checks for other PRs (integration-test job now conditional on `run-e2e == 'true'`)

**Recommended test plan:**
1. Log in as organization admin → toggle 2FA column on → verify badges appear correctly
2. Log in as non-admin → confirm 2FA column option is not visible in display settings
3. Use network tab to verify API responses exclude `twoFactorEnabled` for non-admin calls
4. Test with users who have 2FA enabled/disabled to verify badge accuracy

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Frontend["packages/features/users/components/<br/>UserTable/UserListTable.tsx"]:::major-edit
    Backend["packages/trpc/server/routers/viewer/<br/>organizations/listMembers.handler.ts"]:::major-edit
    Workflow[".github/workflows/pr.yml"]:::minor-edit
    Schema["Prisma User Schema<br/>(twoFactorEnabled field)"]:::context
    Permissions["checkAdminOrOwner<br/>Permission Logic"]:::context

    Frontend -->|"Displays 2FA badges<br/>with admin checks"| Backend
    Backend -->|"Conditionally includes<br/>twoFactorEnabled field"| Schema
    Frontend -->|"Uses adminOrOwner<br/>for column visibility"| Permissions
    Backend -->|"Checks ctx.user.organization<br/>.isOrgAdmin"| Permissions
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: Could not perform full end-to-end testing locally due to login configuration issues - human testing is critical
- **Security focus**: This feature handles sensitive 2FA status data, so permission verification is the highest priority
- **CI workflow fix**: Reverted integration-test dependencies as requested by keithwillcode and added conditional logic to prevent "required" check failures
- **Translation ready**: Uses existing i18n strings ("2fa", "enabled", "disabled") from common.json

**Link to Devin run**: https://app.devin.ai/sessions/fd09017e029846f5946625a8029896a9  
**Requested by**: @joeauyeung