### PR TITLE
fix: await handleGroupEvents to ensure SCIM group membership creation completes

### DIFF
--- a/apps/web/app/api/scim/v2.0/[...directory]/route.ts
+++ b/apps/web/app/api/scim/v2.0/[...directory]/route.ts
@@ -45,7 +45,7 @@ const handleEvents = async (event: DirectorySyncEvent) => {
   }
 
   if (event.event.includes("group")) {
-    handleGroupEvents(event, organizationId);
+    await handleGroupEvents(event, organizationId);
   }
 
   if (event.event === "user.created" || event.event === "user.updated") {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where SCIM group events from MS Entra (and other providers) were not completing before the SCIM response was sent, causing group memberships to not be created reliably.

The issue was that `handleGroupEvents` was called without `await` while `handleUserEvents` was correctly awaited. This meant the SCIM handler would respond immediately without waiting for the group membership creation to complete.

**Root cause:** Line 48 in `apps/web/app/api/scim/v2.0/[...directory]/route.ts` was missing the `await` keyword for the async `handleGroupEvents` function.

## Key Changes

- Added `await` to `handleGroupEvents` call to ensure group processing (membership creation, profile creation, email sending) completes before SCIM response is sent
- This matches the existing pattern used for user events on line 52

## How should this be tested?

**Prerequisites:**
- Organization with SCIM configured
- MS Entra (or other SCIM provider) integration set up

**Test Steps:**
1. Configure a team in Cal.com and map it to a SCIM group via dSyncTeamGroupMapping
2. Push a group from MS Entra with multiple members assigned
3. Verify that all users are added as members of the mapped team immediately
4. Check that membership records are created in the database
5. Verify emails are sent to new members

**Expected Result:**
- All group members should be added to the team
- Memberships should be created in the database before SCIM responds
- No race conditions or timing issues

## Important Review Notes

⚠️ **Error Handling Change**: Previously, errors in `handleGroupEvents` were silently ignored since it wasn't awaited. Now errors will propagate to the SCIM response. This is the correct behavior but changes error reporting.

⚠️ **Testing Limitation**: This fix was identified through code analysis. It has NOT been tested with an actual MS Entra group push. Manual testing is strongly recommended before merging.

⚠️ **Performance**: SCIM responses will now take slightly longer as they wait for membership creation and email sending to complete. This is the correct behavior but changes timing.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change - N/A, this is a bug fix with no API changes
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works - No automated test added yet; manual testing with MS Entra strongly recommended

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas - N/A, single line change
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/1a408e7fed584e0385c360d55e6b70bc  
**Requested by:** joe@cal.com (@joeauyeung)