### PR TITLE
chore: Avoid double build on Prima package

### DIFF
--- a/apps/api/v1/package.json
+++ b/apps/api/v1/package.json
@@ -39,7 +39,6 @@
     "next-axiom": "^0.17.0",
     "next-swagger-doc": "^0.3.6",
     "next-validations": "^0.2.0",
-    "typescript": "^5.9.0-beta",
     "tzdata": "^1.0.30",
     "uuid": "^8.3.2",
     "zod": "^3.22.4"

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -109,8 +109,7 @@
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.1.0",
-    "typescript": "^5.9.0-beta"
+    "tsconfig-paths": "^4.1.0"
   },
   "prisma": {
     "schema": "../../../packages/prisma/schema.prisma"

--- a/apps/ui-playground/package.json
+++ b/apps/ui-playground/package.json
@@ -33,7 +33,6 @@
     "eslint": "^8.34.0",
     "eslint-config-next": "15.1.6",
     "postcss": "^8",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.9.0-beta"
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -221,6 +221,7 @@ const nextConfig = (phase) => {
       "@calcom/embed-snippet",
       "@calcom/features",
       "@calcom/lib",
+      "@calcom/prisma",
       "@calcom/trpc",
     ],
     modularizeImports: {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -221,7 +221,6 @@ const nextConfig = (phase) => {
       "@calcom/embed-snippet",
       "@calcom/features",
       "@calcom/lib",
-      "@calcom/prisma",
       "@calcom/trpc",
     ],
     modularizeImports: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -198,8 +198,7 @@
     "postcss": "^8.4.18",
     "tailwindcss": "^3.3.3",
     "tailwindcss-animate": "^1.0.6",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.9.0-beta"
+    "ts-node": "^10.9.1"
   },
   "nextBundleAnalysis": {
     "budget": 358400,

--- a/example-apps/credential-sync/package.json
+++ b/example-apps/credential-sync/package.json
@@ -25,7 +25,6 @@
     "eslint": "^8.34.0",
     "eslint-config-next": "14.0.4",
     "postcss": "^8",
-    "tailwindcss": "^3.3.0",
-    "typescript": "^4.9.4"
+    "tailwindcss": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "c8": "^7.13.0",
     "checkly": "latest",
     "dotenv-checker": "^1.1.5",
+    "eslint": "^8.34.0",
     "eslint-plugin-import": "^2.32.0",
     "husky": "^8.0.0",
     "i18n-unused": "^0.13.0",
@@ -110,7 +111,8 @@
     "prismock": "1.35.3",
     "resize-observer-polyfill": "^1.5.1",
     "tsc-absolute": "^1.0.0",
-    "typescript": "5.9.0-beta",
+    "turbo": "^2.5.5",
+    "typescript": "5.9.2",
     "vitest": "^2.1.9",
     "vitest-fetch-mock": "^0.3.0",
     "vitest-mock-extended": "^2.0.2"
@@ -122,9 +124,7 @@
     "@vercel/functions": "^1.4.0",
     "city-timezones": "^1.2.1",
     "date-fns-tz": "^3.2.0",
-    "eslint": "^8.34.0",
-    "p-limit": "^6.2.0",
-    "turbo": "^2.5.5"
+    "p-limit": "^6.2.0"
   },
   "resolutions": {
     "types-ramda": "0.29.4",

--- a/packages/app-store-cli/package.json
+++ b/packages/app-store-cli/package.json
@@ -30,7 +30,6 @@
     "chokidar": "^3.5.3",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.9.0-beta"
+    "ts-node": "^10.9.1"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,7 +32,6 @@
     "prettier": "^2.8.6",
     "prettier-plugin-tailwindcss": "^0.2.5",
     "tailwind-scrollbar": "^2.0.1",
-    "tailwindcss": "^3.3.3",
-    "typescript": "^5.9.0-beta"
+    "tailwindcss": "^3.3.3"
   }
 }

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -51,7 +51,6 @@
     "@playwright/test": "^1.45.3",
     "@vitejs/plugin-basic-ssl": "^1.1.0",
     "autoprefixer": "^10.4.12",
-    "npm-run-all": "^4.1.5",
     "postcss": "^8.4.18",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.9.0-beta",

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -49,7 +49,6 @@
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^2.2.0",
     "eslint": "^8.34.0",
-    "npm-run-all": "^4.1.5",
     "typescript": "^5.9.0-beta",
     "vite": "^4.5.2"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,8 +7,7 @@
   "dependencies": {
     "@typescript-eslint/parser": "^5.52.0",
     "@typescript-eslint/utils": "^5.52.0",
-    "ts-node-maintained": "^10.9.5",
-    "typescript": "^5.9.0-beta"
+    "ts-node-maintained": "^10.9.5"
   },
   "devDependencies": {
     "@types/eslint": "^8.4.5"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@calcom/tsconfig": "*",
     "@calcom/types": "*",
-    "@faker-js/faker": "^7.3.0",
-    "typescript": "^5.9.0-beta"
+    "@faker-js/faker": "^7.3.0"
   }
 }

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@types/node": "^20.3.1",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.9.0-beta",
     "vite": "^5.0.12",
     "vite-plugin-dts": "^3.7.2",
     "vite-plugin-environment": "^1.1.3"

--- a/packages/prisma/__mocks__/prisma.ts
+++ b/packages/prisma/__mocks__/prisma.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import type { PrismaClient } from "@calcom/prisma";
+import type { PrismaClient } from "../client";
 
 beforeEach(() => {
   mockReset(prisma);

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -1,5 +1,4 @@
-import { PrismaClient, type Prisma } from "@calcom/prisma/client";
-
+import { PrismaClient, type Prisma } from "./client/index";
 import { bookingIdempotencyKeyExtension } from "./extensions/booking-idempotency-key";
 import { disallowUndefinedDeleteUpdateManyExtension } from "./extensions/disallow-undefined-delete-update-many";
 import { excludeLockedUsersExtension } from "./extensions/exclude-locked-users";

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -28,9 +28,14 @@
     "@prisma/generator-helper": "^6.7.0",
     "prisma": "^6.7.0",
     "prisma-kysely": "2.2.0",
-    "ts-node": "^10.9.1",
     "zod": "^3.22.4",
     "zod-prisma-types": "^3.2.4"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2"
+  },
+  "peerDependencies": {
+    "typescript": "*"
   },
   "files": [
     "client",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -21,9 +21,6 @@
     "seed-insights": "ts-node --transpile-only ../../scripts/seed-insights.ts",
     "seed-pbac": "ts-node --transpile-only ../../scripts/seed-pbac-organization.ts"
   },
-  "devDependencies": {
-    "npm-run-all": "^4.1.5"
-  },
   "dependencies": {
     "@calcom/lib": "*",
     "@prisma/client": "^6.7.0",
@@ -35,8 +32,6 @@
     "zod": "^3.22.4",
     "zod-prisma-types": "^3.2.4"
   },
-  "main": "index.ts",
-  "types": "index.d.ts",
   "files": [
     "client",
     "zod",
@@ -44,5 +39,17 @@
   ],
   "prisma": {
     "seed": "ts-node --transpile-only ../../scripts/seed.ts"
+  },
+  "exports": {
+    ".": "./index.ts",
+    "./client": "./client/index.js",
+    "./zod-utils": "./zod-utils.ts",
+    "./selects": "./selects/index.ts",
+    "./selects/*": "./selects/*.ts",
+    "./enums": "./enums/index.ts",
+    "./zod/modelSchema/*": "./zod/modelSchema/*",
+    "./zod/inputTypeSchema/*": "./zod/inputTypeSchema/*",
+    "./prisma.module": "./prisma.module.ts",
+    "./__mocks__/prisma": "./__mocks__/prisma.ts"
   }
 }

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@calcom/tsconfig/base.json",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "noEmitOnError": false,
+    "target": "ESNext",
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "paths": {}
+  }
+}

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "esModuleInterop": true,
-    "noEmitOnError": false,
-    "target": "ESNext",
-    "moduleResolution": "bundler",
-    "module": "ESNext",
-    "paths": {}
-  }
+    "noEmitOnError": false
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -7,9 +7,9 @@
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {
+    "generate": "yarn trpc:generate || true",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
-    "build": "yarn trpc:generate || true",
     "trpc:generate": "yarn tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -20,8 +20,5 @@
     "@trpc/server": "11.0.0-next-beta.222",
     "superjson": "1.9.1",
     "zod": "^3.22.4"
-  },
-  "devDependencies": {
-    "typescript": "^5.9.0-beta"
   }
 }

--- a/packages/trpc/tsconfig.json
+++ b/packages/trpc/tsconfig.json
@@ -19,7 +19,7 @@
     "declarationMap": false,
     "resolveJsonModule": true,
     "declarationDir": "types/server",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "paths": {
       "~/*": ["./*"]
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -113,7 +113,6 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "lucide-static": "^0.424.0",
-    "node-html-parser": "^6.1.13",
-    "typescript": "^5.9.0-beta"
+    "node-html-parser": "^6.1.13"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -92,7 +92,6 @@
     "cmk": "^0.1.1",
     "date-fns": "^3.6.0",
     "downshift": "^6.1.9",
-    "next": "^13.5.6",
     "next-seo": "^6.0.0",
     "react": "^18.2.0",
     "react-colorful": "^5.6.0",
@@ -114,5 +113,8 @@
     "fs-extra": "^11.2.0",
     "lucide-static": "^0.424.0",
     "node-html-parser": "^6.1.13"
+  },
+  "peerDependencies": {
+    "next": "*"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -440,8 +440,11 @@
       "cache": false,
       "outputs": ["dist/**", "build/**"]
     },
+    "generate": {
+      "outputs": ["packages/trpc/generated/**"]
+    },
     "dev": {
-      "dependsOn": ["//#env-check:common", "//#env-check:app-store"],
+      "dependsOn": ["@calcom/trpc#generate", "//#env-check:common", "//#env-check:app-store"],
       "cache": false
     },
     "dx": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,9 +3827,11 @@ __metadata:
     "@prisma/generator-helper": ^6.7.0
     prisma: ^6.7.0
     prisma-kysely: 2.2.0
-    ts-node: ^10.9.1
+    ts-node: ^10.9.2
     zod: ^3.22.4
     zod-prisma-types: ^3.2.4
+  peerDependencies:
+    typescript: "*"
   languageName: unknown
   linkType: soft
 
@@ -45942,6 +45944,44 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
+"ts-node@npm:^10.9.2":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: fde256c9073969e234526e2cfead42591b9a2aec5222bac154b0de2fa9e4ceb30efcd717ee8bc785a56f3a119bdd5aa27b333d9dbec94ed254bd26f8944c67ac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,7 +3825,6 @@ __metadata:
     "@prisma/client": ^6.7.0
     "@prisma/extension-accelerate": ^1.3.0
     "@prisma/generator-helper": ^6.7.0
-    npm-run-all: ^4.1.5
     prisma: ^6.7.0
     prisma-kysely: 2.2.0
     ts-node: ^10.9.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4062,6 +4062,7 @@ __metadata:
     "@trpc/react-query": 11.0.0-next-beta.222
     "@trpc/server": 11.0.0-next-beta.222
     superjson: 1.9.1
+    tsc: 2.0.4
     zod: ^3.22.4
   languageName: unknown
   linkType: soft
@@ -4124,7 +4125,6 @@ __metadata:
     fast-glob: ^3.3.2
     fs-extra: ^11.2.0
     lucide-static: ^0.424.0
-    next: ^13.5.6
     next-seo: ^6.0.0
     node-html-parser: ^6.1.13
     react: ^18.2.0
@@ -4135,6 +4135,8 @@ __metadata:
     react-select: ^5.7.0
     tailwind-merge: ^1.13.2
     uuid: ^11.1.0
+  peerDependencies:
+    next: "*"
   languageName: unknown
   linkType: soft
 
@@ -9555,13 +9557,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/env@npm:13.5.7"
-  checksum: 7703ba37a5ad9c280fb8a04af43231b41bec2ed0bcf182a7e9e147b12e9d710ef96bbdc8e67aa27d2cf1abd4b57951d1c12018ba6ff03fbd87f31876362f5f58
-  languageName: node
-  linkType: hard
-
 "@next/env@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/env@npm:14.0.4"
@@ -9610,13 +9605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-darwin-arm64@npm:13.5.7"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@next/swc-darwin-arm64@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/swc-darwin-arm64@npm:14.0.4"
@@ -9635,13 +9623,6 @@ __metadata:
   version: 15.4.6
   resolution: "@next/swc-darwin-arm64@npm:15.4.6"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@next/swc-darwin-x64@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-darwin-x64@npm:13.5.7"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -9666,13 +9647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-linux-arm64-gnu@npm:13.5.7"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@next/swc-linux-arm64-gnu@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/swc-linux-arm64-gnu@npm:14.0.4"
@@ -9691,13 +9665,6 @@ __metadata:
   version: 15.4.6
   resolution: "@next/swc-linux-arm64-gnu@npm:15.4.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-arm64-musl@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-linux-arm64-musl@npm:13.5.7"
-  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -9722,13 +9689,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-linux-x64-gnu@npm:13.5.7"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@next/swc-linux-x64-gnu@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/swc-linux-x64-gnu@npm:14.0.4"
@@ -9747,13 +9707,6 @@ __metadata:
   version: 15.4.6
   resolution: "@next/swc-linux-x64-gnu@npm:15.4.6"
   conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-x64-musl@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-linux-x64-musl@npm:13.5.7"
-  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -9778,13 +9731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-win32-arm64-msvc@npm:13.5.7"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@next/swc-win32-arm64-msvc@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/swc-win32-arm64-msvc@npm:14.0.4"
@@ -9806,24 +9752,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-win32-ia32-msvc@npm:13.5.7"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@next/swc-win32-ia32-msvc@npm:14.0.4":
   version: 14.0.4
   resolution: "@next/swc-win32-ia32-msvc@npm:14.0.4"
   conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@next/swc-win32-x64-msvc@npm:13.5.7":
-  version: 13.5.7
-  resolution: "@next/swc-win32-x64-msvc@npm:13.5.7"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -36526,61 +36458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^13.5.6":
-  version: 13.5.7
-  resolution: "next@npm:13.5.7"
-  dependencies:
-    "@next/env": 13.5.7
-    "@next/swc-darwin-arm64": 13.5.7
-    "@next/swc-darwin-x64": 13.5.7
-    "@next/swc-linux-arm64-gnu": 13.5.7
-    "@next/swc-linux-arm64-musl": 13.5.7
-    "@next/swc-linux-x64-gnu": 13.5.7
-    "@next/swc-linux-x64-musl": 13.5.7
-    "@next/swc-win32-arm64-msvc": 13.5.7
-    "@next/swc-win32-ia32-msvc": 13.5.7
-    "@next/swc-win32-x64-msvc": 13.5.7
-    "@swc/helpers": 0.5.2
-    busboy: 1.6.0
-    caniuse-lite: ^1.0.30001406
-    postcss: 8.4.31
-    styled-jsx: 5.1.1
-    watchpack: 2.4.0
-  peerDependencies:
-    "@opentelemetry/api": ^1.1.0
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    sass: ^1.3.0
-  dependenciesMeta:
-    "@next/swc-darwin-arm64":
-      optional: true
-    "@next/swc-darwin-x64":
-      optional: true
-    "@next/swc-linux-arm64-gnu":
-      optional: true
-    "@next/swc-linux-arm64-musl":
-      optional: true
-    "@next/swc-linux-x64-gnu":
-      optional: true
-    "@next/swc-linux-x64-musl":
-      optional: true
-    "@next/swc-win32-arm64-msvc":
-      optional: true
-    "@next/swc-win32-ia32-msvc":
-      optional: true
-    "@next/swc-win32-x64-msvc":
-      optional: true
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    sass:
-      optional: true
-  bin:
-    next: dist/bin/next
-  checksum: 056a0126fbb2197ee3c397c5599e5dafe57cb23d8420ab4ebd8c62a9a73f06305b8d323315097fa772408f11791106896e714fdccc8dae7f02064531ecc52a20
-  languageName: node
-  linkType: hard
-
 "next@npm:^15.4.5":
   version: 15.4.6
   resolution: "next@npm:15.4.6"
@@ -45851,6 +45728,15 @@ __metadata:
   bin:
     tsc-absolute: dist/index.js
   checksum: fe8308f7addddce83012bc1451f7009ae37771b08a9972370b7a46eb63e3dc919783ea3894c06101459335fdb275eda8de300498894e55d460408991f97f5409
+  languageName: node
+  linkType: hard
+
+"tsc@npm:2.0.4":
+  version: 2.0.4
+  resolution: "tsc@npm:2.0.4"
+  bin:
+    tsc: bin/tsc
+  checksum: 50b10240887424c66454687f0fca4e319713b35cb44f0dab228719eb4dd757251f83c3d79e60d29dfbe90c2d6f1272f793b83e75a9fca2c622b4213ad3eb8cb1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,7 +2766,6 @@ __metadata:
     ts-loader: ^9.4.3
     ts-node: ^10.9.1
     tsconfig-paths: ^4.1.0
-    typescript: ^5.9.0-beta
     uuid: ^8.3.2
     winston: ^3.13.0
     winston-transport: ^4.7.0
@@ -2797,7 +2796,6 @@ __metadata:
     next-swagger-doc: ^0.3.6
     next-validations: ^0.2.0
     node-mocks-http: ^1.11.0
-    typescript: ^5.9.0-beta
     tzdata: ^1.0.30
     uuid: ^8.3.2
     zod: ^3.22.4
@@ -2819,7 +2817,6 @@ __metadata:
     meow: ^9.0.0
     react: ^18.2.0
     ts-node: ^10.9.1
-    typescript: ^5.9.0-beta
   bin:
     app-store-cli: dist/cli.js
   languageName: unknown
@@ -3051,7 +3048,6 @@ __metadata:
     prettier-plugin-tailwindcss: ^0.2.5
     tailwind-scrollbar: ^2.0.1
     tailwindcss: ^3.3.3
-    typescript: ^5.9.0-beta
   languageName: unknown
   linkType: soft
 
@@ -3199,7 +3195,6 @@ __metadata:
     "@playwright/test": ^1.45.3
     "@vitejs/plugin-basic-ssl": ^1.1.0
     autoprefixer: ^10.4.12
-    npm-run-all: ^4.1.5
     postcss: ^8.4.18
     tailwindcss: ^3.3.3
     typescript: ^5.9.0-beta
@@ -3219,7 +3214,6 @@ __metadata:
     "@types/react-dom": ^18.0.9
     "@vitejs/plugin-react": ^2.2.0
     eslint: ^8.34.0
-    npm-run-all: ^4.1.5
     typescript: ^5.9.0-beta
     vite: ^4.5.2
   peerDependencies:
@@ -3246,7 +3240,6 @@ __metadata:
     "@typescript-eslint/parser": ^5.52.0
     "@typescript-eslint/utils": ^5.52.0
     ts-node-maintained: ^10.9.5
-    typescript: ^5.9.0-beta
   languageName: unknown
   linkType: soft
 
@@ -3269,7 +3262,6 @@ __metadata:
     react: ^18
     react-dom: ^18
     tailwindcss: ^3.3.0
-    typescript: ^4.9.4
   languageName: unknown
   linkType: soft
 
@@ -3584,7 +3576,6 @@ __metadata:
     sonner: ^1.7.4
     tsdav: 2.0.3
     tslog: ^4.9.2
-    typescript: ^5.9.0-beta
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -3768,7 +3759,6 @@ __metadata:
     "@calcom/lib": "*"
     "@types/node": ^20.3.1
     "@vitejs/plugin-react": ^4.2.1
-    typescript: ^5.9.0-beta
     vite: ^5.0.12
     vite-plugin-dts: ^3.7.2
     vite-plugin-environment: ^1.1.3
@@ -4059,7 +4049,6 @@ __metadata:
     react-dom: ^18.0.0
     react-hot-toast: ^2.5.2
     tailwindcss: ^3.4.1
-    typescript: ^5.9.0-beta
   languageName: unknown
   linkType: soft
 
@@ -4073,7 +4062,6 @@ __metadata:
     "@trpc/react-query": 11.0.0-next-beta.222
     "@trpc/server": 11.0.0-next-beta.222
     superjson: 1.9.1
-    typescript: ^5.9.0-beta
     zod: ^3.22.4
   languageName: unknown
   linkType: soft
@@ -4146,7 +4134,6 @@ __metadata:
     react-inlinesvg: ^4.1.3
     react-select: ^5.7.0
     tailwind-merge: ^1.13.2
-    typescript: ^5.9.0-beta
     uuid: ^11.1.0
   languageName: unknown
   linkType: soft
@@ -4357,7 +4344,6 @@ __metadata:
     tailwindcss-radix: ^2.6.0
     ts-node: ^10.9.1
     turndown: ^7.1.3
-    typescript: ^5.9.0-beta
     uuid: ^8.3.2
     zod: ^3.22.4
   languageName: unknown
@@ -21700,7 +21686,7 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     tsc-absolute: ^1.0.0
     turbo: ^2.5.5
-    typescript: 5.9.0-beta
+    typescript: 5.9.2
     vitest: ^2.1.9
     vitest-fetch-mock: ^0.3.0
     vitest-mock-extended: ^2.0.2
@@ -21989,7 +21975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.4.1, chalk@npm:^2.4.2":
+"chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -23474,19 +23460,6 @@ __metadata:
   dependencies:
     tslib: ^2.4.0
   checksum: 7c1e02e0a9670b62416a3ea1df7ae880fdad3aa0a857de8932c4e5f8acd71298c7e3db9da8e9da603f5692cd1879938f5e72e34a9f5d1345987bef656d117fc1
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "cross-spawn@npm:6.0.5"
-  dependencies:
-    nice-try: ^1.0.4
-    path-key: ^2.0.1
-    semver: ^5.5.0
-    shebang-command: ^1.2.0
-    which: ^1.2.9
-  checksum: f893bb0d96cd3d5751d04e67145bdddf25f99449531a72e82dcbbd42796bbc8268c1076c6b3ea51d4d455839902804b94bc45dfb37ecbb32ea8e54a6741c3ab9
   languageName: node
   linkType: hard
 
@@ -33638,18 +33611,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-json-file@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "load-json-file@npm:4.0.0"
-  dependencies:
-    graceful-fs: ^4.1.2
-    parse-json: ^4.0.0
-    pify: ^3.0.0
-    strip-bom: ^3.0.0
-  checksum: 8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
-  languageName: node
-  linkType: hard
-
 "load-json-file@npm:^5.3.0":
   version: 5.3.0
   resolution: "load-json-file@npm:5.3.0"
@@ -34770,13 +34731,6 @@ __metadata:
   version: 1.5.0
   resolution: "memory-pager@npm:1.5.0"
   checksum: d1a2e684583ef55c61cd3a49101da645b11ad57014dfc565e0b43baa9004b743f7e4ab81493d8fff2ab24e9950987cc3209c94bcc4fc8d7e30a475489a1f15e9
-  languageName: node
-  linkType: hard
-
-"memorystream@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "memorystream@npm:0.3.1"
-  checksum: f18b42440d24d09516d01466c06adf797df7873f0d40aa7db02e5fb9ed83074e5e65412d0720901d7069363465f82dc4f8bcb44f0cde271567a61426ce6ca2e9
   languageName: node
   linkType: hard
 
@@ -36686,13 +36640,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nice-try@npm:^1.0.4":
-  version: 1.0.5
-  resolution: "nice-try@npm:1.0.5"
-  checksum: 0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
-  languageName: node
-  linkType: hard
-
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -37094,7 +37041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
+"normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -37175,27 +37122,6 @@ __metadata:
   version: 0.1.0
   resolution: "nostr-wasm@npm:0.1.0"
   checksum: c0b404912d47c98efa69b4838a5bb7b2094c869b1aa2a96359c978c911878e9b37228296ef6432254815c9d15cdeebaa16b6d45106db4f3673bb5a6a00cc669c
-  languageName: node
-  linkType: hard
-
-"npm-run-all@npm:^4.1.5":
-  version: 4.1.5
-  resolution: "npm-run-all@npm:4.1.5"
-  dependencies:
-    ansi-styles: ^3.2.1
-    chalk: ^2.4.1
-    cross-spawn: ^6.0.5
-    memorystream: ^0.3.1
-    minimatch: ^3.0.4
-    pidtree: ^0.3.0
-    read-pkg: ^3.0.0
-    shell-quote: ^1.6.1
-    string.prototype.padend: ^3.0.0
-  bin:
-    npm-run-all: bin/npm-run-all/index.js
-    run-p: bin/run-p/index.js
-    run-s: bin/run-s/index.js
-  checksum: 373b72c6a36564da13c1642c1fd9bb4dcc756bce7a3648f883772f02661095319820834ff813762d2fee403e9b40c1cd27c8685807c107440f10eb19c006d4a0
   languageName: node
   linkType: hard
 
@@ -38420,13 +38346,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "path-key@npm:2.0.1"
-  checksum: f7ab0ad42fe3fb8c7f11d0c4f849871e28fbd8e1add65c370e422512fc5887097b9cf34d09c1747d45c942a8c1e26468d6356e2df3f740bf177ab8ca7301ebfd
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^3.0.0, path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -38516,15 +38435,6 @@ __metadata:
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
   checksum: 56e13e45962e776e9e7cd72e87a441cfe41f33fd539d097237ceb16adc922281136ca12f5a742962e33d8dda9569f630ba594de56d8b7b6e49adf31803c5e771
-  languageName: node
-  linkType: hard
-
-"path-type@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "path-type@npm:3.0.0"
-  dependencies:
-    pify: ^3.0.0
-  checksum: 735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
   languageName: node
   linkType: hard
 
@@ -38824,15 +38734,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pidtree@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "pidtree@npm:0.3.1"
-  bin:
-    pidtree: bin/pidtree.js
-  checksum: eb49025099f1af89a4696f7673351421f13420f3397b963c901fe23a1c9c2ff50f4750321970d4472c0ffbb065e4a6c3c27f75e226cc62284b19e21d32ce7012
-  languageName: node
-  linkType: hard
-
 "pidtree@npm:^0.5.0":
   version: 0.5.0
   resolution: "pidtree@npm:0.5.0"
@@ -38846,13 +38747,6 @@ __metadata:
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
-  languageName: node
-  linkType: hard
-
-"pify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pify@npm:3.0.0"
-  checksum: 6cdcbc3567d5c412450c53261a3f10991665d660961e06605decf4544a61a97a54fefe70a68d5c37080ff9d6f4cf51444c90198d1ba9f9309a6c0d6e9f5c4fde
   languageName: node
   linkType: hard
 
@@ -40929,17 +40823,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg@npm:3.0.0"
-  dependencies:
-    load-json-file: ^4.0.0
-    normalize-package-data: ^2.3.2
-    path-type: ^3.0.0
-  checksum: 398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
-  languageName: node
-  linkType: hard
-
 "read-pkg@npm:^5.2.0":
   version: 5.2.0
   resolution: "read-pkg@npm:5.2.0"
@@ -42765,7 +42648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0, semver@npm:^5.6.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -43236,28 +43119,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-command@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "shebang-command@npm:1.2.0"
-  dependencies:
-    shebang-regex: ^1.0.0
-  checksum: 9eed1750301e622961ba5d588af2212505e96770ec376a37ab678f965795e995ade7ed44910f5d3d3cb5e10165a1847f52d3348c64e146b8be922f7707958908
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
   dependencies:
     shebang-regex: ^3.0.0
   checksum: 6b52fe87271c12968f6a054e60f6bde5f0f3d2db483a1e5c3e12d657c488a15474121a1d55cd958f6df026a54374ec38a4a963988c213b7570e1d51575cea7fa
-  languageName: node
-  linkType: hard
-
-"shebang-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "shebang-regex@npm:1.0.0"
-  checksum: 404c5a752cd40f94591dfd9346da40a735a05139dac890ffc229afba610854d8799aaa52f87f7e0c94c5007f2c6af55bdcaeb584b56691926c5eaf41dc8f1372
   languageName: node
   linkType: hard
 
@@ -44294,17 +44161,6 @@ __metadata:
     regexp.prototype.flags: ^1.4.1
     side-channel: ^1.0.4
   checksum: fc09f3ccbfb325de0472bcc87a6be0598a7499e0b4a31db5789676155b15754a4cc4bb83924f15fc9ed48934dac7366ee52c8b9bd160bed6fd072c93b489e75c
-  languageName: node
-  linkType: hard
-
-"string.prototype.padend@npm:^3.0.0":
-  version: 3.1.3
-  resolution: "string.prototype.padend@npm:3.1.3"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
-  checksum: ef9ee0542c17975629bc6d21497e8faaa142d873e9f07fb65de2a955df402a1eac45cbed375045a759501e9d4ef80e589e11f0e12103c20df0770e47f6b59bc7
   languageName: node
   linkType: hard
 
@@ -46653,27 +46509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.0-beta":
-  version: 5.9.0-beta
-  resolution: "typescript@npm:5.9.0-beta"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 42564de845d58e611b774b6222eec4aa75eaf88c79dde2b6e4d2366e2e9da344af0cdb1cc5a8fc2300dc8f33a794fafd1f7aa3ffea63caefe61f2745cb471ab8
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^4.9.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^5.9.0-beta, typescript@npm:^5.9.2":
+"typescript@npm:5.9.2, typescript@npm:^5.9.0-beta, typescript@npm:^5.9.2":
   version: 5.9.2
   resolution: "typescript@npm:5.9.2"
   bin:
@@ -46693,27 +46529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.9.0-beta#~builtin<compat/typescript>":
-  version: 5.9.0-beta
-  resolution: "typescript@patch:typescript@npm%3A5.9.0-beta#~builtin<compat/typescript>::version=5.9.0-beta&hash=1f5320"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 4a3a8b55e8b64f01ae92bab8b93771817e716e4956a07fe16d8ce33a0078da11e2ab5402f4ea8db6820dc4dbe13ca5affabfa57da9f7176e753f6e9f80ed79db
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^5.9.0-beta#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@5.9.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.0-beta#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
   version: 5.9.2
   resolution: "typescript@patch:typescript@npm%3A5.9.2#~builtin<compat/typescript>::version=5.9.2&hash=1f5320"
   bin:
@@ -48316,17 +48132,6 @@ __metadata:
     gopd: ^1.2.0
     has-tostringtag: ^1.0.2
   checksum: 162d2a07f68ea323f88ed9419861487ce5d02cb876f2cf9dd1e428d04a63133f93a54f89308f337b27cabd312ee3d027cae4a79002b2f0a85b79b9ef4c190670
-  languageName: node
-  linkType: hard
-
-"which@npm:^1.2.9":
-  version: 1.3.1
-  resolution: "which@npm:1.3.1"
-  dependencies:
-    isexe: ^2.0.0
-  bin:
-    which: ./bin/which
-  checksum: f2e185c6242244b8426c9df1510e86629192d93c1a986a7d2a591f2c24869e7ffd03d6dac07ca863b2e4c06f59a4cc9916c585b72ee9fa1aa609d0124df15e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Prisma package is included on transpilePackages and also has it's own build script what implies in this package being builded twice (transpilePackages compiling the dist folder)

