### PR TITLE
Fix: Link dialog opens outside screen boundaries in checkbox question…

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -55,9 +55,27 @@ function positionEditorElement(editor: HTMLInputElement, rect: DOMRect | null) {
     editor.style.top = "-1000px";
     editor.style.left = "-1000px";
   } else {
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let top = rect.top + rect.height + window.pageYOffset + 10;
+    let left = rect.left + window.pageXOffset - editor.offsetWidth / 2 + rect.width / 2;
+
+    // Ensure the popup doesn't go outside the viewport horizontally
+    if (left < 0) {
+      left = 10; // Add some padding from the left edge
+    } else if (left + editor.offsetWidth > viewportWidth) {
+      left = viewportWidth - editor.offsetWidth - 10; // Add some padding from the right edge
+    }
+
+    // Ensure the popup doesn't go outside the viewport vertically
+    if (top + editor.offsetHeight > viewportHeight + window.pageYOffset) {
+      top = rect.top + window.pageYOffset - editor.offsetHeight - 10; // Position above the element
+    }
+
     editor.style.opacity = "1";
-    editor.style.top = `${rect.top + rect.height + window.pageYOffset + 10}px`;
-    editor.style.left = `${rect.left + window.pageXOffset - editor.offsetWidth / 2 + rect.width / 2}px`;
+    editor.style.top = `${top}px`;
+    editor.style.left = `${left}px`;
   }
 }
 


### PR DESCRIPTION
… editor

It fixes the UI issue of the toggle popup going outside the screen while using smartphone.

I have changed some stylings so that the whole popup appears on the screen.

- Fixes #24267 
- Fixes CAL-6520



[Screencast from 2025-10-15 00-04-42.webm](https://github.com/user-attachments/assets/0eecde80-bfe0-468d-bbab-fa3ee8c6cd0c)

## Mandatory Tasks (DO NOT REMOVE)

- [✅] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [✅] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [✅] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Follow the steps to reproduce in the issue.
