### PR TITLE
fix: impersonate correct user using email

### DIFF
--- a/packages/features/ee/users/components/UsersTable.tsx
+++ b/packages/features/ee/users/components/UsersTable.tsx
@@ -135,8 +135,8 @@ function UsersTableBare() {
     },
   });
 
-  const handleImpersonateUser = async (username: string | null) => {
-    await signIn("impersonation-auth", { username: username, callbackUrl: `${WEBAPP_URL}/event-types` });
+  const handleImpersonateUser = async (email: string | null) => {
+    await signIn("impersonation-auth", { username: email, callbackUrl: `${WEBAPP_URL}/event-types` });
   };
 
   //we must flatten the array of arrays from the useInfiniteQuery hook
@@ -243,7 +243,7 @@ function UsersTableBare() {
                         {
                           id: "impersonate-user",
                           label: "Impersonate User",
-                          onClick: () => handleImpersonateUser(user?.username),
+                          onClick: () => handleImpersonateUser(user?.email),
                           icon: "user",
                         },
                         {
@@ -275,7 +275,7 @@ function UsersTableBare() {
                           id: "impersonation",
                           label: "Impersonate",
                           onClick: () => {
-                            setSelectedUser(user.username);
+                            setSelectedUser(user.email);
                             setShowImpersonateModal(true);
                           },
                           icon: "venetian-mask",
@@ -345,7 +345,7 @@ const DeleteUserDialog = ({
   onClose: () => void;
 }) => {
   return (
-    // eslint-disable-next-line @typescript-eslint/no-empty-function -- noop
+     
     <Dialog name="delete-user" open={!!user} onOpenChange={(open) => (open ? () => {} : onClose())}>
       <ConfirmationDialogContent
         title="Delete User"


### PR DESCRIPTION
## What does this PR do?

Fixes the impersonation bug where clicking "Impersonate" from the admin user page would impersonate the wrong user when multiple users share the same username.

**Problem:**
- When searching for a user by email (e.g., `ryan@cal.com`) in the admin panel, the impersonation feature was using the `username` field instead of `email`
- This caused issues when multiple users have the same username (e.g., one user with username "ryan" at `i.cal.com/ryan` and another at `glide.cal.com/ryan`)
- The system would impersonate the wrong user based on username collision

**Solution:**
- Changed the impersonation logic in `UsersTable.tsx` to use `user.email` instead of `user.username`
- This ensures the correct user is impersonated since email addresses are unique per user
- Aligns with the existing pattern used in `ImpersonationMemberModal.tsx` which already uses email

The backend already supports this: The ImpersonationProvider.ts ([line 235](https://github.com/calcom/cal.com/blob/main/packages/features/ee/impersonation/lib/ImpersonationProvider.ts#L235C1-L235C71)) already looks up users by BOTH username OR email:
```
   where: {
     OR: [{ username: creds?.username }, { email: creds?.username }]
   }
```
   
So passing email in the username field works perfectly fine.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Impersonation now uses the user's email, not username, to sign in. This prevents impersonating the wrong user when usernames are missing or duplicated.

- **Bug Fixes**
  - Use email in handleImpersonateUser and pass it to impersonation-auth (as username) for signIn.
  - Update table actions and the impersonate modal to use user.email.

<!-- End of auto-generated description by cubic. -->

