### PR TITLE
style: fix height of report button

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -470,7 +470,7 @@ function BookingListItem(booking: BookingItemProps) {
                   onClick={reportActionWithHandler.onClick}
                   disabled={reportActionWithHandler.disabled}
                   data-testid={reportActionWithHandler.id}
-                  className="h-8 w-8"
+                  className="min-h-[34px]"
                   tooltip={reportActionWithHandler.label}
                 />
               </div>

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -470,7 +470,7 @@ function BookingListItem(booking: BookingItemProps) {
                   onClick={reportActionWithHandler.onClick}
                   disabled={reportActionWithHandler.disabled}
                   data-testid={reportActionWithHandler.id}
-                  className="min-h-[34px]"
+                  className="min-h-[34px] min-w-[34px]"
                   tooltip={reportActionWithHandler.label}
                 />
               </div>


### PR DESCRIPTION
## What does this PR do?

![Screenshot 2025-11-04 at 11 46 44 PM](https://github.com/user-attachments/assets/70a7e62f-adbb-43dc-95ef-7903ac929f56)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the report button in BookingListItem to use 34px minimum height and width, fixing inconsistent sizing and preventing layout misalignment.

<sup>Written for commit 696646374b3ae95c712818640633a232ecd6bbac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





