### PR TITLE
chore: reduce atoms bundle size prisma types

### DIFF
--- a/.changeset/ninety-colts-search.md
+++ b/.changeset/ninety-colts-search.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": minor
+---
+
+Reduced bundle size by removing unnecessary types

--- a/packages/platform/atoms/kysely-types/index.ts
+++ b/packages/platform/atoms/kysely-types/index.ts
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export type ColumnType<SelectType, InsertType = SelectType, UpdateType = SelectType> = SelectType;

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -7,7 +7,7 @@
   "version": "1.9.0",
   "scripts": {
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
-    "build": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify && mkdir ./dist/packages/prisma-client && cp -rf ../../prisma/client/*.d.ts ./dist/packages/prisma-client",
+    "build": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify",
     "publish-npm": "yarn build && npm publish --access public",
     "test": "jest",
     "dev-on": "node scripts/dev-on.js",

--- a/packages/platform/atoms/prisma-types/index.ts
+++ b/packages/platform/atoms/prisma-types/index.ts
@@ -1,0 +1,9 @@
+// src/prisma-types.ts
+
+// These types are derived from Prisma's internal types
+// to ensure type safety without importing the full client.
+export type JsonValue = string | number | boolean | JsonObject | JsonArray | null;
+
+export type JsonObject = { [key: string]: JsonValue };
+
+export type JsonArray = Array<JsonValue>;

--- a/packages/platform/atoms/tsconfig.json
+++ b/packages/platform/atoms/tsconfig.json
@@ -59,6 +59,7 @@
     "../../features/data-table",
     "../../kysely/types.ts",
     "./prisma-types/index.ts",
+    "./kysely-types/index.ts",
     "../../lib/intervalLimits/intervalLimitSchema.ts"
   ],
   "exclude": [

--- a/packages/platform/atoms/tsconfig.json
+++ b/packages/platform/atoms/tsconfig.json
@@ -56,7 +56,10 @@
     "../../features/shell",
     "../../features/components",
     "../../features/form-builder",
-    "../../features/data-table"
+    "../../features/data-table",
+    "../../kysely/types.ts",
+    "./prisma-types/index.ts",
+    "../../lib/intervalLimits/intervalLimitSchema.ts"
   ],
   "exclude": [
     "dist",

--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -19,7 +19,26 @@ export default defineConfig(({ mode }) => {
         "@calcom/platform-utils",
       ],
     },
-    plugins: [react(), dts({ insertTypesEntry: true })],
+    plugins: [
+      react(),
+      dts({
+        insertTypesEntry: true,
+        beforeWriteFile: (filePath, content) => {
+          // Check if the content includes the broken path from kysely
+          if (filePath.includes("useCreateEventType")) {
+            console.log("CONTENT USECRE", content.includes(`kysely/types.ts').$Enums`));
+          }
+          if (content.includes(`kysely/types.ts').$Enums`)) {
+            // Replace the broken path with the correct import
+            return {
+              filePath,
+              content: content.replace(`kysely/types.ts').$Enums`, `kysely/types.ts')`),
+            };
+          }
+          return { filePath, content };
+        },
+      }),
+    ],
     define: {
       "process.env.NEXT_PUBLIC_WEBAPP_URL": `"${webAppUrl}"`,
     },
@@ -34,7 +53,16 @@ export default defineConfig(({ mode }) => {
         formats: ["es"],
       },
       rollupOptions: {
-        external: ["react", "fs", "path", "os", "react/jsx-runtime", "react-dom", "react-dom/client"],
+        external: [
+          "react",
+          "fs",
+          "path",
+          "os",
+          "react/jsx-runtime",
+          "react-dom",
+          "react-dom/client",
+          "@prisma/client",
+        ],
         output: {
           format: "esm",
           globals: {
@@ -54,10 +82,8 @@ export default defineConfig(({ mode }) => {
         "@calcom/lib/hooks/useLocale": path.resolve(__dirname, "./lib/useLocale"),
         "@radix-ui/react-tooltip": path.resolve(__dirname, "./src/components/ui/tooltip.tsx"),
         "@radix-ui/react-dialog": path.resolve(__dirname, "./src/components/ui/dialog.tsx"),
-        ".prisma/client": path.resolve(__dirname, "../../prisma-client"),
-        "@prisma/client": path.resolve(__dirname, "../../prisma-client"),
-        "@calcom/prisma/client": path.resolve(__dirname, "../../prisma-client"),
-        "@calcom/prisma": path.resolve(__dirname, "../../prisma"),
+        "@calcom/prisma/client/runtime/library": resolve("./prisma-types/index.ts"),
+        "@calcom/prisma/client": path.resolve(__dirname, "../../kysely/types.ts"),
         "@calcom/dayjs": path.resolve(__dirname, "../../dayjs"),
         "@calcom/platform-constants": path.resolve(__dirname, "../constants/index.ts"),
         "@calcom/platform-types": path.resolve(__dirname, "../types/index.ts"),

--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
             // Replace the broken path with the correct import
             return {
               filePath,
-              content: content.replace(`kysely/types.ts').$Enums`, `kysely/types.ts')`),
+              content: content.replaceAll(`kysely/types.ts').$Enums`, `kysely/types.ts')`),
             };
           }
           return { filePath, content };
@@ -81,6 +81,7 @@ export default defineConfig(({ mode }) => {
         "@radix-ui/react-dialog": path.resolve(__dirname, "./src/components/ui/dialog.tsx"),
         "@calcom/prisma/client/runtime/library": resolve("./prisma-types/index.ts"),
         "@calcom/prisma/client": path.resolve(__dirname, "../../kysely/types.ts"),
+        kysely: path.resolve(__dirname, "./kysely-types/index.ts"),
         "@calcom/dayjs": path.resolve(__dirname, "../../dayjs"),
         "@calcom/platform-constants": path.resolve(__dirname, "../constants/index.ts"),
         "@calcom/platform-types": path.resolve(__dirname, "../types/index.ts"),

--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -25,9 +25,6 @@ export default defineConfig(({ mode }) => {
         insertTypesEntry: true,
         beforeWriteFile: (filePath, content) => {
           // Check if the content includes the broken path from kysely
-          if (filePath.includes("useCreateEventType")) {
-            console.log("CONTENT USECRE", content.includes(`kysely/types.ts').$Enums`));
-          }
           if (content.includes(`kysely/types.ts').$Enums`)) {
             // Replace the broken path with the correct import
             return {


### PR DESCRIPTION
## What does this PR do?
This change removes post-build copying of Prisma .d.ts files from the atoms build script. It introduces a new prisma-types module exporting JsonValue, JsonObject, and JsonArray. TypeScript config now includes Kysely types, the new prisma-types, and an interval limit schema. Vite config updates include aliasing Prisma client/runtime to local Kysely and prisma-types paths, adding @prisma/client to Rollup externals, and a dts beforeWriteFile hook to adjust a Kysely path in generated typings. Existing plugins remain unchanged.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] n/a - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
