### PR TITLE
chore: Default `fetchCrm` to true for `getRoutedUrl`

### DIFF
--- a/packages/features/routing-forms/lib/getRoutedUrl.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.ts
@@ -53,8 +53,7 @@ export function hasEmbedPath(pathWithQuery: string) {
   return onlyPath.endsWith("/embed") || onlyPath.endsWith("/embed/");
 }
 
-// We have fetchCrm as configurable temporarily to allow us to test the CRM logic in the APIV2. Soon after we would hardcode it to true
-const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | "req">, fetchCrm = false) => {
+const _getRoutedUrl = async (context: Pick<GetServerSidePropsContext, "query" | "req">, fetchCrm = true) => {
   const queryParsed = querySchema.safeParse(context.query);
   const isEmbed = hasEmbedPath(context.req.url || "");
   const pageProps = {


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Default fetchCrm to true in getRoutedUrl to re-enable CRM prefetching by default. This makes routing decisions CRM-aware without needing to pass the flag.

<!-- End of auto-generated description by cubic. -->

