### PR TITLE
feat: add booking uid to zapier payload

### DIFF
--- a/packages/features/webhooks/lib/scheduleTrigger.ts
+++ b/packages/features/webhooks/lib/scheduleTrigger.ts
@@ -205,6 +205,7 @@ export async function listBookings(
         id: "desc",
       },
       select: {
+        uid: true,
         title: true,
         description: true,
         customInputs: true,

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -78,7 +78,7 @@ export type OOOEntryPayloadType = {
 export type EventPayloadType = CalendarEvent &
   TranscriptionGeneratedPayload &
   EventTypeInfo & {
-    uid?: string;
+    uid?: string | null;
     metadata?: { [key: string]: string | number | boolean | null };
     bookingId?: number;
     status?: string;

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -78,6 +78,7 @@ export type OOOEntryPayloadType = {
 export type EventPayloadType = CalendarEvent &
   TranscriptionGeneratedPayload &
   EventTypeInfo & {
+    uid?: string;
     metadata?: { [key: string]: string | number | boolean | null };
     bookingId?: number;
     status?: string;
@@ -130,6 +131,7 @@ function getZapierPayload(data: WithUTCOffsetType<EventPayloadType & { createdAt
   const location = getHumanReadableLocationValue(data.location || "", t);
 
   const body = {
+    uid: data.uid,
     title: data.title,
     description: data.description,
     customInputs: data.customInputs,


### PR DESCRIPTION
## What does this PR do?

Adds uid (the unique booking identifier) to the Zapier payload, same as we have it in the webhook payload.


```
uid: "<booking-uid>"
```

It’s added to the `/listBookings` endpoint, which Zapier uses to fetch recent items for sample data, and to `sendPayload` so live Zapier triggers receive the booking UID.