### PR TITLE
fix: Return empty available days if error querying calendar

### DIFF
--- a/apps/api/v2/src/ee/calendars/services/calendars.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/calendars.service.ts
@@ -83,32 +83,31 @@ export class CalendarsService {
       calendarsToLoad,
       userId
     );
-    try {
-      const calendarBusyTimes = await getBusyCalendarTimes(
-        this.buildNonDelegationCredentials(credentials),
-        dateFrom,
-        dateTo,
-        composedSelectedCalendars
-      );
-      const calendarBusyTimesConverted = calendarBusyTimes.map(
-        (busyTime: EventBusyDate & { timeZone?: string }) => {
-          const busyTimeStart = DateTime.fromJSDate(new Date(busyTime.start)).setZone(timezone);
-          const busyTimeEnd = DateTime.fromJSDate(new Date(busyTime.end)).setZone(timezone);
-          const busyTimeStartDate = busyTimeStart.toJSDate();
-          const busyTimeEndDate = busyTimeEnd.toJSDate();
-          return {
-            ...busyTime,
-            start: busyTimeStartDate,
-            end: busyTimeEndDate,
-          };
-        }
-      );
-      return calendarBusyTimesConverted;
-    } catch (error) {
+    const calendarBusyTimesQuery = await getBusyCalendarTimes(
+      this.buildNonDelegationCredentials(credentials),
+      dateFrom,
+      dateTo,
+      composedSelectedCalendars
+    );
+    if (!calendarBusyTimesQuery.success) {
       throw new InternalServerErrorException(
         "Unable to fetch connected calendars events. Please try again later."
       );
     }
+    const calendarBusyTimesConverted = calendarBusyTimesQuery.data.map(
+      (busyTime: EventBusyDate & { timeZone?: string }) => {
+        const busyTimeStart = DateTime.fromJSDate(new Date(busyTime.start)).setZone(timezone);
+        const busyTimeEnd = DateTime.fromJSDate(new Date(busyTime.end)).setZone(timezone);
+        const busyTimeStartDate = busyTimeStart.toJSDate();
+        const busyTimeEndDate = busyTimeEnd.toJSDate();
+        return {
+          ...busyTime,
+          start: busyTimeStartDate,
+          end: busyTimeEndDate,
+        };
+      }
+    );
+    return calendarBusyTimesConverted;
   }
 
   async getUniqCalendarCredentials(calendarsToLoad: Calendar[], userId: User["id"]) {

--- a/apps/web/test/lib/getSchedule.test.ts
+++ b/apps/web/test/lib/getSchedule.test.ts
@@ -1281,12 +1281,15 @@ describe("getSchedule", () => {
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
       const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
 
-      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
-        {
-          start: `${plus3DateString}T04:00:00.000Z`,
-          end: `${plus3DateString}T05:59:59.000Z`,
-        },
-      ]);
+      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({
+        success: true,
+        data: [
+          {
+            start: `${plus3DateString}T04:00:00.000Z`,
+            end: `${plus3DateString}T05:59:59.000Z`,
+          },
+        ],
+      });
 
       const scenarioData = {
         eventTypes: [
@@ -1347,12 +1350,15 @@ describe("getSchedule", () => {
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
       const { dateString: plus3DateString } = getDate({ dateIncrement: 3 });
 
-      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([
-        {
-          start: `${plus3DateString}T04:00:00.000Z`,
-          end: `${plus3DateString}T05:59:59.000Z`,
-        },
-      ]);
+      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({
+        success: true,
+        data: [
+          {
+            start: `${plus3DateString}T04:00:00.000Z`,
+            end: `${plus3DateString}T05:59:59.000Z`,
+          },
+        ],
+      });
 
       const scenarioData = {
         eventTypes: [
@@ -1421,7 +1427,7 @@ describe("getSchedule", () => {
       const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
       const { dateString: plus2DateString } = getDate({ dateIncrement: 2 });
 
-      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+      CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
 
       const scenarioData = {
         eventTypes: [

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -268,7 +268,7 @@ export const getBusyCalendarTimes = async (
     }
   } catch (e) {
     log.warn("Error getting busy calendar times", safeStringify(e));
-    return { success: false, data: [{ start: startDate, stop: endDate, source: "error-placeholder" }] };
+    return { success: false, data: [{ start: startDate, end: endDate, source: "error-placeholder" }] };
   }
   return { success: true, data: results.reduce((acc, availability) => acc.concat(availability), []) };
 };

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -250,15 +250,6 @@ export const getBusyCalendarTimes = async (
   // Add 14 hours from the start date to avoid problems in UTC+ time zones.
   const endDate = dayjs(dateTo).add(14, "hours").format();
   try {
-    log.debug(
-      "getBusyCalendarTimes manipulated dates",
-      safeStringify({
-        newStartDate: startDate,
-        newEndDate: endDate,
-        oldStartDate: dateFrom,
-        oldEndDate: dateTo,
-      })
-    );
     if (includeTimeZone) {
       results = await getCalendarsEventsWithTimezones(
         deduplicatedCredentials,

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -276,10 +276,10 @@ export const getBusyCalendarTimes = async (
       );
     }
   } catch (e) {
-    log.warn(safeStringify(e));
-    return [{ start: startDate, stop: endDate, source: "error-placeholder" }];
+    log.warn("Error getting busy calendar times", safeStringify(e));
+    return { success: false, data: [{ start: startDate, stop: endDate, source: "error-placeholder" }] };
   }
-  return results.reduce((acc, availability) => acc.concat(availability), []);
+  return { success: true, data: results.reduce((acc, availability) => acc.concat(availability), []) };
 };
 
 export const createEvent = async (

--- a/packages/lib/CalendarManager.ts
+++ b/packages/lib/CalendarManager.ts
@@ -245,12 +245,11 @@ export const getBusyCalendarTimes = async (
   }
 
   // const months = getMonths(dateFrom, dateTo);
+  // Subtract 11 hours from the start date to avoid problems in UTC- time zones.
+  const startDate = dayjs(dateFrom).subtract(11, "hours").format();
+  // Add 14 hours from the start date to avoid problems in UTC+ time zones.
+  const endDate = dayjs(dateTo).add(14, "hours").format();
   try {
-    // Subtract 11 hours from the start date to avoid problems in UTC- time zones.
-    const startDate = dayjs(dateFrom).subtract(11, "hours").format();
-    // Add 14 hours from the start date to avoid problems in UTC+ time zones.
-    const endDate = dayjs(dateTo).add(14, "hours").format();
-
     log.debug(
       "getBusyCalendarTimes manipulated dates",
       safeStringify({
@@ -278,6 +277,7 @@ export const getBusyCalendarTimes = async (
     }
   } catch (e) {
     log.warn(safeStringify(e));
+    return [{ start: startDate, stop: endDate, source: "error-placeholder" }];
   }
   return results.reduce((acc, availability) => acc.concat(availability), []);
 };

--- a/packages/lib/getBusyTimes.ts
+++ b/packages/lib/getBusyTimes.ts
@@ -179,13 +179,24 @@ const _getBusyTimes = async (params: {
   performance.measure(`prisma booking get took $1'`, "prismaBookingGetStart", "prismaBookingGetEnd");
   if (credentials?.length > 0 && !bypassBusyCalendarTimes) {
     const startConnectedCalendarsGet = performance.now();
-    const calendarBusyTimes = await getBusyCalendarTimes(
+
+    const calendarBusyTimesQuery = await getBusyCalendarTimes(
       credentials,
       startTime,
       endTime,
       selectedCalendars,
       shouldServeCache
     );
+
+    if (!calendarBusyTimesQuery.success) {
+      throw new Error(
+        `Failed to fetch busy calendar times for selected calendars ${selectedCalendars.map(
+          (calendar) => calendar.id
+        )}`
+      );
+    }
+
+    const calendarBusyTimes = calendarBusyTimesQuery.data;
     const endConnectedCalendarsGet = performance.now();
     logger.debug(
       `Connected Calendars get took ${

--- a/packages/lib/getUserAvailability.ts
+++ b/packages/lib/getUserAvailability.ts
@@ -411,24 +411,39 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
     ? EventTypeRepository.getSelectedCalendarsFromUser({ user, eventTypeId: eventType.id })
     : user.userLevelSelectedCalendars;
 
-  const busyTimes = await getBusyTimes({
-    credentials: user.credentials,
-    startTime: getBusyTimesStart,
-    endTime: getBusyTimesEnd,
-    eventTypeId,
-    userId: user.id,
-    userEmail: user.email,
-    username: `${user.username}`,
-    beforeEventBuffer,
-    afterEventBuffer,
-    selectedCalendars,
-    seatedEvent: !!eventType?.seatsPerTimeSlot,
-    rescheduleUid: initialData?.rescheduleUid || null,
-    duration,
-    currentBookings: initialData?.currentBookings,
-    bypassBusyCalendarTimes,
-    shouldServeCache,
-  });
+  let busyTimes = [];
+  try {
+    busyTimes = await getBusyTimes({
+      credentials: user.credentials,
+      startTime: getBusyTimesStart,
+      endTime: getBusyTimesEnd,
+      eventTypeId,
+      userId: user.id,
+      userEmail: user.email,
+      username: `${user.username}`,
+      beforeEventBuffer,
+      afterEventBuffer,
+      selectedCalendars,
+      seatedEvent: !!eventType?.seatsPerTimeSlot,
+      rescheduleUid: initialData?.rescheduleUid || null,
+      duration,
+      currentBookings: initialData?.currentBookings,
+      bypassBusyCalendarTimes,
+      shouldServeCache,
+    });
+  } catch (error) {
+    log.error(`Error fetching busy times for user ${username}:`, error);
+    return {
+      busy: [],
+      timeZone,
+      dateRanges: [],
+      oooExcludedDateRanges: [],
+      workingHours: [],
+      dateOverrides: [],
+      currentSeats: [],
+      datesOutOfOffice: [],
+    };
+  }
 
   const detailedBusyTimes: EventBusyDetails[] = [
     ...busyTimes.map((a) => ({

--- a/packages/lib/getUserAvailability.ts
+++ b/packages/lib/getUserAvailability.ts
@@ -441,7 +441,7 @@ const _getUserAvailability = async function getUsersWorkingHoursLifeTheUniverseA
       workingHours: [],
       dateOverrides: [],
       currentSeats: [],
-      datesOutOfOffice: [],
+      datesOutOfOffice: undefined,
     };
   }
 

--- a/packages/lib/server/getLuckyUser.test.ts
+++ b/packages/lib/server/getLuckyUser.test.ts
@@ -55,7 +55,7 @@ it("can find lucky user with maximize availability", async () => {
     }),
   ];
 
-  CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+  CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
   prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
 
   // TODO: we may be able to use native prisma generics somehow?
@@ -107,7 +107,7 @@ it("can find lucky user with maximize availability and priority ranking", async 
     }),
   ];
 
-  CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+  CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
   prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
 
   // TODO: we may be able to use native prisma generics somehow?
@@ -289,7 +289,7 @@ describe("maximize availability and weights", () => {
       }),
     ];
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
     prismaMock.user.findMany.mockResolvedValue(users);
     prismaMock.host.findMany.mockResolvedValue([]);
@@ -392,7 +392,7 @@ describe("maximize availability and weights", () => {
       }),
     ];
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
     prismaMock.user.findMany.mockResolvedValue(users);
     prismaMock.host.findMany.mockResolvedValue([]);
@@ -500,7 +500,7 @@ describe("maximize availability and weights", () => {
       }),
     ];
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
     prismaMock.user.findMany.mockResolvedValue(users);
     prismaMock.host.findMany.mockResolvedValue([]);
@@ -600,7 +600,7 @@ describe("maximize availability and weights", () => {
       },
     ];
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
 
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([
       {
@@ -820,7 +820,7 @@ describe("maximize availability and weights", () => {
       },
     ];
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
 
     // TODO: we may be able to use native prisma generics somehow?
@@ -1282,7 +1282,7 @@ describe("attribute weights and virtual queues", () => {
       chosenRouteId: routeId,
     };
 
-    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue([]);
+    CalendarManagerMock.getBusyCalendarTimes.mockResolvedValue({ success: true, data: [] });
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);
 
     prismaMock.user.findMany.mockResolvedValue(users);

--- a/packages/lib/server/getLuckyUser.test.ts
+++ b/packages/lib/server/getLuckyUser.test.ts
@@ -707,13 +707,16 @@ describe("maximize availability and weights", () => {
     ];
 
     CalendarManagerMock.getBusyCalendarTimes
-      .mockResolvedValueOnce([
-        {
-          start: dayjs().utc().startOf("month").toDate(),
-          end: dayjs().utc().startOf("month").add(3, "day").toDate(),
-          timeZone: "UTC",
-        },
-      ])
+      .mockResolvedValueOnce({
+        success: true,
+        data: [
+          {
+            start: dayjs().utc().startOf("month").toDate(),
+            end: dayjs().utc().startOf("month").add(3, "day").toDate(),
+            timeZone: "UTC",
+          },
+        ],
+      })
       .mockResolvedValue([]);
 
     prismaMock.outOfOfficeEntry.findMany.mockResolvedValue([]);

--- a/packages/lib/server/getLuckyUser.ts
+++ b/packages/lib/server/getLuckyUser.ts
@@ -456,7 +456,7 @@ async function getCalendarBusyTimesOfInterval(
   rrTimestampBasis: RRTimestampBasis,
   meetingStartTime?: Date
 ): Promise<{ userId: number; busyTimes: (EventBusyDate & { timeZone?: string })[] }[]> {
-  return Promise.all(
+  const usersBusyTimesQuery = await Promise.all(
     usersWithCredentials.map((user) =>
       getBusyCalendarTimes(
         user.credentials,
@@ -465,12 +465,19 @@ async function getCalendarBusyTimesOfInterval(
         user.userLevelSelectedCalendars,
         true,
         true
-      ).then((busyTimes) => ({
-        userId: user.id,
-        busyTimes,
-      }))
+      )
     )
   );
+
+  return usersBusyTimesQuery.reduce((usersBusyTime, userBusyTimeQuery, index) => {
+    if (userBusyTimeQuery.success) {
+      usersBusyTime.push({
+        userId: usersWithCredentials[index].id,
+        busyTimes: userBusyTimeQuery.data,
+      });
+    }
+    return usersBusyTime;
+  }, [] as { userId: number; busyTimes: Awaited<ReturnType<typeof getBusyCalendarTimes>>["data"] }[]);
 }
 
 async function getBookingsOfInterval({

--- a/packages/trpc/server/routers/viewer/availability/calendarOverlay.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/calendarOverlay.handler.ts
@@ -98,6 +98,8 @@ export const calendarOverlayHandler = async ({ ctx, input }: ListOptions) => {
     });
   }
 
+  const calendarBusyTimes = calendarBusyTimesQuery.data;
+
   // Convert to users timezone
 
   const userTimeZone = input.loggedInUsersTz;

--- a/packages/trpc/server/routers/viewer/availability/calendarOverlay.handler.ts
+++ b/packages/trpc/server/routers/viewer/availability/calendarOverlay.handler.ts
@@ -84,12 +84,19 @@ export const calendarOverlayHandler = async ({ ctx, input }: ListOptions) => {
   });
 
   // get all clanedar services
-  const calendarBusyTimes = await getBusyCalendarTimes(
+  const calendarBusyTimesQuery = await getBusyCalendarTimes(
     credentials,
     dateFrom,
     dateTo,
     composedSelectedCalendars
   );
+
+  if (!calendarBusyTimesQuery.success) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to fetch busy calendar times",
+    });
+  }
 
   // Convert to users timezone
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- If there is an error reading a calendar, instead of returning an empty array for busy times, we return an empty array for available days

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Connect a calendar
- Have the calendar error out
- The slots showing should be 0 instead of all slots

