### PR TITLE
fix: filter event types by selected members' team assignments

### DIFF
--- a/packages/features/users/components/UserTable/BulkActions/EventTypesList.tsx
+++ b/packages/features/users/components/UserTable/BulkActions/EventTypesList.tsx
@@ -31,7 +31,14 @@ interface Props {
 export function EventTypesList({ table, orgTeams }: Props) {
   const { t } = useLocale();
   const utils = trpc.useUtils();
-  const teamIds = orgTeams?.map((team) => team.id);
+  const selectedUsers = table.getSelectedRowModel().flatRows.map((row) => row.original);
+
+  const selectedUserTeamIds = Array.from(
+    new Set(selectedUsers.flatMap((user) => user.teams.map((team) => team.id)))
+  );
+
+  const teamIds = selectedUserTeamIds.length > 0 ? selectedUserTeamIds : orgTeams?.map((team) => team.id);
+
   const { data } = trpc.viewer.eventTypes.getByViewer.useQuery({
     filters: { teamIds, schedulingTypes: [SchedulingType.ROUND_ROBIN] },
   });
@@ -76,7 +83,6 @@ export function EventTypesList({ table, orgTeams }: Props) {
   const [selectedTeams, setSelectedTeams] = useState<Set<number>>(new Set());
   const [removeHostFromEvents, setRemoveHostFromEvents] = useState<Set<number>>(new Set());
   const teams = data?.eventTypeGroups;
-  const selectedUsers = table.getSelectedRowModel().flatRows.map((row) => row.original);
 
   // Add value array to the set
   const addValue = (set: Set<number>, setSet: Dispatch<SetStateAction<Set<number>>>, value: number[]) => {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the organization member table where selecting members and choosing event types would show all organization event types instead of filtering based on the teams the selected members are assigned to.

**Changes:**
- Modified `EventTypesList` component to extract team IDs from selected users
- Filter event types query to only show types from teams that selected members belong to  
- Fall back to showing all organization teams when no users are selected
- Removed duplicate `selectedUsers` variable definition

## How should this be tested?

**Important**: This change was not fully tested locally due to authentication issues with the development environment, so thorough testing by reviewers is critical.

### Test Steps:
1. Navigate to `/settings/organizations/{org-slug}/members`
2. Select one or more members who belong to specific teams (not all teams)
3. Click "Add to event type" button
4. Verify that only event types from the teams those members belong to are shown
5. Test edge cases:
   - Select members from different teams - should show event types from all their teams
   - Select members who belong to no teams - should fall back to all org event types
   - Select no members - should show all org event types

### Environment Requirements:
- Organization with multiple teams
- Members assigned to specific teams (not all teams)  
- Round-robin event types configured for different teams

## Human Review Checklist

**High Priority:**
- [ ] Verify the fix works end-to-end with real organization data
- [ ] Test that `user.teams` data structure exists and has expected `id` property
- [ ] Confirm filtering logic works correctly for edge cases (no teams, multiple teams, etc.)
- [ ] Verify fallback behavior when no users are selected
- [ ] Test performance with larger numbers of selected users/teams

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - this is a bug fix that doesn't change public APIs or require documentation updates.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: Due to authentication issues, comprehensive testing was not completed locally.

---

**Link to Devin run**: https://app.devin.ai/sessions/2fb37dd552954d67a4623ee1b40e9e79  
**Requested by**: @joeauyeung