### PR TITLE
fix: simplify Zapier integration, remove API key setup (#24651)

### DIFF
--- a/apps/web/components/apps/zapier/Setup.tsx
+++ b/apps/web/components/apps/zapier/Setup.tsx
@@ -1,179 +1,19 @@
 import Link from "next/link";
-import { useState } from "react";
-import { Toaster } from "sonner";
 
-import AppNotInstalledMessage from "@calcom/app-store/_components/AppNotInstalledMessage";
-import ServerTrans from "@calcom/lib/components/ServerTrans";
-import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
-import { Icon } from "@calcom/ui/components/icon";
-import { showToast } from "@calcom/ui/components/toast";
-import { Tooltip } from "@calcom/ui/components/tooltip";
 
-export interface IZapierSetupProps {
-  inviteLink?: string;
-}
-
-const ZAPIER = "zapier";
-
-export default function ZapierSetup(props: IZapierSetupProps) {
-  const [newApiKeys, setNewApiKeys] = useState<Record<string, string>>({});
-  const { t } = useLocale();
-  const utils = trpc.useUtils();
-  const integrations = trpc.viewer.apps.integrations.useQuery({ variant: "automation" });
-  const oldApiKey = trpc.viewer.apiKeys.findKeyOfType.useQuery({ appId: ZAPIER });
-  const teamsList = trpc.viewer.teams.listOwnedTeams.useQuery(undefined, {
-    refetchOnWindowFocus: false,
-  });
-  const teams = teamsList.data?.map((team) => ({ id: team.id, name: team.name }));
-  const deleteApiKey = trpc.viewer.apiKeys.delete.useMutation({
-    onSuccess: () => {
-      utils.viewer.apiKeys.findKeyOfType.invalidate();
-    },
-  });
-  const zapierCredentials: { userCredentialIds: number[] } | undefined = integrations.data?.items.find(
-    (item: { type: string }) => item.type === "zapier_automation"
-  );
-  const [credentialId] = zapierCredentials?.userCredentialIds || [false];
-  const showContent = integrations.data && integrations.isSuccess && credentialId;
-  const isCalDev = process.env.NEXT_PUBLIC_WEBAPP_URL === "https://app.cal.dev";
-
-  async function createApiKey(teamId?: number) {
-    const event = { note: "Zapier", expiresAt: null, appId: ZAPIER, teamId };
-    const apiKey = await utils.client.viewer.apiKeys.create.mutate(event);
-
-    if (oldApiKey.data) {
-      const oldKey = teamId
-        ? oldApiKey.data.find((key) => key.teamId === teamId)
-        : oldApiKey.data.find((key) => !key.teamId);
-
-      if (oldKey) {
-        deleteApiKey.mutate({
-          id: oldKey.id,
-        });
-      }
-    }
-
-    return apiKey;
-  }
-
-  async function generateApiKey(teamId?: number) {
-    const apiKey = await createApiKey(teamId);
-    setNewApiKeys({ ...newApiKeys, [teamId || ""]: apiKey });
-  }
-
-  if (integrations.isPending) {
-    return <div className="bg-emphasis absolute z-50 flex h-screen w-full items-center" />;
-  }
-
+export default function ZapierSetup() {
   return (
-    <div className="bg-emphasis flex h-screen">
-      {showContent ? (
-        <div className="bg-default m-auto max-w-[43em] overflow-auto rounded pb-10 md:p-10">
-          <div className="md:flex md:flex-row">
-            <div className="invisible md:visible">
-              <img className="h-11" src="/api/app-store/zapier/icon.svg" alt="Zapier Logo" />
-            </div>
-            <div className="ml-2 ltr:mr-2 rtl:ml-2 md:ml-5">
-              <div className="text-default">{t("setting_up_zapier")}</div>
-
-              <>
-                <div className="mt-1 text-xl">{t("generate_api_key")}:</div>
-                {!teams ? (
-                  <Button color="secondary" onClick={() => createApiKey()} className="mb-4 mt-2">
-                    {t("generate_api_key")}
-                  </Button>
-                ) : (
-                  <>
-                    <div className="mt-8 text-sm font-semibold">Your event types:</div>
-                    {!newApiKeys[""] ? (
-                      <Button color="secondary" onClick={() => generateApiKey()} className="mb-4 mt-2">
-                        {t("generate_api_key")}
-                      </Button>
-                    ) : (
-                      <CopyApiKey apiKey={newApiKeys[""]} />
-                    )}
-                    {teams.map((team) => {
-                      return (
-                        <div key={team.name}>
-                          <div className="mt-2 text-sm font-semibold">{team.name}:</div>
-                          {!newApiKeys[team.id] ? (
-                            <Button
-                              color="secondary"
-                              onClick={() => generateApiKey(team.id)}
-                              className="mb-4 mt-2">
-                              {t("generate_api_key")}
-                            </Button>
-                          ) : (
-                            <CopyApiKey apiKey={newApiKeys[team.id]} />
-                          )}
-                        </div>
-                      );
-                    })}
-                  </>
-                )}
-              </>
-
-              <ol className="mb-5 ml-5 mt-5 list-decimal ltr:mr-5 rtl:ml-5">
-                {isCalDev && (
-                  <li>
-                    {t("go_to")}
-                    <a href={props.inviteLink} className="text-orange-600 underline">
-                      {t("zapier_invite_link")}
-                    </a>
-                  </li>
-                )}
-                <ServerTrans
-                  t={t}
-                  i18nKey="zapier_setup_instructions"
-                  components={[
-                    <li key="instruction_1">Log into your Zapier account and create a new Zap.</li>,
-                    <li key="instruction_2">
-                      Select Cal.com as your Trigger app. Also choose a Trigger event.
-                    </li>,
-                    <li key="instruction_3">Choose your account and then enter your Unique API Key.</li>,
-                    <li key="instruction_4">Test your Trigger.</li>,
-                    <li key="instruction_5">You&apos;re set!</li>,
-                  ]}
-                />
-              </ol>
-              <Link href="/apps/installed/automation?hl=zapier" passHref={true} legacyBehavior>
-                <Button color="secondary">{t("done")}</Button>
-              </Link>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <AppNotInstalledMessage appName="zapier" />
-      )}
-      <Toaster position="bottom-right" />
-    </div>
-  );
-}
-
-const CopyApiKey = ({ apiKey }: { apiKey: string }) => {
-  const { t } = useLocale();
-  return (
-    <div>
-      <div className="my-2 mt-3 flex-wrap sm:flex sm:flex-nowrap">
-        <code className="bg-subtle h-full w-full whitespace-pre-wrap rounded-md py-[6px] pl-2 pr-2 sm:rounded-r-none sm:pr-5">
-          {apiKey}
-        </code>
-        <Tooltip side="top" content={t("copy_to_clipboard")}>
-          <Button
-            onClick={() => {
-              navigator.clipboard.writeText(apiKey);
-              showToast(t("api_key_copied"), "success");
-            }}
-            type="button"
-            className="mt-4 text-base sm:mt-0 sm:rounded-l-none">
-            <Icon name="clipboard" className="h-4 w-4 ltr:mr-2 rtl:ml-2" />
-            {t("copy")}
+    <div className="bg-emphasis flex h-screen items-center justify-center p-4">
+      <div className="text-center">
+        <p className="mb-4 text-lg font-medium">Integrate Cal.com with Zapier in a few clicks.</p>
+        <Link href="https://zapier.com/apps/calcom/integrations" passHref>
+          <Button color="secondary" size="lg">
+            Go to Zapier Integration
           </Button>
-        </Tooltip>
+        </Link>
+        <p className="text-subtle mt-3 text-sm">You’ll be redirected to Zapier to complete the setup.</p>
       </div>
-      <div className="text-subtle mb-5 mt-2 text-sm">{t("copy_somewhere_safe")}</div>
     </div>
   );
-};
+}

--- a/apps/web/components/apps/zapier/Setup.tsx
+++ b/apps/web/components/apps/zapier/Setup.tsx
@@ -1,18 +1,25 @@
 import Link from "next/link";
 
+import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 
 export default function ZapierSetup() {
+  const { t } = useLocale();
+
   return (
     <div className="bg-emphasis flex h-screen items-center justify-center p-4">
       <div className="text-center">
-        <p className="mb-4 text-lg font-medium">Integrate Cal.com with Zapier in a few clicks.</p>
+        <p className="mb-4 text-lg font-medium">
+          {t("zapier_integration_intro", "Integrate Cal.com with Zapier in a few clicks.")}
+        </p>
         <Link href="https://zapier.com/apps/calcom/integrations" passHref>
           <Button color="secondary" size="lg">
-            Go to Zapier Integration
+            {t("zapier_go_to_integration", "Go to Zapier Integration")}
           </Button>
         </Link>
-        <p className="text-subtle mt-3 text-sm">You’ll be redirected to Zapier to complete the setup.</p>
+        <p className="text-subtle mt-3 text-sm">
+          {t("zapier_redirect_note", "You’ll be redirected to Zapier to complete the setup.")}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Previously, the Zapier integration screen required users to manually generate and copy API keys for each team. This is obsolete because Zapier handles authentication internally.

This PR:
- Removes all API key generation and manual setup logic.
- Adds a simple, centered button linking directly to Zapier's Cal.com integration page.
- Simplifies the user experience and reduces maintenance overhead.

Closes #24651


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Zapier integration by removing manual API key setup and replacing it with a single button that opens Zapier’s Cal.com integration. Aligns with Linear #24651 by using Zapier’s built-in authentication and reducing setup friction.

- **Refactors**
  - Removed API key generation and team-specific key flow.
  - Deleted TRPC queries/mutations, local state, toasts, tooltips, and copy-to-clipboard UI.
  - Reduced Setup.tsx to a minimal, centered view linking to Zapier.

<!-- End of auto-generated description by cubic. -->

