### PR TITLE
fix: OG image error from missing height field

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -151,6 +151,7 @@ export const Meeting = ({ title, users = [], profile }: MeetingImageProps) => {
                 src={avatar}
                 alt="Profile picture"
                 width="160"
+                height="160"
               />
             ))}
             {avatars.length > 3 && (
@@ -217,7 +218,7 @@ export const App = ({ name, description, slug }: AppImageProps) => (
 
     <div tw="flex items-center w-full">
       <div tw="flex">
-        <img src={`${WEBAPP_URL}${slug}`} alt="App icon" width="172" />
+        <img src={`${WEBAPP_URL}${slug}`} alt="App icon" width="172" height="172" />
       </div>
     </div>
     <div style={{ color: "#111827" }} tw="flex mt-auto w-full flex-col">


### PR DESCRIPTION
## What does this PR do?

- This will make our logs cleaner by addressing `Error: Image size cannot be determined. Please provide the width and height of the image.` coming from user avatar `img` in Meeting OG image and from app icon `img` in App OG image
- Left a self-review

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

