### PR TITLE
feat: allow deleting any time slot in overrides UI

### DIFF
--- a/packages/features/schedules/components/DateOverrideInputDialog.tsx
+++ b/packages/features/schedules/components/DateOverrideInputDialog.tsx
@@ -172,7 +172,7 @@ const DateOverrideForm = ({
                     {t("date_overrides_unavailable")}
                   </p>
                 ) : (
-                  <DayRanges name="range" userTimeFormat={userTimeFormat} />
+                  <DayRanges name="range" userTimeFormat={userTimeFormat} allowDeleteFirstSlot={true} />
                 )}
               </div>
               <Switch

--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -240,6 +240,7 @@ export const DayRanges = <TFieldValues extends FieldValues>({
   labels,
   userTimeFormat,
   classNames,
+  allowDeleteFirstSlot = false,
 }: {
   name: ArrayPath<TFieldValues>;
   control?: Control<TFieldValues>;
@@ -247,6 +248,7 @@ export const DayRanges = <TFieldValues extends FieldValues>({
   labels?: ScheduleLabelsType;
   userTimeFormat: number | null;
   classNames?: Pick<scheduleClassNames, "dayRanges" | "timeRangeField" | "timePicker">;
+  allowDeleteFirstSlot?: boolean;
 }) => {
   const { t } = useLocale();
   const { getValues } = useFormContext();
@@ -274,14 +276,6 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                 />
               )}
             />
-            <RemoveTimeButton
-              index={index}
-              remove={remove}
-              className="text-default border-none"
-              disabled={disabled}
-              labels={labels}
-            />
-
             {index === 0 && (
               <Button
                 disabled={disabled}
@@ -307,6 +301,15 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                     prepend(slotRange.prepend);
                   }
                 }}
+              />
+            )}
+            {(allowDeleteFirstSlot || index !== 0) && (
+              <RemoveTimeButton
+                index={index}
+                remove={remove}
+                className="text-default border-none"
+                disabled={disabled}
+                labels={labels}
               />
             )}
           </div>

--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -274,6 +274,14 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                 />
               )}
             />
+            <RemoveTimeButton
+              index={index}
+              remove={remove}
+              className="text-default border-none"
+              disabled={disabled}
+              labels={labels}
+            />
+
             {index === 0 && (
               <Button
                 disabled={disabled}
@@ -300,9 +308,6 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                   }
                 }}
               />
-            )}
-            {index !== 0 && (
-              <RemoveTimeButton index={index} remove={remove} className="text-default border-none" />
             )}
           </div>
         </Fragment>


### PR DESCRIPTION
## What does this PR do?

This PR improves the schedule overrides UI by adding a delete (trash) icon to every time slot, not just the last one. Previously, only the later time slots could be directly removed via the bin icon. 

- Fixes #24817
- Fixes [CAL-6668](https://linear.app/calcom/issue/CAL-6668/overrides-ui-for-removing-time-slots-is-limited)

## Visual Demo (For contributors especially)

Before:

https://github.com/user-attachments/assets/3e07de83-5faf-466f-b3ff-3bbd90deeffd


After: 

https://github.com/user-attachments/assets/a01c01e5-9564-4c69-9212-dcb922a0b9ff


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in `/docs` if this PR makes changes that would require a documentation change. If N/A, write **N/A** here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Environment variables:**  
- Navigate to [availability](https://app.cal.com/availability/) 
- Select any schedule and navigate to Date overrides 
- Add multiple time slots for a single day.
- Observe that the first slot cannot be deleted.




