### PR TITLE
refactor: use dependency injection for InsightsRoutingService

### DIFF
--- a/packages/features/insights/hooks/useInsightsOrgTeams.ts
+++ b/packages/features/insights/hooks/useInsightsOrgTeams.ts
@@ -15,7 +15,7 @@ export function useInsightsOrgTeams() {
   const teamId = orgTeamsType === "org" ? currentOrgId : orgTeamsType === "team" ? selectedTeamId : undefined;
   const userId = orgTeamsType === "yours" ? session.data?.user.id : undefined;
 
-  // Adding `scope` for InsightsRoutingService
+  // Adding `scope` for InsightsRoutingBaseService
   // (renaming 'yours' to 'user')
   const scope: "org" | "team" | "user" = orgTeamsType === "yours" ? "user" : orgTeamsType;
 

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -10,8 +10,8 @@ import {
   routingRepositoryBaseInputSchema,
   bookingRepositoryBaseInputSchema,
 } from "@calcom/features/insights/server/raw-data.schema";
+import { getInsightsRoutingService } from "@calcom/lib/di/containers/insights-routing";
 import { InsightsBookingService } from "@calcom/lib/server/service/insightsBooking";
-import { InsightsRoutingService } from "@calcom/lib/server/service/insightsRouting";
 import type { readonlyPrisma } from "@calcom/prisma";
 import { BookingStatus } from "@calcom/prisma/enums";
 import authedProcedure from "@calcom/trpc/server/procedures/authedProcedure";
@@ -1742,8 +1742,7 @@ export const insightsRouter = router({
         timeView,
         weekStart: ctx.user.weekStart,
       });
-      const insightsRoutingService = new InsightsRoutingService({
-        prisma: ctx.insightsDb,
+      const insightsRoutingService = getInsightsRoutingService({
         options: {
           scope: input.scope,
           teamId: input.selectedTeamId,

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -1742,7 +1742,7 @@ export const insightsRouter = router({
         timeView,
         weekStart: ctx.user.weekStart,
       });
-      const insightsRoutingService = getInsightsRoutingService().configure({
+      const insightsRoutingService = getInsightsRoutingService({
         options: {
           scope: input.scope,
           teamId: input.selectedTeamId,

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -1742,7 +1742,7 @@ export const insightsRouter = router({
         timeView,
         weekStart: ctx.user.weekStart,
       });
-      const insightsRoutingService = getInsightsRoutingService({
+      const insightsRoutingService = getInsightsRoutingService().configure({
         options: {
           scope: input.scope,
           teamId: input.selectedTeamId,

--- a/packages/lib/di/containers/insights-routing.ts
+++ b/packages/lib/di/containers/insights-routing.ts
@@ -1,0 +1,27 @@
+import { createContainer } from "@evyweb/ioctopus";
+
+import { DI_TOKENS } from "@calcom/lib/di/tokens";
+import type {
+  InsightsRoutingServicePublicOptions,
+  InsightsRoutingServiceFilterOptions,
+  InsightsRoutingBaseService,
+} from "@calcom/lib/server/service/insightsRoutingBase";
+import type { InsightsRoutingService } from "@calcom/lib/server/service/insightsRoutingDI";
+import { prismaModule } from "@calcom/prisma/prisma.module";
+
+import { insightsRoutingModule } from "../modules/insights-routing";
+
+export function getInsightsRoutingService({
+  options,
+  filters,
+}: {
+  options: InsightsRoutingServicePublicOptions;
+  filters: InsightsRoutingServiceFilterOptions;
+}): InsightsRoutingBaseService {
+  const container = createContainer();
+  container.load(DI_TOKENS.READ_ONLY_PRISMA_CLIENT, prismaModule);
+  container.load(DI_TOKENS.INSIGHTS_ROUTING_SERVICE_MODULE, insightsRoutingModule);
+
+  const diService = container.get<InsightsRoutingService>(DI_TOKENS.INSIGHTS_ROUTING_SERVICE);
+  return diService.create({ options, filters });
+}

--- a/packages/lib/di/containers/insights-routing.ts
+++ b/packages/lib/di/containers/insights-routing.ts
@@ -1,15 +1,27 @@
 import { createContainer } from "@evyweb/ioctopus";
 
 import { DI_TOKENS } from "@calcom/lib/di/tokens";
+import type {
+  InsightsRoutingServicePublicOptions,
+  InsightsRoutingServiceFilterOptions,
+  InsightsRoutingBaseService,
+} from "@calcom/lib/server/service/insightsRoutingBase";
 import type { InsightsRoutingService } from "@calcom/lib/server/service/insightsRoutingDI";
 import { prismaModule } from "@calcom/prisma/prisma.module";
 
 import { insightsRoutingModule } from "../modules/insights-routing";
 
-export function getInsightsRoutingService() {
+export function getInsightsRoutingService({
+  options,
+  filters,
+}: {
+  options: InsightsRoutingServicePublicOptions;
+  filters: InsightsRoutingServiceFilterOptions;
+}): InsightsRoutingBaseService {
   const container = createContainer();
   container.load(DI_TOKENS.READ_ONLY_PRISMA_CLIENT, prismaModule);
   container.load(DI_TOKENS.INSIGHTS_ROUTING_SERVICE_MODULE, insightsRoutingModule);
 
-  return container.get<InsightsRoutingService>(DI_TOKENS.INSIGHTS_ROUTING_SERVICE);
+  const diService = container.get<InsightsRoutingService>(DI_TOKENS.INSIGHTS_ROUTING_SERVICE);
+  return diService.create({ options, filters });
 }

--- a/packages/lib/di/containers/insights-routing.ts
+++ b/packages/lib/di/containers/insights-routing.ts
@@ -1,27 +1,15 @@
 import { createContainer } from "@evyweb/ioctopus";
 
 import { DI_TOKENS } from "@calcom/lib/di/tokens";
-import type {
-  InsightsRoutingServicePublicOptions,
-  InsightsRoutingServiceFilterOptions,
-  InsightsRoutingBaseService,
-} from "@calcom/lib/server/service/insightsRoutingBase";
 import type { InsightsRoutingService } from "@calcom/lib/server/service/insightsRoutingDI";
 import { prismaModule } from "@calcom/prisma/prisma.module";
 
 import { insightsRoutingModule } from "../modules/insights-routing";
 
-export function getInsightsRoutingService({
-  options,
-  filters,
-}: {
-  options: InsightsRoutingServicePublicOptions;
-  filters: InsightsRoutingServiceFilterOptions;
-}): InsightsRoutingBaseService {
+export function getInsightsRoutingService() {
   const container = createContainer();
   container.load(DI_TOKENS.READ_ONLY_PRISMA_CLIENT, prismaModule);
   container.load(DI_TOKENS.INSIGHTS_ROUTING_SERVICE_MODULE, insightsRoutingModule);
 
-  const diService = container.get<InsightsRoutingService>(DI_TOKENS.INSIGHTS_ROUTING_SERVICE);
-  return diService.create({ options, filters });
+  return container.get<InsightsRoutingService>(DI_TOKENS.INSIGHTS_ROUTING_SERVICE);
 }

--- a/packages/lib/di/modules/insights-routing.ts
+++ b/packages/lib/di/modules/insights-routing.ts
@@ -1,0 +1,11 @@
+import { createModule } from "@evyweb/ioctopus";
+
+import type { IInsightsRoutingService } from "@calcom/lib/server/service/insightsRoutingDI";
+import { InsightsRoutingService } from "@calcom/lib/server/service/insightsRoutingDI";
+
+import { DI_TOKENS } from "../tokens";
+
+export const insightsRoutingModule = createModule();
+insightsRoutingModule.bind(DI_TOKENS.INSIGHTS_ROUTING_SERVICE).toClass(InsightsRoutingService, {
+  prisma: DI_TOKENS.READ_ONLY_PRISMA_CLIENT,
+} satisfies Record<keyof IInsightsRoutingService, symbol>);

--- a/packages/lib/di/tokens.ts
+++ b/packages/lib/di/tokens.ts
@@ -20,4 +20,6 @@ export const DI_TOKENS = {
   ROUTING_FORM_RESPONSE_REPOSITORY_MODULE: Symbol("RoutingFormResponseRepositoryModule"),
   AVAILABLE_SLOTS_SERVICE: Symbol("AvailableSlotsService"),
   AVAILABLE_SLOTS_SERVICE_MODULE: Symbol("AvailableSlotsModule"),
+  INSIGHTS_ROUTING_SERVICE: Symbol("InsightsRoutingService"),
+  INSIGHTS_ROUTING_SERVICE_MODULE: Symbol("InsightsRoutingServiceModule"),
 };

--- a/packages/lib/server/service/__tests__/insightsRouting.integration-test.ts
+++ b/packages/lib/server/service/__tests__/insightsRouting.integration-test.ts
@@ -7,7 +7,7 @@ import { ColumnFilterType } from "@calcom/features/data-table/lib/types";
 import prisma from "@calcom/prisma";
 import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 
-import { InsightsRoutingService } from "../../service/insightsRouting";
+import { InsightsRoutingBaseService as InsightsRoutingService } from "../../service/insightsRoutingBase";
 
 // SQL condition constants for testing
 const NOTHING_CONDITION = Prisma.sql`1=0`;

--- a/packages/lib/server/service/insightsRoutingBase.ts
+++ b/packages/lib/server/service/insightsRoutingBase.ts
@@ -53,7 +53,7 @@ export type InsightsRoutingServiceFilterOptions = {
 
 const NOTHING_CONDITION = Prisma.sql`1=0`;
 
-export class InsightsRoutingService {
+export class InsightsRoutingBaseService {
   private prisma: typeof readonlyPrisma;
   private options: InsightsRoutingServiceOptions | null;
   private filters: InsightsRoutingServiceFilterOptions;

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -13,7 +13,7 @@ export interface IInsightsRoutingService {
 export class InsightsRoutingService {
   constructor(private readonly dependencies: IInsightsRoutingService) {}
 
-  create({
+  configure({
     options,
     filters,
   }: {

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -13,7 +13,7 @@ export interface IInsightsRoutingService {
 export class InsightsRoutingService {
   constructor(private readonly dependencies: IInsightsRoutingService) {}
 
-  configure({
+  create({
     options,
     filters,
   }: {

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -13,10 +13,6 @@ export interface IInsightsRoutingService {
 export class InsightsRoutingService {
   constructor(private readonly dependencies: IInsightsRoutingService) {}
 
-  get prisma() {
-    return this.dependencies.prisma;
-  }
-
   create({
     options,
     filters,

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -6,12 +6,12 @@ import {
   type InsightsRoutingServiceFilterOptions,
 } from "./insightsRoutingBase";
 
-export interface IInsightsRoutingService {
+export interface Dependencies {
   prisma: typeof readonlyPrisma;
 }
 
 export class InsightsRoutingService {
-  constructor(private readonly dependencies: IInsightsRoutingService) {}
+  constructor(private readonly deps: Dependencies) {}
 
   create({
     options,
@@ -21,7 +21,7 @@ export class InsightsRoutingService {
     filters: InsightsRoutingServiceFilterOptions;
   }): InsightsRoutingBaseService {
     return new InsightsRoutingBaseService({
-      prisma: this.dependencies.prisma,
+      prisma: this.deps.prisma,
       options,
       filters,
     });

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -6,12 +6,12 @@ import {
   type InsightsRoutingServiceFilterOptions,
 } from "./insightsRoutingBase";
 
-export interface Dependencies {
+export interface IInsightsRoutingService {
   prisma: typeof readonlyPrisma;
 }
 
 export class InsightsRoutingService {
-  constructor(private readonly deps: Dependencies) {}
+  constructor(private readonly dependencies: IInsightsRoutingService) {}
 
   create({
     options,
@@ -21,7 +21,7 @@ export class InsightsRoutingService {
     filters: InsightsRoutingServiceFilterOptions;
   }): InsightsRoutingBaseService {
     return new InsightsRoutingBaseService({
-      prisma: this.deps.prisma,
+      prisma: this.dependencies.prisma,
       options,
       filters,
     });

--- a/packages/lib/server/service/insightsRoutingDI.ts
+++ b/packages/lib/server/service/insightsRoutingDI.ts
@@ -1,0 +1,33 @@
+import type { readonlyPrisma } from "@calcom/prisma";
+
+import {
+  InsightsRoutingBaseService,
+  type InsightsRoutingServicePublicOptions,
+  type InsightsRoutingServiceFilterOptions,
+} from "./insightsRoutingBase";
+
+export interface IInsightsRoutingService {
+  prisma: typeof readonlyPrisma;
+}
+
+export class InsightsRoutingService {
+  constructor(private readonly dependencies: IInsightsRoutingService) {}
+
+  get prisma() {
+    return this.dependencies.prisma;
+  }
+
+  create({
+    options,
+    filters,
+  }: {
+    options: InsightsRoutingServicePublicOptions;
+    filters: InsightsRoutingServiceFilterOptions;
+  }): InsightsRoutingBaseService {
+    return new InsightsRoutingBaseService({
+      prisma: this.dependencies.prisma,
+      options,
+      filters,
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces dependency injection to `InsightsRoutingService`.

Unlike other services, here's a little difference:

The original service `InsightsRoutingService` (now renamed to `InsightsRoutingBaseService`) needs instance variables and instance methods that uses them (not static), and it relies on the parameters passed to the constructor. Due to this difference, I put one more layer:

```
      // packages/features/insights/server/trpc-router.ts
      const insightsRoutingService = getInsightsRoutingService().configure({
        options: {
          scope: input.scope,
          teamId: input.selectedTeamId,
          userId: ctx.user.id,
          orgId: ctx.user.organizationId,
        },
        filters: {
          startDate: input.startDate,
          endDate: input.endDate,
          columnFilters: input.columnFilters,
        },
      });
```

`getInsightsRoutingService()` returns an instance of `InsightsRoutingService` (dependency injected), and `configure` method of that instance returns an instance of `InsightsRoutingBaseService`.

This pattern was inevitable to pass parameters to dependency-injected service.

Let me know if you have a better idea!

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## How to test

Go to /insights/routing and see if "Routing funnel" chart is correctly rendered.