### PR TITLE
chore: Remove payment fee from `chargeCard`

### DIFF
--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -27,12 +27,6 @@ export const stripeCredentialKeysSchema = z.object({
   stripe_publishable_key: z.string(),
 });
 
-const stripeAppKeysSchema = z.object({
-  client_id: z.string(),
-  payment_fee_fixed: z.number(),
-  payment_fee_percentage: z.number(),
-});
-
 export class PaymentService implements IAbstractPaymentService {
   private stripe: Stripe;
   private credentials: z.infer<typeof stripeCredentialKeysSchema> | null;
@@ -242,11 +236,6 @@ export class PaymentService implements IAbstractPaymentService {
 
       const setupIntent = paymentObject.setupIntent;
 
-      // Parse keys with zod
-      const { payment_fee_fixed, payment_fee_percentage } = stripeAppKeysSchema.parse(stripeAppKeys?.keys);
-
-      const paymentFee = Math.round(payment.amount * payment_fee_percentage + payment_fee_fixed);
-
       // Ensure that the stripe customer & payment method still exists
       const customer = await this.stripe.customers.retrieve(setupIntent.customer as string, {
         stripeAccount: this.credentials.stripe_user_id,
@@ -266,7 +255,6 @@ export class PaymentService implements IAbstractPaymentService {
       const params: Stripe.PaymentIntentCreateParams = {
         amount: payment.amount,
         currency: payment.currency,
-        application_fee_amount: paymentFee,
         customer: setupIntent.customer as string,
         payment_method: setupIntent.payment_method as string,
         off_session: true,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the processing fee that Cal.com added on top of Stripe's fees when charging a card the no show fee. We made the decision to remove this fee for normal bookings but this was left in.


