### PR TITLE
fix: spinner misalignment before skeleton load on Event Type page

### DIFF
--- a/packages/features/eventtypes/components/EventTypeLayout.tsx
+++ b/packages/features/eventtypes/components/EventTypeLayout.tsx
@@ -276,7 +276,7 @@ function EventTypeSingleLayout({
           </Button>
         </div>
       }>
-      <Suspense fallback={<Icon name="loader" />}>
+      <Suspense fallback={<Icon name="loader" className="mx-auto my-5 animate-spin" />}>
         <div className="flex flex-col xl:flex-row xl:space-x-6">
           <div className="hidden xl:block">
             <VerticalTabs


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes a visual bug where the loading spinner on event type settings pages briefly renders in the wrong position during page load. The spinner was appearing misaligned (left-aligned without proper spacing or animation) before the page skeletons loaded, creating an unpolished user experience especially noticeable on slower networks.

- Fixes #23678 
- Fixes [CAL-6382](https://linear.app/calcom/issue/CAL-6382/spinner-misaligned-for-a-fraction-of-a-second-before-skeletons-load-on)
## Visual Demo (For contributors especially)


#### Before fix:
<img width="3321" height="2160" alt="486837273-d5ad9e58-e665-4664-b2fc-62c62bbde94b" src="https://github.com/user-attachments/assets/6cb2b8c6-dd8f-4a05-ac5b-987c48cec5bb" />

### After fix:

https://github.com/user-attachments/assets/0144b23e-859b-4173-9781-9bafe6dc6a52


### Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- No special environment variables required
- Standard Cal.com development setup