### PR TITLE
chore: invites to submit hook instead of relying on state

### DIFF
--- a/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
+++ b/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
@@ -16,7 +16,11 @@ export const useSubmitOnboarding = () => {
 
   const intentToCreateOrg = trpc.viewer.organizations.intentToCreateOrg.useMutation();
 
-  const submitOnboarding = async (store: OnboardingState, userEmail: string) => {
+  const submitOnboarding = async (
+    store: OnboardingState,
+    userEmail: string,
+    invitesToSubmit: OnboardingState["invites"]
+  ) => {
     setIsSubmitting(true);
     setError(null);
 
@@ -26,7 +30,6 @@ export const useSubmitOnboarding = () => {
         organizationDetails,
         organizationBrand,
         teams,
-        invites,
         inviteRole,
         resetOnboarding,
       } = store;
@@ -46,7 +49,7 @@ export const useSubmitOnboarding = () => {
         }));
 
       // Prepare invites data
-      const invitedMembersData = invites
+      const invitedMembersData = invitesToSubmit
         .filter((invite) => invite.email.trim().length > 0)
         .map((invite) => ({
           email: invite.email,

--- a/apps/web/modules/onboarding/organization/invite/organization-invite-view.tsx
+++ b/apps/web/modules/onboarding/organization/invite/organization-invite-view.tsx
@@ -63,7 +63,7 @@ export const OrganizationInviteView = ({ userEmail }: OrganizationInviteViewProp
   const handleSubmitOnboarding = async (invitesData: FormValues["invites"]) => {
     // Save invites to store before submitting
     setInvites(invitesData);
-    await submitOnboarding(store, userEmail);
+    await submitOnboarding(store, userEmail, invitesData);
   };
 
   const handleContinue = async (data?: FormValues) => {


### PR DESCRIPTION
## What does this PR do?
Pass invites to submit hook instead of relying on state. State can be out of sync on last step as its not commited onChange but onsubmit. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the invite list directly to the onboarding submit hook to avoid stale state and ensure the final step submits the correct invites. Fixes missed or outdated invites during onboarding.

- **Bug Fixes**
  - submitOnboarding now accepts invites as a parameter and uses them for submission.
  - OrganizationInviteView passes invitesData to submitOnboarding instead of relying on store.invites.

<!-- End of auto-generated description by cubic. -->

