### PR TITLE
fix: e2e test - wait for session to load next step

### DIFF
--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -548,9 +548,10 @@ test.describe("Booking round robin event", () => {
     users,
   }) => {
     const [testUser] = users.get();
-    await testUser.apiLogin();
 
     const team = await testUser.getFirstTeamMembership();
+
+    await testUser.apiLogin(`/team/${team.team.slug}`);
 
     // Click first event type (round robin)
     await page.click('[data-testid="event-type-link"]');

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -657,8 +657,8 @@ const createUserFixture = (user: UserWithIncludes, page: Page) => {
     eventTypes: user.eventTypes,
     routingForms: user.routingForms,
     self,
-    apiLogin: async (password?: string) =>
-      apiLogin({ ...(await self()), password: password || user.username }, store.page),
+    apiLogin: async (navigateToUrl?: string, password?: string) =>
+      apiLogin({ ...(await self()), password: password || user.username }, store.page, navigateToUrl),
     /** Don't forget to close context at the end */
     apiLoginOnNewBrowser: async (browser: Browser, password?: string) => {
       const newContext = await browser.newContext();
@@ -969,7 +969,8 @@ export async function login(
 
 export async function apiLogin(
   user: Pick<Prisma.User, "username"> & Partial<Pick<Prisma.User, "email">> & { password: string | null },
-  page: Page
+  page: Page,
+  navigateToUrl?: string
 ) {
   // Get CSRF token
   const csrfToken = await page
@@ -1001,10 +1002,10 @@ export async function apiLogin(
    * We picked /settings/my-account/profile due to it being one of
    * our lighest protected pages and doesnt do anything other than load the user profile
    */
-  await page.goto("/settings/my-account/profile");
+  await page.goto(navigateToUrl || "/settings/my-account/profile");
 
   // Wait for the session to be fully established
-  await page.waitForSelector('[data-testid="profile-submit-button"]');
+  await page.waitForLoadState();
 
   return response;
 }

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -1000,7 +1000,7 @@ export async function apiLogin(
   await page.goto("/event-types");
 
   // Wait for the session to be fully established
-  await page.waitForLoadState("networkidle");
+  await page.waitForSelector('[data-testid="event-types"]');
 
   return response;
 }

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -994,13 +994,17 @@ export async function apiLogin(
 
   expect(response.status()).toBe(200);
 
-  // Critical: Navigate to a protected page to trigger NextAuth session loading
-  // This forces NextAuth to run the jwt and session callbacks that populate
-  // the session with profile, org, and other important data
-  await page.goto("/event-types");
+  /**
+   * Critical: Navigate to a protected page to trigger NextAuth session loading
+   * This forces NextAuth to run the jwt and session callbacks that populate
+   * the session with profile, org, and other important data
+   * We picked /settings/my-account/profile due to it being one of
+   * our lighest protected pages and doesnt do anything other than load the user profile
+   */
+  await page.goto("/settings/my-account/profile");
 
   // Wait for the session to be fully established
-  await page.waitForSelector('[data-testid="event-types"]');
+  await page.waitForSelector('[data-testid="profile-submit-button"]');
 
   return response;
 }


### PR DESCRIPTION
In OUR e2e tests. Sessions were not loading correctly and were showing different information in comparison to local dev when manually navigating. This is because the session loading via next-auth request was being interrupted with a navigation event so the session was only partial populated with the infomation we get from the credentials callback api. 

Causing some things like RSC to not work as expected because the JWT was never generated with the correct infomation. 

