### PR TITLE
refactor: extract booking actions dropdown to separate component

### DIFF
--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -367,11 +367,8 @@ export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps)
     eventType: booking.eventType.id ? booking.eventType : null,
   };
 
-  if (!shouldShowEditActions(actionContext)) {
-    return null;
-  }
-
-  return (
+  // Render dialogs that might be triggered from BookingListItem even if dropdown is not shown
+  const dialogs = (
     <>
       <RescheduleDialog
         isOpenDialog={isOpenRescheduleDialog}
@@ -475,7 +472,17 @@ export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps)
           booking={{ ...parsedBooking, eventType: parsedBooking.eventType }}
         />
       )}
+    </>
+  );
 
+  // Don't render dropdown if edit actions shouldn't be shown
+  if (!shouldShowEditActions(actionContext)) {
+    return dialogs;
+  }
+
+  return (
+    <>
+      {dialogs}
       <Dropdown>
         <DropdownMenuTrigger asChild>
           <Button

--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -29,6 +29,7 @@ import { ReportBookingDialog } from "@components/dialog/ReportBookingDialog";
 import { RerouteDialog } from "@components/dialog/RerouteDialog";
 import { RescheduleDialog } from "@components/dialog/RescheduleDialog";
 
+import type { BookingItemProps } from "./BookingListItem";
 import {
   getCancelEventAction,
   getEditEventActions,
@@ -37,7 +38,6 @@ import {
   shouldShowEditActions,
   type BookingActionContext,
 } from "./bookingActions";
-import type { BookingItemProps } from "./BookingListItem";
 
 interface BookingActionsDropdownProps {
   booking: BookingItemProps;
@@ -301,7 +301,7 @@ export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps)
 
     return (
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent title={t("mark_as_no_show")} description={t("mark_as_no_show_description")}>
+        <DialogContent title={t("mark_as_no_show")}>
           <div className="space-y-2">
             {attendees.map((attendee, index) => (
               <label key={attendee.email} className="flex items-center space-x-2">

--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -37,7 +37,7 @@ import {
   shouldShowEditActions,
   type BookingActionContext,
 } from "./bookingActions";
-import type { BookingItemProps } from "./BookingListItem";
+import type { BookingItemProps } from "./types";
 
 interface BookingActionsDropdownProps {
   booking: BookingItemProps;

--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -1,0 +1,545 @@
+import { useState } from "react";
+
+import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { MeetingSessionDetailsDialog } from "@calcom/features/ee/video/MeetingSessionDetailsDialog";
+import ViewRecordingsDialog from "@calcom/features/ee/video/ViewRecordingsDialog";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import { Button } from "@calcom/ui/components/button";
+import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuPortal,
+} from "@calcom/ui/components/dropdown";
+import { TextAreaField } from "@calcom/ui/components/form";
+import type { ActionType } from "@calcom/ui/components/table";
+import { showToast } from "@calcom/ui/components/toast";
+
+import { AddGuestsDialog } from "@components/dialog/AddGuestsDialog";
+import { ChargeCardDialog } from "@components/dialog/ChargeCardDialog";
+import { EditLocationDialog } from "@components/dialog/EditLocationDialog";
+import { ReassignDialog } from "@components/dialog/ReassignDialog";
+import { ReportBookingDialog } from "@components/dialog/ReportBookingDialog";
+import { RerouteDialog } from "@components/dialog/RerouteDialog";
+import { RescheduleDialog } from "@components/dialog/RescheduleDialog";
+
+import {
+  getCancelEventAction,
+  getEditEventActions,
+  getAfterEventActions,
+  getReportAction,
+  shouldShowEditActions,
+  type BookingActionContext,
+} from "./bookingActions";
+import type { BookingItemProps } from "./BookingListItem";
+
+interface BookingActionsDropdownProps {
+  booking: BookingItemProps;
+}
+
+export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps) {
+  const { t } = useLocale();
+  const utils = trpc.useUtils();
+
+  const [rejectionReason, setRejectionReason] = useState<string>("");
+  const [rejectionDialogIsOpen, setRejectionDialogIsOpen] = useState(false);
+  const [chargeCardDialogIsOpen, setChargeCardDialogIsOpen] = useState(false);
+  const [viewRecordingsDialogIsOpen, setViewRecordingsDialogIsOpen] = useState<boolean>(false);
+  const [meetingSessionDetailsDialogIsOpen, setMeetingSessionDetailsDialogIsOpen] = useState<boolean>(false);
+  const [isNoShowDialogOpen, setIsNoShowDialogOpen] = useState<boolean>(false);
+  const [isOpenRescheduleDialog, setIsOpenRescheduleDialog] = useState(false);
+  const [isOpenReassignDialog, setIsOpenReassignDialog] = useState(false);
+  const [isOpenSetLocationDialog, setIsOpenLocationDialog] = useState(false);
+  const [isOpenAddGuestsDialog, setIsOpenAddGuestsDialog] = useState(false);
+  const [isOpenReportDialog, setIsOpenReportDialog] = useState(false);
+  const [rerouteDialogIsOpen, setRerouteDialogIsOpen] = useState(false);
+
+  const cardCharged = booking?.payment[0]?.success;
+
+  const attendeeList = booking.attendees.map((attendee) => {
+    return {
+      name: attendee.name,
+      email: attendee.email,
+      id: attendee.id,
+      noShow: attendee.noShow || false,
+      phoneNumber: attendee.phoneNumber,
+    };
+  });
+
+  const noShowMutation = trpc.viewer.loggedInViewerRouter.markNoShow.useMutation({
+    onSuccess: async (data) => {
+      showToast(data.message, "success");
+      await utils.viewer.bookings.invalidate();
+    },
+    onError: (err) => {
+      showToast(err.message, "error");
+    },
+  });
+
+  const mutation = trpc.viewer.bookings.confirm.useMutation({
+    onSuccess: (data) => {
+      if (data?.status === "REJECTED") {
+        setRejectionDialogIsOpen(false);
+        showToast(t("booking_rejection_success"), "success");
+      } else {
+        showToast(t("booking_confirmation_success"), "success");
+      }
+      utils.viewer.bookings.invalidate();
+      utils.viewer.me.bookingUnconfirmedCount.invalidate();
+    },
+    onError: () => {
+      showToast(t("booking_confirmation_failed"), "error");
+      utils.viewer.bookings.invalidate();
+    },
+  });
+
+  const setLocationMutation = trpc.viewer.bookings.editLocation.useMutation({
+    onSuccess: () => {
+      showToast(t("location_updated"), "success");
+      setIsOpenLocationDialog(false);
+      utils.viewer.bookings.invalidate();
+    },
+    onError: (e) => {
+      const errorMessages: Record<string, string> = {
+        UNAUTHORIZED: t("you_are_unauthorized_to_make_this_change_to_the_booking"),
+        BAD_REQUEST: e.message,
+      };
+
+      const message = errorMessages[e.data?.code as string] || t("location_update_failed");
+      showToast(message, "error");
+    },
+  });
+
+  const isUpcoming = new Date(booking.endTime) >= new Date();
+  const isOngoing = isUpcoming && new Date() >= new Date(booking.startTime);
+  const isBookingInPast = new Date(booking.endTime) < new Date();
+  const isCancelled = booking.status === "CANCELLED";
+  const isConfirmed = booking.status === "ACCEPTED";
+  const isRejected = booking.status === "REJECTED";
+  const isPending = booking.status === "PENDING";
+  const isRescheduled = booking.fromReschedule !== null;
+  const isRecurring = booking.recurringEventId !== null;
+
+  const getBookingStatus = (): "upcoming" | "past" | "cancelled" | "rejected" => {
+    if (isCancelled) return "cancelled";
+    if (isRejected) return "rejected";
+    if (isBookingInPast) return "past";
+    return "upcoming";
+  };
+
+  const isTabRecurring = booking.listingStatus === "recurring";
+  const isTabUnconfirmed = booking.listingStatus === "unconfirmed";
+
+  const isBookingFromRoutingForm = !!booking.routedFromRoutingFormReponse && !!booking.eventType?.team;
+
+  const userEmail = booking.loggedInUser.userEmail;
+  const userSeat = booking.seatsReferences.find((seat) => !!userEmail && seat.attendee?.email === userEmail);
+  const isAttendee = !!userSeat;
+
+  const isCalVideoLocation =
+    !booking.location ||
+    booking.location === "integrations:daily" ||
+    (typeof booking.location === "string" && booking.location.trim() === "");
+
+  const isDisabledCancelling = booking.eventType.disableCancelling;
+  const isDisabledRescheduling = booking.eventType.disableRescheduling;
+
+  const getSeatReferenceUid = () => {
+    return userSeat?.referenceUid;
+  };
+
+  const bookingConfirm = async (confirm: boolean) => {
+    let body = {
+      bookingId: booking.id,
+      confirmed: confirm,
+      reason: rejectionReason,
+    };
+
+    if ((isTabRecurring || isTabUnconfirmed) && isRecurring) {
+      body = Object.assign({}, body, { recurringEventId: booking.recurringEventId });
+    }
+    mutation.mutate(body);
+  };
+
+  const saveLocation = async ({
+    newLocation,
+    credentialId,
+  }: {
+    newLocation: string;
+    credentialId: number | null;
+  }) => {
+    try {
+      await setLocationMutation.mutateAsync({
+        bookingId: booking.id,
+        newLocation,
+        credentialId,
+      });
+    } catch {
+      // Errors are shown through the mutation onError handler
+    }
+  };
+
+  const actionContext: BookingActionContext = {
+    booking,
+    isUpcoming,
+    isOngoing,
+    isBookingInPast,
+    isCancelled,
+    isConfirmed,
+    isRejected,
+    isPending,
+    isRescheduled,
+    isRecurring,
+    isTabRecurring,
+    isTabUnconfirmed,
+    isBookingFromRoutingForm,
+    isDisabledCancelling,
+    isDisabledRescheduling,
+    isCalVideoLocation,
+    showPendingPayment: false, // This will be calculated below
+    isAttendee,
+    cardCharged,
+    attendeeList,
+    getSeatReferenceUid,
+    t,
+  } as BookingActionContext;
+
+  const cancelEventAction = getCancelEventAction(actionContext);
+
+  const baseEditEventActions = getEditEventActions(actionContext);
+  const editEventActions: ActionType[] = baseEditEventActions.map((action) => ({
+    ...action,
+    onClick:
+      action.id === "reschedule_request"
+        ? () => setIsOpenRescheduleDialog(true)
+        : action.id === "reroute"
+        ? () => setRerouteDialogIsOpen(true)
+        : action.id === "change_location"
+        ? () => setIsOpenLocationDialog(true)
+        : action.id === "add_members"
+        ? () => setIsOpenAddGuestsDialog(true)
+        : action.id === "reassign"
+        ? () => setIsOpenReassignDialog(true)
+        : undefined,
+  })) as ActionType[];
+
+  const baseAfterEventActions = getAfterEventActions(actionContext);
+  const afterEventActions: ActionType[] = baseAfterEventActions.map((action) => ({
+    ...action,
+    onClick:
+      action.id === "view_recordings"
+        ? () => setViewRecordingsDialogIsOpen(true)
+        : action.id === "meeting_session_details"
+        ? () => setMeetingSessionDetailsDialogIsOpen(true)
+        : action.id === "charge_card"
+        ? () => setChargeCardDialogIsOpen(true)
+        : action.id === "no_show"
+        ? () => {
+            if (attendeeList.length === 1) {
+              const attendee = attendeeList[0];
+              noShowMutation.mutate({
+                bookingUid: booking.uid,
+                attendees: [{ email: attendee.email, noShow: !attendee.noShow }],
+              });
+              return;
+            }
+            setIsNoShowDialogOpen(true);
+          }
+        : undefined,
+    disabled:
+      action.disabled ||
+      (action.id === "no_show" && !(isBookingInPast || isOngoing)) ||
+      (action.id === "view_recordings" && !booking.isRecorded),
+  })) as ActionType[];
+
+  const reportAction = getReportAction(actionContext);
+  const reportActionWithHandler = {
+    ...reportAction,
+    onClick: () => setIsOpenReportDialog(true),
+  };
+
+  const NoShowAttendeesDialog = ({
+    bookingUid,
+    attendees,
+    setIsOpen,
+    isOpen,
+  }: {
+    bookingUid: string;
+    attendees: Array<{
+      name: string;
+      email: string;
+      id: number;
+      noShow: boolean;
+      phoneNumber: string | null;
+    }>;
+    setIsOpen: (open: boolean) => void;
+    isOpen: boolean;
+  }) => {
+    const [noShowAttendees, setNoShowAttendees] = useState<
+      Array<{
+        email: string;
+        noShow: boolean;
+      }>
+    >(attendees.map((attendee) => ({ email: attendee.email, noShow: attendee.noShow })));
+
+    const noShowMutation = trpc.viewer.loggedInViewerRouter.markNoShow.useMutation({
+      onSuccess: async (data) => {
+        showToast(data.message, "success");
+        setIsOpen(false);
+        await utils.viewer.bookings.invalidate();
+      },
+      onError: (err) => {
+        showToast(err.message, "error");
+      },
+    });
+
+    return (
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent title={t("mark_as_no_show")} description={t("mark_as_no_show_description")}>
+          <div className="space-y-2">
+            {attendees.map((attendee, index) => (
+              <label key={attendee.email} className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={noShowAttendees[index]?.noShow || false}
+                  onChange={(e) => {
+                    const newNoShowAttendees = [...noShowAttendees];
+                    newNoShowAttendees[index] = {
+                      email: attendee.email,
+                      noShow: e.target.checked,
+                    };
+                    setNoShowAttendees(newNoShowAttendees);
+                  }}
+                />
+                <span>
+                  {attendee.name} ({attendee.email})
+                </span>
+              </label>
+            ))}
+          </div>
+          <DialogFooter>
+            <DialogClose />
+            <Button
+              onClick={() => {
+                noShowMutation.mutate({
+                  bookingUid,
+                  attendees: noShowAttendees,
+                });
+              }}>
+              {t("confirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  };
+
+  const parsedBooking = {
+    ...booking,
+    eventType: booking.eventType.id ? booking.eventType : null,
+  };
+
+  if (!shouldShowEditActions(actionContext)) {
+    return null;
+  }
+
+  return (
+    <>
+      <RescheduleDialog
+        isOpenDialog={isOpenRescheduleDialog}
+        setIsOpenDialog={setIsOpenRescheduleDialog}
+        bookingUId={booking.uid}
+      />
+      {isOpenReassignDialog && (
+        <ReassignDialog
+          isOpenDialog={isOpenReassignDialog}
+          setIsOpenDialog={setIsOpenReassignDialog}
+          bookingId={booking.id}
+          teamId={booking.eventType?.team?.id || 0}
+          bookingFromRoutingForm={isBookingFromRoutingForm}
+        />
+      )}
+      <EditLocationDialog
+        booking={booking}
+        saveLocation={saveLocation}
+        isOpenDialog={isOpenSetLocationDialog}
+        setShowLocationModal={setIsOpenLocationDialog}
+        teamId={booking.eventType?.team?.id}
+      />
+      <AddGuestsDialog
+        isOpenDialog={isOpenAddGuestsDialog}
+        setIsOpenDialog={setIsOpenAddGuestsDialog}
+        bookingId={booking.id}
+      />
+      <ReportBookingDialog
+        isOpenDialog={isOpenReportDialog}
+        setIsOpenDialog={setIsOpenReportDialog}
+        bookingUid={booking.uid}
+        isRecurring={isRecurring}
+        status={getBookingStatus()}
+      />
+      {booking.paid && booking.payment[0] && (
+        <ChargeCardDialog
+          isOpenDialog={chargeCardDialogIsOpen}
+          setIsOpenDialog={setChargeCardDialogIsOpen}
+          bookingId={booking.id}
+          paymentAmount={booking.payment[0].amount}
+          paymentCurrency={booking.payment[0].currency}
+        />
+      )}
+      {isCalVideoLocation && (
+        <ViewRecordingsDialog
+          booking={booking}
+          isOpenDialog={viewRecordingsDialogIsOpen}
+          setIsOpenDialog={setViewRecordingsDialogIsOpen}
+          timeFormat={booking.loggedInUser.userTimeFormat ?? null}
+        />
+      )}
+      {isCalVideoLocation && meetingSessionDetailsDialogIsOpen && (
+        <MeetingSessionDetailsDialog
+          booking={booking}
+          isOpenDialog={meetingSessionDetailsDialogIsOpen}
+          setIsOpenDialog={setMeetingSessionDetailsDialogIsOpen}
+          timeFormat={booking.loggedInUser.userTimeFormat ?? null}
+        />
+      )}
+      {isNoShowDialogOpen && (
+        <NoShowAttendeesDialog
+          bookingUid={booking.uid}
+          attendees={attendeeList}
+          setIsOpen={setIsNoShowDialogOpen}
+          isOpen={isNoShowDialogOpen}
+        />
+      )}
+      <Dialog open={rejectionDialogIsOpen} onOpenChange={setRejectionDialogIsOpen}>
+        <DialogContent title={t("rejection_reason_title")} description={t("rejection_reason_description")}>
+          <div>
+            <TextAreaField
+              name="rejectionReason"
+              label={
+                <>
+                  {t("rejection_reason")}
+                  <span className="text-subtle font-normal"> (Optional)</span>
+                </>
+              }
+              value={rejectionReason}
+              onChange={(e) => setRejectionReason(e.target.value)}
+            />
+          </div>
+
+          <DialogFooter>
+            <DialogClose />
+            <Button
+              disabled={mutation.isPending}
+              data-testid="rejection-confirm"
+              onClick={() => {
+                bookingConfirm(false);
+              }}>
+              {t("rejection_confirmation")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      {isBookingFromRoutingForm && parsedBooking.eventType && (
+        <RerouteDialog
+          isOpenDialog={rerouteDialogIsOpen}
+          setIsOpenDialog={setRerouteDialogIsOpen}
+          booking={{ ...parsedBooking, eventType: parsedBooking.eventType }}
+        />
+      )}
+
+      <Dropdown>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            color="secondary"
+            variant="icon"
+            StartIcon="ellipsis"
+            data-testid="booking-actions-dropdown"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuContent>
+            <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("edit_event")}</DropdownMenuLabel>
+            {editEventActions.map((action) => (
+              <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={action.color}
+                  StartIcon={action.icon}
+                  href={action.href}
+                  disabled={action.disabled}
+                  onClick={action.onClick}
+                  data-bookingid={action.bookingId}
+                  data-testid={action.id}
+                  className={action.disabled ? "text-muted" : undefined}>
+                  {action.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("after_event")}</DropdownMenuLabel>
+            {afterEventActions.map((action) => (
+              <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={action.color}
+                  StartIcon={action.icon}
+                  href={action.href}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  data-bookingid={action.bookingId}
+                  data-testid={action.id}
+                  className={action.disabled ? "text-muted" : undefined}>
+                  {action.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            ))}
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="rounded-lg"
+                key={reportActionWithHandler.id}
+                disabled={reportActionWithHandler.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={reportActionWithHandler.color}
+                  StartIcon={reportActionWithHandler.icon}
+                  onClick={reportActionWithHandler.onClick}
+                  disabled={reportActionWithHandler.disabled}
+                  data-testid={reportActionWithHandler.id}
+                  className={reportActionWithHandler.disabled ? "text-muted" : undefined}>
+                  {reportActionWithHandler.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            </>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="rounded-lg"
+              key={cancelEventAction.id}
+              disabled={cancelEventAction.disabled}>
+              <DropdownItem
+                type="button"
+                color={cancelEventAction.color}
+                StartIcon={cancelEventAction.icon}
+                href={cancelEventAction.disabled ? undefined : cancelEventAction.href}
+                onClick={cancelEventAction.onClick}
+                disabled={cancelEventAction.disabled}
+                data-bookingid={cancelEventAction.bookingId}
+                data-testid={cancelEventAction.id}
+                className={cancelEventAction.disabled ? "text-muted" : undefined}>
+                {cancelEventAction.label}
+              </DropdownItem>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenuPortal>
+      </Dropdown>
+    </>
+  );
+}

--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import type { z } from "zod";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { MeetingSessionDetailsDialog } from "@calcom/features/ee/video/MeetingSessionDetailsDialog";
 import ViewRecordingsDialog from "@calcom/features/ee/video/ViewRecordingsDialog";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
@@ -465,13 +467,30 @@ export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps)
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      {isBookingFromRoutingForm && parsedBooking.eventType && (
-        <RerouteDialog
-          isOpenDialog={rerouteDialogIsOpen}
-          setIsOpenDialog={setRerouteDialogIsOpen}
-          booking={{ ...parsedBooking, eventType: parsedBooking.eventType }}
-        />
-      )}
+      {isBookingFromRoutingForm &&
+        parsedBooking.eventType &&
+        parsedBooking.eventType.id !== undefined &&
+        parsedBooking.eventType.slug !== undefined &&
+        parsedBooking.eventType.title !== undefined &&
+        parsedBooking.routedFromRoutingFormReponse && (
+          <RerouteDialog
+            isOpenDialog={rerouteDialogIsOpen}
+            setIsOpenDialog={setRerouteDialogIsOpen}
+            booking={{
+              ...parsedBooking,
+              metadata: parsedBooking.metadata as z.infer<typeof bookingMetadataSchema>,
+              routedFromRoutingFormReponse: parsedBooking.routedFromRoutingFormReponse,
+              eventType: {
+                length: parsedBooking.eventType.length ?? 0,
+                schedulingType: parsedBooking.eventType.schedulingType ?? null,
+                title: parsedBooking.eventType.title,
+                id: parsedBooking.eventType.id,
+                slug: parsedBooking.eventType.slug,
+                team: parsedBooking.eventType.team ?? null,
+              },
+            }}
+          />
+        )}
     </>
   );
 

--- a/apps/web/components/booking/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/BookingActionsDropdown.tsx
@@ -29,6 +29,7 @@ import { ReportBookingDialog } from "@components/dialog/ReportBookingDialog";
 import { RerouteDialog } from "@components/dialog/RerouteDialog";
 import { RescheduleDialog } from "@components/dialog/RescheduleDialog";
 
+import { useBookingActionsStoreContext } from "./BookingActionsStoreProvider";
 import {
   getCancelEventAction,
   getEditEventActions,
@@ -47,18 +48,39 @@ export function BookingActionsDropdown({ booking }: BookingActionsDropdownProps)
   const { t } = useLocale();
   const utils = trpc.useUtils();
 
-  const [rejectionReason, setRejectionReason] = useState<string>("");
-  const [rejectionDialogIsOpen, setRejectionDialogIsOpen] = useState(false);
-  const [chargeCardDialogIsOpen, setChargeCardDialogIsOpen] = useState(false);
-  const [viewRecordingsDialogIsOpen, setViewRecordingsDialogIsOpen] = useState<boolean>(false);
-  const [meetingSessionDetailsDialogIsOpen, setMeetingSessionDetailsDialogIsOpen] = useState<boolean>(false);
-  const [isNoShowDialogOpen, setIsNoShowDialogOpen] = useState<boolean>(false);
-  const [isOpenRescheduleDialog, setIsOpenRescheduleDialog] = useState(false);
-  const [isOpenReassignDialog, setIsOpenReassignDialog] = useState(false);
-  const [isOpenSetLocationDialog, setIsOpenLocationDialog] = useState(false);
-  const [isOpenAddGuestsDialog, setIsOpenAddGuestsDialog] = useState(false);
-  const [isOpenReportDialog, setIsOpenReportDialog] = useState(false);
-  const [rerouteDialogIsOpen, setRerouteDialogIsOpen] = useState(false);
+  // Use store for all dialog states
+  const rejectionReason = useBookingActionsStoreContext((state) => state.rejectionReason);
+  const setRejectionReason = useBookingActionsStoreContext((state) => state.setRejectionReason);
+  const rejectionDialogIsOpen = useBookingActionsStoreContext((state) => state.rejectionDialogIsOpen);
+  const setRejectionDialogIsOpen = useBookingActionsStoreContext((state) => state.setRejectionDialogIsOpen);
+  const chargeCardDialogIsOpen = useBookingActionsStoreContext((state) => state.chargeCardDialogIsOpen);
+  const setChargeCardDialogIsOpen = useBookingActionsStoreContext((state) => state.setChargeCardDialogIsOpen);
+  const viewRecordingsDialogIsOpen = useBookingActionsStoreContext(
+    (state) => state.viewRecordingsDialogIsOpen
+  );
+  const setViewRecordingsDialogIsOpen = useBookingActionsStoreContext(
+    (state) => state.setViewRecordingsDialogIsOpen
+  );
+  const meetingSessionDetailsDialogIsOpen = useBookingActionsStoreContext(
+    (state) => state.meetingSessionDetailsDialogIsOpen
+  );
+  const setMeetingSessionDetailsDialogIsOpen = useBookingActionsStoreContext(
+    (state) => state.setMeetingSessionDetailsDialogIsOpen
+  );
+  const isNoShowDialogOpen = useBookingActionsStoreContext((state) => state.isNoShowDialogOpen);
+  const setIsNoShowDialogOpen = useBookingActionsStoreContext((state) => state.setIsNoShowDialogOpen);
+  const isOpenRescheduleDialog = useBookingActionsStoreContext((state) => state.isOpenRescheduleDialog);
+  const setIsOpenRescheduleDialog = useBookingActionsStoreContext((state) => state.setIsOpenRescheduleDialog);
+  const isOpenReassignDialog = useBookingActionsStoreContext((state) => state.isOpenReassignDialog);
+  const setIsOpenReassignDialog = useBookingActionsStoreContext((state) => state.setIsOpenReassignDialog);
+  const isOpenSetLocationDialog = useBookingActionsStoreContext((state) => state.isOpenSetLocationDialog);
+  const setIsOpenLocationDialog = useBookingActionsStoreContext((state) => state.setIsOpenLocationDialog);
+  const isOpenAddGuestsDialog = useBookingActionsStoreContext((state) => state.isOpenAddGuestsDialog);
+  const setIsOpenAddGuestsDialog = useBookingActionsStoreContext((state) => state.setIsOpenAddGuestsDialog);
+  const isOpenReportDialog = useBookingActionsStoreContext((state) => state.isOpenReportDialog);
+  const setIsOpenReportDialog = useBookingActionsStoreContext((state) => state.setIsOpenReportDialog);
+  const rerouteDialogIsOpen = useBookingActionsStoreContext((state) => state.rerouteDialogIsOpen);
+  const setRerouteDialogIsOpen = useBookingActionsStoreContext((state) => state.setRerouteDialogIsOpen);
 
   const cardCharged = booking?.payment[0]?.success;
 

--- a/apps/web/components/booking/BookingActionsStoreProvider.tsx
+++ b/apps/web/components/booking/BookingActionsStoreProvider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useContext, useRef, type ReactNode } from "react";
+import { useStore } from "zustand";
+import type { StoreApi } from "zustand";
+
+import { createBookingActionsStore, type BookingActionsStore } from "./store";
+
+export const BookingActionsStoreContext = createContext<StoreApi<BookingActionsStore> | null>(null);
+
+export interface BookingActionsStoreProviderProps {
+  children: ReactNode;
+}
+
+export const BookingActionsStoreProvider = ({ children }: BookingActionsStoreProviderProps) => {
+  const storeRef = useRef<StoreApi<BookingActionsStore>>();
+  if (!storeRef.current) {
+    storeRef.current = createBookingActionsStore();
+  }
+
+  return (
+    <BookingActionsStoreContext.Provider value={storeRef.current}>
+      {children}
+    </BookingActionsStoreContext.Provider>
+  );
+};
+
+export const useBookingActionsStoreContext = <T,>(
+  selector: (store: BookingActionsStore) => T,
+  equalityFn?: (a: T, b: T) => boolean
+): T => {
+  const bookingActionsStoreContext = useContext(BookingActionsStoreContext);
+
+  if (!bookingActionsStoreContext) {
+    throw new Error("useBookingActionsStoreContext must be used within BookingActionsStoreProvider");
+  }
+
+  return useStore(bookingActionsStoreContext, selector, equalityFn);
+};

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -46,6 +46,8 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 
+import { BookingActionsDropdown } from "./BookingActionsDropdown";
+import { useBookingActionsStoreContext, BookingActionsStoreProvider } from "./BookingActionsStoreProvider";
 import {
   getPendingActions,
   getCancelEventAction,
@@ -55,7 +57,6 @@ import {
   type BookingActionContext,
   getReportAction,
 } from "./bookingActions";
-import { BookingActionsDropdown } from "./BookingActionsDropdown";
 import type { BookingItemProps } from "./types";
 
 type ParsedBooking = ReturnType<typeof buildParsedBooking>;
@@ -271,10 +272,12 @@ function BookingListItem(booking: BookingItemProps) {
 
   const showPendingPayment = paymentAppData.enabled && booking.payment.length && !booking.paid;
 
+  const setIsOpenReportDialog = useBookingActionsStoreContext((state) => state.setIsOpenReportDialog);
+
   const reportAction = getReportAction(actionContext);
   const reportActionWithHandler = {
     ...reportAction,
-    onClick: () => {}, // This will be handled by BookingActionsDropdown
+    onClick: () => setIsOpenReportDialog(true),
   };
 
   return (
@@ -995,4 +998,13 @@ const AssignmentReasonTooltip = ({ assignmentReason }: { assignmentReason: Assig
   );
 };
 
-export default BookingListItem;
+// Wrap BookingListItem with BookingActionsStoreProvider to provide isolated store for each booking
+const BookingListItemWithProvider = (props: BookingItemProps) => {
+  return (
+    <BookingActionsStoreProvider>
+      <BookingListItem {...props} />
+    </BookingActionsStoreProvider>
+  );
+};
+
+export default BookingListItemWithProvider;

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -19,7 +19,6 @@ import { getEveryFreqFor } from "@calcom/lib/recurringStrings";
 import type { AssignmentReason } from "@calcom/prisma/client";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
-import type { RouterInputs, RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import type { Ensure } from "@calcom/types/utils";
 import classNames from "@calcom/ui/classNames";
@@ -57,22 +56,7 @@ import {
   getReportAction,
 } from "./bookingActions";
 import { BookingActionsDropdown } from "./BookingActionsDropdown";
-
-type BookingListingStatus = RouterInputs["viewer"]["bookings"]["get"]["filters"]["status"];
-
-type BookingItem = RouterOutputs["viewer"]["bookings"]["get"]["bookings"][number];
-
-export type BookingItemProps = BookingItem & {
-  listingStatus: BookingListingStatus;
-  recurringInfo: RouterOutputs["viewer"]["bookings"]["get"]["recurringInfo"][number] | undefined;
-  loggedInUser: {
-    userId: number | undefined;
-    userTimeZone: string | undefined;
-    userTimeFormat: number | null | undefined;
-    userEmail: string | undefined;
-  };
-  isToday: boolean;
-};
+import type { BookingItemProps } from "./types";
 
 type ParsedBooking = ReturnType<typeof buildParsedBooking>;
 type TeamEvent = Ensure<NonNullable<ParsedBooking["eventType"]>, "team">;

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -186,6 +186,7 @@ function BookingListItem(booking: BookingItemProps) {
 
   const isDisabledCancelling = booking.eventType.disableCancelling;
   const isDisabledRescheduling = booking.eventType.disableRescheduling;
+  const cardCharged = booking?.payment[0]?.success;
 
   const bookingConfirm = async (confirm: boolean) => {
     let body = {

--- a/apps/web/components/booking/bookingActions.ts
+++ b/apps/web/components/booking/bookingActions.ts
@@ -1,7 +1,7 @@
 import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import type { ActionType } from "@calcom/ui/components/table";
 
-import type { BookingItemProps } from "./BookingListItem";
+import type { BookingItemProps } from "./types";
 
 export interface BookingActionContext {
   booking: BookingItemProps;

--- a/apps/web/components/booking/store.ts
+++ b/apps/web/components/booking/store.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { createStore } from "zustand";
+
+export type BookingActionsStore = {
+  // Dialog states
+  rejectionDialogIsOpen: boolean;
+  chargeCardDialogIsOpen: boolean;
+  viewRecordingsDialogIsOpen: boolean;
+  meetingSessionDetailsDialogIsOpen: boolean;
+  isNoShowDialogOpen: boolean;
+  isOpenRescheduleDialog: boolean;
+  isOpenReassignDialog: boolean;
+  isOpenSetLocationDialog: boolean;
+  isOpenAddGuestsDialog: boolean;
+  isOpenReportDialog: boolean;
+  rerouteDialogIsOpen: boolean;
+
+  // Dialog setters
+  setRejectionDialogIsOpen: (isOpen: boolean) => void;
+  setChargeCardDialogIsOpen: (isOpen: boolean) => void;
+  setViewRecordingsDialogIsOpen: (isOpen: boolean) => void;
+  setMeetingSessionDetailsDialogIsOpen: (isOpen: boolean) => void;
+  setIsNoShowDialogOpen: (isOpen: boolean) => void;
+  setIsOpenRescheduleDialog: (isOpen: boolean) => void;
+  setIsOpenReassignDialog: (isOpen: boolean) => void;
+  setIsOpenLocationDialog: (isOpen: boolean) => void;
+  setIsOpenAddGuestsDialog: (isOpen: boolean) => void;
+  setIsOpenReportDialog: (isOpen: boolean) => void;
+  setRerouteDialogIsOpen: (isOpen: boolean) => void;
+
+  // Rejection reason state
+  rejectionReason: string;
+  setRejectionReason: (reason: string) => void;
+};
+
+export const createBookingActionsStore = () => {
+  return createStore<BookingActionsStore>((set) => ({
+    // Initial dialog states
+    rejectionDialogIsOpen: false,
+    chargeCardDialogIsOpen: false,
+    viewRecordingsDialogIsOpen: false,
+    meetingSessionDetailsDialogIsOpen: false,
+    isNoShowDialogOpen: false,
+    isOpenRescheduleDialog: false,
+    isOpenReassignDialog: false,
+    isOpenSetLocationDialog: false,
+    isOpenAddGuestsDialog: false,
+    isOpenReportDialog: false,
+    rerouteDialogIsOpen: false,
+
+    // Dialog setters
+    setRejectionDialogIsOpen: (isOpen: boolean) => set({ rejectionDialogIsOpen: isOpen }),
+    setChargeCardDialogIsOpen: (isOpen: boolean) => set({ chargeCardDialogIsOpen: isOpen }),
+    setViewRecordingsDialogIsOpen: (isOpen: boolean) => set({ viewRecordingsDialogIsOpen: isOpen }),
+    setMeetingSessionDetailsDialogIsOpen: (isOpen: boolean) =>
+      set({ meetingSessionDetailsDialogIsOpen: isOpen }),
+    setIsNoShowDialogOpen: (isOpen: boolean) => set({ isNoShowDialogOpen: isOpen }),
+    setIsOpenRescheduleDialog: (isOpen: boolean) => set({ isOpenRescheduleDialog: isOpen }),
+    setIsOpenReassignDialog: (isOpen: boolean) => set({ isOpenReassignDialog: isOpen }),
+    setIsOpenLocationDialog: (isOpen: boolean) => set({ isOpenSetLocationDialog: isOpen }),
+    setIsOpenAddGuestsDialog: (isOpen: boolean) => set({ isOpenAddGuestsDialog: isOpen }),
+    setIsOpenReportDialog: (isOpen: boolean) => set({ isOpenReportDialog: isOpen }),
+    setRerouteDialogIsOpen: (isOpen: boolean) => set({ rerouteDialogIsOpen: isOpen }),
+
+    // Rejection reason state
+    rejectionReason: "",
+    setRejectionReason: (reason: string) => set({ rejectionReason: reason }),
+  }));
+};

--- a/apps/web/components/booking/store.ts
+++ b/apps/web/components/booking/store.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import { createStore } from "zustand";
 
 export type BookingActionsStore = {
@@ -17,17 +18,17 @@ export type BookingActionsStore = {
   rerouteDialogIsOpen: boolean;
 
   // Dialog setters
-  setRejectionDialogIsOpen: (isOpen: boolean) => void;
-  setChargeCardDialogIsOpen: (isOpen: boolean) => void;
-  setViewRecordingsDialogIsOpen: (isOpen: boolean) => void;
-  setMeetingSessionDetailsDialogIsOpen: (isOpen: boolean) => void;
-  setIsNoShowDialogOpen: (isOpen: boolean) => void;
-  setIsOpenRescheduleDialog: (isOpen: boolean) => void;
-  setIsOpenReassignDialog: (isOpen: boolean) => void;
-  setIsOpenLocationDialog: (isOpen: boolean) => void;
-  setIsOpenAddGuestsDialog: (isOpen: boolean) => void;
-  setIsOpenReportDialog: (isOpen: boolean) => void;
-  setRerouteDialogIsOpen: (isOpen: boolean) => void;
+  setRejectionDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setChargeCardDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setViewRecordingsDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setMeetingSessionDetailsDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsNoShowDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpenRescheduleDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpenReassignDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpenLocationDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpenAddGuestsDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpenReportDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setRerouteDialogIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 
   // Rejection reason state
   rejectionReason: string;
@@ -50,18 +51,53 @@ export const createBookingActionsStore = () => {
     rerouteDialogIsOpen: false,
 
     // Dialog setters
-    setRejectionDialogIsOpen: (isOpen: boolean) => set({ rejectionDialogIsOpen: isOpen }),
-    setChargeCardDialogIsOpen: (isOpen: boolean) => set({ chargeCardDialogIsOpen: isOpen }),
-    setViewRecordingsDialogIsOpen: (isOpen: boolean) => set({ viewRecordingsDialogIsOpen: isOpen }),
-    setMeetingSessionDetailsDialogIsOpen: (isOpen: boolean) =>
-      set({ meetingSessionDetailsDialogIsOpen: isOpen }),
-    setIsNoShowDialogOpen: (isOpen: boolean) => set({ isNoShowDialogOpen: isOpen }),
-    setIsOpenRescheduleDialog: (isOpen: boolean) => set({ isOpenRescheduleDialog: isOpen }),
-    setIsOpenReassignDialog: (isOpen: boolean) => set({ isOpenReassignDialog: isOpen }),
-    setIsOpenLocationDialog: (isOpen: boolean) => set({ isOpenSetLocationDialog: isOpen }),
-    setIsOpenAddGuestsDialog: (isOpen: boolean) => set({ isOpenAddGuestsDialog: isOpen }),
-    setIsOpenReportDialog: (isOpen: boolean) => set({ isOpenReportDialog: isOpen }),
-    setRerouteDialogIsOpen: (isOpen: boolean) => set({ rerouteDialogIsOpen: isOpen }),
+    setRejectionDialogIsOpen: (isOpen) =>
+      set((state) => ({
+        rejectionDialogIsOpen: typeof isOpen === "function" ? isOpen(state.rejectionDialogIsOpen) : isOpen,
+      })),
+    setChargeCardDialogIsOpen: (isOpen) =>
+      set((state) => ({
+        chargeCardDialogIsOpen: typeof isOpen === "function" ? isOpen(state.chargeCardDialogIsOpen) : isOpen,
+      })),
+    setViewRecordingsDialogIsOpen: (isOpen) =>
+      set((state) => ({
+        viewRecordingsDialogIsOpen:
+          typeof isOpen === "function" ? isOpen(state.viewRecordingsDialogIsOpen) : isOpen,
+      })),
+    setMeetingSessionDetailsDialogIsOpen: (isOpen) =>
+      set((state) => ({
+        meetingSessionDetailsDialogIsOpen:
+          typeof isOpen === "function" ? isOpen(state.meetingSessionDetailsDialogIsOpen) : isOpen,
+      })),
+    setIsNoShowDialogOpen: (isOpen) =>
+      set((state) => ({
+        isNoShowDialogOpen: typeof isOpen === "function" ? isOpen(state.isNoShowDialogOpen) : isOpen,
+      })),
+    setIsOpenRescheduleDialog: (isOpen) =>
+      set((state) => ({
+        isOpenRescheduleDialog: typeof isOpen === "function" ? isOpen(state.isOpenRescheduleDialog) : isOpen,
+      })),
+    setIsOpenReassignDialog: (isOpen) =>
+      set((state) => ({
+        isOpenReassignDialog: typeof isOpen === "function" ? isOpen(state.isOpenReassignDialog) : isOpen,
+      })),
+    setIsOpenLocationDialog: (isOpen) =>
+      set((state) => ({
+        isOpenSetLocationDialog:
+          typeof isOpen === "function" ? isOpen(state.isOpenSetLocationDialog) : isOpen,
+      })),
+    setIsOpenAddGuestsDialog: (isOpen) =>
+      set((state) => ({
+        isOpenAddGuestsDialog: typeof isOpen === "function" ? isOpen(state.isOpenAddGuestsDialog) : isOpen,
+      })),
+    setIsOpenReportDialog: (isOpen) =>
+      set((state) => ({
+        isOpenReportDialog: typeof isOpen === "function" ? isOpen(state.isOpenReportDialog) : isOpen,
+      })),
+    setRerouteDialogIsOpen: (isOpen) =>
+      set((state) => ({
+        rerouteDialogIsOpen: typeof isOpen === "function" ? isOpen(state.rerouteDialogIsOpen) : isOpen,
+      })),
 
     // Rejection reason state
     rejectionReason: "",

--- a/apps/web/components/booking/types.ts
+++ b/apps/web/components/booking/types.ts
@@ -1,0 +1,17 @@
+import type { RouterInputs, RouterOutputs } from "@calcom/trpc/react";
+
+type BookingListingStatus = RouterInputs["viewer"]["bookings"]["get"]["filters"]["status"];
+
+type BookingItem = RouterOutputs["viewer"]["bookings"]["get"]["bookings"][number];
+
+export type BookingItemProps = BookingItem & {
+  listingStatus: BookingListingStatus;
+  recurringInfo: RouterOutputs["viewer"]["bookings"]["get"]["recurringInfo"][number] | undefined;
+  loggedInUser: {
+    userId: number | undefined;
+    userTimeZone: string | undefined;
+    userTimeFormat: number | null | undefined;
+    userEmail: string | undefined;
+  };
+  isToday: boolean;
+};


### PR DESCRIPTION
## What does this PR do?

Refactors the booking actions dropdown button and all related dialogs from `BookingListItem.tsx` into a separate, reusable component called `BookingActionsDropdown`. This improves code organization and enables reusing the dropdown in other parts of the application.

**Changes:**
- Created `BookingActionsDropdown.tsx` component that receives a `booking` prop and handles all dropdown items and their actions
- Extracted all dialog state management, mutations, and dialog components from `BookingListItem.tsx`
- Moved the dropdown UI and action handling logic to the new component
- Fixed pre-existing lint warning by replacing `<img>` with Next.js `<Image />` component for provider icons

**Note:** The rejection dialog was intentionally kept in `BookingListItem.tsx` as it's triggered by the pending actions section, not the dropdown menu.

## Requested by

- **User:** eunjae@cal.com (@eunjae-lee)
- **Devin session:** https://app.devin.ai/sessions/d9233e384c34433891ac7864f0a84b98

## Visual Demo

Not applicable - This is a refactoring change with no visual differences expected. The dropdown should look and behave exactly the same as before.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required (internal refactoring only)
- [x] Automated tests are needed but not yet added (existing manual testing required)

## How should this be tested?

**Test the dropdown actions work correctly:**

1. Go to the bookings page (`/bookings`)
2. For various booking types (upcoming, past, pending, cancelled), click the three-dot menu on a booking
3. Test each dropdown action:
   - **Edit Event section:** Reschedule, Reassign, Change location, Add guests, Reroute
   - **After Event section:** View recordings, Meeting session details, Charge card, Mark as no-show
   - **Report:** Report booking
   - **Cancel:** Cancel event

**Specific scenarios to test:**

- **Pending bookings:** Verify rejection dialog still works (it wasn't moved to the new component)
- **Past bookings with recordings:** Verify "View recordings" opens the recordings dialog
- **Team bookings:** Verify reassign and reroute actions work
- **Seated events:** Verify multi-attendee no-show dialog works
- **Bookings with payment:** Verify charge card dialog works

**Expected behavior:** All actions should work exactly as they did before the refactoring.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code in hard-to-understand areas
- I have checked if my changes generate no new warnings