### PR TITLE
chore: add an eslint rule to warn importing trpc package in app store package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,17 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ["packages/app-store/**/*.{ts,tsx,js,jsx}"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            paths: ["@calcom/trpc"],
+            patterns: ["@calcom/trpc/*"],
+          },
+        ],
+      },
+    },
   ],
 };


### PR DESCRIPTION

## What does this PR do?

This PR adds an ESLint rule to prevent importing the `@calcom/trpc` package within the app store package, helping maintain better architectural boundaries and preventing potential circular dependencies.

### Changes Made

- **Added ESLint restriction rule**: Configured `no-restricted-imports` in `.eslintrc.js` to warn when importing:
  - `@calcom/trpc` (direct import)
  - `@calcom/trpc/*` (any sub-path imports)
- **Scope**: The rule applies specifically to files in `packages/app-store/**/*`
- **Severity**: Set to "warn" level to alert developers without breaking the build

### Why This Restriction?

1. **Architectural Separation**: Keeps the app store package decoupled from tRPC-specific implementations
2. **Dependency Management**: Prevents potential circular dependencies between app store and tRPC packages  
3. **Modularity**: Maintains cleaner separation of concerns, making the app store more portable and testable
4. **Performance**: Reduces bundle size by avoiding unnecessary tRPC imports in app store components

### Technical Details

The ESLint rule configuration:
```javascript
"overrides": [
  {
    "files": ["packages/app-store/**/*"],
    "rules": {
      "no-restricted-imports": [
        "warn",
        {
          paths: ["@calcom/trpc"],
          patterns: ["@calcom/trpc/*"],
        },
      ],
    },
  },
]
```

This ensures developers are warned when attempting to import tRPC utilities directly in app store code, encouraging the use of proper abstraction layers instead.

## How should this be tested?

1. Try importing `@calcom/trpc` in any file within `packages/app-store/` - you should see an ESLint warning
2. Verify existing app store functionality continues to work without tRPC imports
3. Run `npm run lint` to ensure the rule is properly applied
4. Test that the rule doesn't affect tRPC imports outside the app store package

---

🏁 Script executed:
```
#!/bin/bash
# Check the specific changes made in this PR
git diff HEAD~1 HEAD

# Also check if there are any differences between current state and main/master
git log --oneline -5
```

Length of output: 232

---

🏁 Script executed:
```
#!/bin/bash
# Look at the current eslint configuration to see the rule that was added
cat .eslintrc.js | grep -A 10 -B 10 "no-restricted-imports"
```

Length of output: 758

---



</details>

Perfect! Now I can see the complete picture. The PR adds an ESLint rule that prevents importing `@calcom/trpc` in the app-store package. Here's the updated and complete PR description:

@hbjORbj Here's a comprehensive PR description for this PR:

## What does this PR do?

This PR adds an ESLint rule to prevent importing the `@calcom/trpc` package within the app store package (`packages/app-store/**/*`), helping maintain better architectural boundaries and preventing potential circular dependencies.

### Changes Made

- **Added ESLint restriction rule**: Configured `no-restricted-imports` in `.eslintrc.js` to warn when importing:
  - `@calcom/trpc` (direct import)
  - `@calcom/trpc/*` (any sub-path imports)
- **Scope**: The rule applies specifically to files in `packages/app-store/**/*.{ts,tsx,js,jsx}`
- **Severity**: Set to "warn" level to alert developers without breaking the build

### Why This Restriction?

1. **Architectural Separation**: Keeps the app store package decoupled from tRPC-specific implementations
2. **Dependency Management**: Prevents potential circular dependencies between app store and tRPC packages  
3. **Modularity**: Maintains cleaner separation of concerns, making the app store more portable and testable
4. **Performance**: Reduces bundle size by avoiding unnecessary tRPC imports in app store components
5. **Consistency**: Mirrors the existing restriction that prevents `@calcom/lib` and `@calcom/prisma` from importing `@calcom/app-store`

### Technical Details

The ESLint rule configuration added:
```javascript
{
  files: ["packages/app-store/**/*.{ts,tsx,js,jsx}"],
  rules: {
    "no-restricted-imports": [
      "warn",
      {
        paths: ["@calcom/trpc"],
        patterns: ["@calcom/trpc/*"],
      },
    ],
  },
}
```

This creates a bidirectional architectural boundary:
- App store cannot import tRPC (this PR)
- Lib/Prisma packages cannot import app store (existing rule)

## How should this be tested?

1. **ESLint Warning Test**: Try importing `@calcom/trpc` in any file within `packages/app-store/` - you should see an ESLint warning
2. **Functionality Test**: Verify existing app store functionality continues to work without tRPC imports
3. **Lint Check**: Run `npm run lint` to ensure the rule is properly applied
4. **Scope Test**: Confirm that the rule doesn't affect tRPC imports outside the app store package
5. **Build Test**: Ensure the application still builds and runs correctly with this architectural constraint

This change helps maintain cleaner package boundaries and prevents architectural drift in the Cal.com codebase.