### PR TITLE
feat: add ready-for-e2e label check to Atoms E2E workflow

### DIFF
--- a/.github/workflows/atoms-e2e.yml
+++ b/.github/workflows/atoms-e2e.yml
@@ -1,14 +1,7 @@
 name: Atoms E2E Tests
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'packages/platform/atoms/**'
-      - 'packages/platform/examples/base/**'
-      - 'apps/api/v2/**'
-      - '.github/workflows/atoms-e2e.yml'
+  workflow_call:
 
 permissions:
   actions: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -262,5 +262,5 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.has-files-requiring-all-checks == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
+        if: needs.changes.outputs.has-files-requiring-all-checks == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || (contains(needs.*.result, 'skipped') && needs.check-label.outputs.run-e2e == 'true'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -204,7 +204,7 @@ jobs:
   e2e-atoms:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
     uses: ./.github/workflows/atoms-e2e.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -262,11 +262,10 @@ jobs:
         e2e-embed,
         e2e-embed-react,
         e2e-app-store,
-        e2e-atoms,
       ]
     if: always()
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       - name: fail if conditional jobs failed
-        if: needs.changes.outputs.has-files-requiring-all-checks == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || (contains(needs.*.result, 'skipped') && needs.check-label.outputs.run-e2e == 'true'))
+        if: needs.changes.outputs.has-files-requiring-all-checks == 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled'))
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
     outputs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
+      atoms-changes: ${{ steps.filter.outputs.atoms-changes }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +35,11 @@ jobs:
           filters: |
             has-files-requiring-all-checks:
               - "!(**.md|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json)"
+            atoms-changes:
+              - 'packages/platform/atoms/**'
+              - 'packages/platform/examples/base/**'
+              - 'apps/api/v2/**'
+              - '.github/workflows/atoms-e2e.yml'
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
@@ -198,7 +204,7 @@ jobs:
   atoms-e2e:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
     uses: ./.github/workflows/atoms-e2e.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -195,6 +195,13 @@ jobs:
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit
 
+  atoms-e2e:
+    name: Tests
+    needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    uses: ./.github/workflows/atoms-e2e.yml
+    secrets: inherit
+
   analyze:
     name: Analyze Build
     needs: [build]
@@ -204,7 +211,7 @@ jobs:
   merge-reports:
     name: Merge reports
     if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store, atoms-e2e]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
@@ -249,6 +256,7 @@ jobs:
         e2e-embed,
         e2e-embed-react,
         e2e-app-store,
+        atoms-e2e,
       ]
     if: always()
     runs-on: buildjet-2vcpu-ubuntu-2204

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
     outputs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
+      atoms-changes: ${{ steps.filter.outputs.atoms-changes }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +35,11 @@ jobs:
           filters: |
             has-files-requiring-all-checks:
               - "!(**.md|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json)"
+            atoms-changes:
+              - 'packages/platform/atoms/**'
+              - 'packages/platform/examples/base/**'
+              - 'apps/api/v2/**'
+              - '.github/workflows/atoms-e2e.yml'
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
@@ -198,7 +204,7 @@ jobs:
   e2e-atoms:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
     uses: ./.github/workflows/atoms-e2e.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -201,7 +201,7 @@ jobs:
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit
 
-  atoms-e2e:
+  e2e-atoms:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
     if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
@@ -217,7 +217,7 @@ jobs:
   merge-reports:
     name: Merge reports
     if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store, atoms-e2e]
+    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store, e2e-atoms]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
@@ -262,7 +262,7 @@ jobs:
         e2e-embed,
         e2e-embed-react,
         e2e-app-store,
-        atoms-e2e,
+        e2e-atoms,
       ]
     if: always()
     runs-on: buildjet-2vcpu-ubuntu-2204

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,6 @@ jobs:
       pull-requests: read
     outputs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
-      atoms-changes: ${{ steps.filter.outputs.atoms-changes }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
     steps:
       - uses: actions/checkout@v4
@@ -35,11 +34,6 @@ jobs:
           filters: |
             has-files-requiring-all-checks:
               - "!(**.md|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json)"
-            atoms-changes:
-              - 'packages/platform/atoms/**'
-              - 'packages/platform/examples/base/**'
-              - 'apps/api/v2/**'
-              - '.github/workflows/atoms-e2e.yml'
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
@@ -204,7 +198,7 @@ jobs:
   e2e-atoms:
     name: Tests
     needs: [changes, check-label, build, build-api-v1, build-api-v2, build-atoms]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' && needs.changes.outputs.atoms-changes == 'true' }}
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/atoms-e2e.yml
     secrets: inherit
 


### PR DESCRIPTION
# feat: add ready-for-e2e label check to Atoms E2E workflow

## Summary

Modified the Atoms E2E Tests workflow to only run when the `ready-for-e2e` label is present on a PR, following the same pattern used by other E2E workflows in the repository.

**Key Changes:**
- Converted `atoms-e2e.yml` from `pull_request` trigger to `workflow_call` trigger
- Added `atoms-e2e` job to `pr.yml` with conditional execution based on `ready-for-e2e` label
- Integrated the workflow into the existing label check system and build dependencies
- Added `atoms-e2e` to merge-reports and required job dependencies

This ensures the Atoms E2E workflow follows the same gating mechanism as other E2E tests, preventing unnecessary CI resource usage on PRs not ready for full E2E validation.

## Review & Testing Checklist for Human

- [ ] **Test label gating behavior** - Create a test PR and verify atoms-e2e does NOT run without the `ready-for-e2e` label
- [ ] **Test workflow execution** - Add the `ready-for-e2e` label to a PR and verify atoms-e2e runs successfully
- [ ] **Verify build dependencies** - Ensure atoms-e2e workflow has access to all required build artifacts (especially build-atoms)
- [ ] **Check test result integration** - Confirm atoms-e2e test results are properly included in merge-reports workflow
- [ ] **Validate CI status checks** - Verify the workflow appears correctly in GitHub's required status checks

**Recommended Test Plan:**
1. Create a test PR that touches atoms-related files
2. Verify atoms-e2e does not appear in CI checks initially  
3. Add `ready-for-e2e` label and confirm atoms-e2e runs
4. Check that test results are collected and reported properly

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    PR[Pull Request Opened/Updated]
    CheckLabel["check-label job<br/>(checks for ready-for-e2e)"]
    BuildAtoms["build-atoms job"]
    AtomsE2E["atoms-e2e job<br/>(NEW INTEGRATION)"]
    MergeReports["merge-reports job"]
    
    PR --> CheckLabel
    PR --> BuildAtoms
    CheckLabel --> AtomsE2E
    BuildAtoms --> AtomsE2E
    AtomsE2E --> MergeReports
    
    CheckLabel -.->|"if run-e2e == false"| Skip[Skip atoms-e2e]
    
    subgraph Files
        AtomsYml[".github/workflows/<br/>atoms-e2e.yml"]:::major-edit
        PrYml[".github/workflows/<br/>pr.yml"]:::major-edit
    end
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end


classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- This change aligns the Atoms E2E workflow with the established pattern used by all other E2E workflows in the repository
- The workflow maintains all its existing environment variables and test configuration
- **Risk**: This is a workflow integration change that hasn't been tested end-to-end - careful validation is needed
- Session requested by @keithwillcode
- Link to Devin run: https://app.devin.ai/sessions/58bd0fb4fc9d4809bd2dad63c78ba554