### PR TITLE
docs: fix path to coding style guide

### DIFF
--- a/docs/developing/open-source-contribution/pull-requests.mdx
+++ b/docs/developing/open-source-contribution/pull-requests.mdx
@@ -26,7 +26,7 @@ Feel free to add a short video or screenshots of what your PR achieves. Loom is 
 
 ### Code Quality & Styling
 
-All submitted code must match our [code styling](/code-styling) standards. We will reject pull requests that differ significantly from our standardised code styles.
+All submitted code must match our [code styling](./code-styling) standards. We will reject pull requests that differ significantly from our standardised code styles.
 
 All code is automatically checked by Codacy and our linting process, and will notify you if there are any issues with the code that you submit. We require that code passes these quality checks before merging.
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes path to coding style guide in docs

- Fixes #22748  (GitHub issue number)
- Fixes CAL-6153 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

[Screencast from 2025-07-26 03-08-18.webm](https://github.com/user-attachments/assets/ef2f2930-7bf2-4bb5-a3ba-be945ef2a077)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

