### PR TITLE
fix: Allow install on teams for concurrent meeting apps

### DIFF
--- a/apps/web/components/apps/AppPage.tsx
+++ b/apps/web/components/apps/AppPage.tsx
@@ -113,7 +113,7 @@ export const AppPage = ({
 
   const handleAppInstall = () => {
     setIsLoading(true);
-    if (isConferencing(categories)) {
+    if (isConferencing(categories) && !concurrentMeetings) {
       mutation.mutate({
         type,
         variant,

--- a/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
+++ b/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
@@ -317,7 +317,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       isConferencing,
       isOrg,
       // conferencing apps dont support team install
-      installableOnTeams: !isConferencing,
+      installableOnTeams: !appMetadata?.concurrentMeetings || !isConferencing,
     } as OnboardingPageProps,
   };
 };

--- a/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
+++ b/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
@@ -317,7 +317,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       isConferencing,
       isOrg,
       // conferencing apps dont support team install
-      installableOnTeams: !appMetadata?.concurrentMeetings || !isConferencing,
+      installableOnTeams: !!appMetadata?.concurrentMeetings || !isConferencing,
     } as OnboardingPageProps,
   };
 };

--- a/packages/features/apps/components/AppCard.tsx
+++ b/packages/features/apps/components/AppCard.tsx
@@ -56,7 +56,7 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
   }, [app.name, searchText]);
 
   const handleAppInstall = () => {
-    if (isConferencing(app.categories)) {
+    if (isConferencing(app.categories) && !app.concurrentMeetings) {
       mutation.mutate({
         type: app.type,
         variant: app.variant,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allows conferencing apps to be installed on a team when the `concurrentMeeting` property is true in the app's metadata

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Add `concurrentMeetings` to a conferencing app's metadata
- When installing the app it should bring you to the account selection on the install page
