### PR TITLE
fix(analytics): prevent dashboard GTM on booking success page

### DIFF
--- a/apps/web/components/GTM.tsx
+++ b/apps/web/components/GTM.tsx
@@ -1,5 +1,7 @@
 import { GoogleTagManager } from "@next/third-parties/google";
 import { useQuery } from "@tanstack/react-query";
+// 1. Add usePathname to the imports
+import { usePathname } from "next/navigation";
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
@@ -45,8 +47,9 @@ export function useGeolocation() {
 
 export function GoogleTagManagerComponent() {
   const { isUS, loading } = useGeolocation();
-
-  if (!isUS || !GTM_ID || loading) {
+  const pathname = usePathname();
+  const isBookingSuccessPage = pathname?.endsWith("/book/success");
+  if (!isUS || !GTM_ID || loading || isBookingSuccessPage) {
     return null;
   }
 


### PR DESCRIPTION
Closes #22617

## What does this PR do?

This PR prevents the main dashboard's Google Tag Manager (GTM) container from loading on the booking success page (`/[user]/book/success`).

Currently, the incorrect dashboard GTM script loads on this page, which can lead to skewed analytics data. This change isolates the booking success page from the main app's analytics container by adding a path check in the `GoogleTagManagerComponent`. This ensures only the correct booking-flow analytics are active.

- Fixes #22617

## Visual Demo (For contributors especially)

N/A — This change affects a background analytics script and has no direct visual component. The verification is done by inspecting network requests as described in the testing steps below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This change can be verified by checking for the absence of the GTM script on the booking success page.

**Note for Testers:** The dashboard GTM script is also configured to only load for users with a **US-based geolocation**. If you are testing from outside the US, the script will not load on *any* page. This is expected. The key is to confirm it remains unloaded on the success page.

1.  Run the application and open your browser's Developer Tools (`F12`) to the **Network** tab.
2.  In the "Filter" box, type `gtm.js`.
3.  **Test Case A: Normal Page**
    - Navigate to a standard dashboard page, like `/event-types`.
    - **Expected Result:** If testing from the US, the `gtm.js` script should appear in the network log. If outside the US, the log will be empty (this is OK).
4.  **Test Case B: Booking Success Page**
    - Go through a full booking flow and land on the booking **success page**.
    - **Expected Result:** The network log should remain empty. The `gtm.js` script **must not** load on this page, regardless of your location. This confirms the fix is working.
