### PR TITLE
Remove all PBAC feature flag checks and always enable PBAC logic

### DIFF
--- a/apps/web/playwright/insights.e2e.ts
+++ b/apps/web/playwright/insights.e2e.ts
@@ -1,6 +1,5 @@
 import { expect } from "@playwright/test";
 
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { randomString } from "@calcom/lib/random";
 import { prisma } from "@calcom/prisma";
@@ -328,10 +327,6 @@ test.describe("Insights", async () => {
         customRoleId: customRole.id,
       },
     });
-
-    const featuresRepository = new FeaturesRepository(prisma);
-    const isPBACEnabled = await featuresRepository.checkIfTeamHasFeature(orgId, "pbac");
-    expect(isPBACEnabled).toBe(true);
 
     const permissionService = new PermissionCheckService();
     const hasPermission = await permissionService.checkPermission({

--- a/packages/features/pbac/services/__tests__/role-management.factory.test.ts
+++ b/packages/features/pbac/services/__tests__/role-management.factory.test.ts
@@ -1,10 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { isOrganisationAdmin } from "@calcom/lib/server/queries/organisations";
-import { prisma } from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/enums";
-
 import { RoleManagementError, RoleManagementErrorCode } from "../../domain/errors/role-management.error";
 import { DEFAULT_ROLE_IDS } from "../../lib/constants";
 import { PermissionCheckService } from "../permission-check.service";
@@ -12,7 +7,6 @@ import { RoleManagementFactory } from "../role-management.factory";
 import { RoleService } from "../role.service";
 
 // Mock dependencies
-vi.mock("@calcom/features/flags/features.repository");
 vi.mock("../role.service");
 vi.mock("../permission-check.service");
 vi.mock("@calcom/prisma", () => ({
@@ -30,10 +24,8 @@ describe("RoleManagementFactory", () => {
   const organizationId = 123;
   const userId = 456;
   const membershipId = 789;
-  const role = MembershipRole.ADMIN;
 
   let factory: RoleManagementFactory;
-  let mockFeaturesRepository: { checkIfTeamHasFeature: ReturnType<typeof vi.fn> };
   let mockRoleService: {
     assignRoleToMember: ReturnType<typeof vi.fn>;
     roleBelongsToTeam: ReturnType<typeof vi.fn>;
@@ -44,10 +36,6 @@ describe("RoleManagementFactory", () => {
     vi.resetAllMocks();
 
     // Setup mocks
-    mockFeaturesRepository = {
-      checkIfTeamHasFeature: vi.fn(),
-    };
-
     mockRoleService = {
       assignRoleToMember: vi.fn(),
       roleBelongsToTeam: vi.fn(),
@@ -63,9 +51,6 @@ describe("RoleManagementFactory", () => {
       writable: true,
     });
 
-    vi.spyOn(FeaturesRepository.prototype, "checkIfTeamHasFeature").mockImplementation(
-      mockFeaturesRepository.checkIfTeamHasFeature
-    );
     vi.spyOn(RoleService.prototype, "assignRoleToMember").mockImplementation(
       mockRoleService.assignRoleToMember
     );
@@ -88,24 +73,13 @@ describe("RoleManagementFactory", () => {
   });
 
   describe("createRoleManager", () => {
-    it("should create PBACRoleManager when PBAC is enabled", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(true);
+    it("should always create PBACRoleManager", async () => {
       const manager = await factory.createRoleManager(organizationId);
       expect(manager.constructor.name).toBe("PBACRoleManager");
-    });
-
-    it("should create LegacyRoleManager when PBAC is disabled", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(false);
-      const manager = await factory.createRoleManager(organizationId);
-      expect(manager.constructor.name).toBe("LegacyRoleManager");
     });
   });
 
   describe("PBACRoleManager", () => {
-    beforeEach(() => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(true);
-    });
-
     describe("checkPermissionToChangeRole", () => {
       it("should allow role change when user has permission", async () => {
         mockPermissionCheckService.checkPermission.mockResolvedValue(true);
@@ -160,74 +134,6 @@ describe("RoleManagementFactory", () => {
         ).rejects.toThrow(
           new RoleManagementError("You do not have access to this role", RoleManagementErrorCode.INVALID_ROLE)
         );
-      });
-    });
-  });
-
-  describe("LegacyRoleManager", () => {
-    beforeEach(() => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(false);
-      vi.mocked(prisma.membership.update).mockResolvedValue({
-        id: 1,
-        teamId: organizationId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        role: MembershipRole.MEMBER,
-        userId: userId,
-        disableImpersonation: false,
-        accepted: true,
-        customRoleId: null,
-      });
-      vi.mocked(isOrganisationAdmin).mockResolvedValue(false);
-    });
-
-    describe("checkPermissionToChangeRole", () => {
-      it("should allow role change when user is owner", async () => {
-        vi.mocked(isOrganisationAdmin).mockResolvedValue({
-          id: 1,
-          teamId: organizationId,
-          userId: userId,
-          role: MembershipRole.OWNER,
-          accepted: true,
-          disableImpersonation: false,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          customRoleId: null,
-        });
-        const manager = await factory.createRoleManager(organizationId);
-        await expect(
-          manager.checkPermissionToChangeRole(userId, organizationId, "org")
-        ).resolves.not.toThrow();
-      });
-
-      it("should throw UNAUTHORIZED when user is not owner", async () => {
-        vi.mocked(isOrganisationAdmin).mockResolvedValue(false);
-        const manager = await factory.createRoleManager(organizationId);
-        await expect(manager.checkPermissionToChangeRole(userId, organizationId, "org")).rejects.toThrow(
-          new RoleManagementError(
-            "Only owners or admin can update roles",
-            RoleManagementErrorCode.UNAUTHORIZED
-          )
-        );
-      });
-    });
-
-    describe("assignRole", () => {
-      it("should update membership role in database", async () => {
-        const manager = await factory.createRoleManager(organizationId);
-        await manager.assignRole(userId, organizationId, role, membershipId);
-
-        expect(prisma.membership.update).toHaveBeenCalledWith({
-          where: {
-            userId_teamId: {
-              userId,
-              teamId: organizationId,
-            },
-          },
-          data: {
-            role,
-          },
-        });
       });
     });
   });

--- a/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/updateUser.handler.ts
@@ -170,8 +170,7 @@ export const updateUserHandler = async ({ ctx, input }: UpdateUserOptions) => {
     });
   }
 
-  // We cast to membership role as we know pbac insnt enabled on this instance.
-  if (checkAdminOrOwner(input.role as MembershipRole) && roleManager.isPBACEnabled) {
+  if (checkAdminOrOwner(input.role as MembershipRole)) {
     const teamIds = requestedMember.team.children
       .map((sub_team) => sub_team.members.find((item) => item.userId === input.userId)?.teamId)
       .filter(Boolean) as number[]; //filter out undefined

--- a/packages/trpc/server/routers/viewer/pbac/_router.tsx
+++ b/packages/trpc/server/routers/viewer/pbac/_router.tsx
@@ -1,11 +1,9 @@
 import { z } from "zod";
 
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { isValidPermissionString } from "@calcom/features/pbac/domain/types/permission-registry";
 import type { PermissionString } from "@calcom/features/pbac/domain/types/permission-registry";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { RoleService } from "@calcom/features/pbac/services/role.service";
-import prisma from "@calcom/prisma";
 import { RoleType, MembershipRole } from "@calcom/prisma/enums";
 
 import authedProcedure from "../../../procedures/authedProcedure";
@@ -178,13 +176,6 @@ export const permissionsRouter = router({
     .query(async ({ ctx, input }) => {
       if (!ctx.user?.id) {
         throw new Error("Unauthorized");
-      }
-
-      const featureRepo = new FeaturesRepository(prisma);
-      const teamHasPBACFeature = await featureRepo.checkIfTeamHasFeature(input.teamId, "pbac");
-
-      if (!teamHasPBACFeature) {
-        throw new Error("PBAC is not enabled for this team");
       }
 
       // Check if user has permission to view roles

--- a/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listMembers.handler.ts
@@ -85,19 +85,17 @@ export const listMembersHandler = async ({ ctx, input }: ListMembersHandlerOptio
 
   const organizationId = team?.parentId || teamId;
 
-  // Get custom roles if PBAC is enabled
+  // Get custom roles from PBAC (always enabled)
   let customRoles: { [key: string]: { id: string; name: string } } = {};
   try {
     const roleManager = await RoleManagementFactory.getInstance().createRoleManager(organizationId);
-    if (roleManager.isPBACEnabled) {
-      const roles = await roleManager.getTeamRoles(teamId);
-      customRoles = roles.reduce((acc, role) => {
-        acc[role.id] = role;
-        return acc;
-      }, {} as { [key: string]: { id: string; name: string } });
-    }
-  } catch (error) {
-    // PBAC not enabled or error occurred, continue with traditional roles
+    const roles = await roleManager.getTeamRoles(teamId);
+    customRoles = roles.reduce((acc, role) => {
+      acc[role.id] = role;
+      return acc;
+    }, {} as { [key: string]: { id: string; name: string } });
+  } catch {
+    // Error occurred getting roles, continue with traditional roles
   }
 
   const membersWithApps = await Promise.all(

--- a/packages/trpc/server/routers/viewer/teams/removeMember/RemoveMemberServiceFactory.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeMember/RemoveMemberServiceFactory.ts
@@ -1,21 +1,11 @@
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { prisma } from "@calcom/prisma";
-
 import type { IRemoveMemberService } from "./IRemoveMemberService";
-import { LegacyRemoveMemberService } from "./LegacyRemoveMemberService";
 import { PBACRemoveMemberService } from "./PBACRemoveMemberService";
 
 export class RemoveMemberServiceFactory {
   /**
-   * Creates the appropriate RemoveMemberService based on whether PBAC is enabled
-   * Caches the service per team/org to avoid repeated feature flag checks
+   * Creates the appropriate RemoveMemberService - always returns PBAC service
    */
-  static async create(teamId: number): Promise<IRemoveMemberService> {
-    const featuresRepository = new FeaturesRepository(prisma);
-    const isPBACEnabled = await featuresRepository.checkIfTeamHasFeature(teamId, "pbac");
-
-    const service = isPBACEnabled ? new PBACRemoveMemberService() : new LegacyRemoveMemberService();
-
-    return service;
+  static async create(): Promise<IRemoveMemberService> {
+    return new PBACRemoveMemberService();
   }
 }

--- a/packages/trpc/server/routers/viewer/teams/removeMember/__tests__/RemoveMemberServiceFactory.test.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeMember/__tests__/RemoveMemberServiceFactory.test.ts
@@ -1,74 +1,35 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-
-import { LegacyRemoveMemberService } from "../LegacyRemoveMemberService";
 import { PBACRemoveMemberService } from "../PBACRemoveMemberService";
 import { RemoveMemberServiceFactory } from "../RemoveMemberServiceFactory";
 
-vi.mock("@calcom/features/flags/features.repository");
-vi.mock("../LegacyRemoveMemberService");
 vi.mock("../PBACRemoveMemberService");
 
 describe("RemoveMemberServiceFactory", () => {
-  let mockFeaturesRepository: {
-    checkIfTeamHasFeature: vi.Mock;
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockFeaturesRepository = {
-      checkIfTeamHasFeature: vi.fn(),
-    };
-
-    vi.mocked(FeaturesRepository).mockImplementation(() => mockFeaturesRepository as any);
   });
 
   describe("Service Creation", () => {
-    it("should create LegacyRemoveMemberService when PBAC is disabled", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(false);
-
+    it("should always create PBACRemoveMemberService", async () => {
       const teamId = 1;
       const service = await RemoveMemberServiceFactory.create(teamId);
 
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(teamId, "pbac");
-      expect(service).toBeInstanceOf(LegacyRemoveMemberService);
-    });
-
-    it("should create PBACRemoveMemberService when PBAC is enabled", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(true);
-
-      const teamId = 1;
-      const service = await RemoveMemberServiceFactory.create(teamId);
-
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(teamId, "pbac");
       expect(service).toBeInstanceOf(PBACRemoveMemberService);
     });
   });
 
-  describe("Service Creation for Different Teams", () => {
-    it("should create different services for different teams", async () => {
-      // Team 1 has PBAC disabled
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(false);
-      // Team 2 has PBAC enabled
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
-
+  describe("Multiple Team Support", () => {
+    it("should create different service instances for different teams", async () => {
       const service1 = await RemoveMemberServiceFactory.create(1);
       const service2 = await RemoveMemberServiceFactory.create(2);
 
-      expect(service1).toBeInstanceOf(LegacyRemoveMemberService);
+      expect(service1).toBeInstanceOf(PBACRemoveMemberService);
       expect(service2).toBeInstanceOf(PBACRemoveMemberService);
       expect(service1).not.toBe(service2);
-
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledTimes(2);
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(1, "pbac");
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(2, "pbac");
     });
 
     it("should create service for each call (no caching in current implementation)", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(true);
-
       const teamId = 1;
 
       // Make multiple calls
@@ -79,27 +40,14 @@ describe("RemoveMemberServiceFactory", () => {
       // All should be different instances (no caching currently)
       expect(service1).not.toBe(service2);
       expect(service2).not.toBe(service3);
-
-      // Feature flag should be called each time
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledTimes(3);
     });
   });
 
-  describe("Error Handling", () => {
-    it("should propagate errors from features repository", async () => {
-      const error = new Error("Features repository error");
-      mockFeaturesRepository.checkIfTeamHasFeature.mockRejectedValue(error);
-
-      await expect(RemoveMemberServiceFactory.create(1)).rejects.toThrow("Features repository error");
-    });
-
-    it("should handle null/undefined feature flag gracefully", async () => {
-      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValue(null as any);
-
+  describe("Edge Cases", () => {
+    it("should handle service creation without errors", async () => {
       const service = await RemoveMemberServiceFactory.create(1);
 
-      // Should default to Legacy when feature flag is falsy
-      expect(service).toBeInstanceOf(LegacyRemoveMemberService);
+      expect(service).toBeInstanceOf(PBACRemoveMemberService);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

This PR removes all PBAC (Permission-Based Access Control) feature flag checks throughout the Cal.com codebase and modifies the system to always execute PBAC logic instead of conditionally checking if the feature is enabled.

**Key Changes:**
- Removes `checkIfTeamHasFeature(teamId, "pbac")` calls and related conditional logic
- Always uses `PBACRoleManager` instead of conditionally choosing between `PBACRoleManager` and `LegacyRoleManager`
- Always uses `PBACRemoveMemberService` instead of `LegacyRemoveMemberService`
- Updates permission checking to always use PBAC logic instead of fallback role-based checks
- Removes unused `FeaturesRepository` dependencies and legacy classes where no longer needed
- Updates all related tests to reflect always-enabled PBAC behavior
- Removes problematic ESLint disable comments that were causing configuration issues

**Files Modified:**
- `permission-check.service.ts` - Always executes PBAC permission checks
- `role-management.factory.ts` - Always returns PBACRoleManager
- `resource-permissions.ts` - Removes fallback role logic
- `RemoveMemberServiceFactory.ts` - Always returns PBACRemoveMemberService
- Settings layout components - Always shows PBAC menu items based on permissions
- Various handler files - Removes feature flag checks
- All related test files - Updated to reflect always-enabled PBAC

**Requested by:** @sean-brydon  
**Link to Devin run:** https://app.devin.ai/sessions/226f2d7ed5de42d2982162107ac5ba25

## How should this be tested?

⚠️ **Critical Testing Required** - This is a breaking change that removes fallback behavior.


**Pre-deployment verification:**
1. **Database state check**: Verify all production teams/organizations have proper PBAC configuration
2. **Permission testing**: Test all permission-related flows (team management, role assignment, member removal)
3. **Performance testing**: Monitor database query performance with always-on PBAC logic
4. **Error handling**: Test behavior when PBAC services encounter errors (no fallback available)

**Test scenarios:**
- Team member management (add/remove/update roles)
- Organization role and permission management  
- Settings navigation and menu visibility
- API endpoints that check permissions
- Edge cases with teams that previously relied on legacy role behavior

**Environment variables:**
- No new environment variables required
- Existing PBAC-related configuration should remain unchanged

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## ⚠️ Critical Review Points

**High Risk Areas to Review:**
1. **Breaking change impact**: Verify no production teams depend on legacy role behavior
2. **Database assumptions**: Ensure all teams have proper PBAC setup before deployment
3. **Performance implications**: Review impact of always running PBAC logic vs simple role checks
4. **Error handling**: Confirm graceful behavior when PBAC services fail (no fallback available)
5. **Completeness**: Search codebase for any remaining PBAC feature flag references that might have been missed

**Search patterns to verify:**
- `checkIfTeamHasFeature.*pbac`
- `PBAC.*feature.*flag`
- `isPBACEnabled`
- `LegacyRoleManager` usage

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings