### PR TITLE
fix: sanitize username input to prevent hyperlinks

### DIFF
--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -21,8 +21,9 @@ import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/
 import { Label, Input } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 
-import type { TRPCClientErrorLike } from "@trpc/client";
 import { sanitizeUsername } from "@lib/sanitizeUsername";
+
+import type { TRPCClientErrorLike } from "@trpc/client";
 
 export enum UsernameChangeStatusEnum {
   UPGRADE = "UPGRADE",
@@ -106,7 +107,8 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
   const updateUsername = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async () => {
       onSuccessMutation && (await onSuccessMutation());
-      await update({ username: inputUsernameValue });
+      const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
+      await update({ username: sanitizedUsername });
       setOpenDialogSaveUsername(false);
     },
     onError: (error) => {
@@ -236,7 +238,8 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
               if (searchParams?.toString() !== _searchParams.toString()) {
                 router.replace(`${pathname}?${_searchParams.toString()}`);
               }
-              setInputUsernameValue(event.target.value);
+              const sanitized = sanitizeUsername(event.target.value);
+              setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"
           />

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -20,8 +20,7 @@ import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
 import { Label, Input } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-
-import { sanitizeUsername } from "@lib/sanitizeUsername";
+import slugify from "@calcom/lib/slugify";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -83,7 +82,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
 
   useEffect(() => {
     // Use the current username or if it's not set, use the one available from stripe
-    setInputUsernameValue(sanitizeUsername(currentUsername || stripeCustomer?.username || ""));
+    setInputUsernameValue(slugify(currentUsername || stripeCustomer?.username || ""));
   }, [setInputUsernameValue, currentUsername, stripeCustomer?.username]);
 
   useEffect(() => {
@@ -107,7 +106,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
   const updateUsername = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async () => {
       onSuccessMutation && (await onSuccessMutation());
-      const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
+      const sanitizedUsername = slugify(inputUsernameValue || "");
       await update({ username: sanitizedUsername });
       setOpenDialogSaveUsername(false);
     },
@@ -174,7 +173,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
   };
 
   const saveUsername = () => {
-    const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
+    const sanitizedUsername = slugify(inputUsernameValue || "");
     if (usernameChangeCondition !== UsernameChangeStatusEnum.UPGRADE) {
       updateUsername.mutate({
         username: sanitizedUsername,
@@ -238,7 +237,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
               if (searchParams?.toString() !== _searchParams.toString()) {
                 router.replace(`${pathname}?${_searchParams.toString()}`);
               }
-              const sanitized = sanitizeUsername(event.target.value);
+              const sanitized = slugify(event.target.value);
               setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -22,6 +22,7 @@ import { Label, Input } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
+import { sanitizeUsername } from "@lib/sanitizeUsername";
 
 export enum UsernameChangeStatusEnum {
   UPGRADE = "UPGRADE",
@@ -171,11 +172,12 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
   };
 
   const saveUsername = () => {
+    const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
     if (usernameChangeCondition !== UsernameChangeStatusEnum.UPGRADE) {
       updateUsername.mutate({
-        username: inputUsernameValue,
+        username: sanitizedUsername,
       });
-      setCurrentUsername(inputUsernameValue);
+      setCurrentUsername(sanitizedUsername);
     }
   };
 

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -83,7 +83,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
 
   useEffect(() => {
     // Use the current username or if it's not set, use the one available from stripe
-    setInputUsernameValue(currentUsername || stripeCustomer?.username || "");
+    setInputUsernameValue(sanitizeUsername(currentUsername || stripeCustomer?.username || ""));
   }, [setInputUsernameValue, currentUsername, stripeCustomer?.username]);
 
   useEffect(() => {

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -13,6 +13,7 @@ import { fetchUsername } from "@calcom/lib/fetchUsername";
 import hasKeyInMetadata from "@calcom/lib/hasKeyInMetadata";
 import { useDebounce } from "@calcom/lib/hooks/useDebounce";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import slugify from "@calcom/lib/slugify";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
@@ -20,7 +21,6 @@ import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
 import { Label, Input } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
-import slugify from "@calcom/lib/slugify";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -82,7 +82,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
 
   useEffect(() => {
     // Use the current username or if it's not set, use the one available from stripe
-    setInputUsernameValue(slugify(currentUsername || stripeCustomer?.username || ""));
+    setInputUsernameValue(slugify(currentUsername || stripeCustomer?.username || "", true));
   }, [setInputUsernameValue, currentUsername, stripeCustomer?.username]);
 
   useEffect(() => {
@@ -237,7 +237,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
               if (searchParams?.toString() !== _searchParams.toString()) {
                 router.replace(`${pathname}?${_searchParams.toString()}`);
               }
-              const sanitized = slugify(event.target.value);
+              const sanitized = slugify(event.target.value, true);
               setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -16,8 +16,7 @@ import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/
 import { TextField } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-
-import { sanitizeUsername } from "@lib/sanitizeUsername";
+import slugify from "@calcom/lib/slugify";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -74,7 +73,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
 
   const updateUsernameMutation = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async () => {
-      const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
+      const sanitizedUsername = slugify(inputUsernameValue || "");
       onSuccessMutation && (await onSuccessMutation());
       setOpenDialogSaveUsername(false);
       setCurrentUsername(sanitizedUsername);
@@ -111,7 +110,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
   };
 
   const updateUsername = async () => {
-    const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
+    const sanitizedUsername = slugify(inputUsernameValue || "");
     updateUsernameMutation.mutate({
       username: sanitizedUsername,
     });
@@ -138,7 +137,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
             )}
             onChange={(event) => {
               event.preventDefault();
-              const sanitized = sanitizeUsername(event.target.value);
+              const sanitized = slugify(event.target.value);
               setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -17,8 +17,9 @@ import { TextField } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
-import type { TRPCClientErrorLike } from "@trpc/client";
 import { sanitizeUsername } from "@lib/sanitizeUsername";
+
+import type { TRPCClientErrorLike } from "@trpc/client";
 
 interface ICustomUsernameProps {
   currentUsername: string | undefined;
@@ -110,8 +111,9 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
   };
 
   const updateUsername = async () => {
+    const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
     updateUsernameMutation.mutate({
-      username: inputUsernameValue,
+      username: sanitizedUsername,
     });
   };
 
@@ -136,7 +138,8 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
             )}
             onChange={(event) => {
               event.preventDefault();
-              setInputUsernameValue(event.target.value);
+              const sanitized = sanitizeUsername(event.target.value);
+              setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"
             {...rest}

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -18,6 +18,7 @@ import { Icon } from "@calcom/ui/components/icon";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
+import { sanitizeUsername } from "@lib/sanitizeUsername";
 
 interface ICustomUsernameProps {
   currentUsername: string | undefined;
@@ -72,10 +73,11 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
 
   const updateUsernameMutation = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async () => {
+      const sanitizedUsername = sanitizeUsername(inputUsernameValue || "");
       onSuccessMutation && (await onSuccessMutation());
       setOpenDialogSaveUsername(false);
-      setCurrentUsername(inputUsernameValue);
-      await update({ username: inputUsernameValue });
+      setCurrentUsername(sanitizedUsername);
+      await update({ username: sanitizedUsername });
     },
     onError: (error) => {
       onErrorMutation && onErrorMutation(error);

--- a/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/UsernameTextfield.tsx
@@ -137,7 +137,7 @@ const UsernameTextfield = (props: ICustomUsernameProps & Partial<React.Component
             )}
             onChange={(event) => {
               event.preventDefault();
-              const sanitized = slugify(event.target.value);
+              const sanitized = slugify(event.target.value, true);
               setInputUsernameValue(sanitized);
             }}
             data-testid="username-input"

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -10,6 +10,7 @@ import { trpc } from "@calcom/trpc/react";
 import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 
 import useRouterQuery from "@lib/hooks/useRouterQuery";
+import { sanitizeUsername } from "@lib/sanitizeUsername";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -56,7 +57,7 @@ export const UsernameAvailabilityField = ({
       : { username: currentUsernameState || "", setQuery: setCurrentUsernameState };
   const formMethods = useForm({
     defaultValues: {
-      username: currentUsername,
+      username: sanitizeUsername(currentUsername || user.username || ""),
     },
   });
 
@@ -78,7 +79,12 @@ export const UsernameAvailabilityField = ({
           setCurrentUsername={setCurrentUsername}
           inputUsernameValue={value}
           usernameRef={ref}
-          setInputUsernameValue={onChange}
+          setInputUsernameValue={(val) => {
+            const sanitizedUsername = sanitizeUsername(val);
+            onChange(sanitizedUsername);
+            formMethods.setValue("username", sanitized, { shouldDirty: true });
+            setCurrentUsername(sanitizedUsername);
+          }}
           onSuccessMutation={onSuccessMutation}
           onErrorMutation={onErrorMutation}
           disabled={!!user.organization?.id}

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -6,11 +6,11 @@ import { Controller, useForm } from "react-hook-form";
 
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { WEBSITE_URL, IS_SELF_HOSTED } from "@calcom/lib/constants";
+import slugify from "@calcom/lib/slugify";
 import { trpc } from "@calcom/trpc/react";
 import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 
 import useRouterQuery from "@lib/hooks/useRouterQuery";
-import slugify from "@calcom/lib/slugify";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -80,9 +80,9 @@ export const UsernameAvailabilityField = ({
           inputUsernameValue={value}
           usernameRef={ref}
           setInputUsernameValue={(val) => {
-            const sanitizedUsername = slugify(val);
-            formMethods.setValue("username", sanitizedUsername, { shouldDirty: true });
-            onChange?.(sanitizedUsername);
+            const displayValue = val.toLowerCase().trim();
+            formMethods.setValue("username", displayValue, { shouldDirty: true });
+            onChange?.(displayValue);
           }}
           onSuccessMutation={onSuccessMutation}
           onErrorMutation={onErrorMutation}

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -81,9 +81,8 @@ export const UsernameAvailabilityField = ({
           usernameRef={ref}
           setInputUsernameValue={(val) => {
             const sanitizedUsername = sanitizeUsername(val);
-            onChange(sanitizedUsername);
-            formMethods.setValue("username", sanitized, { shouldDirty: true });
-            setCurrentUsername(sanitizedUsername);
+            formMethods.setValue("username", sanitizedUsername, { shouldDirty: true });
+            onChange?.(sanitizedUsername);
           }}
           onSuccessMutation={onSuccessMutation}
           onErrorMutation={onErrorMutation}

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -81,7 +81,7 @@ export const UsernameAvailabilityField = ({
           usernameRef={ref}
           setInputUsernameValue={(val) => {
             const displayValue = val.toLowerCase().trim();
-            formMethods.setValue("username", displayValue, { shouldDirty: true });
+            formMethods.setValue("username", displayValue);
             onChange?.(displayValue);
           }}
           onSuccessMutation={onSuccessMutation}

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -80,7 +80,7 @@ export const UsernameAvailabilityField = ({
           inputUsernameValue={value}
           usernameRef={ref}
           setInputUsernameValue={(val) => {
-            const displayValue = val.toLowerCase().trim();
+            const displayValue = slugify(val, true);
             formMethods.setValue("username", displayValue);
             onChange?.(displayValue);
           }}

--- a/apps/web/components/ui/UsernameAvailability/index.tsx
+++ b/apps/web/components/ui/UsernameAvailability/index.tsx
@@ -10,7 +10,7 @@ import { trpc } from "@calcom/trpc/react";
 import type { AppRouter } from "@calcom/trpc/types/server/routers/_app";
 
 import useRouterQuery from "@lib/hooks/useRouterQuery";
-import { sanitizeUsername } from "@lib/sanitizeUsername";
+import slugify from "@calcom/lib/slugify";
 
 import type { TRPCClientErrorLike } from "@trpc/client";
 
@@ -57,7 +57,7 @@ export const UsernameAvailabilityField = ({
       : { username: currentUsernameState || "", setQuery: setCurrentUsernameState };
   const formMethods = useForm({
     defaultValues: {
-      username: sanitizeUsername(currentUsername || user.username || ""),
+      username: slugify(currentUsername || user.username || ""),
     },
   });
 
@@ -80,7 +80,7 @@ export const UsernameAvailabilityField = ({
           inputUsernameValue={value}
           usernameRef={ref}
           setInputUsernameValue={(val) => {
-            const sanitizedUsername = sanitizeUsername(val);
+            const sanitizedUsername = slugify(val);
             formMethods.setValue("username", sanitizedUsername, { shouldDirty: true });
             onChange?.(sanitizedUsername);
           }}

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -1,8 +1,0 @@
-export const sanitizeUsername = (username: string): string => {
-  if (!username) return "";
-
-  return username
-    .replace(/^https?:\/\//i, "")
-    .replace(/[^a-zA-Z0-9-_.+*]/g, "")
-    .toLowerCase();
-};

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -1,0 +1,15 @@
+// apps/web/lib/sanitizeUsername.ts
+export const sanitizeUsername = (username: string) => {
+  if (!username) return "";
+
+  // Remove any URL scheme (http, https)
+  username = username.replace(/^https?:\/\//i, "");
+
+  // Remove any slashes, spaces, or other invalid characters
+  username = username.replace(/[^a-zA-Z0-9-_+]/g, "");
+
+  // Convert to lowercase
+  username = username.toLowerCase();
+
+  return username;
+};

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -1,4 +1,3 @@
-// apps/web/lib/sanitizeUsername.ts
 export const sanitizeUsername = (username: string): string => {
   if (!username) return "";
 

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -3,7 +3,7 @@ export const sanitizeUsername = (username: string): string => {
   if (!username) return "";
 
   return username
-    .replace(/^https?:\/\//i, "") // Remove any URL scheme (http, https)
-    .replace(/[^a-zA-Z0-9-_.+*]/g, "") // Remove invalid characters
-    .toLowerCase(); // Convert to lowercase
+    .replace(/^https?:\/\//i, "")
+    .replace(/[^a-zA-Z0-9-_.+*]/g, "")
+    .toLowerCase();
 };

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -6,7 +6,7 @@ export const sanitizeUsername = (username: string) => {
   username = username.replace(/^https?:\/\//i, "");
 
   // Remove any slashes, spaces, or other invalid characters
-  username = username.replace(/[^a-zA-Z0-9-_.+]/g, "");
+  username = username.replace(/[^a-zA-Z0-9-_.+*]/g, "");
 
   // Convert to lowercase
   username = username.toLowerCase();

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -6,7 +6,7 @@ export const sanitizeUsername = (username: string) => {
   username = username.replace(/^https?:\/\//i, "");
 
   // Remove any slashes, spaces, or other invalid characters
-  username = username.replace(/[^a-zA-Z0-9-_+]/g, "");
+  username = username.replace(/[^a-zA-Z0-9-_.+]/g, "");
 
   // Convert to lowercase
   username = username.toLowerCase();

--- a/apps/web/lib/sanitizeUsername.ts
+++ b/apps/web/lib/sanitizeUsername.ts
@@ -1,15 +1,9 @@
 // apps/web/lib/sanitizeUsername.ts
-export const sanitizeUsername = (username: string) => {
+export const sanitizeUsername = (username: string): string => {
   if (!username) return "";
 
-  // Remove any URL scheme (http, https)
-  username = username.replace(/^https?:\/\//i, "");
-
-  // Remove any slashes, spaces, or other invalid characters
-  username = username.replace(/[^a-zA-Z0-9-_.+*]/g, "");
-
-  // Convert to lowercase
-  username = username.toLowerCase();
-
-  return username;
+  return username
+    .replace(/^https?:\/\//i, "") // Remove any URL scheme (http, https)
+    .replace(/[^a-zA-Z0-9-_.+*]/g, "") // Remove invalid characters
+    .toLowerCase(); // Convert to lowercase
 };


### PR DESCRIPTION
## What does this PR do?
This PR ensures that usernames are properly sanitized before being saved or displayed. Previously, usernames containing hyperlinks or invalid characters could break UI behavior or introduce unintended links. 

Maintains support for allowed characters such as `+` for group meetings.

#### Video Demo:

I copy pasting following URL into username field: `https://google.com`

Before:


https://github.com/user-attachments/assets/2dcbdc5e-0a21-4684-9e8c-60b130bcaaa3



After: 


https://github.com/user-attachments/assets/ba2dffb9-a5d6-4406-b598-684a1c5489b6



## Allowed Characters

- **Letters**: a-z, A-Z → converted to lowercase  
- **Numbers**: 0-9  
- **Special characters**: `-`, `_`, `+`, `.` , `*` 

### Examples of allowed usernames

| Input                   | Sanitized Output      |
|-------------------------|--------------------|
| `JohnDoe`               | `johndoe`          |
| `john.doe`              | `john.doe`         |
| `john_doe`              | `john_doe`         |
| `john-doe`              | `john-doe`         |
| `john*doe`              | `john*doe`         |
| `john+doe123`           | `john+doe123`      |
| `https://John.Doe`      | `john.doe`         |
| `http://John-Doe_123`   | `john-doe_123`     |

---

## Disallowed Characters

- Spaces  
- Slashes `/` or `\`  
- Special symbols like `@`, `#`, `!`, `$`, `%`, `&`, etc.  
- URL schemes (`http`, `https`) are removed  

### Examples of disallowed characters

| Input                   | Sanitized Output      |
|-------------------------|--------------------|
| `John Doe`              | `johndoe`          |
| `john/doe`              | `johndoe`          |
| `john@doe`              | `johndoe`          |
| `john#doe!`             | `johndoe`          |
| `https://evil.com/john` | `evil.comjohn`     |
