### PR TITLE
chore: Refactor logs

### DIFF
--- a/packages/app-store/_utils/getCalendar.ts
+++ b/packages/app-store/_utils/getCalendar.ts
@@ -49,7 +49,6 @@ export const getCalendar = async (
     log.warn(`calendar of type ${calendarType} is not implemented`);
     return null;
   }
-  log.info("Got calendarApp", calendarApp.lib.CalendarService);
   const CalendarService = calendarApp.lib.CalendarService;
   return new CalendarService(credential);
 };

--- a/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
+++ b/packages/features/bookings/lib/handleNewBooking/ensureAvailableUsers.ts
@@ -222,7 +222,7 @@ const _ensureAvailableUsers = async (
 
     if (!dateRanges.length) {
       loggerWithEventDetails.error(
-        `User does not have availability at this time.`,
+        `User ${user.id} does not have availability at this time.`,
         piiFreeInputDataForLogging
       );
       return;

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -277,7 +277,10 @@ export const getBusyCalendarTimes = async (
       );
     }
   } catch (e) {
-    log.warn(safeStringify(e));
+    log.warn(`Error getting calendar availability`, {
+      selectedCalendarIds: selectedCalendars.map((calendar) => calendar.externalId),
+      error: safeStringify(e),
+    });
   }
   return results.reduce((acc, availability) => acc.concat(availability), []);
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- The `Got calendarApp` log every time we were fetching calendars to load slots and bookings for every host of an event type. In the last hour we logged this almost 6000 times. The log looks like `[INFO[0m[0m] CalendarManager Got calendarApp [36m[class E][39m` which doesn't provide a lot.
