### PR TITLE
chore: Add next-auth-options.ts to Foundation code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /packages/app-store/office365calendar/**/* @calcom/Foundation
 /packages/app-store/zohocalendar/**/* @calcom/Foundation
 /packages/embeds/**/* @calcom/Foundation
+/packages/features/auth/lib/next-auth-options.ts @calcom/Foundation
 /packages/features/bookings/lib/**/* @calcom/Foundation
 /packages/lib/getAggregatedAvailability.ts @calcom/Foundation
 /packages/lib/getUserAvailability.ts @calcom/Foundation


### PR DESCRIPTION
## Summary
- Added `packages/features/auth/lib/next-auth-options.ts` to CODEOWNERS for @calcom/Foundation team

## Test plan
- [ ] Verify CODEOWNERS file syntax is correct
- [ ] Confirm Foundation team will be automatically requested for review on changes to this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)