### PR TITLE
chore: avoid using PrismaMock

### DIFF
--- a/apps/api/v1/eslint.config.mjs
+++ b/apps/api/v1/eslint.config.mjs
@@ -1,3 +1,11 @@
+import { forbid } from "@calcom/eslint-config/base";
 import { nextJsConfig } from "@calcom/eslint-config/next-js";
 
-export default nextJsConfig;
+export default [
+  ...nextJsConfig,
+  forbid({
+    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
+];

--- a/apps/api/v1/eslint.config.mjs
+++ b/apps/api/v1/eslint.config.mjs
@@ -1,11 +1,3 @@
-import { forbid } from "@calcom/eslint-config/base";
 import { nextJsConfig } from "@calcom/eslint-config/next-js";
 
-export default [
-  ...nextJsConfig,
-  forbid({
-    from: "../../tests/libs/__mocks__/prismaMock.ts",
-    target: ".",
-    message: "Please don't use prismaMock",
-  }),
-];
+export default nextJsConfig;

--- a/apps/ui-playground/eslint.config.mjs
+++ b/apps/ui-playground/eslint.config.mjs
@@ -1,3 +1,11 @@
+import { forbid } from "@calcom/eslint-config/base";
 import { nextJsConfig } from "@calcom/eslint-config/next-js";
 
-export default nextJsConfig;
+export default [
+  ...nextJsConfig,
+  forbid({
+    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
+];

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,3 +1,11 @@
+import { forbid } from "@calcom/eslint-config/base";
 import { nextJsConfig } from "@calcom/eslint-config/next-js";
 
-export default [...nextJsConfig];
+export default [
+  ...nextJsConfig,
+  forbid({
+    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
+];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,10 @@
-import { config } from "@calcom/eslint-config/base";
+import { config, forbid } from "@calcom/eslint-config/base";
 
-export default config;
+export default [
+  ...config,
+  forbid({
+    from: "tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
+];

--- a/packages/features/eslint.config.mjs
+++ b/packages/features/eslint.config.mjs
@@ -7,4 +7,9 @@ export default [
     from: "../app-store/**",
     target: ".",
   }),
+  forbid({
+    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
 ];

--- a/packages/platform/examples/base/eslint.config.mjs
+++ b/packages/platform/examples/base/eslint.config.mjs
@@ -1,3 +1,11 @@
+import { forbid } from "@calcom/eslint-config/base";
 import { nextJsConfig } from "@calcom/eslint-config/next-js";
 
-export default nextJsConfig;
+export default [
+  ...nextJsConfig,
+  forbid({
+    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    target: ".",
+    message: "Please don't use prismaMock",
+  }),
+];

--- a/packages/platform/examples/base/eslint.config.mjs
+++ b/packages/platform/examples/base/eslint.config.mjs
@@ -4,7 +4,7 @@ import { nextJsConfig } from "@calcom/eslint-config/next-js";
 export default [
   ...nextJsConfig,
   forbid({
-    from: "../../tests/libs/__mocks__/prismaMock.ts",
+    from: "../../../../tests/libs/__mocks__/prismaMock.ts",
     target: ".",
     message: "Please don't use prismaMock",
   }),

--- a/tests/libs/__mocks__/prismaMock.ts
+++ b/tests/libs/__mocks__/prismaMock.ts
@@ -16,4 +16,7 @@ beforeEach(() => {
   mockReset(prisma);
 });
 
+/**
+ * @deprecated Please don't use prismaMock
+ */
 export default prisma;


### PR DESCRIPTION
## What does this PR do?

- Adds an eslint warning for importing PrismaMock
- Deprecate PrismaMock

<img width="1850" height="160" alt="image" src="https://github.com/user-attachments/assets/2a114410-b910-429e-87f2-b276f129d5bb" />

