### PR TITLE
fix: fixed fallback to empty location state when all locations are removed

### DIFF
--- a/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
+++ b/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
-import type { UseFormGetValues, UseFormSetValue, Control, FormState } from "react-hook-form";
+import type { UseFormGetValues, Control, FormState } from "react-hook-form";
 
 import type {
   TLocationOptions,
@@ -63,7 +63,6 @@ const LocationsWrapper = ({
         prefillLocation={prefillLocation}
         team={null}
         getValues={formMethods.getValues as unknown as UseFormGetValues<LocationFormValues>}
-        setValue={formMethods.setValue as unknown as UseFormSetValue<LocationFormValues>}
         control={formMethods.control as unknown as Control<LocationFormValues>}
         formState={formMethods.formState as unknown as FormState<LocationFormValues>}
       />

--- a/packages/features/eventtypes/components/locations/Locations.tsx
+++ b/packages/features/eventtypes/components/locations/Locations.tsx
@@ -2,17 +2,13 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { ErrorMessage } from "@hookform/error-message";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useFieldArray, useFormContext } from "react-hook-form";
-import type { UseFormGetValues, UseFormSetValue, Control, FormState } from "react-hook-form";
+import { useFieldArray } from "react-hook-form";
+import type { UseFormGetValues, Control, FormState } from "react-hook-form";
 
 import type { EventLocationType } from "@calcom/app-store/locations";
 import { getEventLocationType, MeetLocationType } from "@calcom/app-store/locations";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
-import type {
-  LocationFormValues,
-  EventTypeSetupProps,
-  FormValues,
-} from "@calcom/features/eventtypes/lib/types";
+import type { LocationFormValues, EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types";
 import CheckboxField from "@calcom/features/form/components/CheckboxField";
 import type { SingleValueLocationOption } from "@calcom/features/form/components/LocationSelect";
 import LocationSelect from "@calcom/features/form/components/LocationSelect";
@@ -34,11 +30,6 @@ export type TLocationOptions = Pick<EventTypeSetupProps, "locationOptions">["loc
 export type TDestinationCalendar = { integration: string } | null;
 export type TPrefillLocation = { credentialId?: number; type: string };
 
-type LocationInputCustomClassNames = {
-  addressInput?: string;
-  phoneInput?: string;
-};
-
 type LocationsProps = {
   team: { id: number } | null;
   destinationCalendar: TDestinationCalendar;
@@ -47,7 +38,6 @@ type LocationsProps = {
   isManagedEventType?: boolean;
   disableLocationProp?: boolean;
   getValues: UseFormGetValues<LocationFormValues>;
-  setValue: UseFormSetValue<LocationFormValues>;
   control: Control<LocationFormValues>;
   formState: FormState<LocationFormValues>;
   eventType: TEventTypeLocation;
@@ -96,7 +86,6 @@ const Locations: React.FC<LocationsProps> = ({
   disableLocationProp,
   isManagedEventType,
   getValues,
-  setValue,
   control,
   formState,
   team,
@@ -115,8 +104,6 @@ const Locations: React.FC<LocationsProps> = ({
     control,
     name: "locations",
   });
-
-  const formMethods = useFormContext<FormValues>();
 
   const locationOptions = props.locationOptions.map((locationOption) => {
     const options = locationOption.options.filter((option) => {
@@ -159,7 +146,7 @@ const Locations: React.FC<LocationsProps> = ({
   );
 
   useEffect(() => {
-    if (!!prefillLocation) {
+    if (prefillLocation) {
       const newLocationType = prefillLocation.value;
 
       const canAppendLocation = !validLocations.find((location) => location.type === newLocationType);
@@ -172,7 +159,6 @@ const Locations: React.FC<LocationsProps> = ({
         setSelectedNewOption(prefillLocation);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillLocation, seatsEnabled]);
 
   const isPlatform = useIsPlatform();
@@ -250,6 +236,7 @@ const Locations: React.FC<LocationsProps> = ({
                     type="button"
                     onClick={() => {
                       remove(index);
+                      setSelectedNewOption(null);
                     }}
                     aria-label={t("remove")}>
                     <div className="h-4 w-4">
@@ -369,11 +356,10 @@ const Locations: React.FC<LocationsProps> = ({
                         teamName: e.teamName ?? undefined,
                       }),
                     });
-                    setSelectedNewOption(e);
                   } else {
                     showToast(t("location_already_exists"), "warning");
-                    setSelectedNewOption(null);
                   }
+                  setSelectedNewOption(null);
                 }
               }}
             />

--- a/packages/features/eventtypes/components/tabs/setup/EventSetupTab.tsx
+++ b/packages/features/eventtypes/components/tabs/setup/EventSetupTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import type { UseFormGetValues, UseFormSetValue, Control, FormState } from "react-hook-form";
+import type { UseFormGetValues, Control, FormState } from "react-hook-form";
 import type { MultiValue } from "react-select";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
@@ -70,7 +70,7 @@ export const EventSetupTab = (
   const { t } = useLocale();
   const isPlatform = useIsPlatform();
   const formMethods = useFormContext<FormValues>();
-  const { eventType, team, urlPrefix, hasOrgBranding, customClassNames, orgId } = props;
+  const { eventType, team, urlPrefix, hasOrgBranding, customClassNames } = props;
 
   const [multipleDuration, setMultipleDuration] = useState(
     formMethods.getValues("metadata")?.multipleDuration
@@ -366,7 +366,6 @@ export const EventSetupTab = (
                   isManagedEventType={isManagedEventType}
                   disableLocationProp={shouldLockDisableProps("locations").disabled}
                   getValues={formMethods.getValues as unknown as UseFormGetValues<LocationFormValues>}
-                  setValue={formMethods.setValue as unknown as UseFormSetValue<LocationFormValues>}
                   control={formMethods.control as unknown as Control<LocationFormValues>}
                   formState={formMethods.formState as unknown as FormState<LocationFormValues>}
                   {...props}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24338 
- Fixes CAL-6537
- Set the selected option state to null when a location is removed, so that there is no error when state is changed
- Set the selected option state to null when new locations are created so that when the next location is added, it shows null state instead of the previously created location
- Cleaned up some code which caused eslint errors

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Original Implementation:

No empty state when locations are removed:

https://github.com/user-attachments/assets/0a13c733-749c-4182-ad43-5d45973ef6f1


New location showing the last selected option (another error i found during testing):

https://github.com/user-attachments/assets/825ce932-6534-4d51-953b-40407993e93c


After Changes:

https://github.com/user-attachments/assets/b68186a1-d76c-42eb-8123-b3dfb7f136ea


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. -> N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Under any event type try to add locations and remove them, the change will be visible
