### PR TITLE
fix: On serverless initialisation redisModule doesn't exist yet

### DIFF
--- a/packages/lib/di/containers/get-user-availability.ts
+++ b/packages/lib/di/containers/get-user-availability.ts
@@ -14,12 +14,11 @@ import { UserAvailabilityService } from "../../getUserAvailability";
 
 const container = createContainer();
 container.load(DI_TOKENS.PRISMA_MODULE, prismaModule);
+container.load(DI_TOKENS.REDIS_CLIENT, redisModule);
 container.load(DI_TOKENS.OOO_REPOSITORY_MODULE, oooRepositoryModule);
 container.load(DI_TOKENS.BOOKING_REPOSITORY_MODULE, bookingRepositoryModule);
 container.load(DI_TOKENS.EVENT_TYPE_REPOSITORY_MODULE, eventTypeRepositoryModule);
 container.load(DI_TOKENS.GET_USER_AVAILABILITY_SERVICE_MODULE, getUserAvailabilityModule);
-container.load(DI_TOKENS.REDIS_CLIENT, redisModule);
-
 
 export function getUserAvailabilityService() {
   return container.get<UserAvailabilityService>(DI_TOKENS.GET_USER_AVAILABILITY_SERVICE);


### PR DESCRIPTION
## What does this PR do?

Fixes DI order