### PR TITLE
perf: optimize public event query by using lightweight session lookup

### DIFF
--- a/packages/trpc/server/middlewares/sessionMiddleware.ts
+++ b/packages/trpc/server/middlewares/sessionMiddleware.ts
@@ -87,7 +87,7 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
 
 export type UserFromSession = Awaited<ReturnType<typeof getUserFromSession>>;
 
-const getSession = async (ctx: TRPCContextInner) => {
+export const getSession = async (ctx: TRPCContextInner) => {
   const { req } = ctx;
   const { getServerSession } = await import("@calcom/features/auth/lib/getServerSession");
   return req ? await getServerSession({ req }) : null;

--- a/packages/trpc/server/routers/publicViewer/procedures/event.ts
+++ b/packages/trpc/server/routers/publicViewer/procedures/event.ts
@@ -1,12 +1,10 @@
-import { getUserSession } from "../../../middlewares/sessionMiddleware";
+import { getSession } from "../../../middlewares/sessionMiddleware";
 import publicProcedure from "../../../procedures/publicProcedure";
 import { ZEventInputSchema } from "../event.schema";
 
-const NAMESPACE = "publicViewer";
-const namespaced = (s: string) => `${NAMESPACE}.${s}`;
-
 export const event = publicProcedure.input(ZEventInputSchema).query(async (opts) => {
-  const { user } = await getUserSession(opts.ctx);
+  const session = await getSession(opts.ctx);
+  const userId = session?.user?.id;
   const { default: handler } = await import("../event.handler");
-  return handler({ input: opts.input, userId: user?.id });
+  return handler({ input: opts.input, userId });
 });


### PR DESCRIPTION
## What does this PR do?

The `getUserSession()` function is significantly heavier than `getSession()` as you can see below:

<img width="630" height="715" alt="Screenshot 2025-09-05 at 7 53 55 PM" src="https://github.com/user-attachments/assets/dadc7f00-ebe0-43e0-bffa-90d011e7fd4f" />

For the public event endpoint, we only need the `userId`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Tests passing are sufficient