### PR TITLE
fix: changesets node version

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node and registry for OIDC
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "20.17.0"
           registry-url: "https://registry.npmjs.org"
       - name: Setup node, yarn and install dependencies
         uses: ./.github/actions/yarn-install


### PR DESCRIPTION
Fixes #24811

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Node to 20.17.0 in the Changesets workflow to prevent publish failures from Node/npm version mismatches. Aligns with CAL-6667 and fixes #24811.

<sup>Written for commit b1482bc3a7174a3ed4f04f90f2339d9ed5fd2693. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

