### PR TITLE
revert: "feat: skip authentication check for reschedule bookings with validation"

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-04-15/controllers/bookings.controller.ts
@@ -205,11 +205,7 @@ export class BookingsController_2024_04_15 {
       clientId?.toString() || (await this.getOAuthClientIdFromEventType(body.eventTypeId));
     const { orgSlug, locationUrl } = body;
     try {
-      if (body.rescheduleUid) {
-        await this.validateRescheduleBooking(body.rescheduleUid, body.eventTypeId);
-      } else {
-        await this.checkBookingRequiresAuthentication(req, body.eventTypeId);
-      }
+      await this.checkBookingRequiresAuthentication(req, body.eventTypeId);
       const bookingRequest = await this.createNextApiBookingRequest(req, oAuthClientId, locationUrl, isEmbed);
       const booking = await this.regularBookingService.createBooking({
         bookingData: bookingRequest.body,
@@ -461,25 +457,6 @@ export class BookingsController_2024_04_15 {
       return undefined;
     }
     return oAuthClientParams.platformClientId;
-  }
-
-  private async validateRescheduleBooking(rescheduleUid: string, eventTypeId: number): Promise<void> {
-    const { bookingInfo } = await getBookingInfo(rescheduleUid);
-    if (!bookingInfo) {
-      throw new NotFoundException(
-        `Booking with UID=${rescheduleUid} does not exist. Cannot reschedule a non-existent booking.`
-      );
-    }
-    if (bookingInfo.status !== "ACCEPTED" && bookingInfo.status !== "PENDING") {
-      throw new BadRequestException(
-        `Booking with UID=${rescheduleUid} has invalid status (status: ${bookingInfo.status}). Only ACCEPTED or PENDING bookings can be rescheduled.`
-      );
-    }
-    if (bookingInfo.eventTypeId !== eventTypeId) {
-      throw new BadRequestException(
-        `Booking with UID=${rescheduleUid} is for a different event type (eventTypeId: ${bookingInfo.eventTypeId}). Cannot reschedule to a different event type (eventTypeId: ${eventTypeId}).`
-      );
-    }
   }
 
   private async checkBookingRequiresAuthentication(req: Request, eventTypeId: number): Promise<void> {


### PR DESCRIPTION
Reverts calcom/cal.com#24903

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that skipped authentication for rescheduled bookings. All bookings, including reschedules, now go through checkBookingRequiresAuthentication again, and the reschedule validation helper was removed.

<sup>Written for commit d33679261d4c3aa05def2148ec3af498847870b8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

