### PR TITLE
chore: added missing `packages/prisma/client/*`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ tsconfig.tsbuildinfo
 .turbo
 
 # Prisma generated files
+packages/prisma/client/*
 apps/api/v2/generated/prisma/*
 packages/prisma/generated/prisma/*
 packages/prisma/zod/**/*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ tsconfig.tsbuildinfo
 
 # Prisma generated files
 packages/prisma/client/*
+!packages/prisma/client/index.ts
 apps/api/v2/generated/prisma/*
 packages/prisma/generated/prisma/*
 packages/prisma/zod/**/*.ts


### PR DESCRIPTION
## What does this PR do?

added `packages/prisma/client/*`  in `.gitignore` because it causing client include in commit   

which was removed by this [commit](https://github.com/calcom/cal.com/commit/6923b97cd20290fb4471a386c8e882233319aaa3#diff-bddff097fc6e854943202aaacbd7f8c0b5b7e8131d6c20580fa9ec7f79fc98fd) 



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added packages/prisma/client/* to .gitignore to prevent generated Prisma client files from being committed. Restores consistent ignore rules for Prisma outputs and reduces repo noise.

<!-- End of auto-generated description by cubic. -->

