### PR TITLE
fix(workflows): hide organizer email in workflow emails (#23392)

### DIFF
--- a/packages/features/ee/workflows/api/scheduleEmailReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleEmailReminders.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import dayjs from "@calcom/dayjs";
 import generateIcsString from "@calcom/emails/lib/generateIcsString";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
+import { SENDER_NAME } from "@calcom/lib/constants";
 import { getBookerBaseUrl } from "@calcom/lib/getBookerUrl/server";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -352,7 +353,9 @@ export async function handler(req: NextRequest) {
                   },
                 ]
               : undefined,
-            sender: reminder.workflowStep.sender,
+            sender: reminder.booking?.eventType?.hideOrganizerEmail
+              ? SENDER_NAME
+              : reminder.workflowStep.sender,
             ...(!reminder.booking?.eventType?.hideOrganizerEmail && {
               replyTo:
                 reminder.booking?.eventType?.customReplyToEmail ??
@@ -441,7 +444,9 @@ export async function handler(req: NextRequest) {
             subject: emailContent.emailSubject,
             to: [sendTo],
             html: emailContent.emailBody,
-            sender: reminder.workflowStep?.sender,
+            sender: reminder.booking?.eventType?.hideOrganizerEmail
+              ? SENDER_NAME
+              : reminder.workflowStep?.sender,
             ...(!reminder.booking?.eventType?.hideOrganizerEmail && {
               replyTo:
                 reminder.booking?.eventType?.customReplyToEmail ||

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -6,7 +6,7 @@ import generateIcsString from "@calcom/emails/lib/generateIcsString";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { preprocessNameFieldDataWithVariant } from "@calcom/features/form-builder/utils";
 import tasker from "@calcom/features/tasker";
-import { WEBSITE_URL } from "@calcom/lib/constants";
+import { SENDER_NAME, WEBSITE_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import prisma from "@calcom/prisma";
@@ -270,7 +270,7 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
       html: emailContent.emailBody,
       ...(!evt.hideOrganizerEmail && { replyTo: evt?.eventType?.customReplyToEmail || evt.organizer.email }),
       attachments,
-      sender,
+      sender: evt.hideOrganizerEmail ? SENDER_NAME : sender,
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #23392
- Fixes CAL-23392

This PR ensures that workflow emails (such as reminders) fully respect the "Hide organizer's email" setting.  
Previously, organizer emails could still be exposed in the sender field of workflow emails even when the setting was enabled.  

The fix updates both `emailReminderManager.ts` and `scheduleEmailReminders.ts` to conditionally use the `SENDER_NAME` constant whenever `hideOrganizerEmail` is true. This aligns workflow emails with regular booking emails, ensuring consistent privacy and preventing unintended exposure of organizer addresses.

- Original: Workflow reminder email showed the organizer’s email in the sender field even with "Hide organizer's email" enabled.  
- Updated: Workflow reminder email now displays "Cal.com" (from `SENDER_NAME`) instead of the organizer’s email when the setting is enabled.  


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.  
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. → N/A  
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.  

## How should this be tested?

1. Create an event type with "Hide organizer's email" enabled.  
2. Attach a workflow that sends email reminders.  
3. Book the event and check the workflow reminder email.  
   - Expected behavior: The email should **not show the organizer’s email address** anywhere in the sender details.  
4. Repeat the same test with "Hide organizer's email" disabled.  
   - Expected behavior: The email should **show the organizer’s email address** as usual.  

Result: Consistent and privacy-respecting behavior across all workflow and booking emails.  

## Checklist

