### PR TITLE
fix: timezone variable name does not match webhook payload

### DIFF
--- a/packages/features/webhooks/components/WebhookForm.tsx
+++ b/packages/features/webhooks/components/WebhookForm.tsx
@@ -177,8 +177,8 @@ function getWebhookVariables(t: (key: string) => string) {
           description: t("webhook_attendee_email"),
         },
         {
-          name: "attendees.0.timezone",
-          variable: "{{attendees.0.timezone}}",
+          name: "attendees.0.timeZone",
+          variable: "{{attendees.0.timeZone}}",
           type: "String",
           description: t("webhook_attendee_timezone"),
         },


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with the custom webhook payload. The data is returned as `attendees.0.timeZone` but the variable name when constructing a custom payload suggests `attendees.0.timezone` (note the lowercase)

## Visual Demo (For contributors especially)

<img width="1484" height="770" alt="CleanShot 2025-10-05 at 11 22 11@2x" src="https://github.com/user-attachments/assets/07871adb-f56a-4150-9d64-37ad349a39c2" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Add console log to your API and observe the payload coming from cal.com
- Trigger a ping test to see the default payload

You will see the following payload

```ts
{
  triggerEvent: 'PING',
  createdAt: '2025-10-05T15:28:45.646Z',
  payload: {
    type: 'Test',
    title: 'Test trigger event',
    startTime: '2025-10-05T15:28:45.646Z',
    endTime: '2025-10-05T15:28:45.646Z',
    attendees: [
      {
        email: 'jdoe@example.com',
        name: 'John Doe',
        timeZone: 'Europe/London', // See the time zone here is capitalized
        language: { locale: 'en' },
        utcOffset: 60
      }
    ],
    organizer: {
      name: 'Cal',
      email: 'no-reply@cal.com',
      timeZone: 'Europe/London',
      language: { locale: 'en' },
      utcOffset: 60
    }
  }
}
```