### PR TITLE
fix: use highest role for org admins accessing sub team event types

### DIFF
--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -177,6 +177,56 @@ describe("PermissionCheckService", () => {
       });
     });
 
+    it("should use highest role when user is MEMBER of sub team but ADMIN of parent org (PBAC disabled)", async () => {
+      const teamMembership = {
+        id: 1,
+        teamId: 1,
+        userId: 1,
+        accepted: true,
+        role: "MEMBER" as MembershipRole,
+        customRoleId: null,
+        disableImpersonation: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const orgMembership = {
+        id: 2,
+        teamId: 100,
+        userId: 1,
+        accepted: true,
+        role: "ADMIN" as MembershipRole,
+        customRoleId: null,
+        disableImpersonation: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(false);
+      (MembershipRepository.findUniqueByUserIdAndTeamId as Mock)
+        .mockResolvedValueOnce(teamMembership) // Has team membership as MEMBER
+        .mockResolvedValueOnce(orgMembership); // Has org membership as ADMIN
+      mockRepository.getTeamById.mockResolvedValueOnce({ id: 1, parentId: 100 });
+
+      const result = await service.checkPermission({
+        userId: 1,
+        teamId: 1,
+        permission: "eventType.update",
+        fallbackRoles: ["ADMIN", "OWNER"],
+      });
+
+      expect(result).toBe(true);
+      expect(mockRepository.getTeamById).toHaveBeenCalledWith(1);
+      expect(MembershipRepository.findUniqueByUserIdAndTeamId).toHaveBeenNthCalledWith(1, {
+        userId: 1,
+        teamId: 1,
+      });
+      expect(MembershipRepository.findUniqueByUserIdAndTeamId).toHaveBeenNthCalledWith(2, {
+        userId: 1,
+        teamId: 100,
+      });
+    });
+
     it("should check org-level permissions when user has no team membership but PBAC is enabled", async () => {
       mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
       mockRepository.getMembershipByUserAndTeam.mockResolvedValueOnce(null);

--- a/packages/features/pbac/services/__tests__/permission-check.service.test.ts
+++ b/packages/features/pbac/services/__tests__/permission-check.service.test.ts
@@ -227,6 +227,39 @@ describe("PermissionCheckService", () => {
       });
     });
 
+    it("should check org-level permissions when user is MEMBER of sub team but ADMIN of parent org (PBAC enabled)", async () => {
+      mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
+      mockRepository.getMembershipByUserAndTeam.mockResolvedValueOnce({
+        id: 1,
+        teamId: 1,
+        userId: 1,
+        customRoleId: "team_member_role",
+        team: { id: 1, parentId: 100 },
+      });
+      mockRepository.getOrgMembership.mockResolvedValueOnce({
+        id: 2,
+        teamId: 100,
+        userId: 1,
+        customRoleId: "org_admin_role",
+      });
+      mockRepository.checkRolePermission
+        .mockResolvedValueOnce(false) // Team member role doesn't have permission
+        .mockResolvedValueOnce(true); // Org admin role has permission
+
+      const result = await service.checkPermission({
+        userId: 1,
+        teamId: 1,
+        permission: "eventType.update",
+        fallbackRoles: ["ADMIN", "OWNER"],
+      });
+
+      expect(result).toBe(true);
+      expect(mockRepository.getMembershipByUserAndTeam).toHaveBeenCalledWith(1, 1);
+      expect(mockRepository.getOrgMembership).toHaveBeenCalledWith(1, 100);
+      expect(mockRepository.checkRolePermission).toHaveBeenNthCalledWith(1, "team_member_role", "eventType.update");
+      expect(mockRepository.checkRolePermission).toHaveBeenNthCalledWith(2, "org_admin_role", "eventType.update");
+    });
+
     it("should check org-level permissions when user has no team membership but PBAC is enabled", async () => {
       mockFeaturesRepository.checkIfTeamHasFeature.mockResolvedValueOnce(true);
       mockRepository.getMembershipByUserAndTeam.mockResolvedValueOnce(null);

--- a/packages/features/pbac/services/permission-check.service.ts
+++ b/packages/features/pbac/services/permission-check.service.ts
@@ -118,30 +118,33 @@ export class PermissionCheckService {
         return this.hasPermission({ userId, teamId }, permission);
       }
 
-      // Fallback to role-based check - check both team and org membership
+      // Fallback to role-based check - use highest role between team and org membership
       const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({
         userId,
         teamId,
       });
 
-      // If user has team membership, check their role
-      if (membership) {
-        return this.checkFallbackRoles(membership.role, fallbackRoles);
-      }
+      let effectiveRole: MembershipRole | null = membership?.role ?? null;
 
-      // No team membership - check if team has parent org and user is org member
+      // Check if team has parent org and get org membership
       const team = await this.repository.getTeamById(teamId);
       if (team?.parentId) {
         const orgMembership = await MembershipRepository.findUniqueByUserIdAndTeamId({
           userId,
           teamId: team.parentId,
         });
+        
+        // Use the highest role between team and org
         if (orgMembership) {
-          return this.checkFallbackRoles(orgMembership.role, fallbackRoles);
+          effectiveRole = this.getHighestRole(effectiveRole, orgMembership.role);
         }
       }
 
-      return false;
+      if (!effectiveRole) {
+        return false;
+      }
+
+      return this.checkFallbackRoles(effectiveRole, fallbackRoles);
     } catch (error) {
       this.logger.error(error);
       return false;
@@ -179,30 +182,33 @@ export class PermissionCheckService {
         return this.hasPermissions({ userId, teamId }, permissions);
       }
 
-      // Fallback to role-based check - check both team and org membership
+      // Fallback to role-based check - use highest role between team and org membership
       const membership = await MembershipRepository.findUniqueByUserIdAndTeamId({
         userId,
         teamId,
       });
 
-      // If user has team membership, check their role
-      if (membership) {
-        return this.checkFallbackRoles(membership.role, fallbackRoles);
-      }
+      let effectiveRole: MembershipRole | null = membership?.role ?? null;
 
-      // No team membership - check if team has parent org and user is org member
+      // Check if team has parent org and get org membership
       const team = await this.repository.getTeamById(teamId);
       if (team?.parentId) {
         const orgMembership = await MembershipRepository.findUniqueByUserIdAndTeamId({
           userId,
           teamId: team.parentId,
         });
+        
+        // Use the highest role between team and org
         if (orgMembership) {
-          return this.checkFallbackRoles(orgMembership.role, fallbackRoles);
+          effectiveRole = this.getHighestRole(effectiveRole, orgMembership.role);
         }
       }
 
-      return false;
+      if (!effectiveRole) {
+        return false;
+      }
+
+      return this.checkFallbackRoles(effectiveRole, fallbackRoles);
     } catch (error) {
       this.logger.error(error);
       return false;
@@ -282,6 +288,22 @@ export class PermissionCheckService {
 
   private checkFallbackRoles(userRole: MembershipRole, allowedRoles: MembershipRole[]): boolean {
     return allowedRoles.includes(userRole);
+  }
+
+  private getHighestRole(
+    role1: MembershipRole | null,
+    role2: MembershipRole | null
+  ): MembershipRole | null {
+    if (!role1) return role2;
+    if (!role2) return role1;
+
+    const roleHierarchy: Record<MembershipRole, number> = {
+      OWNER: 3,
+      ADMIN: 2,
+      MEMBER: 1,
+    };
+
+    return roleHierarchy[role1] >= roleHierarchy[role2] ? role1 : role2;
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

Fixes a permission issue where organization admins were unable to update sub team event types when they weren't directly listed as an admin of the sub team.

**Problem**: When an org admin is also a member of a sub team (but only with MEMBER role), they get a "permission required eventType.update" error when trying to update that team's event types, even though their org-level ADMIN role should grant them permission.

**Root Cause**: The `PermissionCheckService.checkPermission()` method was using the team membership role directly without considering the user's organization-level role. It would find the MEMBER role in the sub team and stop there, never checking if the user had a higher role (ADMIN) in the parent organization.

**Solution**: Updated the permission check logic to evaluate both team and organization membership, then use the highest role when checking permissions. This aligns with how `getEventTypePermissions()` already works in the codebase.

## Changes Made

- Added `getHighestRole()` helper method to compare and return the higher of two roles (OWNER > ADMIN > MEMBER)
- Updated `checkPermission()` to check both team and org membership, using the highest role
- Updated `checkPermissions()` with the same logic for consistency
- Added test case verifying org admins can access sub team event types

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a bug fix to existing permission logic, no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Test Scenario
1. Set up an organization with a sub team
2. Add a user to the organization as an ADMIN
3. Add the same user to the sub team as a MEMBER (not admin)
4. Create an event type for the sub team
5. As the org admin user, attempt to update the sub team's event type

**Expected**: The org admin should be able to update the event type successfully.

**Before this fix**: User would get "permission required eventType.update" error.

### Automated Test Coverage
- Unit test added: `should use highest role when user is MEMBER of sub team but ADMIN of parent org (PBAC disabled)`
- This test verifies the permission check correctly uses the ADMIN role from the org instead of the MEMBER role from the sub team

## Human Review Checklist

Please pay special attention to:

1. **Role hierarchy correctness**: Verify `getHighestRole()` correctly implements OWNER > ADMIN > MEMBER
2. **Security implications**: Confirm this doesn't grant inappropriate permissions to users who shouldn't have them
3. **Edge cases**: Consider scenarios like:
   - User is OWNER in team but MEMBER in org (should use OWNER)
   - User is ADMIN in team but OWNER in org (should use OWNER)
   - User has no team membership but is ADMIN in org (already worked, should still work)
4. **Test coverage**: Is the test case sufficient for a security-sensitive change?

---

**Link to Devin run**: https://app.devin.ai/sessions/22419460024b4edfa00a94d9d1d254d7

**Requested by**: joe@cal.com (@joeauyeung)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a permissions bug where org admins couldn’t update sub-team event types if they were only members of that sub-team. Permission checks now consider both team and org roles and use the highest.

- **Bug Fixes**
  - Updated checkPermission and checkPermissions to use the highest role between team and parent org membership.
  - Added getHighestRole helper with OWNER > ADMIN > MEMBER hierarchy.
  - Added unit test covering org ADMIN + sub-team MEMBER scenario.

<!-- End of auto-generated description by cubic. -->

