### PR TITLE
fix: prevent non-managed users from being assigned as hosts in platform teams

### DIFF
--- a/docs/platform/guides/teams-setup.mdx
+++ b/docs/platform/guides/teams-setup.mdx
@@ -10,7 +10,7 @@ This page guides you through the steps to set up teams via the API v2. An organi
 1. You need to have an OAuth client set up, since we'll need the client id and client secret from the OAuth client to be included in the API requests. Here is the link for the [OAuth client setup guide](https://cal.com/docs/platform/quickstart)
 2. You need to have an ESSENTIALS plan or above
 3. In order to create a team and access team info you need to be an organization admin/owner
-4. In order to create and access a team event type you need to be a team admin/owner
+4. In order to create and access a team event type you need to be an organization admin/owner (for platform teams) or a team admin/owner (for regular teams)
 5. For all requests made to the below teams endpoint, you need to provide `x-cal-client-id` and `x-cal-secret-key` headers.
 
 ## Steps

--- a/packages/lib/server/queries/teams/platform-team-utils.ts
+++ b/packages/lib/server/queries/teams/platform-team-utils.ts
@@ -1,0 +1,54 @@
+import type { PrismaClient } from "@calcom/prisma";
+
+export async function getTeamUserIds({
+  teamId,
+  prisma,
+}: {
+  teamId: number;
+  prisma: PrismaClient;
+}): Promise<number[]> {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { createdByOAuthClientId: true },
+  });
+
+  const isPlatformTeam = !!team?.createdByOAuthClientId;
+
+  if (isPlatformTeam) {
+    const managedMemberships = await prisma.membership.findMany({
+      where: {
+        teamId,
+        accepted: true,
+        user: {
+          isPlatformManaged: true,
+        },
+      },
+      select: { userId: true },
+    });
+    return managedMemberships.map((membership) => membership.userId);
+  } else {
+    const allMemberships = await prisma.membership.findMany({
+      where: {
+        teamId,
+        accepted: true,
+      },
+      select: { userId: true },
+    });
+    return allMemberships.map((membership) => membership.userId);
+  }
+}
+
+export async function isPlatformTeam({
+  teamId,
+  prisma,
+}: {
+  teamId: number;
+  prisma: PrismaClient;
+}): Promise<boolean> {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { createdByOAuthClientId: true },
+  });
+
+  return !!team?.createdByOAuthClientId;
+}


### PR DESCRIPTION
# refactor: use org admin/owner for platform team management instead of team membership

## Summary

This PR changes the platform team management approach from requiring team-level admin/owner membership to organization-level admin/owner membership. The key issue was that managed users who were team admins/owners were being incorrectly assigned as hosts when `assignAllTeamMembers: true` was set for platform teams, even though their purpose is management-only.

**Key Changes:**
- **teams/me endpoint**: Now returns all organization teams for org admins/owners, not just teams they're members of
- **Host assignment filtering**: Org admins/owners are excluded from automatic host assignment in platform teams
- **Event type creation**: Org admins/owners can create event types for platform teams without being managed users
- **Documentation**: Updated to reflect org membership requirements instead of team membership

The solution ensures that managed users who are org admins/owners can manage platform teams without being incorrectly assigned as hosts during event type creation.

## Review & Testing Checklist for Human

- [ ] **Test platform team functionality end-to-end**: Create a platform team with both managed users and org admins/owners, verify that org admins can see/manage all teams via teams/me endpoint, and confirm only managed users (not org admins) are assigned as hosts when `assignAllTeamMembers: true`
- [ ] **Test regular team functionality**: Ensure non-platform teams continue to work normally with no regressions in team membership, event type creation, or host assignment
- [ ] **Performance impact testing**: Check if the new database queries for org admin status and user filtering impact performance, especially in organizations with many teams/users
- [ ] **Edge case validation**: Test scenarios where users are both managed users AND org admins/owners to ensure the filtering logic handles these cases correctly

**Recommended test plan:**
1. Create a platform team with mixed user types (managed users, org admins, regular users)
2. Test teams/me endpoint as org admin vs regular user
3. Create event types with `assignAllTeamMembers: true` and verify host assignment
4. Test event type creation permissions for different user types
5. Repeat similar tests with regular teams to ensure no regressions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["organizations-teams.controller.ts<br/>(teams/me endpoint)"]:::major-edit
    B["teams/index.ts<br/>(team member assignment)"]:::major-edit
    C["create.handler.ts<br/>(event type creation)"]:::major-edit
    D["platform-team-utils.ts<br/>(NEW utility functions)"]:::major-edit
    E["teams-setup.mdx<br/>(documentation)"]:::minor-edit
    F["MembershipsRepository<br/>(org admin checks)"]:::context
    
    A -->|"uses isUserOrganizationAdmin()"| F
    B -->|"filters org admins from hosts"| F
    C -->|"validates org admin permissions"| F
    D -->|"provides isPlatformTeam() utility"| B
    D -->|"provides isPlatformTeam() utility"| C
    
    A -->|"returns all org teams for admins"| G["Teams/Me API Response"]:::context
    B -->|"excludes org admins from assignment"| H["Host Assignment Logic"]:::context
    C -->|"allows org admin event creation"| I["Event Type Creation"]:::context

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Database queries added**: Multiple new queries to check org admin status and filter users - monitor for performance impact in large organizations
- **Logic complexity**: The filtering involves platform team detection + org admin checks + managed user filtering, increasing the chance of edge cases
- **Testing limitation**: Local e2e tests couldn't run due to environment issues, so runtime behavior needs human verification
- **Requirements evolution**: Changed from team-level to org-level approach mid-implementation based on user feedback

**Link to Devin run**: https://app.devin.ai/sessions/f2ff91aefbf949e38d6a3c736702d40b  
**Requested by**: Devanshu Sharma (@Devanshusharma2005)