### PR TITLE
fix: spacing between bold and italic buttons in description of new event type

### DIFF
--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -360,7 +360,6 @@ export default function ToolbarPlugin(props: TextEditorProps) {
         }
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.updateTemplate]);
 
   useEffect(() => {
@@ -375,7 +374,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
         $getRoot().select();
         try {
           $insertNodes(nodes);
-        } catch (e: unknown) {
+        } catch {
           // resolves: "topLevelElement is root node at RangeSelection.insertNodes"
           // @see https://stackoverflow.com/questions/73094258/setting-editor-from-html
           const paragraphNode = $createParagraphNode();
@@ -397,7 +396,6 @@ export default function ToolbarPlugin(props: TextEditorProps) {
         });
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -467,7 +465,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
           </>
         )}
 
-        <>
+        <div className="flex gap-1">
           {!props.excludedToolbarItems?.includes("bold") && (
             <Button
               aria-label="Bold"
@@ -508,7 +506,7 @@ export default function ToolbarPlugin(props: TextEditorProps) {
               {isLink && createPortal(<FloatingLinkEditor editor={editor} />, document.body)}{" "}
             </>
           )}
-        </>
+        </div>
         {props.variables && (
           <div className={`${props.addVariableButtonTop ? "-mt-10" : ""} ml-auto`}>
             <AddVariablesDropdown


### PR DESCRIPTION

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24446
- Fixes CAL-6570
- Added a div with flex & gap so that the bold and italic buttons have spacing between them when both are selected
- Fixed some lines which were causing linting errors

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.


#### Image Demo (if applicable):

Before:

<img width="312" height="137" alt="Screenshot from 2025-10-18 10-56-06" src="https://github.com/user-attachments/assets/1cc67b82-8bb6-4c80-9f68-46b93e8e2a68" />


After:

<img width="312" height="137" alt="Screenshot from 2025-10-18 11-00-43" src="https://github.com/user-attachments/assets/80501cce-010c-4640-ab12-9f96a25654b5" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a new event type
- Select both bold and italic option in the event description
- Check that the buttons have spacing between them and dont overlap

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes spacing between bold and italic buttons in the new event type description so they no longer overlap. Wraps the buttons in a flex container with a small gap and removes lint suppressions, aligning with CAL-6570 and closing #24446.

<!-- End of auto-generated description by cubic. -->

