### PR TITLE
chore: redirect if part of orgs or not company email

### DIFF
--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/layout.tsx
@@ -1,0 +1,36 @@
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { isCompanyEmail } from "@calcom/features/ee/organizations/lib/utils";
+import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
+import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { prisma } from "@calcom/prisma";
+
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
+
+export default async function OrganizationOnboardingLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+
+  if (!session?.user?.id) {
+    return redirect("/auth/login");
+  }
+
+  const userEmail = session.user.email || "";
+  const userId = session.user.id;
+
+  const gettingStartedPath = await OnboardingPathService.getGettingStartedPath(prisma);
+
+  if (!isCompanyEmail(userEmail)) {
+    return redirect(gettingStartedPath);
+  }
+
+  const userRepository = new UserRepository(prisma);
+  const { organizations } = await userRepository.findOrganizations({ userId });
+
+  if (organizations.length > 0) {
+    return redirect(gettingStartedPath);
+  }
+
+  return children;
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new layout component for organization onboarding that:
- Redirects unauthenticated users to the login page
- Redirects users without company emails to the standard getting started path
- Redirects users who already belong to organizations to the standard getting started path
- Only allows users with company emails who don't belong to any organization to proceed with organization onboarding

## How should this be tested?

- Test with a user who has a company email and doesn't belong to any organization - should proceed to organization onboarding
- Test with a user who has a non-company email - should redirect to standard getting started path
- Test with a user who already belongs to an organization - should redirect to standard getting started path
- Test with an unauthenticated user - should redirect to login page

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings