### PR TITLE
fix: add users to managed event types when auto-accepting sub-team memberships

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1001,7 +1001,7 @@ export async function handleNewUsersInvites({
 }) {
   const translation = await getTranslation(language, "common");
 
-  await createNewUsersConnectToOrgIfExists({
+  const createdUsers = await createNewUsersConnectToOrgIfExists({
     invitations: invitationsForNewUsers,
     isOrg,
     teamId: teamId,
@@ -1011,6 +1011,14 @@ export async function handleNewUsersInvites({
     language,
     creationSource,
   });
+
+  const autoAcceptedUsers = createdUsers.filter(
+    (user) => orgConnectInfoByUsernameOrEmail[user.email].autoAccept
+  );
+
+  if (autoAcceptedUsers.length > 0) {
+    await Promise.all(autoAcceptedUsers.map((user) => updateNewTeamMemberEventTypes(user.id, teamId)));
+  }
 
   const sendVerifyEmailsPromises = invitationsForNewUsers.map((invitation) => {
     return sendSignupToOrganizationEmail({


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where users auto-accepted to sub teams via domain matching were not being automatically added to managed event types with `assignAllTeamMembers: true`.

**Root Cause**: The invitation flow was missing calls to `updateNewTeamMemberEventTypes` in two scenarios:
1. When existing users are auto-accepted to the parent organization (which batch-accepts pending sub-team memberships)  
2. When new users are invited directly to sub-teams with matching auto-accept domains

**Solution**: Added the missing `updateNewTeamMemberEventTypes` calls in both code paths to ensure users get properly assigned to managed event types.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). **N/A** - This is a bug fix that doesn't change the documented API or user-facing behavior.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Integration Tests**: Added comprehensive integration tests that verify both scenarios work correctly. The tests:
1. Create organizations with auto-accept domains
2. Set up managed event types with `assignAllTeamMembers: true`  
3. Simulate the invitation flows
4. Verify that child event types are created for the users

**Manual Testing** (if needed):
1. Set up an organization with `orgAutoAcceptEmail` domain matching
2. Create a sub-team with a managed event type (`assignAllTeamMembers: true`)
3. Test both scenarios:
   - Invite existing user to organization → verify they get added to sub-team managed event types
   - Invite new user directly to sub-team → verify they get added to managed event types

## Key Changes

### Bug Fix #1: Existing users auto-accepted to org
```typescript
// Before: Only batch-accepted sub-team memberships, didn't call updateNewTeamMemberEventTypes
// After: Query pending memberships first, then call updateNewTeamMemberEventTypes for each
const pendingSubTeamMemberships = await prisma.membership.findMany({...});
await prisma.membership.updateMany({...}); 
await Promise.all(
  pendingSubTeamMemberships.map(({ teamId }) => updateNewTeamMemberEventTypes(user.id, teamId))
);
```

### Bug Fix #2: New users invited to sub-team  
```typescript
// Before: Created users but never called updateNewTeamMemberEventTypes
// After: Filter auto-accepted users and add them to managed event types
const createdUsers = await createNewUsersConnectToOrgIfExists({...});
const autoAcceptedUsers = createdUsers.filter(
  (user) => orgConnectInfoByUsernameOrEmail[user.email].autoAccept
);
await Promise.all(autoAcceptedUsers.map((user) => updateNewTeamMemberEventTypes(user.id, teamId)));
```

## Review Focus Areas

- **Database Query Logic**: Verify the query for pending sub-team memberships captures the correct memberships
- **Auto-Accept Detection**: Confirm the filtering logic `orgConnectInfoByUsernameOrEmail[user.email].autoAccept` works correctly
- **Performance**: Consider impact of additional database queries in organizations with many sub-teams
- **Integration Tests**: Review test scenarios match the actual bug conditions

---

**Link to Devin run**: https://app.devin.ai/sessions/c0d0a43edbe6412dbec727ffd00e1e6f  
**Requested by**: @joeauyeung