### PR TITLE
fix: flaky admin integration tests by ensuring organization settings are properly configured

### DIFF
--- a/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 
 import prisma from "@calcom/prisma";
 
@@ -8,6 +8,30 @@ import {
 } from "../../../lib/utils/retrieveScopedAccessibleUsers";
 
 describe("retrieveScopedAccessibleUsers tests", () => {
+  beforeAll(async () => {
+    const acmeOrg = await prisma.team.findFirst({
+      where: {
+        slug: "acme",
+        isOrganization: true,
+      },
+    });
+
+    if (acmeOrg) {
+      await prisma.organizationSettings.upsert({
+        where: {
+          organizationId: acmeOrg.id,
+        },
+        update: {
+          isAdminAPIEnabled: true,
+        },
+        create: {
+          organizationId: acmeOrg.id,
+          orgAutoAcceptEmail: "acme.com",
+          isAdminAPIEnabled: true,
+        },
+      });
+    }
+  });
   describe("getAccessibleUsers", () => {
     it("Does not return members when only admin user ID is supplied", async () => {
       const adminUser = await prisma.user.findFirstOrThrow({ where: { email: "owner1-acme@example.com" } });


### PR DESCRIPTION
## What does this PR do?

Fixes flaky integration tests that were randomly failing in PRs due to inconsistent database state. The tests were failing when the Acme organization's `isAdminAPIEnabled` flag wasn't set to `true`, causing admin permission checks to fail unpredictably.

This PR adds `beforeAll` hooks to four integration test files to ensure organization settings are properly configured before tests run:

- **Acme organization**: Ensures `isAdminAPIEnabled: true` (required for admin API access tests)
- **Dunder Mifflin organization**: Ensures `isAdminAPIEnabled: false` (required for negative test cases)

Also removes an unused variable that was causing a lint error.

**Link to Devin run**: https://app.devin.ai/sessions/973dc4bc1a294608a9f9a2fd09ad7307  
**Requested by**: @anikdhabal (anik@cal.com)

## Fixes

This addresses the following flaky test failures:
- `isAdmin.integration-test.ts`: "Returns org-wide admin when user is set as such & admin API access is granted"
- `retrieveScopedAccessibleUsers.integration-test.ts`: "Returns members when admin user ID is supplied and members IDs are supplied"
- `retrieveScopedAccessibleUsers.integration-test.ts`: "Returns members when admin user ID is an admin of an org"
- `_get.integration-test.ts`: "Returns bookings for org users when accessed by org admin"
- `_patch.integration-test.ts`: "Allows PATCH when user is org-wide admin"

## How should this be tested?

1. Ensure the database is seeded: `yarn db-seed`
2. Run the affected integration tests:
   ```bash
   yarn test apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
   yarn test apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
   yarn test apps/api/v1/test/lib/bookings/_get.integration-test.ts
   yarn test apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts
   ```
3. All tests should pass consistently
4. Verify CI passes without flaky failures

## Review Checklist

**Critical items to review:**
- [ ] Verify the `beforeAll` hooks correctly configure the organization settings required by each test
- [ ] Confirm that removing the `testUserBooking` variable in `_get.integration-test.ts:345-348` doesn't break the test's intended behavior (it was unused and causing lint errors)
- [ ] Check that these database modifications in `beforeAll` don't interfere with test isolation or parallel test execution
- [ ] Verify CI passes and the previously flaky tests remain stable

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - test-only changes
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works - These are test fixes themselves

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stabilizes admin-related integration tests by setting org settings in beforeAll hooks so they no longer depend on seed state. Also removes an unused variable that caused a lint error.

- **Bug Fixes**
  - Upserts organizationSettings in four test files to ensure Acme has isAdminAPIEnabled: true and Dunder Mifflin has isAdminAPIEnabled: false.
  - Fixes flaky failures in admin guard, accessible users, and bookings GET/PATCH tests.

<!-- End of auto-generated description by cubic. -->

