### PR TITLE
fix: Teams list not getting refreshed after adding a new team

### DIFF
--- a/packages/features/ee/teams/components/CreateANewTeamForm.tsx
+++ b/packages/features/ee/teams/components/CreateANewTeamForm.tsx
@@ -13,6 +13,7 @@ import { DialogFooter } from "@calcom/ui/components/dialog";
 import { Form } from "@calcom/ui/components/form";
 import { TextField } from "@calcom/ui/components/form";
 import { revalidateEventTypesList } from "@calcom/web/app/(use-page-wrapper)/(main-nav)/event-types/actions";
+import { revalidateTeamsList } from "@calcom/web/app/(use-page-wrapper)/(main-nav)/teams/actions";
 
 import { useOrgBranding } from "../../organizations/context/provider";
 import { subdomainSuffix } from "../../organizations/lib/orgDomains";
@@ -44,6 +45,7 @@ export const CreateANewTeamForm = (props: CreateANewTeamFormProps) => {
     onSuccess: async (data) => {
       await utils.viewer.eventTypes.getUserEventGroups.invalidate();
       revalidateEventTypesList();
+      revalidateTeamsList();
       onSuccess(data);
     },
 


### PR DESCRIPTION
## What does this PR do?

Teams list not getting refreshed after adding a new team

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)
#### Video Demo (if applicable):

**Before**

https://github.com/user-attachments/assets/fe44fd8b-625e-4944-86fb-6747f4d79a65

**After**

https://github.com/user-attachments/assets/3d4c4771-e1d4-452e-a39f-90abf6162184

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Check video demo above
