### PR TITLE
fix: Standardize email field editable to system-but-optional

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/services/event-types.service.ts
@@ -137,7 +137,11 @@ export class EventTypesService_2024_04_15 {
       !bookingFields.find((field) => field.type === "email") &&
       !bookingFields.find((field) => field.type === "phone")
     ) {
-      bookingFields.push({ ...systemBeforeFieldEmail, type: BaseField.email, editable: Editable.system });
+      bookingFields.push({
+        ...systemBeforeFieldEmail,
+        type: BaseField.email,
+        editable: Editable.systemButOptional,
+      });
     }
 
     await updateEventType({

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/booking-fields.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/internal-to-api/booking-fields.ts
@@ -556,7 +556,7 @@ export const systemBeforeFieldEmail: EmailSystemField = {
   type: "email",
   name: "email",
   required: true,
-  editable: "system",
+  editable: "system-but-optional",
   sources: [
     {
       label: "Default",

--- a/apps/web/test/utils/bookingScenario/bookingScenario.ts
+++ b/apps/web/test/utils/bookingScenario/bookingScenario.ts
@@ -2397,7 +2397,7 @@ export const getDefaultBookingFields = ({
           label: "",
           hidden: false,
           sources: [{ id: "default", type: "default", label: "Default" }],
-          editable: "system",
+          editable: "system-but-optional",
           required: true,
           placeholder: "",
           defaultLabel: "email_address",


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistency in email booking field's `editable` property across different event types. Some events had `editable: "system"` while others had `editable: "system-but-optional"` for the same email field, causing unpredictable behavior.

**Changes:**
- Standardizes email field to use `editable: "system-but-optional"` across all API versions and test utilities
- Updates API v2024_04_15 service to use `Editable.systemButOptional` when adding email fields
- Updates API v2024_06_14 transformer's `systemBeforeFieldEmail` definition  
- Updates test utility to match production behavior

