### PR TITLE
fix: polish sign-in translation

### DIFF
--- a/apps/web/public/static/locales/pl/common.json
+++ b/apps/web/public/static/locales/pl/common.json
@@ -342,7 +342,7 @@
   "dont_have_an_account": "Nie masz konta?",
   "2fa_code": "Kod dwuskładnikowy",
   "sign_in_account": "Zaloguj się na swoje konto",
-  "sign_in": "Zarejestruj",
+  "sign_in": "Zaloguj się",
   "go_back_login": "Wróć na stronę logowania",
   "error_during_login": "Wystąpił błąd podczas logowania. Wróć do ekranu logowania i spróbuj ponownie.",
   "request_password_reset": "Wyślij wiadomość e-mail umożliwiającą zresetowanie",


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect Polish translation of the authentication button.

- Fixes #24262
- Fixes CAL-6519 

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Before**
<img width="243" height="43" alt="Image" src="https://github.com/user-attachments/assets/46f0903e-8ef5-4e14-857c-e2ca429f5b95" /> 

<img width="560" height="636" alt="Image" src="https://github.com/user-attachments/assets/8c0d4028-92c4-420a-84b7-d4440e4509a9" />

**After**
<img width="467" height="449" alt="Image" src="https://github.com/user-attachments/assets/c9874765-941c-404f-9056-6a6593cc3d78" />

 <img width="377" height="106" alt="Image" src="https://github.com/user-attachments/assets/31fc7ea4-1709-40af-bb12-05eb5d7f3c6e" />

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to https://app.cal.com/auth/login (polish language)
2. Observe the text of the authentication buttons.

## Checklist
