### PR TITLE
fix(timezone): correct mismatched bracket in timezone dropdown labels (#23453)

### DIFF
--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -28,11 +28,10 @@ const formatOffset = (offset: string) =>
   offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
-  const offsetUnit = option.label.split("-")[0].substring(1);
   const cityName = option.label.split(") ")[1];
+  const gmtOffset = formatOffset(dayjs.tz(undefined, option.value).format("Z"));
 
-  const timezoneValue = ` ${offsetUnit} ${formatOffset(dayjs.tz(undefined, option.value).format("Z"))}`;
   return timezones.length > 0
-    ? `${cityName}${timezoneValue}`
-    : `${option.value.replace(/_/g, " ")}${timezoneValue}`;
+    ? `${cityName} (GMT${gmtOffset})`
+    : `${option.value.replace(/_/g, " ")} (GMT${gmtOffset}) ${cityName}`;
 };

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -28,10 +28,10 @@ const formatOffset = (offset: string) =>
   offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
-  const cityName = option.label.split(") ")[1];
+  const baseCity = (option.value.split("/").pop() ?? option.value).replace(/_/g, " ");
   const gmtOffset = formatOffset(dayjs.tz(undefined, option.value).format("Z"));
 
   return timezones.length > 0
-    ? `${cityName} (GMT${gmtOffset})`
-    : `${option.value.replace(/_/g, " ")} (GMT${gmtOffset}) ${cityName}`;
+    ? `${baseCity} (GMT${gmtOffset})`
+    : `${option.value.replace(/_/g, " ")} (GMT${gmtOffset}) ${baseCity} ${gmtOffset}`;
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #23453 (GitHub issue number)
- Fixes CAL-23469 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.
##BEFORE
<img width="1920" height="1080" alt="Screenshot 2025-08-30 at 11 57 46 PM" src="https://github.com/user-attachments/assets/a6a0f185-9e97-4a9e-989e-d0ebb3bb71de" />

##AFTER
<img width="1920" height="1080" alt="Screenshot 2025-08-30 at 11 58 34 PM" src="https://github.com/user-attachments/assets/b5ab8a53-ffb2-4b97-862b-ffb189d35ce1" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to **Settings > Timezone** in the dashboard.
2. Open the timezone dropdown list.
3. Scroll down to entries such as **Africa/Lome**.
4. Verify that the timezone is displayed as `Africa/Lome (GMT+0:00) Lome +0:00` with proper bracket formatting.
5. Ensure no unmatched brackets are present in other timezone entries.

No special environment variables or test data required.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
