### PR TITLE
fix: duplicate get schedule

### DIFF
--- a/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
+++ b/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
@@ -36,7 +36,8 @@ export const usePrefetch = ({ date, month, bookerLayout, bookerState }: UsePrefe
     bookerLayout.layout,
     bookerState,
     monthAfterAdding1Month,
-    monthAfterAddingExtraDaysColumnView
+    monthAfterAddingExtraDaysColumnView,
+    prefetchNextMonth
   );
 
   return {

--- a/packages/features/bookings/Booker/utils/getPrefetchMonthCount.test.ts
+++ b/packages/features/bookings/Booker/utils/getPrefetchMonthCount.test.ts
@@ -7,87 +7,96 @@ import { getPrefetchMonthCount } from "./getPrefetchMonthCount";
 describe("getPrefetchMonthCount", () => {
   describe("COLUMN_VIEW layout", () => {
     it("should return 2 when months are different", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 1, 2);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 1, 2, false);
       expect(result).toBe(2);
     });
 
     it("should return undefined when months are the same", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 5, 5);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 5, 5, false);
       expect(result).toBe(undefined);
     });
 
     it("should return 2 regardless of bookerState when months are different", () => {
-      expect(getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_time", 3, 4)).toBe(2);
-      expect(getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "booking", 7, 8)).toBe(2);
+      expect(getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_time", 3, 4, false)).toBe(2);
+      expect(getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "booking", 7, 8, false)).toBe(2);
+    });
+
+    it("should return 2 even when prefetchNextMonth is true", () => {
+      expect(getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_time", 3, 4, true)).toBe(2);
     });
   });
 
   describe("WEEK_VIEW layout", () => {
     it("should return undefined when state is selecting_time", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "selecting_time", 1, 2);
+      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "selecting_time", 1, 2, false);
       expect(result).toBe(undefined);
     });
 
     it("should return undefined when state is not selecting_time", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "selecting_date", 1, 2);
+      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "selecting_date", 1, 2, false);
       expect(result).toBe(undefined);
     });
 
     it("should return undefined even with different months", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "booking", 0, 11);
+      const result = getPrefetchMonthCount(BookerLayouts.WEEK_VIEW, "booking", 0, 11, false);
       expect(result).toBe(undefined);
     });
   });
 
   describe("MONTH_VIEW layout with selecting_time state", () => {
-    it("should return 2 when months are different", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_time", 3, 4);
+    it("should return 2 when months are different and NOT prefetching", () => {
+      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_time", 3, 4, false);
       expect(result).toBe(2);
     });
 
+    it("should return undefined when months are different but ALREADY prefetching", () => {
+      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_time", 3, 4, true);
+      expect(result).toBe(undefined);
+    });
+
     it("should return undefined when months are the same", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_time", 6, 6);
+      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_time", 6, 6, false);
       expect(result).toBe(undefined);
     });
   });
 
   describe("MONTH_VIEW layout with other states", () => {
     it("should return undefined when state is selecting_date", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_date", 1, 2);
+      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "selecting_date", 1, 2, false);
       expect(result).toBe(undefined);
     });
 
     it("should return undefined when state is booking", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "booking", 1, 2);
+      const result = getPrefetchMonthCount(BookerLayouts.MONTH_VIEW, "booking", 1, 2, false);
       expect(result).toBe(undefined);
     });
   });
 
   describe("invalid month inputs", () => {
     it("should return undefined when first month is NaN", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", NaN, 5);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", NaN, 5, false);
       expect(result).toBe(undefined);
     });
 
     it("should return undefined when second month is NaN", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 5, NaN);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 5, NaN, false);
       expect(result).toBe(undefined);
     });
 
     it("should return undefined when both months are invalid", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_time", Infinity, -Infinity);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_time", Infinity, -Infinity, false);
       expect(result).toBe(undefined);
     });
   });
 
   describe("edge cases", () => {
     it("should handle month transitions (11 to 0)", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 11, 0);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", 11, 0, false);
       expect(result).toBe(2);
     });
 
     it("should handle negative month numbers if they are different", () => {
-      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", -1, 5);
+      const result = getPrefetchMonthCount(BookerLayouts.COLUMN_VIEW, "selecting_date", -1, 5, false);
       expect(result).toBe(2);
     });
   });

--- a/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
+++ b/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
@@ -18,13 +18,17 @@ export const getPrefetchMonthCount = (
 
   if (!isDifferentMonth) return undefined;
 
+  // Column view always needs 2 months because it displays multiple weeks side-by-side,
+  // regardless of user state or whether we're already prefetching
   if (isColumnView) return 2;
 
-  // For month view, only add extra months when:
-  // 1. User is selecting time AND
-  // 2. We're NOT already prefetching the next month
-  // This prevents duplicate calls when bookerState changes to "selecting_time"
-  // after the initial data load
+  // Month view conditionally needs an extra month for performance optimization.
+  // Only return 2 when:
+  // 1. User is selecting time slots (improves UX by preloading more availability)
+  // 2. We're NOT already prefetching next month (prevents duplicate API calls)
+  //
+  // If prefetchNextMonth is already true (e.g., viewing dates after 15th of month),
+  // we don't need extra months since the next month is already being fetched via prefetchNextMonth
   if (!isWeekView && isSelectingTime && !prefetchNextMonth) return 2;
 
   return undefined;

--- a/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
+++ b/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
@@ -18,7 +18,6 @@ export const getPrefetchMonthCount = (
 
   if (!isDifferentMonth) return undefined;
 
-  // For column view, always return 2 when months are different
   if (isColumnView) return 2;
 
   // For month view, only add extra months when:

--- a/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
+++ b/packages/features/bookings/Booker/utils/getPrefetchMonthCount.ts
@@ -7,7 +7,8 @@ export const getPrefetchMonthCount = (
   bookerLayout: string,
   bookerState: BookerState,
   firstMonth: number,
-  secondMonth: number
+  secondMonth: number,
+  prefetchNextMonth: boolean
 ) => {
   const isDifferentMonth = areDifferentValidMonths(firstMonth, secondMonth);
 
@@ -17,7 +18,15 @@ export const getPrefetchMonthCount = (
 
   if (!isDifferentMonth) return undefined;
 
-  if (isColumnView || (!isWeekView && isSelectingTime)) return 2;
+  // For column view, always return 2 when months are different
+  if (isColumnView) return 2;
+
+  // For month view, only add extra months when:
+  // 1. User is selecting time AND
+  // 2. We're NOT already prefetching the next month
+  // This prevents duplicate calls when bookerState changes to "selecting_time"
+  // after the initial data load
+  if (!isWeekView && isSelectingTime && !prefetchNextMonth) return 2;
 
   return undefined;
 };

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -139,15 +139,12 @@ const BookerPlatformWrapperComponent = (props: BookerWebWrapperAtomProps) => {
 
   const isEmbed = useIsEmbed();
 
-  console.log("[BookerWebWrapper DEBUG] date", date, month, bookerLayout, bookerState);
-
   const { prefetchNextMonth, monthCount } = usePrefetch({
     date,
     month,
     bookerLayout,
     bookerState,
   });
-  console.log("[BookerWebWrapper DEBUG] prefetchNextMonth", prefetchNextMonth, monthCount);
   /**
    * Prioritize dateSchedule load
    * Component will render but use data already fetched from here, and no duplicate requests will be made

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -139,12 +139,15 @@ const BookerPlatformWrapperComponent = (props: BookerWebWrapperAtomProps) => {
 
   const isEmbed = useIsEmbed();
 
+  console.log("[BookerWebWrapper DEBUG] date", date, month, bookerLayout, bookerState);
+
   const { prefetchNextMonth, monthCount } = usePrefetch({
     date,
     month,
     bookerLayout,
     bookerState,
   });
+  console.log("[BookerWebWrapper DEBUG] prefetchNextMonth", prefetchNextMonth, monthCount);
   /**
    * Prioritize dateSchedule load
    * Component will render but use data already fetched from here, and no duplicate requests will be made


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When the initial getSchedule request completed, bookerState automatically transitioned from "loading" → "selecting_time". This caused getPrefetchMonthCount to change from undefined → 2, triggering a second API call with different endTime (e.g., Nov 30 → Dec 31). 

![Screenshot 2025-10-15 at 3 21 23 PM](https://github.com/user-attachments/assets/a2ba3997-7ee7-4c72-991f-7af67c2a1984)


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


