### PR TITLE
chore: Removed unneeded yarn reinstall API v2 Docker

### DIFF
--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -16,14 +16,8 @@ ENV DATABASE_URL=${DATABASE_URL}
 COPY . .
 
 RUN yarn install
-
-# Build prisma schema and make sure that it is linked to v2 node_modules
 RUN yarn workspace @calcom/api-v2 run generate-schemas
-RUN rm -rf apps/api/v2/node_modules
-RUN yarn install
-
 RUN yarn workspace @calcom/platform-libraries run build
-
 RUN yarn workspace @calcom/api-v2 run build
 
 EXPOSE 80


### PR DESCRIPTION
Now that we are on Prisma v6.16 and its generated code doesn't go into `node_modules`, this isn't needed.