### PR TITLE
feat: add impersonation to cmd+k menu for admins

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1242,6 +1242,7 @@
   "impersonate_user_tip": "All uses of this feature is audited.",
   "impersonating_user_warning": "Impersonating username \"{{user}}\".",
   "impersonating_stop_instructions": "Click here to stop",
+  "recent_impersonations": "Recent Impersonations",
   "event_location_changed": "Updated - Your event changed the location",
   "new_guests_added": "Added - New guests added to your event",
   "location_changed_event_type_subject": "Location Changed: {{eventType}} with {{name}} at {{date}}",

--- a/packages/features/kbar/ImpersonationSection.tsx
+++ b/packages/features/kbar/ImpersonationSection.tsx
@@ -1,0 +1,98 @@
+import { signIn } from "next-auth/react";
+import { useEffect, useState } from "react";
+
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { localStorage } from "@calcom/lib/webstorage";
+import { Button } from "@calcom/ui/components/button";
+import { TextField } from "@calcom/ui/components/form";
+
+const MAX_RECENT_IMPERSONATIONS = 5;
+
+interface RecentImpersonation {
+  username: string;
+  timestamp: number;
+}
+
+export const ImpersonationSection = () => {
+  const { t } = useLocale();
+  const [username, setUsername] = useState("");
+  const [recentImpersonations, setRecentImpersonations] = useState<RecentImpersonation[]>([]);
+
+  useEffect(() => {
+    const storedImpersonations = localStorage.getItem("recentImpersonations");
+    if (storedImpersonations) {
+      try {
+        setRecentImpersonations(JSON.parse(storedImpersonations));
+      } catch (e) {
+        console.error("Failed to parse recent impersonations", e);
+        localStorage.removeItem("recentImpersonations");
+      }
+    }
+  }, []);
+
+  const handleImpersonation = (impersonateUsername: string) => {
+    if (!impersonateUsername) return;
+
+    const newImpersonation: RecentImpersonation = {
+      username: impersonateUsername,
+      timestamp: Date.now(),
+    };
+
+    const updatedImpersonations = [
+      newImpersonation,
+      ...recentImpersonations.filter((item) => item.username !== impersonateUsername),
+    ].slice(0, MAX_RECENT_IMPERSONATIONS);
+
+    setRecentImpersonations(updatedImpersonations);
+    localStorage.setItem("recentImpersonations", JSON.stringify(updatedImpersonations));
+
+    signIn("impersonation-auth", {
+      username: impersonateUsername,
+      callbackUrl: `${WEBAPP_URL}/event-types`,
+    });
+  };
+
+  return (
+    <div className="flex flex-col space-y-4 p-4">
+      <div className="text-emphasis text-sm font-medium">{t("user_impersonation_heading")}</div>
+      <div className="text-subtle text-xs">{t("impersonate_user_tip")}</div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleImpersonation(username);
+        }}
+        className="flex items-center space-x-2">
+        <TextField
+          containerClassName="w-full"
+          placeholder={t("user")}
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+          type="text"
+        />
+        <Button type="submit" className="h-9">
+          {t("impersonate")}
+        </Button>
+      </form>
+
+      {recentImpersonations.length > 0 && (
+        <div className="mt-4">
+          <div className="text-emphasis mb-2 text-sm font-medium">{t("recent_impersonations")}</div>
+          <div className="flex flex-col space-y-2">
+            {recentImpersonations.map((item) => (
+              <button
+                key={item.username}
+                className="text-emphasis hover:bg-subtle flex items-center justify-between rounded-md px-2 py-1 text-sm"
+                onClick={() => handleImpersonation(item.username)}>
+                <span>{item.username}</span>
+                <span className="text-subtle text-xs">{new Date(item.timestamp).toLocaleDateString()}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
# feat: add impersonation to cmd+k menu for admins

## Summary

This PR adds an impersonation feature to the cmd+k menu that is only visible to app-level ADMINs. When an admin opens the cmd+k menu and selects the "Impersonate" option (shortcut: `i` + `u`), they see:

- A text input field to enter a username/email for impersonation
- A list of recent impersonations stored in localStorage (max 5 entries)
- Integration with the existing impersonation authentication flow

**Key Changes:**
- **New component**: `ImpersonationSection.tsx` - Handles the impersonation UI and localStorage management
- **Modified**: `Kbar.tsx` - Added admin-only impersonation action and conditional rendering logic
- **Added translation**: `recent_impersonations` string in common.json

## Review & Testing Checklist for Human

- [ ] **Verify admin-only access**: Confirm that only users with `role: "ADMIN"` can see the impersonation option in cmd+k menu
- [ ] **Test impersonation flow end-to-end**: Enter a valid username and verify the impersonation authentication works correctly
- [ ] **Check localStorage behavior**: Test recent impersonations storage/retrieval, including edge cases like corrupted data or incognito mode
- [ ] **Validate UI/UX integration**: Ensure the new section fits well within the cmd+k menu design and doesn't break existing keyboard navigation
- [ ] **Test error handling**: Try invalid usernames and verify appropriate error handling

**Recommended Test Plan:**
1. Log in as an admin user and open cmd+k menu
2. Search for "impersonate" or use shortcut `i` + `u`
3. Enter a valid test username and submit
4. Verify impersonation succeeds and redirects to event-types page
5. Repeat impersonation with different users to test recent list functionality

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    KbarTsx["packages/features/kbar/Kbar.tsx"]:::major-edit
    ImpersonationSection["packages/features/kbar/ImpersonationSection.tsx"]:::major-edit
    CommonJson["apps/web/public/static/locales/en/common.json"]:::minor-edit
    ImpersonationProvider["packages/features/ee/impersonation/lib/ImpersonationProvider.ts"]:::context
    WebStorage["@calcom/lib/webstorage"]:::context
    NextAuth["next-auth signIn"]:::context

    KbarTsx --> ImpersonationSection
    ImpersonationSection --> WebStorage
    ImpersonationSection --> NextAuth
    ImpersonationSection --> CommonJson
    NextAuth --> ImpersonationProvider

    KbarTsx -.-> |"Admin check: session?.user.role === 'ADMIN'"| ImpersonationSection
    ImpersonationSection -.-> |"signIn('impersonation-auth')"| NextAuth

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- Used the safe localStorage wrapper from `@calcom/lib/webstorage` to handle cross-domain and incognito mode issues
- The impersonation action is added to the "admin" section of the cmd+k menu with shortcut `i` + `u`
- Recent impersonations are limited to 5 entries and stored with timestamps
- The UI conditionally renders between the normal cmd+k results and the impersonation section

**Link to Devin run**: https://app.devin.ai/sessions/6e11cf8236f340c59ad68439a07620dc  
**Requested by**: @sean-brydon