### PR TITLE
fix: run changesets on github hosted runner

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     if: github.repository == 'calcom/cal.com' # prevent this action from running on forks
     name: Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     if: github.repository == 'calcom/cal.com' # prevent this action from running on forks
     name: Release
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #24824



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the changesets release workflow to a GitHub-hosted ubuntu-latest runner to improve reliability and remove the BuildJet dependency. Fixes #24824.

- **Bug Fixes**
  - Update runs-on to ubuntu-latest in .github/workflows/changesets.yml.

<sup>Written for commit bee932a8adedff5a4926d1405b263ca82d85d0c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



