### PR TITLE
refactor: replace checkAdminOrOwner with team.create permission in teams page

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -67,7 +67,9 @@ export const ServerTeamsListing = async ({
       <TeamsListing
         teams={teams}
         orgId={orgId ?? null}
-        isOrgAdmin={canCreateTeam}
+        permissions={{
+          canCreateTeam: canCreateTeam,
+        }}
         teamNameFromInvite={teamNameFromInvite ?? null}
         errorMsgFromInvite={errorMsgFromInvite}
       />

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -52,15 +52,14 @@ export const ServerTeamsListing = async ({
   const orgId = userProfile?.organizationId ?? session?.user.org?.id;
 
   const permissionCheckService = new PermissionCheckService();
-  const teamIdsWithCreatePermission = orgId
-    ? await permissionCheckService.getTeamIdsWithPermission({
+  const canCreateTeam = orgId
+    ? await permissionCheckService.checkPermission({
         userId: session.user.id,
+        teamId: orgId,
         permission: "team.create",
         fallbackRoles: [MembershipRole.ADMIN, MembershipRole.OWNER],
       })
-    : [];
-
-  const canCreateTeam = !orgId || teamIdsWithCreatePermission.includes(orgId);
+    : false;
 
   return {
     Main: (

--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -19,7 +19,9 @@ import TeamList from "./TeamList";
 
 type TeamsListingProps = {
   orgId: number | null;
-  isOrgAdmin: boolean;
+  permissions: {
+    canCreateTeam: boolean;
+  };
   teams: RouterOutputs["viewer"]["teams"]["list"];
   teamNameFromInvite: string | null;
   errorMsgFromInvite: string | null;
@@ -27,7 +29,7 @@ type TeamsListingProps = {
 
 export function TeamsListing({
   orgId,
-  isOrgAdmin,
+  permissions,
   teams: data,
   teamNameFromInvite,
   errorMsgFromInvite,
@@ -51,7 +53,7 @@ export function TeamsListing({
     }
   );
 
-  const isCreateTeamButtonDisabled = !!(orgId && !isOrgAdmin);
+  const isCreateTeamButtonDisabled = !!(orgId && !permissions.canCreateTeam);
 
   const features = [
     {
@@ -128,7 +130,7 @@ export function TeamsListing({
           features={features}
           background="/tips/teams"
           buttons={
-            !orgId || isOrgAdmin ? (
+            !orgId || permissions.canCreateTeam ? (
               <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
                 <ButtonGroup>
                   <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>


### PR DESCRIPTION
## What does this PR do?

This PR refactors the teams server page to migrate from role-based access control to Permission-Based Access Control (PBAC), following the established PBAC refactoring guide patterns.

**Key Changes:**
- Replaces `checkAdminOrOwner` with `PermissionCheckService` to check `team.create` permission
- Updates `TeamsListing` component to use a `permissions` object instead of `isOrgAdmin` boolean prop
- Maintains existing functionality while moving to server-side permission checks

**Files Modified:**
- `apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx` - Permission check logic
- `packages/features/ee/teams/components/TeamsListing.tsx` - Component props interface

---

**Link to Devin run:** https://app.devin.ai/sessions/24bad72c8df24c66852409ffe4222142
**Requested by:** @eunjae-lee

## How should this be tested?

⚠️ **Important**: Local testing was limited due to authentication issues during development.

**Test Scenarios:**
1. **Organization Admin/Owner**: Should see enabled "Create Team" button
2. **Organization Member**: Should see disabled "Create Team" button  
3. **Non-organization User**: Should see enabled "Create Team" button
4. **Various permission levels**: Test users with different team membership roles

**Test Steps:**
1. Navigate to `/teams` page with different user permission levels
2. Verify create team button state matches user permissions
3. Test team creation flow works for authorized users
4. Verify error handling for unauthorized access attempts

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - follows existing PBAC patterns
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: Limited testing due to local auth issues

## Review Focus Areas

**Critical Review Points:**
1. **Permission Logic Correctness**: Verify `getTeamIdsWithPermission` with `team.create` permission correctly replaces `checkAdminOrOwner` behavior
2. **Fallback Roles**: Confirm `[MembershipRole.ADMIN, MembershipRole.OWNER]` matches original role check logic
3. **Edge Cases**: Review logic for users without organization membership (`!orgId || teamIdsWithCreatePermission.includes(orgId)`)
4. **Component Interface**: Ensure no other `TeamsListing` call sites are broken by the props change
5. **UI Behavior**: Test create team button state with various user permission levels

**Security Considerations:**
- Permission checks are now performed server-side (improvement)
- Uses established PBAC service patterns
- Maintains principle of least privilege

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] I have followed the PBAC refactoring guide patterns