### PR TITLE
feat: improved UX for horizontal tab navigation

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3597,6 +3597,10 @@
   "search_variables": "Search variables",
   "no_variables_found": "No variables found",
   "api_key_name_too_long": "Name must not exceed {{max}} characters",
+  "auto_charge_for_last_minute_cancellation": "Auto charge no-show fee for last minute cancellations",
+  "before_scheduled_start_time": "Before scheduled start time",
+  "cancel_booking_acknowledge_no_show_fee": "I acknowledge that by cancelling the booking within {{timeValue}} {{timeUnit}} of the start time I will be charged the no show fee of {{amount, currency}}",
+  "contact_organizer": "If you have any questions, please contact the organizer.",
   "scroll_left": "Scroll left",
   "scroll_right": "Scroll right",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3597,5 +3597,7 @@
   "search_variables": "Search variables",
   "no_variables_found": "No variables found",
   "api_key_name_too_long": "Name must not exceed {{max}} characters",
+  "scroll_left": "Scroll left",
+  "scroll_right": "Scroll right",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3597,10 +3597,6 @@
   "search_variables": "Search variables",
   "no_variables_found": "No variables found",
   "api_key_name_too_long": "Name must not exceed {{max}} characters",
-  "auto_charge_for_last_minute_cancellation": "Auto charge no-show fee for last minute cancellations",
-  "before_scheduled_start_time": "Before scheduled start time",
-  "cancel_booking_acknowledge_no_show_fee": "I acknowledge that by cancelling the booking within {{timeValue}} {{timeUnit}} of the start time I will be charged the no show fee of {{amount, currency}}",
-  "contact_organizer": "If you have any questions, please contact the organizer.",
   "scroll_left": "Scroll left",
   "scroll_right": "Scroll right",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"

--- a/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
 import { Icon } from "../../icon";
 import type { HorizontalTabItemProps } from "./HorizontalTabItem";
 import HorizontalTabItem from "./HorizontalTabItem";
@@ -12,6 +14,7 @@ export interface NavTabProps {
 }
 
 const HorizontalTabs = function ({ tabs, linkShallow, linkScroll, actions, ...props }: NavTabProps) {
+  const { t } = useLocale();
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
   const navRef = useRef<HTMLElement>(null);
@@ -45,7 +48,8 @@ const HorizontalTabs = function ({ tabs, linkShallow, linkScroll, actions, ...pr
           <button
             onClick={() => scroll("left")}
             className="z-10 flex h-6 w-8 items-center justify-center transition-opacity hover:opacity-70"
-            aria-label="Scroll left">
+            aria-label={t("scroll_left")}
+            data-testid="scroll-left-button">
             <Icon name="chevron-left" className="h-4 w-4 text-white drop-shadow-sm" />
           </button>
         )}
@@ -63,7 +67,8 @@ const HorizontalTabs = function ({ tabs, linkShallow, linkScroll, actions, ...pr
           <button
             onClick={() => scroll("right")}
             className="z-10 flex h-6 w-8 items-center justify-center transition-opacity hover:opacity-70"
-            aria-label="Scroll right">
+            aria-label={t("scroll_right")}
+            data-testid="scroll-right-button">
             <Icon name="chevron-right" className="h-4 w-4 text-white drop-shadow-sm" />
           </button>
         )}

--- a/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
@@ -1,3 +1,6 @@
+import { useState, useRef, useEffect } from "react";
+
+import { Icon } from "../../icon";
 import type { HorizontalTabItemProps } from "./HorizontalTabItem";
 import HorizontalTabItem from "./HorizontalTabItem";
 
@@ -9,16 +12,62 @@ export interface NavTabProps {
 }
 
 const HorizontalTabs = function ({ tabs, linkShallow, linkScroll, actions, ...props }: NavTabProps) {
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(false);
+  const navRef = useRef<HTMLElement>(null);
+
+  const checkScrollPosition = () => {
+    if (navRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } = navRef.current;
+      const hasOverflow = scrollWidth > clientWidth;
+
+      setShowLeftArrow(hasOverflow && scrollLeft > 0);
+      setShowRightArrow(hasOverflow && scrollLeft < scrollWidth - clientWidth - 1);
+    }
+  };
+
+  useEffect(() => {
+    checkScrollPosition();
+    window.addEventListener("resize", checkScrollPosition);
+    return () => window.removeEventListener("resize", checkScrollPosition);
+  }, [tabs]);
+
+  const scroll = (direction: "left" | "right") => {
+    if (navRef.current) {
+      navRef.current.scrollBy({ left: direction === "left" ? -300 : 300, behavior: "smooth" });
+    }
+  };
+
   return (
     <div className="mb-4 max-w-full lg:mb-5">
-      <nav
-        className="no-scrollbar flex space-x-0.5 overflow-x-scroll rounded-md"
-        aria-label="Tabs"
-        {...props}>
-        {tabs.map((tab, idx) => (
-          <HorizontalTabItem {...tab} key={idx} linkShallow={linkShallow} linkScroll={linkScroll} />
-        ))}
-      </nav>
+      <div className="relative flex items-center">
+        {showLeftArrow && (
+          <button
+            onClick={() => scroll("left")}
+            className="z-10 flex h-6 w-8 items-center justify-center transition-opacity hover:opacity-70"
+            aria-label="Scroll left">
+            <Icon name="chevron-left" className="h-4 w-4 text-white drop-shadow-sm" />
+          </button>
+        )}
+        <nav
+          ref={navRef}
+          className="no-scrollbar flex flex-1 space-x-0.5 overflow-x-auto rounded-md"
+          aria-label="Tabs"
+          onScroll={checkScrollPosition}
+          {...props}>
+          {tabs.map((tab, idx) => (
+            <HorizontalTabItem {...tab} key={idx} linkShallow={linkShallow} linkScroll={linkScroll} />
+          ))}
+        </nav>
+        {showRightArrow && (
+          <button
+            onClick={() => scroll("right")}
+            className="z-10 flex h-6 w-8 items-center justify-center transition-opacity hover:opacity-70"
+            aria-label="Scroll right">
+            <Icon name="chevron-right" className="h-4 w-4 text-white drop-shadow-sm" />
+          </button>
+        )}
+      </div>
       {actions && actions}
     </div>
   );

--- a/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/HorizontalTabs.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
@@ -6,7 +6,7 @@ import { Icon } from "../../icon";
 import type { HorizontalTabItemProps } from "./HorizontalTabItem";
 import HorizontalTabItem from "./HorizontalTabItem";
 
-export interface NavTabProps {
+export interface NavTabProps extends React.ComponentPropsWithoutRef<"nav"> {
   tabs: HorizontalTabItemProps[];
   linkShallow?: boolean;
   linkScroll?: boolean;

--- a/packages/ui/components/navigation/tabs/navigation.test.tsx
+++ b/packages/ui/components/navigation/tabs/navigation.test.tsx
@@ -103,14 +103,14 @@ describe("Navigation Components", () => {
 
       test("shows scroll arrows when content overflows", () => {
         setupScrollTest(0);
-        expect(screen.getByLabelText("Scroll right")).toBeInTheDocument();
-        expect(screen.queryByLabelText("Scroll left")).not.toBeInTheDocument();
+        expect(screen.getByTestId("scroll-right-button")).toBeInTheDocument();
+        expect(screen.queryByTestId("scroll-left-button")).not.toBeInTheDocument();
       });
 
       test("shows both arrows when scrolled to middle", () => {
         setupScrollTest(100);
-        expect(screen.getByLabelText("Scroll left")).toBeInTheDocument();
-        expect(screen.getByLabelText("Scroll right")).toBeInTheDocument();
+        expect(screen.getByTestId("scroll-left-button")).toBeInTheDocument();
+        expect(screen.getByTestId("scroll-right-button")).toBeInTheDocument();
       });
 
       test("scrolls left when left arrow is clicked", () => {
@@ -118,7 +118,7 @@ describe("Navigation Components", () => {
         const scrollBySpy = vi.fn();
         navElement.scrollBy = scrollBySpy;
 
-        fireEvent.click(screen.getByLabelText("Scroll left"));
+        fireEvent.click(screen.getByTestId("scroll-left-button"));
         expect(scrollBySpy).toHaveBeenCalledWith({ left: -300, behavior: "smooth" });
       });
 
@@ -127,7 +127,7 @@ describe("Navigation Components", () => {
         const scrollBySpy = vi.fn();
         navElement.scrollBy = scrollBySpy;
 
-        fireEvent.click(screen.getByLabelText("Scroll right"));
+        fireEvent.click(screen.getByTestId("scroll-right-button"));
         expect(scrollBySpy).toHaveBeenCalledWith({ left: 300, behavior: "smooth" });
       });
     });
@@ -146,8 +146,8 @@ describe("Navigation Components", () => {
 
       fireEvent.scroll(navElement);
 
-      expect(screen.queryByLabelText("Scroll left")).not.toBeInTheDocument();
-      expect(screen.queryByLabelText("Scroll right")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("scroll-left-button")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("scroll-right-button")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

Improves the usability of the HorizontalTabs component by adding left and right scroll buttons when the tab list overflows horizontally.

## Before: tabs were only scrollable via trackpad gestures or touch swipe, which was unintuitive for desktop users

https://github.com/user-attachments/assets/3bcb35d5-dcfe-4e38-a80a-ed3508a4a6f4

## After: added an arrow to improve UX

https://github.com/user-attachments/assets/b352d893-3540-446d-8961-2796445e38f7


A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

