### PR TITLE
refactor: update the config to auto close stale pr

### DIFF
--- a/.github/workflows/cron-stale-issue.yml
+++ b/.github/workflows/cron-stale-issue.yml
@@ -20,8 +20,8 @@ jobs:
           days-before-close: -1
           days-before-issue-stale: 60
           days-before-issue-close: -1
-          days-before-pr-stale: 14
-          days-before-pr-close: -1
-          stale-pr-message: "This PR is being marked as stale due to inactivity."
-          close-pr-message: "This PR is being closed due to inactivity. Please reopen if work is intended to be continued."
+          days-before-pr-stale: 7
+          days-before-pr-close: 14
+          stale-pr-message: "This PR has been marked as stale due to inactivity. If you're still working on it or need any help, please let us know or update the PR to keep it active."
+          close-pr-message: "This PR has been closed due to inactivity. Please feel free to reopen it if you'd like to continue the work."
           operations-per-run: 100


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened the stale PR workflow to mark PRs stale after 7 days and auto-close after 14 days to keep the queue clean. Updated messages to be clearer and more helpful.

- **Refactors**
  - days-before-pr-stale: 14 → 7
  - days-before-pr-close: -1 → 14 (enable auto-close)
  - Refreshed stale/close messages to encourage updates or reopening

<!-- End of auto-generated description by cubic. -->

