### PR TITLE
fix: add authentication guard to /apps/installed routes

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
@@ -37,7 +37,7 @@ const InstalledAppsWrapper = async ({ params }: PageProps) => {
 
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
   if (!session?.user?.id) {
-    redirect("/auth/login");
+    return redirect("/auth/login");
   }
 
   const [calendarsCaller, appsCaller] = await Promise.all([

--- a/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
@@ -1,12 +1,16 @@
 import { createRouterCaller } from "app/_trpc/context";
 import type { PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { AppCategories } from "@calcom/prisma/enums";
 import { appsRouter } from "@calcom/trpc/server/routers/viewer/apps/_router";
 import { calendarsRouter } from "@calcom/trpc/server/routers/viewer/calendars/_router";
+
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import InstalledApps from "~/apps/installed/[category]/installed-category-view";
 
@@ -29,6 +33,11 @@ const InstalledAppsWrapper = async ({ params }: PageProps) => {
 
   if (!parsedParams.success) {
     redirect("/apps/installed/calendar");
+  }
+
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+  if (!session?.user?.id) {
+    redirect("/auth/login");
   }
 
   const [calendarsCaller, appsCaller] = await Promise.all([


### PR DESCRIPTION
# fix: add authentication guard to /apps/installed routes

## Summary

This PR fixes a 500 error that occurs when unauthenticated users access `/apps/installed/calendar` (and other installed app categories). The issue was caused by the server component making tRPC calls without first validating that a user session exists.

**Changes made:**
- Added session validation using `getServerSession` before making tRPC calls in the `/apps/installed/[category]` server component  
- Redirects unauthenticated users to `/auth/login` instead of allowing the server to throw 500 errors
- Follows the same authentication pattern used consistently throughout the Cal.com codebase

**Root cause:** The server component was calling `createRouterCaller` for tRPC operations without ensuring a valid session existed first. When `getTRPCContext` is called without a session, subsequent database queries fail, resulting in 500 errors.

## Review & Testing Checklist for Human

- [x] **Verify authentication logic matches existing patterns** - Compare the session check implementation with other server components like `/availability/page.tsx` and `/event-types/page.tsx` to ensure consistency
- [x] **Test unauthenticated redirect flow** - Navigate to `/apps/installed/calendar` without being logged in and verify it redirects to `/auth/login` instead of showing a 500 error
- [ ] **Test authenticated user flow** - Ensure logged-in users can still access `/apps/installed/calendar` and other categories normally without any regressions
- [ ] **Test multiple app categories** - Verify the fix works for all installed app categories (conferencing, payment, etc.), not just calendar
- [ ] **Check middleware interaction** - Ensure the server-level auth check doesn't conflict with existing middleware logic that handles `return-to` cookies for `/apps/installed` routes

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    User[["User Access<br/>/apps/installed/calendar"]] --> Middleware[["middleware.ts<br/>(return-to cookie logic)"]]:::context
    Middleware --> PageComponent[["apps/installed/[category]/page.tsx<br/><br/>NEW: Session Check Added"]]:::major-edit
    
    PageComponent --> SessionCheck{{"getServerSession()<br/>validation"}}
    SessionCheck -->|"No Session"| LoginRedirect[["redirect('/auth/login')"]]:::major-edit
    SessionCheck -->|"Valid Session"| TRPCCalls[["createRouterCaller()<br/>calendarsRouter & appsRouter"]]:::context
    
    TRPCCalls --> GetServerSession[["@calcom/features/auth/lib/<br/>getServerSession"]]:::context
    TRPCCalls --> BuildLegacyRequest[["@lib/buildLegacyCtx"]]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

**Testing performed:**
- ✅ Type checking passed (`yarn type-check:ci --force`)
- ✅ Local testing confirmed unauthenticated users redirect to `/auth/login`
- ✅ Tested multiple categories (`/calendar`, `/conferencing`) - both redirect correctly
- ⚠️ Lint failed in unrelated `@calcom/lib` package (not related to this change)

**Session details:**
- Link to Devin run: https://app.devin.ai/sessions/cccbdc9ce00844aabe2d63162db9450b
- Requested by: @emrysal

**Screenshots of successful redirect:**
![Authentication redirect working](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_oJuTJ80VM9letuVV/ae9f48fe-11e1-402a-9f4f-512758314cf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7WIXTJXWM%2F20250814%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250814T140713Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEP7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIDY6kINYfoAqBV93D%2FEc4CNDVHCm8993VZ7LZZeMH3BoAiEA7Np4020RBSeVlwKW9KAkC97Wa6kfSn5pEenvbhiiYuoqtwUIRxABGgwyNzI1MDY0OTgzMDMiDOCJBMiAHTBM8i7ckiqUBSwrdTAqz2B9q1w9WPTrpTYNheGZEIFBptMAKp6nlcX%2FNDabtgXn0hBTBHTHtxJmCm%2B%2BP4sKvmioLkl7xUe4uyNL0nVC3pMR3RK3IUToalgFTZNApFElYQcUFd%2F6hfvjrvS7KYZ8yIGYR8an4GDhrW7KM9HOy3Tad%2FH2nN5fG%2BEvmBAbLiJA2BA9IuMNn8hwRp7vyhjtQLlI3YA3L5POk%2B0TRZNtAHFo52LorjMvo8vVodAQ5xZRm4MjikFk8wLs8w6c3Ac3IKO9rjqf1VYnr5gxdZeYQyW99v3I2bC2MULU8xHV4j%2BxsuewvncBk3Dz%2FUc9VhO%2Bosogxg3tRA2VoONqRmwZS8a2dpoW4QM%2FQI6HAd9H5Nq1MQ5xgH7FRxCDPq2chIKH21Fdd%2B4XeoTU810oFd2ADMjyOQ2ow%2Fxu365n9VhcFRVvqkYasmWIl0YzWvIbHeMB9sv7Dbv%2Bq7c77MHNpAcn2GHMertSSIFnlpzUFwToe%2BUf8iGU6EM7qWj0%2FWMNFRBWSMxSs9Pm02nWPm6PUfm0lL3nNm5mc5Ix86Nil5F1RnDxSDWTyfLkHZCzM6i%2FKTM7ZxgFcxNiawSyF9r5UhL41yMUTrgXuQPx61TMIMv9SWEXHb3i7a2QftW5FzN9P%2FnJi41EbeffOmqCeIbEQ26x7rh0cH2bLn2mvReQ%2FVqJHQG5o1BoCf2owwZx3mDfiWUOarUI48rpYBnyejfURtCZ2eZrlivZFLDwc%2FSolh3Sz1NQQ2ltokFEQJMcreOKRAH0qne3%2FF%2By0I7mOFSKlDmsVYwHbiNy%2F%2BksWRNl0D736tAsfqjsMQxi%2F9CoXpHGGx1n5hpHtBWm50ETMH7sn25xXw3oQ%2FGWbV972aoMblwnoTCx1ffEBjqYAZeZzDN%2FdwPtBGydDtsvgtZz5rGz8aUpaPzXQr0Yb9MrmkmY8BuA%2B6FYvU6UecPh6zMiBzkAg4eQI9JtA5WxwIVl1VSsLBKc7em7ub3vxluwTaHDq9MTy4I9toWocuNIQ%2BE%2FTKCjh%2F08%2BpFyTkPza%2BRdj2UtRo4Iadv3oyhWKHSYx4yoLk7%2Bmk2ml3T439MELqbfUMtO3uji&X-Amz-Signature=e5f278609f0100147339942b3cf263729c5799e603f6d57a97073b3d82ae1dcf)
![Conferencing category redirect](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_oJuTJ80VM9letuVV/21110cd2-aaf4-4d37-a030-db4835fd4bed?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7WIXTJXWM%2F20250814%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250814T140713Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEP7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIDY6kINYfoAqBV93D%2FEc4CNDVHCm8993VZ7LZZeMH3BoAiEA7Np4020RBSeVlwKW9KAkC97Wa6kfSn5pEenvbhiiYuoqtwUIRxABGgwyNzI1MDY0OTgzMDMiDOCJBMiAHTBM8i7ckiqUBSwrdTAqz2B9q1w9WPTrpTYNheGZEIFBptMAKp6nlcX%2FNDabtgXn0hBTBHTHtxJmCm%2B%2BP4sKvmioLkl7xUe4uyNL0nVC3pMR3RK3IUToalgFTZNApFElYQcUFd%2F6hfvjrvS7KYZ8yIGYR8an4GDhrW7KM9HOy3Tad%2FH2nN5fG%2BEvmBAbLiJA2BA9IuMNn8hwRp7vyhjtQLlI3YA3L5POk%2B0TRZNtAHFo52LorjMvo8vVodAQ5xZRm4MjikFk8wLs8w6c3Ac3IKO9rjqf1VYnr5gxdZeYQyW99v3I2bC2MULU8xHV4j%2BxsuewvncBk3Dz%2FUc9VhO%2Bosogxg3tRA2VoONqRmwZS8a2dpoW4QM%2FQI6HAd9H5Nq1MQ5xgH7FRxCDPq2chIKH21Fdd%2B4XeoTU810oFd2ADMjyOQ2ow%2Fxu365n9VhcFRVvqkYasmWIl0YzWvIbHeMB9sv7Dbv%2Bq7c77MHNpAcn2GHMertSSIFnlpzUFwToe%2BUf8iGU6EM7qWj0%2FWMNFRBWSMxSs9Pm02nWPm6PUfm0lL3nNm5mc5Ix86Nil5F1RnDxSDWTyfLkHZCzM6i%2FKTM7ZxgFcxNiawSyF9r5UhL41yMUTrgXuQPx61TMIMv9SWEXHb3i7a2QftW5FzN9P%2FnJi41EbeffOmqCeIbEQ26x7rh0cH2bLn2mvReQ%2FVqJHQG5o1BoCf2owwZx3mDfiWUOarUI48rpYBnyejfURtCZ2eZrlivZFLDwc%2FSolh3Sz1NQQ2ltokFEQJMcreOKRAH0qne3%2FF%2By0I7mOFSKlDmsVYwHbiNy%2F%2BksWRNl0D736tAsfqjsMQxi%2F9CoXpHGGx1n5hpHtBWm50ETMH7sn25xXw3oQ%2FGWbV972aoMblwnoTCx1ffEBjqYAZeZzDN%2FdwPtBGydDtsvgtZz5rGz8aUpaPzXQr0Yb9MrmkmY8BuA%2B6FYvU6UecPh6zMiBzkAg4eQI9JtA5WxwIVl1VSsLBKc7em7ub3vxluwTaHDq9MTy4I9toWocuNIQ%2BE%2FTKCjh%2F08%2BpFyTkPza%2BRdj2UtRo4Iadv3oyhWKHSYx4yoLk7%2Bmk2ml3T439MELqbfUMtO3uji&X-Amz-Signature=feeda5d3fdda2103c553b2ec50b8d56e2f8361f309f0faa8e8f57450a2250ed2)