### PR TITLE
fix: use IS_CALCOM constant for pbac dogfood

### DIFF
--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,9 +14,13 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", () => ({
-  IS_CALCOM: true,
-}));
+vi.mock("@calcom/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    IS_CALCOM: true,
+  };
+});
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,13 +14,9 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    IS_CALCOM: true,
-  };
-});
+vi.mock("@calcom/lib/constants", () => ({
+  IS_CALCOM: true,
+}));
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,9 +14,13 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", () => ({
-  IS_CALCOM: true,
-}));
+vi.mock("@calcom/lib/constants", async () => {
+  const actual = await vi.importActual<typeof import("@calcom/lib/constants")>("@calcom/lib/constants");
+  return {
+    ...actual,
+    IS_CALCOM: true,
+  };
+});
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -19,6 +19,10 @@ vi.mock("@calcom/lib/constants", async () => {
   return {
     ...actual,
     IS_CALCOM: true,
+    SENDER_ID: "Cal",
+    SENDER_NAME: "Cal.com",
+    IS_SELF_HOSTED: false,
+    SCANNING_WORKFLOW_STEPS: false,
   };
 });
 

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,15 +14,11 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", async () => {
-  const actual = await vi.importActual<typeof import("@calcom/lib/constants")>("@calcom/lib/constants");
+vi.mock("@calcom/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal();
   return {
     ...actual,
     IS_CALCOM: true,
-    SENDER_ID: "Cal",
-    SENDER_NAME: "Cal.com",
-    IS_SELF_HOSTED: false,
-    SCANNING_WORKFLOW_STEPS: false,
   };
 });
 

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,8 +14,8 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
-vi.mock("@calcom/lib/constants", async (importOriginal) => {
-  const actual = await importOriginal();
+vi.mock("@calcom/lib/constants", async () => {
+  const actual = await import("@calcom/lib/constants");
   return {
     ...actual,
     IS_CALCOM: true,

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -14,6 +14,9 @@ vi.mock("../../infrastructure/repositories/PermissionRepository");
 vi.mock("@calcom/features/flags/features.repository");
 vi.mock("@calcom/lib/server/repository/membership");
 vi.mock("../permission.service");
+vi.mock("@calcom/lib/constants", () => ({
+  IS_CALCOM: true,
+}));
 
 type MockRepository = {
   [K in keyof IPermissionRepository]: Mock;

--- a/packages/features/pbac/services/permission-check.service.ts
+++ b/packages/features/pbac/services/permission-check.service.ts
@@ -1,4 +1,5 @@
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import { IS_CALCOM } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import prisma from "@calcom/prisma";
@@ -16,7 +17,7 @@ import type {
 import { PermissionRepository } from "../infrastructure/repositories/PermissionRepository";
 import { PermissionService } from "./permission.service";
 
-const DOGFOOD_PBAC_INTERNALLY = true;
+const DOGFOOD_PBAC_INTERNALLY = IS_CALCOM;
 
 export class PermissionCheckService {
   private readonly PBAC_FEATURE_FLAG = "pbac" as const;

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -21,6 +21,7 @@ const initialConstants = {
   PUBLIC_QUICK_AVAILABILITY_ROLLOUT: 100,
   SINGLE_ORG_SLUG: "",
   DEFAULT_GROUP_ID: "default_group_id",
+  IS_CALCOM: false,
 } as Partial<typeof constants>;
 
 export const mockedConstants = { ...initialConstants };

--- a/packages/lib/__mocks__/constants.ts
+++ b/packages/lib/__mocks__/constants.ts
@@ -22,6 +22,9 @@ const initialConstants = {
   SINGLE_ORG_SLUG: "",
   DEFAULT_GROUP_ID: "default_group_id",
   IS_CALCOM: false,
+  SENDER_ID: "Cal",
+  SENDER_NAME: "Cal.com",
+  SCANNING_WORKFLOW_STEPS: false,
 } as Partial<typeof constants>;
 
 export const mockedConstants = { ...initialConstants };


### PR DESCRIPTION
Rely on IS_CALCOM for dogfooding PBAC internally instead of true - which was causing complications in development when we don't want to safely ignore the permission fallbacks