### PR TITLE
test: [Booking Refactor - Preparation - 1] Make all test files import handleNewBooking from a single place

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/global-booking-limits.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/global-booking-limits.test.ts
@@ -17,12 +17,12 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./test/getNewBookingHandler";
+
 // Local test runs sometime gets too slow
 const timeout = process.env.CI ? 5000 : 20000;
 
 const eventLength = 30;
-
-const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
 
 const booker = getBooker({
   email: "booker@example.com",
@@ -69,6 +69,7 @@ describe(
       // eslint-disable-next-line playwright/no-skipped-test
       test(`Booking limits per week
     `, async ({}) => {
+        const handleNewBooking = getNewBookingHandler();
         await createBookingScenario(
           getScenarioData({
             eventTypes: [
@@ -207,6 +208,7 @@ describe(
       });
 
       test(`Booking limits per day`, async ({}) => {
+        const handleNewBooking = getNewBookingHandler();
         await createBookingScenario(
           getScenarioData({
             eventTypes: [
@@ -293,6 +295,7 @@ describe(
       });
 
       test(`Booking limits per month`, async ({}) => {
+        const handleNewBooking = getNewBookingHandler();
         await createBookingScenario(
           getScenarioData({
             eventTypes: [
@@ -424,6 +427,7 @@ describe(
       });
 
       test(`Booking limits per year`, async ({}) => {
+        const handleNewBooking = getNewBookingHandler();
         await createBookingScenario(
           getScenarioData({
             eventTypes: [

--- a/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/booking-limits.test.ts
@@ -30,6 +30,8 @@ import { PeriodType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 // Local test runs sometime gets too slow
 const timeout = process.env.CI ? 5000 : 20000;
 
@@ -49,7 +51,7 @@ describe("handleNewBooking", () => {
             2. following year without bookings: should create a booking in the database
         `,
         async ({}) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
 
           const booker = getBooker({
             email: "booker@example.com",
@@ -167,7 +169,7 @@ describe("handleNewBooking", () => {
             2. following year without bookings: should create a booking in the database
         `,
         async ({}) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
 
           const booker = getBooker({
             email: "booker@example.com",
@@ -296,7 +298,7 @@ describe("handleNewBooking", () => {
       test.skipIf([todayDate, tomorrowDate].includes("01"))(
         `should fail a booking if exceeds booking limits with bookings in the past`,
         async ({}) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
 
           const booker = getBooker({
             email: "booker@example.com",
@@ -377,7 +379,7 @@ describe("handleNewBooking", () => {
       test(
         `should fail a booking if exceeds booking limits with bookings in week across two months`,
         async ({}) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
 
           const booker = getBooker({
             email: "booker@example.com",
@@ -466,7 +468,7 @@ describe("handleNewBooking", () => {
 
   describe("Buffers", () => {
     test("should throw error when booking is not respecting buffers with event types that have before and after buffer ", async ({}) => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",
@@ -560,7 +562,7 @@ describe("handleNewBooking", () => {
 
     test(`should throw error when booking is within a before event buffer of an existing booking
         `, async ({}) => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",
@@ -627,7 +629,7 @@ describe("handleNewBooking", () => {
   });
   test(`should throw error when booking is within a after event buffer of an existing booking
         `, async ({}) => {
-    const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+    const handleNewBooking = getNewBookingHandler();
 
     const booker = getBooker({
       email: "booker@example.com",
@@ -695,7 +697,7 @@ describe("handleNewBooking", () => {
   test(
     `should fail booking if the start date is in the past`,
     async ({}) => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -770,7 +772,7 @@ describe("handleNewBooking", () => {
       async () => {
         // In IST it is 2024-05-22 12:39am
         vi.setSystemTime("2024-05-21T19:09:13Z");
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/complex-schedules.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/complex-schedules.test.ts
@@ -28,6 +28,8 @@ import dayjs from "@calcom/dayjs";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 export const Timezones = {
   "-05:00": "America/New_York",
   "00:00": "Europe/London",
@@ -48,7 +50,7 @@ describe("handleNewBooking", () => {
       async ({ emails }) => {
         const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
         const newYorkTimeZone = Timezones["-05:00"];
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/date-overrides.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/date-overrides.test.ts
@@ -28,6 +28,8 @@ import dayjs from "@calcom/dayjs";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 export const Timezones = {
   "-05:00": "America/New_York",
   "00:00": "Europe/London",
@@ -48,7 +50,7 @@ describe("handleNewBooking", () => {
       async ({ emails }) => {
         const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
         const newYorkTimeZone = Timezones["-05:00"];
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -210,7 +212,7 @@ describe("handleNewBooking", () => {
       async ({ emails }) => {
         const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
         const newYorkTimeZone = Timezones["-05:00"];
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/delegation-credential.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/delegation-credential.test.ts
@@ -45,6 +45,8 @@ import { BookingStatus } from "@calcom/prisma/enums";
 import { MembershipRole } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 vi.mock("@calcom/app-store/calendar.services.generated", () => {
   class MockGoogleCalendarService {
     credential: any;
@@ -160,7 +162,7 @@ describe("handleNewBooking", () => {
       3. Should use Google Meet as the location even when not explicitly set.
 `,
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",
@@ -339,7 +341,7 @@ describe("handleNewBooking", () => {
       3. Should use Google Meet as the location even when not explicitly set and no destination calendar is set for User/EventType
 `,
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",
@@ -516,7 +518,7 @@ describe("handleNewBooking", () => {
       2. Should create an event in Outlook calendar with Delegation credential
 `,
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",
@@ -709,7 +711,7 @@ describe("handleNewBooking", () => {
     test(
       `should fail calendar event creation when organizer isn't part of the organization of DelegationCredential Credential`,
       async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",
@@ -878,7 +880,7 @@ describe("handleNewBooking", () => {
       3. Should use Google Meet as the location even when not explicitly set.
 `,
       async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",
@@ -1031,7 +1033,7 @@ describe("handleNewBooking", () => {
     test(
       `should use Cal Video as the location if that is the default conferencing app set by the user. It must not use Google Meet coming from Delegation credential.`,
       async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const org = await createOrganization({
           name: "Test Org",

--- a/packages/features/bookings/lib/handleNewBooking/test/dynamic-group-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/dynamic-group-booking.test.ts
@@ -29,6 +29,8 @@ import { ErrorCode } from "@calcom/lib/errorCodes";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 export type CustomNextApiRequest = NextApiRequest & Request;
 
 export type CustomNextApiResponse = NextApiResponse & Response;
@@ -41,7 +43,7 @@ describe("handleNewBooking", () => {
     test(
       `should allow a booking if there is no conflicting booking in any of the users' selectedCalendars`,
       async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const groupUserId1 = 101;
         const groupUserId2 = 102;
         const booker = getBooker({
@@ -137,7 +139,7 @@ describe("handleNewBooking", () => {
       test(
         `should fail a booking if there is already a conflicting booking in the first user's selectedCalendars`,
         async () => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const groupUserId1 = 101;
           const groupUserId2 = 102;
           const booker = getBooker({
@@ -217,7 +219,7 @@ describe("handleNewBooking", () => {
       test(
         `should fail a booking if there is already a conflicting booking in the second user's selectedCalendars`,
         async () => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const groupUserId1 = 101;
           const groupUserId2 = 102;
           const booker = getBooker({

--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -63,6 +63,8 @@ import { CreationSource, WatchlistSeverity, WatchlistType } from "@calcom/prisma
 import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 export type CustomNextApiRequest = NextApiRequest & Request;
 
 export type CustomNextApiResponse = NextApiResponse & Response;
@@ -81,7 +83,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_CREATED webhook
     `,
       async ({ emails, org }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -262,7 +264,7 @@ describe("handleNewBooking", () => {
           3. Should trigger BOOKING_CREATED webhook
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -422,7 +424,7 @@ describe("handleNewBooking", () => {
           3. Should trigger BOOKING_CREATED webhook
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -577,7 +579,7 @@ describe("handleNewBooking", () => {
       test(
         `an error in creating a calendar event should not stop the booking creation - Current behaviour is wrong as the booking is created but no-one is notified of it`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -698,7 +700,7 @@ describe("handleNewBooking", () => {
       test(
         "If destination calendar has no credential ID due to some reason, it should create the event in first connected calendar instead",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -864,7 +866,7 @@ describe("handleNewBooking", () => {
       test(
         "If destination calendar is there for Google Calendar but there are no Google Calendar credentials but there is an Apple Calendar credential connected, it should create the event in Apple Calendar",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1021,7 +1023,7 @@ describe("handleNewBooking", () => {
       test(
         `should create a successful booking with right location app when event has location option as video client`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1114,7 +1116,7 @@ describe("handleNewBooking", () => {
         `,
         //test with inPerson event type
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1197,7 +1199,7 @@ describe("handleNewBooking", () => {
       test(
         `should create a successful booking with organizer default conferencing app when event's location is not set`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1291,7 +1293,7 @@ describe("handleNewBooking", () => {
       test(
         `should create a successful booking with Zoom if used`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -1379,7 +1381,7 @@ describe("handleNewBooking", () => {
       test(
         `Booking should still be created using calvideo, if error occurs with zoom`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -1473,7 +1475,7 @@ describe("handleNewBooking", () => {
       test(
         `should fail if the time difference between a booking's start and end times is not equal to the event length.`,
         async () => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
 
           const booker = getBooker({
             email: "booker@example.com",
@@ -1533,7 +1535,7 @@ describe("handleNewBooking", () => {
       test(
         "should create a booking with UTM tracking",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1618,7 +1620,7 @@ describe("handleNewBooking", () => {
       test(
         `should create a booking with creation source as WEBAPP`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1699,7 +1701,7 @@ describe("handleNewBooking", () => {
         test(
           `should fail a booking if there is already a Cal.com booking overlapping the time`,
           async ({}) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
 
             const booker = getBooker({
               email: "booker@example.com",
@@ -1771,7 +1773,7 @@ describe("handleNewBooking", () => {
         test(
           `should fail a booking if there is already a booking in the organizer's selectedCalendars(Single Calendar) with the overlapping time`,
           async () => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const organizerId = 101;
             const booker = getBooker({
               email: "booker@example.com",
@@ -1856,7 +1858,7 @@ describe("handleNewBooking", () => {
         test(
           `should allow a booking even if there is already a booking in the organizer's selectedCalendars(Single Calendar) with the overlapping time but useEventLevelSelectedCalendars is false and SelectedCalendar is for an event`,
           async () => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const organizerId = 101;
             const eventTypeId = 1;
             const useEventLevelSelectedCalendars = false;
@@ -1940,8 +1942,8 @@ describe("handleNewBooking", () => {
           test(
             `should fail a booking if there is already a booking in the organizer's selectedCalendars(Single Calendar) with the overlapping time as chosen in the event type`,
             async () => {
-              const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking"))
-                .default;
+              const handleNewBooking = getNewBookingHandler();
+
               const organizerId = 101;
               const eventTypeId = 1;
               const useEventLevelSelectedCalendars = true;
@@ -2020,8 +2022,8 @@ describe("handleNewBooking", () => {
           test(
             `should allow a booking even if there is already a booking in the organizer's selectedCalendars(Single Calendar) with the overlapping time and useEventLevelSelectedCalendars is true but the selectedCalendar is of different eventType`,
             async () => {
-              const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking"))
-                .default;
+              const handleNewBooking = getNewBookingHandler();
+
               const organizerId = 101;
               const eventTypeId = 1;
               const anotherEventTypeId = 2;
@@ -2118,7 +2120,7 @@ describe("handleNewBooking", () => {
             4. Should trigger BOOKING_REQUESTED workflow
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -2255,7 +2257,7 @@ describe("handleNewBooking", () => {
         4. Should trigger BOOKING_REQUESTED workflow
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -2381,7 +2383,7 @@ describe("handleNewBooking", () => {
             3. Should trigger BOOKING_CREATED webhook
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2517,7 +2519,7 @@ describe("handleNewBooking", () => {
             4. Should trigger BOOKING_REQUESTED workflows
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -2647,7 +2649,7 @@ describe("handleNewBooking", () => {
     test(
       `if booking with Cal Video(Daily Video) fails, booking creation fails with uncaught error`,
       async ({}) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.org",
           name: "Booker",
@@ -2715,7 +2717,7 @@ describe("handleNewBooking", () => {
       3. Should trigger BOOKING_CREATED webhook
     `,
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -2841,7 +2843,7 @@ describe("handleNewBooking", () => {
             7. Workflow triggers once payment is successful
       `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -3024,7 +3026,7 @@ describe("handleNewBooking", () => {
       `,
         async ({ emails }) => {
           const bookingInitiatedEmail = "booking_initiated@workflow.com";
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const subscriberUrl = "http://my-webhook.example.com";
           const booker = getBooker({
             email: "booker@example.com",
@@ -3202,7 +3204,7 @@ describe("handleNewBooking", () => {
       test(
         `cannot book same slot multiple times `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -3350,7 +3352,7 @@ describe("handleNewBooking", () => {
       test(
         `Payment retry scenario - should return existing payment UID and prevent duplicate bookings when retrying canceled payment`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -3467,7 +3469,7 @@ describe("handleNewBooking", () => {
 
   describe("Returning original booking", () => {
     test("Return the original booking if a request is made twice by the same attendee when a booking requires confirmation", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -3525,7 +3527,7 @@ describe("handleNewBooking", () => {
       expect(secondResponse.id).toEqual(response.id);
     });
     test("Return the original booking if request is made by the same attendee for a round robin event", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -3587,7 +3589,7 @@ describe("handleNewBooking", () => {
 
   describe("Blocked users", () => {
     test("user is locked", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -3642,7 +3644,7 @@ describe("handleNewBooking", () => {
     });
 
     test("username is critical in watchlist", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -3704,7 +3706,7 @@ describe("handleNewBooking", () => {
     });
 
     test("domain is critical in watchlist", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -3766,7 +3768,7 @@ describe("handleNewBooking", () => {
     });
 
     test("domain is critical in watchlist", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/getNewBookingHandler.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/getNewBookingHandler.ts
@@ -1,0 +1,8 @@
+async function handler(input: any) {
+  const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+  return handleNewBooking(input);
+}
+
+export function getNewBookingHandler() {
+  return handler;
+}

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -45,6 +45,8 @@ import { resetTestSMS } from "@calcom/lib/testSMS";
 import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 // Local test runs sometime gets too slow
 const timeout = process.env.CI ? 5000 : 20000;
 
@@ -65,7 +67,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_RESCHEDULED webhook
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -304,7 +306,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_RESCHEDULED webhook
     `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -510,7 +512,7 @@ describe("handleNewBooking", () => {
       test(
         `an error in updating a calendar event should not stop the rescheduling - Current behaviour is wrong as the booking is resheduled but no-one is notified of it`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -697,7 +699,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_REQUESTED webhook instead of BOOKING_RESCHEDULED
     `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const subscriberUrl = "http://my-webhook.example.com";
             const booker = getBooker({
               email: "booker@example.com",
@@ -903,7 +905,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_RESCHEDULED webhook
     `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -1147,7 +1149,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_RESCHEDULED webhook
     `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -1388,7 +1390,7 @@ describe("handleNewBooking", () => {
         4. Should trigger BOOKING_REQUESTED webhook
       `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const subscriberUrl = "http://my-webhook.example.com";
             const booker = getBooker({
               email: "booker@example.com",
@@ -1598,7 +1600,7 @@ describe("handleNewBooking", () => {
           4. Should trigger BOOKING_RESCHEDULED webhook
     `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -1856,7 +1858,7 @@ describe("handleNewBooking", () => {
           4. Should update/create necessary video conference links
         `,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2008,7 +2010,7 @@ describe("handleNewBooking", () => {
       test(
         "should send correct schedule/cancellation/reassigned emails to hosts when round robin is rescheduled to different host",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2167,7 +2169,7 @@ describe("handleNewBooking", () => {
       test(
         "should send rescheduling emails when round robin is rescheduled to same host",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2315,7 +2317,7 @@ describe("handleNewBooking", () => {
       test(
         "[Event Type with Both Email and Attendee Phone Number as required fields] should send rescheduling emails when round robin is rescheduled to same host",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const TEST_ATTENDEE_NUMBER = "+919876543210";
           const booker = getBooker({
             email: "booker@example.com",
@@ -2516,7 +2518,7 @@ describe("handleNewBooking", () => {
       test(
         "should reschedule event with same round robin host",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2673,7 +2675,7 @@ describe("handleNewBooking", () => {
       test(
         "should reschedule as per routedTeamMemberIds(instead of same host) even if rescheduleWithSameRoundRobinHost is true but it is a rerouting scenario",
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -2832,7 +2834,7 @@ describe("handleNewBooking", () => {
     test(
       "should use correct credentials when round robin reschedule changes host - original host credentials for deletion, new host for creation",
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -2960,7 +2962,7 @@ describe("handleNewBooking", () => {
     test(
       "should set correct booking reference when rescheduling with phone location change",
       async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "test@example.com",
           name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/round-robin-no-hosts.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/round-robin-no-hosts.test.ts
@@ -18,6 +18,8 @@ import { ErrorCode } from "@calcom/lib/errorCodes";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 const timeout = process.env.CI ? 5000 : 20000;
 
 describe("handleNewBooking - Round Robin Host Validation", () => {
@@ -26,7 +28,7 @@ describe("handleNewBooking - Round Robin Host Validation", () => {
   test(
     "should throw NoAvailableUsersFound when Round Robin event has both fixed and round robin hosts busy",
     async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",
@@ -139,7 +141,7 @@ describe("handleNewBooking - Round Robin Host Validation", () => {
   test(
     "should throw RoundRobinHostsUnavailableForBooking when Round Robin event has fixed hosts but no round robin host is available",
     async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",

--- a/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-reschedule-destination-calendar.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-reschedule-destination-calendar.test.ts
@@ -24,6 +24,8 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "../getNewBookingHandler";
+
 export type CustomNextApiRequest = NextApiRequest & Request;
 
 export type CustomNextApiResponse = NextApiResponse & Response;
@@ -46,7 +48,7 @@ describe("handleNewBooking", () => {
         4. Verify both hosts have the booking in their calendars
     `,
       async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "booker@example.com",

--- a/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-scheduling.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/team-bookings/collective-scheduling.test.ts
@@ -43,6 +43,8 @@ import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "../getNewBookingHandler";
+
 export type CustomNextApiRequest = NextApiRequest & Request;
 
 export type CustomNextApiResponse = NextApiResponse & Response;
@@ -63,7 +65,7 @@ describe("handleNewBooking", () => {
           - Destination calendars for event-type and non-first hosts are used to create calendar events
         `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -245,7 +247,7 @@ describe("handleNewBooking", () => {
         test(
           `rejects a booking when even one of the hosts is busy`,
           async ({}) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -371,7 +373,7 @@ describe("handleNewBooking", () => {
           - Destination calendars for event-type and non-first hosts are used to create calendar events
         `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -544,7 +546,7 @@ describe("handleNewBooking", () => {
           - Destination calendars for event-type and non-first hosts are used to create calendar events
         `,
           async ({ emails, sms }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const org = await createOrganization({
               name: "Test Org",
               slug: "testorg",
@@ -777,7 +779,7 @@ describe("handleNewBooking", () => {
           - Destination calendars for event-type and non-first hosts are used to create calendar events
         `,
           async ({ emails, sms }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const org = await createOrganization({
               name: "Test Org",
               slug: "testorg",
@@ -1014,7 +1016,7 @@ describe("handleNewBooking", () => {
           - Destination calendars for event-type and non-first hosts are used to create calendar events
         `,
           async ({ emails, sms }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const org = await createOrganization({
               name: "Test Org",
               slug: "testorg",
@@ -1214,7 +1216,7 @@ describe("handleNewBooking", () => {
         test(
           `rejects a booking when the timeslot isn't within the common schedule`,
           async ({}) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const booker = getBooker({
               email: "booker@example.com",
               name: "Booker",
@@ -1328,7 +1330,7 @@ describe("handleNewBooking", () => {
       test(
         `When Cal Video is the location, it uses global instance credentials and createMeeting is called for it`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1508,7 +1510,7 @@ describe("handleNewBooking", () => {
       test(
         `When Zoom is the location, it uses credentials of the first host and createMeeting is called for it.`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1709,7 +1711,7 @@ describe("handleNewBooking", () => {
       test(
         `When event type location is Organizer Default App and user metadata is empty, default to Cal Video`,
         async ({ emails }) => {
-          const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+          const handleNewBooking = getNewBookingHandler();
           const booker = getBooker({
             email: "booker@example.com",
             name: "Booker",
@@ -1903,7 +1905,7 @@ describe("handleNewBooking", () => {
           - Reschedule and Cancel link in email are not of the org domain because the team is not part of any org
         `,
           async ({ emails }) => {
-            const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+            const handleNewBooking = getNewBookingHandler();
             const org = await createOrganization({
               name: "Test Org",
               slug: "testorg",
@@ -2096,7 +2098,7 @@ describe("handleNewBooking", () => {
 
     describe("Round Robin Assignment", () => {
       test(`successfully books contact owner if rr lead skip is enabled`, async ({ emails }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",

--- a/packages/features/bookings/lib/handleNewBooking/test/team-bookings/round-robin.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/team-bookings/round-robin.test.ts
@@ -22,12 +22,14 @@ import { ErrorCode } from "@calcom/lib/errorCodes";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 
+import { getNewBookingHandler } from "../getNewBookingHandler";
+
 describe("Round Robin handleNewBooking", () => {
   setupAndTeardown();
 
   describe("Round Robin with groups", () => {
     test("Books one host from each round robin group", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -208,7 +210,7 @@ describe("Round Robin handleNewBooking", () => {
     });
 
     test("Throws error when one round robin group has no available hosts", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -369,7 +371,7 @@ describe("Round Robin handleNewBooking", () => {
     });
 
     test("Creates successful booking even when one group has no hosts", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -500,7 +502,7 @@ describe("Round Robin handleNewBooking", () => {
     });
 
     test("Correctly handles hosts without groupId falling back to DEFAULT_GROUP_ID", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -648,7 +650,7 @@ describe("Round Robin handleNewBooking", () => {
     });
 
     test("Handles edge case where host.groupId is null vs undefined properly", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const booker = getBooker({
         email: "booker@example.com",
         name: "Booker",
@@ -780,7 +782,7 @@ describe("Round Robin handleNewBooking", () => {
 
   describe("Seated Round Robin Event", () => {
     test("For second seat booking, organizer remains the same with no team members included", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const EventManager = (await import("@calcom/lib/EventManager")).default;
 
       const eventManagerSpy = vi.spyOn(EventManager.prototype, "updateCalendarAttendees");

--- a/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
@@ -26,6 +26,8 @@ import { resetTestSMS } from "@calcom/lib/testSMS";
 import { SMSLockState, SchedulingType } from "@calcom/prisma/enums";
 import { test } from "@calcom/web/test/fixtures/fixtures";
 
+import { getNewBookingHandler } from "./getNewBookingHandler";
+
 vi.mock("@calcom/lib/constants", async () => {
   const actual = await vi.importActual<typeof import("@calcom/lib/constants")>("@calcom/lib/constants");
 
@@ -49,7 +51,7 @@ describe("handleNewBooking", () => {
     test(
       "should send workflow email and sms when booking is created",
       async ({ emails, sms }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -160,7 +162,7 @@ describe("handleNewBooking", () => {
     test(
       "should not send workflow sms when booking is created if the organizer is locked for sms sending",
       async ({ sms }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -253,7 +255,7 @@ describe("handleNewBooking", () => {
     test(
       "should send workflow email and sms when booking is created",
       async ({ emails, sms }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -401,7 +403,7 @@ describe("handleNewBooking", () => {
     test(
       "should not send workflow sms when booking is created if the team is locked for sms sending",
       async ({ emails, sms }) => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
         const booker = getBooker({
           email: "booker@example.com",
           name: "Booker",
@@ -539,7 +541,7 @@ describe("handleNewBooking", () => {
     test("should trigger workflow when a new team event is booked and this team is active on org workflow", async ({
       emails,
     }) => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const org = await createOrganization({
         name: "Test Org",
         slug: "testorg",
@@ -653,7 +655,7 @@ describe("handleNewBooking", () => {
     test("should trigger workflow when a new user event is booked and the user is part of an org team that is active on a org workflow", async ({
       sms,
     }) => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const org = await createOrganization({
         name: "Test Org",
         slug: "testorg",

--- a/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
+++ b/packages/features/bookings/lib/handleSeats/test/handleSeats.test.ts
@@ -25,6 +25,7 @@ import { ErrorCode } from "@calcom/lib/errorCodes";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { BookingStatus } from "@calcom/prisma/enums";
 
+import { getNewBookingHandler } from "../../handleNewBooking/test/getNewBookingHandler";
 import * as handleSeatsModule from "../handleSeats";
 
 describe("handleSeats", () => {
@@ -33,7 +34,7 @@ describe("handleSeats", () => {
   describe("Correct parameters being passed into handleSeats from handleNewBooking", () => {
     vi.mock("./handleSeats");
     test("On new booking handleSeats is not called", async () => {
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
       const spy = vi.spyOn(handleSeatsModule, "default");
 
       const booker = getBooker({
@@ -96,7 +97,7 @@ describe("handleSeats", () => {
 
     test("handleSeats is called when a new attendee is added", async () => {
       const spy = vi.spyOn(handleSeatsModule, "default");
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",
@@ -241,7 +242,7 @@ describe("handleSeats", () => {
 
     test("handleSeats is called on rescheduling a seated event", async () => {
       const spy = vi.spyOn(handleSeatsModule, "default");
-      const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+      const handleNewBooking = getNewBookingHandler();
 
       const booker = getBooker({
         email: "booker@example.com",
@@ -383,7 +384,7 @@ describe("handleSeats", () => {
   describe("As an attendee", () => {
     describe("Creating a new booking", () => {
       test("Attendee should be added to existing seated event", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "seat2@example.com",
@@ -510,7 +511,7 @@ describe("handleSeats", () => {
 
       // Testing in case of a wave of people book a time slot at the same time
       test("Attendee should be added to existing seated event when bookingUid is not present", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "seat2@example.com",
@@ -635,7 +636,7 @@ describe("handleSeats", () => {
       });
 
       test("If attendee is already a part of the booking then throw an error", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "seat1@example.com",
@@ -744,7 +745,7 @@ describe("handleSeats", () => {
       });
 
       test("If event is already full, fail", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "seat3@example.com",
@@ -866,7 +867,7 @@ describe("handleSeats", () => {
       });
 
       test("Verify Seat Availability Calculation Based on Booked Seats, Not Total Attendees", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "seat2@example.com",
@@ -1045,7 +1046,7 @@ describe("handleSeats", () => {
 
     describe("Rescheduling a booking", () => {
       test("When rescheduling to an existing booking, move attendee", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const attendeeToReschedule = getMockBookingAttendee({
           id: 2,
@@ -1248,7 +1249,7 @@ describe("handleSeats", () => {
       });
 
       test("When rescheduling to an empty timeslot, create a new booking", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const attendeeToReschedule = getMockBookingAttendee({
           id: 2,
@@ -1408,7 +1409,7 @@ describe("handleSeats", () => {
       });
 
       test("When last attendee is rescheduled, delete old booking", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const attendeeToReschedule = getMockBookingAttendee({
           id: 2,
@@ -1841,7 +1842,7 @@ describe("handleSeats", () => {
   describe("As an owner", () => {
     describe("Rescheduling a booking", () => {
       test("When rescheduling to new timeslot, ensure all attendees are moved", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "booker@example.com",
@@ -2000,7 +2001,7 @@ describe("handleSeats", () => {
       });
 
       test("When rescheduling to existing booking, merge attendees ", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "booker@example.com",
@@ -2207,7 +2208,7 @@ describe("handleSeats", () => {
         expect(originalBooking?.status).toEqual(BookingStatus.CANCELLED);
       });
       test("When merging more attendees than seats, fail ", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "booker@example.com",
@@ -2384,7 +2385,7 @@ describe("handleSeats", () => {
       });
 
       test("When trying to reschedule in a non-available slot, throw an error", async () => {
-        const handleNewBooking = (await import("@calcom/features/bookings/lib/handleNewBooking")).default;
+        const handleNewBooking = getNewBookingHandler();
 
         const booker = getBooker({
           email: "booker@example.com",


### PR DESCRIPTION
## What does this PR do?

Replace scattered handleNewBooking imports in test files to use _getNewBookingHandler_ import. It allows us to easily replace the logic to start using RegularBookingService in the followup PR here - https://github.com/calcom/cal.com/pull/23156

These are changes in just the test files which are verified automatically by the unit tests and thus is safe to merge.