### PR TITLE
fix: require notice threshold when type time

### DIFF
--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/confirmation-policy.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/confirmation-policy.input.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsEnum, IsOptional, IsInt, ValidateNested, IsBoolean } from "class-validator";
+import { IsEnum, IsOptional, IsInt, ValidateNested, IsBoolean, ValidateIf } from "class-validator";
 import type { ValidatorConstraintInterface, ValidationOptions } from "class-validator";
 import { ValidatorConstraint, registerDecorator } from "class-validator";
 
@@ -35,7 +35,7 @@ export class BaseConfirmationPolicy_2024_06_14 {
   })
   type!: ConfirmationPolicyEnum;
 
-  @IsOptional()
+  @ValidateIf((o) => o.type === ConfirmationPolicyEnum.TIME || o.noticeThreshold !== undefined)
   @ValidateNested()
   @Type(() => NoticeThreshold_2024_06_14)
   @ApiPropertyOptional({


### PR DESCRIPTION

### **What does this PR do?**

**Problem:**
The `@IsOptional()` decorator on line 38 allowed the `noticeThreshold` field to be completely omitted, even when `type === "time"`. While there was a custom validator (`ConfirmationPolicyValidator`) checking for this condition, the `@IsOptional()` decorator was evaluated first and bypassed the validation logic.

**Solution:**
Replaced `@IsOptional()` with `@ValidateIf()` to conditionally enforce the presence of the `noticeThreshold` field based on the value of `type`:

```typescript
@ValidateIf((o) => o.type === ConfirmationPolicyEnum.TIME || o.noticeThreshold !== undefined)
```

This ensures the following behaviors:

* **When `type === "time"`:** The `noticeThreshold` field **must** be present and will be validated.
* **When `type === "always"`:** The `noticeThreshold` field is **optional** and will not be validated if omitted.
* **When `noticeThreshold` is provided:** It will always be validated regardless of the `type` value.

**Result:**
With this change, if you send the following request:

```json
{
  "type": "time",
  "requiresConfirmationThreshold": { "time": 10 }
}
```

Without providing the `noticeThreshold` field, the validation will fail and return an appropriate error message, enforcing that `noticeThreshold` is required when `type` is `"time"`.