### PR TITLE
fix: specify atoms package.json repository

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: "20.17.0"
           registry-url: "https://registry.npmjs.org"
+          always-auth: false
       - name: Setup node, yarn and install dependencies
         uses: ./.github/actions/yarn-install
       - name: Install npm at version supporting OIDC

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -5,6 +5,10 @@
   "description": "Customizable UI components to integrate scheduling into your product.",
   "authors": "Cal.com, Inc.",
   "version": "1.12.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/calcom/cal.com"
+  },
   "scripts": {
     "dev": "yarn vite build --watch & npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify --watch",
     "build": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx tailwindcss -i ./globals.css -o ./globals.min.css --postcss --minify",


### PR DESCRIPTION
Fixes #24827



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repository metadata to packages/platform/atoms/package.json so npm and tooling correctly link to https://github.com/calcom/cal.com. Also sets always-auth to false in the changesets workflow, addressing #24827.

<sup>Written for commit ed28c2ea7278dc9059a3ff6d0d65f4fa8ae019d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



