### PR TITLE
fix: update E2E Atoms workflow naming to match convention

### DIFF
--- a/.github/workflows/e2e-atoms.yml
+++ b/.github/workflows/e2e-atoms.yml
@@ -1,4 +1,4 @@
-name: Atoms E2E Tests
+name: E2E Atoms
 
 on:
   workflow_call:
@@ -19,7 +19,7 @@ env:
 jobs:
   e2e-atoms:
     timeout-minutes: 15
-    name: Atoms E2E Tests
+    name: E2E Atoms
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: docker/login-action@v3
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/yarn-playwright-install
-      - name: Run Atoms E2E Tests
+      - name: Run E2E Atoms Tests
         working-directory: packages/platform/examples/base
         run: yarn test:e2e
       - name: Upload Test Results


### PR DESCRIPTION
## What does this PR do?

Updates the GitHub Actions workflow name from "Atoms E2E Tests" to "E2E Atoms" to match the naming convention used by other E2E test workflows in the repository.

**Changes made:**
- Workflow name: `Atoms E2E Tests` → `E2E Atoms`
- Job name: `Atoms E2E Tests` → `E2E Atoms` 
- Step name: `Run Atoms E2E Tests` → `Run E2E Atoms Tests`

**Motivation:** 
Other E2E workflows follow the "E2E [Component]" pattern:
- `E2E` (main E2E tests)
- `E2E App Store Tests`
- `E2E Embed Core tests and booking flow (for non-embed as well)`

The Atoms workflow was the only one using "Atoms E2E Tests" instead of "E2E Atoms".

## How should this be tested?

- [ ] Verify YAML syntax is valid
- [ ] Confirm the workflow name appears correctly in GitHub Actions UI
- [ ] Check that no external references to "Atoms E2E Tests" exist in the codebase or documentation
- [ ] Validate that the workflow still triggers and runs as expected

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write **N/A** here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

**Link to Devin run:** https://app.devin.ai/sessions/9db22d5ce90a4153b13b4216fea0ef0a
**Requested by:** @keithwillcode