### PR TITLE
hotfix: Bring back English translation for cal.ai banner

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -836,6 +836,8 @@
   "workflow_validation_failed": "Workflow validation failed",
   "workflow_validation_empty_fields": "One or more workflow steps have empty message content",
   "workflow_validation_unverified_contacts": "One or more phone numbers or email addresses are not verified",
+  "supercharge_your_workflows_with_cal_ai": "Supercharge your Workflows with Cal.ai",
+  "supercharge_your_workflows_with_cal_ai_description": "Lifelike AI agents that book meetings, send reminders, and follow up with your customers.",
   "phone_number_imported_successfully": "Phone number imported and linked to agent successfully",
   "phone_number_deleted_successfully": "Phone number deleted successfully",
   "delete_phone_number_confirmation": "Are you sure you want to delete this phone number? This action cannot be undone.",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored English translations for the Cal.ai banner by adding the missing title and description keys to the en/common.json, ensuring the banner renders correctly in English.

<sup>Written for commit 291f1364c5f377a16056d72ac328f38b9b282713. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

