### PR TITLE
refactor: update workflow template config for free users

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
+++ b/packages/features/ee/workflows/components/WorkflowStepContainer.tsx
@@ -380,11 +380,6 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
     name: "steps",
   });
 
-  // Extract current step template from watched steps array
-  const currentStepTemplate = step ? steps?.[step.stepNumber - 1]?.template : null;
-
-  const isReminderTemplate = currentStepTemplate === WorkflowTemplates.REMINDER;
-
   const hasAiAction = hasCalAIAction(steps);
   const hasEmailToHostAction = steps.some((s) => s.action === WorkflowActions.EMAIL_HOST);
   const hasWhatsappAction = steps.some((s) => isWhatsappAction(s.action));
@@ -1335,7 +1330,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                       refEmailSubject.current = e;
                     }}
                     rows={2}
-                    disabled={props.readOnly || (!hasActiveTeamPlan && !isReminderTemplate)}
+                    disabled={props.readOnly || !hasActiveTeamPlan}
                     className="my-0 focus:ring-transparent"
                     required
                     {...restEmailSubjectForm}
@@ -1368,7 +1363,7 @@ export default function WorkflowStepContainer(props: WorkflowStepProps) {
                 editable={
                   !props.readOnly &&
                   !isWhatsappAction(step.action) &&
-                  (hasActiveTeamPlan || isSMSAction(step.action) || isReminderTemplate)
+                  (hasActiveTeamPlan || isSMSAction(step.action))
                 }
                 excludedToolbarItems={
                   !isSMSAction(step.action) ? [] : ["blockType", "bold", "italic", "link"]

--- a/packages/features/ee/workflows/lib/getOptions.ts
+++ b/packages/features/ee/workflows/lib/getOptions.ts
@@ -62,7 +62,7 @@ function convertToTemplateOptions(
     return {
       label: t(`${template.toLowerCase()}`),
       value: template,
-      needsTeamsUpgrade: !hasPaidPlan && template !== WorkflowTemplates.REMINDER,
+      needsTeamsUpgrade: !hasPaidPlan && template === WorkflowTemplates.CUSTOM,
     } as { label: string; value: any; needsTeamsUpgrade: boolean };
   });
 }


### PR DESCRIPTION
## What does this PR do?

- Enables all built‑in workflow templates for free users 
- Keeps Custom template as a paid feature.
- Prevents free users from editing email subject and body on any template (to reduce spam); SMS body stays editable as before.
- Updates the UI to reflect these rules (Custom shows as upgrade-only; editors are disabled for free plans).
- Paid users keep full access: can use Custom and edit all fields.


https://github.com/user-attachments/assets/3a83b1e8-70a2-4857-97ad-825a79cd6b4d


