### PR TITLE
feat: Update HubSpot meetings to CANCELLED status instead of archiving on booking cancellation

### DIFF
--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -116,7 +116,6 @@ export default class HubspotCalendarService implements CRM {
   private hubspotCancelMeeting = async (uid: string) => {
     const simplePublicObjectInput: SimplePublicObjectInput = {
       properties: {
-        hs_timestamp: Date.now().toString(),
         hs_meeting_outcome: "CANCELLED",
       },
     };

--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -207,7 +207,6 @@ export default class HubspotCalendarService implements CRM {
     return await this.handleMeetingCreation(event, contacts);
   }
 
-   
   async updateEvent(uid: string, event: CalendarEvent): Promise<any> {
     const auth = await this.auth;
     await auth.getToken();
@@ -217,7 +216,7 @@ export default class HubspotCalendarService implements CRM {
   async deleteEvent(uid: string): Promise<void> {
     const auth = await this.auth;
     await auth.getToken();
-    return await this.hubspotCancelMeeting(uid);
+    await this.hubspotCancelMeeting(uid);
   }
 
   async getContacts({ emails }: { emails: string | string[] }): Promise<Contact[]> {

--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -21,10 +21,6 @@ import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 import refreshOAuthTokens from "../../_utils/oauth/refreshOAuthTokens";
 import type { HubspotToken } from "../api/callback";
 
-interface CustomPublicObjectInput extends SimplePublicObjectInput {
-  id?: string;
-}
-
 export default class HubspotCalendarService implements CRM {
   private url = "";
   private integrationName = "";
@@ -117,8 +113,15 @@ export default class HubspotCalendarService implements CRM {
     return this.hubspotClient.crm.objects.meetings.basicApi.update(uid, simplePublicObjectInput);
   };
 
-  private hubspotDeleteMeeting = async (uid: string) => {
-    return this.hubspotClient.crm.objects.meetings.basicApi.archive(uid);
+  private hubspotCancelMeeting = async (uid: string) => {
+    const simplePublicObjectInput: SimplePublicObjectInput = {
+      properties: {
+        hs_timestamp: Date.now().toString(),
+        hs_meeting_outcome: "CANCELLED",
+      },
+    };
+
+    return this.hubspotClient.crm.objects.meetings.basicApi.update(uid, simplePublicObjectInput);
   };
 
   private hubspotAuth = async (credential: CredentialPayload) => {
@@ -204,7 +207,7 @@ export default class HubspotCalendarService implements CRM {
     return await this.handleMeetingCreation(event, contacts);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   async updateEvent(uid: string, event: CalendarEvent): Promise<any> {
     const auth = await this.auth;
     await auth.getToken();
@@ -214,7 +217,7 @@ export default class HubspotCalendarService implements CRM {
   async deleteEvent(uid: string): Promise<void> {
     const auth = await this.auth;
     await auth.getToken();
-    return await this.hubspotDeleteMeeting(uid);
+    return await this.hubspotCancelMeeting(uid);
   }
 
   async getContacts({ emails }: { emails: string | string[] }): Promise<Contact[]> {

--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -116,7 +116,7 @@ export default class HubspotCalendarService implements CRM {
   private hubspotCancelMeeting = async (uid: string) => {
     const simplePublicObjectInput: SimplePublicObjectInput = {
       properties: {
-        hs_meeting_outcome: "CANCELLED",
+        hs_meeting_outcome: "CANCELED",
       },
     };
 


### PR DESCRIPTION
## What does this PR do?

Changes the HubSpot integration to preserve meeting history when bookings are cancelled. Instead of archiving (permanently deleting) meetings in HubSpot, we now update the meeting status to "CANCELED".

**Key changes:**
- Renamed `hubspotDeleteMeeting` to `hubspotCancelMeeting`
- Changed from `archive()` to `update()` API call with `hs_meeting_outcome: "CANCELED"`
- Removed `hs_timestamp` field from cancellation update (keeping it minimal)
- Removed unused `CustomPublicObjectInput` interface
- Fixed type signature in `deleteEvent` method (removed return statement)

**Important:** Changed to "CANCELED" (lowercase, American spelling) based on HubSpot API documentation instead of "CANCELLED".

**Link to Devin run:** https://app.devin.ai/sessions/a2085e04c4e34bcc8a4f88612027a54b  
**Requested by:** joe@cal.com (@joeauyeung)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

⚠️ **CRITICAL**: This PR has NOT been tested with live HubSpot credentials and requires manual verification before merging.

**Test setup:**
1. Configure HubSpot integration with valid credentials
2. Create a test booking that generates a HubSpot meeting
3. Cancel the booking through Cal.com
4. Verify in HubSpot that:
   - The meeting still exists (not archived/deleted)
   - The meeting outcome is set to "CANCELED" (or equivalent visible status)
   - Meeting history is preserved and visible

**Critical items to verify:**
- [ ] "CANCELED" is accepted as a valid value for `hs_meeting_outcome` in HubSpot's API (not rejected as invalid enum)
- [ ] The meeting update succeeds without the `hs_timestamp` field
- [ ] OAuth token refresh works correctly (auth flow is called before API request)
- [ ] No errors occur when cancelling bookings with HubSpot integration enabled
- [ ] Error logs show successful update, not silent failures

**Potential issues to watch for:**
- HubSpot API might require "CANCELLED" (with double L) instead of "CANCELED"
- HubSpot might require `hs_timestamp` field for all update operations
- The API might reject updates with only one field
- Different HubSpot account tiers might have different valid enum values

## Human Review Checklist

**High priority - MUST verify before merge:**
- [ ] **Test with live HubSpot credentials** - This is the most critical item
- [ ] **Verify "CANCELED" works** - The enum value must be accepted by HubSpot API
- [ ] **Confirm meetings are preserved** - Check that meetings aren't deleted/archived
- [ ] **Check error logs** - Ensure no silent failures are occurring

**Context:**
- Original behavior: Meetings were permanently archived/deleted from HubSpot when bookings were cancelled
- New behavior: Meetings remain in HubSpot with status updated to "CANCELED"  
- Reason for change: User reported meetings weren't being marked as canceled, likely because "CANCELLED" was invalid
- Risk: Based on documentation review only, not tested with actual API

## Checklist

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings