### PR TITLE
fix: “Maximum update depth exceeded” on email verification Dialog

### DIFF
--- a/.changeset/bitter-peas-pull.md
+++ b/.changeset/bitter-peas-pull.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": minor
+---
+
+Fix Booker atom verify email dialog infinite re-render when entering verification code

--- a/packages/features/bookings/components/VerifyCodeDialog.tsx
+++ b/packages/features/bookings/components/VerifyCodeDialog.tsx
@@ -68,6 +68,7 @@ export const VerifyCodeDialog = ({
     value,
     email,
     verifyCodeWithSessionNotRequired,
+    setVerificationCode,
   ]);
 
   useEffect(() => {
@@ -77,7 +78,8 @@ export const VerifyCodeDialog = ({
     if (hasVerified || error || isPending || !/^\d{6}$/.test(value.trim())) return;
 
     verifyCode();
-  }, [error, isPending, value, verifyCode, hasVerified]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error, isPending, value, hasVerified]);
 
   useEffect(() => setValue(""), [isOpenDialog]);
 


### PR DESCRIPTION
## What does this PR do?

Fixes infinite loop causing "Maximum update depth exceeded" error when entering the 6th digit of the email verification code.

## Before
https://www.loom.com/share/fd56cd3ef13d41939bd4623cb68af627

## After
https://www.loom.com/share/e94fba14b1f74e8fbeca3ea2e5c78a5d
