### PR TITLE
fix: addOnLeading text field caret cropping

### DIFF
--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -165,7 +165,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
               "w-full min-w-0 truncate border-0 bg-transparent focus:outline-none focus:ring-0",
               "text-default rounded-lg text-sm font-medium leading-none",
               "placeholder:text-muted disabled:cursor-not-allowed disabled:bg-transparent",
-              addOnLeading && "pl-0.5 pr-0",
+              addOnLeading && "rounded-none pl-0.5 pr-0",
               addOnSuffix && "pl-0",
               className
             )}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When we have a text field input with addOnLeading, the caret gets cropped on the first character. This is because the input field has a border radius set. This PR attempts to fix that issue by removing the border radius when the input has the addOnLeading prop.

- Fixes #23224 
- Fixes CAL-6284

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):
**Bug**
https://app.birdeatsbug.com/MbESg-7jw6l-Z4TRE0ZNAp5ATq7An4vABmzW3Rje2dek

**Solution**
https://app.birdeatsbug.com/93UviSDXrOGxnBSEap9yPTAh-j9LEgQi3CBTUTfJ44BL

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set? - No
- What are the minimal test data to have? - Minimal Dev Setup
- What is expected (happy path) to have (input and output)?
1. Log in
2. Go to Event Types, for example
3. Click on "Create"
4. Click on the slug input field
5. Observe the caret not being cropped
- Any other important info that could help to test that PR - N/A

## Checklist

<!-- Remove bullet points below that don't apply to you -->
