### PR TITLE
refactor: remove cal ai tip

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1800,7 +1800,6 @@
   "team_url": "Team URL",
   "team_members": "Team members",
   "more": "More",
-  "cal_ai_workflows": "Cal.ai Workflows",
   "and_count_more": "and {{count}} more",
   "more_page_footer": "We view the mobile application as an extension of the web application. If you are performing any complicated actions, please refer back to the web application.",
   "workflow_example_1": "Send SMS reminder 24 hours before event starts to attendee",

--- a/packages/features/tips/Tips.tsx
+++ b/packages/features/tips/Tips.tsx
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+ 
 import shuffle from "lodash/shuffle";
 import { useState, memo } from "react";
 
@@ -156,17 +156,7 @@ export const tips: Tip[] = [
   },
 ];
 
-const CalAIWorkflowsTip: Tip = {
-  id: 18,
-  thumbnailUrl: "https://img.youtube.com/vi/fMHW6jYPIb8/0.jpg",
-  title: "cal_ai_workflows",
-  description: "supercharge_your_workflows_with_cal_ai_description",
-  href: "/workflows",
-  coverPhoto: "/cal-ai-workflow-sidebar.jpg",
-  variant: "NewLaunchSidebarCard",
-};
-
-const reversedTips = [...shuffle(tips).slice(0).reverse(), CalAIWorkflowsTip];
+const reversedTips = [...shuffle(tips).slice(0).reverse()];
 
 function Tips() {
   const { t } = useLocale();
@@ -216,7 +206,6 @@ function Tips() {
         }}>
         {list.map((tip) => {
           const isTopTip = baseOriginalList.indexOf(tip) === 0;
-          const isCalAIWorkflowsTip = tip.title === "cal_ai_workflows";
           return (
             <div
               className="relative"
@@ -242,10 +231,8 @@ function Tips() {
                   learnMore={
                     isTopTip
                       ? {
-                          href: isCalAIWorkflowsTip
-                            ? "/workflow/new?action=calAi&templateWorkflowId=wf-11"
-                            : tip.href,
-                          text: isCalAIWorkflowsTip ? t("try_now") : t("learn_more"),
+                          href: tip.href,
+                          text: t("learn_more"),
                         }
                       : undefined
                   }
@@ -256,7 +243,6 @@ function Tips() {
                     tabIndex: isTopTip ? undefined : -1,
                     "aria-hidden": isTopTip ? undefined : "true",
                   }}
-                  buttonClassName={isCalAIWorkflowsTip ? "text-white" : undefined}
                 />
               </div>
             </div>


### PR DESCRIPTION
## What does this PR do?

- Removes the last remaining Cal AI tip from the app’s sidebar.
- Deletes an unused image related to that tip.
- Cleans up a leftover English text label tied to the tip.