### PR TITLE
feat: add mobile click/touch support to Tooltip component

### DIFF
--- a/packages/lib/hooks/useMediaQuery.ts
+++ b/packages/lib/hooks/useMediaQuery.ts
@@ -4,13 +4,17 @@ const useMediaQuery = (query: string) => {
   const [matches, setMatches] = useState(false);
 
   useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+
     const media = window.matchMedia(query);
     if (media.matches !== matches) {
       setMatches(media.matches);
     }
     const listener = () => setMatches(media.matches);
-    window.addEventListener("resize", listener);
-    return () => window.removeEventListener("resize", listener);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
   }, [matches, query]);
 
   return matches;


### PR DESCRIPTION
## What does this PR do?

This PR makes the `Tooltip` component accessible on mobile devices by adding click/touch support while preserving existing desktop hover behavior. Previously, tooltips were completely inaccessible on mobile devices since they only responded to hover events.

**Key Changes:**
- **Mobile Detection**: Uses `useMediaQuery("(max-width: 768px)")` to detect mobile devices
- **Click/Touch Support**: Adds click handlers to show/hide tooltips on mobile
- **Auto-Hide**: Tooltips automatically disappear after 3 seconds on mobile
- **Click-Outside-To-Close**: Tapping outside a tooltip closes it on mobile
- **Touch Optimization**: Adds `touch-action: manipulation` for better mobile performance
- **Desktop Preservation**: Maintains existing hover behavior on desktop devices

**Additional Fix:**
- **SSR Compatibility**: Fixed `useMediaQuery` hook to work in SSR and test environments by adding `window` existence checks and using proper media query change listeners

## Visual Demo

**Testing Note**: Due to local development server issues, comprehensive visual testing was limited. The implementation follows established patterns from other mobile-responsive components in the codebase.

**Expected Behavior:**
- **Desktop**: Tooltips continue to work on hover (unchanged)
- **Mobile**: Tooltips now respond to tap/click interactions with auto-hide and tap-outside-to-close

## How should this be tested?

**Mobile Testing (Critical):**
1. Test on actual mobile devices or browser mobile emulation
2. Find pages with tooltips (settings pages, booking forms, navigation icons)
3. Verify tooltips show on tap and hide after 3 seconds
4. Verify tap-outside-to-close works
5. Test rapid tapping doesn't cause state issues

**Desktop Testing:**
1. Verify hover behavior is unchanged
2. Test that mobile click handlers don't interfere with desktop usage

**Edge Cases:**
- Multiple tooltips open simultaneously
- Tooltips with existing click handlers on triggers
- Screen reader compatibility
- Fast navigation/page changes during tooltip timeouts

**Environment:**
- No special environment variables needed
- Standard Cal.com development setup

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Documentation update: N/A - no user-facing API changes
- [x] Automated tests: Unit tests pass, mobile behavior follows established patterns

## Human Review Checklist

**🚨 Critical Testing Required:**
- [ ] **Mobile device testing** - Verify click/touch functionality works correctly
- [ ] **Desktop regression testing** - Confirm hover behavior unchanged
- [ ] **Accessibility testing** - Screen reader compatibility with click-based tooltips
- [ ] **Edge case testing** - Multiple tooltips, rapid clicking, timeout cleanup
- [ ] **Memory leak testing** - Event listeners and timeouts are properly cleaned up

**🔍 Code Review Focus:**
- [ ] Event handler chaining logic in `TriggerWrapper`
- [ ] State management between internal/external open state
- [ ] Timeout cleanup in useEffect hooks
- [ ] SSR compatibility in useMediaQuery changes

---

**Link to Devin run**: https://app.devin.ai/sessions/f0182ee2355041a08a1f678d0d18b125  
**Requested by**: @eunjae-lee


**Note**: This PR addresses a significant accessibility gap for mobile users who previously had no way to access tooltip content. The implementation is designed to be non-breaking for existing desktop usage while providing intuitive mobile interactions.