### PR TITLE
chore: deprecated prisma default export

### DIFF
--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -90,6 +90,9 @@ type OmitPrismaClient = Omit<
 // we cant pass tx to functions as types miss match since we have a custom prisma client https://github.com/prisma/prisma/discussions/20924#discussioncomment-10077649
 export type PrismaTransaction = OmitPrismaClient;
 
+/**
+ * @deprecated Use named export `prisma` instead
+ */
 export default prisma;
 
 export * from "./selects";


### PR DESCRIPTION
## What does this PR do?

As we agreed to avoid using default exports, this PR deprecates Prisma’s default export.