### PR TITLE
chore: CODEOWNER change for /apps/web/lib files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,12 @@
 /apps/api/**/* @calcom/Platform @calcom/Foundation
 /apps/ui-playground/**/* @calcom/Consumer @calcom/Foundation
 /apps/web/**/layout.tsx @calcom/Consumer @calcom/Foundation
-/apps/web/lib/**/* @calcom/Foundation
+/apps/web/lib/csp.ts @calcom/Foundation
+/apps/web/lib/buildNonce.ts @calcom/Foundation
+/apps/web/lib/daily-webhook/**/* @calcom/Foundation
+/apps/web/lib/core/**/* @calcom/Foundation
+/apps/web/lib/booking.ts @calcom/Foundation
+/apps/web/lib/handleOrgRedirect.ts @calcom/Foundation
 /apps/web/middleware.ts @calcom/Foundation
 /deploy/**/* @calcom/Foundation
 /infra/**/* @calcom/Foundation


### PR DESCRIPTION

Summary
- Loosen overly broad ownership on apps/web/lib so routine web changes don’t require Foundation by default, while keeping infra-critical bits under Foundation review.
- Small CI/repo hygiene tweaks included.

What changed
- CODEOWNERS: Replace the blanket rule
  - Removed: /apps/web/lib/**/* @calcom/Foundation
  - Kept under Foundation ownership (explicit list):
    - /apps/web/lib/csp.ts @calcom/Foundation
    - /apps/web/lib/buildNonce.ts @calcom/Foundation
    - /apps/web/lib/daily-webhook/**/* @calcom/Foundation
    - /apps/web/lib/core/**/* @calcom/Foundation
    - /apps/web/lib/booking.ts @calcom/Foundation
    - /apps/web/lib/handleOrgRedirect.ts @calcom/Foundation
  - Everything else in apps/web/lib now follows default ownership, reducing required Foundation reviews for non-infra changes.

Why
- The previous blanket ownership created unnecessary review load and slowed iteration on routine web-layer work. This change keeps security/infra-sensitive areas protected while unblocking the rest.

Additional repo/CI updates
- Labeler: Add "self-hosted" to ignore-labels to avoid mislabeling when that tag is present.
- New Performance Tests workflow (.github/workflows/performance-tests.yml):
  - Triggers: release created or manual dispatch.
  - Uses Grafana k6 (setup-k6 and run-k6 actions) with org secrets (K6_CLOUD_TOKEN, K6_CLOUD_PROJECT_ID).
  - Runs smoke, load, stress, and spike suites from tests/performance/*.

Impact
- Developer experience: Fewer mandatory Foundation reviews for routine apps/web/lib changes; faster PR throughput.
- Security/infra: No reduction in scrutiny for sensitive paths (CSP, nonce, daily webhooks, core, booking, org redirect).
- Runtime behavior: None (config/ownership/CI only).

Risk and rollback
- Low risk. If needed, revert CODEOWNERS changes to the previous blanket pattern.

Checklist
- No user-facing changes.
- No migrations.
- No new env vars (workflow uses existing secrets).
- Verified patterns match intended files and do not unintentionally broaden sensitive coverage.