### PR TITLE
fix: 405 method not allowed error for queuedFormResponseCleanup

### DIFF
--- a/apps/web/app/api/cron/queuedFormResponseCleanup/route.ts
+++ b/apps/web/app/api/cron/queuedFormResponseCleanup/route.ts
@@ -2,4 +2,4 @@ import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
 
 import { handleQueuedFormResponseCleanup } from "@calcom/app-store/routing-forms/cron/queuedFormResponseCleanup";
 
-export const POST = defaultResponderForAppDir(handleQueuedFormResponseCleanup);
+export const GET = defaultResponderForAppDir(handleQueuedFormResponseCleanup);


### PR DESCRIPTION
Switch to allowing GET request as vercel.json sends GET request to cron