### PR TITLE
fix: preserve guests from URL params when guests field is hidden

### DIFF
--- a/apps/web/app/api/cron/bookingReminder/route.ts
+++ b/apps/web/app/api/cron/bookingReminder/route.ts
@@ -65,6 +65,7 @@ async function postHandler(request: NextRequest) {
             recurringEvent: true,
             bookingFields: true,
             metadata: true,
+            seatsPerTimeSlot: true,
           },
         },
         responses: true,
@@ -124,6 +125,7 @@ async function postHandler(request: NextRequest) {
         ...getCalEventResponses({
           bookingFields: booking.eventType?.bookingFields ?? null,
           booking,
+          seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
         }),
         location: booking.location ?? "",
         startTime: booking.startTime.toISOString(),

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -13,6 +13,7 @@ export const getCalEventResponses = ({
   bookingFields,
   booking,
   responses,
+  seatsPerTimeSlot,
 }: {
   // If the eventType has been deleted and a booking is Accepted later on, then bookingFields will be null and we can't know the label of fields. So, we should store the label as well in the DB
   // Also, it is no longer straightforward to identify if a field is system field or not
@@ -32,6 +33,7 @@ export const getCalEventResponses = ({
     };
   }>;
   responses?: z.infer<typeof bookingResponsesDbSchema>;
+  seatsPerTimeSlot?: number | null;
 }) => {
   const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
   const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;
@@ -63,9 +65,13 @@ export const getCalEventResponses = ({
 
       // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list
       if (field.name == "guests" && field.hidden) {
-        const guestsValue = backwardCompatibleResponses[field.name];
-        if (!guestsValue || (Array.isArray(guestsValue) && guestsValue.length === 0)) {
+        if (seatsPerTimeSlot && seatsPerTimeSlot > 0) {
           backwardCompatibleResponses[field.name] = [];
+        } else {
+          const guestsValue = backwardCompatibleResponses[field.name];
+          if (!guestsValue || (Array.isArray(guestsValue) && guestsValue.length === 0)) {
+            backwardCompatibleResponses[field.name] = [];
+          }
         }
       }
 

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -63,7 +63,10 @@ export const getCalEventResponses = ({
 
       // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list
       if (field.name == "guests" && field.hidden) {
-        backwardCompatibleResponses[field.name] = [];
+        const guestsValue = backwardCompatibleResponses[field.name];
+        if (!guestsValue || (Array.isArray(guestsValue) && guestsValue.length === 0)) {
+          backwardCompatibleResponses[field.name] = [];
+        }
       }
 
       if (field.editable === "user" || field.editable === "user-readonly") {

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -241,6 +241,7 @@ async function handler(input: CancelBookingInput) {
     ...getCalEventResponses({
       bookingFields: bookingToDelete.eventType?.bookingFields ?? null,
       booking: bookingToDelete,
+      seatsPerTimeSlot: bookingToDelete.eventType?.seatsPerTimeSlot,
     }),
     startTime: bookingToDelete?.startTime ? dayjs(bookingToDelete.startTime).format() : "",
     endTime: bookingToDelete?.endTime ? dayjs(bookingToDelete.endTime).format() : "",

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -64,6 +64,7 @@ const _getBookingData = async <T extends z.ZodType>({
     getCalEventResponses({
       bookingFields: eventType.bookingFields,
       responses,
+      seatsPerTimeSlot: eventType.seatsPerTimeSlot,
     });
   return {
     ...parsedBody,

--- a/packages/features/credentials/handleDeleteCredential.ts
+++ b/packages/features/credentials/handleDeleteCredential.ts
@@ -327,6 +327,7 @@ const handleDeleteCredential = async ({
                 ...getCalEventResponses({
                   bookingFields: booking.eventType?.bookingFields ?? null,
                   booking,
+                  seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
                 }),
                 startTime: booking.startTime.toISOString(),
                 endTime: booking.endTime.toISOString(),

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -286,6 +286,7 @@ export const roundRobinManualReassignment = async ({
     ...getCalEventResponses({
       bookingFields: eventType.bookingFields ?? null,
       booking,
+      seatsPerTimeSlot: eventType.seatsPerTimeSlot,
     }),
     customReplyToEmail: eventType?.customReplyToEmail,
     location: bookingLocation,

--- a/packages/features/ee/round-robin/roundRobinReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.ts
@@ -330,6 +330,7 @@ export const roundRobinReassignment = async ({
     ...getCalEventResponses({
       bookingFields: eventType?.bookingFields ?? null,
       booking,
+      seatsPerTimeSlot: eventType?.seatsPerTimeSlot,
     }),
     hideOrganizerEmail: eventType.hideOrganizerEmail,
     customReplyToEmail: eventType?.customReplyToEmail,

--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -174,6 +174,7 @@ export async function handler(req: NextRequest) {
           const { responses } = getCalEventResponses({
             bookingFields: reminder.booking.eventType?.bookingFields ?? null,
             booking: reminder.booking,
+            seatsPerTimeSlot: reminder.booking.eventType?.seatsPerTimeSlot,
           });
 
           const organizerOrganizationProfile = await prisma.profile.findFirst({

--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -94,6 +94,7 @@ export async function handler(req: NextRequest) {
         const { responses } = getCalEventResponses({
           bookingFields: reminder.booking.eventType?.bookingFields ?? null,
           booking: reminder.booking,
+          seatsPerTimeSlot: reminder.booking.eventType?.seatsPerTimeSlot,
         });
 
         const organizerOrganizationProfile = await prisma.profile.findFirst({

--- a/packages/features/tasker/tasks/crm/lib/buildCalendarEvent.ts
+++ b/packages/features/tasker/tasks/crm/lib/buildCalendarEvent.ts
@@ -24,6 +24,7 @@ const buildCalendarEvent: (bookingUid: string) => Promise<CalendarEvent> = async
         select: {
           slug: true,
           bookingFields: true,
+          seatsPerTimeSlot: true,
         },
       },
       attendees: {
@@ -86,6 +87,7 @@ const buildCalendarEvent: (bookingUid: string) => Promise<CalendarEvent> = async
     ...getCalEventResponses({
       bookingFields: booking?.eventType?.bookingFields ?? null,
       booking,
+      seatsPerTimeSlot: booking?.eventType?.seatsPerTimeSlot,
     }),
   };
 

--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -75,6 +75,7 @@ export async function addSubscription({
           eventType: {
             select: {
               bookingFields: true,
+              seatsPerTimeSlot: true,
             },
           },
           attendees: {
@@ -92,6 +93,7 @@ export async function addSubscription({
           ...getCalEventResponses({
             bookingFields: booking.eventType?.bookingFields ?? null,
             booking,
+            seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
           }),
         };
       });
@@ -225,6 +227,7 @@ export async function listBookings(
             currency: true,
             length: true,
             bookingFields: true,
+            seatsPerTimeSlot: true,
             team: true,
           },
         },
@@ -248,6 +251,7 @@ export async function listBookings(
         ...getCalEventResponses({
           bookingFields: booking.eventType?.bookingFields ?? null,
           booking,
+          seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
         }),
         location: getHumanReadableLocationValue(booking.location || "", t),
       };


### PR DESCRIPTION
# Fix guest handling for hidden guest fields and seated events

## Summary

This PR fixes a bug where guests passed as URL parameters were not being added to bookings when the guests field was hidden. The fix introduces logic to distinguish between regular events (where hidden guest field should still accept URL parameter guests) and seated events (where guests should never be accepted regardless of URL parameters).

**Key Changes:**
- Modified `getCalEventResponses()` to accept optional `seatsPerTimeSlot` parameter
- Updated guest handling logic to exclude guests entirely for seated events (`seatsPerTimeSlot > 0`)
- For regular events with hidden guests field, URL parameter guests are now preserved
- Updated 11+ call sites to pass `seatsPerTimeSlot` information
- Added `seatsPerTimeSlot` to database select clauses where needed for type safety

## Review & Testing Checklist for Human

**Critical Items (3):**
- [ ] **Verify core guest logic in `getCalEventResponses.ts` lines 64-75** - Review the conditional logic that handles guests differently for seated vs regular events. This is the most complex part of the change.
- [ ] **End-to-end testing** - Test booking creation with hidden guests field + URL parameters for both:
  - Regular event (guests should be added from URL params)  
  - Seated event (guests should be ignored even with URL params)
- [ ] **Call site validation** - Check that all `getCalEventResponses()` call sites were updated correctly and no important ones were missed. Verify the database select clauses include `seatsPerTimeSlot` where I added it.

**Recommended Test Plan:**
1. Create a regular event type with guests field hidden (`disableGuests: true`)
2. Book with URL params containing guests - verify guests are added to booking
3. Create a seated event type (`seatsPerTimeSlot > 0`) 
4. Book with URL params containing guests - verify guests are NOT added
5. Test existing booking flows still work (reschedule, cancel, etc.)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    URL["Booking URL with<br/>guest parameters"] --> BookingFlow["handleNewBooking/<br/>getBookingData.ts"]:::minor-edit
    
    BookingFlow --> GetResponses["getCalEventResponses.ts"]:::major-edit
    
    GetResponses --> Logic{"Is seatsPerTimeSlot > 0?<br/>(Seated Event)"}
    Logic -->|Yes| ExcludeGuests["Always exclude guests"]
    Logic -->|No| CheckHidden{"Is guests field hidden?"}
    CheckHidden -->|Yes| PreserveGuests["Preserve URL param guests"]
    CheckHidden -->|No| NormalFlow["Normal guest handling"]
    
    
    EventType["EventType with<br/>seatsPerTimeSlot"] --> BookingFlow
    
    GetResponses --> CallSites["Multiple call sites:<br/>- buildCalendarEvent.ts<br/>- scheduleTrigger.ts<br/>- bookingReminder/route.ts<br/>- handleDeleteCredential.ts<br/>+ 7 more files"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

- **Session Info**: Requested by @joeauyeung | [Devin Session](https://app.devin.ai/sessions/1c854c8255b04479af1b65019329f3d6)
- **Backward Compatibility**: `seatsPerTimeSlot` parameter is optional to maintain compatibility with existing call sites
- **Type Safety**: All changes passed TypeScript compilation and unit tests (2889 tests passed)
- **Risk Areas**: The conditional guest logic is the highest risk area - seated events must never accept guests while regular events with hidden fields should accept URL parameter guests