### PR TITLE
chore: Determine to serve cache high level

### DIFF
--- a/packages/features/calendar-cache/lib/getShouldServeCache.test.ts
+++ b/packages/features/calendar-cache/lib/getShouldServeCache.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IFeaturesRepository } from "@calcom/features/flags/features.repository.interface";
 
 import { CacheService } from "./getShouldServeCache";
+import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
 
 describe("CacheService.getShouldServeCache", () => {
   const mockFeaturesRepository: IFeaturesRepository = {
@@ -57,7 +58,7 @@ describe("CacheService.getShouldServeCache", () => {
       const result = await cacheService.getShouldServeCache(undefined, 123);
 
       expect(result).toBe(true);
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(123, "calendar-cache-serve");
+      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(123, CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE);
     });
 
     it("should check feature repository when teamId is provided and return false if feature is disabled", async () => {
@@ -66,7 +67,7 @@ describe("CacheService.getShouldServeCache", () => {
       const result = await cacheService.getShouldServeCache(undefined, 456);
 
       expect(result).toBe(false);
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(456, "calendar-cache-serve");
+      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(456, CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE);
     });
   });
 
@@ -86,7 +87,7 @@ describe("CacheService.getShouldServeCache", () => {
       const result = await cacheService.getShouldServeCache(undefined, 999);
 
       expect(result).toBe(true);
-      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(999, "calendar-cache-serve");
+      expect(mockFeaturesRepository.checkIfTeamHasFeature).toHaveBeenCalledWith(999, CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE);
     });
   });
 });

--- a/packages/features/calendar-cache/lib/getShouldServeCache.ts
+++ b/packages/features/calendar-cache/lib/getShouldServeCache.ts
@@ -1,5 +1,5 @@
 import type { IFeaturesRepository } from "@calcom/features/flags/features.repository.interface";
-import { CalendarSubscriptionService } from "calendar-subscription/lib/CalendarSubscriptionService";
+import { CalendarSubscriptionService } from "@calcom/features/calendar-subscription/lib/CalendarSubscriptionService";
 
 export interface ICacheService {
   featuresRepository: IFeaturesRepository;

--- a/packages/features/calendar-cache/lib/getShouldServeCache.ts
+++ b/packages/features/calendar-cache/lib/getShouldServeCache.ts
@@ -1,4 +1,5 @@
 import type { IFeaturesRepository } from "@calcom/features/flags/features.repository.interface";
+import { CalendarSubscriptionService } from "calendar-subscription/lib/CalendarSubscriptionService";
 
 export interface ICacheService {
   featuresRepository: IFeaturesRepository;
@@ -10,6 +11,6 @@ export class CacheService {
   async getShouldServeCache(shouldServeCache?: boolean | undefined, teamId?: number) {
     if (typeof shouldServeCache === "boolean") return shouldServeCache;
     if (!teamId) return false;
-    return await this.dependencies.featuresRepository.checkIfTeamHasFeature(teamId, "calendar-cache-serve");
+    return await this.dependencies.featuresRepository.checkIfTeamHasFeature(teamId, CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE);
   }
 }

--- a/packages/features/calendars/lib/getCalendarsEvents.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.ts
@@ -94,7 +94,7 @@ const getCalendarsEvents = async (
 
   const calendarAndCredentialPairs = await Promise.all(
     calendarCredentials.map(async (credential) => {
-      const calendar = await getCalendar(credential);
+      const calendar = await getCalendar(credential, shouldServeCache);
       return [calendar, credential] as const;
     })
   );
@@ -193,7 +193,7 @@ function getServerUrlFromCalendarExternalId(externalId: string): string | null {
   try {
     const url = new URL(externalId);
     return `${url.protocol}//${url.host}`;
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -215,7 +215,7 @@ function getServerUrlFromCredential(credential: CredentialForCalendarService): s
 
     const url = new URL(decryptedData.url);
     return `${url.protocol}//${url.host}`;
-  } catch (error) {
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
## What does this PR do?

For each user at the moment we do two calls; checkIfUserHasFeature - it checks the userFeatures repository and then also figures out of the cache is enabled for a team or parent team. We also do this per calendar; so if a user has multiple calendars; we multiplex further.

This PR proposes a single check, mostly using the shouldServeCache functionality of "old cache" and re-purposing. For big organisations the performance overhead is quite significant.

Also; Most of the time, calendar cache is enabled on a per team basis. It's actually very unlikely we will ever enable it globally.

Recs:
* Remove check for global calendar cache entirely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Determine calendar cache once per team and pass it to calendar creation, cutting repeated feature checks per credential. Improves performance for large orgs and removes the global cache path.

- **Refactors**
  - getCalendar now accepts shouldServeCache to skip internal feature checks when provided.
  - getCalendarsEvents passes shouldServeCache to each calendar.
  - CacheService.getShouldServeCache uses the team-based feature flag constant; returns false without teamId.
  - Minor cleanup of catch blocks.

<!-- End of auto-generated description by cubic. -->

