### PR TITLE
refactor: set minimum seat count two for seated events

### DIFF
--- a/apps/api/v1/lib/validations/event-type.ts
+++ b/apps/api/v1/lib/validations/event-type.ts
@@ -108,7 +108,7 @@ const schemaEventTypeEditParams = z
       .transform((s) => slugify(s))
       .optional(),
     length: z.number().int().optional(),
-    seatsPerTimeSlot: z.number().min(1).max(MAX_SEATS_PER_TIME_SLOT).nullable().optional(),
+    seatsPerTimeSlot: z.number().min(2).max(MAX_SEATS_PER_TIME_SLOT).nullable().optional(),
     seatsShowAttendees: z.boolean().optional(),
     seatsShowAvailabilityCount: z.boolean().optional(),
     bookingFields: eventTypeBookingFields.optional(),

--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -1048,8 +1048,8 @@ export const EventAdvancedTab = ({
                         //For old events if value > MAX_SEATS_PER_TIME_SLOT
                         value={value > MAX_SEATS_PER_TIME_SLOT ? MAX_SEATS_PER_TIME_SLOT : value ?? 1}
                         step={1}
-                        placeholder="1"
-                        min={1}
+                        placeholder="2"
+                        min={2}
                         max={MAX_SEATS_PER_TIME_SLOT}
                         containerClassName={classNames(
                           "max-w-80",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/seats.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/seats.input.ts
@@ -6,7 +6,7 @@ import { MAX_SEATS_PER_TIME_SLOT } from "@calcom/platform-constants";
 // Class representing the seat options
 export class Seats_2024_06_14 {
   @IsInt()
-  @Min(1)
+  @Min(2)
   @Max(MAX_SEATS_PER_TIME_SLOT)
   @ApiProperty({
     description: "Number of seats available per time slot",

--- a/packages/trpc/server/routers/viewer/eventTypes/types.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/types.ts
@@ -101,7 +101,7 @@ const BaseEventTypeUpdateInput = EventTypeSchema.extend({
   assignRRMembersUsingSegment: z.boolean().optional(),
   rrSegmentQueryValue: rrSegmentQueryValueSchema.optional(),
   useEventLevelSelectedCalendars: z.boolean().optional(),
-  seatsPerTimeSlot: z.number().min(1).max(MAX_SEATS_PER_TIME_SLOT).nullable().optional(),
+  seatsPerTimeSlot: z.number().min(2).max(MAX_SEATS_PER_TIME_SLOT).nullable().optional(),
   hostGroups: z.array(hostGroupSchema).optional(),
 })
   .partial()


### PR DESCRIPTION
## What does this PR do?

This PR enforces a minimum seat count of 2 for the "Offer seats" feature.

Currently, the feature allows setting a minimum of 1 seat, which is functionally equivalent to a regular 1-on-1 booking and doesn’t align with the purpose of seat sharing. By enforcing a minimum of 2 seats, we ensure the feature behaves as intended, enabling multiple participants to join the same time slot.


https://github.com/user-attachments/assets/c694b3bd-7db2-4ae3-abdd-d3005eb3dc49

