### PR TITLE
fix(docker): correct build context for calcom-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
   calcom-api:
     container_name: calcom-api
     build:
-      context: ./calcom
+      context: .
       dockerfile: apps/api/v2/Dockerfile
       args:
         DATABASE_URL: ${DATABASE_URL}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24842 
- Fixes CAL-6675

This PR corrects the `build.context` for the `calcom-api` service in the `docker-compose.yml` file. The context was pointing to a non-existent `./calcom` directory, which caused `docker compose up -d` to fail. This changes it to `.` to match the repository's current structure.

## Demo

`docker compose ps` now runs the containers as expected, following the deployment steps exactly.

#### Image Demo:

I have tested this locally. Here is the output from `docker compose ps` showing all services are running:

<img width="1920" height="166" alt="Screenshot 2025-11-02 21-10-08" src="https://github.com/user-attachments/assets/1b16370b-e2a4-4c2a-b3ad-d4cd142eb6c4" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Follow Docker deployment guide
2. `docker compose up -d` should now work

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas (N/A)
- I have checked if my changes generate no new warnings
