### PR TITLE
fix: Fixed the webhook select indicators which is misaligned when the height increases.

### DIFF
--- a/packages/features/webhooks/components/WebhookForm.tsx
+++ b/packages/features/webhooks/components/WebhookForm.tsx
@@ -211,6 +211,12 @@ const WebhookForm = (props: {
                   grow
                   options={translatedTriggerOptions}
                   isMulti
+                  styles={{
+                    indicatorsContainer: (base) => ({
+                      ...base,
+                      alignItems: "flex-start",
+                    }),
+                  }}
                   value={selectValue}
                   onChange={(event) => {
                     onChange(event.map((selection) => selection.value));


### PR DESCRIPTION
## What does this PR do?

This PR fixes the alignment of the dropdown arrow and clear (X) button in the Event Triggers multi-select on the Webhook form. Previously, when many items were selected, the height of the select box increased and these buttons would appear vertically centered. Now, they always stay at the top, making the UI look cleaner and easier to use.

## Visual Demo

#### Image Demo:

- **Before:**
<img width="767" height="616" alt="before (1)" src="https://github.com/user-attachments/assets/82a5b09c-d4b8-457d-84e1-08c03964441e" />


- **After:** 
<img width="767" height="616" alt="after (1)" src="https://github.com/user-attachments/assets/3f961bf5-b6f0-496c-98c2-daa38a3b521b" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to the Webhooks form in the developer settings and create a New webhook. [Link](https://app.cal.com/settings/developer/webhooks)
2. In the Event Triggers field, select many options so the select box grows in height ( though many options would already be selected ).
3. Check that the dropdown arrow and clear (X) button always stay in the middle and not at the top of the select box. 
4. No special environment variables or test data are needed.

**Expected Result:**  
The dropdown arrow and clear button should always be at the top of the select box, no matter how many items are selected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate