### PR TITLE
fix: round robin settings can be updated only on change

### DIFF
--- a/packages/features/ee/teams/components/RoundRobinSettings.tsx
+++ b/packages/features/ee/teams/components/RoundRobinSettings.tsx
@@ -26,12 +26,22 @@ const RoundRobinSettings = ({ team }: RoundRobinSettingsProps) => {
   const rrResetInterval = team?.rrResetInterval ?? undefined;
   const utils = trpc.useUtils();
 
+  const initialResetInterval = rrResetInterval ?? RRResetInterval.MONTH;
+  const initialTimestampBasis = team?.rrTimestampBasis ?? RRTimestampBasis.CREATED_AT;
+
   const form = useForm<{ rrResetInterval: RRResetInterval; rrTimestampBasis: RRTimestampBasis }>({
     defaultValues: {
-      rrResetInterval: rrResetInterval ?? RRResetInterval.MONTH,
-      rrTimestampBasis: team?.rrTimestampBasis ?? RRTimestampBasis.CREATED_AT,
+      rrResetInterval: initialResetInterval,
+      rrTimestampBasis: initialTimestampBasis,
     },
   });
+
+  const [watchedResetInterval, watchedTimestampBasis] = form.watch([
+    "rrResetInterval",
+    "rrTimestampBasis",
+  ]);
+  const hasChanges =
+    watchedResetInterval !== initialResetInterval || watchedTimestampBasis !== initialTimestampBasis;
 
   const mutation = trpc.viewer.teams.update.useMutation({
     onError: (err) => {
@@ -85,7 +95,7 @@ const RoundRobinSettings = ({ team }: RoundRobinSettingsProps) => {
         </div>
       </div>
       <SectionBottomActions align="end">
-        <Button type="submit" color="primary" loading={mutation.isPending}>
+        <Button type="submit" disabled={!hasChanges} color="primary" loading={mutation.isPending}>
           {t("update")}
         </Button>
       </SectionBottomActions>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24852
- Fixes CAL-6679
- added watch variables for Reset Interval & Timestamp Basis so that the update button only appears if these change, otherwise it will be disabled

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

Before:

https://github.com/user-attachments/assets/b1f4e25a-0826-40c0-ab8e-08e3752e4a67

After:

https://github.com/user-attachments/assets/60f1685b-31a5-4cc5-a622-76e1f7c94c02


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to team settings
- If there is no change in the round robin settings then the update button is disabled
- If you change any field then the update button is enabled now
