### PR TITLE
fix: v2/slots showing booked times as available 

### DIFF
--- a/apps/web/test/lib/getSchedule/selectedSlots.test.ts
+++ b/apps/web/test/lib/getSchedule/selectedSlots.test.ts
@@ -260,7 +260,7 @@ describe("getSchedule", () => {
       expect(slot?.attendees).toBe(1);
     });
 
-    test("should block slots even when reservation is for a different event type", async () => {
+    test("should NOT block slots when reservation is for a different event type", async () => {
       // In IST timezone, it is 2024-05-31T07:00:00
       vi.setSystemTime("2024-05-31T01:30:00Z");
       const yesterdayDateString = "2024-05-30";
@@ -303,10 +303,10 @@ describe("getSchedule", () => {
         input: getTestScheduleInput({ yesterdayDateString, plus5DateString }),
       });
 
-      // The 4:00 slot should still be unavailable even when the reservation is for a different event type
+      // The 4:00 slot SHOULD be available because the reservation is for a different event type
       expect(schedule).toHaveTimeSlots(
         [
-          // "04:00:00.000Z",
+          "04:00:00.000Z",
           "04:45:00.000Z",
           "05:30:00.000Z",
           "06:15:00.000Z",

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -170,7 +170,9 @@ export class AvailableSlotsService {
         currentTimeInUtc,
       })) || [];
 
-    const slotsSelectedByOtherUsers = unexpiredSelectedSlots.filter((slot) => slot.uid !== bookerClientUid);
+    const slotsSelectedByOtherUsers = unexpiredSelectedSlots.filter(
+      (slot) => slot.uid !== bookerClientUid && slot.eventTypeId === eventTypeId
+    );
 
     await _cleanupExpiredSlots({ eventTypeId });
 


### PR DESCRIPTION
## What does this PR do?

Fixes slot reservations incorrectly blocking availability across different event types. When team members are shared across multiple event types, reservations from one event type were blocking slots for all other event types.


- Fixes #24353 (GitHub issue number)
- Fixes CAL-6543 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create two team event types with the same team members (e.g., Event A and Event B)
2. Reserve a slot for Event A at 10:00 AM
3. Query available slots for Event B via v2/slots API
4. Verify that 10:00 AM slot is available for Event B (previously it was incorrectly blocked)
5. Verify that 10:00 AM slot is unavailable for Event A (correctly blocked)

**Expected:** Slot reservations only block availability for the same event type, not across different event types.

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
