### PR TITLE
feat: replace isOwnerOrAdmin with PBAC checkPermission in insights services

### DIFF
--- a/packages/lib/server/service/InsightsRoutingBaseService.ts
+++ b/packages/lib/server/service/InsightsRoutingBaseService.ts
@@ -11,12 +11,12 @@ import {
   isSingleSelectFilterValue,
 } from "@calcom/features/data-table/lib/utils";
 import type { DateRange } from "@calcom/features/insights/server/insightsDateUtils";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import type { PrismaClient } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
 import type { BookingStatus } from "@calcom/prisma/enums";
 import { MembershipRole } from "@calcom/prisma/enums";
 
-import { MembershipRepository } from "../repository/membership";
 import { TeamRepository } from "../repository/team";
 
 export const insightsRoutingServiceOptionsSchema = z.discriminatedUnion("scope", [
@@ -865,14 +865,13 @@ export class InsightsRoutingBaseService {
   }
 
   private async isOwnerOrAdmin(userId: number, targetId: number): Promise<boolean> {
-    // Check if the user is an owner or admin of the organization or team
-    const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({ userId, teamId: targetId });
-    return Boolean(
-      membership &&
-        membership.accepted &&
-        membership.role &&
-        (membership.role === MembershipRole.OWNER || membership.role === MembershipRole.ADMIN)
-    );
+    const permissionCheckService = new PermissionCheckService();
+    return await permissionCheckService.checkPermission({
+      userId,
+      teamId: targetId,
+      permission: "insights.read",
+      fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
+    });
   }
 
   private buildFormFieldSqlCondition(fieldId: string, filterValue: FilterValue): Prisma.Sql | null {


### PR DESCRIPTION
## What does this PR do?

This PR replaces the manual `isOwnerOrAdmin` methods in the insights services with the centralized PBAC (Permission-Based Access Control) system's `checkPermission` method. This change standardizes authorization logic across the insights functionality.

**Changes:**
- Replace `isOwnerOrAdmin` method in `InsightsBookingBaseService` and `InsightsRoutingBaseService` 
- Use `PermissionCheckService.checkPermission()` with permission `"insights.read"`
- Maintain fallback roles `MembershipRole.OWNER` and `MembershipRole.ADMIN` for backward compatibility
- Remove unused imports (`MembershipRepository`, `ColumnFilterType`, etc.)

**Requested by:** @eunjae-lee
**Link to Devin run:** https://app.devin.ai/sessions/634b25e6e6dd440688ea4e153e4b5c08

## How should this be tested?

⚠️ **This change affects authorization logic and requires careful testing:**

1. **Test with PBAC-enabled teams:**
   - Verify users with `insights.read` permission can access insights data
   - Verify users without the permission are denied access

2. **Test with non-PBAC teams (fallback behavior):**
   - Verify team owners can access insights
   - Verify team admins can access insights  
   - Verify regular members are denied access

3. **Test both insights endpoints:**
   - Booking insights (`InsightsBookingBaseService`)
   - Routing insights (`InsightsRoutingBaseService`)

4. **Environment setup:**
   - Ensure PBAC feature flag is properly configured
   - Verify `insights.read` permission exists in the PBAC system

## Critical Review Points

⚠️ **High-risk areas requiring careful review:**

- [ ] **Behavioral equivalence**: Verify the new PBAC check produces identical results to the original membership role check
- [ ] **PBAC configuration**: Confirm `insights.read` permission is properly defined and configured
- [ ] **Fallback logic**: Ensure fallback roles work correctly when PBAC is disabled
- [ ] **No regression testing**: This change wasn't manually tested - recommend thorough testing before merge
- [ ] **Security implications**: Authorization changes could affect data access - verify no unauthorized access is granted

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.