### PR TITLE
fix: resolve paid booking reschedule logic

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getRequiresConfirmationFlags.ts
@@ -17,6 +17,7 @@ export async function getRequiresConfirmationFlags({
   paymentAppData,
   originalRescheduledBookingOrganizerId,
   bookerEmail,
+  isReschedulingPaidBooking = false,
 }: {
   eventType: EventType;
   bookingStartTime: string;
@@ -24,13 +25,15 @@ export async function getRequiresConfirmationFlags({
   paymentAppData: PaymentAppData;
   originalRescheduledBookingOrganizerId: number | undefined;
   bookerEmail: string;
+  isReschedulingPaidBooking?: boolean;
 }) {
   const requiresConfirmation = await determineRequiresConfirmation(eventType, bookingStartTime, bookerEmail);
   const userReschedulingIsOwner = isUserReschedulingOwner(userId, originalRescheduledBookingOrganizerId);
   const isConfirmedByDefault = determineIsConfirmedByDefault(
     requiresConfirmation,
     paymentAppData.price,
-    userReschedulingIsOwner
+    userReschedulingIsOwner,
+    isReschedulingPaidBooking
   );
 
   return {
@@ -87,7 +90,8 @@ function isUserReschedulingOwner(
 function determineIsConfirmedByDefault(
   requiresConfirmation: boolean,
   price: number,
-  userReschedulingIsOwner: boolean
+  userReschedulingIsOwner: boolean,
+  isReschedulingPaidBooking = false
 ): boolean {
-  return (!requiresConfirmation && price === 0) || userReschedulingIsOwner;
+  return (!requiresConfirmation && price === 0) || userReschedulingIsOwner || isReschedulingPaidBooking;
 }


### PR DESCRIPTION
## What does this PR do?
- Resolves critical issues in the paid booking resechedule logic by changing Block-scoped of the isReschudlingPaidBooking 
- changed the booking detection from AND to OR
- updated the booking status logic to properly handle paid booking reschedules

- Fixes #22857  (GitHub issue number)
- Fixes CAL-6191 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Test cases have been updated to check the changes and they are passing in reschudle.test.ts

