### PR TITLE
[CAL-890] Add time notice constraint for disable reschedule/cancel

### DIFF
--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -59,6 +59,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
           allowReschedulingPastBookings: true,
           disableRescheduling: true,
           allowReschedulingCancelledBookings: true,
+          metadata: true,
           team: {
             select: {
               id: true,
@@ -122,6 +123,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     booking: {
       uid,
       status: booking.status,
+      startTime: booking.startTime,
       endTime: booking.endTime,
       responses: booking.responses,
       eventType: {
@@ -129,6 +131,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         allowReschedulingPastBookings: eventType.allowReschedulingPastBookings,
         allowBookingFromCancelledBookingReschedule: !!eventType.allowReschedulingCancelledBookings,
         teamId: eventType.team?.id ?? null,
+        metadata: eventType.metadata,
       },
     },
     eventUrl,

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1300,6 +1300,7 @@
   "description_allow_rescheduling_cancelled_bookings": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking",
   "disable_cancelling": "Disable Cancelling",
   "description_disable_cancelling": "Guests can no longer cancel the event with calendar invite or email",
+  "when_less_than_x_mins_before_meeting": "When less than <0></0> before meeting",
   "revoke_api_key": "Revoke API key",
   "api_key_copied": "API key copied!",
   "api_key_expires_on": "The API key will expire on",

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -115,7 +115,11 @@ async function handler(input: CancelBookingInput) {
     if (disableCancellingThreshold) {
       const bookingStartTime = dayjs(bookingToDelete.startTime);
       const now = dayjs();
-      const timeDifference = bookingStartTime.diff(now, disableCancellingThreshold.unit);
+      const timeDifference = bookingStartTime.diff(
+        now,
+        disableCancellingThreshold.unit,
+        true
+      );
       
       // If we're less than the threshold time before the booking, disallow cancellation
       if (timeDifference <= disableCancellingThreshold.time) {

--- a/packages/features/bookings/lib/reschedule/determineReschedulePreventionRedirect.ts
+++ b/packages/features/bookings/lib/reschedule/determineReschedulePreventionRedirect.ts
@@ -78,10 +78,14 @@ export function determineReschedulePreventionRedirect(
     if (disableReschedulingThreshold && booking.startTime) {
       const bookingStartTime = dayjs(booking.startTime);
       const now = dayjs();
-      const timeDifference = bookingStartTime.diff(now, disableReschedulingThreshold.unit);
-      
+      const timeDifference = bookingStartTime.diff(
+        now,
+        disableReschedulingThreshold.unit,
+        true
+      );
+
       // If we're less than the threshold time before the booking, prevent reschedule
-      if (timeDifference <= disableReschedulingThreshold.time) {
+      if (timeDifference < disableReschedulingThreshold.time) {
         return `/booking/${booking.uid}`;
       }
     } else if (!disableReschedulingThreshold) {

--- a/packages/features/eventtypes/components/tabs/advanced/DisableCancellingController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/DisableCancellingController.tsx
@@ -1,0 +1,231 @@
+import * as RadioGroup from "@radix-ui/react-radio-group";
+import type { UnitTypeLongPlural } from "dayjs";
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import type z from "zod";
+
+import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
+import type { EventTypeSetup, SettingsToggleClassNames } from "@calcom/features/eventtypes/lib/types";
+import type { FormValues } from "@calcom/features/eventtypes/lib/types";
+import ServerTrans from "@calcom/lib/components/ServerTrans";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
+import classNames from "@calcom/ui/classNames";
+import { Select } from "@calcom/ui/components/form";
+import { Input } from "@calcom/ui/components/form";
+import { SettingsToggle } from "@calcom/ui/components/form";
+import { RadioField } from "@calcom/ui/components/radio";
+
+export type DisableCancellingCustomClassNames = SettingsToggleClassNames & {
+  radioGroupContainer?: string;
+  alwaysDisabledRadio?: string;
+  conditionalDisabledRadio?: {
+    container?: string;
+    timeInput?: string;
+    timeUnitSelect?: string;
+  };
+};
+
+type DisableCancellingControllerProps = {
+  metadata: z.infer<typeof EventTypeMetaDataSchema>;
+  disableCancelling: boolean;
+  onDisableCancelling: Dispatch<SetStateAction<boolean>>;
+  eventType: EventTypeSetup;
+  customClassNames?: DisableCancellingCustomClassNames;
+};
+
+export default function DisableCancellingController({
+  metadata,
+  eventType,
+  disableCancelling,
+  onDisableCancelling,
+  customClassNames,
+}: DisableCancellingControllerProps) {
+  const { t } = useLocale();
+  const [disableCancellingSetup, setDisableCancellingSetup] = useState(
+    metadata?.disableCancellingThreshold
+  );
+  const defaultDisableCancellingSetup = { time: 120, unit: "minutes" as UnitTypeLongPlural };
+  const formMethods = useFormContext<FormValues>();
+
+  useEffect(() => {
+    if (!disableCancelling) {
+      formMethods.setValue("metadata.disableCancellingThreshold", undefined, { shouldDirty: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disableCancelling]);
+
+  const { shouldLockDisableProps } = useLockedFieldsManager({ eventType, translate: t, formMethods });
+  const disableCancellingLockedProps = shouldLockDisableProps("disableCancelling");
+
+  const options = [
+    { label: t("minute_timeUnit"), value: "minutes" },
+    { label: t("hour_timeUnit"), value: "hours" },
+  ];
+
+  const defaultValue = options.find(
+    (opt) =>
+      opt.value === (metadata?.disableCancellingThreshold?.unit ?? defaultDisableCancellingSetup.unit)
+  );
+
+  return (
+    <div className="block items-start sm:flex">
+      <div className="w-full">
+        <Controller
+          name="disableCancelling"
+          control={formMethods.control}
+          render={() => (
+            <SettingsToggle
+              labelClassName={classNames("text-sm", customClassNames?.label)}
+              toggleSwitchAtTheEnd={true}
+              switchContainerClassName={classNames(
+                "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+                disableCancelling && "rounded-b-none",
+                customClassNames?.container
+              )}
+              childrenClassName={classNames("lg:ml-0", customClassNames?.children)}
+              descriptionClassName={customClassNames?.description}
+              title={t("disable_cancelling")}
+              data-testid="disable-cancelling"
+              disabled={disableCancellingLockedProps.disabled}
+              description={t("description_disable_cancelling")}
+              checked={disableCancelling}
+              LockedIcon={disableCancellingLockedProps.LockedIcon}
+              onCheckedChange={(val) => {
+                formMethods.setValue("disableCancelling", val, { shouldDirty: true });
+                onDisableCancelling(val);
+              }}>
+              <div className="border-subtle rounded-b-lg border border-t-0 p-6">
+                <RadioGroup.Root
+                  defaultValue={
+                    disableCancelling
+                      ? disableCancellingSetup === undefined
+                        ? "always"
+                        : "notice"
+                      : undefined
+                  }
+                  onValueChange={(val) => {
+                    if (val === "always") {
+                      formMethods.setValue("disableCancelling", true, { shouldDirty: true });
+                      onDisableCancelling(true);
+                      formMethods.setValue("metadata.disableCancellingThreshold", undefined, {
+                        shouldDirty: true,
+                      });
+                      setDisableCancellingSetup(undefined);
+                    } else if (val === "notice") {
+                      formMethods.setValue("disableCancelling", true, { shouldDirty: true });
+                      onDisableCancelling(true);
+                      formMethods.setValue(
+                        "metadata.disableCancellingThreshold",
+                        disableCancellingSetup || defaultDisableCancellingSetup,
+                        { shouldDirty: true }
+                      );
+                    }
+                  }}>
+                  <div
+                    className={classNames(
+                      "flex flex-col flex-wrap justify-start gap-y-2",
+                      customClassNames?.radioGroupContainer
+                    )}>
+                    {(disableCancellingSetup === undefined || !disableCancellingLockedProps.disabled) && (
+                      <RadioField
+                        label={t("always")}
+                        disabled={disableCancellingLockedProps.disabled}
+                        id="always"
+                        value="always"
+                        className={customClassNames?.alwaysDisabledRadio}
+                      />
+                    )}
+                    {(disableCancellingSetup !== undefined || !disableCancellingLockedProps.disabled) && (
+                      <>
+                        <RadioField
+                          disabled={disableCancellingLockedProps.disabled}
+                          className={classNames(
+                            "items-center",
+                            customClassNames?.conditionalDisabledRadio?.container
+                          )}
+                          label={
+                            <>
+                              <ServerTrans
+                                t={t}
+                                i18nKey="when_less_than_x_mins_before_meeting"
+                                components={[
+                                  <div
+                                    key="when_less_than_x_mins_before_meeting"
+                                    className="mx-2 inline-flex items-center">
+                                    <Input
+                                      type="number"
+                                      min={1}
+                                      disabled={disableCancellingLockedProps.disabled}
+                                      onChange={(evt) => {
+                                        const val = Number(evt.target?.value);
+                                        setDisableCancellingSetup({
+                                          unit:
+                                            disableCancellingSetup?.unit ??
+                                            defaultDisableCancellingSetup.unit,
+                                          time: val,
+                                        });
+                                        formMethods.setValue(
+                                          "metadata.disableCancellingThreshold.time",
+                                          val,
+                                          { shouldDirty: true }
+                                        );
+                                      }}
+                                      className={classNames(
+                                        "border-default h-9! !m-0 block w-16 rounded-r-none border-r-0 text-sm [appearance:textfield] focus:z-10 focus:border-r",
+                                        customClassNames?.conditionalDisabledRadio?.timeInput
+                                      )}
+                                      defaultValue={metadata?.disableCancellingThreshold?.time || 120}
+                                    />
+                                    <label
+                                      className={classNames(
+                                        disableCancellingLockedProps.disabled && "cursor-not-allowed"
+                                      )}>
+                                      <Select
+                                        inputId="notice"
+                                        options={options}
+                                        isSearchable={false}
+                                        isDisabled={disableCancellingLockedProps.disabled}
+                                        className={
+                                          customClassNames?.conditionalDisabledRadio?.timeUnitSelect
+                                        }
+                                        innerClassNames={{
+                                          control: "rounded-l-none max-h-4 px-3 bg-subtle py-1",
+                                        }}
+                                        onChange={(opt) => {
+                                          setDisableCancellingSetup({
+                                            time:
+                                              disableCancellingSetup?.time ??
+                                              defaultDisableCancellingSetup.time,
+                                            unit: opt?.value as UnitTypeLongPlural,
+                                          });
+                                          formMethods.setValue(
+                                            "metadata.disableCancellingThreshold.unit",
+                                            opt?.value as UnitTypeLongPlural,
+                                            { shouldDirty: true }
+                                          );
+                                        }}
+                                        defaultValue={defaultValue}
+                                      />
+                                    </label>
+                                  </div>,
+                                ]}
+                              />
+                            </>
+                          }
+                          id="notice"
+                          value="notice"
+                        />
+                      </>
+                    )}
+                  </div>
+                </RadioGroup.Root>
+              </div>
+            </SettingsToggle>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/features/eventtypes/components/tabs/advanced/DisableReschedulingController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/DisableReschedulingController.tsx
@@ -1,0 +1,233 @@
+import * as RadioGroup from "@radix-ui/react-radio-group";
+import type { UnitTypeLongPlural } from "dayjs";
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import type z from "zod";
+
+import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
+import type { EventTypeSetup, SettingsToggleClassNames } from "@calcom/features/eventtypes/lib/types";
+import type { FormValues } from "@calcom/features/eventtypes/lib/types";
+import ServerTrans from "@calcom/lib/components/ServerTrans";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
+import classNames from "@calcom/ui/classNames";
+import { Select } from "@calcom/ui/components/form";
+import { Input } from "@calcom/ui/components/form";
+import { SettingsToggle } from "@calcom/ui/components/form";
+import { RadioField } from "@calcom/ui/components/radio";
+
+export type DisableReschedulingCustomClassNames = SettingsToggleClassNames & {
+  radioGroupContainer?: string;
+  alwaysDisabledRadio?: string;
+  conditionalDisabledRadio?: {
+    container?: string;
+    timeInput?: string;
+    timeUnitSelect?: string;
+  };
+};
+
+type DisableReschedulingControllerProps = {
+  metadata: z.infer<typeof EventTypeMetaDataSchema>;
+  disableRescheduling: boolean;
+  onDisableRescheduling: Dispatch<SetStateAction<boolean>>;
+  eventType: EventTypeSetup;
+  customClassNames?: DisableReschedulingCustomClassNames;
+};
+
+export default function DisableReschedulingController({
+  metadata,
+  eventType,
+  disableRescheduling,
+  onDisableRescheduling,
+  customClassNames,
+}: DisableReschedulingControllerProps) {
+  const { t } = useLocale();
+  const [disableReschedulingSetup, setDisableReschedulingSetup] = useState(
+    metadata?.disableReschedulingThreshold
+  );
+  const defaultDisableReschedulingSetup = { time: 120, unit: "minutes" as UnitTypeLongPlural };
+  const formMethods = useFormContext<FormValues>();
+
+  useEffect(() => {
+    if (!disableRescheduling) {
+      formMethods.setValue("metadata.disableReschedulingThreshold", undefined, { shouldDirty: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disableRescheduling]);
+
+  const { shouldLockDisableProps } = useLockedFieldsManager({ eventType, translate: t, formMethods });
+  const disableReschedulingLockedProps = shouldLockDisableProps("disableRescheduling");
+
+  const options = [
+    { label: t("minute_timeUnit"), value: "minutes" },
+    { label: t("hour_timeUnit"), value: "hours" },
+  ];
+
+  const defaultValue = options.find(
+    (opt) =>
+      opt.value === (metadata?.disableReschedulingThreshold?.unit ?? defaultDisableReschedulingSetup.unit)
+  );
+
+  return (
+    <div className="block items-start sm:flex">
+      <div className="w-full">
+        <Controller
+          name="disableRescheduling"
+          control={formMethods.control}
+          render={() => (
+            <SettingsToggle
+              labelClassName={classNames("text-sm", customClassNames?.label)}
+              toggleSwitchAtTheEnd={true}
+              switchContainerClassName={classNames(
+                "border-subtle rounded-lg border py-6 px-4 sm:px-6",
+                disableRescheduling && "rounded-b-none",
+                customClassNames?.container
+              )}
+              childrenClassName={classNames("lg:ml-0", customClassNames?.children)}
+              descriptionClassName={customClassNames?.description}
+              title={t("disable_rescheduling")}
+              data-testid="disable-rescheduling"
+              disabled={disableReschedulingLockedProps.disabled}
+              description={t("description_disable_rescheduling")}
+              checked={disableRescheduling}
+              LockedIcon={disableReschedulingLockedProps.LockedIcon}
+              onCheckedChange={(val) => {
+                formMethods.setValue("disableRescheduling", val, { shouldDirty: true });
+                onDisableRescheduling(val);
+              }}>
+              <div className="border-subtle rounded-b-lg border border-t-0 p-6">
+                <RadioGroup.Root
+                  defaultValue={
+                    disableRescheduling
+                      ? disableReschedulingSetup === undefined
+                        ? "always"
+                        : "notice"
+                      : undefined
+                  }
+                  onValueChange={(val) => {
+                    if (val === "always") {
+                      formMethods.setValue("disableRescheduling", true, { shouldDirty: true });
+                      onDisableRescheduling(true);
+                      formMethods.setValue("metadata.disableReschedulingThreshold", undefined, {
+                        shouldDirty: true,
+                      });
+                      setDisableReschedulingSetup(undefined);
+                    } else if (val === "notice") {
+                      formMethods.setValue("disableRescheduling", true, { shouldDirty: true });
+                      onDisableRescheduling(true);
+                      formMethods.setValue(
+                        "metadata.disableReschedulingThreshold",
+                        disableReschedulingSetup || defaultDisableReschedulingSetup,
+                        { shouldDirty: true }
+                      );
+                    }
+                  }}>
+                  <div
+                    className={classNames(
+                      "flex flex-col flex-wrap justify-start gap-y-2",
+                      customClassNames?.radioGroupContainer
+                    )}>
+                    {(disableReschedulingSetup === undefined ||
+                      !disableReschedulingLockedProps.disabled) && (
+                      <RadioField
+                        label={t("always")}
+                        disabled={disableReschedulingLockedProps.disabled}
+                        id="always"
+                        value="always"
+                        className={customClassNames?.alwaysDisabledRadio}
+                      />
+                    )}
+                    {(disableReschedulingSetup !== undefined ||
+                      !disableReschedulingLockedProps.disabled) && (
+                      <>
+                        <RadioField
+                          disabled={disableReschedulingLockedProps.disabled}
+                          className={classNames(
+                            "items-center",
+                            customClassNames?.conditionalDisabledRadio?.container
+                          )}
+                          label={
+                            <>
+                              <ServerTrans
+                                t={t}
+                                i18nKey="when_less_than_x_mins_before_meeting"
+                                components={[
+                                  <div
+                                    key="when_less_than_x_mins_before_meeting"
+                                    className="mx-2 inline-flex items-center">
+                                    <Input
+                                      type="number"
+                                      min={1}
+                                      disabled={disableReschedulingLockedProps.disabled}
+                                      onChange={(evt) => {
+                                        const val = Number(evt.target?.value);
+                                        setDisableReschedulingSetup({
+                                          unit:
+                                            disableReschedulingSetup?.unit ??
+                                            defaultDisableReschedulingSetup.unit,
+                                          time: val,
+                                        });
+                                        formMethods.setValue(
+                                          "metadata.disableReschedulingThreshold.time",
+                                          val,
+                                          { shouldDirty: true }
+                                        );
+                                      }}
+                                      className={classNames(
+                                        "border-default h-9! !m-0 block w-16 rounded-r-none border-r-0 text-sm [appearance:textfield] focus:z-10 focus:border-r",
+                                        customClassNames?.conditionalDisabledRadio?.timeInput
+                                      )}
+                                      defaultValue={metadata?.disableReschedulingThreshold?.time || 120}
+                                    />
+                                    <label
+                                      className={classNames(
+                                        disableReschedulingLockedProps.disabled && "cursor-not-allowed"
+                                      )}>
+                                      <Select
+                                        inputId="notice"
+                                        options={options}
+                                        isSearchable={false}
+                                        isDisabled={disableReschedulingLockedProps.disabled}
+                                        className={
+                                          customClassNames?.conditionalDisabledRadio?.timeUnitSelect
+                                        }
+                                        innerClassNames={{
+                                          control: "rounded-l-none max-h-4 px-3 bg-subtle py-1",
+                                        }}
+                                        onChange={(opt) => {
+                                          setDisableReschedulingSetup({
+                                            time:
+                                              disableReschedulingSetup?.time ??
+                                              defaultDisableReschedulingSetup.time,
+                                            unit: opt?.value as UnitTypeLongPlural,
+                                          });
+                                          formMethods.setValue(
+                                            "metadata.disableReschedulingThreshold.unit",
+                                            opt?.value as UnitTypeLongPlural,
+                                            { shouldDirty: true }
+                                          );
+                                        }}
+                                        defaultValue={defaultValue}
+                                      />
+                                    </label>
+                                  </div>,
+                                ]}
+                              />
+                            </>
+                          }
+                          id="notice"
+                          value="notice"
+                        />
+                      </>
+                    )}
+                  </div>
+                </RadioGroup.Root>
+              </div>
+            </SettingsToggle>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -67,7 +67,9 @@ import { Icon } from "@calcom/ui/components/icon";
 import AddVerifiedEmail from "../../AddVerifiedEmail";
 import type { CustomEventTypeModalClassNames } from "./CustomEventTypeModal";
 import CustomEventTypeModal from "./CustomEventTypeModal";
+import DisableCancellingController from "./DisableCancellingController";
 import type { EmailNotificationToggleCustomClassNames } from "./DisableAllEmailsSetting";
+import DisableReschedulingController from "./DisableReschedulingController";
 import { DisableAllEmailsSetting } from "./DisableAllEmailsSetting";
 import type { RequiresConfirmationCustomClassNames } from "./RequiresConfirmationController";
 import RequiresConfirmationController from "./RequiresConfirmationController";
@@ -679,44 +681,18 @@ export const EventAdvancedTab = ({
 
       {!isPlatform && (
         <>
-          <Controller
-            name="disableCancelling"
-            render={({ field: { onChange } }) => (
-              <SettingsToggle
-                labelClassName="text-sm"
-                toggleSwitchAtTheEnd={true}
-                switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
-                title={t("disable_cancelling")}
-                data-testid="disable-cancelling-toggle"
-                {...disableCancellingLocked}
-                description={t("description_disable_cancelling")}
-                checked={disableCancelling}
-                onCheckedChange={(val) => {
-                  setDisableCancelling(val);
-                  onChange(val);
-                }}
-              />
-            )}
+          <DisableCancellingController
+            eventType={eventType}
+            metadata={formMethods.getValues("metadata")}
+            disableCancelling={disableCancelling}
+            onDisableCancelling={setDisableCancelling}
           />
 
-          <Controller
-            name="disableRescheduling"
-            render={({ field: { onChange } }) => (
-              <SettingsToggle
-                labelClassName="text-sm"
-                toggleSwitchAtTheEnd={true}
-                switchContainerClassName="border-subtle rounded-lg border py-6 px-4 sm:px-6"
-                title={t("disable_rescheduling")}
-                data-testid="disable-rescheduling-toggle"
-                {...disableReschedulingLocked}
-                description={t("description_disable_rescheduling")}
-                checked={disableRescheduling}
-                onCheckedChange={(val) => {
-                  setDisableRescheduling(val);
-                  onChange(val);
-                }}
-              />
-            )}
+          <DisableReschedulingController
+            eventType={eventType}
+            metadata={formMethods.getValues("metadata")}
+            disableRescheduling={disableRescheduling}
+            onDisableRescheduling={setDisableRescheduling}
           />
         </>
       )}

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -115,6 +115,18 @@ const _eventTypeMetaDataSchemaWithoutApps = z.object({
       unit: RequiresConfirmationThresholdUnits,
     })
     .optional(),
+  disableCancellingThreshold: z
+    .object({
+      time: z.number(),
+      unit: RequiresConfirmationThresholdUnits,
+    })
+    .optional(),
+  disableReschedulingThreshold: z
+    .object({
+      time: z.number(),
+      unit: RequiresConfirmationThresholdUnits,
+    })
+    .optional(),
   config: z
     .object({
       useHostSchedulesForTeamEvent: z.boolean().optional(),


### PR DESCRIPTION
Implemented the time notice constraint feature for disabling reschedule/cancel in Cal.com event types. Here's what was done:

✅ Key Features Implemented
Enhanced UI Components

Created DisableCancellingController component with radio button interface
Created DisableReschedulingController component with radio button interface
Both components follow the same pattern as RequiresConfirmationController
Users can now choose:
Always - completely disable the action
When less than X mins/hours before meeting - disable only within a time window
Database/Metadata Schema

Added disableCancellingThreshold to event type metadata
Added disableReschedulingThreshold to event type metadata
Structure: { time: number, unit: 'minutes' | 'hours' }
Business Logic Updates

Cancel Logic (handleCancelBooking.ts): Now checks if current time is within the threshold window before blocking cancellation
Reschedule Logic (determineReschedulePreventionRedirect.ts): Now checks if current time is within the threshold window before blocking rescheduling
Both use dayjs for accurate time calculations
Translations

Added when_less_than_x_mins_before_meeting translation key
Consistent with existing translation patterns
📋 Example Use Cases
Scenario 1: Beauty Salon

Setting: "Disable cancelling when less than 3 hours before appointment"
Result: Clients can cancel up to 3 hours before, but not within 3 hours
Scenario 2: Medical Practice

Setting: "Disable rescheduling when less than 24 hours before appointment"
Result: Patients can reschedule until 24 hours before, then it's locked
🎨 User Interface
The UI presents two radio button options when the toggle is enabled:

Always - The original behavior
When less than [input] [minutes/hours] before meeting - The new time-based constraint
Default value: 120 minutes (2 hours) - a reasonable buffer for most service providers

🔄 Backward Compatibility
Existing settings without thresholds continue to work as "always disabled"
No database migration needed - uses existing metadata JSON field
Gradual adoption possible