### PR TITLE
Fix: Update button label capitalization for consistency

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1156,7 +1156,7 @@
   "signin_with_google": "Sign in with Google",
   "signin_with_saml": "Sign in with SAML",
   "signin_with_saml_oidc": "Sign in with SAML/OIDC",
-  "continue_with_email": "Continue with email",
+  "continue_with_email": "Continue with Email",
   "continue_with_google": "Continue with Google",
   "last_used": "Last used",
   "you_will_need_to_generate": "You will need to generate an access token from your old scheduling tool.",


### PR DESCRIPTION
## What does this PR do?

This PR fixes a minor UI inconsistency in the button labels. The text for the "Continue with email" button has been updated to "Continue with Email" to ensure consistent capitalization across all action buttons.

### Changes
- Updated the label from "Continue with email" to "Continue with Email".

### Fixes
Fixes #23787

