### PR TITLE
fix: make CSRF cookies accessible in embedded iframe contexts

### DIFF
--- a/apps/web/app/api/csrf/route.ts
+++ b/apps/web/app/api/csrf/route.ts
@@ -1,15 +1,21 @@
 import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 
+import { WEBAPP_URL } from "@calcom/lib/constants";
+
 export async function GET() {
   const token = randomBytes(32).toString("hex");
 
   const res = NextResponse.json({ csrfToken: token });
 
+  // We need this cookie to be accessible from embeds where the booking flow is displayed within an iframe on a different origin.
+  // For third‑party iframe contexts (embeds on other sites), browsers require SameSite=None and Secure to make the cookie available.
+  // For local development on http://localhost we fall back to SameSite=Lax to avoid requiring https during development.
+  const useSecureCookies = WEBAPP_URL.startsWith("https://");
   res.cookies.set("calcom.csrf_token", token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    secure: useSecureCookies,
+    sameSite: useSecureCookies ? "none" : "lax",
     path: "/",
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes 403 errors when cancelling scheduled meetings through embedded forms by making CSRF cookies accessible in cross-origin iframe contexts.

**Root cause**: Embedded forms run in iframes on external sites (cross-origin context), but the CSRF cookie was set with `sameSite: "lax"` which browsers block in third-party iframe contexts.

**Solution**: Use conditional `sameSite` cookie settings:
- `sameSite: "none"` for HTTPS environments (required for cross-origin iframe access)
- `sameSite: "lax"` for local development (avoids requiring HTTPS)

This follows the same pattern already established in the `reserveSlot.handler.ts` for embed compatibility.

## How should this be tested?

**Critical**: This fix needs testing in actual embedded iframe contexts to verify it resolves the 403 error:

1. **Embedded context test**:
   - Embed a Cal.com booking form on an external website
   - Complete a booking through the embedded form
   - Attempt to cancel the booking through the embedded cancellation flow
   - Verify no 403 error occurs

2. **Direct booking test**:
   - Create and cancel a booking directly on cal.com
   - Verify existing functionality still works

3. **Environment variables**: 
   - Ensure `WEBAPP_URL` is properly configured for your environment
   - For embeds, this should be `https://app.cal.com`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

