### PR TITLE
chore: remove @id from BookingTimeStatusDenormalized for Prisma .16 support

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1750,7 +1750,7 @@ model BookingDenormalized {
 }
 
 view BookingTimeStatusDenormalized {
-  id             Int           @id @unique
+  id             Int           @unique
   uid            String
   eventTypeId    Int?
   title          String


### PR DESCRIPTION
## What does this PR do?

Removes the `@id` from the view; doesn't generate a new migration; as it doesn't do anything. Prisma upgrade will break on this as views can't have `@id`'s.