### PR TITLE
fix: make createdById at Watchlist nullable

### DIFF
--- a/packages/prisma/migrations/20250924091435_update_watchlist_created_by_id_fkey/migration.sql
+++ b/packages/prisma/migrations/20250924091435_update_watchlist_created_by_id_fkey/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Watchlist" DROP CONSTRAINT "Watchlist_createdById_fkey";
+
+-- AlterTable
+ALTER TABLE "Watchlist" ALTER COLUMN "createdById" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Watchlist" ADD CONSTRAINT "Watchlist_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2268,8 +2268,8 @@ model Watchlist {
   action      WatchlistAction   @default(REPORT)
   severity    WatchlistSeverity @default(LOW)
   createdAt   DateTime          @default(now())
-  createdBy   User              @relation("CreatedWatchlists", onDelete: SetNull, fields: [createdById], references: [id])
-  createdById Int
+  createdBy   User?             @relation("CreatedWatchlists", onDelete: SetNull, fields: [createdById], references: [id])
+  createdById Int?
   updatedAt   DateTime          @updatedAt
   updatedBy   User?             @relation("UpdatedWatchlists", onDelete: SetNull, fields: [updatedById], references: [id])
   updatedById Int?


### PR DESCRIPTION
## What does this PR do?

This prevents from the row being deleted when a user who reported is deleted.

