### PR TITLE
perf: og image caching v1

### DIFF
--- a/apps/web/app/api/social/og/image/route.tsx
+++ b/apps/web/app/api/social/og/image/route.tsx
@@ -102,9 +102,7 @@ async function handler(req: NextRequest) {
               }),
               {
                 status: 400,
-                headers: {
-                  "Content-Type": "application/json",
-                },
+                headers: { "Content-Type": "application/json" },
               }
             );
           }
@@ -137,9 +135,7 @@ async function handler(req: NextRequest) {
               }),
               {
                 status: 400,
-                headers: {
-                  "Content-Type": "application/json",
-                },
+                headers: { "Content-Type": "application/json" },
               }
             );
           }

--- a/apps/web/app/api/social/og/image/route.tsx
+++ b/apps/web/app/api/social/og/image/route.tsx
@@ -87,7 +87,10 @@ async function handler(req: NextRequest) {
 
           return new Response(img.body, {
             status: 200,
-            headers: { "Content-Type": "image/png", "cache-control": "max-age=0" },
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+            },
           });
         } catch (error) {
           if (error instanceof ZodError) {
@@ -99,7 +102,10 @@ async function handler(req: NextRequest) {
               }),
               {
                 status: 400,
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                  "Content-Type": "application/json",
+                  "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+                },
               }
             );
           }
@@ -126,7 +132,10 @@ async function handler(req: NextRequest) {
               }),
               {
                 status: 400,
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                  "Content-Type": "application/json",
+                  "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+                },
               }
             );
           }

--- a/apps/web/app/api/social/og/image/route.tsx
+++ b/apps/web/app/api/social/og/image/route.tsx
@@ -104,7 +104,6 @@ async function handler(req: NextRequest) {
                 status: 400,
                 headers: {
                   "Content-Type": "application/json",
-                  "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
                 },
               }
             );
@@ -122,7 +121,13 @@ async function handler(req: NextRequest) {
           });
           const img = new ImageResponse(<App name={name} description={description} slug={slug} />, ogConfig);
 
-          return new Response(img.body, { status: 200, headers: { "Content-Type": "image/png" } });
+          return new Response(img.body, {
+            status: 200,
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+            },
+          });
         } catch (error) {
           if (error instanceof ZodError) {
             return new Response(
@@ -134,7 +139,6 @@ async function handler(req: NextRequest) {
                 status: 400,
                 headers: {
                   "Content-Type": "application/json",
-                  "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
                 },
               }
             );
@@ -153,7 +157,13 @@ async function handler(req: NextRequest) {
 
           const img = new ImageResponse(<Generic title={title} description={description} />, ogConfig);
 
-          return new Response(img.body, { status: 200, headers: { "Content-Type": "image/png" } });
+          return new Response(img.body, {
+            status: 200,
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+            },
+          });
         } catch (error) {
           if (error instanceof ZodError) {
             return new Response(


### PR DESCRIPTION
## What does this PR do?

- Add browser caching header to OG image generation endpoint (/api/social/og/image)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Tested already:

<img width="896" height="191" alt="Screenshot 2025-08-19 at 7 40 49 PM" src="https://github.com/user-attachments/assets/dce987be-68b7-4daf-bc99-dd2d40dba978" />
