### PR TITLE
feat: add bookingRequiresAuthentication validation to 2024-04-15 booking controller

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-04-15/bookings.module.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/bookings.module.ts
@@ -9,6 +9,8 @@ import { SchedulesModule_2024_04_15 } from "@/ee/schedules/schedules_2024_04_15/
 import { InstantBookingModule } from "@/lib/modules/instant-booking.module";
 import { RecurringBookingModule } from "@/lib/modules/recurring-booking.module";
 import { RegularBookingModule } from "@/lib/modules/regular-booking.module";
+import { PrismaEventTypeRepository } from "@/lib/repositories/prisma-event-type.repository";
+import { PrismaTeamRepository } from "@/lib/repositories/prisma-team.repository";
 import { ApiKeysRepository } from "@/modules/api-keys/api-keys-repository";
 import { AppsRepository } from "@/modules/apps/apps.repository";
 import { BillingModule } from "@/modules/billing/billing.module";
@@ -55,6 +57,8 @@ import { Module } from "@nestjs/common";
     AppsRepository,
     CalendarsRepository,
     SelectedCalendarsRepository,
+    PrismaEventTypeRepository,
+    PrismaTeamRepository,
   ],
   controllers: [BookingsController_2024_04_15],
 })

--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.e2e-spec.ts
@@ -507,6 +507,81 @@ describe("Bookings Endpoints 2024-04-15", () => {
         });
     });
 
+    describe("event type booking requires authentication", () => {
+      let eventTypeRequiringAuthenticationId: number;
+
+      beforeAll(async () => {
+        const eventTypeRequiringAuthentication = await eventTypesRepositoryFixture.create(
+          {
+            title: `event-type-requiring-authentication-${randomString()}`,
+            slug: `event-type-requiring-authentication-${randomString()}`,
+            length: 60,
+            requiresConfirmation: true,
+            bookingRequiresAuthentication: true,
+          },
+          user.id
+        );
+        eventTypeRequiringAuthenticationId = eventTypeRequiringAuthentication.id;
+      });
+
+      it("can't be booked without credentials", async () => {
+        const body: CreateBookingInput_2024_04_15 = {
+          start: "2040-05-23T09:30:00.000Z",
+          end: "2040-05-23T10:30:00.000Z",
+          eventTypeId: eventTypeRequiringAuthenticationId,
+          timeZone: "Europe/London",
+          language: "en",
+          metadata: {},
+          hashedLink: "",
+          responses: {
+            name: "External Attendee",
+            email: "external@example.com",
+            location: {
+              value: "link",
+              optionValue: "",
+            },
+          },
+        };
+
+        await request(app.getHttpServer()).post("/v2/bookings").send(body).expect(401);
+      });
+
+      it("can be booked with event type owner credentials", async () => {
+        const body: CreateBookingInput_2024_04_15 = {
+          start: "2040-05-23T11:30:00.000Z",
+          end: "2040-05-23T12:30:00.000Z",
+          eventTypeId: eventTypeRequiringAuthenticationId,
+          timeZone: "Europe/London",
+          language: "en",
+          metadata: {},
+          hashedLink: "",
+          responses: {
+            name: "External Attendee",
+            email: "external@example.com",
+            location: {
+              value: "link",
+              optionValue: "",
+            },
+          },
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/v2/bookings")
+          .send(body)
+          .set({ Authorization: `Bearer cal_test_${apiKeyString}` })
+          .expect(201);
+
+        const responseBody: ApiSuccessResponse<RegularBookingCreateResult> = response.body;
+        expect(responseBody.status).toEqual(SUCCESS_STATUS);
+        expect(responseBody.data).toBeDefined();
+        expect(responseBody.data.id).toBeDefined();
+
+        if (responseBody.data.id) {
+          await bookingsRepositoryFixture.deleteById(responseBody.data.id);
+        }
+      });
+    });
+
     afterAll(async () => {
       await userRepositoryFixture.deleteByEmail(user.email);
       await bookingsRepositoryFixture.deleteAllBookings(user.id, user.email);

--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
@@ -470,9 +470,7 @@ export class BookingsController_2024_04_15 {
     const isEventTypeOwner = eventType.userId === userId;
     const isHost = eventType.hosts.some((host) => host.userId === userId);
     const isTeamAdminOrOwner =
-      eventType.team?.members.some(
-        (member) => member.userId === userId && (member.role === "ADMIN" || member.role === "OWNER")
-      ) ?? false;
+      eventType.team?.members.some((member) => member.userId === userId) ?? false;
 
     let isOrgAdminOrOwner = false;
     if (eventType.team?.parentId) {
@@ -481,6 +479,8 @@ export class BookingsController_2024_04_15 {
         teamId: eventType.team.parentId,
       });
       isOrgAdminOrOwner = !!orgTeam;
+    } else if (eventType.team?.isOrganization) {
+      isOrgAdminOrOwner = isTeamAdminOrOwner;
     }
 
     const isAuthorized = isEventTypeOwner || isHost || isTeamAdminOrOwner || isOrgAdminOrOwner;

--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
@@ -616,6 +616,9 @@ export class BookingsController_2024_04_15 {
 
     if (err instanceof Error) {
       const error = err as Error;
+      if (err instanceof HttpException) {
+        throw new HttpException(err.getResponse(), err.getStatus());
+      }
       if (Object.values(ErrorCode).includes(error.message as unknown as ErrorCode)) {
         throw new HttpException(error.message, 400);
       }

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -1174,7 +1174,14 @@ export class EventTypeRepository {
           select: {
             id: true,
             parentId: true,
+            isOrganization: true,
             members: {
+              where: {
+                accepted: true,
+                role: {
+                  in: ["ADMIN", "OWNER"],
+                },
+              },
               select: {
                 userId: true,
                 role: true,

--- a/packages/features/eventtypes/repositories/eventTypeRepository.ts
+++ b/packages/features/eventtypes/repositories/eventTypeRepository.ts
@@ -1155,6 +1155,37 @@ export class EventTypeRepository {
     };
   }
 
+  async findByIdIncludeHostsAndTeamMembers({ id }: { id: number }) {
+    return await this.prismaClient.eventType.findUnique({
+      where: {
+        id,
+      },
+      select: {
+        id: true,
+        bookingRequiresAuthentication: true,
+        userId: true,
+        teamId: true,
+        hosts: {
+          select: {
+            userId: true,
+          },
+        },
+        team: {
+          select: {
+            id: true,
+            parentId: true,
+            members: {
+              select: {
+                userId: true,
+                role: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
   async findAllByTeamIdIncludeManagedEventTypes({ teamId }: { teamId?: number }) {
     return await this.prismaClient.eventType.findMany({
       where: {


### PR DESCRIPTION
## What does this PR do?

Adds `bookingRequiresAuthentication` validation to the older 2024-04-15 booking controller to match the behavior of the newer 2024-08-13 controller. This ensures that event types marked with `bookingRequiresAuthentication: true` can only be booked by authenticated and authorized users.

**Changes:**
- Implemented `checkBookingRequiresAuthentication` method that validates user authentication and authorization before creating bookings
- Added comprehensive e2e tests covering authenticated and unauthenticated booking scenarios
- Fixed pre-existing TypeScript lint warning in `setPlatformAttendeesEmails` method (changed `any` to proper type)

**Authorization levels checked:**
1. Event type owner
2. Host
3. Team admin/owner
4. Organization admin/owner

## Visual Demo

N/A - Backend API validation logic only

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change - N/A (internal API validation logic)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works

## How should this be tested?

**Prerequisites:**
- Event type with `bookingRequiresAuthentication: true` flag
- Valid API key for the event type owner

**Test scenarios:**

1. **Unauthenticated booking (should fail with 401):**
   ```bash
   curl -X POST /v2/bookings \
     -H "Content-Type: application/json" \
     -d '{
       "eventTypeId": <eventTypeId>,
       "start": "2040-05-23T09:30:00.000Z",
       "end": "2040-05-23T10:30:00.000Z",
       ...
     }'
   ```

2. **Authenticated booking with owner credentials (should succeed with 201):**
   ```bash
   curl -X POST /v2/bookings \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <apiKey>" \
     -d '{
       "eventTypeId": <eventTypeId>,
       "start": "2040-05-23T09:30:00.000Z",
       "end": "2040-05-23T10:30:00.000Z",
       ...
     }'
   ```

**Expected behavior:**
- Without authentication: Returns 401 with message "This event type requires authentication. Please provide valid credentials."
- With authentication but unauthorized user: Returns 403 with message "You are not authorized to book this event type..."
- With authentication and authorized user: Returns 201 with booking data

## Important Review Notes

⚠️ **Testing Limitation**: Local test execution encountered Prisma adapter configuration errors. While test structure is correct, full validation depends on CI passing.

**Key areas to review:**
1. **Authorization logic** (`checkBookingRequiresAuthentication` method lines 449-524): Verify all authorization levels are correctly checked
2. **Error handling**: Confirm 401 vs 403 responses are appropriate for different scenarios
3. **Type fix** (`setPlatformAttendeesEmails` lines 585-588): Pre-existing `any` type was fixed to pass linting - verify the type matches actual usage
4. **Test coverage**: Ensure tests adequately cover the authentication requirements

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run**: https://app.devin.ai/sessions/36cf581b80b64ddeb3d04e0490f9530f

**Requested by**: morgan@cal.com (@ThyMinimalDev)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces bookingRequiresAuthentication on the 2024-04-15 bookings controller, matching the 2024-08-13 behavior. Addresses Linear issue 1761650922 by allowing bookings only from authenticated and authorized users.

- **New Features**
  - Added checkBookingRequiresAuthentication to require auth for protected event types.
  - Authorizes event type owner, host, team admin/owner, or org admin/owner; returns 401 if unauthenticated, 403 if unauthorized.
  - Added e2e tests for authenticated and unauthenticated booking scenarios.

- **Bug Fixes**
  - Fixed type in setPlatformAttendeesEmails to replace any with a proper type.

<!-- End of auto-generated description by cubic. -->

