### PR TITLE
chore: add eslint rules to avoid importing from app-store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,4 +2,18 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   extends: ["./packages/config/eslint-preset.js"],
+  overrides: [
+    {
+      files: ["packages/lib/**/*.{ts,tsx,js,jsx}", "packages/prisma/**/*.{ts,tsx,js,jsx}"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            paths: ["@calcom/app-store"],
+            patterns: ["@calcom/app-store/*"],
+          },
+        ],
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## What does this PR do?

Add some eslint rules to avoid importing from app-store inside lib and prisma modules. This was added as `warn` instead of `error` to avoid building errors.

<img width="580" height="186" alt="image" src="https://github.com/user-attachments/assets/d5eb92e5-79ac-4528-acaa-38585aee6a7a" />
