### PR TITLE
fix: correct Polish translation for sign_in button

### DIFF
--- a/apps/web/public/static/locales/pl/common.json
+++ b/apps/web/public/static/locales/pl/common.json
@@ -342,7 +342,7 @@
   "dont_have_an_account": "Nie masz konta?",
   "2fa_code": "Kod dwuskładnikowy",
   "sign_in_account": "Zaloguj się na swoje konto",
-  "sign_in": "Zarejestruj",
+  "sign_in": "Zaloguj się",
   "go_back_login": "Wróć na stronę logowania",
   "error_during_login": "Wystąpił błąd podczas logowania. Wróć do ekranu logowania i spróbuj ponownie.",
   "request_password_reset": "Wyślij wiadomość e-mail umożliwiającą zresetowanie",


### PR DESCRIPTION
Fixes #24262

## Summary
Fixed incorrect Polish translation for the 'sign_in' button that was displaying 'Zarejestruj' (Sign up) instead of 'Zaloguj się' (Sign in).

## Changes
- Updated `apps/web/public/static/locales/pl/common.json`
- Changed 'sign_in' translation from 'Zarejestruj' to 'Zaloguj się'

## Test Plan
Verified the fix by:
1. Checking the translation file at http://localhost:3000/static/locales/pl/common.json
2. Confirmed 'sign_in' now correctly shows 'Zaloguj się' (Sign in)
3. Confirmed 'sign_up' still correctly shows 'Zarejestruj' (Sign up)

## Evidence
The translation is now consistent with other Polish UI strings that use 'Zaloguj się' for sign-in actions:
- `sign_in_account`: 'Zaloguj się na swoje konto'
- `sign_in_to_cal_com`: 'Zaloguj się do Cal.com'

Before fix:
```json
"sign_in": "Zarejestruj"
```

After fix:
```json
"sign_in": "Zaloguj się"
```