### PR TITLE
feat: add icelandic language to i18n

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -20,6 +20,7 @@
       "fr",
       "he",
       "hu",
+      "is",
       "it",
       "ja",
       "km",
@@ -38,8 +39,7 @@
       "uk",
       "vi",
       "zh-CN",
-      "zh-TW",
-      "is"
+      "zh-TW"
     ]
   },
   "buckets": {

--- a/i18n.json
+++ b/i18n.json
@@ -38,7 +38,8 @@
       "uk",
       "vi",
       "zh-CN",
-      "zh-TW"
+      "zh-TW",
+      "is"
     ]
   },
   "buckets": {


### PR DESCRIPTION
Summary

This PR adds Icelandic (is) language support to the project.

Context

As discussed in the internal thread, the Icelandic language is supported by lingo.dev, so we can enable it by adding the corresponding entry in i18n.json. This will allow auto-generation of translations for Icelandic once merged.

Changes

Added "is" to the list of supported languages in i18n.json.

Impact

This enables users to switch the language to Icelandic.