### PR TITLE
fix: few more e2e flakes

### DIFF
--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -684,6 +684,10 @@ const createUserFixture = (user: UserWithIncludes, page: Page) => {
     },
     logout: async () => {
       await page.goto("/auth/logout");
+      const logoutBtn = page.getByTestId("logout-btn");
+      await expect(logoutBtn).toHaveText("Go back to the login page");
+      await page.reload();
+      await expect(logoutBtn).toHaveText("Go back to the login page");
     },
     getFirstTeamMembership: async () => {
       const memberships = await prisma.membership.findMany({

--- a/apps/web/playwright/insights.e2e.ts
+++ b/apps/web/playwright/insights.e2e.ts
@@ -271,7 +271,9 @@ test.describe("Insights", async () => {
     ];
 
     for (const title of expectedChartTitles) {
-      const chartCard = page.locator("[data-testid='panel-card'] h2").filter({ hasText: title });
+      const chartCard = page
+        .locator("[data-testid='panel-card'] h2")
+        .filter({ hasText: new RegExp(`^${title}$`) });
       await expect(chartCard).toBeVisible();
     }
   });


### PR DESCRIPTION
- In apps/web/playwright/fixtures/users.ts, the logout flow now locates the logout button by test ID, asserts its text is "Go back to the login page", reloads the page, and re-asserts the text.
- In apps/web/playwright/insights.e2e.ts, chart title selection was changed from substring matching to exact matching using a RegExp with ^ and $ anchors.