### PR TITLE
chore: add indexes for user delete

### DIFF
--- a/packages/prisma/migrations/20251028124351_add_partial_indexes_for_user_delete_cascade/migration.sql
+++ b/packages/prisma/migrations/20251028124351_add_partial_indexes_for_user_delete_cascade/migration.sql
@@ -1,0 +1,11 @@
+CREATE INDEX "Booking_reassignById_idx" ON "Booking"("reassignById")
+WHERE "reassignById" IS NOT NULL;
+
+CREATE INDEX "EventType_instantMeetingScheduleId_idx" ON "EventType"("instantMeetingScheduleId")
+WHERE "instantMeetingScheduleId" IS NOT NULL;
+
+CREATE INDEX "CreditExpenseLog_bookingUid_idx" ON "CreditExpenseLog"("bookingUid")
+WHERE "bookingUid" IS NOT NULL;
+
+CREATE INDEX "WebhookScheduledTriggers_bookingId_idx" ON "WebhookScheduledTriggers"("bookingId")
+WHERE "bookingId" IS NOT NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -244,6 +244,8 @@ model EventType {
   createdAt DateTime? @default(now())
   updatedAt DateTime? @updatedAt
 
+  // @@partial_index([instantMeetingScheduleId])
+
   @@unique([userId, slug])
   @@unique([teamId, slug])
   @@unique([userId, parentId])
@@ -640,6 +642,8 @@ model CreditExpenseLog {
   callDuration    Int?
   creditFor       CreditUsageType?
   externalRef     String?          @unique
+
+  // @@partial_index([bookingUid])
 }
 
 enum CreditType {
@@ -851,6 +855,8 @@ model Booking {
   routingFormResponses         RoutingFormResponseDenormalized[]
   expenseLogs                  CreditExpenseLog[]
   report                       BookingReport?
+
+  // @@partial_index([reassignById])
 
   @@index([eventTypeId])
   @@index([userId])
@@ -1575,6 +1581,8 @@ model WebhookScheduledTriggers {
   webhook       Webhook?  @relation(fields: [webhookId], references: [id], onDelete: Cascade)
   bookingId     Int?
   booking       Booking?  @relation(fields: [bookingId], references: [id], onDelete: Cascade)
+
+  // @@partial_index([bookingId])
 }
 
 enum WorkflowTemplates {


### PR DESCRIPTION
## What does this PR do?

Prisma doesn't support partial indexes, but add migrations and add comments in the prisma schema for documentation and validation.