### PR TITLE
fix: ICS calendars disappearing from destination calendar dropdown

### DIFF
--- a/packages/platform/atoms/destination-calendar/DestinationCalendarSelector.tsx
+++ b/packages/platform/atoms/destination-calendar/DestinationCalendarSelector.tsx
@@ -72,7 +72,7 @@ export const DestinationCalendarSelector = ({
             : selectedCalendar.primary?.name
         })`,
         options: (selectedCalendar.calendars ?? [])
-          .filter((cal) => cal.readOnly === false)
+          .filter((cal) => cal.readOnly === false || cal.integration === "ics-feed_calendar")
           .map((cal) => ({
             label: ` ${cal.name} `,
             subtitle: `(${selectedCalendar?.integration.title?.replace(/calendar/i, "")} - ${


### PR DESCRIPTION
### Problem
ICS calendars were disappearing from the "add events to" dropdown when Google Calendar was connected, preventing users from selecting ICS calendars for event creation.

fixed: #24413

### Solution  
Modified the filtering logic in the destination calendar selector to allow read-only ICS calendars to appear in the dropdown alongside other calendar types.

### Changes Made
- Updated `DestinationCalendarSelector.tsx` to include ICS calendars in dropdown options even when they're marked as read-only