### PR TITLE
fix: v2 create org user with time zone

### DIFF
--- a/apps/api/v2/src/modules/organizations/users/index/controllers/organizations-users.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/users/index/controllers/organizations-users.e2e-spec.ts
@@ -351,6 +351,7 @@ describe("Organizations Users Endpoints", () => {
         email: `organizations-users-new-member-${randomString()}@api.com`,
         bio,
         metadata,
+        timeZone: "Europe/Rome",
       };
 
       const emailSpy = jest
@@ -367,6 +368,7 @@ describe("Organizations Users Endpoints", () => {
       expect(userData.email).toBe(newOrgUser.email);
       expect(userData.bio).toBe(newOrgUser.bio);
       expect(userData.metadata).toEqual(newOrgUser.metadata);
+      expect(userData.timeZone).toBe(newOrgUser.timeZone);
       expect(emailSpy).toHaveBeenCalledWith({
         usernameOrEmail: newOrgUser.email,
         orgName: org.name,

--- a/apps/api/v2/src/modules/users/inputs/create-user.input.ts
+++ b/apps/api/v2/src/modules/users/inputs/create-user.input.ts
@@ -1,3 +1,4 @@
+import { CapitalizeTimeZone } from "@/lib/inputs/capitalize-timezone";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Expose, Transform } from "class-transformer";
 import {
@@ -112,6 +113,7 @@ export class CreateUserInput {
   @ApiProperty({ type: String, required: false, description: "Time zone", example: "America/New_York" })
   @IsOptional()
   @IsString()
+  @CapitalizeTimeZone()
   @Validate(TimeZoneValidator)
   @Expose()
   timeZone?: string;

--- a/apps/api/v2/src/modules/users/validators/timeZoneValidator.ts
+++ b/apps/api/v2/src/modules/users/validators/timeZoneValidator.ts
@@ -1,6 +1,6 @@
 import type { ValidatorConstraintInterface } from "class-validator";
 import { ValidatorConstraint } from "class-validator";
-import tzdata from "tzdata";
+import * as tzdata from "tzdata";
 
 @ValidatorConstraint({ name: "timezoneValidator", async: false })
 export class TimeZoneValidator implements ValidatorConstraintInterface {


### PR DESCRIPTION
Fixes #24067

## Problem

The reason for the issue was `apps/api/v2/src/modules/users/validators/timeZoneValidator.ts` 

Specifically:
```
import tzdata from "tzdata";
```

if you would log tzdata it would be logged as undefined because probably the package does not have module.exports.default.

## Solution

We can fix this by using namespace import `import * as tzdata from "tzdata";` which will import entire module.exports object containing time zones.

Also updated `apps/api/v2/src/modules/users/inputs/create-user.input.ts` to `CapitalizeTimeZone` aka user can pass europe/Rome and it will be capitalized to Europe/Rome so that the validation does not fail.

## Tests
Added test in `organizations-users.e2e-spec.ts` testing organization user creation with time zone.