### PR TITLE
fix: existence check of searchParams in NavigationItem

### DIFF
--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -46,7 +46,7 @@ const useBuildHref = () => {
       childItem.preserveQueryParams &&
       childItem.preserveQueryParams({ prevPathname: prevPathnameRef.current, nextPathname: childItem.href })
     ) {
-      const params = searchParams.toString();
+      const params = searchParams?.toString();
       return params ? `${childItem.href}?${params}` : childItem.href;
     }
     return childItem.href;


### PR DESCRIPTION
## What does this PR do?

The type definition of the `useSearchParams()` seems to always return a value, but it failed to compile in the docker because it seems to be possible to return null. While investigating this type discrepancy, let's fix it by adding a guard here for now.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
