### PR TITLE
docs: add BrowserStack attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ That's where Cal.com comes in. Self-hosted or hosted by us. White-label by desig
 
 <a href="https://producthunt.com/posts/calendso?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-calendso" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=291910&theme=light&period=monthly" alt="Cal.com - The open source Calendly alternative | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a> <a href="https://producthunt.com/posts/calendso?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-calendso" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=291910&theme=light" alt="Cal.com - The open source Calendly alternative | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a> <a href="https://producthunt.com/stories/how-this-open-source-calendly-alternative-rocketed-to-product-of-the-day" target="_blank"><img src="https://cal.com/maker-grant.svg" alt="Cal.com - The open source Calendly alternative | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
+This project is tested with browserstack
+
 ### Built With
 
 - [Next.js](https://nextjs.org/?ref=cal.com)


### PR DESCRIPTION
# docs: add BrowserStack attribution to README

## Summary

Added the required BrowserStack attribution "This project is tested with browserstack" to the README.md file in the Recognition section. This change is needed to meet BrowserStack's requirements for open source account eligibility.

The attribution was placed after the Product Hunt badges and before the "Built With" section, following the existing recognition pattern in the README.

## Review & Testing Checklist for Human

- [ ] Verify the attribution text matches BrowserStack's exact requirements
- [ ] Check that the placement in the Recognition section is appropriate and doesn't disrupt the README flow
- [ ] Confirm the formatting is consistent with the existing README style

**Recommended test plan:** Simply review the README.md file to ensure the attribution looks appropriate and professional within the context of the existing recognition section.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    README["README.md<br/>(Project documentation)"]:::major-edit
    
    subgraph Recognition["Recognition Section"]
        HN["Hacker News badges"]:::context
        PH["Product Hunt badges"]:::context
        BS["BrowserStack attribution<br/>(NEW)"]:::major-edit
        BW["Built With section"]:::context
    end
    
    README --> Recognition
    HN --> BS
    PH --> BS
    BS --> BW
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef context fill:#ffffff
```

### Notes

- This is a minimal documentation change with no functional impact
- The change directly addresses the user's requirement for BrowserStack open source account eligibility
- Session requested by @hariombalhara
- Link to Devin run: https://app.devin.ai/sessions/ae10ee2ac025477699beb00a16191510