### PR TITLE
fix: calendar invite organizer reassignment

### DIFF
--- a/packages/features/ee/round-robin/handleRescheduleEventManager.ts
+++ b/packages/features/ee/round-robin/handleRescheduleEventManager.ts
@@ -77,14 +77,12 @@ export const handleRescheduleEventManager = async ({
   const results = updateManager.results ?? [];
 
   const calVideoResult = results.find((result) => result.type === "daily_video");
-  // Check if Cal Video Creation Failed - That is the fallback for Cal.com and is expected to always work
+  // Log warning if Cal Video creation failed but don't block (consistent with initial booking)
   if (calVideoResult && !calVideoResult.success) {
-    handleRescheduleEventManager.error("Cal Video creation failed", {
+    handleRescheduleEventManager.warn("Cal Video creation failed - continuing without video link", {
       error: calVideoResult.error,
       bookingLocation,
     });
-    // This happens only when Cal Video is down
-    throw new Error("Failed to set video conferencing link, but the meeting has been rescheduled");
   }
 
   const { metadata: videoMetadata, videoCallUrl: _videoCallUrl } = getVideoCallDetails({


### PR DESCRIPTION
## What does this PR do?

Fixes the calendar invite owner not updating when a booking is reassigned to a different team member. After reassignment, the calendar invite now correctly reflects the new host as the owner in both Google Calendar and Outlook.

- Fixes #24357
- Fixes CAL-6547 

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

#Before 
<div>
    <a href="https://www.loom.com/share/b0d3a521ca0547fb96a29bd8344ba8cf">
      <p>#24357-before - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/b0d3a521ca0547fb96a29bd8344ba8cf">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b0d3a521ca0547fb96a29bd8344ba8cf-153c00b33de68b0f-full-play.gif">
    </a>
  </div>
  <br /> <br />
  

#After 
<div>
    <a href="https://www.loom.com/share/14bc90a36e7c430283efe08a418a5ed0">
      <p>#24357-after - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/14bc90a36e7c430283efe08a418a5ed0">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/14bc90a36e7c430283efe08a418a5ed0-1b87c6c1f1ceefe6-full-play.gif">
    </a>
  </div>
  
  <br/> <br/>



#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

##Key changes:

- Update organizer field to use new user's details when host changes

- Preserve original iCalUID to prevent duplicate calendar events

- Update existing calendar event instead of delete+create pattern

- Remove blocking video integration validation (consistent with initial booking behavior)  

- Show individual host name instead of team name in event title

## How should this be tested?

#Prerequisites:

- Team event type with round-robin assignment
- At least 2 team members with calendar integration (Google Calendar recommended)
- No video integration setup required

#Test steps:

- Create a booking assigned to Team Member A
- Check calendar - event organizer should be Member A
- Reassign booking to Team Meamber B via admin panel
- Check calendar - event organizer should update to Member B
- Verify no duplicate events exist
- Verify event title shows "Member B" not team name
- Reassign back to Member A - should work bidirectionally

#Expected outcome:

- Calendar event organizer updates to new host
- Single event (no duplicates)
- Event title shows individual host name
- Reassignment completes without errors

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
