### PR TITLE
fix: prevent booking references with empty UIDs when calendar event creation fails

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -669,16 +669,7 @@ describe("handleNewBooking", () => {
             uid: createdBooking.uid!,
             eventTypeId: mockBookingData.eventTypeId,
             status: BookingStatus.ACCEPTED,
-            references: [
-              {
-                type: appStoreMetadata.googlecalendar.type,
-                // A reference is still created in case of event creation failure, with nullish values. Not sure what's the purpose for this.
-                uid: "",
-                meetingId: null,
-                meetingPassword: null,
-                meetingUrl: null,
-              },
-            ],
+            references: [],
           });
 
           expectWorkflowToBeTriggered({ emailsToReceive: [organizer.email], emails });

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -649,7 +649,6 @@ describe("handleNewBooking", () => {
                 },
                 {
                   type: appStoreMetadata.googlecalendar.type,
-                  // A reference is still created in case of event creation failure, with nullish values. Not sure what's the purpose for this.
                   uid: "ORIGINAL_BOOKING_UID",
                   meetingId: "ORIGINAL_MEETING_ID",
                   meetingPassword: "ORIGINAL_MEETING_PASSWORD",


### PR DESCRIPTION
# fix: prevent booking references with empty UIDs when calendar event creation fails

## Summary

This PR fixes an issue where booking references were being created with empty UIDs when Google Calendar event creation failed. The system was previously writing booking references to the database even when calendar events failed to be created, violating the BookingReference schema constraint that requires non-empty UIDs.

**Root Cause**: In `EventManager.ts`, the `referencesToCreate` array was being populated from all calendar/video creation results, including failed ones where `result.createdEvent?.id` was null/undefined, leading to empty UID strings.

**Solution**: Added filtering logic in both `EventManager.create()` and `EventManager.updateLocation()` methods to exclude failed calendar events before creating booking references. Only events with `result.success === true` AND a valid UID are now included.

**Changes Made**:
- Modified `EventManager.create()` to filter results before mapping to `referencesToCreate`
- Modified `EventManager.updateLocation()` with the same filtering logic
- Added warning logs when skipping reference creation due to failed events
- Preserved existing error logging in `CalendarManager.ts` for debugging calendar failures

## Review & Testing Checklist for Human

- [ ] **Verify filtering logic correctly identifies failed vs successful events** - Check that the `result.success && (valid UID)` condition properly distinguishes between successful and failed calendar/video events
- [ ] **Test booking references are still created for successful events** - Create a booking with working calendar integration and verify booking references are properly created in the database
- [ ] **Test no booking references are created for failed calendar events** - Simulate calendar failure (e.g., invalid credentials) and verify no booking references with empty UIDs are created
- [ ] **Verify warning logs appear when filtering events** - Check that "Skipping booking reference creation for failed [type] event" messages appear in logs when calendar events fail
- [ ] **End-to-end test with real calendar failures** - Test the complete booking flow with actual Google Calendar integration failures to ensure the fix works in production scenarios

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    handleNewBooking["packages/features/bookings/lib/<br/>handleNewBooking.ts"]:::context
    EventManager["packages/lib/<br/>EventManager.ts"]:::major-edit
    CalendarManager["packages/lib/<br/>CalendarManager.ts"]:::context
    BookingRefSchema["packages/prisma/<br/>schema.prisma<br/>(BookingReference model)"]:::context
    
    handleNewBooking -->|"creates booking references<br/>from referencesToCreate"| EventManager
    EventManager -->|"calls createEvent()<br/>for calendar/video"| CalendarManager
    CalendarManager -->|"returns success/failure<br/>results"| EventManager
    EventManager -->|"filters failed events<br/>BEFORE creating references"| BookingRefSchema
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

**Log Messages for Debugging**:
- Look for `createEvent failed` messages in CalendarManager.ts for calendar creation failures
- Look for `Skipping booking reference creation for failed [type] event` warnings when references are filtered out  
- Look for `BookingCreatingMeetingFailed` error code in handleNewBooking.ts when all calendar events fail

**Schema Constraint**: The BookingReference model requires non-empty uid field (`@zod.min(1)`), so filtering out empty UIDs prevents database constraint violations.

**Link to Devin run**: https://app.devin.ai/sessions/102305fdf3db4f80b2e92e5e047bf037  
**Requested by**: @joeauyeung