### PR TITLE
chore: Remove maintenance mode middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -60,22 +60,6 @@ const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   const reqWithEnrichedHeaders = enrichRequestWithHeaders({ req });
   const requestHeaders = new Headers(reqWithEnrichedHeaders.headers);
 
-  if (!url.pathname.startsWith("/api")) {
-    //
-    // NOTE: When tRPC hits an error a 500 is returned, when this is received
-    //       by the application the user is automatically redirected to /auth/login.
-    //
-    //     - For this reason our matchers are sufficient for an app-wide maintenance page.
-    //
-    // Check whether the maintenance page should be shown
-    const isInMaintenanceMode = await safeGet<boolean>("isInMaintenanceMode");
-    // If is in maintenance mode, point the url pathname to the maintenance page
-    if (isInMaintenanceMode) {
-      reqWithEnrichedHeaders.nextUrl.pathname = `/maintenance`;
-      return NextResponse.rewrite(reqWithEnrichedHeaders.nextUrl);
-    }
-  }
-
   const routingFormRewriteResponse = routingForms.handleRewrite(url);
   if (routingFormRewriteResponse) {
     return responseWithHeaders({ url, res: routingFormRewriteResponse, req: reqWithEnrichedHeaders });

--- a/turbo.json
+++ b/turbo.json
@@ -249,7 +249,8 @@
     "CALCOM_SERVICE_ACCOUNT_ENCRYPTION_KEY",
     "CAL_VIDEO_RECORDING_TOKEN_SECRET",
     "ORGANIZER_EMAIL_EXEMPT_DOMAINS",
-    "SLOTS_CACHE_TTL"
+    "SLOTS_CACHE_TTL",
+    "CSP_POLICY"
   ],
   "tasks": {
     "@calcom/prisma#build": {


### PR DESCRIPTION
## What does this PR do?

Removes the maintenance mode from the middleware, this is a (redundant) deployment strategy we will never utilise in the future.