### PR TITLE
feat: Updated prisma query with hand written one (Using UNION instead of OR)

### DIFF
--- a/packages/lib/server/repository/user.ts
+++ b/packages/lib/server/repository/user.ts
@@ -7,7 +7,7 @@ import { getTranslation } from "@calcom/lib/server/i18n";
 import type { PrismaClient } from "@calcom/prisma";
 import { availabilityUserSelect } from "@calcom/prisma";
 import type { User as UserType, DestinationCalendar, SelectedCalendar } from "@calcom/prisma/client";
-import type { Prisma } from "@calcom/prisma/client";
+import { Prisma } from "@calcom/prisma/client";
 import type { CreationSource } from "@calcom/prisma/enums";
 import { MembershipRole, BookingStatus } from "@calcom/prisma/enums";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
@@ -306,32 +306,55 @@ export class UserRepository {
 
   async findManyByEmailsWithEmailVerificationSettings({ emails }: { emails: string[] }) {
     const normalizedEmails = emails.map((e) => e.toLowerCase());
-    return this.prismaClient.user.findMany({
-      where: {
-        OR: [
-          {
-            email: { in: normalizedEmails },
-            emailVerified: { not: null },
-          },
-          {
-            secondaryEmails: {
-              some: {
-                email: { in: normalizedEmails },
-                emailVerified: { not: null },
-              },
-            },
-          },
-        ],
-      },
-      select: {
-        email: true,
-        requiresBookerEmailVerification: true,
-        secondaryEmails: {
-          where: { emailVerified: { not: null } },
-          select: { email: true },
-        },
-      },
-    });
+
+    if (!normalizedEmails.length) return [];
+    const users = await this.findVerifiedUsersByEmailsRaw(normalizedEmails);
+
+    if (!users.length) return [];
+    return users.map((u) => ({
+      email: u.email,
+      requiresBookerEmailVerification: u.requiresBookerEmailVerification,
+    }));
+  }
+
+  private async findVerifiedUsersByEmailsRaw(emails: string[]) {
+    const emailListSql = Prisma.join(emails.map((e) => Prisma.sql`${e}`));
+    return this.prismaClient.$queryRaw<
+      Array<{
+        id: number;
+        email: string;
+        requiresBookerEmailVerification: boolean;
+      }>
+    >(Prisma.sql`
+      SELECT
+        u."id",
+        u."email",
+        u."requiresBookerEmailVerification"
+      FROM
+        "public"."users" AS u
+      WHERE
+        u."email" IN (${emailListSql})
+        AND u."emailVerified" IS NOT NULL
+        AND u."locked" = FALSE
+      UNION
+      SELECT
+        u."id",
+        u."email",
+        u."requiresBookerEmailVerification"
+      FROM
+        "public"."users" AS u
+      WHERE
+        u."id" IN (
+          SELECT
+            t0."userId"
+          FROM
+            "public"."SecondaryEmail" AS t0
+          WHERE
+            t0."email" IN (${emailListSql})
+            AND t0."emailVerified" IS NOT NULL
+        )
+        AND u."locked" = FALSE
+    `);
   }
 
   async findByEmailAndIncludeProfilesAndPassword({ email }: { email: string }) {

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -89,11 +89,6 @@ export const addGuestsHandler = async ({ ctx, input }: AddGuestsOptions) => {
   for (const user of guestUsers) {
     const baseEmail = extractBaseEmail(user.email).toLowerCase();
     emailToRequiresVerification.set(baseEmail, user.requiresBookerEmailVerification ?? false);
-
-    for (const secondary of user.secondaryEmails) {
-      const baseSecondary = extractBaseEmail(secondary.email).toLowerCase();
-      emailToRequiresVerification.set(baseSecondary, user.requiresBookerEmailVerification ?? false);
-    }
   }
 
   const uniqueGuests = guests.filter((guest) => {


### PR DESCRIPTION

Message from @ThyMinimalDev :

query is optimized and uses index
```
Unique  (cost=25.36..25.38 rows=2 width=36) (actual time=0.028..0.029 rows=1 loops=1)
  ->  Sort  (cost=25.36..25.37 rows=2 width=36) (actual time=0.028..0.029 rows=1 loops=1)
        Sort Key: u.id, u.email
        Sort Method: quicksort  Memory: 25kB
        ->  Append  (cost=0.42..25.35 rows=2 width=36) (actual time=0.015..0.024 rows=1 loops=1)
              ->  Index Scan using users_email_username_key on users u  (cost=0.42..8.44 rows=1 width=33) (actual time=0.014..0.015 rows=1 loops=1)
"                    Index Cond: (email = 'keith@cal.com'::text)"
"                    Filter: ((""emailVerified"" IS NOT NULL) AND (NOT locked))"
              ->  Nested Loop  (cost=0.84..16.88 rows=1 width=33) (actual time=0.008..0.009 rows=0 loops=1)
"                    ->  Index Scan using ""SecondaryEmail_email_key"" on ""SecondaryEmail"" t0  (cost=0.42..8.44 rows=1 width=4) (actual time=0.008..0.008 rows=0 loops=1)"
"                          Index Cond: (email = 'keith@cal.com'::text)"
"                          Filter: (""emailVerified"" IS NOT NULL)"
                    ->  Index Scan using users_pkey on users u_1  (cost=0.42..8.44 rows=1 width=33) (never executed)
"                          Index Cond: (id = t0.""userId"")"
                          Filter: (NOT locked)
Planning Time: 0.228 ms
Execution Time: 0.048 ms
```