### PR TITLE
Fix/org owners edit own username

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -38,7 +38,7 @@ interface GoogleCalError extends Error {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ONE_MONTH_IN_MS = 30 * MS_PER_DAY;
- 
+
 const GOOGLE_WEBHOOK_URL_BASE = process.env.GOOGLE_WEBHOOK_URL || process.env.NEXT_PUBLIC_WEBAPP_URL;
 const GOOGLE_WEBHOOK_URL = `${GOOGLE_WEBHOOK_URL_BASE}/api/integrations/googlecalendar/webhook`;
 
@@ -203,13 +203,13 @@ export default class GoogleCalendarService implements Calendar {
       },
       attendees: this.getAttendees({ event: calEvent, hostExternalCalendarId: externalCalendarId }),
       reminders:
-        customReminderMinutes && Number.isFinite(customReminderMinutes)
+        customReminderMinutes !== undefined && Number.isFinite(customReminderMinutes)
           ? {
               useDefault: false,
               overrides: [
                 {
                   method: "popup",
-                  minutes: Math.max(0, Math.floor(customReminderMinutes as number)),
+                  minutes: Math.max(0, Math.floor(customReminderMinutes)),
                 },
               ],
             }
@@ -381,13 +381,13 @@ export default class GoogleCalendarService implements Calendar {
       },
       attendees: this.getAttendees({ event, hostExternalCalendarId: externalCalendarId }),
       reminders:
-        updateCustomReminderMinutes && Number.isFinite(updateCustomReminderMinutes)
+        updateCustomReminderMinutes !== undefined && Number.isFinite(updateCustomReminderMinutes)
           ? {
               useDefault: false,
               overrides: [
                 {
                   method: "popup",
-                  minutes: Math.max(0, Math.floor(updateCustomReminderMinutes as number)),
+                  minutes: Math.max(0, Math.floor(updateCustomReminderMinutes)),
                 },
               ],
             }

--- a/packages/features/ee/teams/components/MemberList.tsx
+++ b/packages/features/ee/teams/components/MemberList.tsx
@@ -433,7 +433,8 @@ function MemberListContent(props: Props) {
           const canImpersonate = props.permissions?.canImpersonate ?? false;
           const canResendInvitation = props.permissions?.canInvite ?? false;
           const editMode =
-            [canChangeRole, canRemove, canImpersonate, canResendInvitation].some(Boolean) && !isSelf;
+            [canChangeRole, canRemove, canImpersonate, canResendInvitation].some(Boolean) &&
+            (!isSelf || props.isOrgAdminOrOwner);
 
           const impersonationMode =
             canImpersonate &&
@@ -668,7 +669,7 @@ function MemberListContent(props: Props) {
     getFacetedUniqueValues: (_, columnId) => () => {
       if (facetedTeamValues) {
         switch (columnId) {
-          case "role":
+          case "role": {
             // Include both traditional roles and PBAC custom roles
             const allRoles = facetedTeamValues.roles.map((role) => ({
               label: role.name,
@@ -676,6 +677,7 @@ function MemberListContent(props: Props) {
             }));
 
             return convertFacetedValuesToMap(allRoles);
+          }
           default:
             return new Map();
         }
@@ -685,7 +687,7 @@ function MemberListContent(props: Props) {
     getRowId: (row) => `${row.id}`,
   });
 
-  const fetchMoreOnBottomReached = useFetchMoreOnBottomReached({
+  const _fetchMoreOnBottomReached = useFetchMoreOnBottomReached({
     tableContainerRef,
     hasNextPage,
     fetchNextPage,

--- a/packages/features/users/components/UserTable/UserListTable.tsx
+++ b/packages/features/users/components/UserTable/UserListTable.tsx
@@ -169,7 +169,7 @@ function UserListTableContent({
   );
 
   // TODO (SEAN): Make Column filters a trpc query param so we can fetch serverside even if the data is not loaded
-  const totalRowCount = data?.meta?.totalRowCount ?? 0;
+  const _totalRowCount = data?.meta?.totalRowCount ?? 0;
   const adminOrOwner = checkAdminOrOwner(org?.user?.role);
 
   //we must flatten the array of arrays from the useInfiniteQuery hook
@@ -448,7 +448,7 @@ function UserListTableContent({
           const isSelf = user.id === session?.user.id;
 
           const permissionsForUser = {
-            canEdit: permissionsRaw.canEdit && user.accepted && !isSelf,
+            canEdit: permissionsRaw.canEdit && user.accepted && (!isSelf || adminOrOwner),
             canRemove: permissionsRaw.canRemove && !isSelf,
             canImpersonate:
               user.accepted &&
@@ -514,7 +514,7 @@ function UserListTableContent({
                 value: team.name,
               }))
             );
-          default:
+          default: {
             const attribute = facetedTeamValues.attributes.find((attr) => attr.id === columnId);
             if (attribute) {
               return convertFacetedValuesToMap(
@@ -525,6 +525,7 @@ function UserListTableContent({
               );
             }
             return new Map();
+          }
         }
       }
       return new Map();

--- a/packages/types/Calendar.d.ts
+++ b/packages/types/Calendar.d.ts
@@ -5,6 +5,7 @@ import type { Time } from "ical.js";
 import type { Frequency } from "rrule";
 import type z from "zod";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { bookingResponse } from "@calcom/features/bookings/lib/getBookingResponsesSchema";
 import type { Calendar } from "@calcom/features/calendars/weeklyview";
 import type { TimeFormat } from "@calcom/lib/timeFormat";
@@ -210,6 +211,9 @@ export interface CalendarEvent {
   disableCancelling?: boolean;
   disableRescheduling?: boolean;
 
+  // Optional per-calendar reminder override in minutes for integrations that support it
+  customReminderMinutes?: number;
+
   // It has responses to all the fields(system + user)
   responses?: CalEventResponses | null;
 
@@ -260,6 +264,8 @@ export interface IntegrationCalendar extends Ensure<Partial<_SelectedCalendar>, 
 export type SelectedCalendarEventTypeIds = (number | null)[];
 
 export interface CalendarServiceEvent extends CalendarEvent {
+  // Optional per-calendar reminder override in minutes for integrations that support it
+  customReminderMinutes?: number;
   calendarDescription: string;
 }
 


### PR DESCRIPTION
Fix: Allow org owners and admins to edit their own usernames
Problem: Org owners and admins couldn't see the triple dot menu to edit their own usernames in the organization member list.
Solution: Modified permission logic to allow org owners/admins to edit themselves while maintaining security for regular members.
Changes:
UserListTable.tsx: Allow edit for self if user is admin/owner
MemberList.tsx: Allow edit for self if user is org admin/owner
Security: Only users with proper admin/owner permissions can edit themselves; regular members still cannot.
Fixes #24377