### PR TITLE
feat: add external link icon to organization admin API menu item

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
@@ -117,6 +117,7 @@ const getTabs = (orgBranding: OrganizationBranding | null) => {
         {
           name: "admin_api",
           href: "https://cal.com/docs/enterprise-features/api/api-reference/bookings#admin-access",
+          isExternalLink: true,
         },
       ],
     },


### PR DESCRIPTION
## What does this PR do?

Adds an external link icon to the "admin_api" menu item in the organization settings sidebar, matching the same visual pattern already used by the "members" menu item.

**Changes:**
- Added `isExternalLink: true` property to the admin_api menu item configuration
- Leverages existing VerticalTabItem component functionality to render the external link icon
- Maintains consistency with other external links in the settings sidebar

## Visual Demo

**Expected behavior:** The admin API menu item should now display a small external link icon next to the text, similar to how the members page already works.

*Note: Visual verification needed as I was unable to complete browser testing due to local authentication issues.*

## How should this be tested?

1. Navigate to `/settings/organizations` (requires organization admin permissions)
2. Look for the "admin_api" menu item in the sidebar
3. Verify it now shows an external link icon next to the text
4. Click the link to confirm it still opens in a new tab to the correct documentation URL
5. Compare with the "members" menu item to ensure visual consistency

**Environment requirements:**
- Must be logged in as an organization admin/owner to see the organization settings sidebar
- Organization context required to access the settings page

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required (UI-only change)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works

**Note on testing:** Existing tests in `packages/ui/components/navigation/tabs/navigation.test.tsx` already cover the `isExternalLink` functionality for VerticalTabItem components.

---

**Link to Devin run:** https://app.devin.ai/sessions/384c36a9d0624a1b8046514c2a208cc2
**Requested by:** @sean-brydon

## Human Review Checklist

- [ ] Visual verification: External link icon appears next to admin API menu item
- [ ] Link behavior: Still opens documentation in new tab when clicked  
- [ ] Visual consistency: Icon matches the style/placement of other external links
- [ ] No regressions: Other menu items in settings sidebar still work correctly