### PR TITLE
fix: Allow team admins/owners to see attendees of team-seated events

### DIFF
--- a/apps/web/lib/booking.ts
+++ b/apps/web/lib/booking.ts
@@ -3,7 +3,7 @@ import { bookingResponsesDbSchema } from "@calcom/features/bookings/lib/getBooki
 import { workflowSelect } from "@calcom/features/ee/workflows/lib/getAllWorkflows";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 
 export const getEventTypesFromDB = async (id: number) => {
@@ -140,7 +140,8 @@ export const handleSeatsEventTypeOnBooking = async (
     }>
   >,
   seatReferenceUid?: string,
-  isHost?: boolean
+  isHost?: boolean,
+  userId?: number
 ) => {
   bookingInfo["responses"] = {};
   type seatAttendee = {
@@ -181,7 +182,26 @@ export const handleSeatsEventTypeOnBooking = async (
     bookingInfo["responses"] = bookingResponsesDbSchema.parse(seatAttendeeData.responses ?? {});
   }
 
-  if (!eventType.seatsShowAttendees && !isHost) {
+  // Check if user is admin/owner of the team
+  let isAdminOrOwner = false;
+  if (userId && bookingInfo?.eventType?.teamId) {
+    const membership = await prisma.membership.findUnique({
+      where: {
+        userId_teamId: {
+          userId,
+          teamId: bookingInfo.eventType.teamId,
+        },
+        role: { in: [MembershipRole.ADMIN, MembershipRole.OWNER] },
+        accepted: true,
+      },
+      select: {
+        id: true,
+      },
+    });
+    isAdminOrOwner = !!membership;
+  }
+
+  if (!eventType.seatsShowAttendees && !isHost && !isAdminOrOwner) {
     if (seatAttendee) {
       const attendee = bookingInfo?.attendees?.find((a) => {
         return (

--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -176,7 +176,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const isLoggedInUserHost = checkIfUserIsHost(userId);
 
   if (bookingInfo !== null && eventType.seatsPerTimeSlot) {
-    await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
+    await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost, userId);
   }
 
   const payment = await prisma.payment.findFirst({

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -13,10 +13,8 @@ import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import type { PrismaClient } from "@calcom/prisma";
-import { SchedulingType } from "@calcom/prisma/enums";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { SchedulingType, BookingStatus, MembershipRole } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
-import { MembershipRole } from "@calcom/prisma/enums";
 import { prisma } from "@calcom/prisma";
 
 import { TRPCError } from "@trpc/server";

--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -16,6 +16,8 @@ import type { PrismaClient } from "@calcom/prisma";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
+import { MembershipRole } from "@calcom/prisma/enums";
+import { prisma } from "@calcom/prisma";
 
 import { TRPCError } from "@trpc/server";
 
@@ -669,13 +671,37 @@ export async function getBookings({
       return hostUser?.id === userId && attendeeEmails.has(hostUser.email);
     });
   };
+
+  const checkIfUserIsAdminOrOwnerOfTeam = async (userId: number, booking: (typeof plainBookings)[number]) => {
+    if (!booking.eventType?.team?.id) {
+      return false;
+    }
+
+    const membership = await prisma.membership.findUnique({
+      where: {
+        userId_teamId: {
+          userId,
+          teamId: booking.eventType.team.id,
+        },
+        role: { in: [MembershipRole.ADMIN, MembershipRole.OWNER] },
+        accepted: true,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return !!membership;
+  };
+
   const bookings = await Promise.all(
     plainBookings.map(async (booking) => {
-      // If seats are enabled, the event is not set to show attendees, and the current user is not the host, filter out attendees who are not the current user
+      // If seats are enabled, the event is not set to show attendees, and the current user is not the host or admin/owner, filter out attendees who are not the current user
       if (
         booking.seatsReferences.length &&
         !booking.eventType?.seatsShowAttendees &&
-        !checkIfUserIsHost(user.id, booking)
+        !checkIfUserIsHost(user.id, booking) &&
+        !(await checkIfUserIsAdminOrOwnerOfTeam(user.id, booking))
       ) {
         booking.attendees = booking.attendees.filter((attendee) => attendee.email === user.email);
       }


### PR DESCRIPTION
- Fixes #22802 

**Problem:** Team admins/owners cannot see attendees of team-seated events unless they are the hosts, affecting both `/bookings` page and booking success page.

**Solution:** Updated attendee filtering logic to check if user is admin/owner of the team, allowing them to see all attendees while maintaining privacy for regular team members.

### How should this be tested?

**Test Setup:**
1. Create a team with admin/owner and regular member
2. Create team event with seats enabled and `seatsShowAttendees: false`
3. Book the event as regular user

**Test Steps:**
1. **Admin Test:** Login as team admin/owner → Go to `/bookings` → Verify can see all attendees
2. **Member Test:** Login as regular member → Go to `/bookings` → Verify only sees own attendee info
3. **Success Page Test:** Repeat above for booking success page

### Expected Results:**
- Admins see all attendees
- Regular members see only their own info
- Works on both booking listing and success pages
