### PR TITLE
fix: Use booking reference credentials to delete calendar events in request reschedule

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -1127,6 +1127,64 @@ export class BookingRepository {
     });
   }
 
+  async findBookingForRequestReschedule({ bookingUid }: { bookingUid: string }) {
+    return await this.prismaClient.booking.findUniqueOrThrow({
+      where: {
+        uid: bookingUid,
+        NOT: {
+          status: {
+            in: [BookingStatus.CANCELLED, BookingStatus.REJECTED],
+          },
+        },
+      },
+      select: {
+        id: true,
+        uid: true,
+        userId: true,
+        title: true,
+        description: true,
+        startTime: true,
+        endTime: true,
+        eventTypeId: true,
+        userPrimaryEmail: true,
+        eventType: {
+          include: {
+            team: {
+              select: {
+                id: true,
+                name: true,
+                parentId: true,
+              },
+            },
+          },
+        },
+        location: true,
+        attendees: true,
+        references: {
+          select: {
+            uid: true,
+            type: true,
+            externalCalendarId: true,
+            credentialId: true,
+            delegationCredentialId: true,
+            credential: {
+              select: credentialForCalendarServiceSelect,
+            },
+            delegationCredential: true,
+          },
+        },
+        customInputs: true,
+        dynamicEventSlugRef: true,
+        dynamicGroupSlugRef: true,
+        destinationCalendar: true,
+        smsReminderNumber: true,
+        workflowReminders: true,
+        responses: true,
+        iCalUID: true,
+      },
+    });
+  }
+
   async getBookingForPaymentProcessing(bookingId: number) {
     return await this.prismaClient.booking.findUnique({
       where: {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where calendar events were not being deleted when users requested a reschedule. The root cause was that the handler was using the **current user's credentials** (the person requesting the reschedule) instead of the **booking owner's credentials** (the person who created the calendar event).

**Changes:**
- Updated the booking query to include credential information in the `references` select
- Changed credential fetching to use the credential ID stored directly on each `BookingReference` 
- Added credential enrichment to properly handle delegation credentials before deletion
- Improved error handling with warning logs when credentials are not found

**Why this matters:**
Previously, if Alice created a booking and Bob requested a reschedule, the system would try to delete the calendar event using Bob's credentials, which would fail since Bob didn't create the event. This PR ensures we always use the correct credentials from the booking reference.

## Visual Demo

N/A - This is a backend bug fix with no UI changes.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - No documentation changes needed for this internal bug fix.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. ✅ Existing test suite passes (`apps/web/test/handlers/requestReschedule.test.ts`)

## How should this be tested?

**Test scenario:**
1. User A creates a booking on their calendar
2. User B (attendee) requests a reschedule for that booking
3. Verify that the calendar event is properly deleted from User A's calendar

**Environment variables:**
- Standard Cal.com setup with `DATABASE_URL`, `NEXTAUTH_SECRET`, etc.
- Calendar integration credentials (e.g., Google Calendar) for multiple test users

**Test data:**
- At least 2 users with connected calendar accounts
- A confirmed booking between them

**Expected outcome:**
- Calendar event should be deleted from the booking owner's calendar
- Booking should be marked as cancelled with `rescheduled: true`
- Request reschedule email should be sent

**Important test cases:**
- Individual event types
- Team events (round-robin and collective)
- Managed event types
- Events with delegation credentials
- Events with multiple calendar integrations

## Checklist

- ~~I haven't read the contributing guide~~
- ~~My code doesn't follow the style guidelines of this project~~
- ~~I haven't commented my code, particularly in hard-to-understand areas~~
- ~~I haven't checked if my changes generate no new warnings~~

## Review Focus Areas

**Key areas that need careful review:**

1. **Credential enrichment logic** (lines 251-266): The use of `enrichUserWithDelegationCredentialsIncludeServiceAccountKey` ensures delegation credentials are properly included. Pay attention to the type cast `as CredentialPayload` - this is necessary but should be verified.

2. **Null credential handling** (lines 283-289): Added warning logs for cases where credentials are not found. Verify this adequately handles edge cases.

3. **Performance considerations**: The code now makes one enrichment call per booking reference (via `Promise.all`). For bookings with many references, this could be slower than the previous approach, though it's more correct.

4. **Type safety**: The change removes the unused `BookingReference` import and adds `CredentialPayload`. The credential selection uses `credentialForCalendarServiceSelect` to ensure the proper fields are included.

---

**Link to Devin run:** https://app.devin.ai/sessions/c19baa11ee9944b5aedc607e446493da  
**Requested by:** joe@cal.com (@joeauyeung)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes calendar and video event deletion in the reschedule flow by using the booking owner’s credentials from each booking reference, not the requester’s. Ensures events are removed even with delegated/service-account credentials.

- **Bug Fixes**
  - Use credentials attached to each BookingReference to delete calendar/video events.
  - Include credential fields in the booking query and enrich with delegation/service-account data.
  - Add warning logs when a credential is missing, instead of silently failing.

<!-- End of auto-generated description by cubic. -->

