### PR TITLE
feat: dogfood pbac internally on IS_CALCOM instances 

### DIFF
--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,6 +14,13 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
+vi.mock("@calcom/lib/constants", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("@calcom/lib/constants");
+  return {
+    ...actual,
+    IS_CALCOM: true,
+  };
+});
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;
@@ -147,6 +154,43 @@ describe("PermissionCheckService", () => {
       expect(result).toBe(false);
     });
 
+    it("should fallback to legacy roles when PBAC permission check fails (dogfood)", async () => {
+      const membership = {
+        id: 1,
+        teamId: 1,
+        userId: 1,
+        accepted: true,
+        role: "ADMIN" as MembershipRole,
+        customRoleId: "admin_role",
+        disableImpersonation: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (MembershipRepository.findUniqueByUserIdAndTeamId as Mock).mockResolvedValueOnce(membership);
+      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
+      mockRepository.getMembershipByMembershipId.mockResolvedValueOnce({
+        id: membership.id,
+        teamId: membership.teamId,
+        userId: membership.userId,
+        customRoleId: membership.customRoleId,
+        team: { parentId: null },
+      });
+      mockRepository.getOrgMembership.mockResolvedValueOnce(null);
+      mockRepository.checkRolePermission.mockResolvedValueOnce(false); // Permission check fails
+
+      const result = await service.checkPermission({
+        userId: 1,
+        teamId: 1,
+        permission: "eventType.create",
+        fallbackRoles: ["ADMIN", "OWNER"],
+      });
+
+      // Should fallback to role check and pass since user is ADMIN
+      expect(result).toBe(true);
+      expect(mockRepository.checkRolePermission).toHaveBeenCalled();
+    });
+
     it("should return false if PBAC enabled but no customRoleId", async () => {
       const membership = {
         id: 1,
@@ -252,13 +296,50 @@ describe("PermissionCheckService", () => {
       expect(mockRepository.checkRolePermissions).not.toHaveBeenCalled();
     });
 
-    it("should return false when permissions array is empty", async () => {
+    it("should fallback to legacy roles when PBAC permissions check fails (dogfood)", async () => {
       const membership = {
         id: 1,
         teamId: 1,
         userId: 1,
         accepted: true,
         role: "ADMIN" as MembershipRole,
+        customRoleId: "admin_role",
+        disableImpersonation: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (MembershipRepository.findUniqueByUserIdAndTeamId as Mock).mockResolvedValueOnce(membership);
+      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
+      mockRepository.getMembershipByMembershipId.mockResolvedValueOnce({
+        id: membership.id,
+        teamId: membership.teamId,
+        userId: membership.userId,
+        customRoleId: membership.customRoleId,
+        team: { parentId: null },
+      });
+      mockRepository.getOrgMembership.mockResolvedValueOnce(null);
+      mockRepository.checkRolePermissions.mockResolvedValueOnce(false); // Permissions check fails
+
+      const result = await service.checkPermissions({
+        userId: 1,
+        teamId: 1,
+        permissions: ["eventType.create", "team.invite"],
+        fallbackRoles: ["ADMIN", "OWNER"],
+      });
+
+      // Should fallback to role check and pass since user is ADMIN
+      expect(result).toBe(true);
+      expect(mockRepository.checkRolePermissions).toHaveBeenCalled();
+    });
+
+    it("should return false when permissions array is empty", async () => {
+      const membership = {
+        id: 1,
+        teamId: 1,
+        userId: 1,
+        accepted: true,
+        role: "MEMBER" as MembershipRole, // Change to MEMBER so fallback also fails
         customRoleId: "admin_role",
         disableImpersonation: false,
         createdAt: new Date(),

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,13 +14,6 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", async () => {
-  const actual = await vi.importActual("@calcom/lib/constants");
-  return {
-    ...actual,
-    IS_CALCOM: true,
-  };
-});
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,8 +14,8 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", async (importOriginal) => {
-  const actual = (await importOriginal()) as typeof import("@calcom/lib/constants");
+vi.mock("@calcom/lib/constants", async () => {
+  const actual = await vi.importActual("@calcom/lib/constants");
   return {
     ...actual,
     IS_CALCOM: true,

--- a/packages/features/pbac/services/permission-check.service.ts
+++ b/packages/features/pbac/services/permission-check.service.ts
@@ -1,4 +1,5 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { IS_CALCOM } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import prisma from "@calcom/prisma";
@@ -15,6 +16,8 @@ import type {
 } from "../domain/types/permission-registry";
 import { PermissionRepository } from "../infrastructure/repositories/PermissionRepository";
 import { PermissionService } from "./permission.service";
+
+const DOGFOOD_PBAC_INTERNALLY = IS_CALCOM;
 
 export class PermissionCheckService {
   private readonly PBAC_FEATURE_FLAG = "pbac" as const;
@@ -126,7 +129,21 @@ export class PermissionCheckService {
           return false;
         }
 
-        return this.hasPermission({ membershipId: membership.id }, permission);
+        const hasPbacPermission = await this.hasPermission({ membershipId: membership.id }, permission);
+
+        if (DOGFOOD_PBAC_INTERNALLY && !hasPbacPermission) {
+          return this.dogfoodFallback({
+            userId,
+            teamId,
+            membershipId: membership.id,
+            permissions: [permission],
+            hasPbacPermission,
+            fallbackRoles,
+            membershipRole: membership.role,
+          });
+        }
+
+        return hasPbacPermission;
       }
 
       return this.checkFallbackRoles(membership.role, fallbackRoles);
@@ -175,7 +192,21 @@ export class PermissionCheckService {
           return false;
         }
 
-        return this.hasPermissions({ membershipId: membership.id }, permissions);
+        const hasPbacPermission = await this.hasPermissions({ membershipId: membership.id }, permissions);
+
+        if (DOGFOOD_PBAC_INTERNALLY && !hasPbacPermission) {
+          return this.dogfoodFallback({
+            userId,
+            teamId,
+            membershipId: membership.id,
+            permissions,
+            hasPbacPermission,
+            fallbackRoles,
+            membershipRole: membership.role,
+          });
+        }
+
+        return hasPbacPermission;
       }
 
       return this.checkFallbackRoles(membership.role, fallbackRoles);
@@ -250,6 +281,52 @@ export class PermissionCheckService {
 
   private checkFallbackRoles(userRole: MembershipRole, allowedRoles: MembershipRole[]): boolean {
     return allowedRoles.includes(userRole);
+  }
+
+  /**
+   * Internal dogfooding fallback for PBAC permissions
+   *
+   * This method is used internally at Cal.com to help us transition to PBAC.
+   * When PBAC is enabled but a user doesn't have the necessary permission strings,
+   * we fall back to checking their legacy fallback roles to avoid breaking existing workflows.
+   *
+   * An alert is logged to Axiom when this fallback occurs so we can identify and fix
+   * missing permissions in our PBAC configuration.
+   *
+   * @private
+   * @param params - Object containing userId, teamId, membershipId, permissions, hasPbacPermission, fallbackRoles, and membershipRole
+   * @returns boolean - Whether the user has permission via fallback roles
+   */
+  private dogfoodFallback(params: {
+    userId: number;
+    teamId: number;
+    membershipId: number;
+    permissions: PermissionString[];
+    hasPbacPermission: boolean;
+    fallbackRoles: MembershipRole[];
+    membershipRole: MembershipRole;
+  }): boolean {
+    const { userId, teamId, membershipId, permissions, hasPbacPermission, fallbackRoles, membershipRole } =
+      params;
+
+    const debugInfo = {
+      userId,
+      teamId,
+      membershipId,
+      permissions,
+      hasPbacPermission,
+      fallbackRoles,
+    };
+
+    this.logger.warn(
+      `PBAC INTERNAL - Failed but user doesnt have permission string to carry out this action. Falling back to fallback roles. \n JSON${JSON.stringify(
+        debugInfo,
+        null,
+        2
+      )}`
+    );
+
+    return this.checkFallbackRoles(membershipRole, fallbackRoles);
   }
 
   /**

--- a/packages/features/pbac/services/permission-check.service.ts
+++ b/packages/features/pbac/services/permission-check.service.ts
@@ -1,5 +1,4 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { IS_CALCOM } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import prisma from "@calcom/prisma";
@@ -17,7 +16,7 @@ import type {
 import { PermissionRepository } from "../infrastructure/repositories/PermissionRepository";
 import { PermissionService } from "./permission.service";
 
-const DOGFOOD_PBAC_INTERNALLY = IS_CALCOM;
+const DOGFOOD_PBAC_INTERNALLY = true;
 
 export class PermissionCheckService {
   private readonly PBAC_FEATURE_FLAG = "pbac" as const;


### PR DESCRIPTION
## What does this PR do?

This PR enabled the PBAC check for pretty much everywhere if the feature flag is enabled for a org. 

However, If PBAC fails for whatever reason - we fall back to our old role checks (current way of checking permissions in prod) and log heavily so we can setup alerts in axiom and figure out where this is happening. 

We will be testing this internally on the Cal.com org while we roll this out slowly with/without a feature flag. 

## How should this be tested?

Use yarn seed-pbac and just explore the app. If you see logs console of `PBAC INTERNAL` there is places where the default role permissions do not match the current implementation without a feature flag