### PR TITLE
chore: Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -41247,19 +41247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use-measure@npm:^2.1.1":
-  version: 2.1.7
-  resolution: "react-use-measure@npm:2.1.7"
-  peerDependencies:
-    react: ">=16.13"
-    react-dom: ">=16.13"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-  checksum: 5f00c14cf50b0710cdbd27b63a005be20283099d2fa2723a97f3a1cf0b2daedddd67249520c21e49e95348f56428689f3229c343dcb9ed37da58f9c227d29bee
-  languageName: node
-  linkType: hard
-
 "react-use@npm:^17.4.2":
   version: 17.5.0
   resolution: "react-use@npm:17.5.0"


### PR DESCRIPTION
yarn.lock is out of sync and is causing issues setting up our Devin machine.