### PR TITLE
fix: few e2e flakes

### DIFF
--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -775,10 +775,10 @@ test.describe("Out of office", () => {
 
       //Default filter 'Last 7 Days' when DateRange Filter is selected
       await test.step("Default filter - 'Last 7 Days'", async () => {
-        await addFilter(page, "dateRange");
         const entriesListRespPromise = page.waitForResponse(
           (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
         );
+        await addFilter(page, "dateRange");
         await entriesListRespPromise;
 
         //1 OOO record should be visible for member3, end=currentDate-4days
@@ -836,10 +836,10 @@ test.describe("Out of office", () => {
 
       //Select 'Last 30 Days'
       await test.step("select 'Last 30 Days'", async () => {
-        await addFilter(page, "dateRange");
         const entriesListRespPromise1 = page.waitForResponse(
           (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
         );
+        await addFilter(page, "dateRange");
         await entriesListRespPromise1;
 
         const entriesListRespPromise2 = page.waitForResponse(


### PR DESCRIPTION
Updates out-of-office.e2e.ts test to create the response wait promise (page.waitForResponse for outOfOfficeEntriesList) before triggering the dateRange filter. The sequence now sets up the response listener prior to calling addFilter(page, "dateRange"), ensuring the intended network response is awaited. 