### PR TITLE
fix: update PlainContactForm positioning to be fixed at bottom right

### DIFF
--- a/apps/web/lib/plain/PlainContactForm.tsx
+++ b/apps/web/lib/plain/PlainContactForm.tsx
@@ -144,7 +144,7 @@ const PlainContactForm = () => {
   };
 
   return (
-    <div className="absolute bottom-4 right-4 z-50">
+    <div className="fixed bottom-4 right-4 z-[120]">
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild className="enabled:hover:bg-subtle bg-subtle shadow-none">
           <Button


### PR DESCRIPTION
## What does this PR do?

This PR will make sure that `PlainContactForm.tsx` will be fixed at bottom right instead of Top Right.

- Fixes #22929 
- Fixes CAL-6207

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

Before :
<img width="243" height="913" alt="image" src="https://github.com/user-attachments/assets/8efaa0df-b6bc-48bc-a597-39881d42553a" />

After :
<img width="334" height="904" alt="image" src="https://github.com/user-attachments/assets/6c50e4f6-bb2a-4104-a253-f0372c03e00d" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables or special test data are required.
- Run the app locally and navigate to a page where the PlainContactForm appears.
- Confirm that the form is now fixed at the bottom right of the screen (not the top right).
- Check both desktop and mobile breakpoints if the component is responsive.