### PR TITLE
fix: add keyboard accessibility to BorderRadiusTable component

### DIFF
--- a/apps/ui-playground/components/ui/BorderRadiusTable.tsx
+++ b/apps/ui-playground/components/ui/BorderRadiusTable.tsx
@@ -46,7 +46,15 @@ export const BorderRadiusTable: React.FC<BorderRadiusTableProps> = () => {
           <div
             key={token.name}
             onClick={() => handleCopy(token.className)}
-            className="border-subtle bg-default hover:bg-subtle group relative cursor-pointer overflow-hidden rounded-lg border p-4">
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleCopy(token.className);
+              }
+            }}
+            className="border-subtle bg-default hover:bg-subtle group relative cursor-pointer overflow-hidden rounded-lg border p-4 focus:outline-none focus:ring-2 focus:ring-blue-500">
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24482  
- Fixes [CAL-6580](https://linear.app/calcom/issue/CAL-6580/keyboard-accessibility-missing-for-borderradiustable-component)

### Description
Adds keyboard accessibility to the BorderRadiusTable component, allowing users to navigate interactive cards using the Tab key and copy Tailwind class names using Enter or Space keys.
Previously, the cards were only accessible via mouse clicks, creating an accessibility barrier for keyboard-only users and screen reader users.

### Before:
Users cannot Tab to focus on cards
Pressing Enter/Space does nothing
Only mouse clicks work

### After:
Users can Tab through all cards
Each card shows a visible focus ring
Pressing Enter or Space copies the Tailwind class name
Copy confirmation toast appears
Mouse clicks continue to work as expected


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds keyboard support to BorderRadiusTable so users can tab to each card and press Enter or Space to copy the Tailwind class. Uses role=button, tabIndex, keydown handling, and a visible focus ring to meet CAL-6580 and fix #24482.

<!-- End of auto-generated description by cubic. -->

