### PR TITLE
fix: show filters on permission errors to prevent users getting stuck

### DIFF
--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -395,6 +395,11 @@ function BookingsContent({ status, permissions }: BookingsProps) {
 
   const getFacetedUniqueValues = useFacetedUniqueValues();
 
+  // Log errors in development for debugging
+  if (process.env.NODE_ENV !== "production" && query.isError) {
+    console.error("Bookings query error:", query.error);
+  }
+
   const table = useReactTable<RowData>({
     data: finalData,
     columns,
@@ -427,7 +432,7 @@ function BookingsContent({ status, permissions }: BookingsProps) {
       <main className="w-full">
         <div className="flex w-full flex-col">
           {query.isError && (
-            <Alert severity="error" title={t("something_went_wrong")} message={query.error.message} />
+            <Alert severity="error" title={t("something_went_wrong")} message={t("change_filter_common")} />
           )}
           {!!bookingsToday.length && status === "upcoming" && !query.isError && (
             <WipeMyCalActionButton bookingStatus={status} bookingsEmpty={isEmpty} />


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24167 
- Fixes [CAL-6490](https://linear.app/calcom/issue/CAL-6490/allow-adjusting-booking-filters-when-no-permission-error-is-shown)

**Problem**: When users encountered permission errors (like a MEMBER trying to access filter segments that query other users' bookings), they got stuck with a "Something went wrong" error because all filter controls were hidden, preventing them from changing filters to fix the issue.

**Solution**: Always show filter controls and provide clear error messaging with actionable guidance, allowing users to change their filters and resolve permission issues.

**Before**: 
- Error alert shown
- All filter controls hidden (FilterBar, Clear Filters, Save Segment, Select Segment)
- User cannot change filters to fix permission issue

**After**:
- Error alert with helpful message ("Change the filter to see results")
- All filter controls remain visible and functional
- Empty table state with guidance icon
- User can modify filters to resolve permission issues

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write **N/A** here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

### Prerequisites:
- Two user accounts: one admin and one that will become a member
- Both users should be in the same organization/team
