### PR TITLE
fix: preserve evt metadata in BOOKING_CREATED webhooks

### DIFF
--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -473,9 +473,16 @@ export async function handleConfirmation(args: {
       eventTypeId: eventType?.id,
       status: "ACCEPTED",
       smsReminderNumber: booking.smsReminderNumber || undefined,
-      metadata: meetingUrl ? { videoCallUrl: meetingUrl } : undefined,
       ...(platformClientParams ? platformClientParams : {}),
     };
+
+    // Add videoCallUrl to existing metadata if meeting URL exists
+    if (meetingUrl) {
+      payload.metadata = {
+        ...(payload.metadata || {}),
+        videoCallUrl: meetingUrl,
+      };
+    }
 
     const promises = subscribersBookingCreated.map((sub) =>
       sendPayload(


### PR DESCRIPTION
Fix metadata inconsistency where BOOKING_CREATED overwrote existing metadata from evt with only videoCallUrl, while BOOKING_REQUESTED preserved all metadata.

Root cause: Property ordering in object spread caused explicit metadata assignment to overwrite the spread evt metadata.

Solution: Preserve evt metadata by merging videoCallUrl after payload creation instead of overwriting during object construction.

This ensures both BOOKING_REQUESTED and BOOKING_CREATED have consistent metadata structures for webhook integrations.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

  Property ordering in object spread caused explicit metadata assignment to overwrite the spread evt metadata:

  ```typescript
  // Before (broken)
  const payload = {
    ...evt,              // Spreads metadata from evt
    metadata: meetingUrl ? { videoCallUrl: meetingUrl } : undefined  // Overwrites!
  }
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR
 