### PR TITLE
chore: add plan for #23104 (draft)

### DIFF
--- a/PLAN-23104.md
+++ b/PLAN-23104.md
@@ -1,0 +1,44 @@
+# Bounty #23104 — Local dev performance (Plan) — DRAFT
+
+Goal
+- Reduce initial local dev page-load time by ~80% (issue target).
+- Avoid compiling/loading the entire App Store when a page needs only a few apps.
+
+Baseline (how I will measure)
+- Command: `yarn workspaces focus @calcom/web && yarn workspace @calcom/web dev`
+- Pages: home and one page that uses apps.
+- Metrics captured:
+  - First compile time shown by Next (cold start).
+  - Time to first HMR after a change (warm rebuild).
+  - Count and total size of files in `.next/server/chunks`.
+- Environment (for reproducibility): OS/WSL, Node v20.x, Yarn Berry, hardware specs.
+- I will add the numeric baseline once setup is finalized.
+
+Approach
+- Map routes → the minimal set of apps actually used.
+- Load those apps with `dynamic import()` only when needed.
+- Break/avoid re-exports in `packages/lib` and `packages/features` that pull the whole App Store.
+- Isolate app registration behind a small registry that can be imported lazily per route.
+- Keep tree-shaking effective by removing circular dependencies.
+
+Validation
+- Compare `.next/server/chunks` (file count and total size) before vs. after.
+- Record cold-start compile time and warm HMR time before vs. after.
+- Run tests to ensure no regressions.
+
+Risks / Notes
+- In dev, some `dynamic import()` may still get included; will verify the output in `.next`.
+- Refactors may require light test updates.
+- Need to avoid any behavior change in production.
+
+Milestones
+1) Reproducible baseline numbers
+2) Route→apps map + lazy registry PoC
+3) Remove problematic re-exports / circular deps
+4) Ensure tests pass and polish
+5) Final measurements and cleanup
+
+Deliverables
+- This plan file
+- Baseline & final metrics
+- Code changes implementing lazy app loading and dependency cleanups


### PR DESCRIPTION
Refs #23104 — draft plan and measurement baseline. **No code changes yet.**

**File added**
- `/bounty/23104-plan/PLAN-23104.md`

**Scope**
- This PR only adds the plan + measurement baseline to officially claim and coordinate the bounty work.
- Implementation changes will come in follow-up PRs.

**Baseline / how I’ll measure locally**
- Start dev: `yarn workspaces focus @calcom/web && yarn workspace @calcom/web dev`
- Measure initial page load for:
  - `/` (home) and one page that uses apps.
- Target: reduce initial local page load time by **≥ 80%**.

/claim #23104


