### PR TITLE
fix: alignment of time unit select box content

### DIFF
--- a/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/RequiresConfirmationController.tsx
@@ -208,7 +208,7 @@ export default function RequiresConfirmationController({
                                           customClassNames?.conditionalConfirmationRadio?.timeUnitSelect
                                         }
                                         innerClassNames={{
-                                          control: "rounded-l-none max-h-4 px-3 bg-subtle",
+                                          control: "rounded-l-none max-h-4 px-3 bg-subtle py-1",
                                         }}
                                         onChange={(opt) => {
                                           setRequiresConfirmationSetup({


### PR DESCRIPTION
## What does this PR do?

This PR align the content inside the Select component adjacent to the Input field for time. Checkout the issue details for more context 

- Fixes #22799  (GitHub issue number)
- Fixes CAL-6170 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

[Screencast from 2025-07-30 02-50-25.webm](https://github.com/user-attachments/assets/0d7eaf77-484e-42f4-84e6-cf0318c6c7d6)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR
