### PR TITLE
refactor: Use sessionStorage instead of localStorage for decoy booking data

### DIFF
--- a/packages/features/bookings/lib/client/decoyBookingStore.ts
+++ b/packages/features/bookings/lib/client/decoyBookingStore.ts
@@ -1,0 +1,74 @@
+import { sessionStorage } from "@calcom/lib/webstorage";
+
+const BOOKING_SUCCESS_STORAGE_KEY_PREFIX = "cal.successfulBooking";
+
+interface DecoyBookingData {
+  booking: {
+    uid: string;
+    title: string | null;
+    startTime: string;
+    endTime: string;
+    booker: { name: string; timeZone?: string; email: string } | null;
+    host: { name: string; timeZone?: string } | null;
+    location: string | null;
+  };
+}
+
+function getStorageKey(uid: string): string {
+  return `${BOOKING_SUCCESS_STORAGE_KEY_PREFIX}.${uid}`;
+}
+
+/**
+ * Stores decoy booking data in sessionStorage using the booking's uid
+ * Data automatically expires when the browser tab/window is closed
+ * @param booking - The booking data to store (must include uid)
+ */
+export function storeDecoyBooking(booking: Record<string, unknown> & { uid: string }): void {
+  const bookingSuccessData = {
+    booking,
+  };
+  const storageKey = getStorageKey(booking.uid);
+  sessionStorage.setItem(storageKey, JSON.stringify(bookingSuccessData));
+}
+
+/**
+ * Retrieves decoy booking data from sessionStorage
+ * @param uid - The booking uid
+ * @returns The stored booking data or null if not found
+ */
+export function getDecoyBooking(uid: string): DecoyBookingData | null {
+  if (!uid) {
+    return null;
+  }
+
+  const storageKey = getStorageKey(uid);
+  const dataStr = sessionStorage.getItem(storageKey);
+
+  if (!dataStr) {
+    return null;
+  }
+
+  try {
+    const data: DecoyBookingData = JSON.parse(dataStr);
+    return data;
+  } catch {
+    // If parsing fails, remove the corrupted data
+    sessionStorage.removeItem(storageKey);
+    return null;
+  }
+}
+
+/**
+ * Removes decoy booking data from sessionStorage
+ * @param uid - The booking uid
+ */
+export function removeDecoyBooking(uid: string): void {
+  if (!uid) {
+    return;
+  }
+
+  const storageKey = getStorageKey(uid);
+  sessionStorage.removeItem(storageKey);
+}
+
+export type { DecoyBookingData };


### PR DESCRIPTION
## What does this PR do?

This PR creates a new storage utility for decoy booking data, using `sessionStorage` instead of `localStorage` for improved privacy and automatic cleanup.

**Context**: This is a follow-up improvement to [PR #24326](https://github.com/calcom/cal.com/pull/24326) (spam detection feature). This PR isolates the storage mechanism change for easier review.

**Key changes**:
- Creates `decoyBookingStore.ts` with three functions: `storeDecoyBooking()`, `getDecoyBooking()`, `removeDecoyBooking()`
- Uses `sessionStorage` which automatically expires when the browser tab closes
- Removes timestamp tracking and TTL logic (no longer needed with sessionStorage)
- Stores booking data structure: uid, title, times, booker info, host info, location

**Why sessionStorage?**
- **Privacy improvement**: Data automatically cleared when tab closes, rather than persisting for minutes/hours
- **Simpler code**: No manual TTL management required
- **Better UX**: Decoy data only exists for the active session

---

## How should this be tested?

This is a standalone utility module that will be integrated in PR #24326. Testing approach:

1. **Unit tests**: Verify in browser console:
   ```javascript
   // Store data
   storeDecoyBooking({ uid: 'test-123', title: 'Test Meeting', ... });
   
   // Retrieve data
   const data = getDecoyBooking('test-123');
   console.log(data); // Should return stored data
   
   // Close tab and reopen - data should be gone
   ```

2. **Integration testing**: Will be covered by PR #24326's spam detection tests

---

## Important Review Points

### 🔒 Privacy Consideration
- Email addresses are still stored client-side (in sessionStorage)
- **Question for reviewer**: Is sessionStorage acceptable for email storage, or should we move to server-side session?

### 🔍 Type Safety
- `storeDecoyBooking()` accepts `Record<string, unknown> & { uid: string }`
- Minimal type validation beyond requiring `uid` field
- **Question for reviewer**: Should we add runtime validation of the booking data structure?

### 🧪 Test Coverage
- No unit tests in this PR
- Integration tests will be in parent PR #24326
- **Question for reviewer**: Should we add unit tests for this utility module?

### 📦 Standalone Module
- This file is not integrated anywhere yet (integration happens in #24326)
- Creates no breaking changes to existing code

---

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if needed (N/A - internal utility, documented via JSDoc)
- [ ] I confirm automated tests are in place (will be covered by parent PR #24326)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (JSDoc added)
- [x] I have checked if my changes generate no new warnings (lint passed)

---

**Requested by**: @hariombalhara (hariom@cal.com)  
**Link to Devin run**: https://app.devin.ai/sessions/3d405ed14bd64872a7b72d2406408b8c