### PR TITLE
fix: correct impossible logical condition Office365CalendarService

### DIFF
--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -661,22 +661,30 @@ export default class Office365CalendarService implements Calendar {
     );
   };
 
-  private handleErrorJsonOffice365Calendar = <Type>(response: Response): Promise<Type | string> => {
+  private async handleErrorJsonOffice365Calendar<Type>(response: Response): Promise<Type | string> {
     if (response.headers.get("content-encoding") === "gzip") {
       return response.text();
     }
 
     if (response.status === 204) {
-      return new Promise((resolve) => resolve({} as Type));
+      return {} as Type;
     }
 
-    if (!response.ok && response.status < 200 && response.status >= 300) {
-      response.json().then(console.log);
-      throw Error(response.statusText);
+    if (!response.ok) {
+      let errorBody: string | object;
+      try {
+        errorBody = await response.json();
+      } catch (e) {
+        errorBody = await response.text();
+      }
+      this.log.error(
+        `handleErrorJsonOffice365Calendar: Office365 API request failed with status ${response.status}`,
+        errorBody
+      );
     }
 
     return response.json();
-  };
+  }
 
   async getMainTimeZone(): Promise<string> {
     try {


### PR DESCRIPTION

## What does this PR do?

Problem

The handleErrorJsonOffice365Calendar function contained a logical contradiction in its error-checking if statement. The condition !response.ok && response.status < 200 && response.status >= 300 was impossible to meet, meaning the error handling block was never executed. This has been a silent bug for approximately three years.

When a non-OK response (e.g., 404, 500) was received, the function would skip the intended error logic, and proceed directly to return response.json();. This would either lead to an uncaught SyntaxError if the response body was not valid JSON, or a logical bug where the caller would incorrectly assume the API call was successful.

Changes

This PR refactors the handleErrorJsonOffice365Calendar function to fix this issue while attempting to maintain the previous behavior as closely as possible to avoid unexpected changes in application flow.

    Corrected Error Handling: The logically flawed if statement has been replaced with a correct if (!response.ok) check. This ensures the error handling block is now properly executed for all non-2xx responses.

    Robust Body Parsing: The code now correctly uses an await within a try...catch block to safely parse the response body, falling back to reading the raw text if the body is not valid JSON.


    Added Diagnostic Log: A this.log.error has been added to the failure path. This provides crucial visibility into previously-silent API failures.

Rationale: "Playing It Safe"

The core motivation for this PR is to "play it safe." Since the original code's error-handling path was never reached, we are unsure what the correct upstream behavior should be. Instead of introducing a new breaking change by throwing an error, this PR keeps the original (buggy) behavior of not throwing an exception but makes the failure visible through logging. This allows us to monitor and understand the types of errors the API returns before deciding on a more definitive error-handling strategy in a future PR.

This change documents the bug and provides the necessary logging to diagnose the consequences of these silent failures over time.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


