### PR TITLE
fix: Ensure 500 error pages are visible in embed

### DIFF
--- a/apps/web/components/error/error-page.tsx
+++ b/apps/web/components/error/error-page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+import "@calcom/embed-core/src/embed-iframe";
 import { HttpError } from "@calcom/lib/http-error";
 import { Button } from "@calcom/ui/components/button";
 

--- a/apps/web/pages/_error.tsx
+++ b/apps/web/pages/_error.tsx
@@ -7,6 +7,7 @@ import type { ErrorProps } from "next/error";
 import NextError from "next/error";
 import React from "react";
 
+import "@calcom/embed-core/src/embed-iframe";
 import { getErrorFromUnknown } from "@calcom/lib/errors";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";


### PR DESCRIPTION
## What does this PR do?

Adds the `@calcom/embed-core/src/embed-iframe` import to error pages to ensure embed functionality is properly initialized when users encounter 500 errors in an embedded context.

e.g. Visiting this page https://app.cal.com/router/embed, shows the entire page is hidden

**Context**: When Cal.com is embedded in an iframe and encounters a 500 error, the error page needs to be able to communicate with the parent frame. Other pages like `PageWrapper.tsx` and `PageWrapperAppDir.tsx` already include this import, but the error pages were missing it.

**Changes**:
- Added `import "@calcom/embed-core/src/embed-iframe";` to `apps/web/pages/_error.tsx`
- Added `import "@calcom/embed-core/src/embed-iframe";` to `apps/web/components/error/error-page.tsx`

---

**Link to Devin run**: https://app.devin.ai/sessions/856e2f4f711a405caad55e0dcb357317  
**Requested by**: @hariombalhara (hariom@cal.com)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - This is an internal fix that doesn't require documentation changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: This change is difficult to test automatically as it requires an embedded iframe context with error conditions.

## How should this be tested?

### Manual Testing Steps:
1. Embed Cal.com in an iframe on another page
2. Trigger a 500 error (e.g., by causing a server-side error in the app)
3. Verify that the error page can communicate with the parent frame (check browser console for embed-related messages)
4. Confirm no errors appear related to embed initialization

**Note**: This fix addresses embed functionality on error pages, which is difficult to test automatically. Manual testing in an embedded context is recommended.

## Important Review Points

⚠️ **Please review carefully**:
- This adds a side-effect import that initializes embed iframe functionality
- The pattern matches other pages (PageWrapper, PageWrapperAppDir) but should be verified for error pages specifically
- Consider if there are other error-related components that might need the same treatment
- Testing in an actual embedded iframe context is recommended to verify this solves the issue

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **N/A** - Simple import addition
- [x] I have checked if my changes generate no new warnings