### PR TITLE
docs: add search tools priority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,16 @@
 - `yarn test <filename> -- --integrationTestsOnly` - Run integration tests
 - `yarn e2e <filename> --grep "<testName>"` - Run specific E2E test
 
+## Tool Preferences
+
+### Search Tools Priority
+
+Use tools in this order of preference:
+
+1. **ast-grep** - For AST-based code searches (if available)
+2. **rg (ripgrep)** - For fast text searches
+3. **grep** - As fallback for text searches
+
 ## 📚 Detailed Documentation
 
 - **[.agents/README.md](.agents/README.md)** - Complete development guide


### PR DESCRIPTION
## What does this PR do?

This PR adds documentation about search tool preferences and priority order for agents working with the Cal.com codebase.

## Changes Made

- Added a new "Tool Preferences" section to AGENTS.md
- Documented the recommended priority order for search tools:
  1. **ast-grep** - For AST-based code searches (if available)
  2. **rg (ripgrep)** - For fast text searches  
  3. **grep** - As fallback for text searches

## Visual Demo

N/A - This is a documentation-only change.

## Mandatory Tasks

- [x] I have self-reviewed the code (documentation change only).
- [x] I have updated the developer docs in /docs - N/A, this change is to AGENTS.md which is agent-specific documentation.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works - N/A, documentation-only change.

## How should this be tested?

This is a documentation change that can be tested by:

- Verifying the AGENTS.md file contains the new "Tool Preferences" section
- Confirming the search tool priority order is clearly documented
- Ensuring the formatting and markdown syntax is correct

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (documentation formatting)
- [x] I have commented appropriately (clear documentation structure)
- [x] My changes generate no new warnings (documentation only)