### PR TITLE
fix: preserve URL parameter guests when guests field is hidden

### DIFF
--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -5,9 +5,9 @@ import { SystemField } from "@calcom/features/bookings/lib/SystemField";
 import type { bookingResponsesDbSchema } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import { contructEmailFromPhoneNumber } from "@calcom/lib/contructEmailFromPhoneNumber";
 import { getBookingWithResponses } from "@calcom/lib/getBooking";
+import { HttpError } from "@calcom/lib/http-error";
 import { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent } from "@calcom/types/Calendar";
-import { HttpError } from "@calcom/lib/http-error";
 
 export const getCalEventResponses = ({
   bookingFields,
@@ -59,11 +59,6 @@ export const getCalEventResponses = ({
       if (!label) {
         //TODO: This error must be thrown while saving event-type as well so that such an event-type can't be saved
         throw new Error(`Missing label for booking field "${field.name}"`);
-      }
-
-      // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list
-      if (field.name == "guests" && field.hidden) {
-        backwardCompatibleResponses[field.name] = [];
       }
 
       if (field.editable === "user" || field.editable === "user-readonly") {


### PR DESCRIPTION
# fix: preserve URL parameter guests when guests field is hidden

## Summary

This PR fixes a bug where guests specified via URL parameters (e.g., `?guests=guest1@example.com,guest2@example.com`) were not being added to bookings when the guests field was hidden in the booking form. 

The issue was caused by logic in `getCalEventResponses.ts` that explicitly set the guests field to an empty array when `field.hidden` was true, which overwrote any guests that came from URL parameters. This change removes that logic, allowing URL parameter guests to flow through to the booking creation process regardless of field visibility.

**Files changed:**
- `packages/features/bookings/lib/getCalEventResponses.ts` - Removed 4 lines that cleared guests when field was hidden

## Review & Testing Checklist for Human

⚠️ **HIGH PRIORITY** - This change affects booking security and functionality:

- [ ] **Test the bug scenario end-to-end**: Create a booking URL with guests parameter when guests field is hidden (via `disableGuests` on event type) and verify guests are actually added to the final booking
- [ ] **Security review**: Ensure this change doesn't introduce vulnerabilities by allowing unauthorized guests to be added to bookings
- [ ] **Verify original intent**: Check git history or team knowledge for why guests were originally cleared when field was hidden - there may be valid business/security reasons
- [ ] **Test edge cases**: Invalid guest emails, too many guests, malformed URL parameters
- [ ] **Regression testing**: Ensure normal booking flow still works when guests field is visible and when it's hidden without URL params

**Recommended test plan:**
1. Create an event type with guests field hidden (`disableGuests: true`)
2. Create booking URL with guests parameter: `/eventslug?guests=test1@example.com,test2@example.com`
3. Complete booking and verify guests are added to attendees
4. Test without URL params to ensure no regression
5. Test with visible guests field to ensure no regression

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    URLParams["URL Parameters<br/>?guests=email1,email2"]
    InitialForm["useInitialFormValues.ts<br/>Parses URL params into form"]
    CalEvent["getCalEventResponses.ts<br/>Processes booking fields"]:::major-edit
    HandleBooking["handleNewBooking.ts<br/>Creates booking with guests"]
    BookingFields["BookingFields.tsx<br/>UI field rendering"]:::context
    
    URLParams --> InitialForm
    InitialForm --> CalEvent
    CalEvent --> HandleBooking
    BookingFields -.-> CalEvent
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Limited testing**: Due to local environment setup issues, I wasn't able to complete full end-to-end testing of the booking flow
- **Simple but impactful change**: While only 4 lines were removed, this affects core booking functionality
- **Session info**: Link to Devin run: https://app.devin.ai/sessions/f2fef3e48e344ebc8ebd447f711da9fc
- **Requested by**: @joeauyeung from joe@cal.com

The change is straightforward but requires careful testing to ensure it doesn't introduce security issues or break existing functionality.