### PR TITLE
perf: Remove tRPC types from @calcom/lib

### DIFF
--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -5,6 +5,6 @@
     "jsx": "preserve",
     "resolveJsonModule": true
   },
-  "include": [".", "../types/next-auth.d.ts", "../types/window.d.ts", "../trpc/types/router.d.ts"],
+  "include": [".", "../types/next-auth.d.ts", "../types/window.d.ts"],
   "exclude": ["dist", "build", "**/node_modules/**"]
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed tRPC router type references from @calcom/lib’s tsconfig to stop including tRPC types during compilation. This reduces type-checking work and speeds up builds by decoupling the lib package from tRPC.

<!-- End of auto-generated description by cubic. -->

