### PR TITLE
chore: add debug logs org team event type creation

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
@@ -39,6 +39,7 @@ import {
   HttpStatus,
   NotFoundException,
   Query,
+  Logger,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
 
@@ -66,6 +67,8 @@ export type EventTypeHandlerResponse = {
 @ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
 @ApiHeader(OPTIONAL_API_KEY_HEADER)
 export class OrganizationsEventTypesController {
+  private readonly logger = new Logger("OrganizationsEventTypesController");
+
   constructor(
     private readonly organizationsEventTypesService: OrganizationsEventTypesService,
     private readonly inputService: InputOrganizationsEventTypesService,
@@ -87,6 +90,10 @@ export class OrganizationsEventTypesController {
       user.id,
       teamId,
       bodyEventType
+    );
+    this.logger.debug(
+      "nl debug - create org team event type - transformedBody",
+      JSON.stringify(transformedBody, null, 2)
     );
 
     const eventType = await this.organizationsEventTypesService.createOrganizationTeamEventType(

--- a/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/organizations-event-types.service.ts
@@ -47,6 +47,10 @@ export class OrganizationsEventTypesService {
         prisma: this.dbWrite.prisma,
       },
     });
+    this.logger.debug(
+      "nl debug - create org team event type - eventTypeCreated",
+      JSON.stringify(eventTypeCreated, null, 2)
+    );
 
     return this.teamsEventTypesService.updateTeamEventType(eventTypeCreated.id, teamId, body, user, true);
   }

--- a/apps/api/v2/src/modules/teams/event-types/services/teams-event-types.service.ts
+++ b/apps/api/v2/src/modules/teams/event-types/services/teams-event-types.service.ts
@@ -133,6 +133,7 @@ export class TeamsEventTypesService {
     });
 
     const eventType = await this.teamsEventTypesRepository.getEventTypeById(eventTypeId);
+    this.logger.debug("nl debug - update team event type - eventType", JSON.stringify(eventType, null, 2));
 
     if (!eventType) {
       throw new NotFoundException(`Event type with id ${eventTypeId} not found`);


### PR DESCRIPTION
Dutch language translations randomly appear in place of name booking field - see 3 requests and name field is messed up - add debug logs.
<img width="1710" height="1107" alt="Screenshot 2025-08-22 at 12 51 29" src="https://github.com/user-attachments/assets/e99e39b4-dcb1-4595-b642-ad1049c432d2" />
<img width="1710" height="1107" alt="Screenshot 2025-08-22 at 12 51 11" src="https://github.com/user-attachments/assets/8eb9c185-2abb-40cc-a76c-c05b0b0d5bdc" />
<img width="1710" height="1107" alt="Screenshot 2025-08-22 at 12 51 04" src="https://github.com/user-attachments/assets/65a39973-7ba4-4875-875b-bbdefb66b561" />

