### PR TITLE
fix: filter deleted booking references in EventManager methods

### DIFF
--- a/packages/lib/EventManager.ts
+++ b/packages/lib/EventManager.ts
@@ -401,10 +401,14 @@ export default class EventManager {
       results.push(result);
     }
 
+    const activeReferences = booking.references.filter((reference) => !reference.deleted);
+    
     // Update the calendar event with the proper video call data
-    const calendarReference = booking.references.find((reference) => reference.type.includes("_calendar"));
+    const calendarReference = activeReferences.find((reference) => reference.type.includes("_calendar"));
     if (calendarReference) {
-      results.push(...(await this.updateAllCalendarEvents(evt, booking)));
+      // Create a booking object with filtered references for updateAllCalendarEvents
+      const bookingWithActiveReferences = { ...booking, references: activeReferences };
+      results.push(...(await this.updateAllCalendarEvents(evt, bookingWithActiveReferences)));
     }
 
     const referencesToCreate = results.map((result) => {
@@ -706,7 +710,9 @@ export default class EventManager {
       crmReferences = [],
       allPromises = [];
 
-    for (const reference of bookingReferences) {
+    const activeReferences = bookingReferences.filter((reference) => !reference.deleted);
+
+    for (const reference of activeReferences) {
       if (reference.type.includes("_calendar") && !reference.type.includes("other_calendar")) {
         calendarReferences.push(reference);
         allPromises.push(

--- a/packages/types/EventManager.d.ts
+++ b/packages/types/EventManager.d.ts
@@ -11,6 +11,7 @@ export interface PartialReference {
   externalCalendarId?: string | null;
   credentialId?: number | null;
   delegationCredentialId?: string | null;
+  deleted?: boolean | null;
 }
 
 export interface EventResult<T> {


### PR DESCRIPTION
# Fix: Filter deleted booking references in EventManager methods

## Summary

Fixes an issue where old booking owners still see calendar events on their calendar when a reassigned booking's location is changed. The problem occurred because the EventManager's `updateLocation` and `deleteEventsAndMeetings` methods were processing all booking references without filtering out soft-deleted ones.

**Root Cause:** When a booking is reassigned, the old booking references are soft-deleted (marked with `deleted: true`) but the EventManager methods weren't filtering these out before attempting calendar operations.

**Solution:** Added filtering logic to exclude deleted booking references before processing calendar updates, following the same pattern already established in the `reschedule` method.

## Review & Testing Checklist for Human

- [ ] **End-to-end test the booking reassignment + location change flow**: Create a round-robin booking, reassign it to a different user, change the location, and verify the old owner's calendar event is removed
- [ ] **Verify type safety**: Confirm that adding the `deleted` field to `PartialReference` doesn't break other parts of the codebase that use this type
- [ ] **Test with real calendar integrations**: Ensure the filtering works correctly with Google Calendar, Outlook, and other calendar providers
- [ ] **Check pattern consistency**: Verify that the filtering logic matches the existing pattern in the `reschedule` method and is applied correctly in both modified methods

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    BookingReassignment["Booking Reassignment Flow"]
    EventManager["packages/lib/EventManager.ts"]:::major-edit
    TypeDef["packages/types/EventManager.d.ts"]:::major-edit
    RescheduleMethod["reschedule() method"]:::context
    UpdateLocationMethod["updateLocation() method"]:::major-edit
    DeleteEventsMethod["deleteEventsAndMeetings() method"]:::major-edit
    BookingReferences["Booking References"]:::context
    CalendarIntegrations["Calendar Integrations"]:::context
    
    BookingReassignment --> EventManager
    EventManager --> UpdateLocationMethod
    EventManager --> DeleteEventsMethod
    EventManager --> RescheduleMethod
    RescheduleMethod -.->|"pattern followed"| UpdateLocationMethod
    RescheduleMethod -.->|"pattern followed"| DeleteEventsMethod
    UpdateLocationMethod --> BookingReferences
    DeleteEventsMethod --> BookingReferences
    BookingReferences --> CalendarIntegrations
    TypeDef -.->|"type definition"| EventManager
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Key Changes:**
1. **EventManager.ts**: Added `activeReferences` filtering in `updateLocation()` and `deleteEventsAndMeetings()` methods to exclude references where `deleted: true`
2. **EventManager.d.ts**: Added `deleted?: boolean | null` to `PartialReference` interface to support the filtering logic

**Testing Limitations:** Due to environment setup issues (ESLint configuration problems), I wasn't able to fully test the end-to-end flow locally. The type checking passed successfully, but comprehensive testing of the booking reassignment + location change scenario is needed.

**Link to Devin run:** https://app.devin.ai/sessions/b8cc831382df4e8f89ff1c8887bb4da2  
**Requested by:** @joeauyeung