### PR TITLE
fix: Local crash on any page requiring billing-plan

### DIFF
--- a/packages/features/ee/billing/domain/billing-plans.ts
+++ b/packages/features/ee/billing/domain/billing-plans.ts
@@ -30,6 +30,8 @@ export class BillingPlanService {
       };
     }[]
   ) {
+    const localReferenceToBillingPlan = BillingPlan;
+
     if (memberships.length === 0) return BillingPlan.INDIVIDUALS;
 
     for (const { team, user } of memberships) {
@@ -74,6 +76,8 @@ export class BillingPlanService {
         }
       }
     }
-    return BillingPlan.UNKNOWN;
+    // Use a local reference because I don't know why Turbopack isn't able to correctly change the variable name for BillingPlan for this statement.
+    // Making a localReference avoids the need to do that change by turbopack and thus fixes the local run-time issue
+    return localReferenceToBillingPlan.UNKNOWN;
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
