### PR TITLE
fix: remove team members from filter segments when removed from team

### DIFF
--- a/packages/lib/server/service/teamService.ts
+++ b/packages/lib/server/service/teamService.ts
@@ -437,8 +437,6 @@ export class TeamService {
         },
       }),
     ]);
-
-    await TeamService.cleanupFilterSegmentsWithRemovedUser(membership.userId, teamId);
   }
 
   private static async getAllChildTeamIds(teamId: number): Promise<number[]> {


### PR DESCRIPTION
closes: #24165

- fixes permission errors when accessing bookings after team members are removed - cleans up filter segments that still reference removed users.

**What does this PR do?**
- Removes user IDs from filter segments when team members are removed
- Prevents "no permissions to fetch bookings" errors for removed team members
- Updates team-scoped filter segments to exclude removed users