### PR TITLE
chore: update style of Routed to per period chart on /insights/routing

### DIFF
--- a/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
+++ b/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
@@ -85,10 +85,10 @@ function FormCard({ selectedPeriod, onPeriodChange, searchQuery, onSearchChange,
   const { t } = useLocale();
 
   return (
-    <div className="border-subtle w-full rounded-md border">
+    <div className="w-full rounded-md">
       <div className="flex flex-col">
         <div className="p-4">
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-4 flex items-center justify-between gap-2">
             <ToggleGroup
               options={[
                 { label: t("per_day"), value: "perDay" },
@@ -99,7 +99,7 @@ function FormCard({ selectedPeriod, onPeriodChange, searchQuery, onSearchChange,
               value={selectedPeriod}
               onValueChange={(value) => value && onPeriodChange(value as "perDay" | "perWeek" | "perMonth")}
             />
-            <div className="flex gap-2">
+            <div className="flex items-center gap-2">
               <div className="w-64">
                 <Input
                   type="text"
@@ -293,7 +293,7 @@ export function RoutedToPerPeriod() {
                 <TableHeader className="bg-subtle sticky top-0 z-10">
                   <TableRow>
                     <TableHead className="bg-subtle sticky left-0 z-30 w-[200px]">{t("user")}</TableHead>
-                    {uniquePeriods.map((period, index) => {
+                    {uniquePeriods.map((period, _index) => {
                       const date = period;
                       const today = new Date();
 
@@ -313,10 +313,10 @@ export function RoutedToPerPeriod() {
                   </TableRow>
                 </TableHeader>
                 <TableBody className="relative">
-                  {processedData.map((row, index) => {
+                  {processedData.map((row, _index) => {
                     return (
                       <TableRow key={row.id} className="divide-muted divide-x">
-                        <TableCell className="bg-default w-[200px]">
+                        <TableCell className="w-[200px]">
                           <HoverCard>
                             <HoverCardTrigger asChild>
                               <div className="flex cursor-pointer items-center gap-2">

--- a/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
+++ b/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
@@ -100,7 +100,7 @@ function FormCard({ selectedPeriod, onPeriodChange, searchQuery, onSearchChange,
               onValueChange={(value) => value && onPeriodChange(value as "perDay" | "perWeek" | "perMonth")}
             />
             <div className="flex items-center gap-2">
-              <div className="w-64">
+              <div className="max-w-64">
                 <Input
                   type="text"
                   placeholder={t("search")}

--- a/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
+++ b/packages/features/insights/components/routing/RoutedToPerPeriod.tsx
@@ -293,7 +293,7 @@ export function RoutedToPerPeriod() {
                 <TableHeader className="bg-subtle sticky top-0 z-10">
                   <TableRow>
                     <TableHead className="bg-subtle sticky left-0 z-30 w-[200px]">{t("user")}</TableHead>
-                    {uniquePeriods.map((period, _index) => {
+                    {uniquePeriods.map((period) => {
                       const date = period;
                       const today = new Date();
 
@@ -313,7 +313,7 @@ export function RoutedToPerPeriod() {
                   </TableRow>
                 </TableHeader>
                 <TableBody className="relative">
-                  {processedData.map((row, _index) => {
+                  {processedData.map((row) => {
                     return (
                       <TableRow key={row.id} className="divide-muted divide-x">
                         <TableCell className="w-[200px]">


### PR DESCRIPTION
## What does this PR do?

This PR fixes the style of "Routed to per period" chart on /insights/routing

## Visual Demo (For contributors especially)

### Before

<img width="505" height="678" alt="Screenshot 2025-10-16 at 10 38 59" src="https://github.com/user-attachments/assets/a6a1ac43-2689-4835-8884-63f4f0447bad" />


### After

<img width="504" height="677" alt="Screenshot 2025-10-16 at 10 41 24" src="https://github.com/user-attachments/assets/540ab893-5a8e-412d-9d85-c58fd76ec035" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

