### PR TITLE
fix: event type settings name field default label

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/booking-fields.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/booking-fields.ts
@@ -520,6 +520,7 @@ export const systemBeforeFieldName: NameSystemField = {
             name: "fullName",
             type: "text",
             required: true,
+            label: "your_name",
           },
         ],
       },

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/internal-to-api.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/internal-to-api.spec.ts
@@ -292,7 +292,7 @@ describe("transformBookingFieldsInternalToApi", () => {
         isDefault: true,
         required: true,
         disableOnPrefill: false,
-        label: undefined,
+        label: "your_name",
         placeholder: undefined,
       },
     ];

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
@@ -725,6 +725,7 @@ describe("Organizations Event Types Endpoints", () => {
               isDefault: true,
               type: "name",
               slug: "name",
+              label: "your_name",
               required: true,
               disableOnPrefill: false,
             },
@@ -822,6 +823,7 @@ describe("Organizations Event Types Endpoints", () => {
               type: "name",
               slug: "name",
               required: true,
+              label: "your_name",
               disableOnPrefill: false,
             },
             {


### PR DESCRIPTION
## Problem
I don't know how come noone reported this before (i think it was working until recently), but if we create event type via api or create event type atom the name booking field did not have a label
<img width="519" height="232" alt="Screenshot 2025-09-02 at 12 44 40" src="https://github.com/user-attachments/assets/b042d46c-f71a-404b-8654-e2031e71490f" />

## Reason
Default label in name booking field is set if `label` equals `your_name`.

## Solution
When creating default name booking field in v2 set `label` by default to `your_name`. Now when creating event type via api or atom label correctly is displayed
<img width="507" height="217" alt="Screenshot 2025-09-02 at 12 46 19" src="https://github.com/user-attachments/assets/976638cc-bfbc-4bb9-9543-bfe4cd68aef4" />
