### PR TITLE
feat(workflows): add localization support for date variables in reminders

### DIFF
--- a/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleWhatsappReminders.ts
@@ -73,7 +73,12 @@ export async function handler(req: NextRequest) {
           : reminder.booking?.user?.timeZone;
 
       const startTime = reminder.booking?.startTime.toISOString();
-      const locale = reminder.booking.user?.locale || "en";
+      // Use the recipient's locale for proper date/time localization
+      // This ensures variables like {EVENT_DATE_ddd} are localized to the recipient's language
+      const locale =
+        reminder.workflowStep.action === WorkflowActions.WHATSAPP_ATTENDEE
+          ? reminder.booking.attendees[0].locale || "en"
+          : reminder.booking.user?.locale || "en";
       const timeFormat = getTimeFormatStringFromUserTimeFormat(reminder.booking.user?.timeFormat);
 
       const templateFunction = getWhatsappTemplateFunction(reminder.workflowStep.template);
@@ -91,7 +96,7 @@ export async function handler(req: NextRequest) {
       });
       const message = templateFunction(
         false,
-        reminder.booking.user?.locale || "en",
+        locale,
         reminder.workflowStep.action,
         timeFormat,
         startTime || "",

--- a/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/emailReminderManager.ts
@@ -190,10 +190,16 @@ export const scheduleEmailReminder = async (args: scheduleEmailReminderArgs) => 
       hideBranding
     ).html;
   } else if (template === WorkflowTemplates.REMINDER) {
+    const isEmailAttendeeAction = action === WorkflowActions.EMAIL_ATTENDEE;
+    // Use the recipient's locale for proper date/time localization
+    // This ensures variables like {EVENT_DATE_ddd} are localized to the recipient's language
+    const reminderLocale = isEmailAttendeeAction
+      ? attendeeToBeUsedInMail.language?.locale
+      : evt.organizer.language.locale;
     emailContent = emailReminderTemplate({
       isEditingMode: false,
-      locale: evt.organizer.language.locale,
-      t: await getTranslation(evt.organizer.language.locale || "en", "common"),
+      locale: reminderLocale,
+      t: await getTranslation(reminderLocale || "en", "common"),
       action,
       timeFormat: evt.organizer.timeFormat,
       startTime,

--- a/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/smsReminderManager.ts
@@ -162,10 +162,16 @@ export const scheduleSMSReminder = async (args: ScheduleTextReminderArgs) => {
       if (smsMessage) {
         smsMessage = await getSMSMessageWithVariables(smsMessage, evt, attendeeToBeUsedInSMS, action);
       } else if (template === WorkflowTemplates.REMINDER) {
+        // Use the recipient's locale for proper date/time localization
+        // This ensures variables like {EVENT_DATE_ddd} are localized to the recipient's language
+        const locale =
+          action === WorkflowActions.SMS_ATTENDEE
+            ? attendeeToBeUsedInSMS.language?.locale
+            : evt.organizer.language.locale;
         smsMessage =
           smsReminderTemplate(
             false,
-            evt.organizer.language.locale,
+            locale,
             action,
             evt.organizer.timeFormat,
             evt.startTime,

--- a/packages/features/ee/workflows/lib/reminders/whatsappReminderManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/whatsappReminderManager.ts
@@ -80,7 +80,12 @@ export const scheduleWhatsappReminder = async (args: ScheduleTextReminderArgs) =
     action === WorkflowActions.WHATSAPP_ATTENDEE ? evt.organizer.name : evt.attendees[0].name;
   const timeZone =
     action === WorkflowActions.WHATSAPP_ATTENDEE ? evt.attendees[0].timeZone : evt.organizer.timeZone;
-  const locale = evt.organizer.language.locale;
+  // Use the recipient's locale for proper date/time localization
+  // This ensures variables like {EVENT_DATE_ddd} are localized to the recipient's language
+  const locale =
+    action === WorkflowActions.WHATSAPP_ATTENDEE
+      ? evt.attendees[0].language?.locale
+      : evt.organizer.language.locale;
   const timeFormat = evt.organizer.timeFormat;
 
   const contentSid = getContentSidForTemplate(template);


### PR DESCRIPTION
Fixes #24280

## What does this PR do?
Enhances localization for workflow reminders across all notification channels (Email, SMS, WhatsApp) to properly support date/time variables in the recipient's locale.

## Description of Changes
- **WhatsApp reminders**: Updated handler to use attendee's locale for proper date/time localization
- **Email reminders**: Modified manager to utilize recipient's locale for email content
- **SMS reminders**: Adjusted manager to apply recipient's locale for SMS messages  
- **WhatsApp manager**: Refined locale selection based on action type (organizer vs attendee)

This ensures that date variables like `EVENT_DATE_ddd` display correctly in the recipient's language (e.g., "Mar" for Tuesday in French instead of "Tue").

## Files Changed
- `emailReminderManager.ts` - Added locale support for email reminders
- `smsReminderManager.ts` - Added locale support for SMS reminders  
- `whatsappReminderManager.ts` - Added locale support for WhatsApp reminders
- `scheduleWhatsappReminders.ts` - Enhanced locale handling for scheduling

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Tested with different locales (en, fr, es, de)
- [x] Verified all reminder types use proper locale
- [x] Confirmed backward compatibility

## Related Issue
Fixes #24280
