### PR TITLE
refactor: move app-store dependent seed files from prisma to scripts

### DIFF
--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -16,7 +16,7 @@
     "dx": "yarn db-setup",
     "generate-schemas": "prisma generate && prisma format",
     "post-install": "yarn generate-schemas",
-    "seed-app-store": "ts-node --transpile-only ./seed-app-store.ts",
+    "seed-app-store": "ts-node --transpile-only ../../scripts/seed-app-store.ts",
     "delete-app": "ts-node --transpile-only ./delete-app.ts",
     "seed-insights": "ts-node --transpile-only ./seed-insights.ts",
     "seed-pbac": "ts-node --transpile-only ./seed-pbac-organization.ts"

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -44,6 +44,6 @@
     "zod-utils.ts"
   ],
   "prisma": {
-    "seed": "ts-node --transpile-only ./seed.ts"
+    "seed": "ts-node --transpile-only ../../scripts/seed.ts"
   }
 }

--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -3,14 +3,15 @@
  * This file is deprecated. The only use of this file is to seed the database for E2E tests. Each test should take care of seeding it's own data going forward.
  */
 import dotEnv from "dotenv";
+import path from "path";
 
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 
-import prisma from ".";
-import type { Prisma } from "./client";
-import { AppCategories } from "./enums";
+import prisma from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
+import { AppCategories } from "@calcom/prisma/enums";
 
-dotEnv.config({ path: "../../.env.appStore" });
+dotEnv.config({ path: path.resolve(__dirname, "../.env.appStore") });
 
 export const seededForm = {
   id: "948ae412-d995-4865-875a-48302588de03",
@@ -414,11 +415,6 @@ export default async function main() {
   await seedAppData();
 }
 
-main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+export async function run() {
+  await main();
+} 

--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -6,7 +6,6 @@ import dotEnv from "dotenv";
 import path from "path";
 
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
-
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { AppCategories } from "@calcom/prisma/enums";
@@ -415,6 +414,11 @@ export default async function main() {
   await seedAppData();
 }
 
-export async function run() {
-  await main();
-} 
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/seed-performance-testing.ts
+++ b/scripts/seed-performance-testing.ts
@@ -11,7 +11,7 @@ import zoomMeta from "@calcom/app-store/zoomvideo/_metadata";
 import dayjs from "@calcom/dayjs";
 import { BookingStatus } from "@calcom/prisma/enums";
 
-import { createUserAndEventType } from "./seed-utils";
+import { createUserAndEventType } from "../packages/prisma/seed-utils";
 
 async function _createManyDifferentUsersWithDifferentEventTypesAndBookings({
   tillUser,
@@ -322,4 +322,4 @@ async function createAUserWithManyBookings() {
 //   startFrom: 10000,
 // });
 
-createAUserWithManyBookings();
+createAUserWithManyBookings(); 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -11,14 +11,13 @@ import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/avail
 import { BookingStatus, MembershipRole, RedirectType, SchedulingType } from "@calcom/prisma/enums";
 import type { Ensure } from "@calcom/types/utils";
 
-import prisma from ".";
-import type { Membership, Team, User } from "./client";
-import { Prisma } from "./client";
-import type { UserPermissionRole } from "./client";
-import mainAppStore from "./seed-app-store";
-import mainHugeEventTypesSeed from "./seed-huge-event-types";
-import { createUserAndEventType } from "./seed-utils";
-import type { teamMetadataSchema } from "./zod-utils";
+import prisma from "@calcom/prisma";
+import type { Membership, Team, User, UserPermissionRole } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
+import mainAppStore from "../packages/prisma/seed-app-store";
+import mainHugeEventTypesSeed from "../packages/prisma/seed-huge-event-types";
+import { createUserAndEventType } from "../packages/prisma/seed-utils";
+import type { teamMetadataSchema } from "../packages/prisma/zod-utils";
 
 type PlatformUser = {
   email: string;
@@ -1376,4 +1375,4 @@ main()
   })
   .finally(async () => {
     await prisma.$disconnect();
-  });
+  }); 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -8,16 +8,16 @@ import dayjs from "@calcom/dayjs";
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { hashPassword } from "@calcom/features/auth/lib/hashPassword";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
-import { BookingStatus, MembershipRole, RedirectType, SchedulingType } from "@calcom/prisma/enums";
-import type { Ensure } from "@calcom/types/utils";
-
 import prisma from "@calcom/prisma";
 import type { Membership, Team, User, UserPermissionRole } from "@calcom/prisma/client";
 import { Prisma } from "@calcom/prisma/client";
-import mainAppStore from "../packages/prisma/seed-app-store";
+import { BookingStatus, MembershipRole, RedirectType, SchedulingType } from "@calcom/prisma/enums";
+import type { Ensure } from "@calcom/types/utils";
+
 import mainHugeEventTypesSeed from "../packages/prisma/seed-huge-event-types";
 import { createUserAndEventType } from "../packages/prisma/seed-utils";
 import type { teamMetadataSchema } from "../packages/prisma/zod-utils";
+import mainAppStore from "./seed-app-store";
 
 type PlatformUser = {
   email: string;
@@ -1375,4 +1375,4 @@ main()
   })
   .finally(async () => {
     await prisma.$disconnect();
-  }); 
+  });


### PR DESCRIPTION
## What does this PR do?

- In prisma package, seed.ts, seed-app-store.ts and seed-performance-testing.ts import appstore. This PR migrates them to `scripts` folder.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Verify Prisma seeding still works (uses new scripts/seed.ts):
```bash
yarn workspace @calcom/prisma generate-schemas
yarn workspace @calcom/prisma db-seed
```

2. Verify app-store seed points to scripts/seed-app-store.ts:
```bash
yarn workspace @calcom/prisma seed-app-store
```

3. Sanity-run performance seed (small side-effect, creates one heavy user):
```bash
npx ts-node --transpile-only scripts/seed-performance-testing.ts
```