### PR TITLE
fix: remove network level caching for i18n

### DIFF
--- a/packages/lib/server/i18n.ts
+++ b/packages/lib/server/i18n.ts
@@ -33,7 +33,7 @@ export async function loadTranslations(_locale: string, _ns: string) {
     const response = await fetchWithTimeout(
       url,
       {
-        cache: process.env.NODE_ENV === "production" ? "force-cache" : "no-store",
+        cache: "no-store",
       },
       process.env.NODE_ENV === "development" ? 30000 : 3000
     );


### PR DESCRIPTION
## What does this PR do?

- We already have application-level caching for translations: https://github.com/calcom/cal.com/blob/main/packages/lib/server/i18n.ts#L11
- We can remove the network level caching so that we don't use the cached version of translations during deployments

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.