### PR TITLE
perf: Replace `isTeamMember` util with an index DB call

### DIFF
--- a/packages/features/ee/teams/lib/queries.ts
+++ b/packages/features/ee/teams/lib/queries.ts
@@ -385,6 +385,17 @@ export async function getTeamWithoutMembers(args: {
   };
 }
 
+export async function isTeamOwner(userId: number, teamId: number) {
+  return !!(await prisma.membership.findFirst({
+    where: {
+      userId,
+      teamId,
+      accepted: true,
+      role: "OWNER",
+    },
+  }));
+}
+
 export function generateNewChildEventTypeDataForDB({
   eventType,
   userId,

--- a/packages/features/ee/teams/lib/queries.ts
+++ b/packages/features/ee/teams/lib/queries.ts
@@ -385,27 +385,6 @@ export async function getTeamWithoutMembers(args: {
   };
 }
 
-export async function isTeamOwner(userId: number, teamId: number) {
-  return !!(await prisma.membership.findFirst({
-    where: {
-      userId,
-      teamId,
-      accepted: true,
-      role: "OWNER",
-    },
-  }));
-}
-
-export async function isTeamMember(userId: number, teamId: number) {
-  return !!(await prisma.membership.findFirst({
-    where: {
-      userId,
-      teamId,
-      accepted: true,
-    },
-  }));
-}
-
 export function generateNewChildEventTypeDataForDB({
   eventType,
   userId,

--- a/packages/lib/server/repository/membership.ts
+++ b/packages/lib/server/repository/membership.ts
@@ -303,13 +303,22 @@ export class MembershipRepository {
     });
   }
 
-  static async findUniqueByUserIdAndTeamId({ userId, teamId }: { userId: number; teamId: number }) {
+  static async findUniqueByUserIdAndTeamId({
+    userId,
+    teamId,
+    accepted,
+  }: {
+    userId: number;
+    teamId: number;
+    accepted?: boolean;
+  }) {
     return await prisma.membership.findUnique({
       where: {
         userId_teamId: {
           userId,
           teamId,
         },
+        accepted,
       },
     });
   }

--- a/packages/trpc/server/routers/viewer/teams/getInternalNotesPresets.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/getInternalNotesPresets.handler.ts
@@ -17,6 +17,7 @@ export const getInternalNotesPresetsHandler = async ({ ctx, input }: UpdateMembe
   const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({
     userId: ctx.user.id,
     teamId: input.teamId,
+    accepted: true,
   });
 
   if (!membership) {

--- a/packages/trpc/server/routers/viewer/teams/getInternalNotesPresets.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/getInternalNotesPresets.handler.ts
@@ -1,4 +1,4 @@
-import { isTeamMember } from "@calcom/features/ee/teams/lib/queries";
+import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import { prisma } from "@calcom/prisma";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
@@ -14,8 +14,13 @@ type UpdateMembershipOptions = {
 };
 
 export const getInternalNotesPresetsHandler = async ({ ctx, input }: UpdateMembershipOptions) => {
-  if (!(await isTeamMember(ctx.user?.id, input.teamId))) {
-    throw new TRPCError({ code: "UNAUTHORIZED" });
+  const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({
+    userId: ctx.user.id,
+    teamId: input.teamId,
+  });
+
+  if (!membership) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "User is not a member of this team" });
   }
 
   return await prisma.internalNotePreset.findMany({

--- a/packages/trpc/server/routers/viewer/teams/getMemberAvailability.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/getMemberAvailability.handler.ts
@@ -20,6 +20,7 @@ export const getMemberAvailabilityHandler = async ({ ctx, input }: GetMemberAvai
   const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({
     userId: ctx.user.id,
     teamId: input.teamId,
+    accepted: true,
   });
 
   if (!membership) {


### PR DESCRIPTION
## What does this PR do?

- Remove `isTeamMember` util and use `MembershipRepository.findUnique` call instead

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.