### PR TITLE
fix: remove TypeScript path mapping and standardize @calcom/ui imports

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/AdvancedPermissionGroup.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/AdvancedPermissionGroup.tsx
@@ -6,9 +6,9 @@ import type { Resource } from "@calcom/features/pbac/domain/types/permission-reg
 import { PERMISSION_REGISTRY, CrudAction } from "@calcom/features/pbac/domain/types/permission-registry";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
+import { Checkbox, Label } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-import { Checkbox, Label } from "@calcom/ui/form";
 
 import { usePermissions } from "./usePermissions";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/CreateRoleCta.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/CreateRoleCta.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { Button } from "@calcom/ui/button";
+import { Button } from "@calcom/ui/components/button";
 
 import { useRoleSheetState } from "../hooks/useRoleQueryStates";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
@@ -13,7 +13,6 @@ import {
   getPermissionsForScope,
 } from "@calcom/features/pbac/domain/types/permission-registry";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { Form, TextField, Checkbox, Label } from "@calcom/ui/components/form";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
@@ -13,11 +13,12 @@ import {
   getPermissionsForScope,
 } from "@calcom/features/pbac/domain/types/permission-registry";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { localStorage } from "@calcom/lib/webstorage";
 import { trpc } from "@calcom/trpc/react";
-import { Button } from "@calcom/ui/button";
+import { Button } from "@calcom/ui/components/button";
+import { Form, TextField, Checkbox, Label } from "@calcom/ui/components/form";
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@calcom/ui/components/sheet";
 import { showToast } from "@calcom/ui/components/toast";
-import { Form, TextField, Checkbox, Label } from "@calcom/ui/form";
 
 import { revalidateTeamRoles } from "../actions";
 import { AdvancedPermissionGroup } from "./AdvancedPermissionGroup";
@@ -154,7 +155,7 @@ export function RoleSheet({ role, open, onOpenChange, teamId, scope = Scope.Orga
         teamId,
         roleId: role.id,
         name: values.name,
-        permissions: values.permissions as any,
+        permissions: values.permissions,
         color: values.color,
       });
     } else {
@@ -163,7 +164,7 @@ export function RoleSheet({ role, open, onOpenChange, teamId, scope = Scope.Orga
         name: values.name,
         description: values.description,
         color: values.color,
-        permissions: values.permissions as any,
+        permissions: values.permissions,
       });
     }
   };

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RoleSheet.tsx
@@ -154,7 +154,7 @@ export function RoleSheet({ role, open, onOpenChange, teamId, scope = Scope.Orga
         teamId,
         roleId: role.id,
         name: values.name,
-        permissions: values.permissions,
+        permissions: values.permissions as any,
         color: values.color,
       });
     } else {
@@ -163,7 +163,7 @@ export function RoleSheet({ role, open, onOpenChange, teamId, scope = Scope.Orga
         name: values.name,
         description: values.description,
         color: values.color,
-        permissions: values.permissions,
+        permissions: values.permissions as any,
       });
     }
   };

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RolesList.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/roles/_components/RolesList.tsx
@@ -2,9 +2,9 @@
 
 import type { Scope } from "@calcom/features/pbac/domain/types/permission-registry";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { Badge } from "@calcom/ui/badge";
-import { Button } from "@calcom/ui/button";
 import classNames from "@calcom/ui/classNames";
+import { Badge } from "@calcom/ui/components/badge";
+import { Button } from "@calcom/ui/components/button";
 import {
   Dropdown,
   DropdownMenuContent,

--- a/apps/web/modules/settings/billing/components/BillingCredits.tsx
+++ b/apps/web/modules/settings/billing/components/BillingCredits.tsx
@@ -16,7 +16,7 @@ import { Button } from "@calcom/ui/components/button";
 import { Select } from "@calcom/ui/components/form";
 import { TextField, Label, InputError } from "@calcom/ui/components/form";
 import { ProgressBar } from "@calcom/ui/components/progress-bar";
-import { showToast } from "@calcom/ui/toast";
+import { showToast } from "@calcom/ui/components/toast";
 
 import { BillingCreditsSkeleton } from "./BillingCreditsSkeleton";
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,8 +9,7 @@
       "@lib/*": ["lib/*"],
       "@server/*": ["server/*"],
       "@prisma/client/*": ["@calcom/prisma/client/*"],
-      "@calcom/repository/*": ["@calcom/lib/server/repository/*"],
-      "@calcom/ui/*": ["../../packages/ui/components/*"]
+      "@calcom/repository/*": ["@calcom/lib/server/repository/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## What does this PR do?

This PR removes a TypeScript path mapping configuration that was enabling ambiguous import syntax and standardizes all `@calcom/ui` imports to use explicit, canonical paths.

**Key Changes:**
- Removes `"@calcom/ui/*": ["../../packages/ui/components/*"]` path mapping from `apps/web/tsconfig.json`
- Updates import statements from `@calcom/ui/componentName` to `@calcom/ui/components/componentName`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). **N/A** - This is an internal import standardization that doesn't require documentation changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
