### PR TITLE
fix: add new end of month UI to mobile

### DIFF
--- a/packages/features/bookings/Booker/components/DatePicker.tsx
+++ b/packages/features/bookings/Booker/components/DatePicker.tsx
@@ -102,7 +102,7 @@ export const DatePicker = ({
   moveToNextMonthOnNoAvailability();
 
   // Determine if this is a compact sidebar view based on layout
-  const isCompact = layout !== "month_view";
+  const isCompact = layout !== "month_view" && layout !== "mobile";
 
   const periodData: PeriodData = {
     ...{

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -207,7 +207,7 @@ export const BookerPlatformWrapper = (
       dayjs(date).month() !== dayjs(date).add(bookerLayout.extraDays, "day").month()) ||
     (bookerLayout.layout === BookerLayouts.COLUMN_VIEW &&
       dayjs(date).month() !== dayjs(date).add(bookerLayout.columnViewExtraDays.current, "day").month()) ||
-    (bookerLayout.layout === BookerLayouts.MONTH_VIEW &&
+    ((bookerLayout.layout === BookerLayouts.MONTH_VIEW || bookerLayout.layout === "mobile") &&
       (!dayjs(date).isValid() || dayjs().isSame(dayjs(month), "month")) &&
       dayjs().isAfter(dayjs(month).startOf("month").add(2, "week")));
 

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -128,7 +128,7 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
       dayjs(date).month() !== dayjs(date).add(bookerLayout.extraDays, "day").month()) ||
     (bookerLayout.layout === BookerLayouts.COLUMN_VIEW &&
       dayjs(date).month() !== dayjs(date).add(bookerLayout.columnViewExtraDays.current, "day").month()) ||
-    (bookerLayout.layout === BookerLayouts.MONTH_VIEW &&
+    ((bookerLayout.layout === BookerLayouts.MONTH_VIEW || bookerLayout.layout === "mobile") &&
       (!dayjs(date).isValid() || dayjs().isSame(dayjs(month), "month")) &&
       dayjs().isAfter(dayjs(month).startOf("month").add(2, "week")));
 


### PR DESCRIPTION
## What does this PR do?

<img width="314" height="454" alt="Screenshot 2025-07-31 at 9 29 41 AM" src="https://github.com/user-attachments/assets/dd19d043-70d4-4785-8d6a-4aabccffc81d" />

<img width="206" height="290" alt="Screenshot 2025-07-31 at 9 32 35 AM" src="https://github.com/user-attachments/assets/2230449c-516a-46b7-80a3-b78c1fa6f311" />
