### PR TITLE
refactor: replace checkAdminOrOwner with PBAC availability.read permission

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
@@ -5,10 +5,11 @@ import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { AvailabilitySliderTable } from "@calcom/features/timezone-buddy/components/AvailabilitySliderTable";
 import { OrganizationRepository } from "@calcom/lib/server/repository/organization";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { availabilityRouter } from "@calcom/trpc/server/routers/viewer/availability/_router";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
@@ -72,8 +73,14 @@ const Page = async ({ searchParams: _searchParams }: PageProps) => {
         orgId: organizationId,
       })
     : false;
-  const isOrgAdminOrOwner = checkAdminOrOwner(session?.user?.org?.role);
-  const canViewTeamAvailability = isOrgAdminOrOwner || !isOrgPrivate;
+
+  const permissionService = new PermissionCheckService();
+  const teamIdsWithPermission = await permissionService.getTeamIdsWithPermission({
+    userId: session.user.id,
+    permission: "availability.read",
+    fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
+  });
+  const canViewTeamAvailability = teamIdsWithPermission.length > 0 || !isOrgPrivate;
 
   return (
     <ShellMainAppDir


### PR DESCRIPTION
## What does this PR do?

Refactors the availability page to replace role-based permission checking (`checkAdminOrOwner`) with Cal.com's Permission-Based Access Control (PBAC) system using the `availability.read` permission. This change aligns with the ongoing PBAC migration initiative.

**Key Changes:**
- Replaces `checkAdminOrOwner(session?.user?.org?.role)` with `PermissionCheckService.getTeamIdsWithPermission()`
- Uses `availability.read` permission with `OWNER` and `ADMIN` fallback roles
- Maintains existing organization privacy logic (`|| !isOrgPrivate`)
- Follows established PBAC pattern from bookings implementation

**Context:** This addresses a Slack request from @eunjae-lee to migrate away from `checkAdminOrOwner` usage in favor of PBAC's `availability.read` permission.

## How should this be tested?

⚠️ **Critical**: This change affects access control logic and requires thorough testing with different user types:

1. **Organization Admin/Owner**: Should be able to view team availability toggle and access team availability page
2. **Organization Member**: Should only see team availability if organization is not private
3. **Team Admin/Owner**: Should be able to view team availability for their teams
4. **Team Member**: Should not see team availability toggle (unless org is public)
5. **Non-member**: Should not have any team availability access

**Test scenarios:**
- Navigate to `/availability` with different user roles
- Verify "Team Availability" toggle appears/disappears correctly  
- Verify team availability page loads when `?type=team` is selected
- Test in both private and public organizations

## Visual Demo

No UI changes expected - this is a backend permission logic change that should preserve existing behavior.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if needed (N/A - internal refactor)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works

## ⚠️ Critical Review Areas

**Security & Access Control:**
- [ ] Verify permission check behavior is equivalent to original `checkAdminOrOwner` logic
- [ ] Confirm `availability.read` is the correct permission string for this use case  
- [ ] Validate fallback roles (`OWNER`, `ADMIN`) match original admin/owner scope
- [ ] Test null safety: original code had `session?.user?.org?.role` optional chaining vs new `session.user.id`

**Behavioral Verification:**
- [ ] Ensure no legitimate users lose access to team availability features
- [ ] Verify organization privacy logic (`|| !isOrgPrivate`) still works correctly
- [ ] Confirm team-level permissions don't inadvertently grant broader access than org-level roles

---

**Link to Devin run:** https://app.devin.ai/sessions/42aa58f552d247148068f19b884b63b1  
**Requested by:** @eunjae-lee via Slack