### PR TITLE
fix: show 'temporarily_out_of_office' text on small screens (#23102)

### DIFF
--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -156,7 +156,7 @@ export function AvailabilityList({ availabilities }: AvailabilityListProps) {
               ))}
             </ul>
           </div>
-          <div className="text-default mb-16 mt-4 block text-center text-sm">
+          <div className="text-default mb-16 mt-4 block whitespace-normal break-words text-center  text-sm">
             {t("temporarily_out_of_office")}{" "}
             <Link href="settings/my-account/out-of-office" className="underline">
               {t("add_a_redirect")}


### PR DESCRIPTION
This PR fixes issue #23102, where the temporarily_out_of_office message was not visible on small screens.

🔍 Problem

On smaller viewports, the message block was not properly styled, resulting in the temporarily_out_of_office message being hidden from users.