### PR TITLE
chore: implement dockerized playwright for unsupported operating systems

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -352,7 +352,7 @@ E2E_TEST_CALCOM_GCAL_KEYS=
 # - PLAYWRIGHT
 # Used to connect to remote Playwright server (E.g, docker container running Playwright)
 PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:4580
-# Set to 1 to run Playwright in headed mode for easier debugging
+# Set to 1 to run Playwright in headless mode (e.g., CI runs)
 PLAYWRIGHT_HEADLESS=
 
 # - APP CREDENTIAL SYNC ***********************************************************************************

--- a/.env.example
+++ b/.env.example
@@ -349,6 +349,12 @@ E2E_TEST_CALCOM_QA_PASSWORD="password"
 E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS=
 E2E_TEST_CALCOM_GCAL_KEYS=
 
+# - PLAYWRIGHT
+# Used to connect to remote Playwright server (E.g, docker container running Playwright)
+PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:4580
+# Set to 1 to run Playwright in headed mode for easier debugging
+PLAYWRIGHT_HEADLESS=
+
 # - APP CREDENTIAL SYNC ***********************************************************************************
 # Used for self-hosters that are implementing Cal.com into their applications that already have certain integrations
 # Under settings/admin/apps ensure that all app secrets are set the same as the parent application

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,9 +188,9 @@ If `npx playwright install` fails on your Linux distribution (e.g., Arch Linux, 
 
 2. Set Playwright to headless mode in your `.env` file:
 
-```sh
-PLAYWRIGHT_HEADLESS=1
-```
+   ```sh
+   PLAYWRIGHT_HEADLESS=1
+   ```
 
 ## Linting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,20 @@ Run `npx playwright install` to download test browsers and resolve the error bel
 Executable doesn't exist at /Users/alice/Library/Caches/ms-playwright/chromium-1048/chrome-mac/Chromium.app/Contents/MacOS/Chromium
 ```
 
+If `npx playwright install` fails on your Linux distribution (e.g., Arch Linux, NixOS), use [Docker setup](https://playwright.dev/docs/docker) instead:
+
+1. Start the Playwright container:
+
+   ```sh
+   yarn workspace @calcom/web e2e:docker-setup
+   ```
+
+2. Set Playwright to headless mode in your `.env` file:
+
+```sh
+PLAYWRIGHT_HEADLESS=1
+```
+
 ## Linting
 
 To check the formatting of your code:

--- a/README.md
+++ b/README.md
@@ -319,6 +319,20 @@ Run `npx playwright install` to download test browsers and resolve the error bel
 Executable doesn't exist at /Users/alice/Library/Caches/ms-playwright/chromium-1048/chrome-mac/Chromium.app/Contents/MacOS/Chromium
 ```
 
+If `npx playwright install` fails on your Linux distribution (e.g., Arch Linux, NixOS), use [Docker setup](https://playwright.dev/docs/docker) instead:
+
+1. Start the Playwright container:
+
+   ```sh
+   yarn workspace @calcom/web e2e:docker-setup
+   ```
+
+2. Set Playwright to headless mode in your `.env` file:
+
+```sh
+PLAYWRIGHT_HEADLESS=1
+```
+
 ### Upgrading from earlier versions
 
 1. Pull the current version:

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  playwright:
+    # NOTE: Always ensure this image version matches `@playwright/test` version in package.json.
+    image: mcr.microsoft.com/playwright:v1.45.3-jammy
+    restart: always
+    container_name: "playwright"
+    init: true
+    ipc: host
+    command: ["/bin/sh", "-c", "cd /home/pwuser/apps/web/ && npm exec -- playwright run-server --port 4580"]
+    volumes:
+      - ../../:/home/pwuser
+    network_mode: host
+    extra_hosts:
+      - "localhost:host-gateway"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "dev-https": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --experimental-https",
     "dx": "yarn dev",
     "test-codegen": "yarn playwright codegen http://localhost:3000",
+    "e2e:docker-setup": "docker compose up -d || docker-compose up -d",
     "type-check": "tsc --pretty --noEmit",
     "type-check:ci": "tsc-absolute --pretty --noEmit",
     "sentry:release": "NODE_OPTIONS='--max-old-space-size=6144' node scripts/create-sentry-release.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -101,7 +101,7 @@ const config: PlaywrightTestConfig = {
     baseURL: process.env.NEXT_PUBLIC_WEBAPP_URL,
     locale: "en-US",
     trace: "retain-on-failure",
-    headless,
+    headless: !!process.env.PLAYWRIGHT_HEADLESS,
   },
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ const DEFAULT_EXPECT_TIMEOUT = process.env.CI ? 30000 : 120000;
 // So, it should me much higher than sum of expect and navigation timeouts as there can be many async expects and navigations in a single test
 const DEFAULT_TEST_TIMEOUT = process.env.CI ? 60000 : 240000;
 
-const headless = process.env.CI ? false : !!process.env.PLAYWRIGHT_HEADLESS;
+const headless = process.env.CI ? true : !!process.env.PLAYWRIGHT_HEADLESS;
 
 const IS_EMBED_TEST = process.argv.some((a) => a.startsWith("--project=@calcom/embed-core"));
 const IS_EMBED_REACT_TEST = process.argv.some((a) => a.startsWith("--project=@calcom/embed-react"));

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ const DEFAULT_EXPECT_TIMEOUT = process.env.CI ? 30000 : 120000;
 // So, it should me much higher than sum of expect and navigation timeouts as there can be many async expects and navigations in a single test
 const DEFAULT_TEST_TIMEOUT = process.env.CI ? 60000 : 240000;
 
-const headless = !!process.env.CI || !!process.env.PLAYWRIGHT_HEADLESS;
+const headless = process.env.CI ? false : !!process.env.PLAYWRIGHT_HEADLESS;
 
 const IS_EMBED_TEST = process.argv.some((a) => a.startsWith("--project=@calcom/embed-core"));
 const IS_EMBED_REACT_TEST = process.argv.some((a) => a.startsWith("--project=@calcom/embed-react"));
@@ -101,7 +101,7 @@ const config: PlaywrightTestConfig = {
     baseURL: process.env.NEXT_PUBLIC_WEBAPP_URL,
     locale: "en-US",
     trace: "retain-on-failure",
-    headless: !!process.env.PLAYWRIGHT_HEADLESS,
+    headless,
   },
   projects: [
     {


### PR DESCRIPTION
## What does this PR do?

This PR adds support for running Playwright E2E tests using Docker on unsupported Linux distributions (e.g., Arch Linux, NixOS) where Playwright browser installation fails due to missing system dependencies.

**Changes include:**

- Added `docker-compose.yml` in `@calcom/web` for playwright container
- Added `e2e:docker-setup` pkg script to start the container
- Updated documentation in `README.md` and `CONTRIBUTING.md`

- Fixes #24597

## Visual Demo (For contributors especially)

**Before**: Contributors on unsupported Linux distros would see this error with no workaround:

```
Playwright Host validation warning:
╔══════════════════════════════════════════════════════╗
║ Host system is missing dependencies to run browsers. ║
║ Missing libraries:                                   ║
║     libicudata.so.66                                 ║
║     libicui18n.so.66                                 ║
║     libicuuc.so.66                                   ║
║     [... 18+ more libraries]                         ║
╚══════════════════════════════════════════════════════╝
```

**After**: Contributors can now make use of Docker with one simple command:

```sh
yarn workspace @calcom/web e2e:docker-setup
PLAYWRIGHT_HEADLESS=1 yarn test-e2e
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). **N/A** - This is purely documentation changes in README, CONTRIBUTING, and commands.md files.
- [] I confirm automated tests are in place that prove my fix is effective or that my feature works. 

## How should this be tested?

1. **Start the Playwright Docker container:**

   ```bash
   yarn workspace @calcom/web e2e:docker-setup
   ```

   - Verify container starts: `docker ps | grep playwright`
   - Should see a container named `playwright` running

2. **Set Playwright in headless mode:**

   ```bash
   export PLAYWRIGHT_HEADLESS=1
   ```

3. **Run E2E tests:**

   ```bash
   yarn test-e2e
   # Or run a specific test:
   yarn e2e some-test.e2e.ts
   ```

4. **Verify documentation:**
   - Check README.md → "E2E-Testing" → "Unsupported Linux distributions"
   - Check CONTRIBUTING.md → "Resolving Issues" → "Unsupported Linux Distribution"
   - Check commands.md → "End-to-End Tests" → "Docker-based E2E Tests"

**Environment variables:**

- `PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:4580/`

**Expected outcome:**

- E2E tests run through the containerized Playwright instance
- Tests pass just as they would with locally-installed browsers