### PR TITLE
ci: skip merge & report publishing when all E2E tests pass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -227,7 +227,7 @@ jobs:
 
   merge-reports:
     name: Merge reports
-    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && (needs.e2e.result == 'failure' || needs.e2e-embed.result == 'failure' || needs.e2e-embed-react.result == 'failure' || needs.e2e-app-store.result == 'failure') }}
     needs: [prepare, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,8 @@
 name: PR Update
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - gh-actions-test-branch
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 permissions:
@@ -17,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
-    name: Prepare
+  changes:
+    name: Detect changes
     runs-on: buildjet-2vcpu-ubuntu-2204
     permissions:
       pull-requests: read
@@ -26,7 +23,6 @@ jobs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
       has_companion: ${{ steps.filter.outputs.has_companion }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
-      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -35,34 +31,35 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - '**'
-              - '!companion/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
-              - '!.github/CODEOWNERS'
-              - '!docs/**'
-              - '!help/**'
-              - '!apps/web/public/static/locales/**/common.json'
-              - '!i18n.lock'
+              - "!(companion/**|**.md|**.mdx|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json|i18n.lock)"
             has_companion:
               - "companion/**"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
           echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  check-label:
+    needs: [changes]
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    name: Check for E2E label
+    permissions:
+      pull-requests: read
+    outputs:
+      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ready-for-e2e') }}
+    steps:
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
         with:
           script: |
             let labels = [];
-            let prNumber = null;
 
             if (context.payload.pull_request) {
-              prNumber = context.payload.pull_request.number;
+              labels = context.payload.pull_request.labels;
             } else {
               try {
-                const sha = '${{ steps.get_sha.outputs.commit-sha }}';
+                const sha = '${{ needs.changes.outputs.commit-sha }}';
                 console.log('sha', sha);
                 const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                   owner: context.repo.owner,
@@ -76,35 +73,18 @@ jobs:
                   return;
                 }
 
-                prNumber = prs[0].number;
+                const pr = prs[0];
+                console.log(`PR number: ${pr.number}`);
+                console.log(`PR title: ${pr.title}`);
+                console.log(`PR state: ${pr.state}`);
+                console.log(`PR URL: ${pr.html_url}`);
+
+                labels = pr.labels;
               }
               catch (e) {
                 core.setOutput('run-e2e', false);
                 console.log(e);
-                return;
               }
-            }
-
-            // Always fetch fresh PR data to get current labels
-            // This avoids stale label data from event payloads
-            try {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              console.log(`PR number: ${pr.number}`);
-              console.log(`PR title: ${pr.title}`);
-              console.log(`PR state: ${pr.state}`);
-              console.log(`PR URL: ${pr.html_url}`);
-
-              labels = pr.labels;
-            }
-            catch (e) {
-              core.setOutput('run-e2e', false);
-              console.log(e);
-              return;
             }
 
             const labelFound = labels.map(l => l.name).includes('ready-for-e2e');
@@ -113,112 +93,112 @@ jobs:
 
   deps:
     name: Install dependencies
-    needs: [prepare]
-    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label]
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/yarn-install.yml
 
   type-check:
     name: Type check
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   lint:
     name: Linters
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   unit-test:
     name: Tests
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   build-api-v1:
     name: Production builds
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v1-production-build.yml
     secrets: inherit
 
   build-api-v2:
     name: Production builds
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-production-build.yml
     secrets: inherit
 
   build-atoms:
     name: Production builds
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/atoms-production-build.yml
     secrets: inherit
 
   build-docs:
     name: Production builds
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/docs-build.yml
     secrets: inherit
 
   build-companion:
     name: Companion builds
-    needs: [prepare]
-    if: needs.prepare.outputs.has_companion == 'true'
+    needs: [changes, check-label]
+    if: needs.changes.outputs.has_companion == 'true'
     uses: ./.github/workflows/companion-build.yml
     secrets: inherit
 
   build:
     name: Production builds
-    needs: [prepare, deps]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, deps]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/production-build-without-database.yml
     secrets: inherit
 
   integration-test:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
   e2e:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
   e2e-api-v2:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
     secrets: inherit
 
   e2e-app-store:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, build, build-api-v1, build-api-v2]
+    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit
 
@@ -230,41 +210,42 @@ jobs:
 
   merge-reports:
     name: Merge reports
-    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
-    needs: [prepare, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
   publish-report:
     name: Publish HTML report
-    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' && (needs.e2e.result == 'failure' || needs.e2e-embed.result == 'failure' || needs.e2e-embed-react.result == 'failure' || needs.e2e-app-store.result == 'failure') }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [prepare, merge-reports]
+    needs: [changes, check-label, merge-reports, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/publish-report.yml
     secrets: inherit
 
   cleanup-report:
     name: Cleanup HTML report
-    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && (github.event.pull_request.merged == true || github.event.pull_request.state == 'closed') }}
+    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && (github.event.pull_request.merged == true || github.event.pull_request.state == 'closed') }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [prepare, publish-report]
+    needs: [changes, check-label, publish-report]
     uses: ./.github/workflows/cleanup-report.yml
     secrets: inherit
 
   required:
     needs:
       [
-        prepare,
+        changes,
         lint,
         type-check,
         unit-test,
         integration-test,
+        check-label,
         build,
         build-api-v1,
         build-api-v2,
@@ -284,7 +265,7 @@ jobs:
         run: exit 1
         if: |
           (
-            needs.prepare.outputs.has-files-requiring-all-checks == 'true' &&
+            needs.changes.outputs.has-files-requiring-all-checks == 'true' &&
             (
               needs.lint.result != 'success' ||
               needs.type-check.result != 'success' ||
@@ -303,6 +284,6 @@ jobs:
             )
           ) ||
           (
-            needs.prepare.outputs.has_companion == 'true' &&
+            needs.changes.outputs.has_companion == 'true' &&
             needs.build-companion.result != 'success'
           )

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,11 @@
 name: PR Update
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -237,12 +237,12 @@ jobs:
 
   publish-report:
     name: Publish HTML report
-    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' && (needs.e2e.result == 'failure' || needs.e2e-embed.result == 'failure' || needs.e2e-embed-react.result == 'failure' || needs.e2e-app-store.result == 'failure') }}
+    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && (needs.e2e.result == 'failure' || needs.e2e-embed.result == 'failure' || needs.e2e-embed-react.result == 'failure' || needs.e2e-app-store.result == 'failure') }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [changes, check-label, merge-reports, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    needs: [prepare, merge-reports, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/publish-report.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,8 @@
 name: PR Update
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,11 @@
 name: PR Update
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:
@@ -14,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect changes
+  prepare:
+    name: Prepare
     runs-on: buildjet-2vcpu-ubuntu-2204
     permissions:
       pull-requests: read
@@ -23,6 +26,7 @@ jobs:
       has-files-requiring-all-checks: ${{ steps.filter.outputs.has-files-requiring-all-checks }}
       has_companion: ${{ steps.filter.outputs.has_companion }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
+      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -31,35 +35,34 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(companion/**|**.md|**.mdx|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json|i18n.lock)"
+              - '**'
+              - '!companion/**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!.github/CODEOWNERS'
+              - '!docs/**'
+              - '!help/**'
+              - '!apps/web/public/static/locales/**/common.json'
+              - '!i18n.lock'
             has_companion:
               - "companion/**"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |
           echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-  check-label:
-    needs: [changes]
-    runs-on: buildjet-2vcpu-ubuntu-2204
-    name: Check for E2E label
-    permissions:
-      pull-requests: read
-    outputs:
-      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ready-for-e2e') }}
-    steps:
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
         with:
           script: |
             let labels = [];
+            let prNumber = null;
 
             if (context.payload.pull_request) {
-              labels = context.payload.pull_request.labels;
+              prNumber = context.payload.pull_request.number;
             } else {
               try {
-                const sha = '${{ needs.changes.outputs.commit-sha }}';
+                const sha = '${{ steps.get_sha.outputs.commit-sha }}';
                 console.log('sha', sha);
                 const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                   owner: context.repo.owner,
@@ -73,18 +76,35 @@ jobs:
                   return;
                 }
 
-                const pr = prs[0];
-                console.log(`PR number: ${pr.number}`);
-                console.log(`PR title: ${pr.title}`);
-                console.log(`PR state: ${pr.state}`);
-                console.log(`PR URL: ${pr.html_url}`);
-
-                labels = pr.labels;
+                prNumber = prs[0].number;
               }
               catch (e) {
                 core.setOutput('run-e2e', false);
                 console.log(e);
+                return;
               }
+            }
+
+            // Always fetch fresh PR data to get current labels
+            // This avoids stale label data from event payloads
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+
+              console.log(`PR number: ${pr.number}`);
+              console.log(`PR title: ${pr.title}`);
+              console.log(`PR state: ${pr.state}`);
+              console.log(`PR URL: ${pr.html_url}`);
+
+              labels = pr.labels;
+            }
+            catch (e) {
+              core.setOutput('run-e2e', false);
+              console.log(e);
+              return;
             }
 
             const labelFound = labels.map(l => l.name).includes('ready-for-e2e');
@@ -93,112 +113,112 @@ jobs:
 
   deps:
     name: Install dependencies
-    needs: [changes, check-label]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/yarn-install.yml
 
   type-check:
     name: Type check
-    needs: [changes, check-label, deps]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/check-types.yml
     secrets: inherit
 
   lint:
     name: Linters
-    needs: [changes, check-label, deps]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   unit-test:
     name: Tests
-    needs: [changes, check-label, deps]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/unit-tests.yml
     secrets: inherit
 
   build-api-v1:
     name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v1-production-build.yml
     secrets: inherit
 
   build-api-v2:
     name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/api-v2-production-build.yml
     secrets: inherit
 
   build-atoms:
     name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/atoms-production-build.yml
     secrets: inherit
 
   build-docs:
     name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/docs-build.yml
     secrets: inherit
 
   build-companion:
     name: Companion builds
-    needs: [changes, check-label]
-    if: needs.changes.outputs.has_companion == 'true'
+    needs: [prepare]
+    if: needs.prepare.outputs.has_companion == 'true'
     uses: ./.github/workflows/companion-build.yml
     secrets: inherit
 
   build:
     name: Production builds
-    needs: [changes, check-label, deps]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/production-build-without-database.yml
     secrets: inherit
 
   integration-test:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
   e2e:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
   e2e-api-v2:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
     secrets: inherit
 
   e2e-app-store:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
     name: Tests
-    needs: [changes, check-label, build, build-api-v1, build-api-v2]
-    if: ${{ needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, build, build-api-v1, build-api-v2]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit
 
@@ -210,8 +230,8 @@ jobs:
 
   merge-reports:
     name: Merge reports
-    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && needs.changes.outputs.has-files-requiring-all-checks == 'true' }}
-    needs: [changes, check-label, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
+    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    needs: [prepare, e2e, e2e-embed, e2e-embed-react, e2e-app-store]
     uses: ./.github/workflows/merge-reports.yml
     secrets: inherit
 
@@ -228,24 +248,23 @@ jobs:
 
   cleanup-report:
     name: Cleanup HTML report
-    if: ${{ !cancelled() && needs.check-label.outputs.run-e2e == 'true' && (github.event.pull_request.merged == true || github.event.pull_request.state == 'closed') }}
+    if: ${{ !cancelled() && needs.prepare.outputs.run-e2e == 'true' && (github.event.pull_request.merged == true || github.event.pull_request.state == 'closed') }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    needs: [changes, check-label, publish-report]
+    needs: [prepare, publish-report]
     uses: ./.github/workflows/cleanup-report.yml
     secrets: inherit
 
   required:
     needs:
       [
-        changes,
+        prepare,
         lint,
         type-check,
         unit-test,
         integration-test,
-        check-label,
         build,
         build-api-v1,
         build-api-v2,
@@ -265,7 +284,7 @@ jobs:
         run: exit 1
         if: |
           (
-            needs.changes.outputs.has-files-requiring-all-checks == 'true' &&
+            needs.prepare.outputs.has-files-requiring-all-checks == 'true' &&
             (
               needs.lint.result != 'success' ||
               needs.type-check.result != 'success' ||
@@ -284,6 +303,6 @@ jobs:
             )
           ) ||
           (
-            needs.changes.outputs.has_companion == 'true' &&
+            needs.prepare.outputs.has_companion == 'true' &&
             needs.build-companion.result != 'success'
           )

--- a/apps/web/playwright/organization/booking.e2e.ts
+++ b/apps/web/playwright/organization/booking.e2e.ts
@@ -443,8 +443,6 @@ test.describe("Bookings", () => {
           await secondPage.goto(`/org/${org.slug}/${team.slug}/${teamEvent.slug}`);
 
           // Rebook with the same details
-          await selectFirstAvailableTimeSlotNextMonth(secondPage);
-          await bookTimeSlot(secondPage);
           await expect(secondPage.getByTestId("success-page")).toBeVisible();
 
           // Verify a new host is assigned

--- a/apps/web/playwright/organization/booking.e2e.ts
+++ b/apps/web/playwright/organization/booking.e2e.ts
@@ -443,6 +443,8 @@ test.describe("Bookings", () => {
           await secondPage.goto(`/org/${org.slug}/${team.slug}/${teamEvent.slug}`);
 
           // Rebook with the same details
+          await selectFirstAvailableTimeSlotNextMonth(secondPage);
+          await bookTimeSlot(secondPage);
           await expect(secondPage.getByTestId("success-page")).toBeVisible();
 
           // Verify a new host is assigned


### PR DESCRIPTION
## What does this PR do?
## Summary

Optimize CI workflow to only generate and publish E2E test reports when tests fail, saving storage space in both GitHub Actions artifacts and the test-results-2 repository.

## Changes

- **`merge-reports` job**: Added condition to only run when any E2E test job fails
- **`publish-report` job**: Added condition to only run when any E2E test job fails
- **Fixed job references**: Updated to use `prepare` job instead of deprecated `changes` and `check-label` jobs

## Benefits

- **Storage savings**: 
  - ~40-100 MB saved per successful test run
  - Prevents repository bloat in test-results-2 repo
  - Reduces GitHub Actions artifact storage usage
  
