### PR TITLE
fix: Schedules reset to default for an RR event when hosts change

### DIFF
--- a/packages/features/eventtypes/components/tabs/assignment/EventTeamAssignmentTab.tsx
+++ b/packages/features/eventtypes/components/tabs/assignment/EventTeamAssignmentTab.tsx
@@ -708,7 +708,7 @@ const Hosts = ({
                 teamMembers={teamMembers}
                 value={value}
                 onChange={(changeValue) => {
-                  const hosts = [...value.filter((host: Host) => host.isFixed), ...changeValue];
+                  const hosts = [...value.filter((host: Host) => host.isFixed), ...updatedHosts(changeValue)];
                   onChange(hosts);
                 }}
                 assignAllTeamMembers={assignAllTeamMembers}


### PR DESCRIPTION
Schedules reset to default for an RR event when hosts change