### PR TITLE
fix: bring back correct routing form teams

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
@@ -18,6 +18,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useHasPaidPlan } from "@calcom/lib/hooks/useHasPaidPlan";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
+import { MembershipRole } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { ArrowButton } from "@calcom/ui/components/arrow-button";
 import { Badge } from "@calcom/ui/components/badge";
@@ -45,6 +46,10 @@ function NewFormButton({ setNewFormDialogState }: { setNewFormDialogState: SetNe
       data-testid="new-routing-form"
       createFunction={(teamId) => {
         setNewFormDialogState({ action: "new", target: teamId ? String(teamId) : "" });
+      }}
+      withPermission={{
+        permission: "routingForm.create",
+        fallbackRoles: [MembershipRole.OWNER, MembershipRole.ADMIN],
       }}
     />
   );


### PR DESCRIPTION
## What does this PR do?
Fixes the issue where org admins/owners using pbac would not see the correct teams to create a routing form on when they have the organization scoped permission (all sub-teams)

<img width="386" height="222" alt="CleanShot 2025-09-30 at 08 56 07" src="https://github.com/user-attachments/assets/f717f87a-255a-4016-81db-c8cfcfff1393" />

## How should this be tested?

Be in an org with pbac enable. Make yourself a member of sub-teams with no routing form permissions
Try create a routing form
