### PR TITLE
feat: org/team event type private links endpoints

### DIFF
--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.303",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.306",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.300",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -38,7 +38,7 @@
     "@axiomhq/winston": "^1.2.0",
     "@calcom/platform-constants": "*",
     "@calcom/platform-enums": "*",
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.303",
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9",
     "@calcom/platform-types": "*",
     "@calcom/platform-utils": "*",
     "@calcom/prisma": "*",

--- a/apps/api/v2/src/ee/event-types-private-links/controllers/event-types-private-links.controller.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/controllers/event-types-private-links.controller.ts
@@ -4,24 +4,10 @@ import { Permissions } from "@/modules/auth/decorators/permissions/permissions.d
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  ParseIntPipe,
-  Patch,
-  Post,
-  UseGuards,
-} from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags, OmitType } from "@nestjs/swagger";
 
-import {
-  EVENT_TYPE_READ,
-  EVENT_TYPE_WRITE,
-  SUCCESS_STATUS,
-} from "@calcom/platform-constants";
+import { EVENT_TYPE_READ, EVENT_TYPE_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
 import {
   CreatePrivateLinkInput,
   CreatePrivateLinkOutput,
@@ -67,10 +53,9 @@ export class EventTypesPrivateLinksController {
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({ summary: "Get all private links for an event type" })
   async getPrivateLinks(
-    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
-    @GetUser("id") userId: number
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number
   ): Promise<GetPrivateLinksOutput> {
-    const privateLinks = await this.privateLinksService.getPrivateLinks(eventTypeId, userId);
+    const privateLinks = await this.privateLinksService.getPrivateLinks(eventTypeId);
 
     return {
       status: SUCCESS_STATUS,
@@ -86,11 +71,10 @@ export class EventTypesPrivateLinksController {
   async updatePrivateLink(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
     @Param("linkId") linkId: string,
-    @Body() body: UpdatePrivateLinkBody,
-    @GetUser("id") userId: number
+    @Body() body: UpdatePrivateLinkBody
   ): Promise<UpdatePrivateLinkOutput> {
     const updateInput = { ...body, linkId };
-    const privateLink = await this.privateLinksService.updatePrivateLink(eventTypeId, userId, updateInput);
+    const privateLink = await this.privateLinksService.updatePrivateLink(eventTypeId, updateInput);
 
     return {
       status: SUCCESS_STATUS,
@@ -105,10 +89,9 @@ export class EventTypesPrivateLinksController {
   @ApiOperation({ summary: "Delete a private link for an event type" })
   async deletePrivateLink(
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
-    @Param("linkId") linkId: string,
-    @GetUser("id") userId: number
+    @Param("linkId") linkId: string
   ): Promise<DeletePrivateLinkOutput> {
-    await this.privateLinksService.deletePrivateLink(eventTypeId, userId, linkId);
+    await this.privateLinksService.deletePrivateLink(eventTypeId, linkId);
 
     return {
       status: SUCCESS_STATUS,
@@ -119,5 +102,3 @@ export class EventTypesPrivateLinksController {
     };
   }
 }
-
-

--- a/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
@@ -5,7 +5,6 @@ import {
   OPTIONAL_X_CAL_SECRET_KEY_HEADER,
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
-import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
@@ -51,11 +50,11 @@ export class OrganizationsEventTypesPrivateLinksController {
   async createPrivateLink(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
-    @Body() body: CreatePrivateLinkInput,
-    @GetUser("id") userId: number
+    @Body() body: CreatePrivateLinkInput
   ): Promise<CreatePrivateLinkOutput> {
     await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
-    const privateLink = await this.privateLinksService.createPrivateLink(eventTypeId, userId, body);
+    // Use teamId as the seed for link generation in org/team context
+    const privateLink = await this.privateLinksService.createPrivateLink(eventTypeId, teamId, body);
     return {
       status: SUCCESS_STATUS,
       data: privateLink,

--- a/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
@@ -14,17 +14,7 @@ import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { TeamsEventTypesService } from "@/modules/teams/event-types/services/teams-event-types.service";
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  ParseIntPipe,
-  Patch,
-  Post,
-  UseGuards,
-} from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
@@ -79,11 +69,10 @@ export class OrganizationsEventTypesPrivateLinksController {
   @ApiOperation({ summary: "Get all private links for a team event type" })
   async getPrivateLinks(
     @Param("teamId", ParseIntPipe) teamId: number,
-    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
-    @GetUser("id") userId: number
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number
   ): Promise<GetPrivateLinksOutput> {
     await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
-    const privateLinks = await this.privateLinksService.getPrivateLinks(eventTypeId, userId);
+    const privateLinks = await this.privateLinksService.getPrivateLinks(eventTypeId);
     return {
       status: SUCCESS_STATUS,
       data: privateLinks,
@@ -99,12 +88,11 @@ export class OrganizationsEventTypesPrivateLinksController {
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
     @Param("linkId") linkId: string,
-    @Body() body: Omit<UpdatePrivateLinkInput, "linkId">,
-    @GetUser("id") userId: number
+    @Body() body: Omit<UpdatePrivateLinkInput, "linkId">
   ): Promise<UpdatePrivateLinkOutput> {
     await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
     const updateInput: UpdatePrivateLinkInput = { ...body, linkId };
-    const privateLink = await this.privateLinksService.updatePrivateLink(eventTypeId, userId, updateInput);
+    const privateLink = await this.privateLinksService.updatePrivateLink(eventTypeId, updateInput);
     return {
       status: SUCCESS_STATUS,
       data: privateLink,
@@ -119,11 +107,10 @@ export class OrganizationsEventTypesPrivateLinksController {
   async deletePrivateLink(
     @Param("teamId", ParseIntPipe) teamId: number,
     @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
-    @Param("linkId") linkId: string,
-    @GetUser("id") userId: number
+    @Param("linkId") linkId: string
   ): Promise<DeletePrivateLinkOutput> {
     await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
-    await this.privateLinksService.deletePrivateLink(eventTypeId, userId, linkId);
+    await this.privateLinksService.deletePrivateLink(eventTypeId, linkId);
     return {
       status: SUCCESS_STATUS,
       data: {
@@ -133,5 +120,3 @@ export class OrganizationsEventTypesPrivateLinksController {
     };
   }
 }
-
-

--- a/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts
@@ -1,0 +1,137 @@
+import { API_VERSIONS_VALUES } from "@/lib/api-versions";
+import {
+  OPTIONAL_API_KEY_HEADER,
+  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
+  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
+} from "@/lib/docs/headers";
+import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
+import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
+import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
+import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
+import { TeamsEventTypesService } from "@/modules/teams/event-types/services/teams-event-types.service";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import {
+  CreatePrivateLinkInput,
+  CreatePrivateLinkOutput,
+  DeletePrivateLinkOutput,
+  GetPrivateLinksOutput,
+  UpdatePrivateLinkInput,
+  UpdatePrivateLinkOutput,
+} from "@calcom/platform-types";
+
+import { PrivateLinksService } from "../services/private-links.service";
+
+@Controller({
+  path: "/v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links",
+  version: API_VERSIONS_VALUES,
+})
+@DocsTags("Orgs / Teams / Event Types / Private Links")
+@ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
+@ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+@ApiHeader(OPTIONAL_API_KEY_HEADER)
+export class OrganizationsEventTypesPrivateLinksController {
+  constructor(
+    private readonly privateLinksService: PrivateLinksService,
+    private readonly teamsEventTypesService: TeamsEventTypesService
+  ) {}
+
+  @Post("/")
+  @Roles("TEAM_ADMIN")
+  @PlatformPlan("ESSENTIALS")
+  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @ApiOperation({ summary: "Create a private link for a team event type" })
+  async createPrivateLink(
+    @Param("teamId", ParseIntPipe) teamId: number,
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
+    @Body() body: CreatePrivateLinkInput,
+    @GetUser("id") userId: number
+  ): Promise<CreatePrivateLinkOutput> {
+    await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
+    const privateLink = await this.privateLinksService.createPrivateLink(eventTypeId, userId, body);
+    return {
+      status: SUCCESS_STATUS,
+      data: privateLink,
+    };
+  }
+
+  @Get("/")
+  @Roles("TEAM_ADMIN")
+  @PlatformPlan("ESSENTIALS")
+  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @ApiOperation({ summary: "Get all private links for a team event type" })
+  async getPrivateLinks(
+    @Param("teamId", ParseIntPipe) teamId: number,
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
+    @GetUser("id") userId: number
+  ): Promise<GetPrivateLinksOutput> {
+    await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
+    const privateLinks = await this.privateLinksService.getPrivateLinks(eventTypeId, userId);
+    return {
+      status: SUCCESS_STATUS,
+      data: privateLinks,
+    };
+  }
+
+  @Patch("/:linkId")
+  @Roles("TEAM_ADMIN")
+  @PlatformPlan("ESSENTIALS")
+  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @ApiOperation({ summary: "Update a private link for a team event type" })
+  async updatePrivateLink(
+    @Param("teamId", ParseIntPipe) teamId: number,
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
+    @Param("linkId") linkId: string,
+    @Body() body: Omit<UpdatePrivateLinkInput, "linkId">,
+    @GetUser("id") userId: number
+  ): Promise<UpdatePrivateLinkOutput> {
+    await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
+    const updateInput: UpdatePrivateLinkInput = { ...body, linkId };
+    const privateLink = await this.privateLinksService.updatePrivateLink(eventTypeId, userId, updateInput);
+    return {
+      status: SUCCESS_STATUS,
+      data: privateLink,
+    };
+  }
+
+  @Delete("/:linkId")
+  @Roles("TEAM_ADMIN")
+  @PlatformPlan("ESSENTIALS")
+  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @ApiOperation({ summary: "Delete a private link for a team event type" })
+  async deletePrivateLink(
+    @Param("teamId", ParseIntPipe) teamId: number,
+    @Param("eventTypeId", ParseIntPipe) eventTypeId: number,
+    @Param("linkId") linkId: string,
+    @GetUser("id") userId: number
+  ): Promise<DeletePrivateLinkOutput> {
+    await this.teamsEventTypesService.validateEventTypeExists(teamId, eventTypeId);
+    await this.privateLinksService.deletePrivateLink(eventTypeId, userId, linkId);
+    return {
+      status: SUCCESS_STATUS,
+      data: {
+        linkId,
+        message: "Private link deleted successfully",
+      },
+    };
+  }
+}
+
+

--- a/apps/api/v2/src/ee/event-types-private-links/event-types-private-links.module.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/event-types-private-links.module.ts
@@ -1,18 +1,19 @@
 import { Module } from "@nestjs/common";
 import { TokensModule } from "@/modules/tokens/tokens.module";
-import { OAuthClientModule } from "@/modules/oauth-clients/oauth-client.module";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { EventTypesModule_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/event-types.module";
+// org-scoped dependencies removed; org controller will live in OrganizationsModule
 import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
 
 import { EventTypesPrivateLinksController } from "./controllers/event-types-private-links.controller";
+// org/team-scoped controller is registered in OrganizationsModule
 import { PrivateLinksInputService } from "./services/private-links-input.service";
 import { PrivateLinksOutputService } from "./services/private-links-output.service";
 import { PrivateLinksService } from "./services/private-links.service";
 import { PrivateLinksRepository } from "./private-links.repository";
 
 @Module({
-  imports: [TokensModule, OAuthClientModule, PrismaModule, EventTypesModule_2024_06_14],
+  imports: [TokensModule, PrismaModule, EventTypesModule_2024_06_14],
   controllers: [EventTypesPrivateLinksController],
   providers: [
     PrivateLinksService,
@@ -21,6 +22,7 @@ import { PrivateLinksRepository } from "./private-links.repository";
     PrivateLinksRepository,
     EventTypeOwnershipGuard,
   ],
+  exports: [PrivateLinksService],
 })
 export class EventTypesPrivateLinksModule {}
 

--- a/apps/api/v2/src/ee/event-types-private-links/event-types-private-links.module.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/event-types-private-links.module.ts
@@ -1,16 +1,14 @@
-import { Module } from "@nestjs/common";
-import { TokensModule } from "@/modules/tokens/tokens.module";
-import { PrismaModule } from "@/modules/prisma/prisma.module";
 import { EventTypesModule_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/event-types.module";
-// org-scoped dependencies removed; org controller will live in OrganizationsModule
 import { EventTypeOwnershipGuard } from "@/modules/event-types/guards/event-type-ownership.guard";
+import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { TokensModule } from "@/modules/tokens/tokens.module";
+import { Module } from "@nestjs/common";
 
 import { EventTypesPrivateLinksController } from "./controllers/event-types-private-links.controller";
-// org/team-scoped controller is registered in OrganizationsModule
+import { PrivateLinksRepository } from "./private-links.repository";
 import { PrivateLinksInputService } from "./services/private-links-input.service";
 import { PrivateLinksOutputService } from "./services/private-links-output.service";
 import { PrivateLinksService } from "./services/private-links.service";
-import { PrivateLinksRepository } from "./private-links.repository";
 
 @Module({
   imports: [TokensModule, PrismaModule, EventTypesModule_2024_06_14],
@@ -25,5 +23,3 @@ import { PrivateLinksRepository } from "./private-links.repository";
   exports: [PrivateLinksService],
 })
 export class EventTypesPrivateLinksModule {}
-
-

--- a/apps/api/v2/src/ee/event-types-private-links/services/private-links.service.ts
+++ b/apps/api/v2/src/ee/event-types-private-links/services/private-links.service.ts
@@ -1,14 +1,13 @@
-import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
-
-import { generateHashedLink, isLinkExpired } from "@calcom/platform-libraries/private-links";
-import { CreatePrivateLinkInput, PrivateLinkOutput, UpdatePrivateLinkInput } from "@calcom/platform-types";
-
+import { PrivateLinksRepository } from "@/ee/event-types-private-links/private-links.repository";
 import { PrivateLinksInputService } from "@/ee/event-types-private-links/services/private-links-input.service";
 import {
   PrivateLinksOutputService,
   type PrivateLinkData,
 } from "@/ee/event-types-private-links/services/private-links-output.service";
-import { PrivateLinksRepository } from "@/ee/event-types-private-links/private-links.repository";
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
+
+import { generateHashedLink, isLinkExpired } from "@calcom/platform-libraries/private-links";
+import { CreatePrivateLinkInput, PrivateLinkOutput, UpdatePrivateLinkInput } from "@calcom/platform-types";
 
 @Injectable()
 export class PrivateLinksService {
@@ -48,7 +47,7 @@ export class PrivateLinksService {
     }
   }
 
-  async getPrivateLinks(eventTypeId: number, userId: number): Promise<PrivateLinkOutput[]> {
+  async getPrivateLinks(eventTypeId: number): Promise<PrivateLinkOutput[]> {
     try {
       const links = await this.repo.listByEventTypeId(eventTypeId);
       const mapped: PrivateLinkData[] = links.map((l) => ({
@@ -69,11 +68,7 @@ export class PrivateLinksService {
     }
   }
 
-  async updatePrivateLink(
-    eventTypeId: number,
-    userId: number,
-    input: UpdatePrivateLinkInput
-  ): Promise<PrivateLinkOutput> {
+  async updatePrivateLink(eventTypeId: number, input: UpdatePrivateLinkInput): Promise<PrivateLinkOutput> {
     try {
       const transformedInput = this.inputService.transformUpdateInput(input);
       const updatedResult = await this.repo.update(eventTypeId, {
@@ -107,7 +102,7 @@ export class PrivateLinksService {
     }
   }
 
-  async deletePrivateLink(eventTypeId: number, userId: number, linkId: string): Promise<void> {
+  async deletePrivateLink(eventTypeId: number, linkId: string): Promise<void> {
     try {
       const { count } = await this.repo.delete(eventTypeId, linkId);
       if (count === 0) {
@@ -124,5 +119,3 @@ export class PrivateLinksService {
     }
   }
 }
-
-

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types-private-links.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types-private-links.e2e-spec.ts
@@ -1,0 +1,183 @@
+import { bootstrap } from "@/app";
+import { AppModule } from "@/app.module";
+import { HttpExceptionFilter } from "@/filters/http-exception.filter";
+import { PrismaExceptionFilter } from "@/filters/prisma-exception.filter";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
+import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
+import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
+import { TokensModule } from "@/modules/tokens/tokens.module";
+import { UsersModule } from "@/modules/users/users.module";
+import { INestApplication } from "@nestjs/common";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { Test } from "@nestjs/testing";
+import * as request from "supertest";
+import { EventTypesRepositoryFixture } from "test/fixtures/repository/event-types.repository.fixture";
+import { OrganizationRepositoryFixture } from "test/fixtures/repository/organization.repository.fixture";
+import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.fixture";
+import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
+import { randomString } from "test/utils/randomString";
+import { withApiAuth } from "test/utils/withApiAuth";
+
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import { CreatePrivateLinkInput } from "@calcom/platform-types";
+
+describe("Organizations / Teams / Event Types / Private Links Endpoints", () => {
+  let app: INestApplication;
+
+  let orgFixture: OrganizationRepositoryFixture;
+  let teamFixture: TeamRepositoryFixture;
+  let userFixture: UserRepositoryFixture;
+  let eventTypesFixture: EventTypesRepositoryFixture;
+
+  let org: any;
+  let team: any;
+  let user: any;
+  let eventType: any;
+
+  const userEmail = `org-private-links-user-${randomString()}@api.com`;
+
+  beforeAll(async () => {
+    const testingModuleBuilder = withApiAuth(
+      userEmail,
+      Test.createTestingModule({
+        providers: [PrismaExceptionFilter, HttpExceptionFilter],
+        imports: [AppModule, UsersModule, TokensModule],
+      })
+    )
+      // Bypass org admin plan and admin API checks and roles in this e2e
+      .overrideGuard(PlatformPlanGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(IsAdminAPIEnabledGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      // Keep IsOrgGuard and IsTeamInOrg to validate org/team path integrity
+      .overrideGuard(ApiAuthGuard)
+      .useValue({ canActivate: () => true });
+
+    const moduleRef = await testingModuleBuilder.compile();
+
+    app = moduleRef.createNestApplication();
+    bootstrap(app as NestExpressApplication);
+
+    orgFixture = new OrganizationRepositoryFixture(moduleRef);
+    teamFixture = new TeamRepositoryFixture(moduleRef);
+    userFixture = new UserRepositoryFixture(moduleRef);
+    eventTypesFixture = new EventTypesRepositoryFixture(moduleRef);
+
+    user = await userFixture.create({
+      email: userEmail,
+      username: `org-private-links-user-${randomString()}`,
+      name: "Test User",
+    });
+
+    org = await orgFixture.create({
+      name: `org-private-links-org-${randomString()}`,
+      slug: `org-private-links-org-${randomString()}`,
+      isOrganization: true,
+    });
+
+    team = await teamFixture.create({
+      name: `org-private-links-team-${randomString()}`,
+      isOrganization: false,
+      parent: { connect: { id: org.id } },
+    });
+
+    // Create a team-owned event type
+    eventType = await eventTypesFixture.createTeamEventType({
+      title: `org-private-links-event-type-${randomString()}`,
+      slug: `org-private-links-event-type-${randomString()}`,
+      length: 30,
+      locations: [],
+      team: { connect: { id: team.id } },
+    });
+
+    await app.init();
+  });
+
+  it("POST /v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links - create", async () => {
+    const body: CreatePrivateLinkInput = { maxUsageCount: 5 };
+    const response = await request(app.getHttpServer())
+      .post(`/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links`)
+      .set("Authorization", "Bearer test")
+      .send(body)
+      .expect(201);
+
+    expect(response.body.status).toBe(SUCCESS_STATUS);
+    expect(response.body.data.linkId).toBeDefined();
+    expect(response.body.data.maxUsageCount).toBe(5);
+    expect(response.body.data.usageCount).toBeDefined();
+  });
+
+  it("GET /v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links - list", async () => {
+    const response = await request(app.getHttpServer())
+      .get(`/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links`)
+      .set("Authorization", "Bearer test")
+      .expect(200);
+
+    expect(response.body.status).toBe(SUCCESS_STATUS);
+    expect(Array.isArray(response.body.data)).toBe(true);
+  });
+
+  it("PATCH /v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links/:linkId - update", async () => {
+    // create first
+    const createResp = await request(app.getHttpServer())
+      .post(`/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links`)
+      .set("Authorization", "Bearer test")
+      .send({ maxUsageCount: 3 })
+      .expect(201);
+
+    const linkId = createResp.body.data.linkId as string;
+
+    const response = await request(app.getHttpServer())
+      .patch(
+        `/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links/${linkId}`
+      )
+      .set("Authorization", "Bearer test")
+      .send({ maxUsageCount: 10 })
+      .expect(200);
+
+    expect(response.body.status).toBe(SUCCESS_STATUS);
+    expect(response.body.data.maxUsageCount).toBe(10);
+  });
+
+  it("DELETE /v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links/:linkId - delete", async () => {
+    // create first
+    const createResp = await request(app.getHttpServer())
+      .post(`/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links`)
+      .set("Authorization", "Bearer test")
+      .send({ maxUsageCount: 2 })
+      .expect(201);
+
+    const linkId = createResp.body.data.linkId as string;
+
+    const response = await request(app.getHttpServer())
+      .delete(
+        `/v2/organizations/${org.id}/teams/${team.id}/event-types/${eventType.id}/private-links/${linkId}`
+      )
+      .set("Authorization", "Bearer test")
+      .expect(200);
+
+    expect(response.body.status).toBe(SUCCESS_STATUS);
+    expect(response.body.data.linkId).toBe(linkId);
+  });
+
+  afterAll(async () => {
+    try {
+      if (eventType?.id) {
+        await eventTypesFixture.delete(eventType.id);
+      }
+      if (team?.id) {
+        await teamFixture.delete(team.id);
+      }
+      if (org?.id) {
+        await orgFixture.delete(org.id);
+      }
+      if (user?.email) {
+        await userFixture.deleteByEmail(user.email);
+      }
+    } catch {}
+    await app.close();
+  });
+});

--- a/apps/api/v2/src/modules/organizations/organizations.module.ts
+++ b/apps/api/v2/src/modules/organizations/organizations.module.ts
@@ -23,6 +23,8 @@ import { OrganizationsConferencingModule } from "@/modules/organizations/confere
 import { OrganizationsConferencingService } from "@/modules/organizations/conferencing/services/organizations-conferencing.service";
 import { OrganizationsDelegationCredentialModule } from "@/modules/organizations/delegation-credentials/organizations-delegation-credential.module";
 import { OrganizationsEventTypesController } from "@/modules/organizations/event-types/organizations-event-types.controller";
+import { EventTypesPrivateLinksModule } from "@/ee/event-types-private-links/event-types-private-links.module";
+import { OrganizationsEventTypesPrivateLinksController } from "@/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller";
 import { OrganizationsEventTypesRepository } from "@/modules/organizations/event-types/organizations-event-types.repository";
 import { OutputTeamEventTypesResponsePipe } from "@/modules/organizations/event-types/pipes/team-event-types-response.transformer";
 import { InputOrganizationsEventTypesService } from "@/modules/organizations/event-types/services/input.service";
@@ -91,6 +93,7 @@ import { Module } from "@nestjs/common";
     OrganizationsStripeModule,
     OrganizationsTeamsRoutingFormsModule,
     OrganizationsConferencingModule,
+    EventTypesPrivateLinksModule,
   ],
   providers: [
     OrganizationsRepository,
@@ -177,6 +180,7 @@ import { Module } from "@nestjs/common";
     OrganizationsTeamsSchedulesController,
     OrganizationsUsersOOOController,
     OrganizationTeamWorkflowsController,
+    OrganizationsEventTypesPrivateLinksController,
   ],
 })
 export class OrganizationsModule {}

--- a/apps/api/v2/swagger/documentation.json
+++ b/apps/api/v2/swagger/documentation.json
@@ -4384,6 +4384,292 @@
         ]
       }
     },
+    "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links": {
+      "post": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_createPrivateLink",
+        "summary": "Create a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrivateLinkInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      },
+      "get": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_getPrivateLinks",
+        "summary": "Get all private links for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPrivateLinksOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      }
+    },
+    "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links/{linkId}": {
+      "patch": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_updatePrivateLink",
+        "summary": "Update a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "linkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      },
+      "delete": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_deletePrivateLink",
+        "summary": "Delete a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "linkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      }
+    },
     "/v2/organizations/{orgId}/teams/{teamId}/memberships": {
       "get": {
         "operationId": "OrganizationsTeamsMembershipsController_getAllOrgTeamMemberships",
@@ -23726,6 +24012,213 @@
           }
         }
       },
+      "CreatePrivateLinkInput": {
+        "type": "object",
+        "properties": {
+          "expiresAt": {
+            "type": "string",
+            "description": "Expiration date for time-based links",
+            "format": "date-time",
+            "example": "2024-12-31T23:59:59.000Z"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use).",
+            "example": 10,
+            "minimum": 1,
+            "default": 1
+          }
+        }
+      },
+      "TimeBasedPrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "type": "string",
+            "description": "The private link ID",
+            "example": "abc123def456"
+          },
+          "eventTypeId": {
+            "type": "number",
+            "description": "Event type ID this link belongs to",
+            "example": 123
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "Whether the link is currently expired",
+            "example": false
+          },
+          "bookingUrl": {
+            "type": "string",
+            "description": "Full booking URL for this private link",
+            "format": "uri",
+            "example": "https://cal.com/d/abc123def456/30min"
+          },
+          "expiresAt": {
+            "type": "string",
+            "description": "Expiration date for this time-based link",
+            "format": "date-time",
+            "example": "2025-12-31T23:59:59.000Z"
+          }
+        },
+        "required": [
+          "linkId",
+          "eventTypeId",
+          "isExpired",
+          "bookingUrl",
+          "expiresAt"
+        ]
+      },
+      "UsageBasedPrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "type": "string",
+            "description": "The private link ID",
+            "example": "abc123def456"
+          },
+          "eventTypeId": {
+            "type": "number",
+            "description": "Event type ID this link belongs to",
+            "example": 123
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "Whether the link is currently expired",
+            "example": false
+          },
+          "bookingUrl": {
+            "type": "string",
+            "description": "Full booking URL for this private link",
+            "format": "uri",
+            "example": "https://cal.com/d/abc123def456/30min"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "Maximum number of times this link can be used",
+            "example": 10
+          },
+          "usageCount": {
+            "type": "number",
+            "description": "Current usage count for this link",
+            "example": 3
+          }
+        },
+        "required": [
+          "linkId",
+          "eventTypeId",
+          "isExpired",
+          "bookingUrl",
+          "maxUsageCount",
+          "usageCount"
+        ]
+      },
+      "CreatePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "description": "Created private link data (either time-based or usage-based)",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+              },
+              {
+                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "GetPrivateLinksOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "type": "array",
+            "description": "Array of private links for the event type (mix of time-based and usage-based)",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+                },
+                {
+                  "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "UpdatePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "description": "Updated private link data (either time-based or usage-based)",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+              },
+              {
+                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "DeletePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "type": "object",
+            "description": "Deleted link information",
+            "properties": {
+              "linkId": {
+                "type": "string",
+                "example": "abc123def456"
+              },
+              "message": {
+                "type": "string",
+                "example": "Private link deleted successfully"
+              }
+            }
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
       "StripConnectOutputDto": {
         "type": "object",
         "properties": {
@@ -25573,6 +26066,23 @@
           "status",
           "data"
         ]
+      },
+      "UpdatePrivateLinkBody": {
+        "type": "object",
+        "properties": {
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "New expiration date for time-based links",
+            "example": "2024-12-31T23:59:59.000Z"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "New maximum number of times the link can be used",
+            "example": 10,
+            "minimum": 1
+          }
+        }
       },
       "MeOrgOutput": {
         "type": "object",
@@ -28212,230 +28722,6 @@
           },
           "data": {
             "$ref": "#/components/schemas/TeamMembershipOutput"
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "CreatePrivateLinkInput": {
-        "type": "object",
-        "properties": {
-          "expiresAt": {
-            "type": "string",
-            "description": "Expiration date for time-based links",
-            "format": "date-time",
-            "example": "2024-12-31T23:59:59.000Z"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use).",
-            "example": 10,
-            "minimum": 1,
-            "default": 1
-          }
-        }
-      },
-      "TimeBasedPrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "linkId": {
-            "type": "string",
-            "description": "The private link ID",
-            "example": "abc123def456"
-          },
-          "eventTypeId": {
-            "type": "number",
-            "description": "Event type ID this link belongs to",
-            "example": 123
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "Whether the link is currently expired",
-            "example": false
-          },
-          "bookingUrl": {
-            "type": "string",
-            "description": "Full booking URL for this private link",
-            "format": "uri",
-            "example": "https://cal.com/d/abc123def456/30min"
-          },
-          "expiresAt": {
-            "type": "string",
-            "description": "Expiration date for this time-based link",
-            "format": "date-time",
-            "example": "2025-12-31T23:59:59.000Z"
-          }
-        },
-        "required": [
-          "linkId",
-          "eventTypeId",
-          "isExpired",
-          "bookingUrl",
-          "expiresAt"
-        ]
-      },
-      "UsageBasedPrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "linkId": {
-            "type": "string",
-            "description": "The private link ID",
-            "example": "abc123def456"
-          },
-          "eventTypeId": {
-            "type": "number",
-            "description": "Event type ID this link belongs to",
-            "example": 123
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "Whether the link is currently expired",
-            "example": false
-          },
-          "bookingUrl": {
-            "type": "string",
-            "description": "Full booking URL for this private link",
-            "format": "uri",
-            "example": "https://cal.com/d/abc123def456/30min"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "Maximum number of times this link can be used",
-            "example": 10
-          },
-          "usageCount": {
-            "type": "number",
-            "description": "Current usage count for this link",
-            "example": 3
-          }
-        },
-        "required": [
-          "linkId",
-          "eventTypeId",
-          "isExpired",
-          "bookingUrl",
-          "maxUsageCount",
-          "usageCount"
-        ]
-      },
-      "CreatePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "description": "Created private link data (either time-based or usage-based)",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-              },
-              {
-                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-              }
-            ]
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "GetPrivateLinksOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "type": "array",
-            "description": "Array of private links for the event type (mix of time-based and usage-based)",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-                },
-                {
-                  "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "UpdatePrivateLinkBody": {
-        "type": "object",
-        "properties": {
-          "expiresAt": {
-            "format": "date-time",
-            "type": "string",
-            "description": "New expiration date for time-based links",
-            "example": "2024-12-31T23:59:59.000Z"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "New maximum number of times the link can be used",
-            "example": 10,
-            "minimum": 1
-          }
-        }
-      },
-      "UpdatePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "description": "Updated private link data (either time-based or usage-based)",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-              },
-              {
-                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-              }
-            ]
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "DeletePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "type": "object",
-            "description": "Deleted link information",
-            "properties": {
-              "linkId": {
-                "type": "string",
-                "example": "abc123def456"
-              },
-              "message": {
-                "type": "string",
-                "example": "Private link deleted successfully"
-              }
-            }
           }
         },
         "required": [

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -4384,6 +4384,292 @@
         ]
       }
     },
+    "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links": {
+      "post": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_createPrivateLink",
+        "summary": "Create a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrivateLinkInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      },
+      "get": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_getPrivateLinks",
+        "summary": "Get all private links for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPrivateLinksOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      }
+    },
+    "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links/{linkId}": {
+      "patch": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_updatePrivateLink",
+        "summary": "Update a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "linkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      },
+      "delete": {
+        "operationId": "OrganizationsEventTypesPrivateLinksController_deletePrivateLink",
+        "summary": "Delete a private link for a team event type",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "For non-platform customers - value must be `Bearer <token>` where `<token>` is api key prefixed with cal_",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-secret-key",
+            "in": "header",
+            "description": "For platform customers - OAuth client secret key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-cal-client-id",
+            "in": "header",
+            "description": "For platform customers - OAuth client ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "eventTypeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "linkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletePrivateLinkOutput"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orgs / Teams / Event Types / Private Links"
+        ]
+      }
+    },
     "/v2/organizations/{orgId}/teams/{teamId}/memberships": {
       "get": {
         "operationId": "OrganizationsTeamsMembershipsController_getAllOrgTeamMemberships",
@@ -23726,6 +24012,213 @@
           }
         }
       },
+      "CreatePrivateLinkInput": {
+        "type": "object",
+        "properties": {
+          "expiresAt": {
+            "type": "string",
+            "description": "Expiration date for time-based links",
+            "format": "date-time",
+            "example": "2024-12-31T23:59:59.000Z"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use).",
+            "example": 10,
+            "minimum": 1,
+            "default": 1
+          }
+        }
+      },
+      "TimeBasedPrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "type": "string",
+            "description": "The private link ID",
+            "example": "abc123def456"
+          },
+          "eventTypeId": {
+            "type": "number",
+            "description": "Event type ID this link belongs to",
+            "example": 123
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "Whether the link is currently expired",
+            "example": false
+          },
+          "bookingUrl": {
+            "type": "string",
+            "description": "Full booking URL for this private link",
+            "format": "uri",
+            "example": "https://cal.com/d/abc123def456/30min"
+          },
+          "expiresAt": {
+            "type": "string",
+            "description": "Expiration date for this time-based link",
+            "format": "date-time",
+            "example": "2025-12-31T23:59:59.000Z"
+          }
+        },
+        "required": [
+          "linkId",
+          "eventTypeId",
+          "isExpired",
+          "bookingUrl",
+          "expiresAt"
+        ]
+      },
+      "UsageBasedPrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "type": "string",
+            "description": "The private link ID",
+            "example": "abc123def456"
+          },
+          "eventTypeId": {
+            "type": "number",
+            "description": "Event type ID this link belongs to",
+            "example": 123
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "Whether the link is currently expired",
+            "example": false
+          },
+          "bookingUrl": {
+            "type": "string",
+            "description": "Full booking URL for this private link",
+            "format": "uri",
+            "example": "https://cal.com/d/abc123def456/30min"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "Maximum number of times this link can be used",
+            "example": 10
+          },
+          "usageCount": {
+            "type": "number",
+            "description": "Current usage count for this link",
+            "example": 3
+          }
+        },
+        "required": [
+          "linkId",
+          "eventTypeId",
+          "isExpired",
+          "bookingUrl",
+          "maxUsageCount",
+          "usageCount"
+        ]
+      },
+      "CreatePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "description": "Created private link data (either time-based or usage-based)",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+              },
+              {
+                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "GetPrivateLinksOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "type": "array",
+            "description": "Array of private links for the event type (mix of time-based and usage-based)",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+                },
+                {
+                  "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "UpdatePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "description": "Updated private link data (either time-based or usage-based)",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
+              },
+              {
+                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
+      "DeletePrivateLinkOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Response status",
+            "example": "success"
+          },
+          "data": {
+            "type": "object",
+            "description": "Deleted link information",
+            "properties": {
+              "linkId": {
+                "type": "string",
+                "example": "abc123def456"
+              },
+              "message": {
+                "type": "string",
+                "example": "Private link deleted successfully"
+              }
+            }
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ]
+      },
       "StripConnectOutputDto": {
         "type": "object",
         "properties": {
@@ -25573,6 +26066,23 @@
           "status",
           "data"
         ]
+      },
+      "UpdatePrivateLinkBody": {
+        "type": "object",
+        "properties": {
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "New expiration date for time-based links",
+            "example": "2024-12-31T23:59:59.000Z"
+          },
+          "maxUsageCount": {
+            "type": "number",
+            "description": "New maximum number of times the link can be used",
+            "example": 10,
+            "minimum": 1
+          }
+        }
       },
       "MeOrgOutput": {
         "type": "object",
@@ -28212,230 +28722,6 @@
           },
           "data": {
             "$ref": "#/components/schemas/TeamMembershipOutput"
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "CreatePrivateLinkInput": {
-        "type": "object",
-        "properties": {
-          "expiresAt": {
-            "type": "string",
-            "description": "Expiration date for time-based links",
-            "format": "date-time",
-            "example": "2024-12-31T23:59:59.000Z"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use).",
-            "example": 10,
-            "minimum": 1,
-            "default": 1
-          }
-        }
-      },
-      "TimeBasedPrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "linkId": {
-            "type": "string",
-            "description": "The private link ID",
-            "example": "abc123def456"
-          },
-          "eventTypeId": {
-            "type": "number",
-            "description": "Event type ID this link belongs to",
-            "example": 123
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "Whether the link is currently expired",
-            "example": false
-          },
-          "bookingUrl": {
-            "type": "string",
-            "description": "Full booking URL for this private link",
-            "format": "uri",
-            "example": "https://cal.com/d/abc123def456/30min"
-          },
-          "expiresAt": {
-            "type": "string",
-            "description": "Expiration date for this time-based link",
-            "format": "date-time",
-            "example": "2025-12-31T23:59:59.000Z"
-          }
-        },
-        "required": [
-          "linkId",
-          "eventTypeId",
-          "isExpired",
-          "bookingUrl",
-          "expiresAt"
-        ]
-      },
-      "UsageBasedPrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "linkId": {
-            "type": "string",
-            "description": "The private link ID",
-            "example": "abc123def456"
-          },
-          "eventTypeId": {
-            "type": "number",
-            "description": "Event type ID this link belongs to",
-            "example": 123
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "Whether the link is currently expired",
-            "example": false
-          },
-          "bookingUrl": {
-            "type": "string",
-            "description": "Full booking URL for this private link",
-            "format": "uri",
-            "example": "https://cal.com/d/abc123def456/30min"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "Maximum number of times this link can be used",
-            "example": 10
-          },
-          "usageCount": {
-            "type": "number",
-            "description": "Current usage count for this link",
-            "example": 3
-          }
-        },
-        "required": [
-          "linkId",
-          "eventTypeId",
-          "isExpired",
-          "bookingUrl",
-          "maxUsageCount",
-          "usageCount"
-        ]
-      },
-      "CreatePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "description": "Created private link data (either time-based or usage-based)",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-              },
-              {
-                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-              }
-            ]
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "GetPrivateLinksOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "type": "array",
-            "description": "Array of private links for the event type (mix of time-based and usage-based)",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-                },
-                {
-                  "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "UpdatePrivateLinkBody": {
-        "type": "object",
-        "properties": {
-          "expiresAt": {
-            "format": "date-time",
-            "type": "string",
-            "description": "New expiration date for time-based links",
-            "example": "2024-12-31T23:59:59.000Z"
-          },
-          "maxUsageCount": {
-            "type": "number",
-            "description": "New maximum number of times the link can be used",
-            "example": 10,
-            "minimum": 1
-          }
-        }
-      },
-      "UpdatePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "description": "Updated private link data (either time-based or usage-based)",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TimeBasedPrivateLinkOutput"
-              },
-              {
-                "$ref": "#/components/schemas/UsageBasedPrivateLinkOutput"
-              }
-            ]
-          }
-        },
-        "required": [
-          "status",
-          "data"
-        ]
-      },
-      "DeletePrivateLinkOutput": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "Response status",
-            "example": "success"
-          },
-          "data": {
-            "type": "object",
-            "description": "Deleted link information",
-            "properties": {
-              "linkId": {
-                "type": "string",
-                "example": "abc123def456"
-              },
-              "message": {
-                "type": "string",
-                "example": "Private link deleted successfully"
-              }
-            }
           }
         },
         "required": [

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/platform-libraries",
-  "version": "9.9.9",
+  "version": "0.0.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/platform-libraries",
-  "version": "0.0.0",
+  "version": "9.9.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@ __metadata:
     "@axiomhq/winston": ^1.2.0
     "@calcom/platform-constants": "*"
     "@calcom/platform-enums": "*"
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9"
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.303"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -3559,7 +3559,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries@npm:@calcom/platform-libraries@9.9.9, @calcom/platform-libraries@workspace:packages/platform/libraries":
+"@calcom/platform-libraries@npm:@calcom/platform-libraries@0.0.303":
+  version: 0.0.303
+  resolution: "@calcom/platform-libraries@npm:0.0.303"
+  dependencies:
+    "@calcom/features": "*"
+    "@calcom/lib": "*"
+  checksum: 5db04a58d66673cf17983560e90b4b57ba1662a75ebac27303eb16f7692853940c6024444dfcf20f782b01fe640546dbefbe15e6f38a1eccd489cb6a4f3d8ff2
+  languageName: node
+  linkType: hard
+
+"@calcom/platform-libraries@workspace:packages/platform/libraries":
   version: 0.0.0-use.local
   resolution: "@calcom/platform-libraries@workspace:packages/platform/libraries"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@ __metadata:
     "@axiomhq/winston": ^1.2.0
     "@calcom/platform-constants": "*"
     "@calcom/platform-enums": "*"
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.300"
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -3559,17 +3559,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries@npm:@calcom/platform-libraries@0.0.300":
-  version: 0.0.300
-  resolution: "@calcom/platform-libraries@npm:0.0.300"
-  dependencies:
-    "@calcom/features": "*"
-    "@calcom/lib": "*"
-  checksum: bff9f08a0586169f2d5a85167f0a0e0e57ca93b637ca858a72b5d3d943ceef37d652efa3d2e6f7561548e4dfe3aabb5c0c6e0a8d38f68d3d21d5e6993e56ad7d
-  languageName: node
-  linkType: hard
-
-"@calcom/platform-libraries@workspace:packages/platform/libraries":
+"@calcom/platform-libraries@npm:@calcom/platform-libraries@9.9.9, @calcom/platform-libraries@workspace:packages/platform/libraries":
   version: 0.0.0-use.local
   resolution: "@calcom/platform-libraries@workspace:packages/platform/libraries"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@ __metadata:
     "@axiomhq/winston": ^1.2.0
     "@calcom/platform-constants": "*"
     "@calcom/platform-enums": "*"
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9"
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.306"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -3559,7 +3559,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries@npm:@calcom/platform-libraries@9.9.9, @calcom/platform-libraries@workspace:packages/platform/libraries":
+"@calcom/platform-libraries@npm:@calcom/platform-libraries@0.0.306":
+  version: 0.0.306
+  resolution: "@calcom/platform-libraries@npm:0.0.306"
+  dependencies:
+    "@calcom/features": "*"
+    "@calcom/lib": "*"
+  checksum: 602b8b446508429096b8e03e9edbe1ff744cf7c7af3fbe8a683aaaf0d3c96d1cd30ff356f72682449ca072beadaae95fdaa5c44b26e30cfce3bb838f519216f9
+  languageName: node
+  linkType: hard
+
+"@calcom/platform-libraries@workspace:packages/platform/libraries":
   version: 0.0.0-use.local
   resolution: "@calcom/platform-libraries@workspace:packages/platform/libraries"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@ __metadata:
     "@axiomhq/winston": ^1.2.0
     "@calcom/platform-constants": "*"
     "@calcom/platform-enums": "*"
-    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@0.0.303"
+    "@calcom/platform-libraries": "npm:@calcom/platform-libraries@9.9.9"
     "@calcom/platform-types": "*"
     "@calcom/platform-utils": "*"
     "@calcom/prisma": "*"
@@ -3559,17 +3559,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/platform-libraries@npm:@calcom/platform-libraries@0.0.303":
-  version: 0.0.303
-  resolution: "@calcom/platform-libraries@npm:0.0.303"
-  dependencies:
-    "@calcom/features": "*"
-    "@calcom/lib": "*"
-  checksum: 5db04a58d66673cf17983560e90b4b57ba1662a75ebac27303eb16f7692853940c6024444dfcf20f782b01fe640546dbefbe15e6f38a1eccd489cb6a4f3d8ff2
-  languageName: node
-  linkType: hard
-
-"@calcom/platform-libraries@workspace:packages/platform/libraries":
+"@calcom/platform-libraries@npm:@calcom/platform-libraries@9.9.9, @calcom/platform-libraries@workspace:packages/platform/libraries":
   version: 0.0.0-use.local
   resolution: "@calcom/platform-libraries@workspace:packages/platform/libraries"
   dependencies:


### PR DESCRIPTION
## What does this PR do?

#### Summary
- Added org/team-scoped private links endpoints that mirror the permissions/guards of Orgs / Teams / Event Types.
- Reused existing private links service; validated team ownership for event types.
- Added e2e tests for the new endpoints.

#### Endpoints
- POST `/v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links`
- GET `/v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links`
- PATCH `/v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links/:linkId`
- DELETE `/v2/organizations/:orgId/teams/:teamId/event-types/:eventTypeId/private-links/:linkId`

#### Permissions and guards
- Decorators: `@Roles("TEAM_ADMIN")`, `@PlatformPlan("ESSENTIALS")`
- Guards: `ApiAuthGuard`, `IsOrgGuard`, `RolesGuard`, `IsTeamInOrg`, `PlatformPlanGuard`, `IsAdminAPIEnabledGuard`
- Event type/Team relationship is enforced via `TeamsEventTypesService.validateEventTypeExists(teamId, eventTypeId)`

#### Implementation notes
- Controller: `apps/api/v2/src/ee/event-types-private-links/controllers/organizations-event-types-private-links.controller.ts`
- Uses existing `PrivateLinksService` for create/list/update/delete.
- Returns standardized responses with `SUCCESS_STATUS` and platform-types outputs.

#### Module changes
- Registered the new controller in `OrganizationsModule`:
  - Imports `EventTypesPrivateLinksModule` for the service.
  - Adds `OrganizationsEventTypesPrivateLinksController` to controllers.
- Slimmed `EventTypesPrivateLinksModule` to only event-type-scoped endpoints and exported `PrivateLinksService`.

#### Tests
- New e2e: `apps/api/v2/src/modules/organizations/event-types/organizations-event-types-private-links.e2e-spec.ts`
  - Covers POST/GET/PATCH/DELETE happy paths.
  - Uses fixtures to create org, team, and team-owned event type.
  - Overrides plan/admin/roles guards for focus; auth remains enabled.

#### API surface and data model
- No DB schema changes.
- No breaking changes for existing endpoints.
- Private link objects and behaviors match the existing event-type private links controller.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Ensure you’re authenticated and a TEAM_ADMIN in the org/team.
- Create a team event type, then:
  - POST to create a link; expect 201 and `data.linkId`.
  - GET to list links; expect 200 with array.
  - PATCH `:linkId` to update `maxUsageCount`; expect 200 with updated value.
  - DELETE `:linkId`; expect 200 with `data.linkId`.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
