### PR TITLE
fix: ensure Hide Team Profile setting works for managed event types

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -106,6 +106,7 @@ export const getPublicEventSelect = (fetchAllUsers: boolean) => {
             name: true,
             bannerUrl: true,
             logoUrl: true,
+            hideTeamProfileLink: true,
           },
         },
         isPrivate: true,
@@ -542,7 +543,10 @@ export const getPublicEvent = async (
           eventWithUserProfiles.team?.parent?.name ||
           eventWithUserProfiles.team?.name) ??
         null,
-      hideProfileLink: eventWithUserProfiles.team?.hideTeamProfileLink ?? false,
+      hideProfileLink:
+        eventWithUserProfiles.team?.hideTeamProfileLink ??
+        eventWithUserProfiles.team?.parent?.hideTeamProfileLink ??
+        false,
       ...(orgDetails
         ? {
             logoUrl: getPlaceholderAvatar(orgDetails?.logoUrl, orgDetails?.name),
@@ -842,7 +846,10 @@ const getPublicEventRefactored = async (
           eventWithUserProfiles.team?.parent?.name ||
           eventWithUserProfiles.team?.name) ??
         null,
-      hideProfileLink: eventWithUserProfiles.team?.hideTeamProfileLink ?? false,
+      hideProfileLink:
+        eventWithUserProfiles.team?.hideTeamProfileLink ??
+        eventWithUserProfiles.team?.parent?.hideTeamProfileLink ??
+        false,
       ...(orgDetails
         ? {
             logoUrl: getPlaceholderAvatar(orgDetails?.logoUrl, orgDetails?.name),


### PR DESCRIPTION
# Fix "Hide Team Profile" setting for managed event types

## Summary
Fixed a bug where the "Hide Team Profile" setting wasn't working for teams with only managed event types. The issue was that managed events (which have `parentId` set) weren't inheriting the parent team's `hideTeamProfileLink` setting, causing profile links to still appear in the booking interface when they should be hidden.

**Root Cause:** The `hideProfileLink` logic in `getPublicEvent.ts` was only checking the direct team's `hideTeamProfileLink` setting, but managed events have complex parent-child relationships where the setting needs to be inherited from the parent team.

**Fix:** Modified the `hideProfileLink` logic in both `getPublicEvent` and `getPublicEventRefactored` functions to check the parent team's `hideTeamProfileLink` setting as a fallback when the direct team setting is not available.

## Review & Testing Checklist for Human
- [ ] **Critical: Test managed event types end-to-end** - Create a team with only managed event types, enable "Hide Team Profile" setting, and verify profile links are hidden during booking flow
- [ ] **Investigate CI test failure** - The "Tests / Unit" check is failing in CI (though all 2889 tests pass locally), determine if this is related to the changes or a flaky test
- [ ] **Verify regular team events still work** - Test that non-managed team events continue to respect the "Hide Team Profile" setting correctly
- [ ] **Check edge cases** - Test scenarios with mixed managed/non-managed events, nested team structures, and organizations

**Recommended Test Plan:**
1. Create a test team with managed event types only
2. Enable "Hide Team Profile" in team appearance settings  
3. Book a managed event and verify no profile links appear
4. Test a regular team event to ensure no regression
5. Test with mixed event types (managed + regular)

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User["User books managed event"] --> BookingFlow["Booking interface"]
    BookingFlow --> getPublicEvent["getPublicEvent.ts<br/>(MODIFIED)"]:::major-edit
    
    getPublicEvent --> TeamQuery["Database query<br/>includes parent team data"]
    TeamQuery --> HideLogic["hideProfileLink logic<br/>checks team AND parent team"]:::major-edit
    
    HideLogic --> Members["Members.tsx<br/>component"]:::context
    Members --> UI["Profile links hidden/shown<br/>in booking UI"]
    
    TeamSettings["Team appearance settings<br/>hideTeamProfileLink"]:::context --> TeamQuery
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes
**Unable to verify functionality**: Login issues prevented browser testing of the actual fix, so end-to-end verification by human reviewer is critical.

**CI Status**: Type checking and linting pass, but "Tests / Unit" fails in CI while all local tests pass (2889/2889), suggesting possible flaky test or environment issue.

**Performance Impact**: Minimal - added one field (`hideTeamProfileLink: true`) to existing parent team query.

**Backwards Compatibility**: Maintained - regular team events continue to work as before, only managed events get the additional fallback logic.

Link to Devin run: https://app.devin.ai/sessions/2180bc338bb94345a0c0807e4c7fa111  
Requested by: @joeauyeung