### PR TITLE
fix: display video meeting time in attendee's timezone with timezone name

### DIFF
--- a/apps/web/modules/videos/views/videos-single-view.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.tsx
@@ -10,7 +10,7 @@ import dayjs from "@calcom/dayjs";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { TRANSCRIPTION_STOPPED_ICON, RECORDING_DEFAULT_ICON } from "@calcom/lib/constants";
-import { formatToLocalizedDate, formatToLocalizedTime } from "@calcom/lib/dayjs";
+import { formatToLocalizedDate, formatToLocalizedTime, formatToLocalizedTimezone } from "@calcom/lib/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";
@@ -306,11 +306,31 @@ export function VideoMeetingInfo(props: VideoMeetingInfo) {
           <h3>{t("what")}:</h3>
           <p>{booking.title}</p>
           <h3>{t("invitee_timezone")}:</h3>
-          <p>{booking.user?.timeZone}</p>
+          <p>{booking.attendees[0]?.timeZone || booking.user?.timeZone}</p>
           <h3>{t("when")}:</h3>
           <p suppressHydrationWarning={true}>
-            {formatToLocalizedDate(startTime)} <br />
-            {formatToLocalizedTime(startTime)}
+            {formatToLocalizedDate(
+              startTime,
+              undefined,
+              "long",
+              booking.attendees[0]?.timeZone || booking.user?.timeZone
+            )}{" "}
+            <br />
+            {formatToLocalizedTime(
+              startTime,
+              undefined,
+              "short",
+              undefined,
+              booking.attendees[0]?.timeZone || booking.user?.timeZone
+            )}
+            <br />
+            <span className="text-gray-400">
+              {formatToLocalizedTimezone(
+                startTime,
+                undefined,
+                booking.attendees[0]?.timeZone || booking.user?.timeZone
+              )}
+            </span>
           </p>
           <h3>{t("time_left")}</h3>
           <ProgressBar


### PR DESCRIPTION
# fix: display video meeting time in attendee's timezone with timezone name

## Summary

Fixed a bug in the Cal Video feature where the `VideoMeetingInfo` component was displaying meeting start times in the organizer's timezone instead of the attendee's timezone. The fix updates the time display logic to use the attendee's timezone and adds the timezone name for clarity.

**Key Changes:**
- Updated `VideoMeetingInfo` component to use `booking.attendees[0]?.timeZone` instead of `booking.user?.timeZone`
- Added timezone name display using `formatToLocalizedTimezone` utility
- Implemented fallback logic to organizer's timezone if attendee timezone is unavailable
- Updated imports to include the timezone formatting function

## Review & Testing Checklist for Human

- [ ] **End-to-end testing**: Create a video meeting and verify the time displays in the attendee's timezone, not the organizer's
- [ ] **Timezone name verification**: Confirm the timezone name appears correctly below the meeting time with proper styling
- [ ] **Edge case testing**: Test scenarios with no attendees, invalid timezones, or missing timezone data
- [ ] **Cross-timezone validation**: Test with attendees in different timezones to ensure correct time conversion
- [ ] **Regression testing**: Verify existing video meeting functionality still works (progress bar, meeting info, etc.)

**Recommended Test Plan:**
1. Set up a test meeting between users in different timezones
2. Join the video meeting as an attendee 
3. Verify the sidebar shows meeting time in attendee's timezone with timezone name
4. Compare with organizer's view to confirm different timezone display

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["apps/web/modules/videos/views/<br/>videos-single-view.tsx"]:::major-edit --> B["VideoMeetingInfo Component"]:::major-edit
    B --> C["booking.attendees[0]?.timeZone"]:::context
    B --> D["booking.user?.timeZone"]:::context
    B --> E["formatToLocalizedDate"]:::context
    B --> F["formatToLocalizedTime"]:::context
    B --> G["formatToLocalizedTimezone"]:::minor-edit
    
    H["packages/lib/dayjs/index.ts"]:::context --> E
    H --> F
    H --> G
    
    C --> I["Attendee Timezone Display"]:::major-edit
    D --> J["Fallback to Organizer TZ"]:::major-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Risk**: Unable to fully test the changes due to local dev environment login issues - human testing is critical
- **Timezone data source**: The fix relies on `booking.attendees[0]?.timeZone` being populated correctly by the booking system
- **UI impact**: Added timezone name appears below meeting time with `text-gray-400` styling to match existing patterns
- **Fallback strategy**: Gracefully falls back to organizer's timezone if attendee timezone is unavailable

**Link to Devin run**: https://app.devin.ai/sessions/a2bc8b2c6b294efd8511b6c4ea956c61  
**Requested by**: @joeauyeung