### PR TITLE
fix: for calendso encrytion key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ CRON_ENABLE_APP_SYNC=false
 
 # Application Key for symmetric encryption and decryption
 # must be 32 bytes for AES256 encryption algorithm
-# You can use: `openssl rand -base64 32` to generate one
+# You can use: `openssl rand -base64 24` to generate one
 CALENDSO_ENCRYPTION_KEY=
 
 # Intercom Config


### PR DESCRIPTION
Using `openssl rand -base64 32` for calendso encrytion key doesn't work and breaks 2FA. so use `openssl rand -base64 24`

## What does this PR do?

Fixed the 2FA that many users are [facing](https://github.com/calcom/docker/pull/458) because of the default to use `openssl rand -base64 32` in the example.env to generate a key for  `CALENDSO_ENCRYPTION_KEY`

- Fixes #458 (GitHub issue number)

## Visual. video or image Demo

I did not include any because this seems like a while documented issue

- [here](https://github.com/calcom/docker/pull/458)
- and [here](https://github.com/calcom/docker/issues/389)
- one [more](https://github.com/calcom/docker/issues/333)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
This needs more testing I can check more. But so far this as worked to fix 2FA
I am using cal.com v5.4.17

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- I haven't commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
