### PR TITLE
perf: Remove next-i18next dependency from packages/emails and packages/lib

### DIFF
--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@calcom/dayjs": "*",
     "@calcom/lib": "*",
-    "next-i18next": "^15.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rrule": "^2.7.1"

--- a/packages/emails/src/templates/CreditBalanceLimitReachedEmail.tsx
+++ b/packages/emails/src/templates/CreditBalanceLimitReachedEmail.tsx
@@ -1,4 +1,4 @@
-import type { TFunction } from "next-i18next";
+import type { TFunction } from "i18next";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 

--- a/packages/emails/src/templates/CreditBalanceLowWarningEmail.tsx
+++ b/packages/emails/src/templates/CreditBalanceLowWarningEmail.tsx
@@ -1,4 +1,4 @@
-import type { TFunction } from "next-i18next";
+import type { TFunction } from "i18next";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 

--- a/packages/features/CalendarEventBuilder.test.ts
+++ b/packages/features/CalendarEventBuilder.test.ts
@@ -1,4 +1,4 @@
-import type { TFunction } from "next-i18next";
+import type { TFunction } from "i18next";
 import { describe, expect, it, vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from "@prisma/client";
-import type { TFunction } from "next-i18next";
+import type { TFunction } from "i18next";
 
 import type { TimeFormat } from "@calcom/lib/timeFormat";
 import type { SchedulingType } from "@calcom/prisma/enums";

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,6 @@
     "jimp": "^0.16.1",
     "lingo.dev": "^0.111.1",
     "next-collect": "^0.2.1",
-    "next-i18next": "^15.4.2",
     "rrule": "^2.7.1",
     "sharp": "0.33.5",
     "sonner": "^1.7.4",


### PR DESCRIPTION
## What does this PR do?

- `packages/lib` already has a dep called `i18next`, so we can remove `next-i18next` and use that package instead
- `packages/emails` has a dependency on `packages/lib`, so we can also safely remove `next-i18next`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.