### PR TITLE
fix: add auto-accepted users to event types with assignAllTeamMembers enabled

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.ts
@@ -52,7 +52,7 @@ function getOrgConnectionInfoGroupedByUsernameOrEmail({
   return uniqueInvitations.reduce((acc, invitation) => {
     return {
       ...acc,
-      [invitation.usernameOrEmail]: getOrgConnectionInfo({
+      [invitation.usernameOrEmail.toLowerCase()]: getOrgConnectionInfo({
         orgVerified: orgState.orgVerified,
         orgAutoAcceptDomain: orgState.autoAcceptEmailDomain,
         email: invitation.usernameOrEmail,


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where new users invited to an organization with auto-accept domain matching weren't being automatically added as hosts to event types that have `assignAllTeamMembers: true` enabled.

**Root Cause**: The `handleNewUsersInvites()` function was creating users and memberships but wasn't calling `updateNewTeamMemberEventTypes()` for auto-accepted users, unlike the existing user flow and signup completion flow which both make this call.

**Changes**:
1. Modified `handleNewUsersInvites()` to capture the created users and call `updateNewTeamMemberEventTypes()` for auto-accepted users
2. Added email normalization to lowercase when accessing the `orgConnectInfoByUsernameOrEmail` map to prevent case-sensitivity issues
3. Updated `getOrgConnectionInfoGroupedByUsernameOrEmail()` to use lowercase keys for consistency
4. Fixed pre-existing lint warnings (ternary expression and unused type) that were blocking the commit

**Related Discussion**: https://calendso.slack.com/archives/D08N48M37GU/p1761633427730019

## Key Areas for Review

⚠️ **Missing Test Coverage**: This PR does not include automated tests for the fix. The change was manually verified by running the existing test suite (3746 passed), but no new tests were added to prevent regression.

🔍 **Email Normalization**: The fix assumes that normalizing emails to lowercase is safe. Review the `user.email.toLowerCase()` usage in line 1006 of utils.ts and the map key generation in line 55 of inviteMember.handler.ts.

🔍 **Error Handling**: Currently using `Promise.all()` for parallel execution of `updateNewTeamMemberEventTypes()`. If one call fails, the entire operation fails. Consider if `Promise.allSettled()` would be more appropriate.

🔍 **Scope**: This PR includes unrelated lint fixes (ternary expression conversion and unused type prefix) that were necessary to pass pre-commit hooks but are technically separate from the main bug fix.

## How should this be tested?

**Manual Test Scenario**:
1. Create an organization with an auto-accept domain (e.g., `@example.com`)
2. Create an event type with "Add all team members, including future members" (assignAllTeamMembers) enabled
3. Invite a new user with an email matching the auto-accept domain (e.g., `newuser@example.com`)
4. Verify the new user receives the signup email
5. **Before this fix**: The new user would NOT be added as a host to the event type
6. **After this fix**: The new user SHOULD be automatically added as a host to the event type

**Expected Behavior**:
- New auto-accepted users should immediately appear as hosts on event types with `assignAllTeamMembers: true`
- They should be able to receive bookings for these event types once they complete signup
- Email case variations (e.g., NewUser@example.com vs newuser@example.com) should be handled correctly

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - No documentation changes needed
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **⚠️ NO - Tests not added in this PR**

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas **N/A** - Code is straightforward
- [x] I have checked that my changes generate no new warnings

---

**Link to Devin run**: https://app.devin.ai/sessions/8efab7e8411e4c3687034a8367bba9a3  
**Requested by**: hariom@cal.com (@hariombalhara)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where new users auto-accepted into an org weren’t added as hosts to event types with “Add all team members” enabled. Auto-accepted users are now added immediately so they can receive bookings.

- **Bug Fixes**
  - Call updateNewTeamMemberEventTypes for auto-accepted new users in handleNewUsersInvites.
  - Normalize emails to lowercase and use lowercase keys to prevent case-sensitivity issues.
  - Minor lint cleanups (replace ternary with if/else, remove unused type).

<!-- End of auto-generated description by cubic. -->

