### PR TITLE
feat: Add videoCallUrl to zapier payload

### DIFF
--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -1,10 +1,10 @@
 import { v4 } from "uuid";
 
+import { DailyLocationType, getHumanReadableLocationValue } from "@calcom/app-store/locations";
 import { selectOOOEntries } from "@calcom/app-store/zapier/api/subscriptions/listOOOEntries";
 import dayjs from "@calcom/dayjs";
 import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventResponses";
 import tasker from "@calcom/features/tasker";
-import { DailyLocationType, getHumanReadableLocationValue } from "@calcom/app-store/locations";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
 import { withReporting } from "@calcom/lib/sentryWrapper";
@@ -12,6 +12,7 @@ import { getTranslation } from "@calcom/lib/server/i18n";
 import { prisma } from "@calcom/prisma";
 import type { Prisma, Webhook, Booking, ApiKey } from "@calcom/prisma/client";
 import { BookingStatus, WebhookTriggerEvents } from "@calcom/prisma/enums";
+import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 
 const SCHEDULING_TRIGGER: WebhookTriggerEvents[] = [
   WebhookTriggerEvents.MEETING_ENDED,
@@ -213,6 +214,7 @@ export async function listBookings(
         location: true,
         cancellationReason: true,
         status: true,
+        metadata: true,
         user: {
           select: {
             username: true,
@@ -249,6 +251,7 @@ export async function listBookings(
     const t = await getTranslation(bookings[0].user?.locale ?? "en", "common");
 
     const updatedBookings = bookings.map((booking) => {
+      const parsedMetadata = bookingMetadataSchema.safeParse(booking.metadata || {});
       return {
         ...booking,
         ...getCalEventResponses({
@@ -256,6 +259,9 @@ export async function listBookings(
           booking,
         }),
         location: getHumanReadableLocationValue(booking.location || "", t),
+        metadata: {
+          videoCallUrl: parsedMetadata.success ? parsedMetadata.data?.videoCallUrl : undefined,
+        },
       };
     });
 

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -159,6 +159,9 @@ function getZapierPayload(data: WithUTCOffsetType<EventPayloadType & { createdAt
     },
     attendees: attendees,
     createdAt: data.createdAt,
+    metadata: {
+      videoCallUrl: data.metadata?.videoCallUrl,
+    },
   };
   return JSON.stringify(body);
 }
@@ -175,7 +178,7 @@ function applyTemplate(template: string, data: WebhookDataType, contentType: Con
 export function jsonParse(jsonString: string) {
   try {
     return JSON.parse(jsonString);
-  } catch (e) {
+  } catch {
     // don't do anything.
   }
   return false;


### PR DESCRIPTION
## What does this PR do?

Adds videoCallUrl to Zapier payload same as we have it in the webhook payload


```
metadata: {
	videoCallUrl: ""
}

```

It’s added to the `/listBookings` endpoint, which Zapier uses to check for recent items to have sample data, and to `sendPayload`