### PR TITLE
fix: Add cal.eu to `IS_CALCOM`

### DIFF
--- a/apps/web/app/_utils.tsx
+++ b/apps/web/app/_utils.tsx
@@ -5,6 +5,7 @@ import { getLocale } from "@calcom/features/auth/lib/getLocale";
 import type { AppImageProps, MeetingImageProps } from "@calcom/lib/OgImages";
 import { constructAppImage, constructGenericImage, constructMeetingImage } from "@calcom/lib/OgImages";
 import { IS_CALCOM, WEBAPP_URL, APP_NAME, SEO_IMG_OGIMG, CAL_URL } from "@calcom/lib/constants";
+import { getCalcomUrl } from "@calcom/lib/getCalcomUrl";
 import { buildCanonical } from "@calcom/lib/next-seo.config";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import { truncateOnWord } from "@calcom/lib/text";
@@ -32,7 +33,7 @@ const _generateMetadataWithoutImage = async (
   const description = getDescription(t);
   const titleSuffix = `| ${APP_NAME}`;
   const displayedTitle = title.includes(titleSuffix) || hideBranding ? title : `${title} ${titleSuffix}`;
-  const metadataBase = new URL(IS_CALCOM ? "https://cal.com" : WEBAPP_URL);
+  const metadataBase = new URL(IS_CALCOM ? getCalcomUrl() : WEBAPP_URL);
 
   return {
     title: title.length === 0 ? APP_NAME : displayedTitle,

--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -9,6 +9,7 @@ import Script from "next/script";
 import "@calcom/embed-core/src/embed-iframe";
 import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
 import { IS_CALCOM, WEBAPP_URL } from "@calcom/lib/constants";
+import { getCalcomUrl } from "@calcom/lib/getCalcomUrl";
 import { buildCanonical } from "@calcom/lib/next-seo.config";
 import { IconSprites } from "@calcom/ui/components/icon";
 
@@ -64,7 +65,7 @@ function PageWrapper(props: AppProps) {
         // Set canonical to https://cal.com or self-hosted URL
         canonical={
           IS_CALCOM
-            ? buildCanonical({ path, origin: "https://cal.com" }) // cal.com & .dev
+            ? buildCanonical({ path, origin: getCalcomUrl() }) // cal.com & .dev
             : buildCanonical({ path, origin: WEBAPP_URL }) // self-hosted
         }
         {...seoConfig.defaultNextSeo}

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -41,12 +41,12 @@ export const CAL_URL = new URL(WEBAPP_URL).hostname.endsWith(".vercel.app")
   : process.env.NEXT_PUBLIC_WEBSITE_URL || WEBAPP_URL;
 
 export const IS_CALCOM =
-  (WEBAPP_URL &&
-    (new URL(WEBAPP_URL).hostname.endsWith("cal.com") ||
-      new URL(WEBAPP_URL).hostname.endsWith("cal.dev") ||
-      new URL(WEBAPP_URL).hostname.endsWith("cal.qa") ||
-      new URL(WEBAPP_URL).hostname.endsWith("cal-staging.com"))) ||
-  new URL(WEBAPP_URL).hostname.endsWith("cal.eu");
+  WEBAPP_URL &&
+  (new URL(WEBAPP_URL).hostname.endsWith("cal.com") ||
+    new URL(WEBAPP_URL).hostname.endsWith("cal.dev") ||
+    new URL(WEBAPP_URL).hostname.endsWith("cal.qa") ||
+    new URL(WEBAPP_URL).hostname.endsWith("cal-staging.com") ||
+    new URL(WEBAPP_URL).hostname.endsWith("cal.eu"));
 
 export const CONSOLE_URL =
   new URL(WEBAPP_URL).hostname.endsWith(".cal.dev") ||

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -41,11 +41,12 @@ export const CAL_URL = new URL(WEBAPP_URL).hostname.endsWith(".vercel.app")
   : process.env.NEXT_PUBLIC_WEBSITE_URL || WEBAPP_URL;
 
 export const IS_CALCOM =
-  WEBAPP_URL &&
-  (new URL(WEBAPP_URL).hostname.endsWith("cal.com") ||
-    new URL(WEBAPP_URL).hostname.endsWith("cal.dev") ||
-    new URL(WEBAPP_URL).hostname.endsWith("cal.qa") ||
-    new URL(WEBAPP_URL).hostname.endsWith("cal-staging.com"));
+  (WEBAPP_URL &&
+    (new URL(WEBAPP_URL).hostname.endsWith("cal.com") ||
+      new URL(WEBAPP_URL).hostname.endsWith("cal.dev") ||
+      new URL(WEBAPP_URL).hostname.endsWith("cal.qa") ||
+      new URL(WEBAPP_URL).hostname.endsWith("cal-staging.com"))) ||
+  new URL(WEBAPP_URL).hostname.endsWith("cal.eu");
 
 export const CONSOLE_URL =
   new URL(WEBAPP_URL).hostname.endsWith(".cal.dev") ||

--- a/packages/lib/getCalcomUrl.ts
+++ b/packages/lib/getCalcomUrl.ts
@@ -1,0 +1,8 @@
+import { WEBAPP_URL, IS_CALCOM } from "./constants";
+
+export const getCalcomUrl = () => {
+  if (IS_CALCOM) {
+    return new URL(WEBAPP_URL).hostname.endsWith("cal.eu") ? "https://cal.eu" : "https://cal.com";
+  }
+  return WEBAPP_URL;
+};


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds cal.eu to the `IS_CALCOM` constant
- Changes where metadata and SEO data points to depending on the host


