### PR TITLE
chore: add review rule for agents to avoid large PRs

### DIFF
--- a/.cursor/rules/review.mdc
+++ b/.cursor/rules/review.mdc
@@ -19,3 +19,10 @@
   - "summary" fields do not end with a period
   - "summary" fields are written in proper American english
 - When changes to API v2 or v1 are made, ensure there are no breaking changes on existing endpoints. Instead, there needs to be a newly versioned endpoint with the updated functionality but the old one must remain functional
+- For large pull requests (>500 lines changed or >10 files touched), advise splitting into smaller, focused PRs:
+  - Split by feature boundaries: separate different features or user stories
+  - Split by layer/component: frontend changes, backend changes, database migrations, and tests in separate PRs
+  - Split by dependency chain: create PRs that can be merged sequentially
+  - Split by file/module: group related file changes together
+  - Suggested pattern: Database migrations → Backend logic → Frontend components → Integration tests
+  - Benefits: easier review, faster feedback, reduced conflicts, easier rollback, better history


### PR DESCRIPTION
## What does this PR do?

This PR adds a review rule for agents to avoid large PRs.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

