### PR TITLE
feat: Rescheduled bookings showing correctly in insights/routing

### DIFF
--- a/packages/features/insights/hooks/useInsightsRoutingFacetedUniqueValues.ts
+++ b/packages/features/insights/hooks/useInsightsRoutingFacetedUniqueValues.ts
@@ -14,6 +14,7 @@ const statusOrder: Record<BookingStatus, number> = {
   [BookingStatus.AWAITING_HOST]: 3,
   [BookingStatus.CANCELLED]: 4,
   [BookingStatus.REJECTED]: 5,
+  [BookingStatus.RESCHEDULED]: 6,
 };
 
 export const useInsightsRoutingFacetedUniqueValues = ({

--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -287,7 +287,14 @@ export class InsightsRoutingBaseService {
         rfrd."formUserId",
         rfrd."bookingUid",
         rfrd."bookingId",
-        UPPER(rfrd."bookingStatus"::text) as "bookingStatus",
+        CASE WHEN EXISTS (
+          SELECT 1 FROM "Booking" b
+          WHERE b."uid" = rfrd."bookingUid" AND b."rescheduledToUid" IS NOT NULL
+        ) THEN 'RESCHEDULED' ELSE UPPER(rfrd."bookingStatus"::text) END as "bookingStatus",
+        CASE WHEN EXISTS (
+          SELECT 1 FROM "Booking" b
+          WHERE b."uid" = rfrd."bookingUid" AND b."rescheduledToUid" IS NOT NULL
+        ) THEN 6 ELSE rfrd."bookingStatusOrder" END as "bookingStatusOrder",
         rfrd."bookingStatusOrder",
         rfrd."bookingCreatedAt",
         rfrd."bookingUserId",

--- a/packages/prisma/migrations/20251104172156_add_rescheduled_booking_status/migration.sql
+++ b/packages/prisma/migrations/20251104172156_add_rescheduled_booking_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."BookingStatus" ADD VALUE 'rescheduled';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -781,6 +781,7 @@ model Attendee {
 }
 
 enum BookingStatus {
+  RESCHEDULED   @map("rescheduled")
   CANCELLED     @map("cancelled")
   ACCEPTED      @map("accepted")
   REJECTED      @map("rejected")


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24531 
- Fixes CAL-6599
- added rescheduled booking status in schema and insights > routing page filter
- added custom logic in `InsightsRoutingBaseService.ts` to mark booking as rescheduled, if it is rescheduled and still being labelled as another status
- marking this PR as draft as i wasn't able to test if the rescheduled filter is working properly or not, with some feedback i can make the changes and test it correctly.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before:

<img width="316" height="374" alt="Screenshot from 2025-11-04 23-54-15" src="https://github.com/user-attachments/assets/94b6850f-27de-44db-824d-426a73782897" />

After:

<img width="316" height="374" alt="Screenshot from 2025-11-04 23-53-13" src="https://github.com/user-attachments/assets/8eabb378-2a37-47d7-8929-f89f6e98066a" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Go to insights/routing
- add booking status filter
- check that the rescheduled filter is present
