### PR TITLE
feat: consider booker availability

### DIFF
--- a/packages/lib/server/repository/schedule.ts
+++ b/packages/lib/server/repository/schedule.ts
@@ -81,6 +81,23 @@ export class ScheduleRepository {
     return schedule;
   }
 
+  static async findScheduleByUserId({ userId }: { userId: number }) {
+    const schedule = await prisma.schedule.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        id: true,
+        userId: true,
+        name: true,
+        availability: true,
+        timeZone: true,
+      },
+    });
+
+    return schedule;
+  }
+
   static async findDetailedScheduleById({
     isManagedEventType,
     scheduleId,

--- a/packages/lib/server/repository/travelSchedule.ts
+++ b/packages/lib/server/repository/travelSchedule.ts
@@ -8,9 +8,11 @@ export class TravelScheduleRepository {
       },
       select: {
         id: true,
+        userId: true,
         startDate: true,
         endDate: true,
         timeZone: true,
+        prevTimeZone: true,
       },
     });
 

--- a/packages/lib/server/repository/user.ts
+++ b/packages/lib/server/repository/user.ts
@@ -50,18 +50,18 @@ export type SessionUser = {
   darkBrandColor: string | null;
   movedToProfileId: number | null;
   completedOnboarding: boolean;
-  destinationCalendar: any;
+  destinationCalendar: unknown;
   locale: string;
   timeFormat: number | null;
   trialEndsAt: Date | null;
-  metadata: any;
+  metadata: never;
   role: string;
   allowDynamicBooking: boolean;
   allowSEOIndexing: boolean;
   receiveMonthlyDigestEmail: boolean;
-  profiles: any[];
-  allSelectedCalendars: any[];
-  userLevelSelectedCalendars: any[];
+  profiles: unknown[];
+  allSelectedCalendars: unknown[];
+  userLevelSelectedCalendars: unknown[];
 };
 
 const log = logger.getSubLogger({ prefix: ["[repository/user]"] });
@@ -110,6 +110,7 @@ const userSelect = {
   allowSEOIndexing: true,
   receiveMonthlyDigestEmail: true,
   verified: true,
+  defaultScheduleId: true,
   disableImpersonation: true,
   locked: true,
   movedToProfileId: true,
@@ -423,7 +424,7 @@ export class UserRepository {
     T extends {
       id: number;
       username: string | null;
-      [key: string]: any;
+      [key: string]: unknown;
     }
   >({
     user,

--- a/packages/trpc/server/routers/viewer/slots/util.test.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from "vitest";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { BookingDateInPastError, isTimeOutOfBounds } from "@calcom/lib/isOutOfBounds";
+import { ScheduleRepository } from "@calcom/lib/server/repository/schedule";
+import { TravelScheduleRepository } from "@calcom/lib/server/repository/travelSchedule";
 
 import { TRPCError } from "@trpc/server";
+
+import { AvailableSlotsService } from "./util";
 
 describe("BookingDateInPastError handling", () => {
   it("should convert BookingDateInPastError to TRPCError with BAD_REQUEST code", () => {
@@ -41,5 +46,639 @@ describe("BookingDateInPastError handling", () => {
     // This should throw a TRPCError with BAD_REQUEST code
     expect(() => testFilteringLogic()).toThrow(TRPCError);
     expect(() => testFilteringLogic()).toThrow("Attempting to book a meeting in the past.");
+  });
+});
+
+// Mock the static repository methods
+vi.mock("@calcom/lib/server/repository/schedule", () => ({
+  ScheduleRepository: {
+    findScheduleByUserId: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/lib/server/repository/travelSchedule", () => ({
+  TravelScheduleRepository: {
+    findTravelSchedulesByUserId: vi.fn(),
+  },
+}));
+
+describe("getBookerAsHostForReschedule", () => {
+  let availableSlotsService: AvailableSlotsService;
+  let mockDependencies: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDependencies = {
+      bookingRepo: {
+        findBookingByUid: vi.fn(),
+      },
+      userRepo: {
+        findByEmail: vi.fn(),
+        findUserWithCredentials: vi.fn(),
+      },
+    };
+
+    availableSlotsService = new AvailableSlotsService(mockDependencies as any);
+  });
+
+  describe("Successful scenarios", () => {
+    it("should return booker as host when booker is a Cal.com user with complete availability data", async () => {
+      const mockBooking = {
+        id: 1,
+        uid: "test-reschedule-uid",
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+        username: "booker",
+        name: "Test Booker",
+        bufferTime: 10,
+        startTime: 540,
+        endTime: 1020,
+        timeFormat: 24,
+        defaultScheduleId: 50,
+        isPlatformManaged: false,
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        timeZone: "America/New_York",
+        allSelectedCalendars: [],
+        userLevelSelectedCalendars: [],
+        credentials: [
+          {
+            id: 1,
+            type: "google_calendar",
+            key: {},
+          },
+        ],
+      };
+
+      const mockSchedules = [
+        {
+          id: 50,
+          userId: 100,
+          name: "Working Hours",
+          timeZone: "America/New_York" as string | null,
+          availability: [
+            {
+              id: 1,
+              userId: 100,
+              eventTypeId: null,
+              days: [1, 2, 3, 4, 5],
+              startTime: new Date("1970-01-01T09:00:00.000Z"),
+              endTime: new Date("1970-01-01T17:00:00.000Z"),
+              date: null,
+              scheduleId: 50,
+            },
+          ],
+        },
+      ];
+
+      const mockTravelSchedules = [
+        {
+          id: 1,
+          userId: 100,
+          startDate: new Date("2025-01-15T00:00:00.000Z"),
+          endDate: new Date("2025-01-20T00:00:00.000Z"),
+          timeZone: "Europe/London",
+          prevTimeZone: null,
+        },
+      ];
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue(mockSchedules);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue(mockTravelSchedules);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-reschedule-uid",
+      });
+
+      // Assertions - Structure
+      expect(result).not.toBeNull();
+      expect(result?.isFixed).toBe(true);
+      expect(result?.createdAt).toBeNull();
+
+      // Assertions - User data
+      expect(result?.user.id).toBe(100);
+      expect(result?.user.email).toBe("booker@example.com");
+      expect(result?.user.username).toBe("booker");
+      expect(result?.user.bufferTime).toBe(10);
+      expect(result?.user.startTime).toBe(540);
+      expect(result?.user.endTime).toBe(1020);
+      expect(result?.user.timeFormat).toBe(24);
+
+      // Assertions - Schedules
+      expect(result?.user.schedules).toHaveLength(1);
+      expect(result?.user.schedules[0].id).toBe(50);
+      expect(result?.user.schedules[0].availability).toHaveLength(1);
+      expect(result?.user.schedules[0].availability[0].days).toEqual([1, 2, 3, 4, 5]);
+
+      // Assertions - Travel schedules
+      expect(result?.user.travelSchedules).toHaveLength(1);
+      expect(result?.user.travelSchedules[0].timeZone).toBe("Europe/London");
+
+      // Assertions - Credentials and empty fields
+      expect(result?.user.credentials).toHaveLength(1);
+      expect(result?.user.availability).toEqual([]);
+
+      // Verify all dependencies were called correctly
+      expect(mockDependencies.bookingRepo.findBookingByUid).toHaveBeenCalledWith({
+        bookingUid: "test-reschedule-uid",
+      });
+      expect(mockDependencies.userRepo.findByEmail).toHaveBeenCalledWith({
+        email: "booker@example.com",
+      });
+      expect(mockDependencies.userRepo.findUserWithCredentials).toHaveBeenCalledWith({
+        id: 100,
+      });
+      expect(ScheduleRepository.findScheduleByUserId).toHaveBeenCalledWith({ userId: 100 });
+      expect(TravelScheduleRepository.findTravelSchedulesByUserId).toHaveBeenCalledWith(100);
+    });
+
+    it("should apply default values for missing user properties", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+        username: null,
+        name: null,
+        bufferTime: null,
+        startTime: null,
+        endTime: null,
+        timeFormat: null,
+        defaultScheduleId: null,
+        isPlatformManaged: null,
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue([]);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result?.user.bufferTime).toBe(0);
+      expect(result?.user.startTime).toBe(0);
+      expect(result?.user.endTime).toBe(1440);
+      expect(result?.user.timeFormat).toBe(12);
+      expect(result?.user.isPlatformManaged).toBe(false);
+      expect(result?.user.username).toBeNull(); // username should remain null if not set
+      expect(result?.user.defaultScheduleId).toBeNull();
+    });
+
+    it("should handle booker with multiple schedules", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      const mockMultipleSchedules = [
+        {
+          id: 50,
+          userId: 100,
+          name: "Working Hours",
+          timeZone: "America/New_York" as string | null,
+          availability: [
+            {
+              id: 1,
+              userId: 100,
+              eventTypeId: null,
+              days: [1, 2, 3, 4, 5],
+              startTime: new Date("1970-01-01T09:00:00.000Z"),
+              endTime: new Date("1970-01-01T17:00:00.000Z"),
+              date: null,
+              scheduleId: 50,
+            },
+          ],
+        },
+        {
+          id: 51,
+          userId: 100,
+          name: "Alternate Hours",
+          timeZone: "Europe/London" as string | null,
+          availability: [
+            {
+              id: 2,
+              userId: 100,
+              eventTypeId: null,
+              days: [1, 2, 3],
+              startTime: new Date("1970-01-01T10:00:00.000Z"),
+              endTime: new Date("1970-01-01T15:00:00.000Z"),
+              date: null,
+              scheduleId: 51,
+            },
+          ],
+        },
+      ];
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue(mockMultipleSchedules);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result?.user.schedules).toHaveLength(2);
+      expect(result?.user.schedules[0].id).toBe(50);
+      expect(result?.user.schedules[0].timeZone).toBe("America/New_York");
+      expect(result?.user.schedules[1].id).toBe(51);
+      expect(result?.user.schedules[1].timeZone).toBe("Europe/London");
+    });
+
+    // NEW TEST: Verify isFixed flag ensures COLLECTIVE scheduling
+    it("should set isFixed to true to ensure COLLECTIVE scheduling type", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue([]);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      // This ensures both host AND booker must be available (COLLECTIVE behavior)
+      expect(result?.isFixed).toBe(true);
+    });
+  });
+
+  describe("Null return scenarios", () => {
+    it("should return null when booking has no attendees", async () => {
+      const mockBooking = {
+        id: 1,
+        attendees: [],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result).toBeNull();
+      expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+    });
+
+    it("should return null when booking attendee has no email", async () => {
+      const mockBooking = {
+        attendees: [{ email: null }],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result).toBeNull();
+      expect(mockDependencies.userRepo.findByEmail).not.toHaveBeenCalled();
+    });
+
+    it("should return null when booking is not found", async () => {
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(null);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "invalid-uid",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when booker email does not match a Cal.com user", async () => {
+      const mockBooking = {
+        attendees: [{ email: "external@example.com" }],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(null);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result).toBeNull();
+      expect(mockDependencies.userRepo.findByEmail).toHaveBeenCalledWith({
+        email: "external@example.com",
+      });
+      expect(mockDependencies.userRepo.findUserWithCredentials).not.toHaveBeenCalled();
+    });
+
+    it("should return null when user credentials cannot be fetched", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(null);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result).toBeNull();
+      expect(mockDependencies.userRepo.findUserWithCredentials).toHaveBeenCalledWith({
+        id: 100,
+      });
+      // Verify schedules weren't fetched after credentials failed
+      expect(ScheduleRepository.findScheduleByUserId).not.toHaveBeenCalled();
+      expect(TravelScheduleRepository.findTravelSchedulesByUserId).not.toHaveBeenCalled();
+    });
+
+    // NEW TEST: Edge case with undefined attendees
+    it("should return null when booking.attendees is undefined", async () => {
+      const mockBooking = {
+        id: 1,
+        attendees: undefined,
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("Schedule transformation", () => {
+    it("should correctly transform schedule availability format", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      const mockScheduleWithExtraFields = [
+        {
+          id: 50,
+          userId: 100,
+          name: "Working Hours",
+          timeZone: "America/New_York",
+          availability: [
+            {
+              id: 1,
+              userId: 100, // Should be removed
+              eventTypeId: null, // Should be removed
+              scheduleId: 50, // Should be removed
+              days: [1, 2, 3, 4, 5],
+              startTime: new Date("1970-01-01T09:00:00.000Z"),
+              endTime: new Date("1970-01-01T17:00:00.000Z"),
+              date: null,
+            },
+          ],
+        },
+      ];
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue(mockScheduleWithExtraFields);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      // Verify transformation kept only necessary fields
+      expect(result?.user.schedules[0].availability[0]).toEqual({
+        date: null,
+        startTime: new Date("1970-01-01T09:00:00.000Z"),
+        endTime: new Date("1970-01-01T17:00:00.000Z"),
+        days: [1, 2, 3, 4, 5],
+      });
+
+      // Ensure extra fields were removed
+      expect(result?.user.schedules[0].availability[0]).not.toHaveProperty("id");
+      expect(result?.user.schedules[0].availability[0]).not.toHaveProperty("userId");
+      expect(result?.user.schedules[0].availability[0]).not.toHaveProperty("eventTypeId");
+      expect(result?.user.schedules[0].availability[0]).not.toHaveProperty("scheduleId");
+    });
+
+    it("should preserve travel schedules without transformation", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      const mockTravelSchedules = [
+        {
+          id: 1,
+          userId: 100,
+          startDate: new Date("2025-01-15T00:00:00.000Z"),
+          endDate: new Date("2025-01-20T00:00:00.000Z"),
+          timeZone: "Europe/London",
+          prevTimeZone: "America/New_York",
+        },
+      ];
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue([]);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue(mockTravelSchedules);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      // Travel schedules should be passed through unchanged
+      expect(result?.user.travelSchedules).toEqual(mockTravelSchedules);
+      expect(result?.user.travelSchedules[0]).toHaveProperty("id");
+      expect(result?.user.travelSchedules[0]).toHaveProperty("userId");
+      expect(result?.user.travelSchedules[0]).toHaveProperty("prevTimeZone");
+    });
+
+    // NEW TEST: Verify schedule with date-specific availability
+    it("should handle date-specific availability rules", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      const specificDate = new Date("2025-12-25T00:00:00.000Z");
+      const mockScheduleWithDateOverride = [
+        {
+          id: 50,
+          userId: 100,
+          name: "Date Override Schedule",
+          timeZone: "Asia/New_York" as string | null,
+          availability: [
+            {
+              id: 1,
+              userId: 100,
+              eventTypeId: null,
+              days: [],
+              startTime: new Date("1970-01-01T10:00:00.000Z"),
+              endTime: new Date("1970-01-01T12:00:00.000Z"),
+              date: specificDate,
+              scheduleId: 50,
+            },
+          ],
+        },
+      ];
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue(mockScheduleWithDateOverride);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      expect(result?.user.schedules[0].availability[0].date).toEqual(specificDate);
+      expect(result?.user.schedules[0].availability[0].days).toEqual([]);
+    });
+  });
+
+  describe("Parallel fetching", () => {
+    it("should fetch schedules and travel schedules in parallel", async () => {
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue([]);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      // Both should be called
+      expect(ScheduleRepository.findScheduleByUserId).toHaveBeenCalledTimes(1);
+      expect(TravelScheduleRepository.findTravelSchedulesByUserId).toHaveBeenCalledTimes(1);
+      expect(ScheduleRepository.findScheduleByUserId).toHaveBeenCalledWith({ userId: 100 });
+      expect(TravelScheduleRepository.findTravelSchedulesByUserId).toHaveBeenCalledWith(100);
+    });
+  });
+
+  // NEW TEST SECTION: Integration with availability calculation
+  describe("Integration with _getAvailableSlots", () => {
+    it("should add booker to allHosts when rescheduleUid is provided", async () => {
+      // This test verifies that the booker is correctly added to the hosts list
+      // which will then be used for availability calculation
+      const mockBooking = {
+        attendees: [{ email: "booker@example.com" }],
+      };
+
+      const mockBookerUser = {
+        id: 100,
+        email: "booker@example.com",
+      };
+
+      const mockBookerWithCredentials = {
+        id: 100,
+        credentials: [],
+      };
+
+      mockDependencies.bookingRepo.findBookingByUid.mockResolvedValue(mockBooking);
+      mockDependencies.userRepo.findByEmail.mockResolvedValue(mockBookerUser);
+      mockDependencies.userRepo.findUserWithCredentials.mockResolvedValue(mockBookerWithCredentials);
+      vi.mocked(ScheduleRepository.findScheduleByUserId).mockResolvedValue([]);
+      vi.mocked(TravelScheduleRepository.findTravelSchedulesByUserId).mockResolvedValue([]);
+
+      const result = await (availableSlotsService as any).getBookerAsHostForReschedule({
+        rescheduleUid: "test-uid",
+      });
+
+      // Verify structure matches what's expected for a host
+      expect(result).toHaveProperty("isFixed");
+      expect(result).toHaveProperty("createdAt");
+      expect(result).toHaveProperty("user");
+      expect(result?.user).toHaveProperty("credentials");
+      expect(result?.user).toHaveProperty("schedules");
+      expect(result?.user).toHaveProperty("travelSchedules");
+    });
   });
 });

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1004,6 +1004,8 @@ export class AvailableSlotsService {
       bookingUid: rescheduleUid,
     });
 
+    if (!rescheduleBooking?.attendees?.length) return null;
+
     const bookerEmail = rescheduleBooking?.attendees[0]?.email;
     if (!bookerEmail) return null;
 
@@ -1151,7 +1153,7 @@ export class AvailableSlotsService {
 
     const hasFallbackRRHosts = allFallbackRRHosts && allFallbackRRHosts.length > qualifiedRRHosts.length;
 
-    // Checking if booker is available.
+    // Checks if the booker is a Cal.com user and available.
     const bookerAsHost = input.rescheduleUid
       ? await this.getBookerAsHostForReschedule({ rescheduleUid: input.rescheduleUid })
       : null;

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1075,6 +1075,9 @@ export class AvailableSlotsService {
             id: bookerUser.id,
           });
 
+          // console.log("Booker User");
+          // console.dir(bookerUser , {depth : null});
+
           // console.dir(bookerWithCredentials  , {depth : null});
 
           if (bookerWithCredentials) {
@@ -1088,9 +1091,10 @@ export class AvailableSlotsService {
             //   userId: bookerUser.id
             // }) || [];
 
-            const bookerSchedules = await ScheduleRepository.findScheduleById({ id: bookerUser.id });
-            console.log("\n \n \n You \n \n \n");
-            console.log("Booker Scheddule : - ", bookerSchedules);
+            const bookerSchedules = await ScheduleRepository.findScheduleByUserId({ userId: bookerUser.id });
+            // console.log("\n \n \n You \n \n \n");
+            // console.log("Booker Schedules :  - ");
+            // console.dir(bookerSchedules, { depth: null });
             // WE HAVE
             // Booker Scheddule : -  {
             //   id: 44,
@@ -1128,9 +1132,18 @@ export class AvailableSlotsService {
             const bookerTravelSchedule = await TravelScheduleRepository.findTravelSchedulesByUserId(
               bookerUser.id
             );
-            console.log("Travel Schedule : - ", bookerTravelSchedule);
+            // console.log("Travel Schedule : - ", bookerTravelSchedule);
             // WE HAVE
-
+            // Travel Schedule : -  [
+            //   {
+            //     id: 2,
+            //     userId: 44,
+            //     startDate: 2025-10-07T18:30:00.000Z,
+            //     endDate: 2025-10-09T18:30:00.000Z,
+            //     timeZone: 'Asia/Kolkata',
+            //     prevTimeZone: null
+            //   }
+            // ]
             // WE NEED
             //          travelSchedules: [
             //          {
@@ -1142,33 +1155,56 @@ export class AvailableSlotsService {
             //            prevTimeZone: null
             //          }
             //        ],
+            //
+            //
+            //
+            // Transform bookerSchedules to match expected format
+            const transformedBookerSchedules = bookerSchedules.map((schedule) => ({
+              id: schedule.id,
+              timeZone: schedule.timeZone,
+              availability: schedule.availability.map((avail) => ({
+                date: avail.date,
+                startTime: avail.startTime,
+                endTime: avail.endTime,
+                days: avail.days,
+              })),
+            }));
+
+            // travelSchedules are already in the correct format, no transformation needed
+            const transformedTravelSchedules = bookerTravelSchedule;
+
             bookerAsHost = {
               isFixed: true,
               createdAt: null,
               user: {
                 ...bookerWithCredentials,
-                // schedules: bookerSchedules,
-                // travelSchedules: bookerTravelSchedules,
-                // Add other fields from the bookerUser that aren't in bookerWithCredentials
+                schedules: transformedBookerSchedules,
+                travelSchedules: transformedTravelSchedules,
+                email: bookerUser.email,
                 username: bookerUser.username,
-                name: bookerUser.name,
                 bufferTime: bookerUser.bufferTime || 0,
                 startTime: bookerUser.startTime || 0,
                 endTime: bookerUser.endTime || 1440,
                 timeFormat: bookerUser.timeFormat || 12,
-                // defaultScheduleId: bookerUser.defaultScheduleId,
+                defaultScheduleId: bookerUser.defaultScheduleId,
                 isPlatformManaged: bookerUser.isPlatformManaged || false,
-                availability: [], // User-level availability overrides
+                availability: [],
               },
             };
-            console.dir(bookerAsHost, { depth: null });
+            // console.dir(bookerAsHost, { depth: null });
           }
         }
       }
     }
 
+    if (bookerAsHost) {
+      allHosts.push(bookerAsHost);
+    }
+
+    console.dir(bookerAsHost, { depth: null });
+
     // console.log("Allhosts : - " , allHosts);
-    // console.log("\n \n \n You 2 \n \n \n");
+    console.log("\n \n \n You 2 \n \n \n");
     console.dir(allHosts, { depth: null });
     // console.dir(eventType , {depth : null});
 

--- a/packages/ui/components/form/checkbox/Checkbox.tsx
+++ b/packages/ui/components/form/checkbox/Checkbox.tsx
@@ -95,11 +95,10 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
                 {descriptionAsSafeHtml ? (
                   <span
                     className={classNames(
-                      "text-default ml-2 text-sm",
+                      "text-default ml-2 text-sm [&_a]:text-blue-500",
                       !label && "font-medium",
                       rest.descriptionClassName
                     )}
-                    // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{
                       __html: markdownToSafeHTML(descriptionAsSafeHtml),
                     }}

--- a/packages/ui/components/form/checkbox/Checkbox.tsx
+++ b/packages/ui/components/form/checkbox/Checkbox.tsx
@@ -95,7 +95,7 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
                 {descriptionAsSafeHtml ? (
                   <span
                     className={classNames(
-                      "text-default ml-2 text-sm [&_a]:text-blue-500",
+                      "text-default ml-2 text-sm",
                       !label && "font-medium",
                       rest.descriptionClassName
                     )}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR updates the rescheduling logic to check if the original booker is a Cal.com user. If they are, it fetches their availability and only shows time slots that work for both the host and the booker. This prevents reschedules to times when the booker is not available. It works regardless of who starts the reschedule, by checking for the ```rescheduleUid```

- Fixes #16378
- Fixes CAL-4531

#### Video Demo (if applicable):

https://github.com/user-attachments/assets/0cc127c9-8c94-4e0c-82cc-d48e0a0f457a

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code does follow the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
