### PR TITLE
fix: Add guests via URL param even if field is hidden

### DIFF
--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -13,6 +13,7 @@ export const getCalEventResponses = ({
   bookingFields,
   booking,
   responses,
+  seatsEnabled,
 }: {
   // If the eventType has been deleted and a booking is Accepted later on, then bookingFields will be null and we can't know the label of fields. So, we should store the label as well in the DB
   // Also, it is no longer straightforward to identify if a field is system field or not
@@ -32,6 +33,7 @@ export const getCalEventResponses = ({
     };
   }>;
   responses?: z.infer<typeof bookingResponsesDbSchema>;
+  seatsEnabled?: boolean;
 }) => {
   const calEventUserFieldsResponses = {} as NonNullable<CalendarEvent["userFieldsResponses"]>;
   const calEventResponses = {} as NonNullable<CalendarEvent["responses"]>;
@@ -62,7 +64,7 @@ export const getCalEventResponses = ({
       }
 
       // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list
-      if (field.name == "guests" && field.hidden) {
+      if (field.name == "guests" && !!seatsEnabled) {
         backwardCompatibleResponses[field.name] = [];
       }
 

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -63,7 +63,6 @@ export const getCalEventResponses = ({
         throw new Error(`Missing label for booking field "${field.name}"`);
       }
 
-      // If the guests field is hidden (disableGuests is set on the event type) don't try and infer guests from attendees list
       if (field.name == "guests" && !!seatsEnabled) {
         backwardCompatibleResponses[field.name] = [];
       }

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -64,6 +64,7 @@ const _getBookingData = async <T extends z.ZodType>({
     getCalEventResponses({
       bookingFields: eventType.bookingFields,
       responses,
+      seatsEnabled: !!eventType.seatsPerTimeSlot,
     });
   return {
     ...parsedBody,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a bug when the guests field is hidden, the URL param for guests wasn't being passed to the new booking

## How should this be tested?

- Hide the guests field for an event type
- Go to the booking page but add the `guests` URL param
- When the booking is created, the guests should be added