### PR TITLE
feat: add initial AuditLogService and /audit-logs API endpoint

### DIFF
--- a/apps/api/v1/lib/audit-log.service.ts
+++ b/apps/api/v1/lib/audit-log.service.ts
@@ -1,0 +1,12 @@
+import type { AuditLogEvent } from "~/lib/types";
+
+export const AuditLogService = {
+  async logEvent(event: AuditLogEvent): Promise<void> {
+    console.log("Audit Log Event:", event);
+  },
+
+  async getEvents(filter?: any): Promise<AuditLogEvent[]> {
+    // Returning Expty array for now
+    return [];
+  },
+};

--- a/apps/api/v1/lib/helpers/audit-log.ts
+++ b/apps/api/v1/lib/helpers/audit-log.ts
@@ -1,0 +1,6 @@
+import { AuditLogService } from "~/lib/audit-log.service";
+import type { AuditLogEvent } from "~/lib/types";
+
+export async function EmitAuditLogEvent(event: AuditLogEvent) {
+  await AuditLogService.logEvent(event);
+}

--- a/apps/api/v1/lib/types.ts
+++ b/apps/api/v1/lib/types.ts
@@ -146,6 +146,18 @@ interface EventTypeExtended extends Omit<EventType, "recurringEvent" | "location
     | any;
 }
 
+//Audit Logs for Teams
+export type AuditLogAction = "RENAME" | "DELETE" | "BOOK" | "CANCEL" | "CREATE";
+
+export interface AuditLogEvent {
+  timestamp: string;
+  userId: string;
+  orgId: string;
+  action: AuditLogAction;
+  resource: string;
+  details: Record<string, any>;
+}
+
 // EventType
 export type EventTypeResponse = BaseResponse & {
   event_type?: Partial<EventType | EventTypeExtended>;

--- a/apps/api/v1/pages/api/audit-logs/_get.ts
+++ b/apps/api/v1/pages/api/audit-logs/_get.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { HttpError } from "@calcom/lib/http-error";
+import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+
+import { AuditLogService } from "~/lib/audit-log.service";
+import type { AuditLogEvent } from "~/lib/types";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { orgId, userId, action } = req.query;
+
+  const filter: Record<string, string | undefined> = {
+    orgId: typeof orgId === "string" ? orgId : undefined,
+    userId: typeof userId === "string" ? userId : undefined,
+    action: typeof action === "string" ? action : undefined,
+  };
+
+  try {
+    const events: AuditLogEvent[] = await AuditLogService.getEvents?.(filter);
+    return res.status(200).json({ events });
+  } catch (error) {
+    throw new HttpError({
+      statusCode: 500,
+      message: "Failed to fetch audit logs",
+    });
+  }
+}
+
+export default defaultResponder(handler);

--- a/apps/api/v1/pages/api/audit-logs/_post.ts
+++ b/apps/api/v1/pages/api/audit-logs/_post.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { HttpError } from "@calcom/lib/http-error";
+import { defaultResponder } from "@calcom/lib/server/defaultResponder";
+
+import { AuditLogService } from "~/lib/audit-log.service";
+import type { AuditLogEvent } from "~/lib/types";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const body = req.body as Partial<AuditLogEvent>;
+  if (!body || typeof body !== "object") {
+    throw new HttpError({
+      statusCode: 400,
+      message: "Invalid/Missing JSON body",
+    });
+  }
+
+  // Required audit event fields
+  const requiredFields = ["timestamp", "userId", "orgId", "action", "resource", "details"];
+  for (const field of requiredFields) {
+    if (!body[field as keyof AuditLogEvent]) {
+      throw new HttpError({
+        statusCode: 400,
+        message: `Missing required field: ${field}`,
+      });
+    }
+  }
+
+  try {
+    await AuditLogService.logEvent(body as AuditLogEvent);
+    return res.status(201).json({ ok: true });
+  } catch (error: unknown) {
+    throw error;
+  }
+}
+
+export default defaultResponder(handler);

--- a/apps/api/v1/pages/api/audit-logs/index.ts
+++ b/apps/api/v1/pages/api/audit-logs/index.ts
@@ -1,0 +1,10 @@
+import { defaultHandler } from "@calcom/lib/server/defaultHandler";
+
+import { withMiddleware } from "~/lib/helpers/withMiddleware";
+
+export default withMiddleware()(
+  defaultHandler({
+    POST: import("./_post"),
+    GET: import("./_get"),
+  })
+);

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -50,6 +50,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.0.0",

--- a/apps/api/v2/src/app.module.ts
+++ b/apps/api/v2/src/app.module.ts
@@ -18,6 +18,7 @@ import { BullModule } from "@nestjs/bull";
 import { MiddlewareConsumer, Module, NestModule, RequestMethod } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { APP_GUARD, APP_INTERCEPTOR, APP_FILTER } from "@nestjs/core";
+import { EventEmitterModule } from "@nestjs/event-emitter";
 import { seconds, ThrottlerModule } from "@nestjs/throttler";
 import { SentryModule, SentryGlobalFilter } from "@sentry/nestjs/setup";
 
@@ -25,6 +26,7 @@ import { AppController } from "./app.controller";
 
 @Module({
   imports: [
+    EventEmitterModule.forRoot(),
     SentryModule.forRoot(),
     ConfigModule.forRoot({
       ignoreEnvFile: true,

--- a/apps/api/v2/src/ee/audit-logs/lib/audit-log.events.ts
+++ b/apps/api/v2/src/ee/audit-logs/lib/audit-log.events.ts
@@ -1,0 +1,10 @@
+export const AUDIT_LOG_EVENT = "audit.log";
+
+export type AuditLogPayload = {
+  teamId: number;
+  actorId: number;
+  action: string;
+  targetType: string;
+  targetId: string;
+  metadata?: Record<string, unknown>;
+};

--- a/apps/api/v2/src/ee/audit-logs/lib/audit-log.service.ts
+++ b/apps/api/v2/src/ee/audit-logs/lib/audit-log.service.ts
@@ -1,0 +1,29 @@
+import { AuditLogPayload } from "@/ee/audit-logs/lib/audit-log.events";
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PrismaWriteService } from "src/modules/prisma/prisma-write.service";
+
+export abstract class AuditLogService {
+  abstract log(payload: AuditLogPayload): Promise<void>;
+}
+
+@Injectable()
+export class PrismaAuditLogService extends AuditLogService {
+  // Injecting the PrismaWriteService class
+  constructor(private readonly prismaWriteService: PrismaWriteService) {
+    super();
+  }
+
+  async log(payload: AuditLogPayload): Promise<void> {
+    await this.prismaWriteService.prisma.auditLog.create({
+      data: {
+        teamId: payload.teamId,
+        actorId: payload.actorId,
+        action: payload.action,
+        targetType: payload.targetType,
+        targetId: payload.targetId,
+        metadata: (payload.metadata || {}) as Prisma.InputJsonValue,
+      },
+    });
+  }
+}

--- a/packages/prisma/migrations/20250718092001_add_audit_log/migration.sql
+++ b/packages/prisma/migrations/20250718092001_add_audit_log/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "teamId" INTEGER NOT NULL,
+    "actorId" INTEGER NOT NULL,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_teamId_idx" ON "AuditLog"("teamId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_actorId_idx" ON "AuditLog"("actorId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_targetType_targetId_idx" ON "AuditLog"("targetType", "targetId");
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -421,6 +421,9 @@ model User {
   creditBalance                  CreditBalance?
   whitelistWorkflows             Boolean                       @default(false)
 
+  // Audit Logs
+  auditLogs AuditLog[] @relation("UserAuditLogs")
+
   @@unique([email])
   @@unique([email, username])
   @@unique([username, organizationId])
@@ -545,6 +548,9 @@ model Team {
   managedOrganization  ManagedOrganization?  @relation("ManagedOrganization")
   managedOrganizations ManagedOrganization[] @relation("ManagerOrganization")
   filterSegments       FilterSegment[]
+
+  // Audit logs
+  auditLogs AuditLog[]
 
   @@unique([slug, parentId])
   @@index([parentId])
@@ -2410,4 +2416,27 @@ model RolePermission {
   @@index([roleId])
   // TODO: come back to this with indexs.
   @@index([action])
+}
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+
+  // The organization/team this log belongs to.
+  teamId Int
+  team   Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  // Who performed the action.
+  actorId Int
+  actor   User @relation("UserAuditLogs", fields: [actorId], references: [id], onDelete: Cascade)
+
+  // What happened.
+  action     String // e.g., "event_type.created", "booking.cancelled"
+  targetType String // e.g., "EventType", "Booking", "User"
+  targetId   String
+  metadata   Json // To store details like old/new values.
+
+  @@index([teamId])
+  @@index([actorId])
+  @@index([targetType, targetId])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,6 +2532,7 @@ __metadata:
     "@nestjs/common": ^10.0.0
     "@nestjs/config": ^3.1.1
     "@nestjs/core": ^10.0.0
+    "@nestjs/event-emitter": ^3.0.1
     "@nestjs/jwt": ^10.2.0
     "@nestjs/passport": ^10.0.2
     "@nestjs/platform-express": ^10.0.0
@@ -8802,6 +8803,18 @@ __metadata:
     "@nestjs/websockets":
       optional: true
   checksum: 145d36ae241e9a7a07ae47d20877d31f9425863e131f95f465970708501d69fe4372a1023cb51b72e8c6d00bbda49029aa9948e41c2bd82b68a9ce62b13d34b8
+  languageName: node
+  linkType: hard
+
+"@nestjs/event-emitter@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@nestjs/event-emitter@npm:3.0.1"
+  dependencies:
+    eventemitter2: 6.4.9
+  peerDependencies:
+    "@nestjs/common": ^10.0.0 || ^11.0.0
+    "@nestjs/core": ^10.0.0 || ^11.0.0
+  checksum: 9e916a3f983f37088d1b3cba3167b5b16032085b6949763cb14db604b259468c0aefe379d8911f4c8e1158c308fb761bd0ee8d08845f56d547cd649252637602
   languageName: node
   linkType: hard
 
@@ -26860,6 +26873,13 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
+"eventemitter2@npm:6.4.9":
+  version: 6.4.9
+  resolution: "eventemitter2@npm:6.4.9"
+  checksum: be59577c1e1c35509c7ba0e2624335c35bbcfd9485b8a977384c6cc6759341ea1a98d3cb9dbaa5cea4fff9b687e504504e3f9c2cc1674cf3bd8a43a7c74ea3eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

This PR introduces the initial groundwork for an Audit Log system.

- Fixes #1461


### Changes Introduced:
- Adds a utility function `logEvent` that logs actions/events to the Console (For now).
- Adds a dummy `getEvents` function for future listing of audit events.
- Introduced an  `AuditLogEvent` interface with fields: `id`, `orgId`, `teamId`, `userId`, `action`, `description`, `timestamp`.

> This setup will be expanded later to include:
> - Filters by team/org/user
> - Pagination and sorting
> - UI integration

---

## Visual Demo 

Since this is just a backend utility setup and there is no UI impact, no video/image is provided. Future commits will demonstrate visual changes (if any).

#### Overall flow:
```mermaid
graph TD
  A[User action: Renamed/Deleted/Booked/Cancelled] --> B(Event Emitter)
  B --> C{AuditLogService Interface}
  C -->|DB Storage| D[AuditLogDbImpl]
  C -->|3rd party| E[AuditLogExternalImpl]
  D & E --> F[Store/Send logs]
  F --> G[Audit log API endpoint]
  H[Optional: Telemetry service] --- F
```

#### Implementation till now:
```mermaid
graph TD
  E[EventEmitter emits event] --> A[AuditLogService]
  A --> T[Console logs event]
```



---

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

---

## How should this be tested?
- ✅ Confirm `getEvents` returns the dummy mocked data (for now).
- ✅ Test event logging with dummy inputs like:
  ```ts
  logEvent({
    timestamp: "timeatamp",
    orgId: "team_456",
    userId: "user_789",
    action: "CANCEL",
    resource: "resources"
    details: "User logged in"
  })
  ```

### Test Config

- No new environment variables added.
- No UI changes yet.