### PR TITLE
chore: Remove Vercel functions memory config

### DIFF
--- a/apps/api/v1/vercel.json
+++ b/apps/api/v1/vercel.json
@@ -1,5 +1,0 @@
-{
-  "functions": {
-    "pages/api/slots/*.ts": {}
-  }
-}

--- a/apps/api/v1/vercel.json
+++ b/apps/api/v1/vercel.json
@@ -1,7 +1,5 @@
 {
   "functions": {
-    "pages/api/slots/*.ts": {
-      "memory": 512
-    }
+    "pages/api/slots/*.ts": {}
   }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -41,10 +41,6 @@
     },
     "pages/api/trpc/workflows/[trpc].ts": {
       "maxDuration": 800
-    },
-    "pages/api/trpc/highPerf/[trpc].ts": {},
-    "pages/api/trpc/appRoutingForms/[trpc].ts": {},
-    "pages/router/embed.tsx": {},
-    "pages/api/book/event.ts": {}
+    }
   }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -42,17 +42,9 @@
     "pages/api/trpc/workflows/[trpc].ts": {
       "maxDuration": 800
     },
-    "pages/api/trpc/highPerf/[trpc].ts": {
-      "memory": 3008
-    },
-    "pages/api/trpc/appRoutingForms/[trpc].ts": {
-      "memory": 2048
-    },
-    "pages/router/embed.tsx": {
-      "memory": 2048
-    },
-    "pages/api/book/event.ts": {
-      "memory": 2048
-    }
+    "pages/api/trpc/highPerf/[trpc].ts": {},
+    "pages/api/trpc/appRoutingForms/[trpc].ts": {},
+    "pages/router/embed.tsx": {},
+    "pages/api/book/event.ts": {}
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR is just for removing `memory` config on Vercel functions since it's not required anymore.
For more check: https://vercel.com/docs/fluid-compute/pricing