### PR TITLE
fix: Avoid using prisma types on client

### DIFF
--- a/packages/lib/redactError.ts
+++ b/packages/lib/redactError.ts
@@ -1,18 +1,12 @@
-import { Prisma } from "@prisma/client";
-
 import logger from "@calcom/lib/logger";
 
 import { IS_PRODUCTION } from "./constants";
 
 const log = logger.getSubLogger({ prefix: [`[redactError]`] });
 
-function shouldRedact<T extends Error>(error: T) {
-  return (
-    error instanceof Prisma.PrismaClientInitializationError ||
-    error instanceof Prisma.PrismaClientKnownRequestError ||
-    error instanceof Prisma.PrismaClientUnknownRequestError ||
-    error instanceof Prisma.PrismaClientValidationError
-  );
+function shouldRedact(error: Error) {
+  const n = error.name || "";
+  return /Prisma/i.test(n);
 }
 
 export const redactError = <T extends Error | unknown>(error: T) => {


### PR DESCRIPTION
## What does this PR do?

Changes the `redactError` to avoid importing Prisma to client due to barrel export at @calcom/prisma/client. The types itself are not a problem however it requires import of Prisma instance.

```
@calcom/web:dev: Import traces:
@calcom/web:dev:   #1 [external]:
@calcom/web:dev:     [externals]/@prisma/client [external]
@calcom/web:dev:     ./packages/lib/redactError.ts [Client Component SSR]
@calcom/web:dev:     ./apps/web/app/error.tsx [Client Component SSR]
@calcom/web:dev:     ./apps/web/app/error.tsx [Server Component]
@calcom/web:dev: 
@calcom/web:dev:   #3 [external]:
@calcom/web:dev:     [externals]/@prisma/client [external]
@calcom/web:dev:     ./packages/lib/redactError.ts [Client Component SSR]
@calcom/web:dev:     ./apps/web/app/error.tsx [Client Component SSR]
@calcom/web:dev:     ./apps/web/app/global-error.tsx [Client Component SSR]
@calcom/web:dev:     ./apps/web/app/global-error.tsx [Server Component]
```