### PR TITLE
fix: team admin/owner can't change others member role

### DIFF
--- a/packages/features/pbac/services/__tests__/role-management.factory.test.ts
+++ b/packages/features/pbac/services/__tests__/role-management.factory.test.ts
@@ -110,13 +110,15 @@ describe("RoleManagementFactory", () => {
       it("should allow role change when user has permission", async () => {
         mockPermissionCheckService.checkPermission.mockResolvedValue(true);
         const manager = await factory.createRoleManager(organizationId);
-        await expect(manager.checkPermissionToChangeRole(userId, organizationId)).resolves.not.toThrow();
+        await expect(
+          manager.checkPermissionToChangeRole(userId, organizationId, "org")
+        ).resolves.not.toThrow();
       });
 
       it("should throw UNAUTHORIZED when user lacks permission", async () => {
         mockPermissionCheckService.checkPermission.mockResolvedValue(false);
         const manager = await factory.createRoleManager(organizationId);
-        await expect(manager.checkPermissionToChangeRole(userId, organizationId)).rejects.toThrow(
+        await expect(manager.checkPermissionToChangeRole(userId, organizationId, "org")).rejects.toThrow(
           new RoleManagementError(
             "You do not have permission to change roles",
             RoleManagementErrorCode.UNAUTHORIZED
@@ -193,13 +195,15 @@ describe("RoleManagementFactory", () => {
           customRoleId: null,
         });
         const manager = await factory.createRoleManager(organizationId);
-        await expect(manager.checkPermissionToChangeRole(userId, organizationId)).resolves.not.toThrow();
+        await expect(
+          manager.checkPermissionToChangeRole(userId, organizationId, "org")
+        ).resolves.not.toThrow();
       });
 
       it("should throw UNAUTHORIZED when user is not owner", async () => {
         vi.mocked(isOrganisationAdmin).mockResolvedValue(false);
         const manager = await factory.createRoleManager(organizationId);
-        await expect(manager.checkPermissionToChangeRole(userId, organizationId)).rejects.toThrow(
+        await expect(manager.checkPermissionToChangeRole(userId, organizationId, "org")).rejects.toThrow(
           new RoleManagementError(
             "Only owners or admin can update roles",
             RoleManagementErrorCode.UNAUTHORIZED

--- a/packages/features/pbac/services/role-management.factory.ts
+++ b/packages/features/pbac/services/role-management.factory.ts
@@ -1,5 +1,6 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { isOrganisationAdmin } from "@calcom/lib/server/queries/organisations";
+import { isTeamAdmin } from "@calcom/lib/server/queries/teams";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 

--- a/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
@@ -47,7 +47,7 @@ export const updateUserHandler = async ({ ctx, input }: UpdateUserOptions) => {
   const roleManager = await RoleManagementFactory.getInstance().createRoleManager(organizationId);
 
   try {
-    await roleManager.checkPermissionToChangeRole(userId, organizationId);
+    await roleManager.checkPermissionToChangeRole(userId, organizationId, "org");
   } catch (error) {
     if (error instanceof RoleManagementError) {
       throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });

--- a/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
@@ -1,5 +1,5 @@
 import { RoleManagementFactory } from "@calcom/features/pbac/services/role-management.factory";
-import { isTeamAdmin, isTeamOwner } from "@calcom/lib/server/queries/teams";
+import { isTeamOwner } from "@calcom/lib/server/queries/teams";
 import { TeamRepository } from "@calcom/lib/server/repository/team";
 import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
@@ -32,7 +32,7 @@ export const changeMemberRoleHandler = async ({ ctx, input }: ChangeMemberRoleOp
 
   // Check permission to change roles
   try {
-    await roleManager.checkPermissionToChangeRole(ctx.user.id, input.teamId, false);
+    await roleManager.checkPermissionToChangeRole(ctx.user.id, input.teamId, true);
   } catch (error) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
@@ -45,8 +45,6 @@ export const changeMemberRoleHandler = async ({ ctx, input }: ChangeMemberRoleOp
     typeof input.role === "string" &&
     Object.values(MembershipRole).includes(input.role as MembershipRole)
   ) {
-    // Traditional role assignment logic
-    if (!(await isTeamAdmin(ctx.user?.id, input.teamId))) throw new TRPCError({ code: "UNAUTHORIZED" });
     // Only owners can award owner role.
     if (input.role === MembershipRole.OWNER && !(await isTeamOwner(ctx.user?.id, input.teamId)))
       throw new TRPCError({ code: "UNAUTHORIZED" });

--- a/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
@@ -32,7 +32,7 @@ export const changeMemberRoleHandler = async ({ ctx, input }: ChangeMemberRoleOp
 
   // Check permission to change roles
   try {
-    await roleManager.checkPermissionToChangeRole(ctx.user.id, organizationId);
+    await roleManager.checkPermissionToChangeRole(ctx.user.id, input.teamId, false);
   } catch (error) {
     throw new TRPCError({
       code: "UNAUTHORIZED",

--- a/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/changeMemberRole.handler.ts
@@ -32,7 +32,7 @@ export const changeMemberRoleHandler = async ({ ctx, input }: ChangeMemberRoleOp
 
   // Check permission to change roles
   try {
-    await roleManager.checkPermissionToChangeRole(ctx.user.id, input.teamId, true);
+    await roleManager.checkPermissionToChangeRole(ctx.user.id, input.teamId, "team");
   } catch (error) {
     throw new TRPCError({
       code: "UNAUTHORIZED",


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where an org member who is a team admin/owner couldn’t change other team members' roles
