### PR TITLE
fix: event-title-overflow

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -623,7 +623,7 @@ function BookingListItem(booking: BookingItemProps) {
                 <div
                   title={title}
                   className={classNames(
-                    "max-w-10/12 sm:max-w-56 text-emphasis text-sm font-medium leading-6 md:max-w-full",
+                    "max-w-10/12 sm:max-w-56 text-emphasis break-words text-sm font-medium leading-6 md:max-w-full",
                     isCancelled ? "line-through" : ""
                   )}>
                   {title}

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -577,7 +577,7 @@ export default function Success(props: PageProps) {
                           </>
                         )}
                         <div className="font-medium">{t("what")}</div>
-                        <div className="col-span-2 mb-6 last:mb-0" data-testid="booking-title">
+                        <div className="col-span-2 mb-6 break-words last:mb-0" data-testid="booking-title">
                           {isRoundRobin ? bookingInfo.title : eventName}
                         </div>
                         <div className="font-medium">{t("when")}</div>

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -178,7 +178,7 @@ const Item = ({
   const content = () => (
     <div>
       <span
-        className="text-default font-semibold ltr:mr-1 rtl:ml-1"
+        className="text-default break-words font-semibold ltr:mr-1 rtl:ml-1"
         data-testid={`event-type-title-${type.id}`}>
         {type.title}
       </span>
@@ -212,7 +212,7 @@ const Item = ({
           <Link href={`/event-types/${type.id}?tabName=setup`} title={type.title}>
             <div>
               <span
-                className="text-default font-semibold break-words ltr:mr-1 rtl:ml-1"
+                className="text-default break-words font-semibold ltr:mr-1 rtl:ml-1"
                 data-testid={`event-type-title-${type.id}`}>
                 {type.title}
               </span>

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -212,7 +212,7 @@ const Item = ({
           <Link href={`/event-types/${type.id}?tabName=setup`} title={type.title}>
             <div>
               <span
-                className="text-default font-semibold ltr:mr-1 rtl:ml-1"
+                className="text-default font-semibold break-words ltr:mr-1 rtl:ml-1"
                 data-testid={`event-type-title-${type.id}`}>
                 {type.title}
               </span>

--- a/packages/features/bookings/components/event-meta/Title.tsx
+++ b/packages/features/bookings/components/event-meta/Title.tsx
@@ -12,7 +12,9 @@ interface EventTitleProps {
 export const EventTitle = ({ children, as, className }: EventTitleProps) => {
   const El = as || "h1";
   return (
-    <El data-testid="event-title" className={classNames("text-text text-xl font-semibold", className)}>
+    <El
+      data-testid="event-title"
+      className={classNames("text-text break-words text-xl font-semibold", className)}>
       {children}
     </El>
   );


### PR DESCRIPTION
- Fixes #24692 
- Fixes [CAL-6639](https://linear.app/calcom/issue/CAL-6639/event-title-overflows-container-with-long-unbroken-words)



## Visual Demo (For contributors especially)

**Before:**
<img width="1865" height="964" alt="Screenshot from 2025-10-25 23-04-40" src="https://github.com/user-attachments/assets/1b97d8e4-2b4b-46e5-8aea-4fb5b0403658" />

**After:**
<img width="1865" height="964" alt="Screenshot from 2025-10-25 23-04-59" src="https://github.com/user-attachments/assets/4a15d1ac-ca18-4c4c-b269-295546fc95fc" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed event title overflow by enabling word wrapping in the Title component so long unbroken titles stay within the container. Addresses Linear CAL-6639.

- **Bug Fixes**
  - Added the break-words class to Title.tsx to wrap long words and prevent overflow across all heading variants.

<!-- End of auto-generated description by cubic. -->

