### PR TITLE
fix: enable format on save with Prettier in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },


### PR DESCRIPTION
## What does this PR do?

Enables automatic code formatting on save in VS Code by setting `editor.formatOnSave: true` and explicitly configuring Prettier as the default formatter.

This resolves an issue where Prettier formatting was not being applied automatically when saving files in VS Code, despite the recommended extensions being installed.

## Summary

**Changes:**
- Set `editor.formatOnSave` to `true` (was `false`)
- Added `editor.defaultFormatter: "esbenp.prettier-vscode"` to ensure Prettier handles formatting

**Current setup confirmed:**
- ESLint v9.36.0 with flat config format is in place
- `eslint-config-prettier` is configured (disables ESLint formatting rules)
- Separation of concerns: ESLint handles code quality, Prettier handles formatting
- ESLint auto-fixes still run via `codeActionsOnSave` on save

## How should this be tested?

1. Open a TypeScript/JavaScript file in VS Code
2. Make formatting changes (remove spaces, break lines incorrectly, etc.)
3. Save the file (`Cmd/Ctrl + S`)
4. Verify the file is automatically formatted by Prettier

**Prerequisites:**
- VS Code with `esbenp.prettier-vscode` extension installed (already in recommended extensions)

## Human Review Checklist

- [ ] Confirm this aligns with the team's desired default developer experience
- [ ] Verify all contributors are comfortable with auto-format-on-save as the default
- [ ] Check if there are workflows where format-on-save could cause issues (e.g., generated files)

## Notes

This is a workspace configuration change that will affect all contributors by default. Individual developers can still override this in their personal VS Code settings if they prefer different behavior.

---

**Link to Devin run:** https://app.devin.ai/sessions/6cf305eef91442bb9ad65082ebfde948  
**Requested by:** hariom@cal.com (@hariombalhara)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - workspace configuration change only
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **N/A** - configuration change, verified manually with Prettier CLI

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **N/A** - JSON configuration
- [x] I have checked if my changes generate no new warnings