### PR TITLE
fix: catch HttpError in getRoutedUrl

### DIFF
--- a/packages/features/routing-forms/lib/getRoutedUrl.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.ts
@@ -24,9 +24,9 @@ import { PrismaRoutingFormRepository } from "@calcom/lib/server/repository/Prism
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import prisma from "@calcom/prisma";
 
-import { TRPCError } from "@trpc/server";
 
 import { getUrlSearchParamsToForward } from "./getUrlSearchParamsToForward";
+import { HttpError } from "@calcom/lib/http-error";
 
 const log = logger.getSubLogger({ prefix: ["[routing-forms]", "[router]"] });
 const querySchema = z
@@ -171,7 +171,7 @@ const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | 
     crmContactOwnerRecordType = result.crmContactOwnerRecordType;
     crmAppSlug = result.crmAppSlug;
   } catch (e) {
-    if (e instanceof TRPCError) {
+    if (e instanceof HttpError) {
       return {
         props: {
           ...pageProps,
@@ -181,7 +181,7 @@ const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | 
         },
       };
     }
-
+  
     log.error("Error handling the response", safeStringify(e));
     throw new Error("Error handling the response");
   }

--- a/packages/features/routing-forms/lib/getRoutedUrl.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.ts
@@ -23,7 +23,7 @@ import { withReporting } from "@calcom/lib/sentryWrapper";
 import { PrismaRoutingFormRepository } from "@calcom/lib/server/repository/PrismaRoutingFormRepository";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import prisma from "@calcom/prisma";
-
+import { TRPCError } from "@trpc/server";
 
 import { getUrlSearchParamsToForward } from "./getUrlSearchParamsToForward";
 import { HttpError } from "@calcom/lib/http-error";
@@ -171,7 +171,7 @@ const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | 
     crmContactOwnerRecordType = result.crmContactOwnerRecordType;
     crmAppSlug = result.crmAppSlug;
   } catch (e) {
-    if (e instanceof HttpError) {
+    if (e instanceof HttpError || e instanceof TRPCError) {
       return {
         props: {
           ...pageProps,


### PR DESCRIPTION
## What does this PR do?
The change updates error handling in packages/features/routing-forms/lib/getRoutedUrl.ts by replacing TRPCError with HttpError. Two catch blocks now check for e instanceof HttpError and, when matched, return page props containing errorMessage set to e.message. Existing logging and rethrow behavior remain unchanged. Control flow is otherwise unaffected. There are no modifications to exported or public declarations. Minor whitespace adjustments were made.
## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] n/a I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


