### PR TITLE
fix: booking limits with seats not working (CAL-4553)

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -462,7 +462,8 @@ export class UserAvailabilityService {
         teamForBookingLimits.id,
         teamForBookingLimits.includeManagedEventsInLimits,
         finalTimezone,
-        initialData?.rescheduleUid ?? undefined
+        initialData?.rescheduleUid ?? undefined,
+        eventType ?? undefined
       );
     }
 

--- a/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
+++ b/packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import LimitManager from "@calcom/lib/intervalLimits/limitManager";
+
+import { getBusyTimesFromBookingLimits } from "./getBusyTimesFromLimits";
+
+const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+
+describe("getBusyTimesFromBookingLimits", () => {
+  describe("seat-aware booking limits", () => {
+    it("should mark slot as busy when booking limit is reached for non-seated events", async () => {
+      const limitManager = new LimitManager();
+      const bookings = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          eventTypeId: 1,
+        },
+        {
+          start: startOfTomorrow.set("hour", 14).toDate(),
+          end: startOfTomorrow.set("hour", 15).toDate(),
+          title: "Booking 2",
+          eventTypeId: 1,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 2 },
+        dateFrom: startOfTomorrow,
+        dateTo: startOfTomorrow.endOf("day"),
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+      expect(busyTimes.length).toBe(1);
+      expect(dayjs(busyTimes[0].start).isSame(startOfTomorrow.startOf("day"))).toBe(true);
+    });
+
+    it("should NOT mark slot as busy when booking limit is reached but seats remain", async () => {
+      const limitManager = new LimitManager();
+      const bookings = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          eventTypeId: 1,
+        },
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 2",
+          eventTypeId: 1,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 2 },
+        dateFrom: startOfTomorrow,
+        dateTo: startOfTomorrow.endOf("day"),
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        eventType: {
+          id: 1,
+          seatsPerTimeSlot: 5,
+          length: 60,
+        } as Parameters<typeof getBusyTimesFromBookingLimits>[0]["eventType"],
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+      expect(busyTimes.length).toBe(0);
+    });
+
+    it("should mark slot as busy when booking limit is reached AND no seats remain", async () => {
+      const limitManager = new LimitManager();
+      const bookings = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1",
+          eventTypeId: 1,
+        },
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 2",
+          eventTypeId: 1,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 2 },
+        dateFrom: startOfTomorrow,
+        dateTo: startOfTomorrow.endOf("day"),
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        eventType: {
+          id: 1,
+          seatsPerTimeSlot: 2,
+          length: 60,
+        } as Parameters<typeof getBusyTimesFromBookingLimits>[0]["eventType"],
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+      expect(busyTimes.length).toBe(1);
+    });
+
+    it("should only count bookings for the same event type when checking seats", async () => {
+      const limitManager = new LimitManager();
+      const bookings = [
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 1 - Event Type 1",
+          eventTypeId: 1,
+        },
+        {
+          start: startOfTomorrow.set("hour", 10).toDate(),
+          end: startOfTomorrow.set("hour", 11).toDate(),
+          title: "Booking 2 - Event Type 2",
+          eventTypeId: 2,
+        },
+      ];
+
+      await getBusyTimesFromBookingLimits({
+        bookings,
+        bookingLimits: { PER_DAY: 2 },
+        dateFrom: startOfTomorrow,
+        dateTo: startOfTomorrow.endOf("day"),
+        limitManager,
+        eventTypeId: 1,
+        timeZone: "UTC",
+        eventType: {
+          id: 1,
+          seatsPerTimeSlot: 3,
+          length: 60,
+        } as Parameters<typeof getBusyTimesFromBookingLimits>[0]["eventType"],
+      });
+
+      const busyTimes = limitManager.getBusyTimes();
+      expect(busyTimes.length).toBe(0);
+    });
+  });
+});

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -64,6 +64,7 @@ export type EventBusyDetails = EventBusyDate & {
   title?: string;
   source?: string | null;
   userId?: number | null;
+  eventTypeId?: number | null;
 };
 
 export type AdditionalInfo = Record<string, unknown> & { calWarnings?: string[] };


### PR DESCRIPTION
## What does this PR do?

- Fix issue where slots with remaining seats were blocked once booking limit was hit
- Add seat-aware logic to booking limits checking in `_getBusyTimesFromBookingLimits`
- Only mark slots as busy when both booking limit is reached AND no seats remain
- Update `getBusyTimesFromTeamLimits` to pass eventType parameter for seat checking
- Maintain backward compatibility for non-seated events
- Add `eventTypeId` to `EventBusyDetails` type for filtering by event type

Resolves CAL-4553: Booking limits with seats not working

- Fixes #17221 (GitHub issue number)
- Fixes CAL-4453 (Linear issue number)

### Updates since last revision

The codebase was significantly refactored since the original PR was created. Files moved from `packages/lib/` to `packages/features/` locations. The branch has been reset to a clean state based on current `main` with only the necessary changes applied to the new file locations:

- `packages/features/busyTimes/lib/getBusyTimesFromLimits.ts` (was `packages/lib/intervalLimits/server/getBusyTimesFromLimits.ts`)
- `packages/features/availability/lib/getUserAvailability.ts` (was `packages/lib/getUserAvailability.ts`)
- `packages/types/Calendar.d.ts`

**Latest update:** Added unit tests for seat-aware booking limits in `packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts` covering:
- Non-seated events blocking when limit is reached
- Seated events NOT blocking when seats remain
- Seated events blocking when no seats remain
- Event type filtering for seat counting

#### Video Demo (if applicable):

https://github.com/user-attachments/assets/1116202f-9bda-4f03-9a58-0141271951ce

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with seats enabled (e.g., 5 seats per time slot)
2. Set a booking limit (e.g., 2 bookings per day)
3. Make 2 bookings for the same time slot
4. Verify that the slot still shows as available (since seats remain)
5. Fill all seats for the slot
6. Verify the slot is now marked as busy

Run unit tests: `TZ=UTC yarn test packages/features/busyTimes/lib/getBusyTimesFromLimits.test.ts`

## Human Review Checklist

- [ ] Verify the seat counting logic: `slotBookings.length` counts bookings, not attendees - confirm this is the intended behavior for seated events
- [ ] Check that `eventType` parameter is properly passed through the `getBusyTimesFromTeamLimits` → `getBusyTimesFromBookingLimits` call chain
- [ ] Verify the `eventTypeId` filtering in the seat-aware check correctly filters bookings for the same event type

---

Link to Devin run: https://app.devin.ai/sessions/1f701af3d3174cc399f6d08a6883cf6c

Co-authored-by: Vansh5632 <vanshchopra5632@gmail.com>