### PR TITLE
fix: Arrows visible when embed has hidden entire page

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -125,16 +125,19 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         style={
           isEmbed
             ? {
-                background: "transparent",
-                // Keep the embed hidden till parent initializes and
-                // - gives it the appropriate styles if UI instruction is there.
-                // - gives iframe the appropriate height(equal to document height) which can only be known after loading the page once in browser.
-                // - Tells iframe which mode it should be in (dark/light) - if there is a a UI instruction for that
-                visibility: "hidden",
-              }
+              background: "transparent",
+              // Keep the embed hidden till parent initializes and
+              // - gives it the appropriate styles if UI instruction is there.
+              // - gives iframe the appropriate height(equal to document height) which can only be known after loading the page once in browser.
+              // - Tells iframe which mode it should be in (dark/light) - if there is a a UI instruction for that
+              visibility: "hidden",
+              // This in addition to visibility: hidden is to ensure that elements with specific opacity set are not visible
+              opacity: 0,
+            }
             : {
-                visibility: "visible",
-              }
+              visibility: "visible",
+              opacity: 1,
+            }
         }>
         <IconSprites />
         <SpeculationRules

--- a/packages/embeds/embed-core/src/embed-iframe.ts
+++ b/packages/embeds/embed-core/src/embed-iframe.ts
@@ -111,15 +111,15 @@ const setEmbedNonStyles = (stylesConfig: EmbedNonStylesConfig) => {
 const registerNewSetter = (
   registration:
     | {
-        elementName: keyof EmbedStyles;
-        setState: SetStyles;
-        styles: true;
-      }
+      elementName: keyof EmbedStyles;
+      setState: SetStyles;
+      styles: true;
+    }
     | {
-        elementName: keyof EmbedNonStylesConfig;
-        setState: setNonStylesConfig;
-        styles: false;
-      }
+      elementName: keyof EmbedNonStylesConfig;
+      setState: setNonStylesConfig;
+      styles: false;
+    }
 ) => {
   // It's possible that 'ui' instruction has already been processed and the registration happened due to some action by the user in iframe.
   // So, we should call the setter immediately with available embedStyles
@@ -285,6 +285,9 @@ export const useEmbedType = () => {
 function makeBodyVisible() {
   if (document.body.style.visibility !== "visible") {
     document.body.style.visibility = "visible";
+  }
+  if (document.body.style.opacity !== "1") {
+    document.body.style.opacity = "1";
   }
   // Ensure that it stays visible and not reverted by React
   runAsap(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where navigation arrows were visible during embed initialization despite the body being hidden.

Reported in this private thread - https://calcominc.slack.com/archives/C08G5F1KCBX/p1761472482406269?thread_ts=1761283399.298459&cid=C08G5F1KCBX


<img width="1148" height="848" alt="image" src="https://github.com/user-attachments/assets/c67c17b3-e332-4f92-a0c8-fe78339c2fcb" />

### Problem
When an embed is initializing, we set `visibility: hidden` on the body to hide the page until:
- Parent iframe gives appropriate styles
- Iframe gets the correct height
- Dark/light mode is determined

However, elements with specific opacity values (like navigation arrows) were still showing through because they had their own opacity settings that weren't affected by `visibility: hidden` alone.

### Solution
- Added `opacity: 0` in addition to `visibility: hidden` during embed initialization
- When making the body visible, we now restore both `visibility: visible` and `opacity: 1`
- This ensures that all elements, including those with specific opacity values, are fully hidden during initialization

### Changes
- **apps/web/app/layout.tsx**: Added opacity properties to embed body styles
  - Initialization: `visibility: "hidden", opacity: 0`
  - Visible state: `visibility: "visible", opacity: 1`
- **packages/embeds/embed-core/src/embed-iframe.ts**: Updated `makeBodyVisible()` to restore opacity to "1" alongside visibility

## Mandatory Tasks
- [x] I have self-reviewed the code
- [x] Documentation changes: N/A - This is a visual bug fix
- [x] Automated tests: Existing embed tests cover this behavior

## How should this be tested?

### Manual Testing
1. Create an embed on any page
2. Reload the page
3. During the brief initialization period, verify that no navigation arrows or other UI elements flash/appear
4. Verify the embed displays correctly after initialization

### Environment
- No special environment variables needed
- Test with any embed configuration
- Expected: No UI elements should be visible during embed initialization

---
## Summary by cubic
Fully hides the host page during embed initialization to stop navigation arrows from showing. Uses visibility and opacity together, then restores both when the page is shown.

- **Bug Fixes**
  - apps/web/app/layout.tsx: add opacity: 0 when isEmbed and opacity: 1 when visible to ensure no elements leak through.
  - embed-core: makeBodyVisible now sets document.body.opacity to "1" alongside visibility to keep state consistent.

