### PR TITLE
chore: Add relation between a host and a membership for future cascades

### DIFF
--- a/packages/prisma/migrations/20250730091450_add_host_many_to_member_one_relation/migration.sql
+++ b/packages/prisma/migrations/20250730091450_add_host_many_to_member_one_relation/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Host" ADD COLUMN     "memberId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Host" ADD CONSTRAINT "Host_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/migrations/20250730091450_add_host_many_to_member_one_relation/migration.sql
+++ b/packages/prisma/migrations/20250730091450_add_host_many_to_member_one_relation/migration.sql
@@ -2,4 +2,10 @@
 ALTER TABLE "Host" ADD COLUMN     "memberId" INTEGER;
 
 -- AddForeignKey
-ALTER TABLE "Host" ADD CONSTRAINT "Host_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Host" ADD CONSTRAINT "Host_memberId_fkey"
+  FOREIGN KEY ("memberId")
+  REFERENCES "Membership"("id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
+CREATE INDEX "Host_memberId_idx" ON "Host"("memberId");


### PR DESCRIPTION
## What does this PR do?

Adds a simple new relation that when set cascades a membership deletion to the host record.