### PR TITLE
refactor: Extract MultiEmailInput component to UI library

### DIFF
--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -234,10 +234,7 @@ export const Components: Record<FieldType, Component> = {
     factory: (props) => {
       return (
         <MultiEmailInput
-          {...props}
-          // Provide a fallback to ensure the label is always a string
           label={props.label || ""}
-          // Adapt the `setValue` prop to the new component's `onChange` prop
           onChange={props.setValue}
           value={props.value || []}
           disabled={props.readOnly}

--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -10,11 +10,8 @@ import PhoneInput from "@calcom/features/components/phone-input";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { AddressInput } from "@calcom/ui/components/address";
 import { InfoBadge } from "@calcom/ui/components/badge";
-import { Button } from "@calcom/ui/components/button";
-import { Label, CheckboxField, EmailField, InputField, Checkbox } from "@calcom/ui/components/form";
-import { Icon } from "@calcom/ui/components/icon";
+import { Label, CheckboxField, InputField, Checkbox, MultiEmailInput } from "@calcom/ui/components/form";
 import { RadioGroup, RadioField } from "@calcom/ui/components/radio";
-import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import { ComponentForField } from "./FormBuilderField";
 import { propsTypes } from "./propsTypes";
@@ -234,83 +231,17 @@ export const Components: Record<FieldType, Component> = {
   },
   multiemail: {
     propsType: propsTypes.multiemail,
-    //TODO: Make it a ui component
-    factory: function MultiEmail({ value, readOnly, label, setValue, ...props }) {
-      const placeholder = props.placeholder;
-      const { t } = useLocale();
-      value = value || [];
+    factory: (props) => {
       return (
-        <>
-          {value.length ? (
-            <div>
-              <label htmlFor="guests" className="text-default  mb-1 block text-sm font-medium">
-                {label}
-              </label>
-              <ul>
-                {value.map((field, index) => (
-                  <li key={index}>
-                    <EmailField
-                      id={`${props.name}.${index}`}
-                      disabled={readOnly}
-                      value={value[index]}
-                      onChange={(e) => {
-                        value[index] = e.target.value.toLowerCase();
-                        setValue(value);
-                      }}
-                      placeholder={placeholder}
-                      label={<></>}
-                      required
-                      onClickAddon={() => {
-                        value.splice(index, 1);
-                        setValue(value);
-                      }}
-                      addOnSuffix={
-                        !readOnly ? (
-                          <Tooltip content="Remove email">
-                            <button className="m-1" type="button">
-                              <Icon name="x" width={12} className="text-default" />
-                            </button>
-                          </Tooltip>
-                        ) : null
-                      }
-                    />
-                  </li>
-                ))}
-              </ul>
-              {!readOnly && (
-                <Button
-                  data-testid="add-another-guest"
-                  type="button"
-                  color="minimal"
-                  StartIcon="user-plus"
-                  className="my-2.5"
-                  onClick={() => {
-                    value.push("");
-                    setValue(value);
-                  }}>
-                  {t("add_another")}
-                </Button>
-              )}
-            </div>
-          ) : (
-            <></>
-          )}
-
-          {!value.length && !readOnly && (
-            <Button
-              data-testid="add-guests"
-              color="minimal"
-              variant="button"
-              StartIcon="user-plus"
-              onClick={() => {
-                value.push("");
-                setValue(value);
-              }}
-              className="mr-auto h-fit whitespace-normal text-left">
-              <span className="flex-1">{label}</span>
-            </Button>
-          )}
-        </>
+        <MultiEmailInput
+          {...props}
+          // Provide a fallback to ensure the label is always a string
+          label={props.label || ""}
+          // Adapt the `setValue` prop to the new component's `onChange` prop
+          onChange={props.setValue}
+          value={props.value || []}
+          disabled={props.readOnly}
+        />
       );
     },
   },

--- a/packages/ui/components/form/index.ts
+++ b/packages/ui/components/form/index.ts
@@ -14,6 +14,7 @@ export {
   FilterSearchField,
 } from "./inputs/Input";
 
+export { MultiEmailInput } from "./inputs/MultiEmailInput";
 export { MultiOptionInput } from "./inputs/MultiOptionInput";
 
 export { InputFieldWithSelect } from "./inputs/InputFieldWithSelect";

--- a/packages/ui/components/form/inputs/MultiEmailInput.tsx
+++ b/packages/ui/components/form/inputs/MultiEmailInput.tsx
@@ -1,0 +1,114 @@
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { Icon } from "@calcom/ui/components/icon";
+import { Tooltip } from "@calcom/ui/components/tooltip";
+
+import { EmailField } from "./Input";
+
+export type MultiEmailInputProps = {
+  /** The name of the input field, used for IDs. */
+  name?: string;
+  /** The current array of email strings. */
+  value: string[] | undefined;
+  /** Callback function to update the email array. */
+  onChange: (value: string[]) => void;
+  /** The main label for the entire component. */
+  label: string;
+  /** Placeholder text for each email input field. */
+  placeholder?: string;
+  /** Whether the fields are editable. */
+  disabled?: boolean;
+};
+
+export function MultiEmailInput({
+  value: valueProp,
+  onChange,
+  label,
+  placeholder,
+  disabled,
+  name,
+}: MultiEmailInputProps) {
+  const { t } = useLocale();
+  const [parent] = useAutoAnimate<HTMLUListElement>();
+  const value = valueProp || [];
+
+  const handleEmailChange = (index: number, email: string) => {
+    const newValue = [...value];
+    newValue[index] = email.toLowerCase();
+    onChange(newValue);
+  };
+
+  const handleRemoveEmail = (index: number) => {
+    const newValue = value.filter((_, i) => i !== index);
+    onChange(newValue);
+  };
+
+  const handleAddEmail = () => {
+    const newValue = [...value, ""];
+    onChange(newValue);
+  };
+
+  if (!value.length && disabled) {
+    return null; // Don't render anything if there are no emails and it's disabled.
+  }
+
+  if (!value.length && !disabled) {
+    return (
+      <Button
+        data-testid="add-guests"
+        color="minimal"
+        variant="button"
+        StartIcon="user-plus"
+        onClick={handleAddEmail}
+        className="mr-auto h-fit whitespace-normal text-left">
+        <span className="flex-1">{label}</span>
+      </Button>
+    );
+  }
+
+  return (
+    <div>
+      <label htmlFor={name} className="text-default mb-1 block text-sm font-medium">
+        {label}
+      </label>
+      <ul ref={parent}>
+        {value.map((email, index) => (
+          <li key={index} className="mb-2">
+            <EmailField
+              id={`${name}.${index}`}
+              disabled={disabled}
+              value={email}
+              onChange={(e) => handleEmailChange(index, e.target.value)}
+              placeholder={placeholder}
+              label={<></>}
+              required
+              onClickAddon={() => handleRemoveEmail(index)}
+              addOnSuffix={
+                !disabled ? (
+                  <Tooltip content={t("remove_email")}>
+                    <button className="m-1" type="button" aria-label={t("remove_email")}>
+                      <Icon name="x" width={12} className="text-default" />
+                    </button>
+                  </Tooltip>
+                ) : null
+              }
+            />
+          </li>
+        ))}
+      </ul>
+      {!disabled && (
+        <Button
+          data-testid="add-another-guest"
+          type="button"
+          color="minimal"
+          StartIcon="user-plus"
+          className="my-2.5"
+          onClick={handleAddEmail}>
+          {t("add_another")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/components/form/inputs/MultiEmailInput.tsx
+++ b/packages/ui/components/form/inputs/MultiEmailInput.tsx
@@ -33,6 +33,7 @@ export function MultiEmailInput({
   const { t } = useLocale();
   const [parent] = useAutoAnimate<HTMLUListElement>();
   const value = valueProp || [];
+  const baseId = (name ?? "multi-email").replace(/[^a-zA-Z0-9_-]/g, "-");
 
   const handleEmailChange = (index: number, email: string) => {
     const newValue = [...value];
@@ -70,14 +71,16 @@ export function MultiEmailInput({
 
   return (
     <div>
-      <label htmlFor={name} className="text-default mb-1 block text-sm font-medium">
+      <label
+        htmlFor={value.length ? `${baseId}.0` : baseId}
+        className="text-default mb-1 block text-sm font-medium">
         {label}
       </label>
       <ul ref={parent}>
         {value.map((email, index) => (
           <li key={index} className="mb-2">
             <EmailField
-              id={`${name}.${index}`}
+              id={`${baseId}.${index}`}
               disabled={disabled}
               value={email}
               onChange={(e) => handleEmailChange(index, e.target.value)}


### PR DESCRIPTION
## What does this PR do?

This PR refactors the multiemail input field within the form builder into a standalone, reusable UI component named MultiEmailInput. This component is now located in packages/ui/components/form/inputs/MultiEmailInput.tsx.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
