### PR TITLE
refactor: extract and clean up NavigationItem component

### DIFF
--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -80,24 +80,284 @@ export type NavigationItemType = {
   preserveQueryParams?: (context: { prevPathname: string | null; nextPathname: string }) => boolean;
 };
 
+function usePersistedExpansionState(itemName: string) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(`nav-expansion-${itemName}`);
+    if (stored !== null) {
+      setIsExpanded(JSON.parse(stored));
+    }
+  }, [itemName]);
+
+  const setPersistedExpansion = (expanded: boolean) => {
+    setIsExpanded(expanded);
+    sessionStorage.setItem(`nav-expansion-${itemName}`, JSON.stringify(expanded));
+  };
+
+  return [isExpanded, setPersistedExpansion] as const;
+}
+
+function useBuildHref() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const prevPathnameRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    prevPathnameRef.current = pathname;
+  }, [pathname]);
+
+  const buildHref = (childItem: NavigationItemType) => {
+    if (
+      childItem.preserveQueryParams &&
+      childItem.preserveQueryParams({ prevPathname: prevPathnameRef.current ?? pathname })
+    ) {
+      const params = searchParams.toString();
+      return params ? `${childItem.href}?${params}` : childItem.href;
+    }
+    return childItem.href;
+  };
+
+  return buildHref;
+}
+
 const defaultIsCurrent: NavigationItemType["isCurrent"] = ({ isChild, item, pathname }) => {
   return isChild ? item.href === pathname : item.href ? pathname?.startsWith(item.href) ?? false : false;
 };
+
+function getNavigationItemClasses(isChild: boolean, index: number, isLocaleReady: boolean) {
+  const baseClasses =
+    "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition";
+
+  const currentPageClasses = isChild
+    ? "[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis"
+    : "[&[aria-current='page']]:bg-emphasis";
+
+  const childSpecificClasses = isChild
+    ? `hidden h-8 pl-16 lg:flex lg:pl-11 ${index === 0 ? "mt-0" : "mt-px"}`
+    : "mt-0.5 text-sm";
+
+  const hoverClasses = isLocaleReady
+    ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+    : "";
+
+  return classNames(baseClasses, currentPageClasses, childSpecificClasses, hoverClasses);
+}
+
+function getParentNavigationItemClasses(isLocaleReady: boolean) {
+  return classNames(
+    "todesktop:py-[7px] text-default group flex w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
+    "[&[aria-current='page']]:!bg-transparent",
+    "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
+    isLocaleReady
+      ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+      : ""
+  );
+}
+
+function NavigationItemIcon({
+  icon,
+  isLoading,
+  current,
+}: {
+  icon?: IconName;
+  isLoading?: boolean;
+  current?: boolean;
+}) {
+  if (!icon) return null;
+
+  return (
+    <Icon
+      name={isLoading ? "rotate-cw" : icon}
+      className={classNames(
+        "todesktop:!text-blue-500 mr-2 h-4 w-4 flex-shrink-0 rtl:ml-2 md:ltr:mx-auto lg:ltr:mr-2",
+        current && "[&[aria-current='page']]:text-inherit",
+        isLoading && "animate-spin"
+      )}
+      aria-hidden="true"
+      aria-current={current ? "page" : undefined}
+    />
+  );
+}
+
+function NavigationItemLabel({
+  name,
+  badge,
+  isLocaleReady,
+}: {
+  name: string;
+  badge?: React.ReactNode;
+  isLocaleReady: boolean;
+}) {
+  const { t } = useLocale();
+
+  if (!isLocaleReady) {
+    return <SkeletonText className="h-[20px] w-full" />;
+  }
+
+  return (
+    <span
+      className="hidden w-full justify-between truncate text-ellipsis lg:flex"
+      data-testid={`${name}-test`}>
+      {t(name)}
+      {badge}
+    </span>
+  );
+}
+
+function TooltipChildrenList({
+  children,
+  parentName,
+  buildHref,
+  pathname,
+  onLinkClick,
+}: {
+  children: NavigationItemType[];
+  parentName: string;
+  buildHref: (item: NavigationItemType) => string;
+  pathname: string | null;
+  onLinkClick: () => void;
+}) {
+  const { t } = useLocale();
+
+  return (
+    <div className="pointer-events-auto flex flex-col space-y-1 p-1">
+      <span className="text-subtle px-2 text-xs font-semibold uppercase tracking-wide">{t(parentName)}</span>
+      <div className="flex flex-col">
+        {children.map((childItem) => {
+          const childIsCurrent =
+            typeof childItem.isCurrent === "function"
+              ? childItem.isCurrent({ isChild: true, item: childItem, pathname })
+              : defaultIsCurrent({ isChild: true, item: childItem, pathname });
+
+          return (
+            <Link
+              key={childItem.name}
+              href={buildHref(childItem)}
+              aria-current={childIsCurrent ? "page" : undefined}
+              onClick={onLinkClick}
+              className={classNames(
+                "group relative block rounded-md px-3 py-1 text-sm font-medium",
+                childIsCurrent ? "bg-emphasis text-white" : "hover:bg-emphasis text-mute hover:text-emphasis"
+              )}>
+              {t(childItem.name)}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ParentNavigationItem({
+  item,
+  isExpanded,
+  isTooltipOpen,
+  current,
+  shouldShowChevron,
+  isLocaleReady,
+  onToggle,
+  pathname,
+  buildHref,
+}: {
+  item: NavigationItemType;
+  isExpanded: boolean;
+  isTooltipOpen: boolean;
+  current: boolean;
+  shouldShowChevron: boolean;
+  isLocaleReady: boolean;
+  onToggle: () => void;
+  pathname: string | null;
+  buildHref: (item: NavigationItemType) => string;
+}) {
+  const { t } = useLocale();
+  const hasChildren = item.child && item.child.length > 0;
+
+  const tooltipContent = hasChildren ? (
+    <TooltipChildrenList
+      children={item.child!}
+      parentName={item.name}
+      buildHref={buildHref}
+      pathname={pathname}
+      onLinkClick={() => {}}
+    />
+  ) : (
+    t(item.name)
+  );
+
+  return (
+    <Tooltip side="right" open={isTooltipOpen} content={tooltipContent} className="lg:hidden">
+      <button
+        data-test-id={item.name}
+        aria-label={t(item.name)}
+        aria-expanded={isExpanded}
+        aria-current={current ? "page" : undefined}
+        onClick={onToggle}
+        className={getParentNavigationItemClasses(isLocaleReady)}>
+        <NavigationItemIcon icon={item.icon} isLoading={item.isLoading} />
+        <NavigationItemLabel name={item.name} badge={item.badge} isLocaleReady={isLocaleReady} />
+        {shouldShowChevron && (
+          <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="ml-auto h-4 w-4" />
+        )}
+      </button>
+    </Tooltip>
+  );
+}
+
+function ChildOrSimpleNavigationItem({
+  item,
+  isChild,
+  index,
+  current,
+  isLocaleReady,
+  buildHref,
+}: {
+  item: NavigationItemType;
+  isChild: boolean;
+  index: number;
+  current: boolean;
+  isLocaleReady: boolean;
+  buildHref: (item: NavigationItemType) => string;
+}) {
+  const { t } = useLocale();
+
+  return (
+    <Tooltip side="right" content={t(item.name)} className="lg:hidden">
+      <Link
+        data-test-id={item.name}
+        href={isChild ? buildHref(item) : item.href}
+        aria-label={t(item.name)}
+        target={item.target}
+        className={classNames(
+          getNavigationItemClasses(isChild, index, isLocaleReady),
+          item.child ? `[&[aria-current='page']]:!bg-transparent` : ""
+        )}
+        aria-current={current ? "page" : undefined}>
+        <NavigationItemIcon icon={item.icon} isLoading={item.isLoading} current={current} />
+        <NavigationItemLabel name={item.name} badge={item.badge} isLocaleReady={isLocaleReady} />
+        {item.name === "workflows" && (
+          <Badge startIcon="sparkles" variant="purple">
+            Cal.ai
+          </Badge>
+        )}
+      </Link>
+    </Tooltip>
+  );
+}
 
 export const NavigationItem: React.FC<{
   index?: number;
   item: NavigationItemType;
   isChild?: boolean;
 }> = (props) => {
-  const { item, isChild } = props;
-  const { t, isLocaleReady } = useLocale();
+  const { item, isChild = false } = props;
+  const { isLocaleReady } = useLocale();
   const pathname = usePathname();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;
-  const current = isCurrent({ isChild: !!isChild, item, pathname });
-  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
+  const current = isCurrent({ isChild, item, pathname });
+  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(item);
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
   const buildHref = useBuildHref();
-
   const isTablet = useMediaQuery("(max-width: 1024px)");
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
@@ -106,149 +366,45 @@ export const NavigationItem: React.FC<{
   const hasChildren = item.child && item.child.length > 0;
   const hasActiveChild =
     hasChildren && item.child?.some((child) => isCurrent({ isChild: true, item: child, pathname }));
-  const shouldShowChildren = isExpanded || hasActiveChild || isCurrent({ pathname, isChild, item });
+  const shouldShowChildren = isExpanded || hasActiveChild || current;
   const shouldShowChevron = hasChildren && !hasActiveChild;
   const isParentNavigationItem = hasChildren && !isChild;
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+    if (isTablet && hasChildren) {
+      setIsTooltipOpen(!isTooltipOpen);
+    }
+  };
 
   return (
     <Fragment>
       {isParentNavigationItem ? (
-        <Tooltip
-          side="right"
-          open={isTooltipOpen}
-          content={
-            hasChildren ? (
-              <div className="pointer-events-auto flex flex-col space-y-1 p-1">
-                <span className="text-subtle px-2 text-xs font-semibold uppercase tracking-wide">
-                  {t(item.name)}
-                </span>
-                <div className="flex flex-col">
-                  {item.child?.map((childItem) => {
-                    const childIsCurrent =
-                      typeof childItem.isCurrent === "function"
-                        ? childItem.isCurrent({ isChild: true, item: childItem, pathname })
-                        : defaultIsCurrent({ isChild: true, item: childItem, pathname });
-                    return (
-                      <Link
-                        key={childItem.name}
-                        href={buildHref(childItem)}
-                        aria-current={childIsCurrent ? "page" : undefined}
-                        onClick={() => setIsTooltipOpen(false)}
-                        className={classNames(
-                          "group relative block rounded-md px-3 py-1 text-sm font-medium",
-                          childIsCurrent
-                            ? "bg-emphasis text-white"
-                            : "hover:bg-emphasis text-mute hover:text-emphasis"
-                        )}>
-                        {t(childItem.name)}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              t(item.name)
-            )
-          }
-          className="lg:hidden">
-          <button
-            data-test-id={item.name}
-            aria-label={t(item.name)}
-            aria-expanded={isExpanded}
-            aria-current={current ? "page" : undefined}
-            onClick={() => {
-              setIsExpanded(!isExpanded);
-              if (isTablet && hasChildren) {
-                setIsTooltipOpen(!isTooltipOpen);
-              }
-            }}
-            className={classNames(
-              "todesktop:py-[7px] text-default group flex w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-              "[&[aria-current='page']]:!bg-transparent",
-              "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
-              isLocaleReady
-                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-                : ""
-            )}>
-            {item.icon && (
-              <Icon
-                name={item.isLoading ? "rotate-cw" : item.icon}
-                className={classNames(
-                  "todesktop:!text-blue-500 mr-2 h-4 w-4 flex-shrink-0 rtl:ml-2 md:ltr:mx-auto lg:ltr:mr-2",
-                  item.isLoading && "animate-spin"
-                )}
-                aria-hidden="true"
-              />
-            )}
-            {isLocaleReady ? (
-              <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-                data-testid={`${item.name}-test`}>
-                {t(item.name)}
-                {item.badge && item.badge}
-              </span>
-            ) : (
-              <SkeletonText className="h-[20px] w-full" />
-            )}
-            {shouldShowChevron && (
-              <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="ml-auto h-4 w-4" />
-            )}
-          </button>
-        </Tooltip>
+        <ParentNavigationItem
+          item={item}
+          isExpanded={isExpanded}
+          isTooltipOpen={isTooltipOpen}
+          current={current}
+          shouldShowChevron={shouldShowChevron}
+          isLocaleReady={isLocaleReady}
+          onToggle={handleToggle}
+          pathname={pathname}
+          buildHref={buildHref}
+        />
       ) : (
-        <Tooltip side="right" content={t(item.name)} className="lg:hidden">
-          <Link
-            data-test-id={item.name}
-            href={isChild ? buildHref(item) : item.href}
-            aria-label={t(item.name)}
-            target={item.target}
-            className={classNames(
-              "todesktop:py-[7px] text-default group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-              item.child
-                ? `[&[aria-current='page']]:!bg-transparent`
-                : `[&[aria-current='page']]:bg-emphasis`,
-              isChild
-                ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
-                    props.index === 0 ? "mt-0" : "mt-px"
-                  }`
-                : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
-              isLocaleReady
-                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-                : ""
-            )}
-            aria-current={current ? "page" : undefined}>
-            {item.icon && (
-              <Icon
-                name={item.isLoading ? "rotate-cw" : item.icon}
-                className={classNames(
-                  "todesktop:!text-blue-500 mr-2 h-4 w-4 flex-shrink-0 rtl:ml-2 md:ltr:mx-auto lg:ltr:mr-2 [&[aria-current='page']]:text-inherit",
-                  item.isLoading && "animate-spin"
-                )}
-                aria-hidden="true"
-                aria-current={current ? "page" : undefined}
-              />
-            )}
-            {isLocaleReady ? (
-              <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-                data-testid={`${item.name}-test`}>
-                {t(item.name)}
-                {item.badge && item.badge}
-              </span>
-            ) : (
-              <SkeletonText className="h-[20px] w-full" />
-            )}
-            {item.name === "workflows" && (
-              <Badge startIcon="sparkles" variant="purple">
-                Cal.ai
-              </Badge>
-            )}
-          </Link>
-        </Tooltip>
+        <ChildOrSimpleNavigationItem
+          item={item}
+          isChild={isChild}
+          index={props.index ?? 0}
+          current={current}
+          isLocaleReady={isLocaleReady}
+          buildHref={buildHref}
+        />
       )}
-      {item.child &&
-        shouldShowChildren &&
-        item.child.map((item, index) => <NavigationItem index={index} key={item.name} item={item} isChild />)}
+      {shouldShowChildren &&
+        item.child?.map((childItem, index) => (
+          <NavigationItem key={childItem.name} index={index} item={childItem} isChild />
+        ))}
     </Fragment>
   );
 };
@@ -256,15 +412,15 @@ export const NavigationItem: React.FC<{
 export const MobileNavigationItem: React.FC<{
   item: NavigationItemType;
   isChild?: boolean;
-}> = (props) => {
-  const { item, isChild } = props;
+}> = ({ item, isChild }) => {
   const pathname = usePathname();
   const { t, isLocaleReady } = useLocale();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;
   const current = isCurrent({ isChild: !!isChild, item, pathname });
-  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
+  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(item);
 
   if (!shouldDisplayNavigationItem) return null;
+
   return (
     <Link
       key={item.name}
@@ -286,13 +442,72 @@ export const MobileNavigationItem: React.FC<{
   );
 };
 
+function MobileMoreItemWithChildren({
+  item,
+  isExpanded,
+  onToggle,
+  buildHref,
+}: {
+  item: NavigationItemType;
+  isExpanded: boolean;
+  onToggle: () => void;
+  buildHref: (item: NavigationItemType) => string;
+}) {
+  const { t, isLocaleReady } = useLocale();
+
+  return (
+    <>
+      <button
+        onClick={onToggle}
+        className="hover:bg-subtle flex w-full items-center justify-between p-5 text-left transition">
+        <span className="text-default flex items-center font-semibold">
+          {item.icon && (
+            <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
+          )}
+          {isLocaleReady ? t(item.name) : <SkeletonText />}
+        </span>
+        <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="text-subtle h-5 w-5" />
+      </button>
+      {isExpanded && item.child && (
+        <ul className="bg-subtle">
+          {item.child.map((childItem) => (
+            <li key={childItem.name} className="border-subtle border-t">
+              <Link
+                href={buildHref(childItem)}
+                className="hover:bg-muted flex items-center p-4 pl-12 transition">
+                <span className="text-default font-medium">
+                  {isLocaleReady ? t(childItem.name) : <SkeletonText />}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}
+
+function MobileMoreItemSimple({ item }: { item: NavigationItemType }) {
+  const { t, isLocaleReady } = useLocale();
+
+  return (
+    <Link href={item.href} className="hover:bg-subtle flex items-center justify-between p-5 transition">
+      <span className="text-default flex items-center font-semibold ">
+        {item.icon && (
+          <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
+        )}
+        {isLocaleReady ? t(item.name) : <SkeletonText />}
+      </span>
+      <Icon name="arrow-right" className="text-subtle h-5 w-5" />
+    </Link>
+  );
+}
+
 export const MobileNavigationMoreItem: React.FC<{
   item: NavigationItemType;
   isChild?: boolean;
-}> = (props) => {
-  const { item } = props;
-  const { t, isLocaleReady } = useLocale();
-  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
+}> = ({ item }) => {
+  const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(item);
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
   const buildHref = useBuildHref();
 
@@ -303,48 +518,14 @@ export const MobileNavigationMoreItem: React.FC<{
   return (
     <li className="border-subtle border-b last:border-b-0" key={item.name}>
       {hasChildren ? (
-        <>
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="hover:bg-subtle flex w-full items-center justify-between p-5 text-left transition">
-            <span className="text-default flex items-center font-semibold">
-              {item.icon && (
-                <Icon
-                  name={item.icon}
-                  className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3"
-                  aria-hidden="true"
-                />
-              )}
-              {isLocaleReady ? t(item.name) : <SkeletonText />}
-            </span>
-            <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="text-subtle h-5 w-5" />
-          </button>
-          {isExpanded && item.child && (
-            <ul className="bg-subtle">
-              {item.child.map((childItem) => (
-                <li key={childItem.name} className="border-subtle border-t">
-                  <Link
-                    href={buildHref(childItem)}
-                    className="hover:bg-muted flex items-center p-4 pl-12 transition">
-                    <span className="text-default font-medium">
-                      {isLocaleReady ? t(childItem.name) : <SkeletonText />}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-        </>
+        <MobileMoreItemWithChildren
+          item={item}
+          isExpanded={isExpanded}
+          onToggle={() => setIsExpanded(!isExpanded)}
+          buildHref={buildHref}
+        />
       ) : (
-        <Link href={item.href} className="hover:bg-subtle flex items-center justify-between p-5 transition">
-          <span className="text-default flex items-center font-semibold ">
-            {item.icon && (
-              <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
-            )}
-            {isLocaleReady ? t(item.name) : <SkeletonText />}
-          </span>
-          <Icon name="arrow-right" className="text-subtle h-5 w-5" />
-        </Link>
+        <MobileMoreItemSimple item={item} />
       )}
     </li>
   );

--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -121,7 +121,15 @@ function useBuildHref() {
   return buildHref;
 }
 
-const defaultIsCurrent: NavigationItemType["isCurrent"] = ({ isChild, item, pathname }) => {
+const defaultIsCurrent = ({
+  isChild,
+  item,
+  pathname,
+}: {
+  item: Pick<NavigationItemType, "href">;
+  isChild?: boolean;
+  pathname: string | null;
+}): boolean => {
   return isChild ? item.href === pathname : item.href ? pathname?.startsWith(item.href) ?? false : false;
 };
 
@@ -225,10 +233,8 @@ function TooltipChildrenList({
       <span className="text-subtle px-2 text-xs font-semibold uppercase tracking-wide">{t(parentName)}</span>
       <div className="flex flex-col">
         {children.map((childItem) => {
-          const childIsCurrent =
-            typeof childItem.isCurrent === "function"
-              ? childItem.isCurrent({ isChild: true, item: childItem, pathname })
-              : defaultIsCurrent({ isChild: true, item: childItem, pathname });
+          const isCurrentFn = childItem.isCurrent ?? defaultIsCurrent;
+          const childIsCurrent = isCurrentFn({ isChild: true, item: childItem, pathname });
 
           return (
             <Link
@@ -363,7 +369,7 @@ export const NavigationItem: React.FC<{
 
   if (!shouldDisplayNavigationItem) return null;
 
-  const hasChildren = item.child && item.child.length > 0;
+  const hasChildren = Boolean(item.child && item.child.length > 0);
   const hasActiveChild =
     hasChildren && item.child?.some((child) => isCurrent({ isChild: true, item: child, pathname }));
   const shouldShowChildren = isExpanded || hasActiveChild || current;

--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -418,7 +418,8 @@ export const NavigationItem: React.FC<{
 export const MobileNavigationItem: React.FC<{
   item: NavigationItemType;
   isChild?: boolean;
-}> = ({ item, isChild }) => {
+}> = (props) => {
+  const { item, isChild } = props;
   const pathname = usePathname();
   const { t, isLocaleReady } = useLocale();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;
@@ -448,71 +449,12 @@ export const MobileNavigationItem: React.FC<{
   );
 };
 
-function MobileMoreItemWithChildren({
-  item,
-  isExpanded,
-  onToggle,
-  buildHref,
-}: {
-  item: NavigationItemType;
-  isExpanded: boolean;
-  onToggle: () => void;
-  buildHref: (item: NavigationItemType) => string;
-}) {
-  const { t, isLocaleReady } = useLocale();
-
-  return (
-    <>
-      <button
-        onClick={onToggle}
-        className="hover:bg-subtle flex w-full items-center justify-between p-5 text-left transition">
-        <span className="text-default flex items-center font-semibold">
-          {item.icon && (
-            <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
-          )}
-          {isLocaleReady ? t(item.name) : <SkeletonText />}
-        </span>
-        <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="text-subtle h-5 w-5" />
-      </button>
-      {isExpanded && item.child && (
-        <ul className="bg-subtle">
-          {item.child.map((childItem) => (
-            <li key={childItem.name} className="border-subtle border-t">
-              <Link
-                href={buildHref(childItem)}
-                className="hover:bg-muted flex items-center p-4 pl-12 transition">
-                <span className="text-default font-medium">
-                  {isLocaleReady ? t(childItem.name) : <SkeletonText />}
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </>
-  );
-}
-
-function MobileMoreItemSimple({ item }: { item: NavigationItemType }) {
-  const { t, isLocaleReady } = useLocale();
-
-  return (
-    <Link href={item.href} className="hover:bg-subtle flex items-center justify-between p-5 transition">
-      <span className="text-default flex items-center font-semibold ">
-        {item.icon && (
-          <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
-        )}
-        {isLocaleReady ? t(item.name) : <SkeletonText />}
-      </span>
-      <Icon name="arrow-right" className="text-subtle h-5 w-5" />
-    </Link>
-  );
-}
-
 export const MobileNavigationMoreItem: React.FC<{
   item: NavigationItemType;
   isChild?: boolean;
-}> = ({ item }) => {
+}> = (props) => {
+  const { item } = props;
+  const { t, isLocaleReady } = useLocale();
   const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(item);
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
   const buildHref = useBuildHref();
@@ -524,14 +466,48 @@ export const MobileNavigationMoreItem: React.FC<{
   return (
     <li className="border-subtle border-b last:border-b-0" key={item.name}>
       {hasChildren ? (
-        <MobileMoreItemWithChildren
-          item={item}
-          isExpanded={isExpanded}
-          onToggle={() => setIsExpanded(!isExpanded)}
-          buildHref={buildHref}
-        />
+        <>
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="hover:bg-subtle flex w-full items-center justify-between p-5 text-left transition">
+            <span className="text-default flex items-center font-semibold">
+              {item.icon && (
+                <Icon
+                  name={item.icon}
+                  className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3"
+                  aria-hidden="true"
+                />
+              )}
+              {isLocaleReady ? t(item.name) : <SkeletonText />}
+            </span>
+            <Icon name={isExpanded ? "chevron-up" : "chevron-down"} className="text-subtle h-5 w-5" />
+          </button>
+          {isExpanded && item.child && (
+            <ul className="bg-subtle">
+              {item.child.map((childItem) => (
+                <li key={childItem.name} className="border-subtle border-t">
+                  <Link
+                    href={buildHref(childItem)}
+                    className="hover:bg-muted flex items-center p-4 pl-12 transition">
+                    <span className="text-default font-medium">
+                      {isLocaleReady ? t(childItem.name) : <SkeletonText />}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       ) : (
-        <MobileMoreItemSimple item={item} />
+        <Link href={item.href} className="hover:bg-subtle flex items-center justify-between p-5 transition">
+          <span className="text-default flex items-center font-semibold ">
+            {item.icon && (
+              <Icon name={item.icon} className="h-5 w-5 flex-shrink-0 ltr:mr-3 rtl:ml-3" aria-hidden="true" />
+            )}
+            {isLocaleReady ? t(item.name) : <SkeletonText />}
+          </span>
+          <Icon name="arrow-right" className="text-subtle h-5 w-5" />
+        </Link>
       )}
     </li>
   );


### PR DESCRIPTION
## What does this PR do?

Refactors the bloated `NavigationItem.tsx` file by extracting logic into smaller, focused sub-components and fixing type errors.
This improves code maintainability and readability without changing any functionality.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->

---

## Summary by cubic

Breaks the sidebar NavigationItem into smaller components and helpers to simplify logic and improve mobile/tooltip behavior. Aligns with the “bookings sidebar nav” Linear work by making the sidebar easier to maintain and more consistent across devices.

- **Refactors**
    - Added NavigationItemType, a default isCurrent, and a buildHref/persisted expansion helper.
    - Split NavigationItem into focused pieces: ParentNavigationItem, ChildOrSimpleNavigationItem, TooltipChildrenList.
    - Extracted class, icon, and label helpers; improved aria attributes and tooltip content.
    - Tightened child rendering (shows when expanded, has active child, or is current) and chevron visibility.
- **Bug Fixes**
    - Resolved a type error in NavigationItem props/hooks.

<!-- End of auto-generated description by cubic. -->