### PR TITLE
fix: more precise error code for event type duplication handler

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.test.ts
@@ -1,0 +1,48 @@
+import prismaMock from "../../../../../../tests/libs/__mocks__/prismaMock";
+
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { TRPCError } from "@trpc/server";
+
+import { duplicateHandler } from "./duplicate.handler";
+
+vi.mock("@calcom/prisma", () => ({
+  default: prismaMock,
+}));
+vi.mock("@calcom/lib/server/repository/eventTypeRepository");
+vi.mock("@calcom/lib/server/repository/calVideoSettings");
+vi.mock("../../viewer/calendars/setDestinationCalendar.handler");
+
+describe("duplicateHandler", () => {
+  const ctx = { user: { id: 1, profile: { id: 1 } } } as any;
+  const input = { id: 123, slug: "test-event", title: "Test", description: "Test", length: 30, teamId: null };
+  const eventType = { id: 123, userId: 1, teamId: null, users: [{ id: 1 }] };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    prismaMock.eventType.findUnique.mockResolvedValue(eventType);
+  });
+
+  it("should throw BAD_REQUEST in case of unique constraint violation", async () => {
+    const { EventTypeRepository } = await import("@calcom/lib/server/repository/eventTypeRepository");
+    vi.mocked(EventTypeRepository).mockImplementation(
+      () =>
+        ({
+          create: vi.fn().mockRejectedValue(
+            new PrismaClientKnownRequestError("Unique constraint failed", {
+              code: "P2002",
+              clientVersion: "mockedVersion",
+            })
+          ),
+        } as any)
+    );
+
+    await expect(duplicateHandler({ ctx, input })).rejects.toThrow(
+      new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Unique constraint violation while creating a duplicate event.",
+      })
+    );
+  });
+});

--- a/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.test.ts
@@ -11,8 +11,6 @@ vi.mock("@calcom/prisma", () => ({
   default: prismaMock,
 }));
 vi.mock("@calcom/lib/server/repository/eventTypeRepository");
-vi.mock("@calcom/lib/server/repository/calVideoSettings");
-vi.mock("../../viewer/calendars/setDestinationCalendar.handler");
 
 describe("duplicateHandler", () => {
   const ctx = { user: { id: 1, profile: { id: 1 } } } as any;

--- a/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
@@ -166,19 +166,8 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
     }
 
     const eventTypeRepo = new EventTypeRepository(prisma);
-    let newEventType;
-    try {
-      newEventType = await eventTypeRepo.create(data);
-    } catch (error: unknown) {
-      if (error instanceof PrismaClientKnownRequestError && error.code === "P2002") {
-        // unique constraint violation
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Unique constraint violation while creating a duplicate event.",
-        });
-      }
-      throw error;
-    }
+
+    const newEventType = await eventTypeRepo.create(data);
 
     // Create custom inputs
     if (customInputs) {
@@ -239,6 +228,13 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
       eventType: newEventType,
     };
   } catch (error) {
+    if (error instanceof PrismaClientKnownRequestError && error.code === "P2002") {
+      // unique constraint violation
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Unique constraint violation while creating a duplicate event.",
+      });
+    }
     throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Error duplicating event type ${error}` });
   }
 };

--- a/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
@@ -166,7 +166,6 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
     }
 
     const eventTypeRepo = new EventTypeRepository(prisma);
-
     const newEventType = await eventTypeRepo.create(data);
 
     // Create custom inputs

--- a/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/duplicate.handler.ts
@@ -1,5 +1,4 @@
 import { Prisma } from "@prisma/client";
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 import { generateHashedLink } from "@calcom/lib/generateHashedLink";
 import { CalVideoSettingsRepository } from "@calcom/lib/server/repository/calVideoSettings";
@@ -227,7 +226,7 @@ export const duplicateHandler = async ({ ctx, input }: DuplicateOptions) => {
       eventType: newEventType,
     };
   } catch (error) {
-    if (error instanceof PrismaClientKnownRequestError && error.code === "P2002") {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
       // unique constraint violation
       throw new TRPCError({
         code: "BAD_REQUEST",


### PR DESCRIPTION
## What does this PR do?

We can see this error quite a number of times
```
Something went wrong Error [TRPCError]: Error duplicating event type PrismaClientKnownRequestError: Invalid `prisma.eventType.create()` invocation: Unique constraint failed on the fields: (`userId`,`slug`)
```

It's being conceived as error code 500 when it should be 400.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- I added an unit test