### PR TITLE
fix: Layout shift in inline embed caused due to showing embed before it was really ready

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe/__tests__/isLinkReady.test.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/__tests__/isLinkReady.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import { type EmbedStore } from "../lib/embedStore";
 import { fakeCurrentDocumentUrl, takeBookerToSlotsLoadingState, takeBookerToReadyState } from "./test-utils";
 
 beforeEach(() => {
@@ -13,15 +14,15 @@ afterEach(() => {
 });
 
 describe("isLinkReady", async () => {
-  let isLinkReady: typeof import("../lib/utils").isLinkReady;
-  let embedStore: typeof import("../lib/embedStore").embedStore;
+  let isLinkReady: (props: { embedStore: EmbedStore }) => boolean;
+  let embedStore: EmbedStore;
 
   beforeEach(async () => {
     ({ isLinkReady } = await import("../lib/utils"));
     ({ embedStore } = await import("../lib/embedStore"));
 
     // Reset embedStore state to ensure test isolation
-    embedStore.parentInformedAboutContentHeight = true;
+    embedStore.providedCorrectHeightToParent = true;
     embedStore.renderState = null;
     embedStore.connectVersion = 1;
   });
@@ -72,11 +73,11 @@ describe("isLinkReady", async () => {
     });
   });
 
-  describe("when parent not informed about content height", () => {
+  describe("when parent not provided correct height", () => {
     it("should return false regardless of other conditions", () => {
       fakeCurrentDocumentUrl({ params: { "cal.embed.pageType": "user.event.booking.slots" } });
       takeBookerToReadyState();
-      embedStore.parentInformedAboutContentHeight = false; // Not informed yet
+      embedStore.providedCorrectHeightToParent = false; // Not informed yet
 
       const result = isLinkReady({ embedStore });
       expect(result).toBe(false);

--- a/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { sdkActionManager } from "../../sdk-event";
+import { embedStore } from "../lib/embedStore";
+import { keepParentInformedAboutDimensionChanges } from "../lib/utils";
+import { fakeCurrentDocumentUrl } from "./test-utils";
+
+type DimensionEvent = {
+  isFirstTime: boolean;
+  height: number;
+  width: number;
+};
+
+type DOMTestData = {
+  documentElementScrollDimensions: { height: number; width: number };
+  mainElementDimensions: { height: number; width: number };
+  readyState: "complete" | "loading";
+};
+
+type DomEnvironment = DOMTestData & {
+  setReadyState: (readyState: "complete" | "loading") => void;
+};
+
+const RUN_ASAP_TICK_MS = 50;
+const WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS = 100;
+
+const createDOMEnvironment = (testData: DOMTestData) => {
+  Object.defineProperty(document, "readyState", {
+    writable: true,
+    configurable: true,
+    value: testData.readyState,
+  });
+
+  const mainElement = document.createElement("main");
+  mainElement.className = "main";
+  document.body.appendChild(mainElement);
+
+  Object.defineProperty(document.documentElement, "scrollHeight", {
+    writable: true,
+    configurable: true,
+    value: testData.documentElementScrollDimensions.height,
+  });
+  Object.defineProperty(document.documentElement, "scrollWidth", {
+    writable: true,
+    configurable: true,
+    value: testData.documentElementScrollDimensions.width,
+  });
+
+  const originalGetComputedStyle = window.getComputedStyle;
+  vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+    if (element.classList?.contains("main") || element.tagName === "MAIN") {
+      return {
+        height: `${testData.mainElementDimensions.height}px`,
+        width: `${testData.mainElementDimensions.width}px`,
+        marginTop: "0px",
+        marginBottom: "0px",
+        marginLeft: "0px",
+        marginRight: "0px",
+      } as CSSStyleDeclaration;
+    }
+    return originalGetComputedStyle(element);
+  });
+
+  return {
+    ...testData,
+    setReadyState: (readyState: "complete" | "loading") => {
+      Object.defineProperty(document, "readyState", {
+        writable: true,
+        configurable: true,
+        value: readyState,
+      });
+    },
+  };
+};
+
+const resetEmbedState = () => {
+  embedStore.providedCorrectHeightToParent = false;
+  embedStore.windowLoadEventFired = false;
+  fakeCurrentDocumentUrl({ params: {} });
+};
+
+const createDimensionTracker = () => {
+  const events: DimensionEvent[] = [];
+  sdkActionManager?.on("__dimensionChanged", (e) => {
+    events.push({
+      isFirstTime: e.detail.data.isFirstTime,
+      height: e.detail.data.iframeHeight,
+      width: e.detail.data.iframeWidth,
+    });
+  });
+  return events;
+};
+
+const expectCorrectHeightNotProvided = () => {
+  expect(embedStore.providedCorrectHeightToParent).toBe(false);
+};
+
+const expectCorrectHeightProvided = () => {
+  expect(embedStore.providedCorrectHeightToParent).toBe(true);
+};
+
+const expectFirstPassEvent = (
+  event: DimensionEvent | undefined,
+  {
+    documentElementScrollHeight,
+    documentElementScrollWidth,
+  }: {
+    documentElementScrollHeight: number;
+    documentElementScrollWidth: number;
+  }
+) => {
+  expect(event).toBeDefined();
+  expect(event?.isFirstTime).toBe(true);
+  expect(event?.height).toBe(documentElementScrollHeight);
+  expect(event?.width).toBe(documentElementScrollWidth);
+};
+
+const expectSecondPassEvent = (
+  event: DimensionEvent | undefined,
+  {
+    mainElementHeight,
+    mainElementWidth,
+  }: {
+    mainElementHeight: number;
+    mainElementWidth: number;
+  }
+) => {
+  expect(event).toBeDefined();
+  expect(event?.isFirstTime).toBe(false);
+  expect(event?.height).toBe(mainElementHeight);
+  expect(event?.width).toBe(mainElementWidth);
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("keepParentInformedAboutDimensionChanges", () => {
+  let domEnvironment: DomEnvironment;
+  beforeEach(() => {
+    domEnvironment = createDOMEnvironment({
+      documentElementScrollDimensions: { height: 1000, width: 800 },
+      mainElementDimensions: { height: 500, width: 400 },
+      readyState: "complete",
+    });
+    resetEmbedState();
+  });
+
+  describe("when iframe dimensions are calculated", () => {
+    it("should not mark height as provided during initial dimension pass", async () => {
+      const dimensionEvents = createDimensionTracker();
+
+      keepParentInformedAboutDimensionChanges({ embedStore });
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS + WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS);
+      expectCorrectHeightNotProvided();
+      const firstEvent = dimensionEvents[0];
+      expectFirstPassEvent(firstEvent, {
+        documentElementScrollHeight: domEnvironment.documentElementScrollDimensions.height,
+        documentElementScrollWidth: domEnvironment.documentElementScrollDimensions.width,
+      });
+    });
+
+    it("should mark height as provided after second dimension pass completes", async () => {
+      const dimensionEvents = createDimensionTracker();
+
+      keepParentInformedAboutDimensionChanges({ embedStore });
+
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS + WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS);
+      expectCorrectHeightNotProvided();
+
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS);
+      expectCorrectHeightProvided();
+      const secondEvent = dimensionEvents[1];
+      expectSecondPassEvent(secondEvent, {
+        mainElementHeight: domEnvironment.mainElementDimensions.height,
+        mainElementWidth: domEnvironment.mainElementDimensions.width,
+      });
+    });
+  });
+
+  describe("when window load state changes", () => {
+    it("should wait for window load completion before calculating dimensions", async () => {
+      domEnvironment = createDOMEnvironment({
+        documentElementScrollDimensions: { height: 1000, width: 800 },
+        mainElementDimensions: { height: 500, width: 400 },
+        readyState: "loading",
+      });
+
+      const dimensionEvents = createDimensionTracker();
+
+      keepParentInformedAboutDimensionChanges({ embedStore });
+
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS + WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS);
+
+      expect(dimensionEvents.length).toBe(0);
+      expectCorrectHeightNotProvided();
+
+      domEnvironment.setReadyState("complete");
+
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS + WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS);
+      expect(dimensionEvents.length).toBe(1);
+    });
+
+    it("should fire window load complete event on first pass", async () => {
+      domEnvironment = createDOMEnvironment({
+        documentElementScrollDimensions: { height: 1000, width: 800 },
+        mainElementDimensions: { height: 500, width: 400 },
+        readyState: "complete",
+      });
+
+      const windowLoadEvents: unknown[] = [];
+      sdkActionManager?.on("__windowLoadComplete", () => {
+        windowLoadEvents.push({});
+      });
+
+      keepParentInformedAboutDimensionChanges({ embedStore });
+
+      await vi.advanceTimersByTimeAsync(RUN_ASAP_TICK_MS + WINDOW_LOAD_COMPLETE_CONFIRMED_DELAY_MS);
+
+      expect(windowLoadEvents.length).toBe(1);
+      expect(embedStore.windowLoadEventFired).toBe(true);
+    });
+  });
+});

--- a/packages/embeds/embed-core/src/embed-iframe/lib/embedStore.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/embedStore.ts
@@ -106,7 +106,7 @@ export const embedStore = {
   reactStylesStateSetters: {} as Record<keyof EmbedStyles, SetStyles>,
   reactNonStylesStateSetters: {} as Record<keyof EmbedNonStylesConfig, setNonStylesConfig>,
   // Embed can show itself only after this is set to true
-  parentInformedAboutContentHeight: false,
+  providedCorrectHeightToParent: false,
   windowLoadEventFired: false,
   setTheme: undefined as ((arg0: EmbedThemeConfig) => void) | undefined,
   theme: undefined as UiConfig["theme"],
@@ -116,3 +116,5 @@ export const embedStore = {
    */
   setUiConfig: [] as ((arg0: UiConfig) => void)[],
 };
+
+export type EmbedStore = typeof embedStore;

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -1,3 +1,6 @@
+import { sdkActionManager } from "../../sdk-event";
+import { type EmbedStore } from "../lib/embedStore";
+
 export function runAsap(fn: (...arg: unknown[]) => void) {
   // We don't use rAF because it runs slower in Safari plus doesn't run if the iframe is hidden sometimes
   return setTimeout(fn, 50);
@@ -22,8 +25,8 @@ function isSkeletonSupportedPageType() {
 /**
  * It is important to be able to check realtime(instead of storing isLinkReady as a variable) if the link is ready, because there is a possibility that  booker might have moved to non-ready state from ready state
  */
-export function isLinkReady({ embedStore }: { embedStore: typeof import("./embedStore").embedStore }) {
-  if (!embedStore.parentInformedAboutContentHeight) {
+export function isLinkReady({ embedStore }: { embedStore: EmbedStore }) {
+  if (!embedStore.providedCorrectHeightToParent) {
     return false;
   }
 
@@ -38,6 +41,107 @@ export function isLinkReady({ embedStore }: { embedStore: typeof import("./embed
     }
   }
   return true;
+}
+
+/**
+ * This function is called once the iframe loads.
+ * It isn't called on "connect"
+ *
+ * Two-pass dimension strategy:
+ * 1. Initial pass: Uses document scroll dimensions to provide maximum space and avoid affecting layout
+ * 2. Second pass: Updates with correct dimensions of main container after parent adjusts iframe
+ *
+ * The correct iframe height is only available after the second pass, so we mark providedCorrectHeightToParent=true
+ * when the second pass runs (regardless of whether dimensions changed or not).
+ */
+export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedStore: EmbedStore }) {
+  let knownIframeHeight: number | null = null;
+  let knownIframeWidth: number | null = null;
+  let isInitialDimensionPass = true;
+  let isWindowLoadComplete = false;
+  runAsap(function informAboutScroll() {
+    if (document.readyState !== "complete") {
+      // Wait for window to load to correctly calculate the initial scroll height.
+      runAsap(informAboutScroll);
+      return;
+    }
+
+    if (!isWindowLoadComplete) {
+      // On Safari, even though document.readyState is complete, still the page is not rendered and we can't compute documentElement.scrollHeight correctly
+      // Postponing to just next cycle allow us to fix this.
+      setTimeout(() => {
+        isWindowLoadComplete = true;
+        informAboutScroll();
+      }, 100);
+      return;
+    }
+
+    if (!embedStore.windowLoadEventFired) {
+      sdkActionManager?.fire("__windowLoadComplete", {});
+    }
+    embedStore.windowLoadEventFired = true;
+
+    // Use the dimensions of main element as in most places there is max-width restriction on it and we just want to show the main content.
+    // It avoids the unwanted padding outside main tag.
+    const mainElement =
+      document.getElementsByClassName("main")[0] ||
+      document.getElementsByTagName("main")[0] ||
+      document.documentElement;
+    const documentScrollHeight = document.documentElement.scrollHeight;
+    const documentScrollWidth = document.documentElement.scrollWidth;
+
+    if (!(mainElement instanceof HTMLElement)) {
+      throw new Error("Main element should be an HTMLElement");
+    }
+
+    const mainElementStyles = getComputedStyle(mainElement);
+    // Use, .height as that gives more accurate value in floating point. Also, do a ceil on the total sum so that whatever happens there is enough iframe size to avoid scroll.
+    const contentHeight = Math.ceil(
+      parseFloat(mainElementStyles.height) +
+        parseFloat(mainElementStyles.marginTop) +
+        parseFloat(mainElementStyles.marginBottom)
+    );
+    const contentWidth = Math.ceil(
+      parseFloat(mainElementStyles.width) +
+        parseFloat(mainElementStyles.marginLeft) +
+        parseFloat(mainElementStyles.marginRight)
+    );
+
+    // During first render let iframe tell parent that how much is the expected height to avoid scroll.
+    // Parent would set the same value as the height of iframe which would prevent scroll.
+    // On subsequent renders, consider html height as the height of the iframe. If we don't do this, then if iframe gets bigger in height, it would never shrink
+    const iframeHeight = isInitialDimensionPass ? documentScrollHeight : contentHeight;
+    const iframeWidth = isInitialDimensionPass ? documentScrollWidth : contentWidth;
+
+    if (!iframeHeight || !iframeWidth) {
+      runAsap(informAboutScroll);
+      return;
+    }
+    const isThereAChangeInDimensions = knownIframeHeight !== iframeHeight || knownIframeWidth !== iframeWidth;
+    if (isThereAChangeInDimensions || !embedStore.providedCorrectHeightToParent) {
+      knownIframeHeight = iframeHeight;
+      knownIframeWidth = iframeWidth;
+
+      // FIXME: This event shouldn't be subscribable by the user. Only by the SDK.
+      sdkActionManager?.fire("__dimensionChanged", {
+        iframeHeight,
+        iframeWidth,
+        isFirstTime: isInitialDimensionPass,
+      });
+    }
+
+    // After the initial pass, we've provided the correct height to parent
+    // This happens on second pass regardless of whether dimensions changed
+    if (!isInitialDimensionPass) {
+      embedStore.providedCorrectHeightToParent = true;
+    }
+
+    isInitialDimensionPass = false;
+    // Parent Counterpart would change the dimension of iframe and thus page's dimension would be impacted which is recursive.
+    // It should stop ideally by reaching a hiddenHeight value of 0.
+    // FIXME: If 0 can't be reached we need to just abandon our quest for perfect iframe and let scroll be there. Such case can be logged in the wild and fixed later on.
+    runAsap(informAboutScroll);
+  });
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes a layout shift issue in inline embeds by implementing a two-pass dimension calculation strategy. The embed now only becomes visible after providing correct dimensions to the parent, preventing visual jumps during initial load.

**Link to Devin run:** https://app.devin.ai/sessions/4c73f62d6c0445cbae36cc575ae9baf3  
**Requested by:** @hariombalhara

### Demo of the fix
https://www.loom.com/share/fca91bb1d70c4456a77edc31e62fb0f6

### Key Changes

1. **Two-pass dimension strategy:**
   - **First pass:** Uses `documentElement.scrollHeight/scrollWidth` to provide maximum initial space, avoiding layout impact
   - **Second pass:** Uses actual main element dimensions after parent adjusts iframe height
   - Embed visibility is now gated on completing the second pass

2. **Refactoring:**
   - Moved `keepParentInformedAboutDimensionChanges()` from `embed-iframe.ts` to `utils.ts` for better organization and testability
   - Renamed `parentInformedAboutContentHeight` → `providedCorrectHeightToParent` for clarity
   - Added `EmbedStore` type export for better type safety

3. **Testing:**
   - Added comprehensive test suite (`utils.test.ts`) with 230 lines of tests
   - Tests cover dimension calculation timing, window load states, and the two-pass strategy
   - Updated existing `isLinkReady.test.ts` to use new variable name

### Critical Logic Change

**Before:** `providedCorrectHeightToParent` was set whenever dimensions were sent to parent (could be first or any subsequent pass)

**After:** `providedCorrectHeightToParent` is only set after the second dimension pass completes (lines 133-137 in utils.ts):

```typescript
// After the initial pass, we've provided the correct height to parent
// This happens on second pass regardless of whether dimensions changed
if (!isInitialDimensionPass) {
  embedStore.providedCorrectHeightToParent = true;
}
```

This ensures `isLinkReady()` returns `true` only after correct dimensions are available, preventing the embed from showing prematurely with incorrect sizing.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - Internal implementation change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Test Embed Loading Behavior

1. **Setup:** Create a test page with an inline Cal.com embed
2. **Test:** Load the page and observe the embed initialization
3. **Expected:** 
   - No layout shift should occur during embed load
   - Embed should appear smoothly after dimensions stabilize
   - Loading indicator should disappear only after correct sizing

### Browser Compatibility Testing

Pay special attention to **Safari** which has specific timing handling (100ms delay for render completion on line 72-75 of utils.ts).

### Automated Tests

Run the new test suite:
```bash
yarn test packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts
```

## Review Focus Areas

⚠️ **Critical areas requiring careful review:**

1. **Second pass guarantee** (lines 133-137 in `utils.ts`): Verify the second dimension pass is guaranteed to execute. If dimensions never stabilize, could the embed get stuck in a loading state?

2. **Safari-specific timeout** (lines 69-76 in `utils.ts`): The 100ms delay for Safari render completion might need adjustment based on testing across Safari versions.

3. **Recursive dimension tracking loop**: The `runAsap` function creates continuous polling. Review the stopping conditions and potential edge cases where the loop might not behave as expected.

4. **Backward compatibility**: Existing embeds might notice a slight delay (one additional dimension pass) before visibility. This should be negligible but worth monitoring in production.

5. **Test coverage**: Tests use mocked timers and DOM. Consider if additional manual testing is needed for real-world browser behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my changes generate no new warnings