### PR TITLE
chore: Use enums instead of hardcoded strings

### DIFF
--- a/packages/features/auth/lib/checkAdminOrOwner.ts
+++ b/packages/features/auth/lib/checkAdminOrOwner.ts
@@ -1,5 +1,5 @@
-import type { MembershipRole } from "@calcom/prisma/enums";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 export function checkAdminOrOwner(role: MembershipRole | null | undefined): role is "OWNER" | "ADMIN" {
-  return role === "OWNER" || role === "ADMIN";
+  return role === MembershipRole.OWNER || role === MembershipRole.ADMIN;
 }

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -39,9 +39,9 @@ import { ProfileRepository } from "@calcom/lib/server/repository/profile";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import type { Membership, Team, UserPermissionRole } from "@calcom/prisma/client";
+import type { Membership, Team } from "@calcom/prisma/client";
 import { CreationSource } from "@calcom/prisma/enums";
-import { IdentityProvider, MembershipRole } from "@calcom/prisma/enums";
+import { IdentityProvider, MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
 import { teamMetadataSchema, userMetadata } from "@calcom/prisma/zod-utils";
 
 import { getOrgUsernameFromEmail } from "../signup/utils/getOrgUsernameFromEmail";
@@ -249,7 +249,7 @@ const providers: Provider[] = [
       // authentication success- but does it meet the minimum password requirements?
       const validateRole = (role: UserPermissionRole) => {
         // User's role is not "ADMIN"
-        if (role !== "ADMIN") return role;
+        if (role !== UserPermissionRole.ADMIN) return role;
         // User's identity provider is not "CAL"
         if (user.identityProvider !== IdentityProvider.CAL) return role;
 

--- a/packages/features/bookings/lib/payment/processNoShowFeeOnCancellation.ts
+++ b/packages/features/bookings/lib/payment/processNoShowFeeOnCancellation.ts
@@ -2,6 +2,7 @@ import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-util
 import logger from "@calcom/lib/logger";
 import { MembershipRepository } from "@calcom/lib/server/repository/membership";
 import type { Payment } from "@calcom/prisma/client";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { handleNoShowFee } from "./handleNoShowFee";
 import { shouldChargeNoShowCancellationFee } from "./shouldChargeNoShowCancellationFee";
@@ -34,7 +35,7 @@ export const processNoShowFeeOnCancellation = async ({
 
     if (
       membership &&
-      (membership.role === UserPermissionRole.OWNER || membership.role === UserPermissionRole.ADMIN)
+      (membership.role === MembershipRole.OWNER || membership.role === MembershipRole.ADMIN)
     ) {
       log.info(
         `Booking ${booking.uid} was cancelled by team admin/owner (${cancelledByUserId}), skipping no-show fee`

--- a/packages/features/bookings/lib/payment/processNoShowFeeOnCancellation.ts
+++ b/packages/features/bookings/lib/payment/processNoShowFeeOnCancellation.ts
@@ -32,7 +32,10 @@ export const processNoShowFeeOnCancellation = async ({
       teamId: booking.eventType.teamId,
     });
 
-    if (membership && (membership.role === "ADMIN" || membership.role === "OWNER")) {
+    if (
+      membership &&
+      (membership.role === UserPermissionRole.OWNER || membership.role === UserPermissionRole.ADMIN)
+    ) {
       log.info(
         `Booking ${booking.uid} was cancelled by team admin/owner (${cancelledByUserId}), skipping no-show fee`
       );

--- a/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
+++ b/packages/features/ee/impersonation/lib/ImpersonationProvider.ts
@@ -11,7 +11,7 @@ import prisma from "@calcom/prisma";
 import type { User } from "@calcom/prisma/client";
 import type { Prisma } from "@calcom/prisma/client";
 import type { Membership } from "@calcom/prisma/client";
-import { MembershipRole } from "@calcom/prisma/enums";
+import { MembershipRole, UserPermissionRole } from "@calcom/prisma/enums";
 import type { OrgProfile, PersonalProfile, UserAsPersonalProfile } from "@calcom/types/UserProfile";
 
 import { Resource, CustomAction } from "../../../pbac/domain/types/permission-registry";
@@ -125,7 +125,8 @@ export function checkUserIdentifier(creds: Partial<Credentials>) {
 
 export function checkGlobalPermission(session: Session | null) {
   if (
-    (session?.user.role !== "ADMIN" && process.env.NEXT_PUBLIC_TEAM_IMPERSONATION === "false") ||
+    (session?.user.role !== UserPermissionRole.ADMIN &&
+      process.env.NEXT_PUBLIC_TEAM_IMPERSONATION === "false") ||
     !session?.user
   ) {
     throw new Error("You do not have permission to do this.");
@@ -214,7 +215,11 @@ async function getImpersonatedUser({
 
   // If you are an admin we dont need to follow this flow -> We can just follow the usual flow
   // If orgId and teamId are the same we can follow the same flow
-  if (session?.user.org?.id && session.user.org.id !== teamId && session?.user.role !== "ADMIN") {
+  if (
+    session?.user.org?.id &&
+    session.user.org.id !== teamId &&
+    session?.user.role !== UserPermissionRole.ADMIN
+  ) {
     TeamWhereClause = {
       disableImpersonation: false,
       accepted: true,
@@ -300,7 +305,7 @@ async function isReturningToSelf({ session, creds }: { session: Session | null; 
     const inOrg =
       returningUser.organizationId || // Keep for backwards compatibility
       returningUser.profiles.some((profile) => profile.organizationId !== undefined); // New way of seeing if the user has a profile in orgs.
-    if (returningUser.role !== "ADMIN" && !inOrg) return;
+    if (returningUser.role !== UserPermissionRole.ADMIN && !inOrg) return;
 
     const hasTeams = returningUser.teams.length >= 1;
 
@@ -353,7 +358,7 @@ const ImpersonationProvider = CredentialsProvider({
     checkGlobalPermission(session);
 
     const impersonatedUser = await getImpersonatedUser({ session, teamId, creds });
-    if (session?.user.role === "ADMIN") {
+    if (session?.user.role === UserPermissionRole.ADMIN) {
       if (impersonatedUser.disableImpersonation) {
         throw new Error("This user has disabled Impersonation.");
       }
@@ -409,7 +414,10 @@ const ImpersonationProvider = CredentialsProvider({
 
     // Legacy role check as additional safeguard (PBAC should handle this but keeping for backwards compatibility)
     // We find team by ID so we know there is only one team in the array
-    if (sessionUserFromDb?.teams[0].role === "ADMIN" && impersonatedUser.teams[0].role === "OWNER") {
+    if (
+      sessionUserFromDb?.teams[0].role === MembershipRole.ADMIN &&
+      impersonatedUser.teams[0].role === MembershipRole.OWNER
+    ) {
       throw new Error("You do not have permission to do this.");
     }
 

--- a/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
+++ b/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
@@ -10,7 +10,7 @@ import { OrganizationOnboardingRepository } from "@calcom/lib/server/repository/
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import { prisma } from "@calcom/prisma";
 import type { OrganizationOnboarding } from "@calcom/prisma/client";
-import type { BillingPeriod } from "@calcom/prisma/enums";
+import { UserPermissionRole, type BillingPeriod } from "@calcom/prisma/enums";
 import { userMetadata } from "@calcom/prisma/zod-utils";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
@@ -294,7 +294,7 @@ export class OrganizationPaymentService {
 
     const { orgOwnerEmail, pricePerSeat, slug, billingPeriod, seats } = organizationOnboarding;
 
-    if (this.user.role === "ADMIN") {
+    if (this.user.role === UserPermissionRole.ADMIN) {
       log.debug("Admin flow, skipping checkout", safeStringify({ organizationOnboarding }));
       return {
         organizationOnboarding,

--- a/packages/features/ee/organizations/lib/OrganizationPermissionService.ts
+++ b/packages/features/ee/organizations/lib/OrganizationPermissionService.ts
@@ -1,8 +1,10 @@
+import { UserPermissionRole } from "@calcom/kysely/types";
 import { ORGANIZATION_SELF_SERVE_MIN_SEATS, ORGANIZATION_SELF_SERVE_PRICE } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { OrganizationRepository } from "@calcom/lib/server/repository/organization";
 import { prisma } from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
 import { TRPCError } from "@trpc/server";
@@ -50,7 +52,7 @@ export class OrganizationPermissionService {
   }
 
   hasPermissionToModifyDefaultPayment(): boolean {
-    return this.user.role === "ADMIN";
+    return this.user.role === UserPermissionRole.ADMIN;
   }
 
   hasModifiedDefaultPayment(data: SeatsPrice & { billingPeriod?: string }): boolean {
@@ -81,7 +83,7 @@ export class OrganizationPermissionService {
           in: teamIds,
         },
         role: {
-          in: ["OWNER", "ADMIN"],
+          in: [MembershipRole.OWNER, MembershipRole.ADMIN],
         },
       },
     });

--- a/packages/lib/server/repository/webhook.ts
+++ b/packages/lib/server/repository/webhook.ts
@@ -3,7 +3,7 @@ import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { prisma } from "@calcom/prisma";
 import type { Webhook } from "@calcom/prisma/client";
-import type { UserPermissionRole } from "@calcom/prisma/enums";
+import { UserPermissionRole } from "@calcom/prisma/enums";
 import { MembershipRole } from "@calcom/prisma/enums";
 
 type WebhookGroup = {
@@ -162,7 +162,7 @@ export class WebhookRepository {
     }
 
     // Add platform webhooks for admins
-    if (userRole === "ADMIN") {
+    if (userRole === UserPermissionRole.ADMIN) {
       const platformWebhooks = await prisma.webhook.findMany({
         where: { platform: true },
       });


### PR DESCRIPTION
## What does this PR do?

Uses enums across the app instead of hard coded strings. Makes this easier for PBAC migration
