### PR TITLE
feat: add v2 attendees api endpoint

### DIFF
--- a/apps/api/v2/src/ee/attendees/2024-09-04/attendees.module.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/attendees.module.ts
@@ -1,0 +1,15 @@
+import { AttendeesRepository_2024_09_04 } from "@/ee/attendees/2024-09-04/attendees.repository";
+import { AttendeesController_2024_09_04 } from "@/ee/attendees/2024-09-04/controllers/attendees.controller";
+import { AttendeesService_2024_09_04 } from "@/ee/attendees/2024-09-04/services/attendees.service";
+import { BookingsModule_2024_08_13 } from "@/ee/bookings/2024-08-13/bookings.module";
+import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { UsersModule } from "@/modules/users/users.module";
+import { Module } from "@nestjs/common";
+
+@Module({
+  imports: [PrismaModule, UsersModule, BookingsModule_2024_08_13],
+  providers: [AttendeesService_2024_09_04, AttendeesRepository_2024_09_04],
+  controllers: [AttendeesController_2024_09_04],
+  exports: [AttendeesService_2024_09_04, AttendeesRepository_2024_09_04],
+})
+export class AttendeesModule_2024_09_04 {}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/attendees.module.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/attendees.module.ts
@@ -3,11 +3,12 @@ import { AttendeesController_2024_09_04 } from "@/ee/attendees/2024-09-04/contro
 import { AttendeesService_2024_09_04 } from "@/ee/attendees/2024-09-04/services/attendees.service";
 import { BookingsModule_2024_08_13 } from "@/ee/bookings/2024-08-13/bookings.module";
 import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { TokensModule } from "@/modules/tokens/tokens.module";
 import { UsersModule } from "@/modules/users/users.module";
 import { Module } from "@nestjs/common";
 
 @Module({
-  imports: [PrismaModule, UsersModule, BookingsModule_2024_08_13],
+  imports: [PrismaModule, TokensModule, UsersModule, BookingsModule_2024_08_13],
   providers: [AttendeesService_2024_09_04, AttendeesRepository_2024_09_04],
   controllers: [AttendeesController_2024_09_04],
   exports: [AttendeesService_2024_09_04, AttendeesRepository_2024_09_04],

--- a/apps/api/v2/src/ee/attendees/2024-09-04/attendees.repository.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/attendees.repository.ts
@@ -46,9 +46,15 @@ export class AttendeesRepository_2024_09_04 {
   async getAttendeeWithBookingWithEventType(id: number) {
     return this.dbRead.prisma.attendee.findUnique({
       where: { id },
-      include: {
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        timeZone: true,
+        bookingId: true,
         booking: {
-          include: {
+          select: {
+            id: true,
             eventType: true,
           },
         },
@@ -59,7 +65,8 @@ export class AttendeesRepository_2024_09_04 {
   async getBookingWithEventType(bookingId: number) {
     return this.dbRead.prisma.booking.findUnique({
       where: { id: bookingId },
-      include: {
+      select: {
+        id: true,
         eventType: true,
       },
     });

--- a/apps/api/v2/src/ee/attendees/2024-09-04/attendees.repository.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/attendees.repository.ts
@@ -1,0 +1,67 @@
+import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
+import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
+import { Injectable } from "@nestjs/common";
+
+import type { CreateAttendeeInput_2024_09_04 } from "./inputs/create-attendee.input";
+import type { UpdateAttendeeInput_2024_09_04 } from "./inputs/update-attendee.input";
+
+@Injectable()
+export class AttendeesRepository_2024_09_04 {
+  constructor(private readonly dbRead: PrismaReadService, private readonly dbWrite: PrismaWriteService) {}
+
+  async createAttendee(data: CreateAttendeeInput_2024_09_04) {
+    return this.dbWrite.prisma.attendee.create({
+      data: {
+        email: data.email,
+        name: data.name,
+        timeZone: data.timeZone,
+        booking: {
+          connect: {
+            id: data.bookingId,
+          },
+        },
+      },
+    });
+  }
+
+  async updateAttendee(id: number, data: UpdateAttendeeInput_2024_09_04) {
+    return this.dbWrite.prisma.attendee.update({
+      where: { id },
+      data: {
+        ...(data.email && { email: data.email }),
+        ...(data.name && { name: data.name }),
+        ...(data.timeZone && { timeZone: data.timeZone }),
+      },
+    });
+  }
+
+  async deleteAttendee(id: number) {
+    return this.dbWrite.prisma.attendee.delete({
+      where: {
+        id,
+      },
+    });
+  }
+
+  async getAttendeeWithBookingWithEventType(id: number) {
+    return this.dbRead.prisma.attendee.findUnique({
+      where: { id },
+      include: {
+        booking: {
+          include: {
+            eventType: true,
+          },
+        },
+      },
+    });
+  }
+
+  async getBookingWithEventType(bookingId: number) {
+    return this.dbRead.prisma.booking.findUnique({
+      where: { id: bookingId },
+      include: {
+        eventType: true,
+      },
+    });
+  }
+}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
@@ -1,0 +1,158 @@
+import { CreateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/create-attendee.input";
+import { UpdateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/update-attendee.input";
+import {
+  CreateAttendeeOutput_2024_09_04,
+  UpdateAttendeeOutput_2024_09_04,
+  GetAttendeeOutput_2024_09_04,
+  DeleteAttendeeOutput_2024_09_04,
+  AttendeeOutput_2024_09_04,
+} from "@/ee/attendees/2024-09-04/outputs/attendee.output";
+import { AttendeesService_2024_09_04 } from "@/ee/attendees/2024-09-04/services/attendees.service";
+import { VERSION_2024_09_04_VALUE } from "@/lib/api-versions";
+import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Permissions } from "@/modules/auth/decorators/permissions/permissions.decorator";
+import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from "@nestjs/common";
+import { ApiOperation, ApiTags as DocsTags, ApiParam } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+
+import { BOOKING_READ, BOOKING_WRITE, SUCCESS_STATUS } from "@calcom/platform-constants";
+
+@Controller({
+  path: "/v2/attendees",
+  version: VERSION_2024_09_04_VALUE,
+})
+@UseGuards(PermissionsGuard)
+@DocsTags("Attendees")
+export class AttendeesController_2024_09_04 {
+  private readonly logger = new Logger("AttendeesController_2024_09_04");
+
+  constructor(private readonly attendeesService: AttendeesService_2024_09_04) {}
+
+  @Post("/")
+  @UseGuards(ApiAuthGuard)
+  @Permissions([BOOKING_WRITE])
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Create an attendee",
+    description: `
+      Creates a new attendee for an existing booking. The user must be the owner of the booking 
+      or have appropriate permissions (team member for team bookings, or system admin).
+    `,
+  })
+  async createAttendee(
+    @Body() body: CreateAttendeeInput_2024_09_04,
+    @GetUser() user: ApiAuthGuardUser
+  ): Promise<CreateAttendeeOutput_2024_09_04> {
+    const attendee = await this.attendeesService.createAttendee(body, user);
+    return {
+      status: SUCCESS_STATUS,
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+    };
+  }
+
+  @Get("/:attendeeId")
+  @UseGuards(ApiAuthGuard)
+  @Permissions([BOOKING_READ])
+  @ApiOperation({
+    summary: "Get an attendee by ID",
+    description: `
+      Retrieves an attendee by their ID. The user must have permission to view the booking
+      that the attendee belongs to.
+    `,
+  })
+  @ApiParam({
+    name: "attendeeId",
+    description: "The ID of the attendee to retrieve",
+    type: "number",
+  })
+  async getAttendee(
+    @Param("attendeeId") attendeeId: string,
+    @GetUser() user: ApiAuthGuardUser
+  ): Promise<GetAttendeeOutput_2024_09_04> {
+    const id = parseInt(attendeeId, 10);
+    if (isNaN(id)) {
+      throw new Error("Invalid attendee ID");
+    }
+    const attendee = await this.attendeesService.getAttendeeById(id, user);
+    return {
+      status: SUCCESS_STATUS,
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+    };
+  }
+
+  @Patch("/:attendeeId")
+  @UseGuards(ApiAuthGuard)
+  @Permissions([BOOKING_WRITE])
+  @ApiOperation({
+    summary: "Update an attendee",
+    description: `
+      Updates an existing attendee by their ID. The user must have permission to modify the booking
+      that the attendee belongs to. Only provided fields will be updated.
+    `,
+  })
+  @ApiParam({
+    name: "attendeeId",
+    description: "The ID of the attendee to update",
+    type: "number",
+  })
+  async updateAttendee(
+    @Param("attendeeId") attendeeId: string,
+    @Body() body: UpdateAttendeeInput_2024_09_04,
+    @GetUser() user: ApiAuthGuardUser
+  ): Promise<UpdateAttendeeOutput_2024_09_04> {
+    const id = parseInt(attendeeId, 10);
+    if (isNaN(id)) {
+      throw new Error("Invalid attendee ID");
+    }
+    const attendee = await this.attendeesService.updateAttendee(id, body, user);
+    return {
+      status: SUCCESS_STATUS,
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+    };
+  }
+
+  @Delete("/:attendeeId")
+  @UseGuards(ApiAuthGuard)
+  @Permissions([BOOKING_WRITE])
+  @ApiOperation({
+    summary: "Delete an attendee",
+    description: `
+      Deletes an attendee by their ID. The user must have permission to modify the booking 
+      that the attendee belongs to.
+    `,
+  })
+  @ApiParam({
+    name: "attendeeId",
+    description: "The ID of the attendee to delete",
+    type: "number",
+  })
+  async deleteAttendee(
+    @Param("attendeeId") attendeeId: string,
+    @GetUser() user: ApiAuthGuardUser
+  ): Promise<DeleteAttendeeOutput_2024_09_04> {
+    const id = parseInt(attendeeId, 10);
+    if (isNaN(id)) {
+      throw new Error("Invalid attendee ID");
+    }
+    const attendee = await this.attendeesService.deleteAttendee(id, user);
+    return {
+      status: SUCCESS_STATUS,
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+    };
+  }
+}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
@@ -26,6 +26,7 @@ import {
   HttpCode,
   HttpStatus,
   Logger,
+  BadRequestException,
 } from "@nestjs/common";
 import { ApiOperation, ApiTags as DocsTags, ApiParam } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
@@ -86,7 +87,7 @@ export class AttendeesController_2024_09_04 {
   ): Promise<GetAttendeeOutput_2024_09_04> {
     const id = parseInt(attendeeId, 10);
     if (isNaN(id)) {
-      throw new Error("Invalid attendee ID");
+      throw new BadRequestException("Invalid attendee ID");
     }
     const attendee = await this.attendeesService.getAttendeeById(id, user);
     return {
@@ -117,7 +118,7 @@ export class AttendeesController_2024_09_04 {
   ): Promise<UpdateAttendeeOutput_2024_09_04> {
     const id = parseInt(attendeeId, 10);
     if (isNaN(id)) {
-      throw new Error("Invalid attendee ID");
+      throw new BadRequestException("Invalid attendee ID");
     }
     const attendee = await this.attendeesService.updateAttendee(id, body, user);
     return {
@@ -147,7 +148,7 @@ export class AttendeesController_2024_09_04 {
   ): Promise<DeleteAttendeeOutput_2024_09_04> {
     const id = parseInt(attendeeId, 10);
     if (isNaN(id)) {
-      throw new Error("Invalid attendee ID");
+      throw new BadRequestException("Invalid attendee ID");
     }
     const attendee = await this.attendeesService.deleteAttendee(id, user);
     return {

--- a/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/controllers/attendees.controller.ts
@@ -61,7 +61,7 @@ export class AttendeesController_2024_09_04 {
     const attendee = await this.attendeesService.createAttendee(body, user);
     return {
       status: SUCCESS_STATUS,
-      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee, { strategy: "excludeAll" }),
     };
   }
 
@@ -91,7 +91,7 @@ export class AttendeesController_2024_09_04 {
     const attendee = await this.attendeesService.getAttendeeById(id, user);
     return {
       status: SUCCESS_STATUS,
-      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee, { strategy: "excludeAll" }),
     };
   }
 
@@ -122,7 +122,7 @@ export class AttendeesController_2024_09_04 {
     const attendee = await this.attendeesService.updateAttendee(id, body, user);
     return {
       status: SUCCESS_STATUS,
-      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee, { strategy: "excludeAll" }),
     };
   }
 
@@ -152,7 +152,7 @@ export class AttendeesController_2024_09_04 {
     const attendee = await this.attendeesService.deleteAttendee(id, user);
     return {
       status: SUCCESS_STATUS,
-      data: plainToClass(AttendeeOutput_2024_09_04, attendee),
+      data: plainToClass(AttendeeOutput_2024_09_04, attendee, { strategy: "excludeAll" }),
     };
   }
 }

--- a/apps/api/v2/src/ee/attendees/2024-09-04/controllers/e2e/attendees.e2e-spec.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/controllers/e2e/attendees.e2e-spec.ts
@@ -474,14 +474,16 @@ describe("Attendees Endpoints 2024-09-04", () => {
 
       beforeAll(async () => {
         // Create a fresh attendee to delete
-        const body: CreateAttendeeInput_2024_09_04 = {
-          bookingId: createdBooking.id,
+        attendeeToDelete = await attendeeRepositoryFixture.create({
+          booking: {
+            connect: {
+              id: createdBooking.id,
+            },
+          },
           email: "to-delete@example.com",
           name: "To Delete",
           timeZone: "UTC",
-        };
-
-        attendeeToDelete = await attendeeRepositoryFixture.create(body);
+        });
       });
 
       it("should delete an attendee", async () => {

--- a/apps/api/v2/src/ee/attendees/2024-09-04/controllers/e2e/attendees.e2e-spec.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/controllers/e2e/attendees.e2e-spec.ts
@@ -1,0 +1,997 @@
+import { bootstrap } from "@/app";
+import { AppModule } from "@/app.module";
+import type { CreateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/create-attendee.input";
+import type { UpdateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/update-attendee.input";
+import {
+  CreateAttendeeOutput_2024_09_04,
+  GetAttendeeOutput_2024_09_04,
+  UpdateAttendeeOutput_2024_09_04,
+  DeleteAttendeeOutput_2024_09_04,
+  AttendeeOutput_2024_09_04,
+} from "@/ee/attendees/2024-09-04/outputs/attendee.output";
+import { CreateScheduleInput_2024_04_15 } from "@/ee/schedules/schedules_2024_04_15/inputs/create-schedule.input";
+import { SchedulesModule_2024_04_15 } from "@/ee/schedules/schedules_2024_04_15/schedules.module";
+import { SchedulesService_2024_04_15 } from "@/ee/schedules/schedules_2024_04_15/services/schedules.service";
+import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
+import { PrismaModule } from "@/modules/prisma/prisma.module";
+import { UsersModule } from "@/modules/users/users.module";
+import { INestApplication } from "@nestjs/common";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { Test } from "@nestjs/testing";
+import * as request from "supertest";
+import { AttendeeRepositoryFixture } from "test/fixtures/repository/attendee.repository.fixture";
+import { BookingsRepositoryFixture } from "test/fixtures/repository/bookings.repository.fixture";
+import { EventTypesRepositoryFixture } from "test/fixtures/repository/event-types.repository.fixture";
+import { HostsRepositoryFixture } from "test/fixtures/repository/hosts.repository.fixture";
+import { MembershipRepositoryFixture } from "test/fixtures/repository/membership.repository.fixture";
+import { OAuthClientRepositoryFixture } from "test/fixtures/repository/oauth-client.repository.fixture";
+import { OrganizationRepositoryFixture } from "test/fixtures/repository/organization.repository.fixture";
+import { ProfileRepositoryFixture } from "test/fixtures/repository/profiles.repository.fixture";
+import { TeamRepositoryFixture } from "test/fixtures/repository/team.repository.fixture";
+import { UserRepositoryFixture } from "test/fixtures/repository/users.repository.fixture";
+import { randomString } from "test/utils/randomString";
+import { withApiAuth } from "test/utils/withApiAuth";
+
+import { CAL_API_VERSION_HEADER, SUCCESS_STATUS, VERSION_2024_09_04 } from "@calcom/platform-constants";
+import type { User, PlatformOAuthClient, Team, Booking, Attendee } from "@calcom/prisma/client";
+
+describe("Attendees Endpoints 2024-09-04", () => {
+  describe("User attendees", () => {
+    let app: INestApplication;
+    let organization: Team;
+
+    let userRepositoryFixture: UserRepositoryFixture;
+    let bookingsRepositoryFixture: BookingsRepositoryFixture;
+    let attendeeRepositoryFixture: AttendeeRepositoryFixture;
+    let schedulesService: SchedulesService_2024_04_15;
+    let eventTypesRepositoryFixture: EventTypesRepositoryFixture;
+    let oauthClientRepositoryFixture: OAuthClientRepositoryFixture;
+    let oAuthClient: PlatformOAuthClient;
+    let organizationsRepositoryFixture: OrganizationRepositoryFixture;
+
+    const userEmail = `attendees-user-${randomString()}@api.com`;
+    let user: User;
+
+    let eventTypeId: number;
+    const eventTypeSlug = `attendees-event-type-${randomString()}`;
+
+    let createdBooking: Booking;
+    let createdAttendee: AttendeeOutput_2024_09_04;
+
+    beforeAll(async () => {
+      const moduleRef = await withApiAuth(
+        userEmail,
+        Test.createTestingModule({
+          imports: [AppModule, PrismaModule, UsersModule, SchedulesModule_2024_04_15],
+        })
+      )
+        .overrideGuard(PermissionsGuard)
+        .useValue({
+          canActivate: () => true,
+        })
+        .compile();
+
+      userRepositoryFixture = new UserRepositoryFixture(moduleRef);
+      bookingsRepositoryFixture = new BookingsRepositoryFixture(moduleRef);
+      attendeeRepositoryFixture = new AttendeeRepositoryFixture(moduleRef);
+      eventTypesRepositoryFixture = new EventTypesRepositoryFixture(moduleRef);
+      oauthClientRepositoryFixture = new OAuthClientRepositoryFixture(moduleRef);
+      organizationsRepositoryFixture = new OrganizationRepositoryFixture(moduleRef);
+      schedulesService = moduleRef.get<SchedulesService_2024_04_15>(SchedulesService_2024_04_15);
+
+      organization = await organizationsRepositoryFixture.create({
+        name: `attendees-organization-${randomString()}`,
+        slug: `attendees-org-${randomString()}`,
+        isOrganization: true,
+      });
+      oAuthClient = await createOAuthClient(organization.id);
+
+      user = await userRepositoryFixture.create({
+        email: userEmail,
+        username: userEmail,
+        platformOAuthClients: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      const userSchedule: CreateScheduleInput_2024_04_15 = {
+        name: `attendees-schedule-${randomString()}`,
+        timeZone: "Europe/Rome",
+        isDefault: true,
+      };
+      await schedulesService.createUserSchedule(user.id, userSchedule);
+
+      const event = await eventTypesRepositoryFixture.create(
+        {
+          title: `attendees-event-type-${randomString()}`,
+          slug: eventTypeSlug,
+          length: 60,
+        },
+        user.id
+      );
+      eventTypeId = event.id;
+
+      // Create initial booking for testing
+      createdBooking = await bookingsRepositoryFixture.create({
+        user: {
+          connect: {
+            id: user.id,
+          },
+        },
+        startTime: new Date(Date.UTC(2030, 0, 8, 13, 0, 0)),
+        endTime: new Date(Date.UTC(2030, 0, 8, 14, 0, 0)),
+        title: "Test booking for attendees",
+        uid: `attendees-booking-${randomString()}`,
+        eventType: {
+          connect: {
+            id: eventTypeId,
+          },
+        },
+        location: "Jammu, India",
+        customInputs: {},
+        metadata: {},
+        responses: {
+          name: "Booking Owner",
+          email: userEmail,
+        },
+      });
+
+      app = moduleRef.createNestApplication();
+      bootstrap(app as NestExpressApplication);
+
+      await app.init();
+    });
+
+    async function createOAuthClient(organizationId: number) {
+      const data = {
+        logo: "logo-url",
+        name: "name",
+        redirectUris: ["http://localhost:5555"],
+        permissions: 32,
+      };
+      const secret = "secret";
+
+      const client = await oauthClientRepositoryFixture.create(organizationId, data, secret);
+      return client;
+    }
+
+    it("should be defined", () => {
+      expect(userRepositoryFixture).toBeDefined();
+      expect(user).toBeDefined();
+      expect(createdBooking).toBeDefined();
+    });
+
+    describe("create attendee", () => {
+      it("should create an attendee for user booking", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: createdBooking.id,
+          email: "new-attendee@example.com",
+          name: "New Attendee",
+          timeZone: "America/New_York",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(201)
+          .then(async (response) => {
+            const responseBody: CreateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data).toBeDefined();
+
+            const data: AttendeeOutput_2024_09_04 = responseBody.data;
+            expect(data.id).toBeDefined();
+            expect(data.bookingId).toEqual(body.bookingId);
+            expect(data.email).toEqual(body.email);
+            expect(data.name).toEqual(body.name);
+            expect(data.timeZone).toEqual(body.timeZone);
+
+            createdAttendee = data;
+          });
+      });
+
+      it("should create multiple attendees for same booking", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: createdBooking.id,
+          email: "second-attendee@example.com",
+          name: "Second Attendee",
+          timeZone: "Europe/London",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(201)
+          .then(async (response) => {
+            const responseBody: CreateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data.bookingId).toEqual(createdBooking.id);
+          });
+      });
+
+      it("should create attendee with special characters in name", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: createdBooking.id,
+          email: "unicode-attendee@example.com",
+          name: "Test 你好 🎉",
+          timeZone: "Asia/Tokyo",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(201)
+          .then(async (response) => {
+            const responseBody: CreateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.data.name).toEqual(body.name);
+          });
+      });
+
+      it("should fail with invalid bookingId", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: 999999,
+          email: "test@example.com",
+          name: "Test",
+          timeZone: "UTC",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+
+      it("should fail with invalid email format", async () => {
+        const body = {
+          bookingId: createdBooking.id,
+          email: "invalid-email",
+          name: "Test",
+          timeZone: "UTC",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+
+      it("should fail with invalid timezone", async () => {
+        const body = {
+          bookingId: createdBooking.id,
+          email: "test@example.com",
+          name: "Test",
+          timeZone: "Invalid/Timezone",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+
+      it("should fail with missing required fields", async () => {
+        const body = {
+          bookingId: createdBooking.id,
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+    });
+
+    describe("get attendee", () => {
+      it("should get an attendee by ID", async () => {
+        return request(app.getHttpServer())
+          .get(`/v2/attendees/${createdAttendee.id}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: GetAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data).toBeDefined();
+
+            const data: AttendeeOutput_2024_09_04 = responseBody.data;
+            expect(data.id).toEqual(createdAttendee.id);
+            expect(data.bookingId).toEqual(createdAttendee.bookingId);
+            expect(data.email).toEqual(createdAttendee.email);
+            expect(data.name).toEqual(createdAttendee.name);
+            expect(data.timeZone).toEqual(createdAttendee.timeZone);
+          });
+      });
+
+      it("should fail with invalid attendeeId format", async () => {
+        return request(app.getHttpServer())
+          .get(`/v2/attendees/invalid-id`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+
+      it("should fail when attendee doesn't exist", async () => {
+        return request(app.getHttpServer())
+          .get(`/v2/attendees/999999`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+    });
+
+    describe("update attendee", () => {
+      it("should update only email", async () => {
+        const originalName = createdAttendee.name;
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          email: "updated-email@example.com",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: UpdateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data.email).toEqual(updateBody.email);
+            expect(responseBody.data.name).toEqual(originalName);
+
+            // Update createdAttendee for next tests
+            createdAttendee = responseBody.data;
+          });
+      });
+
+      it("should update only name", async () => {
+        const originalEmail = createdAttendee.email;
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          name: "Updated Name",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: UpdateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.data.name).toEqual(updateBody.name);
+            expect(responseBody.data.email).toEqual(originalEmail);
+
+            createdAttendee = responseBody.data;
+          });
+      });
+
+      it("should update only timezone", async () => {
+        const originalEmail = createdAttendee.email;
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          timeZone: "Europe/Paris",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: UpdateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.data.timeZone).toEqual(updateBody.timeZone);
+            expect(responseBody.data.email).toEqual(originalEmail);
+
+            createdAttendee = responseBody.data;
+          });
+      });
+
+      it("should update all fields", async () => {
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          email: "all-updated@example.com",
+          name: "All Updated Name",
+          timeZone: "America/Los_Angeles",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: UpdateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.data.email).toEqual(updateBody.email);
+            expect(responseBody.data.name).toEqual(updateBody.name);
+            expect(responseBody.data.timeZone).toEqual(updateBody.timeZone);
+
+            createdAttendee = responseBody.data;
+          });
+      });
+
+      it("should update with same data (no-op)", async () => {
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          email: createdAttendee.email,
+          name: createdAttendee.name,
+          timeZone: createdAttendee.timeZone,
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: UpdateAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.data).toMatchObject({
+              email: createdAttendee.email,
+              name: createdAttendee.name,
+              timeZone: createdAttendee.timeZone,
+            });
+          });
+      });
+
+      it("should fail with invalid email format", async () => {
+        const updateBody = {
+          email: "invalid-email",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+
+      it("should fail with invalid timezone", async () => {
+        const updateBody = {
+          timeZone: "Invalid/Timezone",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${createdAttendee.id}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(400);
+      });
+
+      it("should fail when attendee doesn't exist", async () => {
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          name: "Updated",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/999999`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+    });
+
+    describe("delete attendee", () => {
+      let attendeeToDelete: Attendee;
+
+      beforeAll(async () => {
+        // Create a fresh attendee to delete
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: createdBooking.id,
+          email: "to-delete@example.com",
+          name: "To Delete",
+          timeZone: "UTC",
+        };
+
+        attendeeToDelete = await attendeeRepositoryFixture.create(body);
+      });
+
+      it("should delete an attendee", async () => {
+        return request(app.getHttpServer())
+          .delete(`/v2/attendees/${attendeeToDelete.id}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then(async (response) => {
+            const responseBody: DeleteAttendeeOutput_2024_09_04 = response.body;
+            expect(responseBody.status).toEqual(SUCCESS_STATUS);
+            expect(responseBody.data.id).toEqual(attendeeToDelete.id);
+          });
+      });
+
+      it("should fail to get deleted attendee", async () => {
+        return request(app.getHttpServer())
+          .get(`/v2/attendees/${attendeeToDelete.id}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+
+      it("should fail to delete already deleted attendee", async () => {
+        return request(app.getHttpServer())
+          .delete(`/v2/attendees/${attendeeToDelete.id}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+
+      it("should fail when attendee doesn't exist", async () => {
+        return request(app.getHttpServer())
+          .delete(`/v2/attendees/999999`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(404);
+      });
+    });
+
+    afterAll(async () => {
+      await userRepositoryFixture.delete(user.id);
+      await app.close();
+    });
+  });
+
+  describe("Team attendees", () => {
+    let app: INestApplication;
+    const organizationSlug = `team-attendees-org-${randomString()}`;
+    let organization: Team;
+    const teamSlug = `team-attendees-team-${randomString()}`;
+    let team: Team;
+
+    let userRepositoryFixture: UserRepositoryFixture;
+    let bookingsRepositoryFixture: BookingsRepositoryFixture;
+    let attendeeRepositoryFixture: AttendeeRepositoryFixture;
+    let schedulesService: SchedulesService_2024_04_15;
+    let eventTypesRepositoryFixture: EventTypesRepositoryFixture;
+    let oauthClientRepositoryFixture: OAuthClientRepositoryFixture;
+    let oAuthClient: PlatformOAuthClient;
+    let teamRepositoryFixture: TeamRepositoryFixture;
+    let membershipsRepositoryFixture: MembershipRepositoryFixture;
+    let hostsRepositoryFixture: HostsRepositoryFixture;
+    let organizationsRepositoryFixture: OrganizationRepositoryFixture;
+    let profileRepositoryFixture: ProfileRepositoryFixture;
+
+    const teamUserEmail = `team-attendees-user1-${randomString()}@api.com`;
+    const teamUser2Email = `team-attendees-user2-${randomString()}@api.com`;
+    const teamAdminEmail = `team-attendees-admin-${randomString()}@api.com`;
+    const nonTeamUserEmail = `team-attendees-nonteam-${randomString()}@api.com`;
+    let teamUser: User;
+    let teamUser2: User;
+    let teamAdmin: User;
+    let nonTeamUser: User;
+
+    let teamEventTypeId: number;
+    const teamEventTypeSlug = `team-attendees-event-type-${randomString()}`;
+    let teamBooking: Booking;
+
+    beforeAll(async () => {
+      const moduleRef = await withApiAuth(
+        teamUserEmail,
+        Test.createTestingModule({
+          imports: [AppModule, PrismaModule, UsersModule, SchedulesModule_2024_04_15],
+        })
+      )
+        .overrideGuard(PermissionsGuard)
+        .useValue({
+          canActivate: () => true,
+        })
+        .compile();
+
+      userRepositoryFixture = new UserRepositoryFixture(moduleRef);
+      bookingsRepositoryFixture = new BookingsRepositoryFixture(moduleRef);
+      attendeeRepositoryFixture = new AttendeeRepositoryFixture(moduleRef);
+      eventTypesRepositoryFixture = new EventTypesRepositoryFixture(moduleRef);
+      oauthClientRepositoryFixture = new OAuthClientRepositoryFixture(moduleRef);
+      teamRepositoryFixture = new TeamRepositoryFixture(moduleRef);
+      organizationsRepositoryFixture = new OrganizationRepositoryFixture(moduleRef);
+      profileRepositoryFixture = new ProfileRepositoryFixture(moduleRef);
+      membershipsRepositoryFixture = new MembershipRepositoryFixture(moduleRef);
+      hostsRepositoryFixture = new HostsRepositoryFixture(moduleRef);
+      schedulesService = moduleRef.get<SchedulesService_2024_04_15>(SchedulesService_2024_04_15);
+
+      organization = await organizationsRepositoryFixture.create({
+        name: organizationSlug,
+        slug: organizationSlug,
+        isOrganization: true,
+      });
+      oAuthClient = await createOAuthClient(organization.id);
+
+      team = await teamRepositoryFixture.create({
+        name: teamSlug,
+        slug: teamSlug,
+        isOrganization: false,
+        parent: { connect: { id: organization.id } },
+        createdByOAuthClient: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      teamUser = await userRepositoryFixture.create({
+        email: teamUserEmail,
+        locale: "en",
+        name: "Team User 1",
+        platformOAuthClients: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      teamUser2 = await userRepositoryFixture.create({
+        email: teamUser2Email,
+        locale: "en",
+        name: "Team User 2",
+        platformOAuthClients: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      teamAdmin = await userRepositoryFixture.create({
+        email: teamAdminEmail,
+        locale: "en",
+        name: "Team Admin",
+        platformOAuthClients: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      nonTeamUser = await userRepositoryFixture.create({
+        email: nonTeamUserEmail,
+        locale: "en",
+        name: "Non Team User",
+        platformOAuthClients: {
+          connect: {
+            id: oAuthClient.id,
+          },
+        },
+      });
+
+      const userSchedule: CreateScheduleInput_2024_04_15 = {
+        name: `team-attendees-schedule-${randomString()}`,
+        timeZone: "Europe/Rome",
+        isDefault: true,
+      };
+      await schedulesService.createUserSchedule(teamUser.id, userSchedule);
+      await schedulesService.createUserSchedule(teamUser2.id, userSchedule);
+      await schedulesService.createUserSchedule(teamAdmin.id, userSchedule);
+      await schedulesService.createUserSchedule(nonTeamUser.id, userSchedule);
+
+      await profileRepositoryFixture.create({
+        uid: `usr-${teamUser.id}`,
+        username: teamUserEmail,
+        organization: {
+          connect: {
+            id: organization.id,
+          },
+        },
+        user: {
+          connect: {
+            id: teamUser.id,
+          },
+        },
+      });
+
+      await profileRepositoryFixture.create({
+        uid: `usr-${teamUser2.id}`,
+        username: teamUser2Email,
+        organization: {
+          connect: {
+            id: organization.id,
+          },
+        },
+        user: {
+          connect: {
+            id: teamUser2.id,
+          },
+        },
+      });
+
+      await membershipsRepositoryFixture.create({
+        role: "MEMBER",
+        user: { connect: { id: teamUser.id } },
+        team: { connect: { id: team.id } },
+        accepted: true,
+      });
+
+      await membershipsRepositoryFixture.create({
+        role: "MEMBER",
+        user: { connect: { id: teamUser2.id } },
+        team: { connect: { id: team.id } },
+        accepted: true,
+      });
+
+      await membershipsRepositoryFixture.create({
+        role: "ADMIN",
+        user: { connect: { id: teamAdmin.id } },
+        team: { connect: { id: team.id } },
+        accepted: true,
+      });
+
+      const teamEventType = await eventTypesRepositoryFixture.createTeamEventType({
+        schedulingType: "COLLECTIVE",
+        team: {
+          connect: { id: team.id },
+        },
+        title: `team-attendees-event-type-${randomString()}`,
+        slug: teamEventTypeSlug,
+        length: 60,
+        assignAllTeamMembers: true,
+        bookingFields: [],
+        locations: [],
+      });
+
+      teamEventTypeId = teamEventType.id;
+
+      await hostsRepositoryFixture.create({
+        isFixed: true,
+        user: {
+          connect: {
+            id: teamUser.id,
+          },
+        },
+        eventType: {
+          connect: {
+            id: teamEventType.id,
+          },
+        },
+      });
+
+      // Create team booking
+      teamBooking = await bookingsRepositoryFixture.create({
+        user: {
+          connect: {
+            id: teamUser.id,
+          },
+        },
+        startTime: new Date(Date.UTC(2030, 0, 10, 13, 0, 0)),
+        endTime: new Date(Date.UTC(2030, 0, 10, 14, 0, 0)),
+        title: "Team booking for attendees",
+        uid: `team-attendees-booking-${randomString()}`,
+        eventType: {
+          connect: {
+            id: teamEventTypeId,
+          },
+        },
+        location: "https://meet.google.com/team-meeting",
+        customInputs: {},
+        metadata: {},
+        responses: {
+          name: "Team User 1",
+          email: teamUserEmail,
+        },
+      });
+
+      app = moduleRef.createNestApplication();
+      bootstrap(app as NestExpressApplication);
+
+      await app.init();
+    });
+
+    async function createOAuthClient(organizationId: number) {
+      const data = {
+        logo: "logo-url",
+        name: "name",
+        redirectUris: ["http://localhost:5555"],
+        permissions: 32,
+      };
+      const secret = "secret";
+
+      const client = await oauthClientRepositoryFixture.create(organizationId, data, secret);
+      return client;
+    }
+
+    it("should be defined", () => {
+      expect(teamRepositoryFixture).toBeDefined();
+      expect(team).toBeDefined();
+      expect(teamBooking).toBeDefined();
+    });
+
+    describe("team member permissions", () => {
+      it("team member (host) can create attendee", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: teamBooking.id,
+          email: "team-member-attendee@example.com",
+          name: "Team Member Attendee",
+          timeZone: "UTC",
+        };
+
+        return request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(201);
+      });
+
+      it("team member can get attendee", async () => {
+        // First create an attendee
+        const createBody: CreateAttendeeInput_2024_09_04 = {
+          bookingId: teamBooking.id,
+          email: "team-get-attendee@example.com",
+          name: "Team Get Attendee",
+          timeZone: "UTC",
+        };
+
+        const createResponse = await request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(createBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04);
+
+        const attendeeId = createResponse.body.data.id;
+
+        return request(app.getHttpServer())
+          .get(`/v2/attendees/${attendeeId}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200);
+      });
+
+      it("team member can update attendee", async () => {
+        // First create an attendee
+        const createBody: CreateAttendeeInput_2024_09_04 = {
+          bookingId: teamBooking.id,
+          email: "team-update-attendee@example.com",
+          name: "Team Update Attendee",
+          timeZone: "UTC",
+        };
+
+        const createResponse = await request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(createBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04);
+
+        const attendeeId = createResponse.body.data.id;
+
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          name: "Updated by Team Member",
+        };
+
+        return request(app.getHttpServer())
+          .patch(`/v2/attendees/${attendeeId}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200)
+          .then((response) => {
+            expect(response.body.data.name).toEqual(updateBody.name);
+          });
+      });
+
+      it("team member can delete attendee", async () => {
+        // First create an attendee
+        const createBody: CreateAttendeeInput_2024_09_04 = {
+          bookingId: teamBooking.id,
+          email: "team-delete-attendee@example.com",
+          name: "Team Delete Attendee",
+          timeZone: "UTC",
+        };
+
+        const createResponse = await request(app.getHttpServer())
+          .post("/v2/attendees")
+          .send(createBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04);
+
+        const attendeeId = createResponse.body.data.id;
+
+        return request(app.getHttpServer())
+          .delete(`/v2/attendees/${attendeeId}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200);
+      });
+    });
+
+    describe("team admin permissions (not host)", () => {
+      let adminModuleRef;
+      let adminApp: INestApplication;
+
+      beforeAll(async () => {
+        adminModuleRef = await withApiAuth(
+          teamAdminEmail,
+          Test.createTestingModule({
+            imports: [AppModule, PrismaModule, UsersModule, SchedulesModule_2024_04_15],
+          })
+        )
+          .overrideGuard(PermissionsGuard)
+          .useValue({
+            canActivate: () => true,
+          })
+          .compile();
+
+        adminApp = adminModuleRef.createNestApplication();
+        bootstrap(adminApp as NestExpressApplication);
+        await adminApp.init();
+      });
+
+      it("team admin can create attendee", async () => {
+        const body: CreateAttendeeInput_2024_09_04 = {
+          bookingId: teamBooking.id,
+          email: "admin-attendee@example.com",
+          name: "Admin Attendee",
+          timeZone: "UTC",
+        };
+
+        return request(adminApp.getHttpServer())
+          .post("/v2/attendees")
+          .send(body)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(201);
+      });
+
+      it("team admin can get attendee", async () => {
+        // Create an attendee first
+        const createdAttendee = await attendeeRepositoryFixture.create({
+          booking: {
+            connect: {
+              id: teamBooking.id,
+            },
+          },
+          email: "admin-get-attendee@example.com",
+          name: "Admin Get Attendee",
+          timeZone: "UTC",
+        });
+
+        const attendeeId = createdAttendee.id;
+
+        return request(adminApp.getHttpServer())
+          .get(`/v2/attendees/${attendeeId}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200);
+      });
+
+      it("team admin can update attendee", async () => {
+        // Create an attendee first
+        const createdAttendee = await attendeeRepositoryFixture.create({
+          booking: {
+            connect: {
+              id: teamBooking.id,
+            },
+          },
+          email: "admin-update-attendee@example.com",
+          name: "Admin Update Attendee",
+          timeZone: "UTC",
+        });
+
+        const attendeeId = createdAttendee.id;
+
+        const updateBody: UpdateAttendeeInput_2024_09_04 = {
+          name: "Updated by Admin",
+        };
+
+        return request(adminApp.getHttpServer())
+          .patch(`/v2/attendees/${attendeeId}`)
+          .send(updateBody)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200);
+      });
+
+      it("team admin can delete attendee", async () => {
+        // Create an attendee first
+        const createdAttendee = await attendeeRepositoryFixture.create({
+          booking: {
+            connect: {
+              id: teamBooking.id,
+            },
+          },
+          email: "admin-delete-attendee@example.com",
+          name: "Admin Delete Attendee",
+          timeZone: "UTC",
+        });
+
+        const attendeeId = createdAttendee.id;
+
+        return request(adminApp.getHttpServer())
+          .delete(`/v2/attendees/${attendeeId}`)
+          .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+          .expect(200);
+      });
+      afterAll(async () => {
+        await adminApp.close();
+      });
+    });
+
+    afterAll(async () => {
+      await userRepositoryFixture.delete(teamUser.id);
+      await userRepositoryFixture.delete(teamUser2.id);
+      await userRepositoryFixture.delete(teamAdmin.id);
+      await userRepositoryFixture.delete(nonTeamUser.id);
+      await bookingsRepositoryFixture.deleteById(teamBooking.id);
+      await app.close();
+    });
+  });
+});

--- a/apps/api/v2/src/ee/attendees/2024-09-04/inputs/create-attendee.input.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/inputs/create-attendee.input.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty as DocsProperty } from "@nestjs/swagger";
+import { IsEmail, IsInt, IsString, IsTimeZone } from "class-validator";
+
+export class CreateAttendeeInput_2024_09_04 {
+  @IsInt()
+  @ApiProperty({
+    description: "The ID of the booking to add the attendee to",
+    example: 123,
+  })
+  @DocsProperty()
+  bookingId!: number;
+
+  @IsEmail()
+  @ApiProperty({
+    description: "Email address of the attendee",
+    example: "attendee@example.com",
+  })
+  @DocsProperty()
+  email!: string;
+
+  @IsString()
+  @ApiProperty({
+    description: "Full name of the attendee",
+    example: "John Doe",
+  })
+  @DocsProperty()
+  name!: string;
+
+  @IsTimeZone()
+  @ApiProperty({
+    description: "Timezone of the attendee",
+    example: "America/New_York",
+  })
+  @DocsProperty()
+  timeZone!: string;
+}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/inputs/update-attendee.input.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/inputs/update-attendee.input.ts
@@ -1,0 +1,32 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { ApiProperty as DocsProperty } from "@nestjs/swagger";
+import { IsEmail, IsOptional, IsString, IsTimeZone } from "class-validator";
+
+export class UpdateAttendeeInput_2024_09_04 {
+  @IsOptional()
+  @IsEmail()
+  @ApiPropertyOptional({
+    description: "Email address of the attendee",
+    example: "attendee@example.com",
+  })
+  @DocsProperty()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "Full name of the attendee",
+    example: "John Doe",
+  })
+  @DocsProperty()
+  name?: string;
+
+  @IsOptional()
+  @IsTimeZone()
+  @ApiPropertyOptional({
+    description: "Timezone of the attendee",
+    example: "America/New_York",
+  })
+  @DocsProperty()
+  timeZone?: string;
+}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/outputs/attendee.output.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/outputs/attendee.output.ts
@@ -1,0 +1,104 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty as DocsProperty } from "@nestjs/swagger";
+import { Expose, Type } from "class-transformer";
+import { IsEnum, ValidateNested } from "class-validator";
+
+import { SUCCESS_STATUS, ERROR_STATUS } from "@calcom/platform-constants";
+
+export class AttendeeOutput_2024_09_04 {
+  @ApiProperty({
+    description: "Unique identifier for the attendee",
+    example: 456,
+  })
+  @DocsProperty()
+  @Expose()
+  id!: number;
+
+  @ApiProperty({
+    description: "The ID of the booking this attendee belongs to",
+    example: 123,
+  })
+  @DocsProperty()
+  @Expose()
+  bookingId!: number;
+
+  @ApiProperty({
+    description: "Email address of the attendee",
+    example: "attendee@example.com",
+  })
+  @DocsProperty()
+  @Expose()
+  email!: string;
+
+  @ApiProperty({
+    description: "Full name of the attendee",
+    example: "John Doe",
+  })
+  @DocsProperty()
+  @Expose()
+  name!: string;
+
+  @ApiProperty({
+    description: "Timezone of the attendee",
+    example: "America/New_York",
+  })
+  @DocsProperty()
+  @Expose()
+  timeZone!: string;
+}
+
+export class CreateAttendeeOutput_2024_09_04 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({
+    description: "The created attendee",
+    type: AttendeeOutput_2024_09_04,
+  })
+  @ValidateNested()
+  @Type(() => AttendeeOutput_2024_09_04)
+  data!: AttendeeOutput_2024_09_04;
+}
+
+export class UpdateAttendeeOutput_2024_09_04 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({
+    description: "The updated attendee",
+    type: AttendeeOutput_2024_09_04,
+  })
+  @ValidateNested()
+  @Type(() => AttendeeOutput_2024_09_04)
+  data!: AttendeeOutput_2024_09_04;
+}
+
+export class GetAttendeeOutput_2024_09_04 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({
+    description: "The attendee",
+    type: AttendeeOutput_2024_09_04,
+  })
+  @ValidateNested()
+  @Type(() => AttendeeOutput_2024_09_04)
+  data!: AttendeeOutput_2024_09_04;
+}
+
+export class DeleteAttendeeOutput_2024_09_04 {
+  @ApiProperty({ example: SUCCESS_STATUS, enum: [SUCCESS_STATUS, ERROR_STATUS] })
+  @IsEnum([SUCCESS_STATUS, ERROR_STATUS])
+  status!: typeof SUCCESS_STATUS | typeof ERROR_STATUS;
+
+  @ApiProperty({
+    description: "The deleted attendee",
+    type: AttendeeOutput_2024_09_04,
+  })
+  @ValidateNested()
+  @Type(() => AttendeeOutput_2024_09_04)
+  data!: AttendeeOutput_2024_09_04;
+}

--- a/apps/api/v2/src/ee/attendees/2024-09-04/services/attendees.service.ts
+++ b/apps/api/v2/src/ee/attendees/2024-09-04/services/attendees.service.ts
@@ -1,0 +1,105 @@
+import { AttendeesRepository_2024_09_04 } from "@/ee/attendees/2024-09-04/attendees.repository";
+import { CreateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/create-attendee.input";
+import { UpdateAttendeeInput_2024_09_04 } from "@/ee/attendees/2024-09-04/inputs/update-attendee.input";
+import { BookingsService_2024_08_13 } from "@/ee/bookings/2024-08-13/services/bookings.service";
+import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from "@nestjs/common";
+
+@Injectable()
+export class AttendeesService_2024_09_04 {
+  private readonly logger = new Logger("AttendeesService_2024_09_04");
+
+  constructor(
+    private readonly attendeesRepository: AttendeesRepository_2024_09_04,
+    private readonly bookingsService: BookingsService_2024_08_13
+  ) {}
+
+  async createAttendee(data: CreateAttendeeInput_2024_09_04, user: ApiAuthGuardUser) {
+    // Check if booking exists and user has permission
+    const booking = await this.attendeesRepository.getBookingWithEventType(data.bookingId);
+
+    if (!booking?.eventType || !this.bookingsService.userIsEventTypeAdminOrOwner(user, booking.eventType)) {
+      throw new NotFoundException("Booking not found or you don't have permission to modify it");
+    }
+
+    try {
+      const createdAttendee = await this.attendeesRepository.createAttendee(data);
+
+      return createdAttendee;
+    } catch (error) {
+      this.logger.error("Failed to create attendee", error);
+      throw new BadRequestException("Failed to create attendee");
+    }
+  }
+
+  async getAttendeeById(id: number, user: ApiAuthGuardUser) {
+    const attendee = await this.attendeesRepository.getAttendeeWithBookingWithEventType(id);
+
+    if (!attendee) {
+      throw new NotFoundException("Attendee not found");
+    }
+    if (
+      !attendee.booking?.eventType ||
+      !this.bookingsService.userIsEventTypeAdminOrOwner(user, attendee.booking.eventType)
+    ) {
+      throw new ForbiddenException("You don't have permission to view this attendee");
+    }
+
+    return attendee;
+  }
+
+  async updateAttendee(id: number, data: UpdateAttendeeInput_2024_09_04, user: ApiAuthGuardUser) {
+    const attendee = await this.attendeesRepository.getAttendeeWithBookingWithEventType(id);
+
+    if (!attendee) {
+      throw new NotFoundException("Attendee not found");
+    }
+
+    if (
+      !attendee.booking?.eventType ||
+      !this.bookingsService.userIsEventTypeAdminOrOwner(user, attendee.booking.eventType)
+    ) {
+      throw new ForbiddenException("You don't have permission to update this attendee");
+    }
+
+    try {
+      const updatedAttendee = await this.attendeesRepository.updateAttendee(id, data);
+
+      return updatedAttendee;
+    } catch (error) {
+      this.logger.error("Failed to update attendee", error);
+      throw new BadRequestException("Failed to update attendee");
+    }
+  }
+
+  async deleteAttendee(id: number, user: ApiAuthGuardUser) {
+    const attendee = await this.attendeesRepository.getAttendeeWithBookingWithEventType(id);
+
+    if (!attendee) {
+      throw new NotFoundException("Attendee not found");
+    }
+
+    if (
+      !attendee.booking?.eventType ||
+      !this.bookingsService.userIsEventTypeAdminOrOwner(user, attendee.booking.eventType)
+    ) {
+      throw new ForbiddenException("You don't have permission to delete this attendee");
+    }
+
+    try {
+      // Store attendee data before deletion to return it
+      const attendeeToDelete = await this.attendeesRepository.deleteAttendee(id);
+
+      return attendeeToDelete;
+    } catch (error) {
+      this.logger.error("Failed to delete attendee", error);
+      throw new BadRequestException("Failed to delete attendee");
+    }
+  }
+}

--- a/apps/api/v2/src/ee/platform-endpoints-module.ts
+++ b/apps/api/v2/src/ee/platform-endpoints-module.ts
@@ -1,3 +1,4 @@
+import { AttendeesModule_2024_09_04 } from "@/ee/attendees/2024-09-04/attendees.module";
 import { BookingsModule_2024_04_15 } from "@/ee/bookings/2024-04-15/bookings.module";
 import { BookingsModule_2024_08_13 } from "@/ee/bookings/2024-08-13/bookings.module";
 import { CalendarsModule } from "@/ee/calendars/calendars.module";
@@ -20,6 +21,7 @@ import { Module } from "@nestjs/common";
 
 @Module({
   imports: [
+    AttendeesModule_2024_09_04,
     GcalModule,
     ProviderModule,
     SchedulesModule_2024_04_15,

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -7608,6 +7608,136 @@
         "tags": ["Api Keys"]
       }
     },
+    "/v2/attendees": {
+      "post": {
+        "operationId": "AttendeesController_2024_09_04_createAttendee",
+        "summary": "Create an attendee",
+        "description": "\n      Creates a new attendee for an existing booking. The user must be the owner of the booking \n      or have appropriate permissions (team member for team bookings, or system admin).\n    ",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAttendeeInput_2024_09_04"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAttendeeOutput_2024_09_04"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Attendees"]
+      }
+    },
+    "/v2/attendees/{attendeeId}": {
+      "get": {
+        "operationId": "AttendeesController_2024_09_04_getAttendee",
+        "summary": "Get an attendee by ID",
+        "description": "\n      Retrieves an attendee by their ID. The user must have permission to view the booking\n      that the attendee belongs to.\n    ",
+        "parameters": [
+          {
+            "name": "attendeeId",
+            "required": true,
+            "in": "path",
+            "description": "The ID of the attendee to retrieve",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAttendeeOutput_2024_09_04"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Attendees"]
+      },
+      "patch": {
+        "operationId": "AttendeesController_2024_09_04_updateAttendee",
+        "summary": "Update an attendee",
+        "description": "\n      Updates an existing attendee by their ID. The user must have permission to modify the booking\n      that the attendee belongs to. Only provided fields will be updated.\n    ",
+        "parameters": [
+          {
+            "name": "attendeeId",
+            "required": true,
+            "in": "path",
+            "description": "The ID of the attendee to update",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAttendeeInput_2024_09_04"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAttendeeOutput_2024_09_04"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Attendees"]
+      },
+      "delete": {
+        "operationId": "AttendeesController_2024_09_04_deleteAttendee",
+        "summary": "Delete an attendee",
+        "description": "\n      Deletes an attendee by their ID. The user must have permission to modify the booking \n      that the attendee belongs to.\n    ",
+        "parameters": [
+          {
+            "name": "attendeeId",
+            "required": true,
+            "in": "path",
+            "description": "The ID of the attendee to delete",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAttendeeOutput_2024_09_04"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Attendees"]
+      }
+    },
     "/v2/bookings": {
       "post": {
         "operationId": "BookingsController_2024_08_13_createBooking",
@@ -24069,63 +24199,64 @@
           }
         }
       },
-      "MeOrgOutput": {
+      "CreateAttendeeInput_2024_09_04": {
         "type": "object",
         "properties": {
-          "isPlatform": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "number"
-          }
-        },
-        "required": ["isPlatform", "id"]
-      },
-      "MeOutput": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number"
-          },
-          "username": {
-            "type": "string"
+          "bookingId": {
+            "type": "number",
+            "description": "The ID of the booking to add the attendee to",
+            "example": 123
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "Email address of the attendee",
+            "example": "attendee@example.com"
           },
-          "timeFormat": {
-            "type": "number"
-          },
-          "defaultScheduleId": {
-            "type": "number",
-            "nullable": true
-          },
-          "weekStart": {
-            "type": "string"
+          "name": {
+            "type": "string",
+            "description": "Full name of the attendee",
+            "example": "John Doe"
           },
           "timeZone": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "number",
-            "nullable": true
-          },
-          "organization": {
-            "$ref": "#/components/schemas/MeOrgOutput"
+            "type": "string",
+            "description": "Timezone of the attendee",
+            "example": "America/New_York"
           }
         },
-        "required": [
-          "id",
-          "username",
-          "email",
-          "timeFormat",
-          "defaultScheduleId",
-          "weekStart",
-          "timeZone",
-          "organizationId"
-        ]
+        "required": ["bookingId", "email", "name", "timeZone"]
       },
-      "GetMeOutput": {
+      "AttendeeOutput_2024_09_04": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "Unique identifier for the attendee",
+            "example": 456
+          },
+          "bookingId": {
+            "type": "number",
+            "description": "The ID of the booking this attendee belongs to",
+            "example": 123
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the attendee",
+            "example": "attendee@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of the attendee",
+            "example": "John Doe"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "Timezone of the attendee",
+            "example": "America/New_York"
+          }
+        },
+        "required": ["id", "bookingId", "email", "name", "timeZone"]
+      },
+      "CreateAttendeeOutput_2024_09_04": {
         "type": "object",
         "properties": {
           "status": {
@@ -24134,12 +24265,17 @@
             "enum": ["success", "error"]
           },
           "data": {
-            "$ref": "#/components/schemas/MeOutput"
+            "description": "The created attendee",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttendeeOutput_2024_09_04"
+              }
+            ]
           }
         },
         "required": ["status", "data"]
       },
-      "UpdateMeOutput": {
+      "GetAttendeeOutput_2024_09_04": {
         "type": "object",
         "properties": {
           "status": {
@@ -24148,7 +24284,70 @@
             "enum": ["success", "error"]
           },
           "data": {
-            "$ref": "#/components/schemas/MeOutput"
+            "description": "The attendee",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttendeeOutput_2024_09_04"
+              }
+            ]
+          }
+        },
+        "required": ["status", "data"]
+      },
+      "UpdateAttendeeInput_2024_09_04": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email address of the attendee",
+            "example": "attendee@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of the attendee",
+            "example": "John Doe"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "Timezone of the attendee",
+            "example": "America/New_York"
+          }
+        }
+      },
+      "UpdateAttendeeOutput_2024_09_04": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success",
+            "enum": ["success", "error"]
+          },
+          "data": {
+            "description": "The updated attendee",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttendeeOutput_2024_09_04"
+              }
+            ]
+          }
+        },
+        "required": ["status", "data"]
+      },
+      "DeleteAttendeeOutput_2024_09_04": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success",
+            "enum": ["success", "error"]
+          },
+          "data": {
+            "description": "The deleted attendee",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttendeeOutput_2024_09_04"
+              }
+            ]
           }
         },
         "required": ["status", "data"]
@@ -26372,6 +26571,90 @@
             "items": {
               "$ref": "#/components/schemas/BookingReference"
             }
+          }
+        },
+        "required": ["status", "data"]
+      },
+      "MeOrgOutput": {
+        "type": "object",
+        "properties": {
+          "isPlatform": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "number"
+          }
+        },
+        "required": ["isPlatform", "id"]
+      },
+      "MeOutput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "timeFormat": {
+            "type": "number"
+          },
+          "defaultScheduleId": {
+            "type": "number",
+            "nullable": true
+          },
+          "weekStart": {
+            "type": "string"
+          },
+          "timeZone": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "number",
+            "nullable": true
+          },
+          "organization": {
+            "$ref": "#/components/schemas/MeOrgOutput"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "email",
+          "timeFormat",
+          "defaultScheduleId",
+          "weekStart",
+          "timeZone",
+          "organizationId"
+        ]
+      },
+      "GetMeOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success",
+            "enum": ["success", "error"]
+          },
+          "data": {
+            "$ref": "#/components/schemas/MeOutput"
+          }
+        },
+        "required": ["status", "data"]
+      },
+      "UpdateMeOutput": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success",
+            "enum": ["success", "error"]
+          },
+          "data": {
+            "$ref": "#/components/schemas/MeOutput"
           }
         },
         "required": ["status", "data"]


### PR DESCRIPTION
## What does this PR do?
- Adds Attendees V2 API (`/v2/attendees`)
   - POST: Create new attendee for a booking
   - GET: Retrieve attendee by ID
   - PATCH: Update attendee details
   - DELETE: Remove attendee from booking
   - Full authorization checks (booking owner, team members, org admins)
   - Support for timezones, email validation
- Adds e2e tests for the attendees controller

- Fixes #24109 
- Fixes CAL-6471

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create Attendee
   - Create a booking via API/UI
   - POST to `/v2/attendees` with booking ID, email, name, and timezone
   - Verify attendee is created and associated with the booking

2. Get Attendee
   - GET /`v2/attendees/{attendeeId}`
   - Verify correct attendee details are returned
   - Test with unauthorized user (should fail)
3. Update Attendee
    - PATCH `/v2/attendees/{attendeeId}` with updated fields
    - Verify only provided fields are updated
4. Delete Attendee
   - DELETE `/v2/attendees/{attendeeId}`
   - Verify attendee is removed from booking
5. Team Bookings
   - Create team event type and booking
   - Test attendee operations with team member credentials
   - Verify org admin can manage all attendees

## Checklist