### PR TITLE
chore: Add turbo package to dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -201,7 +201,8 @@
     "tailwindcss": "^3.3.3",
     "tailwindcss-animate": "^1.0.6",
     "ts-node": "^10.9.1",
-    "typescript": "^5.9.0-beta"
+    "typescript": "^5.9.0-beta",
+    "turbo": "^2.5.5"
   },
   "nextBundleAnalysis": {
     "budget": 358400,


### PR DESCRIPTION
This is needed due to Docker build errors indicating that turbo was not an available command. Closes #24535.

## What does this PR do?

- Adds turbo as a dev dependency under the web app

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Pull this patch within a cloned instance of the Cal.com Docker repository 
- Run a full build
- The dockerized instance of Cal.com should build and run successfully. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add turbo to the web app devDependencies to fix Docker builds failing due to the missing "turbo" command. This ensures the Dockerized app builds and runs successfully.

- **Dependencies**
  - Added turbo ^2.5.5 to apps/web devDependencies.

<!-- End of auto-generated description by cubic. -->

