### PR TITLE
fix: Limit Future Bookings in UTC instead of Local Time

### DIFF
--- a/packages/lib/isOutOfBounds.tsx
+++ b/packages/lib/isOutOfBounds.tsx
@@ -113,14 +113,11 @@ export function calculatePeriodLimits({
       // We use organizer's timezone here(in contrast with ROLLING/ROLLING_WINDOW where number of days is available and not the specific date objects).
       // This is because in case of range the start and end date objects are determined by the organizer, so we should consider the range in organizer/event's timezone.
 
-      // FIX: Dates are stored as midnight UTC (e.g., "2024-01-31T00:00:00.000Z") but represent calendar dates.
-      // We need to extract the calendar date and reinterpret it as midnight in the event's timezone.
-      // For example, "2024-01-31T00:00:00.000Z" should represent "Jan 31" in the event timezone, not "Jan 30 4pm PST".
+      // Dates are stored as midnight UTC but represent calendar dates in the event timezone
+      // Extract the date and reinterpret it as midnight in the event timezone
       const startCalendarDate = dayjs.utc(periodStartDate).format("YYYY-MM-DD");
       const endCalendarDate = dayjs.utc(periodEndDate).format("YYYY-MM-DD");
 
-      // Reinterpret these calendar dates as midnight in the event timezone, then find start/end of day
-      // For PST (offset = -480), we add 480 minutes to shift from UTC midnight to PST midnight
       const startOfRangeStartDayInEventTz = dayjs
         .utc(startCalendarDate)
         .add(-eventUtcOffset, "minutes")


### PR DESCRIPTION
## What does this PR do?

This PR fixes the timezone handling bug in date range booking limits where bookings were incorrectly rejected after midnight UTC even when they fell within the valid date range in the event's local timezone.

- Fixes #24523 
- Fixes CAL-[6593](https://linear.app/calcom/issue/CAL-6593/limit-future-bookings-in-utc-instead-of-local-time)


#### Before:

User tries to book at 5:00 PM PST on Jan 31 (last day of range) → Gets error "Could not book the meeting"


https://github.com/user-attachments/assets/9df3988a-519e-402a-b0b3-52e7a2ff2fc1



#### After:

User tries to book at 5:00 PM PST on Jan 31 (last day of range) → Booking succeeds 

The fix works universally for all timezones:

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**No special environment variables needed.**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix validation of date-range booking limits so UTC-stored dates are interpreted as calendar days in the event timezone. Prevents false rejections after midnight UTC and aligns with CAL-6593.

- **Bug Fixes**
  - Parse periodStartDate/periodEndDate as UTC calendar dates, then compute start/end of day in the event timezone.
  - Ensures bookings on the last allowed day in local time (e.g., 5:00 PM PST on Jan 31) succeed.
  - Applies consistently across all timezones.

<!-- End of auto-generated description by cubic. -->

