### PR TITLE
feat: add calendar read and cache tracking to availability snapshot logging

### DIFF
--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -474,6 +474,11 @@ export class UserAvailabilityService {
         dateOverrides: [],
         currentSeats: [],
         datesOutOfOffice: undefined,
+        cacheInfo: {
+          calendarsRead: false,
+          totalCalendarBusyTimes: 0,
+          calendarSources: [],
+        },
       };
     }
 
@@ -581,6 +586,21 @@ export class UserAvailabilityService {
     const dateRangesInWhichUserIsAvailable = subtract(dateRanges, formattedBusyTimes);
     const dateRangesInWhichUserIsAvailableWithoutOOO = subtract(oooExcludedDateRanges, formattedBusyTimes);
 
+    const calendarsWereRead = user.credentials?.length > 0 && !bypassBusyCalendarTimes;
+    const calendarBusyTimes = detailedBusyTimes.filter((bt) => bt.source && !bt.source.startsWith("eventType-"));
+    const uniqueCalendarSources = new Set(calendarBusyTimes.map((bt) => bt.source).filter(Boolean));
+    const cacheInfo = calendarsWereRead
+      ? {
+          calendarsRead: true,
+          totalCalendarBusyTimes: calendarBusyTimes.length,
+          calendarSources: Array.from(uniqueCalendarSources) as string[],
+        }
+      : {
+          calendarsRead: false,
+          totalCalendarBusyTimes: 0,
+          calendarSources: [],
+        };
+
     const result = {
       busy: detailedBusyTimes,
       timeZone: finalTimezone,
@@ -590,6 +610,7 @@ export class UserAvailabilityService {
       dateOverrides,
       currentSeats,
       datesOutOfOffice,
+      cacheInfo,
     };
 
     log.debug(

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1720,6 +1720,7 @@ async function handler(
           availabilitySnapshot: organizerUserAvailability?.availabilityData
             ? formatAvailabilitySnapshot(organizerUserAvailability.availabilityData)
             : null,
+          calendarReadInfo: organizerUserAvailability?.availabilityData?.cacheInfo ?? null,
         });
       }
 


### PR DESCRIPTION
## What does this PR do?

Adds calendar read status and metadata tracking to the availability snapshot that's logged when bookings are created. This helps ensure calendars were actually checked during the booking process and provides visibility into which calendar sources contributed busy times.

**Context**: When debugging booking availability issues, it's important to know whether external calendars were consulted and which providers returned busy times. This PR adds that visibility to the critical booking logs.

**Link to Devin run**: https://app.devin.ai/sessions/682d49a3119a431e917c37ad71b8afbf  
**Requested by**: joe@cal.com (@joeauyeung)

### Changes:
- Added `cacheInfo` field to `getUserAvailability()` return type containing:
  - `calendarsRead`: boolean indicating if calendars were configured to be read
  - `totalCalendarBusyTimes`: count of busy time entries from external calendars
  - `calendarSources`: unique list of calendar provider sources that contributed busy times
- Added `calendarReadInfo` to booking creation critical logs in `RegularBookingService`
- Ensured type consistency by including `cacheInfo` in error handling paths

### Example log output:
```json
{
  "bookingUid": "abc123",
  "selectedCalendarIds": [1, 2, 3],
  "availabilitySnapshot": { ... },
  "calendarReadInfo": {
    "calendarsRead": true,
    "totalCalendarBusyTimes": 5,
    "calendarSources": ["googlecalendar", "office365calendar"]
  }
}
```

## Important Notes for Reviewers

⚠️ **Potential Gap**: This implementation tracks whether calendars were *configured* to be read and which sources returned busy times, but does NOT track actual cache hit/miss status from calendar services. If the requirement is to distinguish between cached vs live calendar API responses, additional changes would be needed to propagate cache metadata through the call chain.

### Key Review Points:
1. **Verify requirement interpretation**: Does "came from cache" mean tracking cache-configured calendars OR actual cache hit/miss from calendar services?
2. **Check filtering logic**: The code filters calendar busy times from booking busy times using `!bt.source.startsWith("eventType-")` - verify this correctly identifies calendar sources
3. **Validate calendarsRead logic**: Uses `user.credentials?.length > 0 && !bypassBusyCalendarTimes` - is this sufficient or should we track actual calendar service calls?
4. **Consider test coverage**: No tests were added - should we add unit tests for the new `cacheInfo` logic?

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is an internal logging change
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: No new tests added; existing tests pass

## How should this be tested?

### Manual Testing:
1. Create a booking with a user who has connected calendar credentials
2. Check the logs for the booking creation event
3. Verify `calendarReadInfo` is present with expected structure
4. Verify `calendarsRead: true` when calendars are configured
5. Verify `calendarSources` lists the calendar providers that had busy times

### Test Scenarios:
- **User with Google Calendar**: Should show `"calendarSources": ["googlecalendar"]`
- **User with no calendars**: Should show `"calendarsRead": false, "calendarSources": []`
- **User with bypassed calendars**: Should show `"calendarsRead": false`
- **User with multiple calendar providers**: Should show all unique sources

### Environment:
- No special environment variables required
- Requires users with connected calendar credentials in test database
- Check critical logs (not debug logs) for the new fields

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas (minimal comments as per guidelines)
- [x] I have checked that my changes generate no new warnings (lint and type checks pass)