### PR TITLE
feat: Adding workflow permission checks inside of eventTypes

### DIFF
--- a/packages/features/pbac/client/components/WorkflowTabPermissionGuard.tsx
+++ b/packages/features/pbac/client/components/WorkflowTabPermissionGuard.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { useWorkflowPermission } from "../hooks/useEventPermission";
+
+interface WorkflowTabPermissionGuardProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export const WorkflowTabPermissionGuard = ({
+  children,
+  fallback = null,
+}: WorkflowTabPermissionGuardProps) => {
+  const { hasPermission } = useWorkflowPermission("workflow.read");
+
+  if (!hasPermission) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+};

--- a/packages/features/pbac/client/context/EventPermissionContext.tsx
+++ b/packages/features/pbac/client/context/EventPermissionContext.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { createStore, useStore } from "zustand";
+
+import type { PermissionString } from "../../domain/types/permission-registry";
+
+export interface EventPermissions {
+  eventTypes: PermissionString[];
+  workflows: PermissionString[];
+}
+
+interface EventPermissionStore {
+  permissions: EventPermissions;
+  setPermissions: (permissions: EventPermissions) => void;
+  hasEventTypePermission: (permission: PermissionString) => boolean;
+  hasWorkflowPermission: (permission: PermissionString) => boolean;
+  hasEventTypePermissions: (permissions: PermissionString[]) => boolean;
+  hasWorkflowPermissions: (permissions: PermissionString[]) => boolean;
+}
+
+const createEventPermissionStore = (
+  initialPermissions: EventPermissions = { eventTypes: [], workflows: [] }
+) =>
+  createStore<EventPermissionStore>()((set, get) => ({
+    permissions: initialPermissions,
+    setPermissions: (permissions) => set({ permissions }),
+    hasEventTypePermission: (permission) => {
+      const { permissions } = get();
+      return permissions.eventTypes.includes(permission);
+    },
+    hasWorkflowPermission: (permission) => {
+      const { permissions } = get();
+      return permissions.workflows.includes(permission);
+    },
+    hasEventTypePermissions: (requiredPermissions) => {
+      const { permissions } = get();
+      return requiredPermissions.every((permission) => permissions.eventTypes.includes(permission));
+    },
+    hasWorkflowPermissions: (requiredPermissions) => {
+      const { permissions } = get();
+      return requiredPermissions.every((permission) => permissions.workflows.includes(permission));
+    },
+  }));
+
+type EventPermissionStoreApi = ReturnType<typeof createEventPermissionStore>;
+
+const EventPermissionContext = createContext<EventPermissionStoreApi | undefined>(undefined);
+
+interface EventPermissionProviderProps {
+  children: React.ReactNode;
+  initialPermissions: EventPermissions;
+}
+
+export const EventPermissionProvider = ({ children, initialPermissions }: EventPermissionProviderProps) => {
+  const store = createEventPermissionStore(initialPermissions);
+
+  return <EventPermissionContext.Provider value={store}>{children}</EventPermissionContext.Provider>;
+};
+
+export const useEventPermissionStore = <T,>(selector: (store: EventPermissionStore) => T): T => {
+  const eventPermissionStoreContext = useContext(EventPermissionContext);
+
+  if (!eventPermissionStoreContext) {
+    throw new Error("useEventPermissionStore must be used within EventPermissionProvider");
+  }
+
+  return useStore(eventPermissionStoreContext, selector);
+};

--- a/packages/features/pbac/client/hooks/useEventPermission.ts
+++ b/packages/features/pbac/client/hooks/useEventPermission.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import type { PermissionString } from "../../domain/types/permission-registry";
+import { useEventPermissionStore } from "../context/EventPermissionContext";
+
+export const useEventTypePermission = (permission: PermissionString) => {
+  return useEventPermissionStore((state) => ({
+    hasPermission: state.hasEventTypePermission(permission),
+    permissions: state.permissions.eventTypes,
+  }));
+};
+
+export const useEventTypePermissions = (permissions: PermissionString[]) => {
+  return useEventPermissionStore((state) => ({
+    hasPermissions: state.hasEventTypePermissions(permissions),
+    permissions: state.permissions.eventTypes,
+  }));
+};
+
+export const useWorkflowPermission = (permission: PermissionString) => {
+  return useEventPermissionStore((state) => ({
+    hasPermission: state.hasWorkflowPermission(permission),
+    permissions: state.permissions.workflows,
+  }));
+};
+
+export const useWorkflowPermissions = (permissions: PermissionString[]) => {
+  return useEventPermissionStore((state) => ({
+    hasPermissions: state.hasWorkflowPermissions(permissions),
+    permissions: state.permissions.workflows,
+  }));
+};
+
+export const useAllEventPermissions = () => {
+  return useEventPermissionStore((state) => state.permissions);
+};

--- a/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
@@ -24,6 +24,7 @@ type Props = {
   team: EventTypeSetupProps["team"];
   eventTypeApps?: EventTypeApps;
   allActiveWorkflows?: Workflow[];
+  canReadWorkflows?: boolean;
 };
 export const useTabsNavigations = ({
   formMethods,
@@ -31,6 +32,7 @@ export const useTabsNavigations = ({
   team,
   eventTypeApps,
   allActiveWorkflows,
+  canReadWorkflows = false,
 }: Props) => {
   const { t } = useLocale();
 
@@ -79,6 +81,7 @@ export const useTabsNavigations = ({
       installedAppsNumber,
       enabledWorkflowsNumber,
       availability,
+      canReadWorkflows,
     });
 
     if (!requirePayment) {
@@ -166,6 +169,7 @@ export const useTabsNavigations = ({
     watchSchedulingType,
     watchChildrenCount,
     activeWebhooksNumber,
+    canReadWorkflows,
   ]);
 
   return { tabsNavigation: EventTypeTabs };
@@ -180,6 +184,7 @@ type getNavigationProps = {
   enabledWorkflowsNumber: number;
   installedAppsNumber: number;
   availability: AvailabilityOption | undefined;
+  canReadWorkflows: boolean;
 };
 
 function getNavigation({
@@ -190,10 +195,11 @@ function getNavigation({
   enabledAppsNumber,
   installedAppsNumber,
   enabledWorkflowsNumber,
+  canReadWorkflows,
 }: getNavigationProps) {
   const duration = multipleDuration?.map((duration) => ` ${duration}`) || length;
 
-  return [
+  const baseNavigation: VerticalTabItemProps[] = [
     {
       name: t("event_setup_tab_title"),
       href: `/event-types/${id}?tabName=setup`,
@@ -223,12 +229,18 @@ function getNavigation({
       info: `${installedAppsNumber} apps, ${enabledAppsNumber} ${t("active")}`,
       "data-testid": "apps",
     },
-    {
+  ];
+
+  // Only add workflows tab if user has permission to read workflows
+  if (canReadWorkflows) {
+    baseNavigation.push({
       name: t("workflows"),
       href: `/event-types/${id}?tabName=workflows`,
       icon: "zap",
       info: `${enabledWorkflowsNumber} ${t("active")}`,
       "data-testid": "workflows",
-    },
-  ] satisfies VerticalTabItemProps[];
+    });
+  }
+
+  return baseNavigation;
 }

--- a/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/activateEventType.handler.ts
@@ -1,6 +1,7 @@
 import { scheduleEmailReminder } from "@calcom/features/ee/workflows/lib/reminders/emailReminderManager";
 import { scheduleSMSReminder } from "@calcom/features/ee/workflows/lib/reminders/smsReminderManager";
 import { scheduleWhatsappReminder } from "@calcom/features/ee/workflows/lib/reminders/whatsappReminderManager";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { getBookerBaseUrl } from "@calcom/lib/getBookerUrl/server";
 import { WorkflowRepository } from "@calcom/lib/server/repository/workflow";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
@@ -37,9 +38,6 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
               some: {
                 userId: ctx.user.id,
                 accepted: true,
-                NOT: {
-                  role: MembershipRole.MEMBER,
-                },
               },
             },
           },
@@ -96,6 +94,21 @@ export const activateEventTypeHandler = async ({ ctx, input }: ActivateEventType
 
   if (!eventType)
     throw new TRPCError({ code: "UNAUTHORIZED", message: "Not authorized to edit this event type" });
+
+  if (eventType.teamId) {
+    const permissionCheckService = new PermissionCheckService();
+
+    const hasPermissionToActivate = await permissionCheckService.checkPermission({
+      userId: ctx.user.id,
+      teamId: eventType.teamId,
+      permission: "eventType.update",
+      fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
+    });
+
+    if (!hasPermissionToActivate) {
+      throw new TRPCError({ code: "UNAUTHORIZED", message: "Not authorized to edit this event type" });
+    }
+  }
 
   // at this point we know that the event type belongs to the user or team
   // so we don't use OR, we use logic.

--- a/packages/trpc/server/routers/viewer/workflows/list.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/list.handler.ts
@@ -1,7 +1,9 @@
 import type { WorkflowType } from "@calcom/features/ee/workflows/components/WorkflowListPage";
 // import dayjs from "@calcom/dayjs";
 // import { getErrorFromUnknown } from "@calcom/lib/errors";
+import { addPermissionsToWorkflows } from "@calcom/lib/server/repository/workflow-permissions";
 import { prisma } from "@calcom/prisma";
+import type { PrismaClient } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
@@ -10,6 +12,7 @@ import type { TListInputSchema } from "./list.schema";
 type ListOptions = {
   ctx: {
     user: NonNullable<TrpcSessionUser>;
+    prisma: PrismaClient;
   };
   input: TListInputSchema;
 };
@@ -156,7 +159,13 @@ export const listHandler = async ({ ctx, input }: ListOptions) => {
 
     workflows.push(...workflowsWithReadOnly);
 
-    return { workflows };
+    // Add permissions to each workflow
+    const workflowsWithPermissions = await addPermissionsToWorkflows(workflows, ctx.user.id);
+
+    // Filter workflows based on view permission
+    const filteredWorkflows = workflowsWithPermissions.filter((workflow) => workflow.permissions.canView);
+
+    return { workflows: filteredWorkflows };
   }
 
   if (input && input.userId) {
@@ -198,7 +207,13 @@ export const listHandler = async ({ ctx, input }: ListOptions) => {
 
     workflows.push(...userWorkflows);
 
-    return { workflows };
+    // Add permissions to each workflow
+    const workflowsWithPermissions = await addPermissionsToWorkflows(workflows, ctx.user.id);
+
+    // Filter workflows based on view permission
+    const filteredWorkflows = workflowsWithPermissions.filter((workflow) => workflow.permissions.canView);
+
+    return { workflows: filteredWorkflows };
   }
 
   const allWorkflows = await prisma.workflow.findMany({
@@ -259,5 +274,11 @@ export const listHandler = async ({ ctx, input }: ListOptions) => {
 
   workflows.push(...workflowsWithReadOnly);
 
-  return { workflows };
+  // Add permissions to each workflow
+  const workflowsWithPermissions = await addPermissionsToWorkflows(workflows, ctx.user.id);
+
+  // Filter workflows based on view permission
+  const filteredWorkflows = workflowsWithPermissions.filter((workflow) => workflow.permissions.canView);
+
+  return { workflows: filteredWorkflows };
 };


### PR DESCRIPTION
PR adds permissions for eventType + workflows to context on inital load of a eventType. Allows us to easily check permissions in nested client components. In this case we hide the workflows tab if the user does not have permission to create/update etc . 