### PR TITLE
fix: Auto Assignment of team member to event when that member is auto-accepted during direct invite to sub-team

### DIFF
--- a/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.integration-test.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/inviteMember.handler.integration-test.ts
@@ -30,25 +30,7 @@ async function verifyMembershipExists(userId: number, teamId: number): Promise<M
   });
 }
 
-async function verifyUserOrganizationConsistency(userId: number): Promise<{
-  profileCount: number;
-  acceptedMembershipCount: number;
-  pendingMembershipCount: number;
-}> {
-  const profiles = await prisma.profile.count({ where: { userId } });
-  const acceptedMemberships = await prisma.membership.count({
-    where: { userId, accepted: true },
-  });
-  const pendingMemberships = await prisma.membership.count({
-    where: { userId, accepted: false },
-  });
 
-  return {
-    profileCount: profiles,
-    acceptedMembershipCount: acceptedMemberships,
-    pendingMembershipCount: pendingMemberships,
-  };
-}
 
 // Test data creation helpers with unique identifiers
 function generateUniqueId() {
@@ -67,7 +49,9 @@ async function createTestUser(data: { email: string; username: string; name?: st
     await prisma.user.deleteMany({
       where: { OR: [{ email: uniqueEmail }, { username: uniqueUsername }] },
     });
-  } catch {}
+  } catch {
+    // Ignore cleanup errors
+  }
 
   return await prisma.user.create({
     data: {
@@ -83,7 +67,7 @@ async function createTestTeam(data: {
   slug: string;
   isOrganization?: boolean;
   parentId?: number;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   organizationSettings?: {
     orgAutoAcceptEmail: string;
     isOrganizationVerified?: boolean;
@@ -329,8 +313,7 @@ describe("inviteMember.handler Integration Tests", () => {
       await inviteMemberHandler({
         ctx: {
           user: createUserContext(inviterUser, organization.id),
-          session: {} as any,
-        } as any,
+        },
         input: {
           teamId: organization.id,
           usernameOrEmail: nonMatchingUser.email,
@@ -418,7 +401,7 @@ describe("inviteMember.handler Integration Tests", () => {
         ],
       });
 
-      const orgMembership = await verifyMembershipExists(
+      await verifyMembershipExists(
         unverifiedUserWithUnacceptedMembership.id,
         organization.id
       );
@@ -433,6 +416,117 @@ describe("inviteMember.handler Integration Tests", () => {
         regularTeam.id
       );
       expect(originalMembership?.accepted).toBe(true);
+    });
+  });
+
+  describe("Subteam Direct Invite Flow", () => {
+    it("should immediately add auto-accepted new users to event types with assignAllTeamMembers=true", async () => {
+      // Setup: Create organization and team
+      const organization = trackTeam(
+        await createTestTeam({
+          name: "Test Organization",
+          slug: "test-org",
+          isOrganization: true,
+          metadata: {},
+          organizationSettings: {
+            orgAutoAcceptEmail: "company.com",
+            isOrganizationVerified: true,
+          },
+        })
+      );
+
+      const team = trackTeam(
+        await createTestTeam({
+          name: "Sales Team",
+          slug: "sales-team",
+          isOrganization: false,
+          parentId: organization.id,
+        })
+      );
+
+      // Create inviter user
+      const inviterUser = trackUser(
+        await createTestUser({
+          email: "inviter@company.com",
+          username: "inviter",
+        })
+      );
+
+      await prisma.membership.create({
+        data: {
+          userId: inviterUser.id,
+          teamId: organization.id,
+          role: MembershipRole.OWNER,
+          accepted: true,
+        },
+      });
+
+      await prisma.membership.create({
+        data: {
+          userId: inviterUser.id,
+          teamId: team.id,
+          role: MembershipRole.OWNER,
+          accepted: true,
+        },
+      });
+
+      // Create event type with assignAllTeamMembers enabled
+      const eventType = await prisma.eventType.create({
+        data: {
+          title: "Team Event",
+          slug: "team-event",
+          length: 30,
+          teamId: team.id,
+          assignAllTeamMembers: true,
+        },
+      });
+
+      // Act: Invite a new user (non-existing) with auto-accept domain
+      const newUserEmail = `newuser-${generateUniqueId()}@company.com`;
+
+      await inviteMembersWithNoInviterPermissionCheck({
+        inviterName: inviterUser.name,
+        teamId: team.id,
+        language: "en",
+        creationSource: "WEBAPP" as const,
+        orgSlug: organization.slug,
+        invitations: [
+          {
+            usernameOrEmail: newUserEmail,
+            role: MembershipRole.MEMBER,
+          },
+        ],
+      });
+
+      // Assert: Verify user was created
+      const createdUser = await prisma.user.findUnique({
+        where: { email: newUserEmail },
+      });
+      expect(createdUser).toBeTruthy();
+      
+      if (createdUser) {
+        trackUser(createdUser);
+
+        // Verify membership is auto-accepted
+        const membership = await verifyMembershipExists(createdUser.id, team.id);
+        expect(membership).toBeTruthy();
+        expect(membership?.accepted).toBe(true);
+
+        // Verify user is immediately added as host to the event type
+        const host = await prisma.host.findFirst({
+          where: {
+            userId: createdUser.id,
+            eventTypeId: eventType.id,
+          },
+        });
+
+        expect(host).toBeTruthy();
+        expect(host?.userId).toBe(createdUser.id);
+        expect(host?.eventTypeId).toBe(eventType.id);
+      }
+
+      // Cleanup event type
+      await prisma.eventType.delete({ where: { id: eventType.id } });
     });
   });
 });

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -645,15 +645,17 @@ export const groupUsersByJoinability = ({
       connectionInfoMap,
     });
 
-    autoJoinStatus.autoAccept
-      ? usersToAutoJoin.push({
-          ...existingUserWithMemberships,
-          ...autoJoinStatus,
-        })
-      : regularUsers.push({
-          ...existingUserWithMemberships,
-          ...autoJoinStatus,
-        });
+    if (autoJoinStatus.autoAccept) {
+      usersToAutoJoin.push({
+        ...existingUserWithMemberships,
+        ...autoJoinStatus,
+      });
+    } else {
+      regularUsers.push({
+        ...existingUserWithMemberships,
+        ...autoJoinStatus,
+      });
+    }
   }
 
   return [usersToAutoJoin, regularUsers];
@@ -750,12 +752,6 @@ export const sendExistingUserTeamInviteEmails = async ({
   });
 
   await sendEmails(sendEmailsPromises);
-};
-
-type inviteMemberHandlerInput = {
-  teamId: number;
-  role?: "ADMIN" | "MEMBER" | "OWNER";
-  language: string;
 };
 
 export async function handleExistingUsersInvites({
@@ -988,7 +984,7 @@ export async function handleNewUsersInvites({
 }) {
   const translation = await getTranslation(language, "common");
 
-  await createNewUsersConnectToOrgIfExists({
+  const createdUsers = await createNewUsersConnectToOrgIfExists({
     invitations: invitationsForNewUsers,
     isOrg,
     teamId: teamId,
@@ -998,6 +994,25 @@ export async function handleNewUsersInvites({
     language,
     creationSource,
   });
+
+  // Add auto-accepted users to team event types with assignAllTeamMembers immediately
+  // Only teams have event types with assignAllTeamMembers, not organizations
+  if (!isOrg) {
+    const autoAcceptedUserIds = createdUsers
+      .filter((user) => orgConnectInfoByUsernameOrEmail[user.email].autoAccept)
+      .map((user) => user.id);
+
+    if (autoAcceptedUserIds.length > 0) {
+      const results = await Promise.allSettled(
+        autoAcceptedUserIds.map((userId) => updateNewTeamMemberEventTypes(userId, teamId))
+      );
+      results.forEach((result) => {
+        if (result.status === "rejected") {
+          log.error("Error updating new team member event types for user", result.reason);
+        }
+      });
+    }
+  }
 
   const sendVerifyEmailsPromises = invitationsForNewUsers.map((invitation) => {
     return sendSignupToOrganizationEmail({


### PR DESCRIPTION
## What does this PR do?

Fixes PRI-318
Fixes a bug where new team members who are auto-accepted during a direct invite to a sub-team are not automatically assigned as hosts to team event types that have `assignAllTeamMembers=true` enabled.

When a user with a verified organization email domain is directly invited to a sub-team, they should be immediately added as a host to all team event types configured to auto-assign team members. Previously, this assignment was skipped, requiring manual host assignment or waiting for a separate sync process.

Fix Demo(Before and After) - https://www.loom.com/share/872620f453af4d06b79bf4fa62070746

**Changes:**
- Captures the created users from `createNewUsersConnectToOrgIfExists` (previously the return value was ignored)
- Filters for auto-accepted users based on organization email verification
- Calls `updateNewTeamMemberEventTypes` for each auto-accepted user to add them as hosts
- Uses best-effort approach with `Promise.allSettled` - errors are logged but don't block the invitation
- Only applies to teams, not organizations (orgs don't have event types with `assignAllTeamMembers`)

**Additional improvements:**
- Removed unused helper function `verifyUserOrganizationConsistency`
- Fixed ESLint error by converting ternary operator to if/else statement
- Removed unused type `inviteMemberHandlerInput`
- Improved type safety in test fixtures

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A, internal logic fix
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Prerequisites:**
- Organization with verified email domain (e.g., `company.com`)
- Sub-team within the organization
- Team event type with `assignAllTeamMembers: true`

**Test steps:**
1. As a team owner, invite a new user (non-existing) with the verified domain email to the sub-team
2. Verify the user is automatically accepted (no pending invitation)
3. Check the event type's hosts - the new user should be immediately listed as a host
4. Verify the user can successfully accept bookings for this event type

**Automated test:**
The new integration test `"should immediately add auto-accepted new users to event types with assignAllTeamMembers=true"` covers this scenario end-to-end.

## Key Review Points

⚠️ **Critical areas to review:**

1. **Filtering logic safety**: Verify that `orgConnectInfoByUsernameOrEmail[user.email]` is always populated for all `createdUsers`. If this map is missing entries, the code will throw runtime errors.

2. **Error handling approach**: The code uses `Promise.allSettled` to handle errors gracefully (logs but doesn't block). Confirm this is the desired behavior - should failures in host assignment block the invitation or just log?

3. **Timing and ordering**: The host assignment happens after user creation but before verification emails. Verify this is the correct point in the flow and doesn't create race conditions.

4. **Return value dependency**: The code relies on `createNewUsersConnectToOrgIfExists` returning the created users. Confirm this function has always returned this value or was updated accordingly.

5. **Test coverage**: The integration test only covers the happy path. Consider if error scenarios need testing (e.g., `updateNewTeamMemberEventTypes` failures).

---

*This PR was developed in collaboration with AI assistant Devin: https://app.devin.ai/sessions/4af13fd73aea4e9c91f5c750770f458a*  
*Requested by: hariom@cal.com (@hariombalhara)*