### PR TITLE
fix(insights): convert string filter values to numbers for integer columns

### DIFF
--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -710,10 +710,8 @@ export class InsightsRoutingBaseService {
     // Extract booking status order filter
     const bookingStatusOrder = filtersMap["bookingStatusOrder"];
     if (bookingStatusOrder && isMultiSelectFilterValue(bookingStatusOrder.value)) {
-      const statusCondition = makeSqlCondition(bookingStatusOrder.value);
-      if (statusCondition) {
-        conditions.push(Prisma.sql`rfrd."bookingStatusOrder" ${statusCondition}`);
-      }
+      const statusOrders = bookingStatusOrder.value.data.map((order) => Number(order));
+      conditions.push(Prisma.sql`rfrd."bookingStatusOrder" = ANY(${statusOrders})`);
     }
 
     // Extract booking assignment reason filter
@@ -764,7 +762,8 @@ export class InsightsRoutingBaseService {
     // Extract member user IDs filter (multi-select)
     const memberUserIds = filtersMap["bookingUserId"];
     if (memberUserIds && isMultiSelectFilterValue(memberUserIds.value)) {
-      conditions.push(Prisma.sql`rfrd."bookingUserId" = ANY(${memberUserIds.value.data})`);
+      const userIds = memberUserIds.value.data.map((id) => Number(id));
+      conditions.push(Prisma.sql`rfrd."bookingUserId" = ANY(${userIds})`);
     }
 
     // Extract form ID filter (single-select)

--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -710,8 +710,15 @@ export class InsightsRoutingBaseService {
     // Extract booking status order filter
     const bookingStatusOrder = filtersMap["bookingStatusOrder"];
     if (bookingStatusOrder && isMultiSelectFilterValue(bookingStatusOrder.value)) {
-      const statusOrders = bookingStatusOrder.value.data.map((order) => Number(order));
-      conditions.push(Prisma.sql`rfrd."bookingStatusOrder" = ANY(${statusOrders})`);
+      // Convert string values to numbers for integer column
+      const integerFilterValue = {
+        ...bookingStatusOrder.value,
+        data: bookingStatusOrder.value.data.map((order) => Number(order)),
+      };
+      const statusCondition = makeSqlCondition(integerFilterValue);
+      if (statusCondition) {
+        conditions.push(Prisma.sql`rfrd."bookingStatusOrder" ${statusCondition}`);
+      }
     }
 
     // Extract booking assignment reason filter
@@ -762,8 +769,15 @@ export class InsightsRoutingBaseService {
     // Extract member user IDs filter (multi-select)
     const memberUserIds = filtersMap["bookingUserId"];
     if (memberUserIds && isMultiSelectFilterValue(memberUserIds.value)) {
-      const userIds = memberUserIds.value.data.map((id) => Number(id));
-      conditions.push(Prisma.sql`rfrd."bookingUserId" = ANY(${userIds})`);
+      // Convert string values to numbers for integer column
+      const integerFilterValue = {
+        ...memberUserIds.value,
+        data: memberUserIds.value.data.map((id) => Number(id)),
+      };
+      const userIdCondition = makeSqlCondition(integerFilterValue);
+      if (userIdCondition) {
+        conditions.push(Prisma.sql`rfrd."bookingUserId" ${userIdCondition}`);
+      }
     }
 
     // Extract form ID filter (single-select)


### PR DESCRIPTION
## What does this PR do?

Fixes PostgreSQL error "operator does not exist: integer = text" when filtering
by `bookingStatusOrder` and `bookingUserId` fields. Frontend sends filter values as
strings, but these database columns are integers requiring type conversion.

Changes:
- Convert `bookingStatusOrder` filter values from strings to numbers
- Convert `bookingUserId` filter values from strings to numbers
- Update tests to use numeric values for `bookingStatusOrder` filters
- Add test for string-to-number conversion in `bookingUserId` filter
- Fix `Prisma.Sql` composition in 3 integration tests

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts string filter values to numbers for integer columns in Insights routing to prevent PostgreSQL type errors. Fixes filtering by bookingStatusOrder and bookingUserId when the frontend sends strings.

- **Bug Fixes**
  - Cast bookingStatusOrder and bookingUserId filter values to numbers and use = ANY([...]).
  - Update tests to expect numeric arrays; add test for string-to-number conversion on bookingUserId.
  - Correct Prisma.sql composition in three integration tests before calling $queryRaw.

<!-- End of auto-generated description by cubic. -->

