### PR TITLE
chore: (PBAC) readonly eventTypes

### DIFF
--- a/packages/features/eventtypes/lib/getEventTypeById.ts
+++ b/packages/features/eventtypes/lib/getEventTypeById.ts
@@ -1,4 +1,5 @@
 //import "server-only";
+import type { LocationObject } from "@calcom/app-store/locations";
 import { getLocationGroupedOptions } from "@calcom/app-store/server";
 import { getEventTypeAppData } from "@calcom/app-store/utils";
 import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-utils";
@@ -10,7 +11,6 @@ import { parseBookingLimit } from "@calcom/lib/intervalLimits/isBookingLimits";
 import { parseDurationLimit } from "@calcom/lib/intervalLimits/isDurationLimits";
 import { parseEventTypeColor } from "@calcom/lib/isEventTypeColor";
 import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
-import type { LocationObject } from "@calcom/app-store/locations";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import { EventTypeRepository } from "@calcom/lib/server/repository/eventTypeRepository";
 import { UserRepository } from "@calcom/lib/server/repository/user";

--- a/packages/features/eventtypes/lib/getEventTypesByViewer.ts
+++ b/packages/features/eventtypes/lib/getEventTypesByViewer.ts
@@ -2,6 +2,7 @@
 import { orderBy } from "lodash";
 
 import { hasFilter } from "@calcom/features/filters/lib/hasFilter";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { getBookerBaseUrlSync } from "@calcom/lib/getBookerUrl/client";
@@ -19,8 +20,6 @@ import { teamMetadataSchema } from "@calcom/prisma/zod-utils";
 import { eventTypeMetaDataSchemaWithUntypedApps } from "@calcom/prisma/zod-utils";
 
 import { TRPCError } from "@trpc/server";
-
-import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 
 const log = logger.getSubLogger({ prefix: ["viewer.eventTypes.getByViewer"] });
 


### PR DESCRIPTION
## What does this PR do?
Uses the correct PBAC logic for setting metadata.readOnly  
