### PR TITLE
fix: lint stage not loading config from file - using root instead

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,8 +1,9 @@
+// lint-staged.config.mjs
 export default {
-  "(apps|packages)/**/*.{js,ts,jsx,tsx}": [
-    "prettier --write",
-    process.env.SKIP_WARNINGS === "1" ? "eslint --fix" : "eslint --fix --max-warnings=0",
-  ],
+  "(apps|packages)/**/*.{js,ts,jsx,tsx}": (files) =>
+    process.env.SKIP_WARNINGS === "1"
+      ? `eslint --fix --flag v10_config_lookup_from_file ${files.join(" ")}`
+      : `eslint --fix --flag v10_config_lookup_from_file --max-warnings=0 ${files.join(" ")}`,
   "*.json": ["prettier --write"],
   "packages/prisma/schema.prisma": ["prisma format"],
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,4 +1,3 @@
-// lint-staged.config.mjs
 export default {
   "(apps|packages)/**/*.{js,ts,jsx,tsx}": (files) =>
     process.env.SKIP_WARNINGS === "1"


### PR DESCRIPTION
## What does this PR do?

Lint staged is not picking the right eslint flat config.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix lint-staged so ESLint uses the correct flat config by passing staged files explicitly and enabling the v10_config_lookup_from_file flag. SKIP_WARNINGS behavior is preserved; Prettier now only runs for JSON and the Prisma schema.

<!-- End of auto-generated description by cubic. -->

