### PR TITLE
test: replace prismaMock with BookingRepository mock in checkBookingLimits tests

### DIFF
--- a/apps/web/test/lib/checkBookingLimits.test.ts
+++ b/apps/web/test/lib/checkBookingLimits.test.ts
@@ -1,11 +1,16 @@
-import prismaMock from "../../../../tests/libs/__mocks__/prismaMock";
-
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import dayjs from "@calcom/dayjs";
 import { getCheckBookingLimitsService } from "@calcom/lib/di/containers/BookingLimits";
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 import { validateIntervalLimitOrder } from "@calcom/lib/intervalLimits/validateIntervalLimitOrder";
+
+const mockCountBookingsByEventTypeAndDateRange = vi.fn();
+vi.mock("@calcom/lib/server/repository/booking", () => ({
+  BookingRepository: vi.fn().mockImplementation(() => ({
+    countBookingsByEventTypeAndDateRange: mockCountBookingsByEventTypeAndDateRange,
+  })),
+}));
 
 type Mockdata = {
   id: number;
@@ -25,21 +30,20 @@ const checkBookingLimitsService = getCheckBookingLimitsService();
 
 describe("Check Booking Limits Tests", () => {
   it("Should return no errors", async () => {
-    prismaMock.booking.count.mockResolvedValue(0);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(0);
     expect(
       checkBookingLimitsService.checkBookingLimits(MOCK_DATA.bookingLimits, MOCK_DATA.startDate, MOCK_DATA.id)
     ).resolves.toBeTruthy();
   });
   it("Should throw an error", async () => {
-    // Mock there being two a day
-    prismaMock.booking.count.mockResolvedValue(2);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(2);
     expect(
       checkBookingLimitsService.checkBookingLimits(MOCK_DATA.bookingLimits, MOCK_DATA.startDate, MOCK_DATA.id)
     ).rejects.toThrowError();
   });
 
   it("Should pass with multiple booking limits", async () => {
-    prismaMock.booking.count.mockResolvedValue(0);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(0);
     expect(
       checkBookingLimitsService.checkBookingLimits(
         {
@@ -52,7 +56,7 @@ describe("Check Booking Limits Tests", () => {
     ).resolves.toBeTruthy();
   });
   it("Should pass with multiple booking limits with one undefined", async () => {
-    prismaMock.booking.count.mockResolvedValue(0);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(0);
 
     expect(
       checkBookingLimitsService.checkBookingLimits(
@@ -66,7 +70,7 @@ describe("Check Booking Limits Tests", () => {
     ).resolves.toBeTruthy();
   });
   it("Should handle multiple limits correctly", async () => {
-    prismaMock.booking.count.mockResolvedValue(1);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(1);
     expect(
       checkBookingLimitsService.checkBookingLimit({
         key: "PER_DAY",
@@ -75,7 +79,7 @@ describe("Check Booking Limits Tests", () => {
         eventId: MOCK_DATA.id,
       })
     ).resolves.not.toThrow();
-    prismaMock.booking.count.mockResolvedValue(3);
+    mockCountBookingsByEventTypeAndDateRange.mockResolvedValue(3);
     expect(
       checkBookingLimitsService.checkBookingLimit({
         key: "PER_WEEK",


### PR DESCRIPTION
## What does this PR do?

This PR refactors the `checkBookingLimits.test.ts` file to replace direct `prismaMock` usage with `BookingRepository` mocking, following the established pattern from PR #24050.

**Changes:**
- Removes `prismaMock` import and usage
- Adds `vi.mock` for `@calcom/lib/server/repository/booking`
- Creates `mockCountBookingsByEventTypeAndDateRange` function to mock the repository method
- Replaces all 6 instances of `prismaMock.booking.count.mockResolvedValue()` with the repository mock

This aligns with the broader initiative to move tests away from direct Prisma mocking to repository layer mocking, which provides better abstraction and more realistic test scenarios.

**Context:**
- Requested by @keithwillcode following the pattern established in PR #24050
- Part of ongoing effort to standardize repository mocking across the codebase
- No functional test logic changes - only the mocking mechanism is updated

## Visual Demo (For contributors especially)

N/A - This is a test refactoring with no user-facing changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is an internal test refactoring.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Test verification:**
```bash
# Run the specific test file to verify all tests pass
TZ=UTC yarn test apps/web/test/lib/checkBookingLimits.test.ts

# Run type checking to ensure no type errors
yarn type-check:ci --force
```

**Expected behavior:**
- All 10 tests should pass (5 booking limit tests + 5 validation tests)
- No type errors should be introduced
- Test behavior should be identical to before - only the mocking mechanism changed

**Key verification points:**
- Verify `mockCountBookingsByEventTypeAndDateRange` correctly mocks the method used by `CheckBookingLimitsService`
- Confirm all 6 instances of the old mock were properly replaced
- Ensure the mock returns the same data types as the original Prisma mock

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/568616dd181d4137a16a16948b6cfe35  
**Requested by:** @keithwillcode