### PR TITLE
chore: Allow underscore variable pattern being ignored for eslint 

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -22,6 +22,7 @@ export const config = [
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
     languageOptions: {
       ecmaVersion: 2021,


### PR DESCRIPTION
## What does this PR do?

Allow `_var` being ignored by eslint. Useful when implementing interfaces.