### PR TITLE
fix: update validation for billing check endpoint

### DIFF
--- a/apps/api/v2/src/modules/billing/controllers/billing.controller.ts
+++ b/apps/api/v2/src/modules/billing/controllers/billing.controller.ts
@@ -21,7 +21,7 @@ import {
   HttpStatus,
   Logger,
   Delete,
-  BadRequestException,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ApiExcludeController } from "@nestjs/swagger";
@@ -51,7 +51,7 @@ export class BillingController {
   @UseGuards(NextAuthGuard, OrganizationRolesGuard)
   @MembershipRoles(["OWNER", "ADMIN", "MEMBER"])
   async checkTeamBilling(
-    @Param("teamId") teamId: number
+    @Param("teamId", ParseIntPipe) teamId: number
   ): Promise<ApiResponse<CheckPlatformBillingResponseDto>> {
     const { status, plan } = await this.billingService.getBillingData(teamId);
 


### PR DESCRIPTION
## What does this PR do?

This PR improves parameter validation for the billing check endpoint by implementing proper type validation for the  parameter.

### Changes Made:
- Added  to the  method in 
- Updated imports to include  from 
- Removed unused  import

### Why this change?
- The  automatically validates that the  parameter is a valid integer
- Provides better error handling by returning a proper 400 Bad Request response when non-numeric values are passed
- Prevents potential downstream issues that could occur when invalid teamId values reach the billing service
- Follows NestJS best practices for parameter validation

## How should this be tested?

### Test Cases:
1. **Valid integer teamId**: 
   - Send GET request to `/v2/billing/123/check` with valid authentication
   - Expected: Returns billing data successfully

2. **Invalid non-numeric teamId**: 
   - Send GET request to `/v2/billing/abc/check` with valid authentication  
   - Expected: Returns 400 Bad Request error with validation message

3. **Invalid decimal teamId**:
   - Send GET request to `/v2/billing/12.34/check` with valid authentication
   - Expected: Returns 400 Bad Request error with validation message

### Prerequisites:
- Valid authentication token for a team member with OWNER, ADMIN, or MEMBER role
- Existing team with billing data to test the valid case

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Documentation update: N/A - This is an internal validation improvement that doesn't change the API contract
- [x] Tests: The existing endpoint tests will verify the validation works correctly