### PR TITLE
chore: Remove DBA as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /packages/lib/slots.ts @calcom/Foundation
 /packages/platform/atoms/**/*WebWrapper.tsx @calcom/Consumer
 /packages/platform/**/* @calcom/Platform @calcom/Foundation
-/packages/prisma/**/* @calcom/DBA
+/packages/prisma/**/* @calcom/Foundation
 /packages/trpc/server/routers/viewer/bookings/confirm.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/bookings/get.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/slots/**/* @calcom/Foundation


### PR DESCRIPTION
We have decided to go back to only having @calcom/foundation review files in the prisma package, not DBA