### PR TITLE
feat: inherit parent team brand colors for managed event types

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -90,18 +90,6 @@ export const getPublicEventSelect = (fetchAllUsers: boolean) => {
     bookingFields: true,
     teamId: true,
     parentId: true,
-    parent: {
-      select: {
-        team: {
-          select: {
-            brandColor: true,
-            darkBrandColor: true,
-            name: true,
-            slug: true,
-          },
-        },
-      },
-    },
     team: {
       select: {
         parentId: true,
@@ -526,12 +514,30 @@ export const getPublicEvent = async (
     users = [];
   }
 
-  if (event.parentId && event.parent?.team && eventWithUserProfiles.team) {
-    if (event.parent.team.brandColor && !eventWithUserProfiles.team.brandColor) {
-      eventWithUserProfiles.team.brandColor = event.parent.team.brandColor;
-    }
-    if (event.parent.team.darkBrandColor && !eventWithUserProfiles.team.darkBrandColor) {
-      eventWithUserProfiles.team.darkBrandColor = event.parent.team.darkBrandColor;
+  if (
+    event.parentId &&
+    eventWithUserProfiles.team &&
+    (!eventWithUserProfiles.team.brandColor || !eventWithUserProfiles.team.darkBrandColor)
+  ) {
+    const parentEventType = await prisma.eventType.findUnique({
+      where: { id: event.parentId },
+      select: {
+        team: {
+          select: {
+            brandColor: true,
+            darkBrandColor: true,
+          },
+        },
+      },
+    });
+
+    if (parentEventType?.team) {
+      if (parentEventType.team.brandColor && !eventWithUserProfiles.team.brandColor) {
+        eventWithUserProfiles.team.brandColor = parentEventType.team.brandColor;
+      }
+      if (parentEventType.team.darkBrandColor && !eventWithUserProfiles.team.darkBrandColor) {
+        eventWithUserProfiles.team.darkBrandColor = parentEventType.team.darkBrandColor;
+      }
     }
   }
 
@@ -834,12 +840,26 @@ const getPublicEventRefactored = async (
     users = [];
   }
 
-  if (event.parentId && event.parent?.team && event.team) {
-    if (event.parent.team.brandColor && !event.team.brandColor) {
-      event.team.brandColor = event.parent.team.brandColor;
-    }
-    if (event.parent.team.darkBrandColor && !event.team.darkBrandColor) {
-      event.team.darkBrandColor = event.parent.team.darkBrandColor;
+  if (event.parentId && event.team && (!event.team.brandColor || !event.team.darkBrandColor)) {
+    const parentEventType = await prisma.eventType.findUnique({
+      where: { id: event.parentId },
+      select: {
+        team: {
+          select: {
+            brandColor: true,
+            darkBrandColor: true,
+          },
+        },
+      },
+    });
+
+    if (parentEventType?.team) {
+      if (parentEventType.team.brandColor && !event.team.brandColor) {
+        event.team.brandColor = parentEventType.team.brandColor;
+      }
+      if (parentEventType.team.darkBrandColor && !event.team.darkBrandColor) {
+        event.team.darkBrandColor = parentEventType.team.darkBrandColor;
+      }
     }
   }
 

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -89,6 +89,19 @@ export const getPublicEventSelect = (fetchAllUsers: boolean) => {
     seatsShowAvailabilityCount: true,
     bookingFields: true,
     teamId: true,
+    parentId: true,
+    parent: {
+      select: {
+        team: {
+          select: {
+            brandColor: true,
+            darkBrandColor: true,
+            name: true,
+            slug: true,
+          },
+        },
+      },
+    },
     team: {
       select: {
         parentId: true,
@@ -513,6 +526,15 @@ export const getPublicEvent = async (
     users = [];
   }
 
+  if (event.parentId && event.parent?.team && eventWithUserProfiles.team) {
+    if (event.parent.team.brandColor && !eventWithUserProfiles.team.brandColor) {
+      eventWithUserProfiles.team.brandColor = event.parent.team.brandColor;
+    }
+    if (event.parent.team.darkBrandColor && !eventWithUserProfiles.team.darkBrandColor) {
+      eventWithUserProfiles.team.darkBrandColor = event.parent.team.darkBrandColor;
+    }
+  }
+
   return {
     ...eventWithUserProfiles,
     bookerLayouts: bookerLayoutsSchema.parse(eventMetaData?.bookerLayouts || null),
@@ -810,6 +832,15 @@ const getPublicEventRefactored = async (
 
   if (event.team?.isPrivate && !isTeamAdminOrOwner && !isOrgAdminOrOwner) {
     users = [];
+  }
+
+  if (event.parentId && event.parent?.team && event.team) {
+    if (event.parent.team.brandColor && !event.team.brandColor) {
+      event.team.brandColor = event.parent.team.brandColor;
+    }
+    if (event.parent.team.darkBrandColor && !event.team.darkBrandColor) {
+      event.team.darkBrandColor = event.parent.team.darkBrandColor;
+    }
   }
 
   const eventDataShared = await processEventDataShared({


### PR DESCRIPTION
# feat: inherit parent team brand colors for managed event types

## Summary

This PR implements brand color inheritance for managed event types, ensuring that child event types display their parent team's brand colors on booking pages when the child's direct team doesn't have brand colors configured.

**Key Changes:**
- Modified `getPublicEventSelect` to include `parentId` and `parent.team` fields with brand color data
- Added brand color inheritance logic in both `getPublicEvent` and `getPublicEventRefactored` functions
- Child event types now inherit `brandColor` and `darkBrandColor` from parent team when their own team lacks these values

## Review & Testing Checklist for Human

- [ ] **End-to-end testing**: Create a managed event type with a parent team that has brand colors set, then verify the child event type's booking page displays the parent's brand colors correctly
- [ ] **Data mutation safety**: Verify that mutating the `event.team` object doesn't cause issues elsewhere in the codebase (check if these objects are used in other contexts)
- [ ] **Business logic validation**: Confirm that inheritance should only occur when child team has no brand colors (vs always inheriting from parent)
- [ ] **Query performance**: Monitor if adding `parent.team` selection impacts event type query performance, especially for organizations with many managed event types
- [ ] **Edge case testing**: Test scenarios like deeply nested managed event types, parent teams without brand colors, and non-managed event types to ensure no regressions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Schema["packages/prisma/schema.prisma<br/>EventType & Team models"]:::context
    GetPublicEvent["packages/features/eventtypes/lib/<br/>getPublicEvent.ts"]:::major-edit
    UseBrandColors["packages/features/bookings/Booker/utils/<br/>use-brand-colors.tsx"]:::context
    BookingPage["Booking Page Rendering"]:::context
    
    Schema --> GetPublicEvent
    GetPublicEvent --> UseBrandColors
    UseBrandColors --> BookingPage
    
    GetPublicEvent -.->|"adds parent.team selection<br/>+ inheritance logic"| GetPublicEvent
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

- The implementation follows existing patterns in the codebase for managed event type inheritance
- Type checking passed successfully, indicating the new fields integrate properly with existing types
- The solution addresses the issue at the data retrieval level rather than display level, ensuring consistency across all booking interfaces
- **Session details**: Requested by @joeauyeung | [Devin session](https://app.devin.ai/sessions/1047301031d84fce98badd5e5178cf81)