### PR TITLE
fix: unify booking input sizing and improve radio spacing (#24237)

### DIFF
--- a/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
+++ b/packages/app-store/routing-forms/components/react-awesome-query-builder/widgets.tsx
@@ -91,7 +91,7 @@ const TextAreaWidget = (props: TextLikeComponentPropsRAQB) => {
     <TextArea
       value={textValue}
       placeholder={placeholder}
-      className="mb-2"
+      className="calcom-input-field mb-2"
       disabled={readOnly}
       onChange={onChange}
       maxLength={maxLength}
@@ -119,8 +119,8 @@ const TextWidget = (props: TextLikeComponentPropsRAQB) => {
   const textValue = value || "";
   return (
     <TextField
-      size="sm"
-      containerClassName="w-full mb-2"
+      size="md"
+      containerClassName="w-full mb-2 calcom-input-field"
       type={type}
       value={textValue}
       noLabel={noLabel}
@@ -136,10 +136,10 @@ const TextWidget = (props: TextLikeComponentPropsRAQB) => {
 function NumberWidget({ value, setValue, ...remainingProps }: TextLikeComponentPropsRAQB) {
   return (
     <TextField
-      size="sm"
+      size="md"
       type="number"
       labelSrOnly={remainingProps.noLabel}
-      containerClassName="w-full"
+      containerClassName="w-full calcom-input-field"
       className="mb-2"
       value={value}
       onChange={(e) => {

--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -140,7 +140,7 @@ export const Components: Record<FieldType, Component> = {
             showAsteriskIndicator={true}
             placeholder={variantField.placeholder}
             label={variantField.label}
-            containerClassName="w-full"
+            containerClassName="w-full calcom-input-field"
             readOnly={props.readOnly}
             value={value}
             required={variantField.required}
@@ -170,7 +170,7 @@ export const Components: Record<FieldType, Component> = {
               readOnly={props.readOnly}
               placeholder={variantField.placeholder}
               label={variantField.label}
-              containerClassName={`w-full testid-${variantField.name}`}
+              containerClassName={`w-full calcom-input-field testid-${variantField.name}`}
               value={value[variantField.name as keyof typeof value]}
               required={variantField.required}
               type="text"
@@ -211,6 +211,7 @@ export const Components: Record<FieldType, Component> = {
           type="email"
           id={props.name}
           noLabel={true}
+          containerClassName="calcom-input-field"
           {...props}
           onChange={(e) => props.setValue(e.target.value)}
         />
@@ -321,7 +322,7 @@ export const Components: Record<FieldType, Component> = {
         ...props,
         listValues: props.options.map((o) => ({ title: o.label, value: o.value })),
       };
-      return <Widgets.MultiSelectWidget id={props.name} {...newProps} />;
+      return <Widgets.MultiSelectWidget id={props.name} className="calcom-multiselect-field" {...newProps} />;
     },
   },
   select: {
@@ -331,7 +332,7 @@ export const Components: Record<FieldType, Component> = {
         ...props,
         listValues: props.options.map((o) => ({ title: o.label, value: o.value })),
       };
-      return <Widgets.SelectWidget id={props.name} {...newProps} />;
+      return <Widgets.SelectWidget id={props.name} className="calcom-select-field" {...newProps} />;
     },
   },
   checkbox: {
@@ -380,6 +381,7 @@ export const Components: Record<FieldType, Component> = {
                 key={`option.${i}.radio`}
                 value={option.label}
                 id={`${name}.option.${i}.radio`}
+                className="calcom-radio-field"
               />
             ))}
           </>

--- a/packages/platform/atoms/globals.css
+++ b/packages/platform/atoms/globals.css
@@ -26215,6 +26215,29 @@ input:hover+.\[input\:hover_\+_\&\]\:border-l-default {
   background-position: -96px -154px
 }
 
+/* Mobile form field consistency fixes */
+@media (max-width: 768px) {
+  /* Ensure all form inputs have consistent height and border radius */
+  .calcom-input-field input,
+  .calcom-select-field .react-select__control,
+  .calcom-multiselect-field .react-select__control {
+    min-height: 35px !important;
+    height: 35px !important;
+    border-radius: 6px !important;
+  }
+
+  /* Improve radio button spacing on mobile */
+  .calcom-radio-field {
+    margin-bottom: 12px !important;
+    padding: 8px 0 !important;
+  }
+
+  .calcom-radio-field label {
+    line-height: 1.5 !important;
+    padding: 4px 0 !important;
+  }
+}
+
 .react-tel-input * {
   box-sizing: border-box;
   -moz-box-sizing: border-box

--- a/packages/platform/atoms/globals.css
+++ b/packages/platform/atoms/globals.css
@@ -26215,9 +26215,8 @@ input:hover+.\[input\:hover_\+_\&\]\:border-l-default {
   background-position: -96px -154px
 }
 
-/* Mobile form field consistency fixes */
+
 @media (max-width: 768px) {
-  /* Ensure all form inputs have consistent height and border radius */
   .calcom-input-field input,
   .calcom-select-field .react-select__control,
   .calcom-multiselect-field .react-select__control {

--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -14,7 +14,7 @@ import type { InputFieldProps, InputProps } from "./types";
 export const inputStyles = cva(
   [
     // Base styles
-    "rounded-[10px] border",
+    "rounded-md border",
     "leading-none font-normal",
 
     // Colors
@@ -43,7 +43,7 @@ export const inputStyles = cva(
     variants: {
       size: {
         sm: "h-7 px-2 py-1 text-xs",
-        md: "h-8 px-3 py-2 text-sm",
+        md: "h-[35px] px-3 py-2 text-sm",
       },
     },
     defaultVariants: {
@@ -125,7 +125,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
     readOnly,
     showAsteriskIndicator,
     onClickAddon,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     t: __t,
     dataTestid,
     size,
@@ -180,7 +180,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
             {...(type == "search" && {
               onChange: (e) => {
                 setInputValue(e.target.value);
-                props.onChange && props.onChange(e);
+                props.onChange?.(e);
               },
               value: inputValue,
             })}
@@ -202,7 +202,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
               className="text-subtle absolute top-2.5 h-4 w-4 cursor-pointer ltr:right-2 rtl:left-2"
               onClick={(e) => {
                 setInputValue("");
-                props.onChange && props.onChange(e as unknown as React.ChangeEvent<HTMLInputElement>);
+                props.onChange?.(e as unknown as React.ChangeEvent<HTMLInputElement>);
               }}
             />
           )}

--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -52,8 +52,8 @@ export const Select = <
       styles={{
         control: (base) => ({
           ...base,
-          minHeight: size === "sm" ? "28px" : "32px",
-          height: grow ? "auto" : size === "sm" ? "28px" : "32px",
+          minHeight: size === "sm" ? "28px" : "35px",
+          height: grow ? "auto" : size === "sm" ? "28px" : "35px",
         }),
       }}
       classNames={{
@@ -81,7 +81,7 @@ export const Select = <
               ? "h-7 px-2 py-1"
               : "h-8 px-3 py-2",
             props.isDisabled && "bg-subtle",
-            "rounded-[10px]",
+            "rounded-md",
             "[&:focus-within]:border-emphasis [&:focus-within]:shadow-outline-gray-focused [&:focus-within]:ring-0 !flex",
             innerClassNames?.control
           ),
@@ -219,7 +219,7 @@ export function SelectWithValidation<
             position: "absolute",
           }}
           value={hiddenInputValue}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
+           
           onChange={() => {}}
           // TODO:Not able to get focus to work
           // onFocus={() => selectRef.current?.focus()}

--- a/packages/ui/components/radio/Radio.tsx
+++ b/packages/ui/components/radio/Radio.tsx
@@ -32,7 +32,7 @@ export const Label = (props: JSX.IntrinsicElements["label"] & { disabled?: boole
   <label
     {...props}
     className={classNames(
-      "text-emphasis ms-2 w-full text-sm font-medium leading-5",
+      "text-emphasis ms-2 w-full text-sm font-medium leading-6",
       props.disabled && "text-subtle"
     )}
   />
@@ -55,8 +55,8 @@ export const RadioField = ({
 }) => (
   <div
     className={classNames(
-      "flex items-start",
-      withPadding && "hover:bg-subtle cursor-pointer rounded-lg p-1.5",
+      "mb-2 flex items-start",
+      withPadding && "hover:bg-subtle cursor-pointer rounded-lg p-2",
       className
     )}>
     <Radio value={value} disabled={disabled} id={id}>

--- a/packages/ui/components/radio/RadioAreaGroup.tsx
+++ b/packages/ui/components/radio/RadioAreaGroup.tsx
@@ -16,7 +16,7 @@ const RadioArea = ({ children, className, classNames: innerClassNames, ...props 
   return (
     <div
       className={classNames(
-        "border-subtle [&:has(input:checked)]:border-emphasis relative flex items-start rounded-[10px] border ",
+        "border-subtle [&:has(input:checked)]:border-emphasis relative flex items-start rounded-md border ",
         className
       )}>
       <RadioGroupPrimitive.Item
@@ -33,7 +33,7 @@ const RadioArea = ({ children, className, classNames: innerClassNames, ...props 
           )}
         />
       </RadioGroupPrimitive.Item>
-      <label htmlFor={id} className={classNames("text-default p-4 pl-10 pt-3", innerClassNames?.container)}>
+      <label htmlFor={id} className={classNames("text-default p-5 pl-12 pt-4", innerClassNames?.container)}>
         {children}
       </label>
     </div>


### PR DESCRIPTION
- Fixes #24237 

**Summary:**  
This PR fixes the accessibility and sizing issues on the booking page inputs and radio buttons. Specifically:  
- All input fields (first name, email, phone, and custom questions) now have the **same height** and **consistent corner radius**.  
- Radio button labels now have **increased line-height** and **vertical spacing** for better readability and easier tap/click accessibility on mobile.  
- Improves overall accessibility, readability, and visual consistency across booking pages.

**Motivation:**  
Users on mobile devices, especially those with glasses, were facing difficulties reading input labels and clicking radio buttons. This fix ensures **better UX and higher accessibility compliance**, reducing potential errors when entering booking information.

---

#### Image Demo 

**Before / After screenshots (mobile view):**

- **Before:**  

<img width="324" height="585" alt="Screenshot 2025-10-03 081907" src="https://github.com/user-attachments/assets/88631415-d299-4f67-881a-401a61ea9675" />
<img width="324" height="577" alt="Screenshot 2025-10-03 081923" src="https://github.com/user-attachments/assets/0a9c1fcf-bdd6-4152-8b20-4e47518f12db" />
  

- **After:**  

<img width="328" height="579" alt="Screenshot 2025-10-03 063242" src="https://github.com/user-attachments/assets/a4958979-2f8e-47d9-8d8b-d4f14fbfc472" />
<img width="327" height="583" alt="Screenshot 2025-10-03 063254" src="https://github.com/user-attachments/assets/b1ec6f05-7d81-4ae4-93a2-bd20b96b8070" />




---

## Mandatory Tasks 

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).  
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. → N/A  
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. → N/A (UI fix)

---

## How should this be tested?

- Run Cal.com locally with a seeded database or your test user:  
  ```bash
  yarn dev
