### PR TITLE
fix: correct API key prefix config key inconsistency

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
@@ -384,7 +384,7 @@ export class BookingsController_2024_04_15 {
     try {
       const bearerToken = req.get("Authorization")?.replace("Bearer ", "");
       if (bearerToken) {
-        if (isApiKey(bearerToken, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")) {
+        if (isApiKey(bearerToken, this.config.get<string>("api.keyPrefix") ?? "cal_")) {
           const strippedApiKey = stripApiKey(bearerToken, this.config.get<string>("api.keyPrefix"));
           const apiKeyHash = sha256Hash(strippedApiKey);
           const keyData = await this.apiKeyRepository.getApiKeyFromHash(apiKeyHash);

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -680,7 +680,7 @@ export class InputBookingsService_2024_08_13 {
     try {
       const bearerToken = req.get("Authorization")?.replace("Bearer ", "");
       if (bearerToken) {
-        if (isApiKey(bearerToken, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")) {
+        if (isApiKey(bearerToken, this.config.get<string>("api.keyPrefix") ?? "cal_")) {
           const strippedApiKey = stripApiKey(bearerToken, this.config.get<string>("api.keyPrefix"));
           const apiKeyHash = sha256Hash(strippedApiKey);
           const keyData = await this.apiKeyRepository.getApiKeyFromHash(apiKeyHash);

--- a/apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.spec.ts
+++ b/apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.spec.ts
@@ -24,7 +24,7 @@ describe("PermissionsGuard", () => {
       createMock<ConfigService>({
         get: jest.fn().mockImplementation((key: string) => {
           switch (key) {
-            case "api.apiKeyPrefix":
+            case "api.keyPrefix":
               return "cal_";
             default:
               return null;

--- a/apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.ts
+++ b/apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.ts
@@ -36,7 +36,7 @@ export class PermissionsGuard implements CanActivate {
     const nextAuthSecret = this.config.get("next.authSecret", { infer: true });
     const nextAuthToken = await getToken({ req: request, secret: nextAuthSecret });
     const oAuthClientId = request.params?.clientId || request.get(X_CAL_CLIENT_ID);
-    const apiKey = bearerToken && isApiKey(bearerToken, this.config.get("api.apiKeyPrefix") ?? "cal_");
+    const apiKey = bearerToken && isApiKey(bearerToken, this.config.get("api.keyPrefix") ?? "cal_");
     const isThirdPartyBearerToken = bearerToken && this.getDecodedThirdPartyAccessToken(bearerToken);
 
     // only check permissions for accessTokens attached to platform oAuth Client or platform oAuth credentials, not for next token or api key or third party oauth client

--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -88,7 +88,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
         if (apiKeyAllowed || accessTokenAllowed) {
           try {
             const requestOrigin = request.get("Origin");
-            request.authMethod = isApiKey(bearerToken, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")
+            request.authMethod = isApiKey(bearerToken, this.config.get<string>("api.keyPrefix") ?? "cal_")
               ? AuthMethods["API_KEY"]
               : AuthMethods["ACCESS_TOKEN"];
             return await this.authenticateBearerToken(bearerToken, request, requestOrigin);
@@ -216,7 +216,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     requestOrigin: string | undefined
   ) {
     try {
-      const user = isApiKey(authString, this.config.get<string>("api.apiKeyPrefix") ?? "cal_")
+      const user = isApiKey(authString, this.config.get<string>("api.keyPrefix") ?? "cal_")
         ? await this.apiKeyStrategy(authString, request)
         : await this.accessTokenStrategy(authString, request, requestOrigin);
 


### PR DESCRIPTION
## Summary

Fixes #23683 - Resolves 401 Unauthorized errors when using API keys with the `/v2/bookings` endpoint.

This PR fixes a critical configuration key inconsistency that was causing API key authentication failures, particularly affecting the Elevenlabs integration and all other API users.

## Root Cause

The configuration file (`apps/api/v2/src/config/app.ts`) defines the API key prefix as **`api.keyPrefix`**, but multiple authentication files were incorrectly referencing **`api.apiKeyPrefix`** (a non-existent config key).

When `config.get("api.apiKeyPrefix")` was called, it returned `undefined`, causing the code to fall back to the hardcoded default `"cal_"`. While this works for the default case, it creates a critical inconsistency:

1. **API key detection** uses `config.get("api.apiKeyPrefix")` → returns `undefined` → falls back to `"cal_"`
2. **API key stripping** uses `config.get("api.keyPrefix")` → returns the actual configured value (e.g., custom prefix from `API_KEY_PREFIX` env var)
3. This mismatch causes incorrect hash computation
4. Database lookup fails
5. Authentication returns **401 Unauthorized**

## Changes

Updated all occurrences from `api.apiKeyPrefix` to `api.keyPrefix` in:

- `apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts` (2 occurrences)
- `apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts` (1 occurrence)
- `apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts` (1 occurrence)
- `apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.ts` (1 occurrence)
- `apps/api/v2/src/modules/auth/guards/permissions/permissions.guard.spec.ts` (1 test occurrence)

**Total:** 5 files changed, 6 insertions(+), 6 deletions(-)

## Test Plan

- [x] Verified all instances of `api.apiKeyPrefix` have been replaced with `api.keyPrefix`
- [x] Confirmed the correct config key matches `apps/api/v2/src/config/app.ts` line 18
- [x] Ran `yarn install` to resolve workspace dependencies
- [x] All authentication code paths now use consistent config key

## Impact

- **Severity:** High (critical authentication failure)
- **Affected Users:** All API users using API keys, especially Elevenlabs integration
- **Category:** Bug fix - Authentication
- **API Version:** v2

## Evidence

From issue #23683:
- User confirmed `/v2/slots` endpoint worked with their API key
- Same API key failed on `/v2/bookings` with 401 error
- This PR fixes the root cause by ensuring config key consistency

---

Related: #23683