### PR TITLE
fix: provide meetingStartTime for test preview to prevent 'Meeting start time is required' crash

### DIFF
--- a/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
+++ b/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
@@ -7,9 +7,9 @@ import type { ServerResponse } from "http";
 import type { NextApiResponse } from "next";
 
 import { enrichFormWithMigrationData } from "@calcom/app-store/routing-forms/enrichFormWithMigrationData";
+import { getLuckyUserService } from "@calcom/features/di/containers/LuckyUser";
 import { getUrlSearchParamsToForwardForTestPreview } from "@calcom/features/routing-forms/lib/getUrlSearchParamsToForward";
 import { enrichHostsWithDelegationCredentials } from "@calcom/lib/delegationCredential/server";
-import { getLuckyUserService } from "@calcom/features/di/containers/LuckyUser";
 import { entityPrismaWhereClause } from "@calcom/lib/entityPermissionUtils.server";
 import { fromEntriesWithDuplicateKeys } from "@calcom/lib/fromEntriesWithDuplicateKeys";
 import { findTeamMembersMatchingAttributeLogic } from "@calcom/lib/raqb/findTeamMembersMatchingAttributeLogic";
@@ -296,6 +296,7 @@ export const findTeamMembersMatchingAttributeLogicOfRouteHandler = async ({
           form,
           chosenRouteId: route.id,
         },
+        meetingStartTime: new Date(),
       })
     : { users: [], perUserData: null, isUsingAttributeWeights: false };
   const timeAfterGetOrderedLuckyUsers = performance.now();

--- a/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
+++ b/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
@@ -296,6 +296,7 @@ export const findTeamMembersMatchingAttributeLogicOfRouteHandler = async ({
           form,
           chosenRouteId: route.id,
         },
+        // During Preview testing we could consider the current time itself as the meeting start time
         meetingStartTime: new Date(),
       })
     : { users: [], perUserData: null, isUsingAttributeWeights: false };


### PR DESCRIPTION
## What does this PR do?

Fixes the "Meeting start time is required" error that occurs when users click "Test Preview" on routing forms where the team's Round Robin timestamp basis is set to "Meeting Start Time" (START_TIME).

**Root Cause:** When Round Robin timestamp basis is set to START_TIME, the system requires a meeting start time to calculate the time interval for load balancing distribution. Test Preview doesn't provide a real meeting time since it's just simulating the routing logic, causing the validation to fail.

**Solution:** Provide the current time (`new Date()`) as the `meetingStartTime` when calling `getOrderedListOfLuckyUsers` in test preview mode. This allows the Round Robin calculation to proceed using the current interval for realistic team member ordering.

## How should this be tested?

**Reproduction Steps:**
1. Create a team with Round Robin enabled 
2. Go to Team Settings → Round Robin Settings
3. Set "Timestamp Basis" to "Meeting Start Time" (not "Booking Creation Time")
4. Create a routing form with attribute logic that routes to an event type from that team
5. Click "Test Preview" on the routing form and submit a response
6. **Before fix:** Error "Meeting start time is required" appears
7. **After fix:** Test preview works and shows ordered team members based on Round Robin logic

**Environment setup:**
- Requires a team with Round Robin load balancing enabled
- Need routing forms with attribute logic configured
- Team's `rrTimestampBasis` must be set to `START_TIME`

**Expected behavior:**
- Test preview should complete successfully and show team members in Round Robin order
- No "Meeting start time is required" error should appear
- Round Robin ordering should be calculated using current time interval

## Visual Demo

**⚠️ Testing Limitation:** Due to the complexity of setting up the full Cal.com environment with teams, routing forms, and Round Robin settings, this fix was implemented based on code analysis and could not be tested locally. **This is the primary risk factor for this PR** - the reviewer should verify the fix actually resolves the issue.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a bug fix that doesn't require documentation changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Unable to add tests due to testing environment limitations** - existing test coverage should be sufficient as this is a minimal parameter addition.

## Human Review Checklist

**Critical items to verify:**
- [ ] **Actually test the reproduction steps** - Can you reproduce the original error and confirm this fix resolves it?
- [ ] **Verify Round Robin behavior** - Does the team member ordering in test preview make sense with current time as meeting start time?
- [ ] **Check for side effects** - Ensure real booking flows (non-preview) still work correctly
- [ ] **Business logic validation** - Is using current time the right approach for test preview, or should we consider other alternatives?

**Implementation Details:**
- Only one line added: `meetingStartTime: new Date()`
- Minor import reordering (automatic formatting)
- No changes to actual booking flows, only test preview

---

**Link to Devin run:** https://app.devin.ai/sessions/acea825e8466431a8ba392038fc718c8  
**Requested by:** @hariombalhara

**Note:** This is a targeted fix for a specific error scenario. The change is minimal and low-risk from a code perspective, but requires verification that the business logic assumptions are correct.