### PR TITLE
fix: show temporarily out-of-office message on all screen sizes

### DIFF
--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -156,7 +156,7 @@ export function AvailabilityList({ availabilities }: AvailabilityListProps) {
               ))}
             </ul>
           </div>
-          <div className="text-default mb-16 mt-4 hidden text-center text-sm md:block">
+          <div className="text-default mb-16 mt-4 block text-center text-sm">
             {t("temporarily_out_of_office")}{" "}
             <Link href="settings/my-account/out-of-office" className="underline">
               {t("add_a_redirect")}


### PR DESCRIPTION
## What does this PR do?

Fixes issue #23102  
Makes the “Temporarily Out-Of-Office” message visible on all screen sizes by removing the `hidden md:block` TailwindCSS classes from the relevant div.

No style or color changes; just a minimal functional fix.

---

## Visual Demo

| Before (mobile)                          | After (mobile)                           |
|-------------------------------------------|------------------------------------------|
| <img width="632" height="641" alt="image" src="https://github.com/user-attachments/assets/9fb8ba5a-8ced-4d48-9fdb-3263e9200ecc" /> | <img width="633" height="682" alt="image" src="https://github.com/user-attachments/assets/ddb55f00-6484-4b05-97de-6d7fc2cedc28" /> |

---

## Mandatory Tasks

- [x] Self-reviewed code
- [ ] Updated /docs (if needed). N/A in this case.
- [x] Confirmed no new warnings in the build

---

## How should this be tested?

1. Open the Availability page on Cal.com.
2. Resize the window to mobile/small screen.
3. Check if the "Temporarily Out-Of-Office? Add a redirect" message is now visible.
4. Confirm the message is still visible on desktop/tablet.

---

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines
- [x] No new warnings
