### PR TITLE
chore: Add a util for adding permissions to roles in PBAC

### DIFF
--- a/packages/prisma/migrations/20251015164346_add_role_permission_function/migration.sql
+++ b/packages/prisma/migrations/20251015164346_add_role_permission_function/migration.sql
@@ -1,0 +1,25 @@
+-- CreateType
+CREATE TYPE permission_tuple AS (resource TEXT, action TEXT);
+
+-- CreateFunction
+CREATE OR REPLACE FUNCTION add_permissions_to_role(
+    p_role_id TEXT,
+    VARIADIC p_permissions permission_tuple[]
+) RETURNS INTEGER AS $$
+DECLARE
+    v_inserted_count INTEGER;
+BEGIN
+    INSERT INTO "RolePermission" (id, "roleId", resource, action, "createdAt")
+    SELECT 
+        gen_random_uuid(),
+        p_role_id,
+        perm.resource,
+        perm.action,
+        NOW()
+    FROM unnest(p_permissions) AS perm
+    ON CONFLICT ("roleId", resource, action) DO NOTHING;
+    
+    GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
+    RETURN v_inserted_count;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Add Role Permission Helper Function

### Summary
This PR adds a PostgreSQL function to simplify adding permissions to roles in the RolePermission table. Instead of writing verbose INSERT statements with multiple VALUES, you can now use a clean function call with tuple arguments.

### Changes
- Added new PostgreSQL type `permission_tuple` for cleaner function signatures
- Added `add_permissions_to_role()` function that accepts a role ID and variable number of permission tuples
- Function automatically generates UUIDs and timestamps for each permission
- Includes conflict handling to prevent duplicate permissions

### Usage Example

**Before:**
```sql
INSERT INTO "RolePermission" (id, "roleId", resource, action, "createdAt")
SELECT
  gen_random_uuid(), 'admin_role', resource, action, NOW()
FROM (
  VALUES
    ('watchlist', 'create'),
    ('watchlist', 'read'),
    ('watchlist', 'update'),
    ('watchlist', 'delete')
) AS permissions(resource, action);
```

**After:**
```sql
SELECT add_permissions_to_role(
    'admin_role',
    ('watchlist', 'create'),
    ('watchlist', 'read'),
    ('watchlist', 'update'),
    ('watchlist', 'delete')
);
```

### Benefits
- Cleaner, more readable syntax for adding permissions
- Less error-prone than manual INSERT statements
- Returns count of permissions actually inserted
- Handles duplicates gracefully with ON CONFLICT DO NOTHING
- Reusable across different roles and permission sets

### Testing
Run the migration and test with:

```sql
-- Youll need to create a test role first
-- Add permissions to a role
SELECT add_permissions_to_role(
    'test_role',
    ('booking', 'create'),
    ('booking', 'read')
);

-- Verify permissions were added
SELECT * FROM "RolePermission" WHERE "roleId" = 'test_role';
```