### PR TITLE
fix(tasker): make task claiming atomic with PostgreSQL SKIP LOCKED to prevent race conditions

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2019,6 +2019,8 @@ model Task {
   lastError           String?
   lastFailedAttemptAt DateTime?
   referenceUid        String?
+  // The time at which the task was claimed by a worker (for atomic task claiming)
+  claimedAt           DateTime?
 
   // unique index on referenceUid,type to avoid duplicate tasks
   @@unique([referenceUid, type])
@@ -2026,6 +2028,8 @@ model Task {
   @@index([succeededAt])
   // for finding tasks that are scheduled to be executed
   @@index([scheduledAt, succeededAt])
+  // for finding unclaimed tasks
+  @@index([claimedAt, scheduledAt, succeededAt])
 }
 
 enum SMSLockState {


### PR DESCRIPTION
This PR fixes a race condition in task claiming by making the process atomic.

### Summary of Changes

* Added a `claimedAt` field to the Task model (with a composite index on `[claimedAt, scheduledAt, succeededAt]`).
* Replaced `findMany()` with transaction-based claiming using PostgreSQL `SELECT FOR UPDATE SKIP LOCKED`.
* Implemented stale claim detection: tasks claimed more than 5 minutes ago are released and can be reclaimed.
* Updated `retry()` to clear `claimedAt`, allowing tasks to be picked up again.

### Benefits

* Prevents duplicate task processing by multiple workers.
* Ensures only one worker can claim a task at a time.
* Handles worker crashes or failures gracefully by reclaiming stale tasks.
* Improves concurrency with database-level guarantees.

### Notes

* Requires a database migration to add the `claimedAt` column before deploying.

Fixes #24186
