### PR TITLE
fix: v2 api event type splitName booking field

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
@@ -38,6 +38,7 @@ import type {
   GuestsDefaultFieldOutput_2024_06_14,
   NameDefaultFieldInput_2024_06_14,
   NotesDefaultFieldInput_2024_06_14,
+  SplitNameDefaultFieldOutput_2024_06_14,
   UpdateEventTypeInput_2024_06_14,
 } from "@calcom/platform-types";
 import type { PlatformOAuthClient, Team, User, Schedule, EventType } from "@calcom/prisma/client";
@@ -1447,23 +1448,23 @@ describe("Event types Endpoints", () => {
       try {
         await eventTypesRepositoryFixture.delete(eventType.id);
       } catch (e) {
-        // Event type might have been deleted by the test
+        console.log(e);
       }
       try {
         await userRepositoryFixture.delete(user.id);
       } catch (e) {
-        // User might have been deleted by the test
+        console.log(e);
       }
       try {
         await userRepositoryFixture.delete(falseTestUser.id);
       } catch (e) {
-        // User might have been deleted by the test
+        console.log(e);
       }
 
       try {
         await userRepositoryFixture.delete(orgUser.id);
       } catch (e) {
-        // User might have been deleted by the test
+        console.log(e);
       }
       await app.close();
     });
@@ -2187,6 +2188,47 @@ describe("Event types Endpoints", () => {
       });
     });
 
+    describe("split name booking field", () => {
+      it("should create an event type with split name booking field", async () => {
+        const splitNameBookingField: SplitNameDefaultFieldOutput_2024_06_14 = {
+          isDefault: true,
+          type: "splitName",
+          slug: "splitName",
+          firstNameLabel: "First name",
+          firstNamePlaceholder: "",
+          lastNameLabel: "last name",
+          lastNamePlaceholder: "",
+          lastNameRequired: false,
+          disableOnPrefill: false,
+        };
+
+        const body: CreateEventTypeInput_2024_06_14 = {
+          title: "Coding class 9",
+          slug: "coding-class-9",
+          description: "Let's learn how to code like a pro.",
+          lengthInMinutes: 60,
+          bookingFields: [splitNameBookingField],
+        };
+
+        return request(app.getHttpServer())
+          .post("/api/v2/event-types")
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_06_14)
+          .send(body)
+          .expect(201)
+          .then(async (response) => {
+            const responseBody: ApiSuccessResponse<EventTypeOutput_2024_06_14> = response.body;
+            const createdEventType = responseBody.data;
+
+            const splitNameBookingField = createdEventType.bookingFields.find(
+              (field) => field.type === "splitName"
+            ) as SplitNameDefaultFieldOutput_2024_06_14 | undefined;
+            expect(splitNameBookingField).toEqual(splitNameBookingField);
+
+            await eventTypesRepositoryFixture.delete(createdEventType.id);
+          });
+      });
+    });
+
     afterAll(async () => {
       await oauthClientRepositoryFixture.delete(oAuthClient.id);
       await teamRepositoryFixture.delete(organization.id);
@@ -2194,12 +2236,12 @@ describe("Event types Endpoints", () => {
         await eventTypesRepositoryFixture.delete(legacyEventTypeId1);
         await eventTypesRepositoryFixture.delete(legacyEventTypeId2);
       } catch (e) {
-        // Event type might have been deleted by the test
+        console.log(e);
       }
       try {
         await userRepositoryFixture.delete(user.id);
       } catch (e) {
-        // User might have been deleted by the test
+        console.log(e);
       }
       await app.close();
     });
@@ -2379,7 +2421,7 @@ describe("Event types Endpoints", () => {
 
         const responseBody: ApiSuccessResponse<EventTypeOutput_2024_06_14> = response.body;
         const updatedEventType = responseBody.data;
-        +expect(updatedEventType.hidden).toBe(false);
+        expect(updatedEventType.hidden).toBe(false);
       });
     });
 
@@ -2389,12 +2431,12 @@ describe("Event types Endpoints", () => {
       try {
         await eventTypesRepositoryFixture.delete(legacyEventTypeId1);
       } catch (e) {
-        // Event type might have been deleted by the test
+        console.log(e);
       }
       try {
         await userRepositoryFixture.delete(user.id);
       } catch (e) {
-        // User might have been deleted by the test
+        console.log(e);
       }
       await app.close();
     });

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
@@ -2219,10 +2219,10 @@ describe("Event types Endpoints", () => {
             const responseBody: ApiSuccessResponse<EventTypeOutput_2024_06_14> = response.body;
             const createdEventType = responseBody.data;
 
-            const splitNameBookingField = createdEventType.bookingFields.find(
+            const splitNameBookingFieldResponse = createdEventType.bookingFields.find(
               (field) => field.type === "splitName"
             ) as SplitNameDefaultFieldOutput_2024_06_14 | undefined;
-            expect(splitNameBookingField).toEqual(splitNameBookingField);
+            expect(splitNameBookingFieldResponse).toEqual(splitNameBookingField);
 
             await eventTypesRepositoryFixture.delete(createdEventType.id);
           });

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -7,6 +7,7 @@ import { registerDecorator, validate, ValidatorConstraint } from "class-validato
 
 const inputBookingFieldTypes = [
   "name",
+  "splitName",
   "email",
   "phone",
   "address",


### PR DESCRIPTION
Linear [CAL-6472](https://linear.app/calcom/issue/CAL-6472/fix-v2-event-type-split-name)

Problem

When creating an event type with split name field there is an error
```
{
    "status": "error",
    "timestamp": "2025-09-25T07:30:51.426Z",
    "path": "/v2/organizations/93/teams/93/event-types",
    "error": {
        "code": "BadRequestException",
        "message": "Validation failed for splitName booking field: type must be one of the following values: name, email, phone, address, text, number, textarea, select, multiselect, multiemail, checkbox, radio, boolean, url",
        "details": {
            "message": "Validation failed for splitName booking field: type must be one of the following values: name, email, phone, address, text, number, textarea, select, multiselect, multiemail, checkbox, radio, boolean, url",
            "error": "Bad Request",
            "statusCode": 400
        }
    }
}
```

Solution

Add splitName within [booking-fields.input.ts](https://github.com/calcom/cal.com/pull/24111/files#diff-6ce91b48224dfe728e31c512191cbac482dd4f1aed148704b093958f4ee59aa6) - it was missing withininputBookingFieldTypes

Add a test creating event type with split name field [event-types.controller.e2e-spec.ts](https://github.com/calcom/cal.com/pull/24111/files#diff-76a5a6d2f3ed8aafa7f694b822bcfd2f8cee38d648cbfb767037447e077f0c4e)