### PR TITLE
fix: Fix booking count discrepancy between KPI cards and trends chart

### DIFF
--- a/packages/lib/server/service/InsightsBookingBaseService.ts
+++ b/packages/lib/server/service/InsightsBookingBaseService.ts
@@ -654,7 +654,7 @@ export class InsightsBookingBaseService {
       SELECT
         DATE("createdAt" AT TIME ZONE ${timeZone}) as "date",
         "timeStatus",
-        "noShowHost",
+        COALESCE("noShowHost", false) AS "noShowHost",
         COUNT(*) as "bookingsCount"
       FROM "BookingTimeStatusDenormalized"
       WHERE ${baseConditions}
@@ -665,7 +665,7 @@ export class InsightsBookingBaseService {
       SELECT
         DATE(b."createdAt" AT TIME ZONE ${timeZone}) as "date",
         b."timeStatus",
-        b."noShowHost",
+        COALESCE(b."noShowHost", false) AS "noShowHost",
         COUNT(CASE WHEN a."noShow" = true THEN 1 END) as "noShowGuests"
       FROM "BookingTimeStatusDenormalized" b
       INNER JOIN "Attendee" a ON a."bookingId" = b.id

--- a/packages/lib/server/service/InsightsBookingBaseService.ts
+++ b/packages/lib/server/service/InsightsBookingBaseService.ts
@@ -659,9 +659,7 @@ export class InsightsBookingBaseService {
       FROM "BookingTimeStatusDenormalized"
       WHERE ${baseConditions}
       GROUP BY
-        DATE("createdAt" AT TIME ZONE ${timeZone}),
-        "timeStatus",
-        "noShowHost"
+        1, 2, 3
     ),
     guest_stats AS (
       SELECT
@@ -673,9 +671,7 @@ export class InsightsBookingBaseService {
       INNER JOIN "Attendee" a ON a."bookingId" = b.id
       WHERE ${baseConditions}
       GROUP BY
-        DATE(b."createdAt" AT TIME ZONE ${timeZone}),
-        b."timeStatus",
-        b."noShowHost"
+        1, 2, 3
     )
     SELECT
       bs."date",

--- a/packages/lib/server/service/InsightsBookingBaseService.ts
+++ b/packages/lib/server/service/InsightsBookingBaseService.ts
@@ -650,31 +650,46 @@ export class InsightsBookingBaseService {
         noShowGuests: number;
       }[]
     >`
-    SELECT
-      "date",
-      CAST(COUNT(*) AS INTEGER) AS "bookingsCount",
-      CAST(COUNT(CASE WHEN "isNoShowGuest" = true THEN 1 END) AS INTEGER) AS "noShowGuests",
-      "timeStatus",
-      "noShowHost"
-    FROM (
+    WITH booking_stats AS (
       SELECT
         DATE("createdAt" AT TIME ZONE ${timeZone}) as "date",
-        "a"."noShow" AS "isNoShowGuest",
+        "timeStatus",
+        "noShowHost",
+        COUNT(*) as "bookingsCount"
+      FROM "BookingTimeStatusDenormalized"
+      WHERE ${baseConditions}
+      GROUP BY
+        DATE("createdAt" AT TIME ZONE ${timeZone}),
         "timeStatus",
         "noShowHost"
-      FROM
-        "BookingTimeStatusDenormalized"
-      JOIN
-        "Attendee" "a" ON "a"."bookingId" = "BookingTimeStatusDenormalized"."id"
-      WHERE
-        ${baseConditions}
-    ) AS bookings
-    GROUP BY
-      "date",
-      "timeStatus",
-      "noShowHost"
-    ORDER BY
-      "date"
+    ),
+    guest_stats AS (
+      SELECT
+        DATE(b."createdAt" AT TIME ZONE ${timeZone}) as "date",
+        b."timeStatus",
+        b."noShowHost",
+        COUNT(CASE WHEN a."noShow" = true THEN 1 END) as "noShowGuests"
+      FROM "BookingTimeStatusDenormalized" b
+      INNER JOIN "Attendee" a ON a."bookingId" = b.id
+      WHERE ${baseConditions}
+      GROUP BY
+        DATE(b."createdAt" AT TIME ZONE ${timeZone}),
+        b."timeStatus",
+        b."noShowHost"
+    )
+    SELECT
+      bs."date",
+      CAST(bs."bookingsCount" AS INTEGER) AS "bookingsCount",
+      bs."timeStatus",
+      bs."noShowHost",
+      CAST(COALESCE(gs."noShowGuests", 0) AS INTEGER) AS "noShowGuests"
+    FROM booking_stats bs
+    LEFT JOIN guest_stats gs ON (
+      bs."date" = gs."date" AND
+      bs."timeStatus" = gs."timeStatus" AND
+      bs."noShowHost" = gs."noShowHost"
+    )
+    ORDER BY bs."date"
   `;
 
     // Initialize aggregate object with zero counts for all date ranges


### PR DESCRIPTION
## What does this PR do?

fixes #9698


https://github.com/user-attachments/assets/59dabdc4-4c68-4682-bf5d-6af3fe7822ad



This PR fixes a data discrepancy between BookingKPICards "events_created" count and EventTrendsChart "Created" sum. The issue was caused by the EventTrendsChart query JOINing with the Attendee table, which resulted in bookings with multiple attendees being counted multiple times in the trends chart while being counted only once in the KPI cards.

**Root cause**: The original query performed `COUNT(*)` after joining with the Attendee table, causing each booking-attendee combination to be counted as a separate "created" event.

**Solution**: Restructured the SQL query to use CTEs (Common Table Expressions) that separate booking statistics from guest statistics, then LEFT JOIN them to preserve no-show guest functionality while ensuring each booking is counted exactly once.

## Visual Demo (For contributors especially)

**Before**: EventTrendsChart "Created" sum would be higher than BookingKPICards "events_created" when bookings had multiple attendees.

**After**: Both metrics now show the same booking count, with the difference being proportional to the average number of attendees per booking that has been eliminated.

*Note: Screenshots would require testing with actual booking data in the insights dashboard.*

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A - This is a bug fix that doesn't change API or user-facing functionality**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Tests would require database setup with booking/attendee data**

## How should this be tested?

**Critical testing areas:**

1. **Data accuracy verification**:
   - Create test bookings with varying numbers of attendees (1, 2, 3+ attendees)
   - Verify BookingKPICards "events_created" matches sum of EventTrendsChart "Created" data points
   - Confirm no-show guest counts remain accurate in both views

2. **Performance testing**:
   - Test query performance with large datasets
   - Compare execution time vs. original query
   - Monitor dashboard load times for insights pages

3. **Edge cases**:
   - Bookings with zero attendees
   - Date range filtering across different timezones
   - Various booking statuses (completed, cancelled, rescheduled)

**Test environment setup**:
- Database with realistic booking and attendee data
- Various booking scenarios with different attendee counts
- Different time ranges and timezone settings

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (SQL query uses descriptive CTE names)
- [x] I have checked if my changes generate no new warnings

## Human Review Focus Areas

**🚨 Critical items to verify:**

1. **SQL Logic Review**: Verify the CTE approach correctly separates booking counts from guest stats
2. **Data Integrity**: Confirm no-show guest counts are preserved with the LEFT JOIN approach  
3. **Performance Impact**: Test query performance with realistic data volumes
4. **Edge Case Handling**: Verify COALESCE logic handles missing guest_stats correctly
5. **Actual Fix Verification**: Test that the discrepancy is actually resolved with real data

---

**Session Info**: Requested by @eunjae-lee in [Devin session](https://app.devin.ai/sessions/dcf02fe84c2a43bead77fce712ae8c8e)