### PR TITLE
fix: pass cancellation reason for seated event cancellations in API v2

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -554,7 +554,7 @@ export class InputBookingsService_2024_08_13 {
   }
 
   isRescheduleSeatedBody(body: RescheduleBookingInput): body is RescheduleSeatedBookingInput_2024_08_13 {
-    return body.hasOwnProperty("seatUid");
+    return Object.hasOwn(body, "seatUid");
   }
 
   async transformInputRescheduleSeatedBooking(
@@ -770,7 +770,7 @@ export class InputBookingsService_2024_08_13 {
   }
 
   isCancelSeatedBody(body: CancelBookingInput): body is CancelSeatedBookingInput_2024_08_13 {
-    return body.hasOwnProperty("seatUid");
+    return Object.hasOwn(body, "seatUid");
   }
 
   async transformInputCancelBooking(bookingUid: string, inputBooking: CancelBookingInput_2024_08_13) {
@@ -817,7 +817,7 @@ export class InputBookingsService_2024_08_13 {
     // for an individual person, so api users need to call booking by booking using uid + seatUid to cancel it.
     return {
       uid: bookingUid,
-      cancellationReason: "",
+      cancellationReason: inputBooking.cancellationReason || "",
       allRemainingBookings: false,
       seatReferenceUid: inputBooking.seatUid,
     };

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -554,7 +554,7 @@ export class InputBookingsService_2024_08_13 {
   }
 
   isRescheduleSeatedBody(body: RescheduleBookingInput): body is RescheduleSeatedBookingInput_2024_08_13 {
-    return Object.hasOwn(body, "seatUid");
+    return body.hasOwnProperty("seatUid");
   }
 
   async transformInputRescheduleSeatedBooking(
@@ -770,7 +770,7 @@ export class InputBookingsService_2024_08_13 {
   }
 
   isCancelSeatedBody(body: CancelBookingInput): body is CancelSeatedBookingInput_2024_08_13 {
-    return Object.hasOwn(body, "seatUid");
+    return body.hasOwnProperty("seatUid");
   }
 
   async transformInputCancelBooking(bookingUid: string, inputBooking: CancelBookingInput_2024_08_13) {

--- a/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking.input.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking.input.ts
@@ -24,4 +24,9 @@ export class CancelSeatedBookingInput_2024_08_13 {
   })
   @IsString()
   seatUid!: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiPropertyOptional({ example: "User requested cancellation" })
+  cancellationReason?: string;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes API v2 cancellation validation issue for seated events where hosts receive "cancellation reason required" error even when providing a valid reason.

**Root cause**: The `transformInputCancelSeatedBooking` function was hardcoding `cancellationReason: ""` instead of passing through the actual cancellation reason from the request.

