### PR TITLE
chore: Update CODEOWNERS for NextAuth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /packages/app-store/office365calendar/**/* @calcom/Foundation
 /packages/app-store/zohocalendar/**/* @calcom/Foundation
 /packages/embeds/**/* @calcom/Foundation
+/packages/features/auth/lib/next-auth-options.ts @calcom/Foundation
 /packages/features/bookings/lib/**/* @calcom/Foundation
 /packages/lib/getAggregatedAvailability.ts @calcom/Foundation
 /packages/lib/getUserAvailability.ts @calcom/Foundation


### PR DESCRIPTION
Ensures we have @calcom/Foundation looking at critical NextAuth code.