### PR TITLE
fix: skip email verification for reschedules with matching email

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/email-verification-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/email-verification-booking.test.ts
@@ -341,5 +341,164 @@ describe("handleNewBooking - Email Verification", () => {
       },
       timeout
     );
+
+    test(
+      "should allow rescheduling without email verification even when requiresBookerEmailVerification is true",
+      async () => {
+        const handleNewBooking = getNewBookingHandler();
+        const { verifyCodeUnAuthenticated } = await import("@calcom/trpc/server/routers/viewer/auth/util");
+
+        const booker = getBooker({
+          email: "booker@example.com",
+          name: "Booker",
+        });
+
+        const organizer = getOrganizer({
+          name: "Organizer",
+          email: "organizer@example.com",
+          id: 101,
+          schedules: [TestData.schedules.IstWorkHours],
+        });
+
+        const scenarioData = getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 15,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+              requiresBookerEmailVerification: true,
+            },
+          ],
+          organizer,
+          bookings: [
+            {
+              uid: "existing-booking-uid",
+              eventTypeId: 1,
+              userId: 101,
+              status: "ACCEPTED",
+              startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // tomorrow
+              endTime: new Date(Date.now() + 24 * 60 * 60 * 1000 + 30 * 60 * 1000).toISOString(), // tomorrow + 30 min
+              attendees: [
+                {
+                  email: booker.email,
+                  name: booker.name,
+                  timeZone: "Asia/Kolkata",
+                },
+              ],
+            },
+          ],
+        });
+
+        await createBookingScenario(scenarioData);
+
+        const mockBookingData = getMockRequestDataForBooking({
+          data: {
+            eventTypeId: 1,
+            rescheduleUid: "existing-booking-uid",
+            responses: {
+              email: booker.email,
+              name: booker.name,
+              location: { optionValue: "", value: "integrations:daily" },
+            },
+          },
+        });
+
+        const result = await handleNewBooking({ bookingData: mockBookingData });
+
+        expect(result).toBeDefined();
+        expect(result.uid).toBeDefined();
+
+        expect(verifyCodeUnAuthenticated).not.toHaveBeenCalled();
+      },
+      timeout
+    );
+
+    test(
+      "should require email verification for reschedule when email doesn't match original booking",
+      async () => {
+        const handleNewBooking = getNewBookingHandler();
+        const { verifyCodeUnAuthenticated } = await import("@calcom/trpc/server/routers/viewer/auth/util");
+
+        const originalBooker = getBooker({
+          email: "original-booker@example.com",
+          name: "Original Booker",
+        });
+
+        const newBooker = getBooker({
+          email: "new-booker@example.com",
+          name: "New Booker",
+        });
+
+        const organizer = getOrganizer({
+          name: "Organizer",
+          email: "organizer@example.com",
+          id: 101,
+          schedules: [TestData.schedules.IstWorkHours],
+        });
+
+        const scenarioData = getScenarioData({
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 15,
+              length: 30,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+              requiresBookerEmailVerification: true,
+            },
+          ],
+          organizer,
+          bookings: [
+            {
+              uid: "existing-booking-uid",
+              eventTypeId: 1,
+              userId: 101,
+              status: "ACCEPTED",
+              startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // tomorrow
+              endTime: new Date(Date.now() + 24 * 60 * 60 * 1000 + 30 * 60 * 1000).toISOString(), // tomorrow + 30 min
+              attendees: [
+                {
+                  email: originalBooker.email,
+                  name: originalBooker.name,
+                  timeZone: "Asia/Kolkata",
+                },
+              ],
+            },
+          ],
+        });
+
+        await createBookingScenario(scenarioData);
+
+        const mockBookingData = getMockRequestDataForBooking({
+          data: {
+            eventTypeId: 1,
+            rescheduleUid: "existing-booking-uid",
+            responses: {
+              email: newBooker.email, // Different email from original booking
+              name: newBooker.name,
+              location: { optionValue: "", value: "integrations:daily" },
+            },
+          },
+        });
+
+        await expect(handleNewBooking({ bookingData: mockBookingData })).rejects.toThrow(
+          expect.objectContaining({
+            statusCode: 400,
+            message: "email_verification_required",
+          })
+        );
+
+        expect(verifyCodeUnAuthenticated).not.toHaveBeenCalled();
+      },
+      timeout
+    );
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the frustrating experience where users have to verify their email again when rescheduling an appointment, even though they've already been verified for the original booking.

- Fixes #24850

## Summary

This PR allows users to reschedule appointments without going through email verification again, but only if their email matches the original booking. This maintains security while improving user experience.

### Key Changes:
- Modified [RegularBookingService.ts](cci:7://file:///c:/Users/tanay/Downloads/Projects%20DEV/cal.com/packages/features/bookings/lib/service/RegularBookingService.ts:0:0-0:0) to conditionally skip email verification for reschedules
- Added [shouldSkipEmailVerificationForReschedule](cci:1://file:///c:/Users/tanay/Downloads/Projects%20DEV/cal.com/packages/features/bookings/lib/service/RegularBookingService.ts:2611:0-2664:1) helper function that validates email matches
- Added comprehensive test coverage for both scenarios

### Security Considerations:
- Email verification is still required if the email address changes
- Verification is required if the original booking cannot be found
- All errors default to requiring verification for safety

## How to test

1. Create an event type with "Requires booker email verification" enabled
2. Book an appointment