### PR TITLE
fix: OG image error from custom fonts not being supported

### DIFF
--- a/apps/web/app/api/social/og/image/route.tsx
+++ b/apps/web/app/api/social/og/image/route.tsx
@@ -35,20 +35,31 @@ async function handler(req: NextRequest) {
   const imageType = searchParams.get("type");
 
   try {
-    const [calFontData, interFontData, interFontMediumData] = await Promise.all([
+    const fontResults = await Promise.allSettled([
       fetch(new URL("/fonts/cal.ttf", WEBAPP_URL)).then((res) => res.arrayBuffer()),
       fetch(new URL("/fonts/Inter-Regular.ttf", WEBAPP_URL)).then((res) => res.arrayBuffer()),
       fetch(new URL("/fonts/Inter-Medium.ttf", WEBAPP_URL)).then((res) => res.arrayBuffer()),
     ]);
+
+    const fonts: SatoriOptions["fonts"] = [];
+
+    if (fontResults[1].status === "fulfilled") {
+      fonts.push({ name: "inter", data: fontResults[1].value, weight: 400 });
+    }
+
+    if (fontResults[2].status === "fulfilled") {
+      fonts.push({ name: "inter", data: fontResults[2].value, weight: 500 });
+    }
+
+    if (fontResults[0].status === "fulfilled") {
+      fonts.push({ name: "cal", data: fontResults[0].value, weight: 400 });
+      fonts.push({ name: "cal", data: fontResults[0].value, weight: 600 });
+    }
+
     const ogConfig = {
       width: 1200,
       height: 630,
-      fonts: [
-        { name: "inter", data: interFontData, weight: 400 },
-        { name: "inter", data: interFontMediumData, weight: 500 },
-        { name: "cal", data: calFontData, weight: 400 },
-        { name: "cal", data: calFontData, weight: 600 },
-      ] as SatoriOptions["fonts"],
+      fonts,
     };
 
     switch (imageType) {


### PR DESCRIPTION
## What does this PR do?
 
### Problem
- The Open Graph image generation was throwing `Error: Font processing error: lookupType: 5 - substFormat: 3 is not yet supported` when Satori (engined used by `@vercel/og` for image processing) tried to process advanced OpenType features in custom fonts
- This happens for bookings in Arabic

### Solution
- Replaced Promise.all with Promise.allSettled to gracefully handle font loading failures while maintaining parallel loading performance


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.