### PR TITLE
chore: User->UUID as a required field, ready for use in foreign keys

### DIFF
--- a/packages/prisma/migrations/20251103175338_make_user_uuid_required/migration.sql
+++ b/packages/prisma/migrations/20251103175338_make_user_uuid_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `uuid` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."users" ALTER COLUMN "uuid" SET NOT NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -349,7 +349,7 @@ model TravelSchedule {
 // It holds Personal Profiles of a User plus it has email, password and other core things..
 model User {
   id                  Int                  @id @default(autoincrement())
-  uuid                String?              @unique @default(uuid()) @db.Uuid
+  uuid                String               @unique @default(uuid()) @db.Uuid
   username            String?
   name                String?
   /// @zod.import(["import { emailSchema } from '@calcom/lib/emailSchema'"]).custom.use(emailSchema)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make User.uuid required (non-null) and update the Prisma schema so we can safely use it as a foreign key across tables.

- **Migration**
  - Sets users.uuid to NOT NULL.
  - Will fail if any existing users have NULL uuid; backfill missing uuids before deploying.

<sup>Written for commit 7bdabdb3d7d80be6e185ea35fecb6a1c2fa5b63d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

