### PR TITLE
docs: cancelling normal booking

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -321,7 +321,7 @@ export class BookingsController_2024_08_13 {
     description: `:bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.
     
     \nCancelling normal bookings:
-    If the booking is not seated and not recurring simply pass :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and optionally cancellationReason in the request body \`{"cancellationReason": "Will travel"}\`.
+    If the booking is not seated and not recurring, simply pass :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and optionally cancellationReason in the request body \`{"cancellationReason": "Will travel"}\`.
 
     \nCancelling seated bookings:
     It is possible to cancel specific seat within a booking as an attendee or all of the seats as the host.

--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -320,6 +320,9 @@ export class BookingsController_2024_08_13 {
     summary: "Cancel a booking",
     description: `:bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.
     
+    \nCancelling normal bookings:
+    If the booking is not seated and not recurring simply pass :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and optionally cancellationReason in the request body \`{"cancellationReason": "Will travel"}\`.
+
     \nCancelling seated bookings:
     It is possible to cancel specific seat within a booking as an attendee or all of the seats as the host.
     \n1. As an attendee - provide :bookingUid in the request URL \`/bookings/:bookingUid/cancel\` and seatUid in the request body \`{"seatUid": "123-123-123"}\` . This will remove this particular attendance from the booking.
@@ -343,7 +346,7 @@ export class BookingsController_2024_08_13 {
       ],
     },
     description:
-      "Accepts different types of cancel booking input: Cancel Booking (Option 1) or Cancel Seated Booking (Option 2)",
+      "Accepts different types of cancel booking input: Cancel Booking (Option 1 which is for normal or recurring bookings) or Cancel Seated Booking (Option 2 which is for seated bookings)",
   })
   @ApiExtraModels(CancelBookingInput_2024_08_13, CancelSeatedBookingInput_2024_08_13)
   async cancelBooking(

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -8518,7 +8518,7 @@
       "post": {
         "operationId": "BookingsController_2024_08_13_cancelBooking",
         "summary": "Cancel a booking",
-        "description": ":bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.\n    \n    \nCancelling seated bookings:\n    It is possible to cancel specific seat within a booking as an attendee or all of the seats as the host.\n    \n1. As an attendee - provide :bookingUid in the request URL `/bookings/:bookingUid/cancel` and seatUid in the request body `{\"seatUid\": \"123-123-123\"}` . This will remove this particular attendance from the booking.\n    \n2. As the host - host can cancel booking for all attendees aka for every seat. Provide :bookingUid in the request URL `/bookings/:bookingUid/cancel` and cancellationReason in the request body `{\"cancellationReason\": \"Will travel\"}` and `Authorization: Bearer token` request header where token is event type owner (host) credential. This will cancel the booking for all attendees.\n    \n    \nCancelling recurring seated bookings:\n    For recurring seated bookings it is not possible to cancel all of them with 1 call\n    like with non-seated recurring bookings by providing recurring bookind uid - you have to cancel each recurrence booking by its bookingUid + seatUid.\n    \n    If you are cancelling a seated booking for an event type with 'show attendees' disabled, then to retrieve attendees in the response either set 'show attendees' to true on event type level or\n    you have to provide an authentication method of event type owner, host, team admin or owner or org admin or owner.\n\n    <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n    ",
+        "description": ":bookingUid can be :bookingUid of an usual booking, individual recurrence or recurring booking to cancel all recurrences.\n    \n    \nCancelling normal bookings:\n    If the booking is not seated and not recurring simply pass :bookingUid in the request URL `/bookings/:bookingUid/cancel` and optionally cancellationReason in the request body `{\"cancellationReason\": \"Will travel\"}`.\n\n    \nCancelling seated bookings:\n    It is possible to cancel specific seat within a booking as an attendee or all of the seats as the host.\n    \n1. As an attendee - provide :bookingUid in the request URL `/bookings/:bookingUid/cancel` and seatUid in the request body `{\"seatUid\": \"123-123-123\"}` . This will remove this particular attendance from the booking.\n    \n2. As the host - host can cancel booking for all attendees aka for every seat. Provide :bookingUid in the request URL `/bookings/:bookingUid/cancel` and cancellationReason in the request body `{\"cancellationReason\": \"Will travel\"}` and `Authorization: Bearer token` request header where token is event type owner (host) credential. This will cancel the booking for all attendees.\n    \n    \nCancelling recurring seated bookings:\n    For recurring seated bookings it is not possible to cancel all of them with 1 call\n    like with non-seated recurring bookings by providing recurring bookind uid - you have to cancel each recurrence booking by its bookingUid + seatUid.\n    \n    If you are cancelling a seated booking for an event type with 'show attendees' disabled, then to retrieve attendees in the response either set 'show attendees' to true on event type level or\n    you have to provide an authentication method of event type owner, host, team admin or owner or org admin or owner.\n\n    <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>\n    ",
         "parameters": [
           {
             "name": "cal-api-version",
@@ -8568,7 +8568,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "Accepts different types of cancel booking input: Cancel Booking (Option 1) or Cancel Seated Booking (Option 2)",
+          "description": "Accepts different types of cancel booking input: Cancel Booking (Option 1 which is for normal or recurring bookings) or Cancel Seated Booking (Option 2 which is for seated bookings)",
           "content": {
             "application/json": {
               "schema": {
@@ -21516,7 +21516,7 @@
             "type": "string",
             "description": "Action to perform",
             "example": "email_host",
-            "enum": ["email_attendee", "email_address"]
+            "enum": ["email_attendee", "email_address", "sms_attendee", "sms_number"]
           }
         },
         "required": ["id", "stepNumber", "recipient", "template", "sender", "message", "action"]
@@ -22537,7 +22537,7 @@
           },
           "steps": {
             "type": "array",
-            "description": "Steps to execute as part of the routing-form workflow, allowed steps are email_attendee,email_address",
+            "description": "Steps to execute as part of the routing-form workflow, allowed steps are email_attendee,email_address,sms_attendee,sms_number",
             "items": {
               "oneOf": [
                 {
@@ -22545,6 +22545,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/WorkflowEmailAttendeeStepDto"
+                },
+                {
+                  "$ref": "#/components/schemas/WorkflowPhoneAttendeeStepDto"
+                },
+                {
+                  "$ref": "#/components/schemas/WorkflowPhoneNumberStepDto"
                 }
               ]
             }
@@ -23136,7 +23142,7 @@
           },
           "steps": {
             "type": "array",
-            "description": "Steps to execute as part of the routing-form workflow, allowed steps are email_attendee,email_address",
+            "description": "Steps to execute as part of the routing-form workflow, allowed steps are email_attendee,email_address,sms_attendee,sms_number",
             "items": {
               "oneOf": [
                 {
@@ -23144,6 +23150,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/UpdateEmailAttendeeWorkflowStepDto"
+                },
+                {
+                  "$ref": "#/components/schemas/UpdatePhoneAttendeeWorkflowStepDto"
+                },
+                {
+                  "$ref": "#/components/schemas/UpdatePhoneNumberWorkflowStepDto"
                 }
               ]
             }
@@ -27029,7 +27041,7 @@
           },
           "cancelSubsequentBookings": {
             "type": "boolean",
-            "description": "For recurring non-seated booking - if true, cancel booking with the bookingUid of the individual recurrence and all recurrences that come after it."
+            "description": "For recurring non-seated booking only - if true, cancel booking with the bookingUid of the individual recurrence and all recurrences that come after it."
           }
         }
       },

--- a/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking.input.ts
+++ b/packages/platform/types/bookings/2024-08-13/inputs/cancel-booking.input.ts
@@ -11,7 +11,7 @@ export class CancelBookingInput_2024_08_13 {
   @IsOptional()
   @ApiPropertyOptional({
     description:
-      "For recurring non-seated booking - if true, cancel booking with the bookingUid of the individual recurrence and all recurrences that come after it.",
+      "For recurring non-seated booking only - if true, cancel booking with the bookingUid of the individual recurrence and all recurrences that come after it.",
   })
   cancelSubsequentBookings?: boolean;
 }


### PR DESCRIPTION
Emphasize that normal booking is cancelled simply by providing bookingUid

Fixes #24702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Cancel Booking endpoint: normal (non-seated, non-recurring) bookings are canceled via /bookings/:bookingUid/cancel with an optional cancellationReason. Also made it explicit that cancelSubsequentBookings applies only to recurring non-seated bookings and clarified input options (Option 1 for normal/recurring, Option 2 for seated).

- **New Features**
  - OpenAPI: added sms_attendee and sms_number workflow step types and updated allowed steps text.

<!-- End of auto-generated description by cubic. -->

