### PR TITLE
fix: secondary email delete in profile fixed

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2883,6 +2883,8 @@
   "add_email": "Add Email",
   "add_emails": "Add Emails",
   "add_email_description": "Add an email address to replace your primary or to use as an alternative email on your event types.",
+  "secondary_email_deleted": "Secondary email deleted successfully",
+  "error_deleting_secondary_email": "Error deleting secondary email",
   "confirm_email": "Confirm your email",
   "confirming_your_booking_sms": "$t(hey_there) {{name}}, confirming your booking on {{date}}.",
   "scheduler_first_name": "The first name of the person booking",

--- a/packages/trpc/server/routers/loggedInViewer/_router.tsx
+++ b/packages/trpc/server/routers/loggedInViewer/_router.tsx
@@ -2,6 +2,7 @@ import authedProcedure from "../../procedures/authedProcedure";
 import { router } from "../../trpc";
 import { ZAddNotificationsSubscriptionInputSchema } from "./addNotificationsSubscription.schema";
 import { ZAddSecondaryEmailInputSchema } from "./addSecondaryEmail.schema";
+import { ZRemoveSecondaryEmailInputSchema } from "./removeSecondaryEmail.schema";
 import { ZConnectAndJoinInputSchema } from "./connectAndJoin.schema";
 import { ZEventTypeOrderInputSchema } from "./eventTypeOrder.schema";
 import { ZNoShowInputSchema } from "./markNoShow.schema";
@@ -9,13 +10,14 @@ import { teamsAndUserProfilesQuery } from "./procedures/teamsAndUserProfilesQuer
 import { ZRemoveNotificationsSubscriptionInputSchema } from "./removeNotificationsSubscription.schema";
 import { ZRoutingFormOrderInputSchema } from "./routingFormOrder.schema";
 
-type AppsRouterHandlerCache = {
+type _AppsRouterHandlerCache = {
   stripeCustomer?: typeof import("./stripeCustomer.handler").stripeCustomerHandler;
   eventTypeOrder?: typeof import("./eventTypeOrder.handler").eventTypeOrderHandler;
   routingFormOrder?: typeof import("./routingFormOrder.handler").routingFormOrderHandler;
   teamsAndUserProfilesQuery?: typeof import("./teamsAndUserProfilesQuery.handler").teamsAndUserProfilesQuery;
   connectAndJoin?: typeof import("./connectAndJoin.handler").Handler;
   addSecondaryEmail?: typeof import("./addSecondaryEmail.handler").addSecondaryEmailHandler;
+  removeSecondaryEmail?: typeof import("./removeSecondaryEmail.handler").removeSecondaryEmailHandler;
   addNotificationsSubscription?: typeof import("./addNotificationsSubscription.handler").addNotificationsSubscriptionHandler;
   removeNotificationsSubscription?: typeof import("./removeNotificationsSubscription.handler").removeNotificationsSubscriptionHandler;
   markNoShow?: typeof import("./markNoShow.handler").markNoShow;
@@ -53,6 +55,12 @@ export const loggedInViewerRouter = router({
     const { addSecondaryEmailHandler } = await import("./addSecondaryEmail.handler");
     return addSecondaryEmailHandler({ ctx, input });
   }),
+  removeSecondaryEmail: authedProcedure
+    .input(ZRemoveSecondaryEmailInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { removeSecondaryEmailHandler } = await import("./removeSecondaryEmail.handler");
+      return removeSecondaryEmailHandler({ ctx, input });
+    }),
   addNotificationsSubscription: authedProcedure
     .input(ZAddNotificationsSubscriptionInputSchema)
     .mutation(async ({ ctx, input }) => {

--- a/packages/trpc/server/routers/loggedInViewer/removeSecondaryEmail.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/removeSecondaryEmail.handler.ts
@@ -1,0 +1,40 @@
+import type { GetServerSidePropsContext, NextApiResponse } from "next";
+import { prisma } from "@calcom/prisma";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
+import { TRPCError } from "@trpc/server";
+import type { TRemoveSecondaryEmailInputSchema } from "./removeSecondaryEmail.schema";
+
+type RemoveSecondaryEmailOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+    res?: NextApiResponse | GetServerSidePropsContext["res"];
+  };
+  input: TRemoveSecondaryEmailInputSchema;
+};
+
+export const removeSecondaryEmailHandler = async ({ ctx, input }: RemoveSecondaryEmailOptions) => {
+  const { user } = ctx;
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: `removeSecondaryEmail.${user.id}`,
+  });
+
+  // Ensure the secondary email exists and belongs to the current user
+  const existing = await prisma.secondaryEmail.findUnique({
+    where: { id: input.id },
+    select: { id: true, userId: true, email: true },
+  });
+
+  if (!existing) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Secondary email not found" });
+  }
+
+  if (existing.userId !== user.id) {
+    throw new TRPCError({ code: "FORBIDDEN", message: "Not authorized to delete this secondary email" });
+  }
+
+  const deleted = await prisma.secondaryEmail.delete({ where: { id: input.id } });
+
+  return { data: deleted, message: "Secondary email removed" };
+};

--- a/packages/trpc/server/routers/loggedInViewer/removeSecondaryEmail.schema.ts
+++ b/packages/trpc/server/routers/loggedInViewer/removeSecondaryEmail.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const ZRemoveSecondaryEmailInputSchema = z.object({
+  id: z.number().int().positive(),
+});
+
+export type TRemoveSecondaryEmailInputSchema = z.infer<typeof ZRemoveSecondaryEmailInputSchema>;


### PR DESCRIPTION
## What does this PR do?

- Fixes #24844 
- Fixes CAL-6676
- added removeSecondaryEmail handler and schema which ensures that the deleted secondary email is also removed from the database.
- updated handleItemDelete to use the removeSecondaryEmail to delete the secondary email correctly.
- secondary email deletion marked as dirtyData so that if form is submitted, the changes are propagated
- changes in code to fix eslint errors

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

Before:

https://github.com/user-attachments/assets/5a1df302-a550-4d42-8518-d70322609db0

After:

https://github.com/user-attachments/assets/1b692d8c-ef17-4e1c-84c0-7a93cf0dbf80

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. - N/A

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Go to profile section
- add secondary email
- delete the email
- create new secondary email with same as the previous one, see that it is allowed now
- refreshing the page doesn't make the deleted mail reappear
