### PR TITLE
feat: skip CI checks for translation-only PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(**.md|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json)"
+              - "!(**.md|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json|i18n.lock)"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |


### PR DESCRIPTION
## What does this PR do?

This PR optimizes CI performance for auto-generated translation PRs by adding `i18n.lock` to the path filter exclusions in the GitHub Actions workflow. When PRs only modify translation files (`common.json` and `i18n.lock`), expensive CI jobs (dependency installation, type checking, linting, testing, and builds) will be skipped.

**Context**: Translation PRs like #23528 from lingo.dev frequently fail to merge quickly due to the active main branch, but they don't require the full test suite since they only contain translation updates.

**Technical change**: Adds `|i18n.lock` to the existing path filter exclusion pattern in `.github/workflows/pr.yml`, extending the current behavior that already skips CI for `common.json`-only changes.

## Visual Demo

Not applicable - this is a workflow configuration change with no visible UI impact.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Documentation update: N/A - this is an internal workflow optimization
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works

## How should this be tested?

**Testing approach:**
1. Create a test PR that only modifies `i18n.lock` and `common.json` files
2. Verify that expensive CI jobs (deps, type-check, lint, unit-test, build-*, e2e-*) are skipped
3. Confirm that the `required` job still passes and the PR remains mergeable
4. Test that PRs with other file changes still trigger full CI as expected

**Key validation points:**
- Path filter syntax works correctly with dorny/paths-filter@v3
- Repository branch protection rules remain satisfied
- No unintended files are excluded by the new pattern

## Checklist

**Human Review Priorities:**
- [ ] **Critical**: Verify path filter syntax is correct for dorny/paths-filter action
- [ ] **Critical**: Confirm repository branch protection rules won't be broken by skipping these jobs
- [ ] **Important**: Validate that `i18n.lock` pattern doesn't accidentally match other important files
- [ ] **Important**: Check if there are other translation-related files that should also be excluded

**Risks to consider:**
- Workflow syntax error could break CI for all PRs
- Exclusion pattern might be too broad or too narrow
- Required status checks configuration might conflict with skipped jobs

---

**Link to Devin run**: https://app.devin.ai/sessions/41b0f3c86b3743ec91d65142254ad345  
**Requested by**: @keithwillcode