### PR TITLE
fix: include busy times in availability snapshot logging

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -397,7 +397,7 @@ function buildTroubleshooterData({
 function formatAvailabilitySnapshot(data: {
   dateRanges: { start: dayjs.Dayjs; end: dayjs.Dayjs }[];
   oooExcludedDateRanges: { start: dayjs.Dayjs; end: dayjs.Dayjs }[];
-  busy?: { start: Date | string; end: Date | string; title?: string; source?: string }[];
+  busy?: { start: Date | string; end: Date | string; title?: string; source?: string | null; userId?: number | null }[];
 }) {
   const formattedBusy = data.busy?.map(({ start, end, source }) => ({
     start: dayjs(start).toISOString(),

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -397,9 +397,26 @@ function buildTroubleshooterData({
 function formatAvailabilitySnapshot(data: {
   dateRanges: { start: dayjs.Dayjs; end: dayjs.Dayjs }[];
   oooExcludedDateRanges: { start: dayjs.Dayjs; end: dayjs.Dayjs }[];
+  busy?: { start: Date | string; end: Date | string; title?: string; source?: string }[];
 }) {
+  const formattedBusy = data.busy?.map(({ start, end, source }) => ({
+    start: dayjs(start).toISOString(),
+    end: dayjs(end).toISOString(),
+    source: source || "unknown",
+  }));
+
+  // Create a summary of busy times by source for quick analysis
+  const busySummary = formattedBusy?.reduce(
+    (acc, busy) => {
+      acc.totalBusy++;
+      const sourceKey = busy.source;
+      acc.bySource[sourceKey] = (acc.bySource[sourceKey] || 0) + 1;
+      return acc;
+    },
+    { totalBusy: 0, bySource: {} as Record<string, number> }
+  );
+
   return {
-    ...data,
     dateRanges: data.dateRanges.map(({ start, end }) => ({
       start: start.toISOString(),
       end: end.toISOString(),
@@ -408,6 +425,8 @@ function formatAvailabilitySnapshot(data: {
       start: start.toISOString(),
       end: end.toISOString(),
     })),
+    busy: formattedBusy || [],
+    busySummary: busySummary || { totalBusy: 0, bySource: {} },
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where Google Calendar busy blocks aren't appearing in the availability snapshot logs, making it impossible for support to diagnose why bookings are being made over blocked times.

**Root Cause**: The `formatAvailabilitySnapshot` function only logged `dateRanges` and `oooExcludedDateRanges`, but completely omitted the `busy` array which contains all busy times from calendar integrations (Google Calendar, Outlook, etc.) and internal bookings.

**Solution**: Enhanced the function to include:
- Full `busy` times array with start/end/source (no PII like titles)
- `busySummary` with counts by source for quick analysis (e.g., `{ totalBusy: 5, bySource: { "google_calendar": 3, "office365_calendar": 2 } }`)

This gives support visibility into which calendar providers had busy blocks when availability was calculated for a booking.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is an internal logging improvement that doesn't require user-facing documentation
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Tests needed** - This logging change needs integration tests to verify the busy times are correctly captured in the availability snapshot

## How should this be tested?

**Manual Testing:**
1. Create a booking on an event type connected to Google Calendar
2. Add some busy blocks in Google Calendar during the available time slots
3. Make a booking that should conflict with those busy blocks
4. Check the application logs for the "Booking created" log entry
5. Verify the `availabilitySnapshot.busy` array contains entries with `start`, `end`, and `source` fields
6. Verify the `availabilitySnapshot.busySummary` shows the correct counts by source

**Expected Output Example:**
```json
{
  "availabilitySnapshot": {
    "dateRanges": [...],
    "oooExcludedDateRanges": [...],
    "busy": [
      {
        "start": "2024-11-04T10:00:00.000Z",
        "end": "2024-11-04T11:00:00.000Z",
        "source": "google_calendar"
      }
    ],
    "busySummary": {
      "totalBusy": 1,
      "bySource": {
        "google_calendar": 1
      }
    }
  }
}
```

## Important Review Points

**⚠️ High Priority:**
- Verify `availabilityData.busy` is actually populated at runtime when bookings are created
- Check that Google Calendar, Outlook, and other calendar providers correctly stamp the `source` field
- Confirm no PII is exposed in the `source` field

**Medium Priority:**
- Consider if automated tests should be added for this logging behavior
- Verify the type change from `Date` to `Date | string` doesn't break anything downstream

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run**: https://app.devin.ai/sessions/df37c4aae2de414a8e73755b1ece6c31  
**Requested by**: joe@cal.com (@joeauyeung)