### PR TITLE
fix: add @calcom/eslint-plugin to base ESLint config

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -5,6 +5,8 @@ import onlyWarn from "eslint-plugin-only-warn";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
 
+import calcomEslintPlugin from "@calcom/eslint-plugin-eslint";
+
 /**
  * A shared ESLint configuration for the repository.
  *
@@ -19,9 +21,11 @@ export const config = [
       turbo: turboPlugin,
       import: importPlugin,
       onlyWarn,
+      "@calcom/eslint": calcomEslintPlugin,
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
+      "@calcom/eslint/no-scroll-into-view-embed": "error",
     },
     languageOptions: {
       ecmaVersion: 2021,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,6 +9,7 @@
     "./react-internal": "./react-internal.js"
   },
   "dependencies": {
+    "@calcom/eslint-plugin-eslint": "workspace:*",
     "@eslint/js": "9.36.0",
     "@next/eslint-plugin-next": "15.4.5",
     "@typescript-eslint/eslint-plugin": "8.39.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,6 +3243,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/eslint-config@workspace:packages/eslint-config"
   dependencies:
+    "@calcom/eslint-plugin-eslint": "workspace:*"
     "@eslint/js": 9.36.0
     "@next/eslint-plugin-next": 15.4.5
     "@typescript-eslint/eslint-plugin": 8.39.0


### PR DESCRIPTION
## What does this PR do?

Fixes the ESLint warning in `packages/embeds/embed-core/src/embed.ts` where the rule `@calcom/eslint/no-scroll-into-view-embed` was not found.

The issue was that the `@calcom/eslint-plugin-eslint` package exists and contains the rule, but it wasn't imported and configured in the base ESLint configuration that all packages inherit from.

**Changes:**
- Added `@calcom/eslint-plugin-eslint` as a workspace dependency to the eslint-config package
- Imported and configured the plugin in `packages/eslint-config/base.js`
- Added the specific `no-scroll-into-view-embed` rule that was causing the warning

## How should this be tested?

**Verify the fix:**
1. Run `npx eslint packages/embeds/embed-core/src/embed.ts` from the root directory
2. Confirm that the previous warning "Definition for rule '@calcom/eslint/no-scroll-into-view-embed' was not found" no longer appears
3. Run `yarn lint:report` to ensure no regressions across all packages
4. Run `yarn type-check:ci --force` to verify no type issues were introduced

**Expected behavior:**
- ESLint should recognize the `@calcom/eslint/no-scroll-into-view-embed` rule
- The rule should properly validate usage of `scrollIntoView` in embed contexts
- No other ESLint or type checking errors should be introduced

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A - this is an internal ESLint configuration fix**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Verified via ESLint execution and lint:report**

## Review Focus Areas

**Key things to verify:**
- [ ] ESLint plugin import syntax is correct in `base.js`
- [ ] Plugin namespace `"@calcom/eslint"` matches the usage in embed.ts disable comments
- [ ] Workspace dependency addition is appropriate for monorepo structure
- [ ] No unintended side effects on other packages that inherit from base ESLint config


---

**Link to Devin run:** https://app.devin.ai/sessions/7a1a6a69fc1240509debc80a872596b5

**Requested by:** @hariombalhara