### PR TITLE
fix: prevent dialog state loss on tab switch in Out of Office page

### DIFF
--- a/packages/features/settings/outOfOffice/OutOfOfficeEntriesList.tsx
+++ b/packages/features/settings/outOfOffice/OutOfOfficeEntriesList.tsx
@@ -116,6 +116,7 @@ function OutOfOfficeEntriesListContent() {
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
         placeholderData: keepPreviousData,
+        refetchOnWindowFocus: false,
       }
     );
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the Out of Office dialog loses its state (form data and open/closed state) when switching browser tabs during entry creation or editing.

The issue was caused by React Query's default `refetchOnWindowFocus: true` behavior. When the user switches tabs and returns, the query refetches data, which was triggering re-renders that caused the dialog state to be lost.

This fix disables `refetchOnWindowFocus` for the `outOfOfficeEntriesList` query while keeping the existing manual `refetch()` calls in the `useEffect` that handle data refresh when needed (after deletions or tab changes).

**Changes:**
- Added `refetchOnWindowFocus: false` to the infinite query options in `OutOfOfficeEntriesList.tsx`

**Link to Devin run:** https://app.devin.ai/sessions/7f195c230b064c769fdd5f33efa05cae  
**Requested by:** rodrigo@cal.com (@rodrigoehlers)

## How should this be tested?

**To reproduce the original bug:**
1. Navigate to Settings > My Account > Out of Office
2. Click "Add" to create a new out of office entry
3. Start filling in the form (select dates, reason, etc.)
4. Switch to a different browser tab and then switch back
5. Bug: The dialog should close and all form state should be lost

**To verify the fix:**
1. Follow the same steps as above
2. Expected: The dialog should remain open with all form data intact after switching tabs

**Additional test scenarios:**
- Try the same with editing an existing entry (click pencil icon on an existing entry)
- Verify that data still refreshes properly after deleting an entry
- Verify that switching between "Mine" and "Team" tabs still refreshes the data correctly

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - this is a bug fix with no API changes
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note: No new tests added - this would require E2E tests to simulate tab switching behavior**

## Important Notes for Reviewers

⚠️ **This fix has not been tested locally** - it's based on code analysis and hypothesis about the root cause. Manual testing is critical before merging.

**Key areas to review:**
1. Verify the fix actually resolves the reported bug (test reproduction steps above)
2. Check if disabling `refetchOnWindowFocus` has any unintended side effects on data freshness
3. Consider whether this one-line fix is the right architectural solution, or if a more robust approach (like hoisting dialog state or using URL-based dialog control) would be better long-term
4. Verify that the existing `useEffect` with manual `refetch()` calls (lines 122-124) adequately handles all cases where data needs to be refreshed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings (lint passes, type errors are pre-existing on main)
- [x] This is a minimal focused change that addresses the specific bug