### PR TITLE
fix: consistent slug validation in team url

### DIFF
--- a/packages/features/ee/teams/components/CreateANewTeamForm.tsx
+++ b/packages/features/ee/teams/components/CreateANewTeamForm.tsx
@@ -118,7 +118,10 @@ export const CreateANewTeamForm = (props: CreateANewTeamFormProps) => {
                   onChange={(e) => {
                     newTeamFormMethods.setValue("name", e?.target.value);
                     if (newTeamFormMethods.formState.touchedFields["slug"] === undefined) {
-                      newTeamFormMethods.setValue("slug", slugify(e?.target.value));
+                      const value = e?.target.value || "";
+                      const slugified = slugify(value);
+                      const sanitized = slugified.replace(/[^a-z0-9-]/g, "");
+                      newTeamFormMethods.setValue("slug", sanitized);
                     }
                   }}
                   autoComplete="off"
@@ -147,7 +150,10 @@ export const CreateANewTeamForm = (props: CreateANewTeamFormProps) => {
                 value={value}
                 defaultValue={value}
                 onChange={(e) => {
-                  newTeamFormMethods.setValue("slug", slugify(e?.target.value, true), {
+                  const value = e?.target.value || "";
+                  const slugified = slugify(value, true);
+                  const sanitized = slugified.replace(/[^a-z0-9-]/g, "");
+                  newTeamFormMethods.setValue("slug", sanitized, {
                     shouldTouch: true,
                   });
                   newTeamFormMethods.clearErrors("slug");


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent team slug validation between the **create** and **edit** flows.
Previously, users could create teams with slugs containing special characters, but editing those teams later caused validation errors.  
This PR unifies slug validation logic across both flows, ensuring consistent and predictable behavior.


- Fixes #24776
- Fixes CAL-6662

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

Before:

https://github.com/user-attachments/assets/ad3581ff-3e14-4f73-83da-0873f28d8822



After:

https://github.com/user-attachments/assets/14db76a0-e3b1-4615-8dcf-153f539bf9b5




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Try creating a team.
- When entering a team URL with invalid characters, it automatically converts it to a valid format.

