### PR TITLE
chore: Implement onboarding redirect logic in event-types and main page components

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { checkOnboardingRedirect } from "@calcom/features/auth/lib/onboardingUtils";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
@@ -11,6 +12,17 @@ const RedirectPage = async () => {
   if (!session?.user?.id) {
     redirect("/auth/login");
   }
+
+  // Check if user needs onboarding and redirect before going to event-types
+  const organizationId = session.user.profile?.organizationId ?? null;
+  const onboardingPath = await checkOnboardingRedirect(session.user.id, {
+    checkEmailVerification: true,
+    organizationId,
+  });
+  if (onboardingPath) {
+    redirect(onboardingPath);
+  }
+
   redirect("/event-types");
 };
 

--- a/packages/features/auth/lib/onboardingUtils.ts
+++ b/packages/features/auth/lib/onboardingUtils.ts
@@ -1,0 +1,79 @@
+import dayjs from "@calcom/dayjs";
+import prisma from "@calcom/prisma";
+
+const ONBOARDING_INTRODUCED_AT = dayjs("September 1 2021").toISOString();
+
+/**
+ * Checks if a user needs onboarding on the server side.
+ * Returns the onboarding path if redirect is needed, null otherwise.
+ *
+ * @param userId - The user ID to check
+ * @param options - Optional configuration
+ * @param options.checkEmailVerification - Whether to check if email verification is required
+ * @param options.organizationId - Optional organizationId from session (to avoid extra query)
+ */
+export async function checkOnboardingRedirect(
+  userId: number,
+  options?: {
+    checkEmailVerification?: boolean;
+    organizationId?: number | null;
+  }
+): Promise<string | null> {
+  // Query minimal user data needed for onboarding check
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      completedOnboarding: true,
+      createdDate: true,
+      emailVerified: true,
+      identityProvider: true,
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  // Use provided organizationId or query it
+  let organizationId: number | null;
+  if (options?.organizationId !== undefined) {
+    organizationId = options.organizationId;
+  } else {
+    // Check if user has any profile with an organization
+    const profile = await prisma.profile.findFirst({
+      where: { userId },
+      select: { organizationId: true },
+      orderBy: { createdAt: "asc" },
+    });
+    organizationId = profile?.organizationId ?? null;
+  }
+
+  // Check if user should be shown onboarding
+  const shouldShowOnboarding =
+    !user.completedOnboarding && !organizationId && dayjs(user.createdDate).isAfter(ONBOARDING_INTRODUCED_AT);
+
+  if (!shouldShowOnboarding) {
+    return null;
+  }
+
+  // Check email verification if needed
+  if (options?.checkEmailVerification) {
+    const { FeaturesRepository } = await import("@calcom/features/flags/features.repository");
+    const featuresRepository = new FeaturesRepository(prisma);
+    const emailVerificationEnabled = await featuresRepository.checkIfFeatureIsEnabledGlobally(
+      "email-verification"
+    );
+
+    if (!user.emailVerified && user.identityProvider === "CAL" && emailVerificationEnabled) {
+      // User needs email verification, don't redirect to onboarding yet
+      return null;
+    }
+  }
+
+  // Determine which onboarding path to use
+  const { FeaturesRepository } = await import("@calcom/features/flags/features.repository");
+  const featuresRepository = new FeaturesRepository(prisma);
+  const onboardingV3Enabled = await featuresRepository.checkIfFeatureIsEnabledGlobally("onboarding-v3");
+
+  return onboardingV3Enabled ? "/onboarding/getting-started" : "/getting-started";
+}


### PR DESCRIPTION
## What does this PR do?

Currently we load /event-types for a few seconds while the onboarding hook catches up. This adds that logic to the serverside and not just client side to ensure onboarding is triggered

Adds server-side onboarding redirect checks to prevent users from accessing event types pages before completing onboarding. This implementation:

- Creates a new `checkOnboardingRedirect` utility function in a dedicated file
- Applies the redirect check on both the root page and event-types page
- Optimizes performance by using organizationId from session when available
- Handles email verification requirements before redirecting to onboarding
- Supports both legacy and v3 onboarding paths based on feature flags

## How should this be tested?

- Create a new user account that hasn't completed onboarding
- Attempt to access the root page or event-types page directly
- Verify you're redirected to the appropriate onboarding flow
- Test with email verification feature flag enabled/disabled
- Test with onboarding-v3 feature flag enabled/disabled
- Verify users who have completed onboarding can access event-types normally
- Verify organization users aren't redirected to onboarding

## Video Demo

Before:

[CleanShot 2025-10-30 at 10.54.41.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/8282decc-a00d-4bc8-9215-fe1c4809fd8f.mp4" />](https://app.graphite.dev/user-attachments/video/8282decc-a00d-4bc8-9215-fe1c4809fd8f.mp4)

After

## [CleanShot 2025-10-30 at 10.54.06.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/2acc7601-6c8c-496a-af4d-08dadef9aa2d.mp4" />](https://app.graphite.dev/user-attachments/video/2acc7601-6c8c-496a-af4d-08dadef9aa2d.mp4)

## Checklist

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works