### PR TITLE
perf: import enums from `@calcom/prisma/enums`

### DIFF
--- a/apps/api/v1/pages/api/event-types/_post.ts
+++ b/apps/api/v1/pages/api/event-types/_post.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest } from "next";
 import { HttpError } from "@calcom/lib/http-error";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { schemaEventTypeCreateBodyParams, schemaEventTypeReadPublic } from "~/lib/validations/event-type";
 import { canUserAccessTeamWithRole } from "~/pages/api/teams/[teamId]/_auth-middleware";

--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
@@ -38,7 +38,6 @@ import {
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ApiQuery, ApiExcludeController as DocsExcludeController } from "@nestjs/swagger";
-import { CreationSource } from "@prisma/client";
 import { Request } from "express";
 import { NextApiRequest } from "next/types";
 import { v4 as uuidv4 } from "uuid";
@@ -65,6 +64,7 @@ import {
 } from "@calcom/platform-types";
 import { ApiResponse } from "@calcom/platform-types";
 import { PrismaClient } from "@calcom/prisma";
+import { CreationSource } from "@calcom/prisma/enums";
 
 type BookingRequest = Request & {
   userId?: number;

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -22,7 +22,6 @@ import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { CreationSource } from "@prisma/client";
 import { isURL, isPhoneNumber } from "class-validator";
 import { Request } from "express";
 import { DateTime } from "luxon";
@@ -46,6 +45,7 @@ import {
 } from "@calcom/platform-types";
 import { BookingInputLocation_2024_08_13 } from "@calcom/platform-types/bookings/2024-08-13/inputs/location.input";
 import { EventType } from "@calcom/prisma/client";
+import { CreationSource } from "@calcom/prisma/enums";
 
 type BookingRequest = NextApiRequest & {
   userId: number | undefined;

--- a/apps/api/v2/src/lib/roles/constants.ts
+++ b/apps/api/v2/src/lib/roles/constants.ts
@@ -1,4 +1,4 @@
-import { MembershipRole } from "@prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export const SYSTEM_ADMIN_ROLE = "SYSADMIN";
 export const ORG_ROLES = [

--- a/apps/api/v2/src/modules/auth/decorators/roles/membership-roles.decorator.ts
+++ b/apps/api/v2/src/modules/auth/decorators/roles/membership-roles.decorator.ts
@@ -1,4 +1,5 @@
 import { Reflector } from "@nestjs/core";
-import { MembershipRole } from "@prisma/client";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export const MembershipRoles = Reflector.createDecorator<MembershipRole[]>();

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-users/oauth-client-users.controller.ts
@@ -1,5 +1,4 @@
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
-import { Locales } from "@/lib/enums/locales";
 import { MembershipRoles } from "@/modules/auth/decorators/roles/membership-roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { OrganizationRolesGuard } from "@/modules/auth/guards/organization-roles/organization-roles.guard";
@@ -7,7 +6,6 @@ import { GetManagedUsersInput } from "@/modules/oauth-clients/controllers/oauth-
 import { CreateManagedUserOutput } from "@/modules/oauth-clients/controllers/oauth-client-users/outputs/create-managed-user.output";
 import { GetManagedUserOutput } from "@/modules/oauth-clients/controllers/oauth-client-users/outputs/get-managed-user.output";
 import { GetManagedUsersOutput } from "@/modules/oauth-clients/controllers/oauth-client-users/outputs/get-managed-users.output";
-import { ManagedUserOutput } from "@/modules/oauth-clients/controllers/oauth-client-users/outputs/managed-user.output";
 import { TOKENS_DOCS } from "@/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller";
 import { KeysResponseDto } from "@/modules/oauth-clients/controllers/oauth-flow/responses/KeysResponse.dto";
 import { OAuthClientGuard } from "@/modules/oauth-clients/guards/oauth-client-guard";
@@ -34,10 +32,10 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { ApiOperation, ApiTags as DocsTags, ApiHeader } from "@nestjs/swagger";
-import { User, MembershipRole } from "@prisma/client";
-import { plainToInstance } from "class-transformer";
+import { User } from "@prisma/client";
 
 import { SUCCESS_STATUS, X_CAL_SECRET_KEY } from "@calcom/platform-constants";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 @Controller({
   path: "/v2/oauth-clients/:clientId/users",

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-webhooks/oauth-client-webhooks.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-client-webhooks/oauth-client-webhooks.controller.ts
@@ -17,11 +17,12 @@ import { OAuthClientWebhooksService } from "@/modules/webhooks/services/oauth-cl
 import { WebhooksService } from "@/modules/webhooks/services/webhooks.service";
 import { Controller, Post, Body, UseGuards, Get, Param, Query, Delete, Patch } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { Webhook, MembershipRole } from "@prisma/client";
+import { Webhook } from "@prisma/client";
 import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS, X_CAL_SECRET_KEY } from "@calcom/platform-constants";
 import { SkipTakePagination } from "@calcom/platform-types";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { OAuthClientGuard } from "../../guards/oauth-client-guard";
 

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-clients/oauth-clients.controller.ts
@@ -37,10 +37,10 @@ import {
   ApiExcludeEndpoint,
   ApiHeader,
 } from "@nestjs/swagger";
-import { User, MembershipRole } from "@prisma/client";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { CreateOAuthClientInput, UpdateOAuthClientInput, Pagination } from "@calcom/platform-types";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 @Controller({
   path: "/v2/oauth-clients",

--- a/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
+++ b/apps/api/v2/src/modules/oauth-clients/services/oauth-clients-users.service.ts
@@ -8,9 +8,10 @@ import { CreateManagedUserInput } from "@/modules/users/inputs/create-managed-us
 import { UpdateManagedUserInput } from "@/modules/users/inputs/update-managed-user.input";
 import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, ConflictException, Injectable, Logger } from "@nestjs/common";
-import { User, CreationSource, PlatformOAuthClient } from "@prisma/client";
+import { User, PlatformOAuthClient } from "@prisma/client";
 
 import { createNewUsersConnectToOrgIfExists, slugify } from "@calcom/platform-libraries";
+import { CreationSource } from "@calcom/prisma/enums";
 
 @Injectable()
 export class OAuthClientUsersService {

--- a/apps/api/v2/src/modules/organizations/attributes/index/inputs/create-organization-attribute.input.ts
+++ b/apps/api/v2/src/modules/organizations/attributes/index/inputs/create-organization-attribute.input.ts
@@ -1,6 +1,5 @@
 import { CreateOrganizationAttributeOptionInput } from "@/modules/organizations/attributes/options/inputs/create-organization-attribute-option.input";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { AttributeType } from "@prisma/client";
 import { Type } from "class-transformer";
 import {
   IsArray,
@@ -11,6 +10,8 @@ import {
   IsString,
   ValidateNested,
 } from "class-validator";
+
+import { AttributeType } from "@calcom/prisma/enums";
 
 export class CreateOrganizationAttributeInput {
   @IsString()

--- a/apps/api/v2/src/modules/organizations/attributes/index/inputs/update-organization-attribute.input.ts
+++ b/apps/api/v2/src/modules/organizations/attributes/index/inputs/update-organization-attribute.input.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { AttributeType } from "@prisma/client";
 import { IsBoolean, IsEnum, IsOptional, IsString } from "class-validator";
+
+import { AttributeType } from "@calcom/prisma/enums";
 
 export class UpdateOrganizationAttributeInput {
   @IsString()

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.e2e-spec.ts
@@ -6,7 +6,7 @@ import { UsersModule } from "@/modules/users/users.module";
 import { INestApplication } from "@nestjs/common";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { Test } from "@nestjs/testing";
-import { SchedulingType, User } from "@prisma/client";
+import { User } from "@prisma/client";
 import * as request from "supertest";
 import { EventTypesRepositoryFixture } from "test/fixtures/repository/event-types.repository.fixture";
 import { MembershipRepositoryFixture } from "test/fixtures/repository/membership.repository.fixture";
@@ -33,6 +33,7 @@ import {
   UpdateTeamEventTypeInput_2024_06_14,
 } from "@calcom/platform-types";
 import { Team } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
 
 describe("Organizations Event Types Endpoints", () => {
   describe("User Authentication - User is Org Admin", () => {

--- a/apps/api/v2/src/modules/organizations/event-types/services/output.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/output.service.ts
@@ -2,10 +2,18 @@ import { OutputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types
 import { TeamsEventTypesRepository } from "@/modules/teams/event-types/teams-event-types.repository";
 import { UsersRepository } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
-import type { EventType, User, Schedule, Host, DestinationCalendar, CalVideoSettings } from "@prisma/client";
-import { SchedulingType, Team } from "@prisma/client";
+import type {
+  Team,
+  EventType,
+  User,
+  Schedule,
+  Host,
+  DestinationCalendar,
+  CalVideoSettings,
+} from "@prisma/client";
 
 import { HostPriority, TeamEventTypeResponseHost } from "@calcom/platform-types";
+import { SchedulingType } from "@calcom/prisma/enums";
 
 type EventTypeRelations = {
   users: User[];

--- a/apps/api/v2/src/modules/organizations/memberships/inputs/create-organization-membership.input.ts
+++ b/apps/api/v2/src/modules/organizations/memberships/inputs/create-organization-membership.input.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsBoolean, IsOptional, IsEnum, IsInt } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class CreateOrgMembershipDto {
   @IsInt()

--- a/apps/api/v2/src/modules/organizations/memberships/inputs/update-organization-membership.input.ts
+++ b/apps/api/v2/src/modules/organizations/memberships/inputs/update-organization-membership.input.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsBoolean, IsOptional, IsEnum } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class UpdateOrgMembershipDto {
   @IsOptional()

--- a/apps/api/v2/src/modules/organizations/teams/index/outputs/organization-team.output.ts
+++ b/apps/api/v2/src/modules/organizations/teams/index/outputs/organization-team.output.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { Expose, Type } from "class-transformer";
 import { IsEnum, IsString, ValidateNested } from "class-validator";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { OrgTeamOutputDto } from "@calcom/platform-types";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class OrgMeTeamOutputDto extends OrgTeamOutputDto {
   @IsString()

--- a/apps/api/v2/src/modules/organizations/teams/memberships/inputs/create-organization-team-membership.input.ts
+++ b/apps/api/v2/src/modules/organizations/teams/memberships/inputs/create-organization-team-membership.input.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsBoolean, IsOptional, IsEnum, IsInt } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class CreateOrgTeamMembershipDto {
   @IsInt()

--- a/apps/api/v2/src/modules/organizations/teams/memberships/inputs/update-organization-team-membership.input.ts
+++ b/apps/api/v2/src/modules/organizations/teams/memberships/inputs/update-organization-team-membership.input.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsBoolean, IsOptional, IsEnum } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class UpdateOrgTeamMembershipDto {
   @IsOptional()

--- a/apps/api/v2/src/modules/organizations/users/index/inputs/create-organization-user.input.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/inputs/create-organization-user.input.ts
@@ -1,7 +1,8 @@
 import { CreateUserInput } from "@/modules/users/inputs/create-user.input";
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsString, IsOptional, IsBoolean, IsEnum } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class CreateOrganizationUserInput extends CreateUserInput {
   @IsOptional()

--- a/apps/api/v2/src/modules/organizations/users/index/services/organizations-users-service.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/services/organizations-users-service.ts
@@ -4,10 +4,11 @@ import { UpdateOrganizationUserInput } from "@/modules/organizations/users/index
 import { OrganizationsUsersRepository } from "@/modules/organizations/users/index/organizations-users.repository";
 import { CreateUserInput } from "@/modules/users/inputs/create-user.input";
 import { Injectable, ConflictException, ForbiddenException } from "@nestjs/common";
-import { Team, CreationSource } from "@prisma/client";
+import { Team } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 
 import { createNewUsersConnectToOrgIfExists } from "@calcom/platform-libraries";
+import { CreationSource } from "@calcom/prisma/enums";
 
 @Injectable()
 export class OrganizationsUsersService {

--- a/apps/api/v2/src/modules/teams/memberships/inputs/create-team-membership.input.ts
+++ b/apps/api/v2/src/modules/teams/memberships/inputs/create-team-membership.input.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { IsBoolean, IsOptional, IsEnum, IsInt } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class CreateTeamMembershipInput {
   @IsInt()

--- a/apps/api/v2/src/modules/teams/memberships/inputs/update-team-membership.input.ts
+++ b/apps/api/v2/src/modules/teams/memberships/inputs/update-team-membership.input.ts
@@ -1,6 +1,7 @@
-import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
+import { ApiPropertyOptional } from "@nestjs/swagger";
 import { IsBoolean, IsOptional, IsEnum } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class UpdateTeamMembershipInput {
   @IsOptional()

--- a/apps/api/v2/src/modules/teams/memberships/outputs/team-membership.output.ts
+++ b/apps/api/v2/src/modules/teams/memberships/outputs/team-membership.output.ts
@@ -1,7 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { Expose, Transform, Type } from "class-transformer";
 import { IsBoolean, IsInt, IsObject, IsOptional, IsString, ValidateNested } from "class-validator";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 class MembershipUserOutputDto {
   @IsOptional()

--- a/apps/api/v2/src/modules/teams/teams/outputs/teams/get-team.output.ts
+++ b/apps/api/v2/src/modules/teams/teams/outputs/teams/get-team.output.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { Expose, Type } from "class-transformer";
-import { IsEnum, IsString, ValidateNested } from "class-validator";
+import { IsEnum, ValidateNested } from "class-validator";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { TeamOutputDto } from "@calcom/platform-types";

--- a/apps/api/v2/src/modules/teams/teams/outputs/teams/get-teams.output.ts
+++ b/apps/api/v2/src/modules/teams/teams/outputs/teams/get-teams.output.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { Expose, Type } from "class-transformer";
-import { IsEnum, IsString, ValidateNested } from "class-validator";
+import { IsEnum, ValidateNested } from "class-validator";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { TeamOutputDto } from "@calcom/platform-types";

--- a/apps/api/v2/src/modules/teams/teams/outputs/teams/update-team.output.ts
+++ b/apps/api/v2/src/modules/teams/teams/outputs/teams/update-team.output.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { MembershipRole } from "@prisma/client";
 import { Expose, Type } from "class-transformer";
-import { IsEnum, IsString, ValidateNested } from "class-validator";
+import { IsEnum, ValidateNested } from "class-validator";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
 import { TeamOutputDto } from "@calcom/platform-types";

--- a/apps/api/v2/src/modules/users/users.repository.ts
+++ b/apps/api/v2/src/modules/users/users.repository.ts
@@ -4,7 +4,8 @@ import { CreateManagedUserInput } from "@/modules/users/inputs/create-managed-us
 import { UpdateManagedUserInput } from "@/modules/users/inputs/update-managed-user.input";
 import { Injectable, NotFoundException } from "@nestjs/common";
 import type { Profile, User, Team, Prisma } from "@prisma/client";
-import { CreationSource } from "@prisma/client";
+
+import { CreationSource } from "@calcom/prisma/enums";
 
 export type UserWithProfile = User & {
   movedToProfile?: (Profile & { organization: Pick<Team, "isPlatform" | "id" | "slug" | "name"> }) | null;

--- a/apps/api/v2/src/modules/webhooks/inputs/webhook.input.ts
+++ b/apps/api/v2/src/modules/webhooks/inputs/webhook.input.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from "@nestjs/swagger";
-import { WebhookTriggerEvents } from "@prisma/client";
 import { IsArray, IsBoolean, IsEnum, IsOptional, IsString } from "class-validator";
+
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 export class CreateWebhookInputDto {
   @IsString()

--- a/apps/api/v2/src/modules/webhooks/outputs/webhook.output.ts
+++ b/apps/api/v2/src/modules/webhooks/outputs/webhook.output.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { WebhookTriggerEvents } from "@prisma/client";
 import { Expose, Type } from "class-transformer";
 import { IsBoolean, IsEnum, IsInt, IsString, ValidateNested, IsArray } from "class-validator";
 
 import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 export class WebhookOutputDto {
   @IsInt()

--- a/apps/api/v2/src/modules/workflows/inputs/workflow-step.input.ts
+++ b/apps/api/v2/src/modules/workflows/inputs/workflow-step.input.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { WorkflowActions, WorkflowTemplates } from "@prisma/client";
 import { Type } from "class-transformer";
 import { IsNumber, IsBoolean, IsString, ValidateNested, IsIn } from "class-validator";
+
+import { WorkflowActions, WorkflowTemplates } from "@calcom/prisma/enums";
 
 export const EMAIL_HOST = "email_host";
 export const EMAIL_ATTENDEE = "email_attendee";

--- a/apps/api/v2/src/modules/workflows/inputs/workflow-trigger.input.ts
+++ b/apps/api/v2/src/modules/workflows/inputs/workflow-trigger.input.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { TimeUnit, WorkflowTriggerEvents } from "@prisma/client";
 import { Type } from "class-transformer";
 import { IsIn, IsNumber, IsString, ValidateNested } from "class-validator";
+
+import { TimeUnit, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 
 export const BEFORE_EVENT = "beforeEvent";
 export const EVENT_CANCELLED = "eventCancelled";

--- a/apps/api/v2/src/modules/workflows/workflows.repository.ts
+++ b/apps/api/v2/src/modules/workflows/workflows.repository.ts
@@ -6,7 +6,8 @@ import { Injectable } from "@nestjs/common";
 import { TUpdateInputSchema } from "@calcom/platform-libraries/workflows";
 import { updateWorkflow } from "@calcom/platform-libraries/workflows";
 import { PrismaClient } from "@calcom/prisma";
-import { TimeUnit, Workflow, WorkflowStep, WorkflowTriggerEvents } from "@calcom/prisma/enums";
+import type { Workflow, WorkflowStep } from "@calcom/prisma/client";
+import { TimeUnit, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 
 export type WorkflowType = Workflow & { activeOn: { eventTypeId: number }[]; steps: WorkflowStep[] };
 

--- a/apps/api/v2/src/modules/workflows/workflows.repository.ts
+++ b/apps/api/v2/src/modules/workflows/workflows.repository.ts
@@ -2,11 +2,11 @@ import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable } from "@nestjs/common";
-import { TimeUnit, Workflow, WorkflowStep, WorkflowTriggerEvents } from "@prisma/client";
 
 import { TUpdateInputSchema } from "@calcom/platform-libraries/workflows";
 import { updateWorkflow } from "@calcom/platform-libraries/workflows";
 import { PrismaClient } from "@calcom/prisma";
+import { TimeUnit, Workflow, WorkflowStep, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 
 export type WorkflowType = Workflow & { activeOn: { eventTypeId: number }[]; steps: WorkflowStep[] };
 

--- a/apps/api/v2/test/fixtures/repository/membership.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/membership.repository.fixture.ts
@@ -1,7 +1,9 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { TestingModule } from "@nestjs/testing";
-import { Membership, MembershipRole, Prisma, Team, User } from "@prisma/client";
+import { Membership, Prisma, Team, User } from "@prisma/client";
+
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export class MembershipRepositoryFixture {
   private prismaReadClient: PrismaReadService["prisma"];

--- a/apps/web/app/(use-page-wrapper)/auth/error/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/error/page.tsx
@@ -3,7 +3,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 import Link from "next/link";
 import { z } from "zod";
 
-import { IdentityProvider } from "@calcom/prisma/client";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import { Button } from "@calcom/ui/components/button";
 import { Icon } from "@calcom/ui/components/icon";
 

--- a/apps/web/app/api/auth/two-factor/totp/disable/route.ts
+++ b/apps/web/app/api/auth/two-factor/totp/disable/route.ts
@@ -10,7 +10,7 @@ import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { symmetricDecrypt } from "@calcom/lib/crypto";
 import { totpAuthenticatorCheck } from "@calcom/lib/totp";
 import prisma from "@calcom/prisma";
-import { IdentityProvider } from "@calcom/prisma/client";
+import { IdentityProvider } from "@calcom/prisma/enums";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 

--- a/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
+++ b/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
@@ -10,7 +10,7 @@ import Locations from "@calcom/features/eventtypes/components/locations/Location
 import type { LocationFormValues } from "@calcom/features/eventtypes/lib/types";
 import type { SingleValueLocationOption } from "@calcom/features/form/components/LocationSelect";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { SchedulingType } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { Label } from "@calcom/ui/components/form";
 import { Skeleton, SkeletonText, SkeletonContainer } from "@calcom/ui/components/skeleton";

--- a/apps/web/lib/handleOrgRedirect.test.ts
+++ b/apps/web/lib/handleOrgRedirect.test.ts
@@ -3,7 +3,7 @@ import type { ParsedUrlQuery } from "querystring";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import * as constants from "@calcom/lib/constants";
-import { RedirectType } from "@calcom/prisma/client";
+import { RedirectType } from "@calcom/prisma/enums";
 
 import { handleOrgRedirect, getRedirectWithOriginAndSearchString } from "./handleOrgRedirect";
 

--- a/apps/web/lib/pages/auth/verify-email.test.ts
+++ b/apps/web/lib/pages/auth/verify-email.test.ts
@@ -2,7 +2,7 @@ import { organizationScenarios } from "@calcom/lib/server/repository/__mocks__/o
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { CreationSource } from "@calcom/prisma/enums";
 import { inviteMembersWithNoInviterPermissionCheck } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler";
 

--- a/apps/web/lib/pages/auth/verify-email.ts
+++ b/apps/web/lib/pages/auth/verify-email.ts
@@ -7,7 +7,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { IS_STRIPE_ENABLED } from "@calcom/lib/constants";
 import { OrganizationRepository } from "@calcom/lib/server/repository/organization";
 import { prisma } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { CreationSource } from "@calcom/prisma/enums";
 import { userMetadata } from "@calcom/prisma/zod-utils";
 import { inviteMembersWithNoInviterPermissionCheck } from "@calcom/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler";

--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -11,7 +11,7 @@ import { getSafe } from "@calcom/lib/getSafe";
 import { maybeGetBookingUidFromSeat } from "@calcom/lib/server/maybeGetBookingUidFromSeat";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import prisma, { bookingMinimalSelect } from "@calcom/prisma";
-import { BookingStatus } from "@calcom/prisma/client";
+import { BookingStatus } from "@calcom/prisma/enums";
 
 const querySchema = z.object({
   uid: z.string(),

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -12,7 +12,7 @@ import { shouldHideBrandingForTeamEvent } from "@calcom/lib/hideBranding";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import type { User } from "@calcom/prisma/client";
-import { BookingStatus, RedirectType, SchedulingType } from "@calcom/prisma/client";
+import { BookingStatus, RedirectType, SchedulingType } from "@calcom/prisma/enums";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";

--- a/apps/web/lib/team/[slug]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/getServerSideProps.tsx
@@ -16,7 +16,7 @@ import slugify from "@calcom/lib/slugify";
 import { stripMarkdown } from "@calcom/lib/stripMarkdown";
 import prisma from "@calcom/prisma";
 import type { Team, OrganizationSettings } from "@calcom/prisma/client";
-import { RedirectType } from "@calcom/prisma/client";
+import { RedirectType } from "@calcom/prisma/enums";
 import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";

--- a/apps/web/modules/settings/admin/components/UsersTable.tsx
+++ b/apps/web/modules/settings/admin/components/UsersTable.tsx
@@ -1,7 +1,7 @@
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { SMSLockState } from "@calcom/prisma/client";
+import { SMSLockState } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { Avatar } from "@calcom/ui/components/avatar";
 import type { IconName } from "@calcom/ui/components/icon";

--- a/apps/web/playwright/booking-limits.e2e.ts
+++ b/apps/web/playwright/booking-limits.e2e.ts
@@ -9,7 +9,7 @@ import dayjs from "@calcom/dayjs";
 import { intervalLimitKeyToUnit } from "@calcom/lib/intervalLimits/intervalLimit";
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 import prisma from "@calcom/prisma";
-import { BookingStatus } from "@calcom/prisma/client";
+import { BookingStatus } from "@calcom/prisma/enums";
 import { entries } from "@calcom/prisma/zod-utils";
 
 import { test } from "./lib/fixtures";

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -4,7 +4,7 @@ import { JSDOM } from "jsdom";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { generateHashedLink } from "@calcom/lib/generateHashedLink";
 import { randomString } from "@calcom/lib/random";
-import { SchedulingType } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
 import type { Schedule, TimeRange } from "@calcom/types/schedule";
 
 import { test, todo } from "./lib/fixtures";

--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -2,8 +2,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
 import prisma from "@calcom/prisma";
-import { BookingStatus } from "@calcom/prisma/client";
-import { MembershipRole, SchedulingType } from "@calcom/prisma/enums";
+import { BookingStatus, MembershipRole, SchedulingType } from "@calcom/prisma/enums";
 
 import { addFilter } from "./filter-helpers";
 import { createTeamEventType } from "./fixtures/users";

--- a/apps/web/playwright/dynamic-booking-pages.e2e.ts
+++ b/apps/web/playwright/dynamic-booking-pages.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { test } from "./lib/fixtures";
 import {

--- a/apps/web/playwright/embed-code-generator.e2e.ts
+++ b/apps/web/playwright/embed-code-generator.e2e.ts
@@ -5,7 +5,7 @@ import { parse } from "node-html-parser";
 
 import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { EMBED_LIB_URL, WEBAPP_URL } from "@calcom/lib/constants";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { test } from "./lib/fixtures";
 

--- a/apps/web/playwright/lib/orgMigration.ts
+++ b/apps/web/playwright/lib/orgMigration.ts
@@ -6,8 +6,8 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { ProfileRepository } from "@calcom/lib/server/repository/profile";
 import prisma from "@calcom/prisma";
 import type { Team, User } from "@calcom/prisma/client";
-import { RedirectType } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
+import { RedirectType } from "@calcom/prisma/enums";
 import type { MembershipRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema, teamMetadataStrictSchema } from "@calcom/prisma/zod-utils";
 

--- a/apps/web/playwright/organization/organization-invitation.e2e.ts
+++ b/apps/web/playwright/organization/organization-invitation.e2e.ts
@@ -2,7 +2,7 @@ import type { Browser, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { SchedulingType } from "@calcom/prisma/enums";
 
 import { test } from "../lib/fixtures";

--- a/apps/web/playwright/reschedule.e2e.ts
+++ b/apps/web/playwright/reschedule.e2e.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 
 import dayjs from "@calcom/dayjs";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 

--- a/apps/web/playwright/webhook.e2e.ts
+++ b/apps/web/playwright/webhook.e2e.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import dayjs from "@calcom/dayjs";
 import prisma from "@calcom/prisma";
-import { BookingStatus } from "@calcom/prisma/client";
+import { BookingStatus } from "@calcom/prisma/enums";
 
 import { test } from "./lib/fixtures";
 import {

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -13,7 +13,7 @@ import { EventRepository } from "@calcom/lib/server/repository/event";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import { BookingStatus, RedirectType } from "@calcom/prisma/client";
+import { BookingStatus, RedirectType } from "@calcom/prisma/enums";
 
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";
 

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -14,7 +14,8 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import { stripMarkdown } from "@calcom/lib/stripMarkdown";
 import prisma from "@calcom/prisma";
-import { RedirectType, type EventType, type User } from "@calcom/prisma/client";
+import { type EventType, type User } from "@calcom/prisma/client";
+import { RedirectType } from "@calcom/prisma/enums";
 import type { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import type { UserProfile } from "@calcom/types/UserProfile";
 

--- a/apps/web/test/utils/bookingScenario/getSampleUserInSession.ts
+++ b/apps/web/test/utils/bookingScenario/getSampleUserInSession.ts
@@ -1,5 +1,4 @@
-import { UserPermissionRole } from "@calcom/prisma/client";
-import { IdentityProvider } from "@calcom/prisma/enums";
+import { IdentityProvider, UserPermissionRole } from "@calcom/prisma/enums";
 
 export const getSampleUserInSession = function () {
   return {

--- a/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
+++ b/packages/app-store/routing-forms/pages/route-builder/[...appPages].tsx
@@ -15,7 +15,7 @@ import { useOrgBranding } from "@calcom/features/ee/organizations/context/provid
 import { areTheySiblingEntities } from "@calcom/lib/entityPermissionUtils.shared";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { buildEmptyQueryValue, raqbQueryValueUtils } from "@calcom/lib/raqb/raqbUtils";
-import { SchedulingType } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";

--- a/packages/app-store/routing-forms/trpc/onFormSubmission.test.ts
+++ b/packages/app-store/routing-forms/trpc/onFormSubmission.test.ts
@@ -4,7 +4,7 @@ import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
 
 import getWebhooks from "@calcom/features/webhooks/lib/getWebhooks";
 import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPayload";
-import { WebhookTriggerEvents } from "@calcom/prisma/client";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 import { _onFormSubmission } from "./utils";
 

--- a/packages/app-store/routing-forms/trpc/utils.ts
+++ b/packages/app-store/routing-forms/trpc/utils.ts
@@ -7,7 +7,7 @@ import { sendGenericWebhookPayload } from "@calcom/features/webhooks/lib/sendPay
 import getOrgIdFromMemberOrTeamId from "@calcom/lib/getOrgIdFromMemberOrTeamId";
 import logger from "@calcom/lib/logger";
 import { withReporting } from "@calcom/lib/sentryWrapper";
-import { WebhookTriggerEvents } from "@calcom/prisma/client";
+import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 import type { Ensure } from "@calcom/types/utils";
 
 import type { SerializableField, OrderedResponses } from "../types/types";

--- a/packages/features/bookings/lib/handleNewRecurringBooking.ts
+++ b/packages/features/bookings/lib/handleNewRecurringBooking.ts
@@ -1,7 +1,7 @@
 import type { CreateBookingMeta, CreateRecurringBookingData } from "@calcom/features/bookings/lib/dto/types";
 import handleNewBooking from "@calcom/features/bookings/lib/handleNewBooking";
 import type { BookingResponse } from "@calcom/features/bookings/types";
-import { SchedulingType } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
 import type { AppsStatus } from "@calcom/types/Calendar";
 
 import type { RegularBookingService } from "./handleNewBooking";

--- a/packages/features/ee/billing/api/webhook/_customer.subscription.updated.ts
+++ b/packages/features/ee/billing/api/webhook/_customer.subscription.updated.ts
@@ -1,6 +1,6 @@
 import { PrismaPhoneNumberRepository } from "@calcom/lib/server/repository/PrismaPhoneNumberRepository";
 import { prisma } from "@calcom/prisma";
-import { PhoneNumberSubscriptionStatus } from "@calcom/prisma/client";
+import { PhoneNumberSubscriptionStatus } from "@calcom/prisma/enums";
 
 import type { SWHMap } from "./__handler";
 import { HttpCode } from "./__handler";

--- a/packages/features/ee/organizations/pages/organization.tsx
+++ b/packages/features/ee/organizations/pages/organization.tsx
@@ -2,7 +2,7 @@ import type { GetServerSidePropsContext } from "next";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export const getServerSideProps = async ({ req }: GetServerSidePropsContext) => {
   const prisma = await import("@calcom/prisma").then((mod) => mod.default);

--- a/packages/features/ee/teams/components/RoundRobinSettings.tsx
+++ b/packages/features/ee/teams/components/RoundRobinSettings.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { RRResetInterval, RRTimestampBasis } from "@calcom/prisma/client";
+import { RRResetInterval, RRTimestampBasis } from "@calcom/prisma/enums";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";

--- a/packages/lib/bookings/filterHostsByLeadThreshold.test.ts
+++ b/packages/lib/bookings/filterHostsByLeadThreshold.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 
 import { getLuckyUserService } from "@calcom/lib/di/containers/LuckyUser";
 import prisma from "@calcom/prisma";
-import { RRResetInterval } from "@calcom/prisma/client";
+import { RRResetInterval } from "@calcom/prisma/enums";
 
 import { filterHostsByLeadThreshold, errorCodes } from "./filterHostsByLeadThreshold";
 

--- a/packages/lib/server/repository/membership.ts
+++ b/packages/lib/server/repository/membership.ts
@@ -1,5 +1,5 @@
 import { availabilityUserSelect, prisma, type PrismaTransaction, type PrismaClient } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import type { Prisma, Membership } from "@calcom/prisma/client";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 

--- a/packages/lib/server/repository/workflow.ts
+++ b/packages/lib/server/repository/workflow.ts
@@ -8,7 +8,7 @@ import type { WorkflowStep } from "@calcom/ee/workflows/lib/types";
 import { hasFilter } from "@calcom/features/filters/lib/hasFilter";
 import { HttpError } from "@calcom/lib/http-error";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import type { Prisma } from "@calcom/prisma/client";
 import { WorkflowMethods } from "@calcom/prisma/enums";
 import type { TFilteredListInputSchema } from "@calcom/trpc/server/routers/viewer/workflows/filteredList.schema";

--- a/packages/lib/service/attribute/utils.ts
+++ b/packages/lib/service/attribute/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for attribute service. Shared across server and client.
  */
 import slugify from "@calcom/lib/slugify";
-import { AttributeType } from "@calcom/prisma/client";
+import { AttributeType } from "@calcom/prisma/enums";
 
 import type { AttributeOptionAssignment, BulkAttributeAssigner } from "./types";
 

--- a/packages/trpc/server/routers/viewer/admin/getSMSLockStateTeamsUsers.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/getSMSLockStateTeamsUsers.handler.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@calcom/prisma";
-import { SMSLockState } from "@calcom/prisma/client";
+import { SMSLockState } from "@calcom/prisma/enums";
 
 import type { TrpcSessionUser } from "../../../types";
 

--- a/packages/trpc/server/routers/viewer/admin/setSMSLockState.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/setSMSLockState.handler.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@calcom/prisma";
-import { SMSLockState } from "@calcom/prisma/client";
+import { SMSLockState } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
 

--- a/packages/trpc/server/routers/viewer/attributes/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/create.handler.ts
@@ -3,7 +3,8 @@ import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permi
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import type { Attribute } from "@calcom/prisma/client";
-import { Prisma, MembershipRole } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
 

--- a/packages/trpc/server/routers/viewer/attributes/delete.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/delete.handler.ts
@@ -1,7 +1,7 @@
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
 

--- a/packages/trpc/server/routers/viewer/attributes/edit.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/edit.handler.ts
@@ -2,7 +2,7 @@ import { Resource } from "@calcom/features/pbac/domain/types/permission-registry
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
 

--- a/packages/trpc/server/routers/viewer/attributes/toggleActive.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/toggleActive.handler.ts
@@ -1,7 +1,7 @@
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { TRPCError } from "@trpc/server";
 

--- a/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
@@ -19,7 +19,7 @@ import { ScheduleRepository } from "@calcom/lib/server/repository/schedule";
 import { HashedLinkService } from "@calcom/lib/server/service/hashedLinkService";
 import { validateBookerLayouts } from "@calcom/lib/validateBookerLayouts";
 import type { PrismaClient } from "@calcom/prisma";
-import { WorkflowTriggerEvents } from "@calcom/prisma/client";
+import { WorkflowTriggerEvents } from "@calcom/prisma/enums";
 import { SchedulingType, EventTypeAutoTranslatedField, RRTimestampBasis } from "@calcom/prisma/enums";
 import { eventTypeAppMetadataOptionalSchema } from "@calcom/prisma/zod-utils";
 import { eventTypeLocations } from "@calcom/prisma/zod-utils";

--- a/packages/trpc/server/routers/viewer/me/checkForInvalidAppCredentials.ts
+++ b/packages/trpc/server/routers/viewer/me/checkForInvalidAppCredentials.ts
@@ -1,7 +1,7 @@
 import { getAppFromSlug } from "@calcom/app-store/utils";
 import { type InvalidAppCredentialBannerProps } from "@calcom/features/users/components/InvalidAppCredentialsBanner";
 import { prisma } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 type checkInvalidAppCredentialsOptions = {

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -53,8 +53,7 @@ import type { TeamRepository } from "@calcom/lib/server/repository/team";
 import type { UserRepository } from "@calcom/lib/server/repository/user";
 import { withSelectedCalendars } from "@calcom/lib/server/repository/user";
 import getSlots from "@calcom/lib/slots";
-import { PeriodType } from "@calcom/prisma/client";
-import { SchedulingType } from "@calcom/prisma/enums";
+import { SchedulingType, PeriodType } from "@calcom/prisma/enums";
 import type { EventBusyDate, EventBusyDetails } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
 


### PR DESCRIPTION
## What does this PR do?

- This PR refactors to import enums from `@calcom/prisma/enums` instead of `@calcom/prisma/client` or `@prisma/client`.

## Impact

With `@prisma/client`: Bundles ~28MB of prisma client code
With `@calcom/prisma/enums`: Bundles ~0.1KB

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- All tests passing are sufficient