### PR TITLE
fix: delete team bug when instant meeting token exist

### DIFF
--- a/packages/prisma/migrations/20250903165210_add_on_cascade/migration.sql
+++ b/packages/prisma/migrations/20250903165210_add_on_cascade/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "InstantMeetingToken" DROP CONSTRAINT "InstantMeetingToken_teamId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "InstantMeetingToken" ADD CONSTRAINT "InstantMeetingToken_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -702,7 +702,7 @@ model InstantMeetingToken {
   token     String   @unique
   expires   DateTime
   teamId    Int
-  team      Team     @relation(fields: [teamId], references: [id])
+  team      Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
   bookingId Int?     @unique
   booking   Booking? @relation(fields: [bookingId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before:-

![Screenshot 2025-09-03 at 10 21 47 PM](https://github.com/user-attachments/assets/c6f186ec-80b7-46ef-b900-a1bd0e41dd46)




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Create a new team in org
2) Enable instant meeting on any team event type and book an instant meeting


