### PR TITLE
refactor: event trends chart on /insights to use InsightsBookingService

### DIFF
--- a/apps/web/modules/insights/insights-view.tsx
+++ b/apps/web/modules/insights/insights-view.tsx
@@ -10,7 +10,7 @@ import {
 import {
   AverageEventDurationChart,
   BookingKPICards,
-  BookingStatusLineChart,
+  EventTrendsChart,
   HighestNoShowHostTable,
   HighestRatedMembersTable,
   BookingsByHourChart,
@@ -70,7 +70,7 @@ function InsightsPageContent() {
       <div className="my-4 space-y-4">
         <BookingKPICards />
 
-        <BookingStatusLineChart />
+        <EventTrendsChart />
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
           <div className="sm:col-span-2">

--- a/packages/features/insights/components/BookingStatusLineChart.tsx
+++ b/packages/features/insights/components/BookingStatusLineChart.tsx
@@ -1,4 +1,6 @@
+import { useDataTable } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { CURRENT_TIMEZONE } from "@calcom/lib/timezoneConstants";
 import { trpc } from "@calcom/trpc";
 
 import { useInsightsParameters } from "../hooks/useInsightsParameters";
@@ -9,7 +11,8 @@ import { LoadingInsight } from "./LoadingInsights";
 
 export const BookingStatusLineChart = () => {
   const { t } = useLocale();
-  const { isAll, teamId, userId, startDate, endDate, eventTypeId } = useInsightsParameters();
+  const { scope, selectedTeamId, memberUserId, startDate, endDate, eventTypeId } = useInsightsParameters();
+  const { timeZone } = useDataTable();
 
   const {
     data: eventsTimeLine,
@@ -17,12 +20,13 @@ export const BookingStatusLineChart = () => {
     isPending,
   } = trpc.viewer.insights.eventsTimeline.useQuery(
     {
+      scope,
+      selectedTeamId,
       startDate,
       endDate,
-      teamId,
+      timeZone: timeZone || CURRENT_TIMEZONE,
       eventTypeId,
-      userId,
-      isAll,
+      memberUserId,
     },
     {
       staleTime: 30000,

--- a/packages/features/insights/components/EventTrendsChart.tsx
+++ b/packages/features/insights/components/EventTrendsChart.tsx
@@ -9,16 +9,16 @@ import { ChartCard } from "./ChartCard";
 import { LineChart } from "./LineChart";
 import { LoadingInsight } from "./LoadingInsights";
 
-export const BookingStatusLineChart = () => {
+export const EventTrendsChart = () => {
   const { t } = useLocale();
   const { scope, selectedTeamId, memberUserId, startDate, endDate, eventTypeId } = useInsightsParameters();
   const { timeZone } = useDataTable();
 
   const {
-    data: eventsTimeLine,
+    data: eventTrends,
     isSuccess,
     isPending,
-  } = trpc.viewer.insights.eventsTimeline.useQuery(
+  } = trpc.viewer.insights.eventTrends.useQuery(
     {
       scope,
       selectedTeamId,
@@ -44,7 +44,7 @@ export const BookingStatusLineChart = () => {
     <ChartCard title={t("event_trends")}>
       <LineChart
         className="linechart ml-4 mt-4 h-80 sm:ml-0"
-        data={eventsTimeLine ?? []}
+        data={eventTrends ?? []}
         categories={["Created", "Completed", "Rescheduled", "Cancelled", "No-Show (Host)", "No-Show (Guest)"]}
         index="Month"
         colors={["purple", "green", "blue", "red", "slate", "orange"]}

--- a/packages/features/insights/components/index.ts
+++ b/packages/features/insights/components/index.ts
@@ -2,7 +2,7 @@ export { AverageEventDurationChart } from "./AverageEventDurationChart";
 export { BookingKPICards } from "./BookingKPICards";
 export { BookingsByHourChart } from "./BookingsByHourChart";
 
-export { BookingStatusLineChart } from "./BookingStatusLineChart";
+export { EventTrendsChart } from "./EventTrendsChart";
 export { FailedBookingsByField } from "./FailedBookingsByField";
 export { HighestNoShowHostTable } from "./HighestNoShowHostTable";
 export { HighestRatedMembersTable } from "./HighestRatedMembersTable";

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -480,7 +480,7 @@ export const insightsRouter = router({
 
     return result;
   }),
-  eventsTimeline: userBelongsToTeamProcedure
+  eventTrends: userBelongsToTeamProcedure
     .input(bookingRepositoryBaseInputSchema)
     .query(async ({ ctx, input }) => {
       const { startDate, endDate, timeZone } = input;

--- a/packages/features/insights/server/trpc-router.ts
+++ b/packages/features/insights/server/trpc-router.ts
@@ -485,7 +485,7 @@ export const insightsRouter = router({
     .query(async ({ ctx, input }) => {
       const { startDate, endDate, timeZone } = input;
 
-      // Calculate timeView and dateRanges in the tRPC router
+      // Calculate timeView and dateRanges
       const timeView = EventsInsights.getTimeView(startDate, endDate);
       const dateRanges = EventsInsights.getDateRanges({
         startDate,
@@ -496,7 +496,6 @@ export const insightsRouter = router({
       });
 
       const insightsBookingService = createInsightsBookingService(ctx, input);
-
       try {
         return await insightsBookingService.getEventTrendsStats({
           timeZone,

--- a/packages/lib/server/service/insightsBooking.ts
+++ b/packages/lib/server/service/insightsBooking.ts
@@ -1,7 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
 
-// Import types from insights events
 import type { DateRange } from "@calcom/features/insights/server/events";
 import type { readonlyPrisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";


### PR DESCRIPTION
## What does this PR do?

This PR refactors Event Trends chart on the /insights page to use `InsightsBookingService`.

- mostly removing `EventsInsights.countGroupedByStatusForRanges()` and moving the logic into 
`InsightsBookingService`
- rename `eventsTimeline` to `eventTrends` to match the actual chart label on the UI (easy to find in code)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Visit /insights and see if "Event Trends" chart works well.