### PR TITLE
fix(bookings): prevent text overflow in cancellation/reschedule reason

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -550,7 +550,7 @@ export default function Success(props: PageProps) {
                           </h4>
                         )}
 
-                      <div className="border-subtle text-default mt-8 grid grid-cols-3 gap-x-4 border-t pt-8 text-left rtl:text-right sm:gap-x-0">
+                      <div className="border-subtle text-default mt-8 grid grid-cols-3 gap-x-4 border-t pt-8 text-left rtl:text-right sm:gap-x-0 break-words whitespace-normal">
                         {(isCancelled || reschedule) && cancellationReason && (
                           <>
                             <div className="font-medium">


### PR DESCRIPTION
fix(bookings): prevent text overflow in cancellation/reschedule reason

## What does this PR do?

This PR fixes the issue where long cancellation or reschedule reasons overflow their container in the UI.

- Added `break-words` and `whitespace-normal` to the parent div to handle long text and URLs correctly.
- Ensures UI layout is preserved for any unexpected long strings.

### Related Issues
- Fixes #24063

## Visual Demo

**Before:**

<img width="1440" height="775" alt="before-fix" src="https://github.com/user-attachments/assets/32a98380-5b60-4fea-ae7d-7bc290e144a9" />


**After:**

<img width="1440" height="774" alt="after-fix" src="https://github.com/user-attachments/assets/656314f7-c4ea-448f-a7df-cdd315a6f104" />



## Mandatory Tasks

- [x] Self-reviewed the code.
- [x] Confirmed that the fix works with test data (long text, URLs).
- [x] Checked that existing automated tests pass.
- [x] Updated developer docs if required (/docs) — N/A.

## How should this be tested?

1. Run the app locally.
2. Navigate to a booking with a long cancellation or reschedule reason.
3. Verify that the text wraps correctly and no overflow occurs.
4. Test with unusually long URLs or strings to confirm the fix holds.

## Checklist

- [x] Code follows the style guidelines of this project.
- [x] No unused variables or imports are introduced.
- [x] No new warnings or errors in the console.
- [x] Properly tested edge cases with long text and URLs.