### PR TITLE
fix: prevent race condition in Google Calendar OAuth token refresh

### DIFF
--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
@@ -248,7 +248,7 @@ async function expectSelectedCalendarToNotHaveGoogleChannelProps(selectedCalenda
 beforeEach(() => {
   vi.clearAllMocks();
   setCredentialsMock.mockClear();
-  oAuthManagerMock.OAuthManager = defaultMockOAuthManager;
+  (oAuthManagerMock.OAuthManager as any) = defaultMockOAuthManager;
   calendarMock.calendar_v3.Calendar.mockClear();
   adminMock.admin_directory_v1.Admin.mockClear();
 
@@ -290,7 +290,7 @@ describe.skip("Calendar Cache", () => {
       ),
     });
 
-    oAuthManagerMock.OAuthManager = defaultMockOAuthManager;
+    (oAuthManagerMock.OAuthManager as any) = defaultMockOAuthManager;
     const calendarService = new CalendarService(credentialInDb1);
 
     // Test cache hit

--- a/packages/app-store/tests/__mocks__/OAuthManager.ts
+++ b/packages/app-store/tests/__mocks__/OAuthManager.ts
@@ -24,9 +24,6 @@ const oAuthManagerMock = mockDeep<typeof OAuthManager>({
   },
 });
 
-// Add the static inMemoryLocks property to the mock
-oAuthManagerMock.OAuthManager.inMemoryLocks = new Map();
-
 export default oAuthManagerMock;
 const setFullMockOAuthManagerRequest = () => {
   useFullMockOAuthManagerRequest = true;
@@ -53,9 +50,6 @@ const defaultMockOAuthManager = vi.fn().mockImplementation(() => {
       };
     }),
   };
-});
-
-// Add static properties to match the actual OAuthManager class
-defaultMockOAuthManager.inMemoryLocks = new Map();
+}) as any;
 
 export { oAuthManagerMock, defaultMockOAuthManager, setFullMockOAuthManagerRequest };

--- a/packages/app-store/tests/__mocks__/OAuthManager.ts
+++ b/packages/app-store/tests/__mocks__/OAuthManager.ts
@@ -24,6 +24,9 @@ const oAuthManagerMock = mockDeep<typeof OAuthManager>({
   },
 });
 
+// Add the static inMemoryLocks property to the mock
+oAuthManagerMock.OAuthManager.inMemoryLocks = new Map();
+
 export default oAuthManagerMock;
 const setFullMockOAuthManagerRequest = () => {
   useFullMockOAuthManagerRequest = true;
@@ -51,5 +54,8 @@ const defaultMockOAuthManager = vi.fn().mockImplementation(() => {
     }),
   };
 });
+
+// Add static properties to match the actual OAuthManager class
+defaultMockOAuthManager.inMemoryLocks = new Map();
 
 export { oAuthManagerMock, defaultMockOAuthManager, setFullMockOAuthManagerRequest };


### PR DESCRIPTION
## What does this PR do?

Fixes a critical race condition in Google Calendar OAuth token refresh that causes invalid tokens to be stored, disrupting calendar synchronization until users manually reconnect their accounts.
Implements instance-level promise-based locking in `OAuthManager` to ensure only one token refresh operation occurs per credential at a time. Concurrent requests now wait for and share the result of a single refresh operation, eliminating the race condition entirely.

- Fixes #23616 
- Fixes [CAL-6374](https://linear.app/calcom/issue/CAL-6374/fix-race-condition-when-refreshing-google-calendar-credentials-tokens)

## Visual Demo (For contributors especially)

#### Technical Changes:
- Added `refreshPromise` property to `OAuthManager` class for instance-level locking
- Modified `getTokenObjectOrFetch()` to check for ongoing refresh operations
- Extracted token refresh logic into `performTokenRefresh()` helper method
- Implemented proper cleanup on both success and error scenarios
- Maintained full backwards compatibility with existing API

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.