### PR TITLE
chore: add max-warnings to avoid pushing new warns

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   "lint-staged": {
     "(apps|packages)/**/*.{js,ts,jsx,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings=0"
     ],
     "*.json": [
       "prettier --write"


### PR DESCRIPTION
## What does this PR do?

By adding this we are avoiding new commits with warning messages, especially eslint ones. So we will ensure all code being pushed will be clear for new warnings. TypeScript violations should be flagged with specific Eslint annotations and will be evaluated in code reviews.