### PR TITLE
fix: block non-numeric chars in time input

### DIFF
--- a/packages/features/ee/workflows/components/TimeTimeUnitInput.tsx
+++ b/packages/features/ee/workflows/components/TimeTimeUnitInput.tsx
@@ -71,7 +71,7 @@ export const TimeTimeUnitInput = (props: Props) => {
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
             const allowedKeys = ["Backspace", "Tab", "ArrowLeft", "ArrowRight", "Delete", "Home", "End"];
             if (allowedKeys.includes(e.key)) return;
-            if (["e", "E", "+", "-", "."].includes(e.key)) {
+            if (["e", "E", "+", "-", ".", "Decimal", "Add", "Subtract"].includes(e.key)) {
               e.preventDefault();
             }
           }}

--- a/packages/features/ee/workflows/components/TimeTimeUnitInput.tsx
+++ b/packages/features/ee/workflows/components/TimeTimeUnitInput.tsx
@@ -3,8 +3,6 @@ import { useFormContext } from "react-hook-form";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { TimeUnit } from "@calcom/prisma/enums";
-import { Icon } from "@calcom/ui/components/icon";
-import { TextField } from "@calcom/ui/components/form";
 import {
   Dropdown,
   DropdownItem,
@@ -12,6 +10,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
+import { TextField } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 
 const TIME_UNITS = [TimeUnit.DAY, TimeUnit.HOUR, TimeUnit.MINUTE] as const;
 
@@ -60,12 +60,21 @@ export const TimeTimeUnitInput = (props: Props) => {
       <div className="grow">
         <TextField
           type="number"
-          min="1"
+          min={1}
+          inputMode="numeric"
+          pattern="[0-9]*"
           label=""
           disabled={props.disabled}
           defaultValue={form.getValues("time") ?? props.defaultTime ?? 24}
           className="rounded-r-none text-sm focus:ring-0"
           {...form.register("time", { valueAsNumber: true })}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            const allowedKeys = ["Backspace", "Tab", "ArrowLeft", "ArrowRight", "Delete", "Home", "End"];
+            if (allowedKeys.includes(e.key)) return;
+            if (["e", "E", "+", "-", "."].includes(e.key)) {
+              e.preventDefault();
+            }
+          }}
           addOnSuffix={
             <TimeUnitAddonSuffix
               timeUnitOptions={timeUnitOptions}


### PR DESCRIPTION
## What does this PR do?

Fixes a UX issue in the workflow editor where users could enter non-numeric characters (e, E, +, -, .) into the "How long before/after event starts?" time input field. This occurred because HTML number inputs accept scientific notation and signs by default.

- Fixes #24834
- Fixes [CAL-6673](https://linear.app/calcom/issue/CAL-6673/workflow-time-input-accepts-non-numeric-characters-e-e)

## Visual Demo (For contributors especially)

#### Video Demo: 

**Before:** 

https://github.com/user-attachments/assets/eb6c43f0-3257-4c98-958d-ddf8fbe54e18

**After:**

https://github.com/user-attachments/assets/03f767c3-33c8-4ae5-a938-b69ac6867ba0


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). **N/A** - This is a bug fix with no API/documentation changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Manual verification recommended** - The fix prevents keyboard input of specific characters which is difficult to test in automated tests but can be verified manually.

## How should this be tested?

- Are there environment variables that should be set?
- Navigate to https://app.cal.com/workflows/
- Enter values in "Which event type will this apply to?" like "E,e,+,-"
