### PR TITLE
perf: initial fix unused exports - wip

### DIFF
--- a/apps/web/components/apps/AppSetupPage.tsx
+++ b/apps/web/components/apps/AppSetupPage.tsx
@@ -22,5 +22,3 @@ export const AppSetupMap = {
 export const AppSetupPage = (props: { slug: string }) => {
   return <DynamicComponent<typeof AppSetupMap> componentMap={AppSetupMap} {...props} />;
 };
-
-export default AppSetupPage;

--- a/apps/web/components/settings/platform/hooks/usePlatformMe.ts
+++ b/apps/web/components/settings/platform/hooks/usePlatformMe.ts
@@ -11,5 +11,3 @@ export function usePlatformMe() {
 
   return meQuery;
 }
-
-export default usePlatformMe;

--- a/apps/web/modules/auth/logout-view.tsx
+++ b/apps/web/modules/auth/logout-view.tsx
@@ -25,8 +25,7 @@ export function Logout(props: PageProps) {
     if (props.query?.survey === "true") {
       router.push(`${WEBSITE_URL}/cancellation`);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.query?.survey]);
+  }, [props.query?.survey, router]);
   const { t } = useLocale();
 
   const message = () => {
@@ -65,5 +64,3 @@ export function Logout(props: PageProps) {
     </AuthContainer>
   );
 }
-
-export default Logout;

--- a/apps/web/modules/auth/setup-view.tsx
+++ b/apps/web/modules/auth/setup-view.tsx
@@ -142,5 +142,3 @@ export function Setup(props: PageProps) {
 }
 
 Setup.isThemeSupported = false;
-
-export default Setup;

--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -99,7 +99,6 @@ export function UserPage(props: PageProps) {
               <>
                 <div
                   className="text-default break-words text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
-                  // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: props.safeBio }}
                 />
               </>
@@ -148,5 +147,3 @@ export function UserPage(props: PageProps) {
     </>
   );
 }
-
-export default UserPage;

--- a/packages/features/users/components/UserTable/InviteMemberModal.tsx
+++ b/packages/features/users/components/UserTable/InviteMemberModal.tsx
@@ -6,7 +6,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { CreationSource } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc";
 import { showToast } from "@calcom/ui/components/toast";
-import usePlatformMe from "@calcom/web/components/settings/platform/hooks/usePlatformMe";
+import { usePlatformMe } from "@calcom/web/components/settings/platform/hooks/usePlatformMe";
 
 import type { UserTableAction } from "./types";
 


### PR DESCRIPTION
## What does this PR do?

Fix knip issues
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Resolved knip unused export warnings by removing default exports and switching to named imports. Fixed Logout effect dependencies to prevent stale router navigation.

- **Refactors**
  - Removed default exports in AppSetupPage, usePlatformMe, Logout, Setup, and UserPage to satisfy knip.
  - Switched InviteMemberModal to a named import for usePlatformMe and cleaned up unused eslint-disable/comments.

- **Bug Fixes**
  - Added router to Logout useEffect dependencies to avoid stale navigation behavior.

<!-- End of auto-generated description by cubic. -->

