### PR TITLE
fix: decode HTML entities in signup redirect URLs

### DIFF
--- a/apps/web/lib/signup/getServerSideProps.tsx
+++ b/apps/web/lib/signup/getServerSideProps.tsx
@@ -15,6 +15,15 @@ import { IS_GOOGLE_LOGIN_ENABLED } from "@server/lib/constants";
 
 const checkValidEmail = (email: string) => emailSchema.safeParse(email).success;
 
+const decodeHtmlEntities = (str: string): string => {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+};
+
 const querySchema = z.object({
   username: z
     .string()
@@ -34,6 +43,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const token = z.string().optional().parse(ctx.query.token);
   const redirectUrlData = z
     .string()
+    .transform((value) => decodeHtmlEntities(value))
     .refine((value) => value.startsWith(WEBAPP_URL), {
       params: (value: string) => ({ value }),
       message: "Redirect URL must start with 'cal.com'",


### PR DESCRIPTION
## What does this PR do?

This PR fixes a signup redirect issue where URLs containing HTML entity-encoded ampersands (`&amp;`) lose query parameters, preventing proper redirection to workflow creation pages with template IDs.

**Problem**: When accessing `/signup?redirect=http://app.cal.com/workflow/new?action=calAi&amp;templateWorkflowId=wf-11`, the `&amp;` encoding caused the `templateWorkflowId=wf-11` parameter to be lost during URL parsing, breaking the workflow template functionality.

**Solution**: Added `decodeHtmlEntities` utility function and integrated it into the redirect URL validation using Zod's `transform` method to decode HTML entities before URL validation.

## Visual Demo

**Before**: URL `http://app.cal.com/workflow/new?action=calAi&amp;templateWorkflowId=wf-11` would lose the `templateWorkflowId` parameter
**After**: URL properly decodes to `http://app.cal.com/workflow/new?action=calAi&templateWorkflowId=wf-11` with all parameters preserved

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required for this internal URL parsing fix
- [ ] **REVIEW NEEDED**: No automated tests added - only verified with manual Node.js testing

## How should this be tested?

1. **Environment**: Standard Cal.com development setup
2. **Test Case**: Navigate to `/signup?redirect=http://app.cal.com/workflow/new?action=calAi&amp;templateWorkflowId=wf-11` while authenticated
3. **Expected**: Should redirect to workflow creation page with `templateWorkflowId=wf-11` parameter intact
4. **Edge cases to test**:
   - URLs with multiple `&amp;` entities
   - URLs with other HTML entities (`&lt;`, `&gt;`, `&quot;`, `&#39;`)
   - Malformed HTML entities
   - URLs without HTML entities (regression test)

## Security Review Required

⚠️ **Important**: This change modifies URL redirect parsing. Please verify:
- Existing `WEBAPP_URL` validation still prevents open redirects
- HTML entity decoding doesn't introduce new attack vectors
- No bypass of existing security restrictions

---

**Link to Devin run**: https://app.devin.ai/sessions/7893e9ea680b403eab430acb80c8cd21  
**Requested by**: @PeerRich