### PR TITLE
chore: return `timeZone` property of event owner in `EventType` for api v1

### DIFF
--- a/apps/api/v1/lib/selects/event-type.ts
+++ b/apps/api/v1/lib/selects/event-type.ts
@@ -57,7 +57,7 @@ export const eventTypeSelect = {
     },
   },
   owner: {
-    select: { username: true, id: true },
+    select: { username: true, id: true, timeZone: true },
   },
   children: {
     select: {


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose the event owner's timeZone in the v1 EventType API response so clients can retrieve it for a given event type. Fixes CAL-6539: unable to retrieve timezone for provided event type.

- **Bug Fixes**
  - Include owner.timeZone in eventTypeSelect (apps/api/v1/lib/selects/event-type.ts).

<sup>Written for commit bd7eb0fd3fd584df98465083f8bb70dd86751a97. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





