### PR TITLE
fix: reset internalClick state when HavingTroubleFindingTime becomes visible (#24185)

### DIFF
--- a/packages/features/bookings/Booker/components/HavingTroubleFindingTime.tsx
+++ b/packages/features/bookings/Booker/components/HavingTroubleFindingTime.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { BOOKER_NUMBER_OF_DAYS_TO_LOAD } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -13,6 +13,12 @@ type Props = {
 export function HavingTroubleFindingTime(props: Props) {
   const { t } = useLocale();
   const [internalClick, setInternalClick] = useState(false);
+
+  useEffect(() => {
+    if (props.visible) {
+      setInternalClick(false);
+    }
+  }, [props.visible]);
 
   if (!props.visible) return null;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a state management issue in the `HavingTroubleFindingTime` component where the `internalClick` state was not being reset properly, causing the component to retain stale state across navigation cycles.

**Problem:**
- The `internalClick` state persisted after the component was hidden and shown again
- This prevented the component from reappearing when the user navigated back to the booking flow
- The stale state could lead to unexpected behavior in prolonged usage scenarios

**Solution:**
- Added a `useEffect` hook that resets `internalClick` to `false` when the component becomes visible
- Ensures proper state cleanup and prevents stale state from persisting across renders
- Maintains the original functionality while fixing the state management issue

- Fixes #24185
- Fixes CAL-6495

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):
N/A

#### Image Demo (if applicable):
N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write **N/A** - This is a bug fix with no user-facing documentation changes required.
- [ x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Environment Setup:
- Ensure `NEXT_PUBLIC_BOOKER_NUMBER_OF_DAYS_TO_LOAD` is set (not "0")
- Desktop viewport (component hidden on mobile)
- Have an event type configured with available time slots
- Month view layout

### Test Steps:
1. Navigate to a booking page in month view
2. Wait for "Having trouble finding time?" banner to appear
3. Click "Show more" button → banner disappears
4. Change selected date or navigate away and return
5. **Expected:** Banner reappears correctly
6. Repeat multiple times to verify state resets consistently

### What to verify:
- ✅ Banner reappears after navigation
- ✅ No console errors
- ✅ Consistent behavior across multiple interactions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets internalClick in HavingTroubleFindingTime when it becomes visible, fixing a stale state that prevented the banner from reappearing in the booking flow. Addresses CAL-6495 (banner not reappearing after navigation).

- **Bug Fixes**
  - Added useEffect to set internalClick to false when visible.
  - Ensures the banner shows again after date changes or navigation.

<!-- End of auto-generated description by cubic. -->

