### PR TITLE
perf: Faster logic by preventing instanceof Dayjs in slots.ts

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -92,7 +92,7 @@ function buildSlotsWithDateRanges({
 
       let prevBoundary = null;
       for (let i = slotBoundariesValueArray.length - 1; i >= 0; i--) {
-        if (slotStartTime.valueOf() >= slotBoundariesValueArray[i]) {
+        if (slotBoundariesValueArray[i] < slotStartTime.valueOf()) {
           prevBoundary = slotBoundariesValueArray[i];
           break;
         }


### PR DESCRIPTION
## What does this PR do?

By avoiding `dayjs()` instantiation a 12.5x performance improvement is achieved on event types with many slots and many date ranges.
