### PR TITLE
fix: properly clean up hosts when removing team members

### DIFF
--- a/packages/features/ee/teams/services/teamService.test.ts
+++ b/packages/features/ee/teams/services/teamService.test.ts
@@ -192,16 +192,22 @@ describe("TeamService", () => {
         team: { id: 1, parentId: null },
       };
 
-      prismaMock.membership.delete.mockResolvedValue(mockMembership as Membership & { team: Team });
+      prismaMock.membership.findUnique.mockResolvedValue(mockMembership as Membership & { team: Team });
+      const removeMembersSpy = vi.spyOn(TeamService, "removeMembers").mockResolvedValue(undefined);
 
       await TeamService.leaveTeamMembership({
         userId: 1,
         teamId: 1,
       });
 
-      expect(prismaMock.membership.delete).toHaveBeenCalledWith({
+      expect(prismaMock.membership.findUnique).toHaveBeenCalledWith({
         where: { userId_teamId: { userId: 1, teamId: 1 } },
         select: { team: true },
+      });
+      expect(removeMembersSpy).toHaveBeenCalledWith({
+        teamIds: [1],
+        userIds: [1],
+        isOrg: false,
       });
     });
 
@@ -210,18 +216,22 @@ describe("TeamService", () => {
         team: { id: 1, parentId: 2 },
       };
 
-      prismaMock.membership.delete
-        .mockResolvedValueOnce(mockMembership as Membership & { team: Team })
-        .mockResolvedValueOnce({} as Membership);
+      prismaMock.membership.findUnique.mockResolvedValue(mockMembership as Membership & { team: Team });
+      const removeMembersSpy = vi.spyOn(TeamService, "removeMembers").mockResolvedValue(undefined);
 
       await TeamService.leaveTeamMembership({
         userId: 1,
         teamId: 1,
       });
 
-      expect(prismaMock.membership.delete).toHaveBeenCalledTimes(2);
-      expect(prismaMock.membership.delete).toHaveBeenNthCalledWith(2, {
-        where: { userId_teamId: { userId: 1, teamId: 2 } },
+      expect(prismaMock.membership.findUnique).toHaveBeenCalledWith({
+        where: { userId_teamId: { userId: 1, teamId: 1 } },
+        select: { team: true },
+      });
+      expect(removeMembersSpy).toHaveBeenCalledWith({
+        teamIds: [1, 2],
+        userIds: [1],
+        isOrg: true,
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where users weren't being removed from the `Host` table when they left a team via the UI (either by removing themselves or declining a team invitation).

**Link to Devin run:** https://app.devin.ai/sessions/764151b4ee51408eb9c5f820860cc26f  
**Requested by:** joe@cal.com (@joeauyeung)

### Problem
The `leaveTeamMembership()` method was directly deleting membership records without cleaning up related data like host assignments. This resulted in orphaned host records pointing to users who were no longer team members.

### Solution
Updated `leaveTeamMembership()` to use `TeamService.removeMembers()`, which already has the proper cleanup logic for:
- Host assignments in team event types
- Managed event types  
- Sub-team memberships (for organizations)

The change is minimal - instead of directly deleting the membership, we now:
1. Find the membership with `findUnique()` (to get team details)
2. Call `removeMembers()` which handles all cleanup in a transaction

This ensures the same cleanup path is used whether a user is removed by an admin or leaves voluntarily.

## How should this be tested?

### Setup
1. Create a team with an event type
2. Add a user as a host to that event type
3. Verify the host record exists in the database: `SELECT * FROM Host WHERE userId = <user_id> AND eventTypeId = <event_type_id>`

### Test Case 1: User declines team invitation
1. Invite a user to the team
2. Add them as host to an event type
3. Have the user decline the invitation via the UI
4. Verify the host record is deleted from the database

### Test Case 2: User leaves team voluntarily  
1. Accept the team membership
2. Add user as host to an event type
3. Have the user leave the team via the UI
4. Verify the host record is deleted

### Test Case 3: Organization sub-team
1. Create an organization with a sub-team
2. Add a user to both org and sub-team
3. Add them as host to sub-team event type
4. Have user leave the sub-team
5. Verify host record is cleaned up and parent org membership handled correctly

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - internal bug fix, no API changes
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Existing integration tests** in `packages/lib/server/service/__tests__/teamService.integration-test.ts` cover the `removeMembers()` method which now handles the cleanup.

## Review Checklist

**Most important to verify:**
1. **isOrg flag determination**: Confirm that `membership.team.parentId !== null` correctly identifies organization memberships
2. **removeMembers() behavior**: Verify this method properly handles both regular teams and organization sub-teams (see lines 487-496 and 549-556 in teamService.ts)
3. **No breaking changes**: Ensure using the `removeMembers()` path doesn't break any existing leave/decline flows