### PR TITLE
fix: disable former slot while rescheduling bookings for individual events

### DIFF
--- a/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
+++ b/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
@@ -135,7 +135,7 @@ export const AvailableTimeSlots = ({
     // This ensures that the currently booked time slot is treated as unavailable while rescheduling.
     if (bookingData?.startTime) {
       const bookingTime = dayjs(bookingData.startTime).utc().format();
-      if (!unavailableTimeSlots.includes(bookingTime)) unavailableTimeSlots.push(bookingTime);
+      if (!unavailableTimeSlots.includes(bookingTime)) return [...unavailableTimeSlots, bookingTime];
     }
     return unavailableTimeSlots;
   }, [unavailableTimeSlots, bookingData]);

--- a/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
+++ b/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
@@ -84,8 +84,6 @@ export const AvailableTimeSlots = ({
   const [layout] = useBookerStoreContext((state) => [state.layout]);
   const isColumnView = layout === BookerLayouts.COLUMN_VIEW;
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // Keep tentativeSelectedTimeslots in the destructure to preserve state shape
-  // but prefix it with an underscore to satisfy the linter for unused vars.
   const { setTentativeSelectedTimeslots, tentativeSelectedTimeslots: _tentativeSelectedTimeslots } =
     useBookerStoreContext((state) => ({
       setTentativeSelectedTimeslots: state.setTentativeSelectedTimeslots,

--- a/packages/features/bookings/components/AvailableTimes.tsx
+++ b/packages/features/bookings/components/AvailableTimes.tsx
@@ -94,7 +94,7 @@ const SlotItem = ({
   watchedCfToken,
   handleSlotClick,
   onTentativeTimeSelect,
-  unavailableTimeSlots = [],
+  unavailableTimeSlots,
   confirmButtonDisabled,
   confirmStepClassNames,
 }: SlotItemProps) => {
@@ -148,7 +148,10 @@ const SlotItem = ({
     }
   };
 
-  const isTimeslotUnavailable = unavailableTimeSlots.includes(slot.time);
+  const slotTime = dayjs.utc(slot.time).toISOString();
+  const isTimeslotUnavailable = (unavailableTimeSlots || []).some(
+    (t) => dayjs.utc(t).toISOString() === slotTime
+  );
   return (
     <AnimatePresence>
       <div className="flex gap-2">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24712
- Fixes CAL-6648
- added `updatedUnavailableTimeSlots` variable which adds the former slot to `unavailableTimeSlots` array when rescheduling.
- updated logic for `isTimeslotUnavailable` to check for the current slot in `unavailableTimeSlots`.
- minor changes to code to fix linting errors.

## Visual Demo (For contributors especially)


#### Image Demo (if applicable):

Before:

<img width="1257" height="628" alt="Screenshot from 2025-10-28 22-36-26" src="https://github.com/user-attachments/assets/2f17f663-183d-4542-aac9-13173e3c44fb" />

After:

<img width="1257" height="628" alt="Screenshot from 2025-10-28 22-34-56" src="https://github.com/user-attachments/assets/78ace0e3-7d35-456f-b644-a3c54abb1ce6" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a booking
- Reschedule the meeting
- Check the available slots, the former time slot will be disabled


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the previously booked time slot when rescheduling an individual event so users can’t reselect the old slot. Addresses CAL-6648 and #24712.

- **Bug Fixes**
  - Added updatedUnavailableTimeSlots to include the current booking’s startTime during reschedule.
  - Normalized time comparisons to UTC ISO and passed the updated list to slot components to correctly mark the former slot as unavailable.

<!-- End of auto-generated description by cubic. -->

