### PR TITLE
fix: events not removed from the previous host calendar due to wrong credentials usage

### DIFF
--- a/packages/features/ee/round-robin/handleRescheduleEventManager.ts
+++ b/packages/features/ee/round-robin/handleRescheduleEventManager.ts
@@ -53,6 +53,8 @@ export const handleRescheduleEventManager = async ({
     prefix: ["handleRescheduleEventManager", `${bookingId}`],
   });
 
+  const skipDeleteEventsAndMeetings = changedOrganizer;
+
   const allCredentials = await getAllCredentialsIncludeServiceAccountKey(
     initParams.user,
     initParams?.eventType
@@ -68,7 +70,9 @@ export const handleRescheduleEventManager = async ({
     rescheduleUid,
     newBookingId,
     changedOrganizer,
-    previousHostDestinationCalendar
+    previousHostDestinationCalendar,
+    undefined,
+    skipDeleteEventsAndMeetings
   );
 
   const results = updateManager.results ?? [];

--- a/packages/features/ee/round-robin/roundRobinDeleteEvents.test.ts
+++ b/packages/features/ee/round-robin/roundRobinDeleteEvents.test.ts
@@ -115,6 +115,8 @@ describe("roundRobinReassignment test", () => {
 
     await roundRobinReassignment({
       bookingId: 123,
+      reassignedById: 101,
+      orgId: null,
     });
 
     // Verify that calendar deletion occurred (may be called multiple times due to duplicate references)
@@ -122,7 +124,7 @@ describe("roundRobinReassignment test", () => {
     const deleteCall = calendarMock.deleteEventCalls[0];
     expect(deleteCall.args.uid).toBe("ORIGINAL_EVENT_ID");
     expect(deleteCall.args.externalCalendarId).toBe("MOCK_EXTERNAL_CALENDAR_ID");
-    expect(deleteCall.args.event.organizer.email).toBe(newHost.email); // Current implementation uses new host credentials
+    expect(deleteCall.args.event.organizer.email).toBe(originalHost.email);
     expect(deleteCall.args.event.uid).toBe(bookingToReassignUid);
 
     // Verify that creation occurred with new host credentials

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
@@ -154,7 +154,9 @@ const expectEventManagerCalledWith = (
     expectedParams.uid,
     undefined,
     expectedParams.changedOrganizer,
-    expectedParams.destinationCalendars ?? expect.any(Array)
+    expectedParams.destinationCalendars ?? expect.any(Array),
+    undefined,
+    true
   );
 };
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.test.ts
@@ -156,7 +156,7 @@ const expectEventManagerCalledWith = (
     expectedParams.changedOrganizer,
     expectedParams.destinationCalendars ?? expect.any(Array),
     undefined,
-    true
+    expectedParams.changedOrganizer
   );
 };
 

--- a/packages/features/ee/round-robin/roundRobinManualReassignment.ts
+++ b/packages/features/ee/round-robin/roundRobinManualReassignment.ts
@@ -7,6 +7,7 @@ import {
   sendRoundRobinScheduledEmailsAndSMS,
   sendRoundRobinUpdatedEmailsAndSMS,
 } from "@calcom/emails";
+import { getAllCredentialsIncludeServiceAccountKey } from "@calcom/features/bookings/lib/getAllCredentialsForUsersOnEvent/getAllCredentials";
 import getBookingResponsesSchema from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import { getEventTypesFromDB } from "@calcom/features/bookings/lib/handleNewBooking/getEventTypesFromDB";
@@ -21,6 +22,7 @@ import {
 import { scheduleWorkflowReminders } from "@calcom/features/ee/workflows/lib/reminders/reminderScheduler";
 import { getEventName } from "@calcom/features/eventtypes/lib/eventNaming";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
+import EventManager from "@calcom/lib/EventManager";
 import { SENDER_NAME } from "@calcom/lib/constants";
 import { enrichUserWithDelegationCredentialsIncludeServiceAccountKey } from "@calcom/lib/delegationCredential/server";
 import { getBookerBaseUrl } from "@calcom/lib/getBookerUrl/server";
@@ -32,6 +34,7 @@ import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import { prisma } from "@calcom/prisma";
 import { WorkflowActions, WorkflowMethods, WorkflowTriggerEvents } from "@calcom/prisma/enums";
 import type { EventTypeMetadata, PlatformClientParams } from "@calcom/prisma/zod-utils";
+import { eventTypeAppMetadataOptionalSchema } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
 import { handleRescheduleEventManager } from "./handleRescheduleEventManager";
@@ -323,6 +326,41 @@ export const roundRobinManualReassignment = async ({
         where: { userId: originalOrganizer.id },
       })
     : null;
+
+  const apps = eventTypeAppMetadataOptionalSchema.parse(eventType?.metadata?.apps);
+
+  // remove the event and meeting using the old host's credentials
+  if (hasOrganizerChanged && originalOrganizer.id !== newUser.id) {
+    const previousHostCredentials = await getAllCredentialsIncludeServiceAccountKey(
+      originalOrganizer,
+      eventType
+    );
+
+    const originalHostEventManager = new EventManager(
+      { ...originalOrganizer, credentials: previousHostCredentials },
+      apps
+    );
+
+    const deletionEvent: CalendarEvent = {
+      ...evt,
+      organizer: {
+        id: originalOrganizer.id,
+        name: originalOrganizer.name || "",
+        email: originalOrganizer.email,
+        username: originalOrganizer.username || undefined,
+        timeZone: originalOrganizer.timeZone,
+        language: { translate: originalOrganizerT, locale: originalOrganizer.locale ?? "en" },
+        timeFormat: getTimeFormatStringFromUserTimeFormat(originalOrganizer.timeFormat),
+      },
+      destinationCalendar: previousHostDestinationCalendar ? [previousHostDestinationCalendar] : [],
+      title: booking.title,
+    };
+
+    await originalHostEventManager.deleteEventsAndMeetings({
+      event: deletionEvent,
+      bookingReferences: booking.references,
+    });
+  }
 
   const { evtWithAdditionalInfo } = await handleRescheduleEventManager({
     evt,

--- a/packages/features/ee/round-robin/roundRobinReassignment.test.ts
+++ b/packages/features/ee/round-robin/roundRobinReassignment.test.ts
@@ -171,7 +171,9 @@ describe("roundRobinReassignment test", () => {
       bookingToReassignUid,
       undefined,
       true,
-      expect.arrayContaining([expect.objectContaining(testDestinationCalendar)])
+      expect.arrayContaining([expect.objectContaining(testDestinationCalendar)]),
+      undefined,
+      true
     );
 
     // Use equal fairness rr algorithm
@@ -279,7 +281,9 @@ describe("roundRobinReassignment test", () => {
       bookingToReassignUid,
       undefined,
       false,
-      []
+      [],
+      undefined,
+      false
     );
 
     // Ensure organizer stays the same

--- a/packages/features/ee/round-robin/utils/bookingSelect.ts
+++ b/packages/features/ee/round-robin/utils/bookingSelect.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@calcom/prisma/client";
+import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export const bookingSelect = {
   uid: true,
@@ -13,8 +14,18 @@ export const bookingSelect = {
   eventTypeId: true,
   destinationCalendar: true,
   user: {
-    include: {
+    select: {
+      id: true,
+      name: true,
+      username: true,
+      email: true,
+      locale: true,
+      timeZone: true,
+      timeFormat: true,
       destinationCalendar: true,
+      credentials: {
+        select: credentialForCalendarServiceSelect,
+      },
     },
   },
   attendees: true,


### PR DESCRIPTION
## What does this PR do?

Events not removed from the previous host calendar due to wrong credentials usage
