### PR TITLE
fix: Add platform-libraries build step to CI workflows

### DIFF
--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Run Tests
         working-directory: apps/api/v2
         run: |
+          yarn workspace @calcom/platform-libraries build
           yarn test:e2e
           EXIT_CODE=$?
           echo "yarn test:e2e command exit code: $EXIT_CODE"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,4 +21,6 @@ jobs:
         working-directory: apps/api/v2
         run: |
           export NODE_OPTIONS="--max_old_space_size=8192"
+          # We need to build the platform libraries before running the tests as there are some calls to platform libraries fns
+          yarn workspace @calcom/platform-libraries build 
           yarn test


### PR DESCRIPTION
# fix: Add platform-libraries build step to CI workflows

## Summary

This PR adds the necessary `yarn workspace @calcom/platform-libraries build` step to both the unit tests and E2E API v2 CI workflows to resolve module resolution failures.

**Root Cause:** API v2 tests import `TeamService` from `@calcom/platform-libraries`, but this package exports compiled JavaScript files from its `dist/` folder rather than TypeScript source. The CI workflows were missing the build step to generate these compiled files, causing tests to fail with "Cannot find module" errors.

**Solution:** Added the platform-libraries build step before running tests in both workflows:
- `unit-tests.yml`: Build step added before `yarn test` 
- `e2e-api-v2.yml`: Build step added before `yarn test:e2e`

## Review & Testing Checklist for Human

- [ ] **Verify CI failures are resolved**: Check that both unit tests and E2E API v2 tests now pass in CI
- [ ] **Monitor build time impact**: Ensure the additional build step doesn't significantly slow down CI execution
- [ ] **Test with fresh CI environment**: Verify the fix works in a clean CI environment without cached dependencies
- [ ] **Check for other platform dependencies**: Confirm no other platform packages (platform-constants, platform-types, etc.) also need building

**Recommended Test Plan:**
1. Trigger CI on this PR and verify all checks pass
2. Monitor CI execution times compared to previous runs
3. Test with a fresh branch to ensure the fix works without local cache

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "CI Workflows"
        UnitTests[".github/workflows/<br/>unit-tests.yml"]:::major-edit
        E2ETests[".github/workflows/<br/>e2e-api-v2.yml"]:::major-edit
    end
    
    subgraph "Platform Packages"
        PlatformLibs["packages/platform/<br/>libraries/"]:::context
        PlatformLibsDist["packages/platform/<br/>libraries/dist/"]:::context
    end
    
    subgraph "API v2 Tests"
        APITests["apps/api/v2/<br/>test files"]:::context
        TeamService["TeamService imports"]:::context
    end
    
    UnitTests -->|"yarn workspace @calcom/<br/>platform-libraries build"| PlatformLibsDist
    E2ETests -->|"yarn workspace @calcom/<br/>platform-libraries build"| PlatformLibsDist
    PlatformLibs -->|"build generates"| PlatformLibsDist
    APITests -->|"imports from"| TeamService
    TeamService -->|"requires"| PlatformLibsDist
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This fix addresses the CI test failures identified in PR #22806 where unit tests were passing locally but failing in CI
- The platform-libraries package uses a compiled distribution model, requiring the build step to generate importable JavaScript modules
- Changes are minimal and focused - only adding necessary build commands to existing workflows
- Requested by hariom@cal.com in Devin session: https://app.devin.ai/sessions/68f60dff1bca4e7eb4a98cb20382e7e0