### PR TITLE
fix: apply before and after buffers correctly during slot generation

### DIFF
--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1145,14 +1145,23 @@ export class AvailableSlotsService {
       eventType.schedulingType === SchedulingType.COLLECTIVE ||
       eventType.schedulingType === SchedulingType.ROUND_ROBIN ||
       allUsersAvailability.length > 1;
+      const baseDuration = input.duration || eventType.length; // ← this is the actual meeting length we’re generating slots for
+      const beforeBuffer = eventType.beforeEventBuffer || 0;
+      const afterBuffer = eventType.afterEventBuffer || 0;
+      const frequency = 
+        eventType.slotInterval && eventType.slotInterval > 0
+        ? eventType.slotInterval
+        : baseDuration + afterBuffer;
 
+    const effectiveOffset = eventType.offsetStart || beforeBuffer;
+        
     const timeSlots = getSlots({
       inviteeDate: startTime,
       eventLength: input.duration || eventType.length,
-      offsetStart: eventType.offsetStart,
+      offsetStart: effectiveOffset,
       dateRanges: aggregatedAvailability,
       minimumBookingNotice: eventType.minimumBookingNotice,
-      frequency: eventType.slotInterval || input.duration || eventType.length,
+      frequency: frequency,
       datesOutOfOffice: !isTeamEvent ? allUsersAvailability[0]?.datesOutOfOffice : undefined,
       showOptimizedSlots: eventType.showOptimizedSlots,
     });


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where before and after event buffers were not being correctly applied during slot generation.
The bug caused time slots to be generated back-to-back without respecting buffer times between meetings.

- Fixes #24253 
- Fixes CAL-6514


https://github.com/user-attachments/assets/eda9e3b6-2cbe-48ec-8576-1cdbe257d83e


<img width="1430" height="465" alt="Screenshot 2025-10-05 at 7 26 05 PM" src="https://github.com/user-attachments/assets/60c3ab00-efcd-488e-b04f-37b0dd10fd0b" />

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Environment variables:
	•	No new environment variables are required.
	•	Existing .env configuration from Cal.com setup is sufficient.

Minimal test data:
	•	Create or edit an Event Type with the following settings:
	•	Duration: 10 minutes
	•	Before buffer: 10 minutes
	•	After buffer: 10 minutes
	•	Working hours: 9:00 AM to 5:00 PM
Expected output:
	•	First slot should start at 9:15 AM (since 10-min before buffer).
	•	Each subsequent slot should start 30 minutes apart (10 min meeting + 10 before + 10 after).
	•	No overlapping or back-to-back slots.

## Checklist