### PR TITLE
feat: replace SkipTakePagination with GetUsersInput in getTeamMemberships

### DIFF
--- a/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.ts
+++ b/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.ts
@@ -12,6 +12,7 @@ import { GetTeamMembershipsOutput } from "@/modules/teams/memberships/outputs/ge
 import { TeamMembershipOutput } from "@/modules/teams/memberships/outputs/team-membership.output";
 import { UpdateTeamMembershipOutput } from "@/modules/teams/memberships/outputs/update-team-membership.output";
 import { TeamsMembershipsService } from "@/modules/teams/memberships/services/teams-memberships.service";
+import { GetUsersInput } from "@/modules/users/inputs/get-users.input";
 import {
   Controller,
   UseGuards,
@@ -32,7 +33,6 @@ import { plainToClass } from "class-transformer";
 
 import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import { updateNewTeamMemberEventTypes } from "@calcom/platform-libraries/event-types";
-import { SkipTakePagination } from "@calcom/platform-types";
 
 @Controller({
   path: "/v2/teams/:teamId/memberships",
@@ -90,13 +90,14 @@ export class TeamsMembershipsController {
   @HttpCode(HttpStatus.OK)
   async getTeamMemberships(
     @Param("teamId", ParseIntPipe) teamId: number,
-    @Query() queryParams: SkipTakePagination
+    @Query() queryParams: GetUsersInput
   ): Promise<GetTeamMembershipsOutput> {
-    const { skip, take } = queryParams;
+    const { skip, take, emails } = queryParams;
     const orgTeamMemberships = await this.teamsMembershipsService.getPaginatedTeamMemberships(
       teamId,
       skip ?? 0,
-      take ?? 250
+      take ?? 250,
+      emails
     );
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
+++ b/apps/api/v2/src/modules/teams/memberships/services/teams-memberships.service.ts
@@ -14,11 +14,12 @@ export class TeamsMembershipsService {
     return teamMembership;
   }
 
-  async getPaginatedTeamMemberships(teamId: number, skip = 0, take = 250) {
+  async getPaginatedTeamMemberships(teamId: number, skip = 0, take = 250, emails?: string[]) {
     const teamMemberships = await this.teamsMembershipsRepository.findTeamMembershipsPaginated(
       teamId,
       skip,
-      take
+      take,
+      emails
     );
     return teamMemberships;
   }

--- a/apps/api/v2/src/modules/teams/memberships/teams-memberships.repository.ts
+++ b/apps/api/v2/src/modules/teams/memberships/teams-memberships.repository.ts
@@ -30,11 +30,21 @@ export class TeamsMembershipsRepository {
     });
   }
 
-  async findTeamMembershipsPaginated(teamId: number, skip: number, take: number) {
+  async findTeamMembershipsPaginated(teamId: number, skip: number, take: number, emails?: string[]) {
+    const whereClause: any = {
+      teamId: teamId,
+    };
+
+    if (emails && emails.length > 0) {
+      whereClause.user = {
+        email: {
+          in: emails,
+        },
+      };
+    }
+
     return await this.dbRead.prisma.membership.findMany({
-      where: {
-        teamId: teamId,
-      },
+      where: whereClause,
       include: { user: { select: MembershipUserSelect } },
       skip,
       take,


### PR DESCRIPTION
## What does this PR do?

This PR modifies the existing `getTeamMemberships` endpoint in the Platform API v2 to replace `SkipTakePagination` with `GetUsersInput` as the query parameter interface, adding email filtering capability to the endpoint.

**Key Changes:**
- **Controller**: Updated `getTeamMemberships` method to use `GetUsersInput` instead of `SkipTakePagination`
- **Service Layer**: Added support for optional `emails` parameter in `getPaginatedTeamMemberships`
- **Repository Layer**: Enhanced `findTeamMembershipsPaginated` with conditional email filtering logic
- **Backward Compatibility**: Maintains existing pagination functionality (`skip`, `take`) while adding new email filtering

**New Functionality:**
- Filter team memberships by email addresses using the `emails` query parameter
- Supports multiple emails as an array (comma-separated in query string)
- Maintains existing pagination behavior when no emails are provided

This change was requested instead of creating a new endpoint, allowing the existing team memberships endpoint to support both basic pagination and email-based filtering.

## Visual Demo

N/A - This is an API endpoint modification without UI changes.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required for internal API modification
- [x] Automated tests are in place (existing unit tests pass, type checking passes)

## How should this be tested?

**API Testing:**
1. **Basic pagination (existing functionality):**
   ```
   GET /v2/teams/{teamId}/memberships?skip=0&take=10
   ```
   Should return paginated team memberships as before

2. **Email filtering (new functionality):**
   ```
   GET /v2/teams/{teamId}/memberships?emails=user1@example.com,user2@example.com
   ```
   Should return only team memberships for users with specified email addresses

3. **Combined filtering:**
   ```
   GET /v2/teams/{teamId}/memberships?emails=user@example.com&skip=0&take=5
   ```
   Should return paginated results filtered by email

**Expected Behavior:**
- Existing API calls should continue to work unchanged
- New `emails` parameter should filter results by user email addresses
- Invalid email formats should be rejected by validation (handled by `GetUsersInput`)
- Empty emails array should return all results (same as no emails parameter)

## Important Review Points

- **API Contract Change**: Verify that replacing `SkipTakePagination` with `GetUsersInput` maintains backward compatibility
- **Database Query Logic**: Review the conditional where clause construction in the repository layer
- **Type Safety**: The `whereClause` uses `any` type - consider if this should be more strictly typed
- **Email Validation**: Ensure `GetUsersInput` validation properly handles email format validation

---

**Link to Devin run:** https://app.devin.ai/sessions/526085756d884f72abd6ce863a3b39bf  
**Requested by:** @Devanshusharma2005