### PR TITLE
chore: Add shared onboarding components (OnboardingCard, OnboardingLayout, browser views)

### DIFF
--- a/apps/web/modules/onboarding/components/OnboardingCard.tsx
+++ b/apps/web/modules/onboarding/components/OnboardingCard.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+import { SkeletonText } from "@calcom/ui/components/skeleton";
+
+type OnboardingCardProps = {
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+  footer: ReactNode;
+  isLoading?: boolean;
+};
+
+export const OnboardingCard = ({ title, subtitle, children, footer, isLoading }: OnboardingCardProps) => {
+  return (
+    <div className="relative flex h-full min-h-0 w-full flex-col">
+      {/* Card Header */}
+      <div className="flex w-full gap-1.5 px-5 py-4">
+        <div className="flex w-full flex-col gap-1">
+          <h1 className="font-cal text-xl font-semibold leading-6">{title}</h1>
+          <p className="text-subtle text-sm font-medium leading-tight">{subtitle}</p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-4">
+        {isLoading ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <SkeletonText className="h-40 w-full" />
+            <SkeletonText className="h-40 w-full" />
+          </div>
+        ) : (
+          children
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex w-full items-center justify-start px-5 py-4">{footer}</div>
+    </div>
+  );
+};
+

--- a/apps/web/modules/onboarding/components/OnboardingLayout.tsx
+++ b/apps/web/modules/onboarding/components/OnboardingLayout.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { Children, type ReactNode } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import { Logo } from "@calcom/ui/components/logo";
+
+type OnboardingLayoutProps = {
+  userEmail: string;
+  currentStep: 1 | 2 | 3;
+  children: ReactNode;
+};
+
+export const OnboardingLayout = ({ userEmail, currentStep, children }: OnboardingLayoutProps) => {
+  const { t } = useLocale();
+
+  const handleSignOut = () => {
+    signOut({ callbackUrl: "/auth/logout" });
+  };
+
+  // Extract children as array
+  const childrenArray = Children.toArray(children);
+  const column1 = childrenArray[0];
+  const column2 = childrenArray[1];
+
+  return (
+    <div className="bg-muted flex min-h-screen w-full flex-col items-center justify-between overflow-clip rounded-[12px] px-6 py-10">
+      {/* Logo and container - centered */}
+      <div className="flex w-full flex-1 flex-col items-center justify-center gap-8">
+        <Logo className="h-5 w-auto shrink-0" />
+        <div className="border-subtle bg-default grid w-full max-w-[1130px] grid-cols-1 gap-6 overflow-hidden rounded-2xl border px-12 py-10 xl:h-[690px] xl:grid-cols-[40%_1fr] xl:pl-10 xl:pr-0">
+          {/* Column 1 - Always visible, 40% on xl+ */}
+          <div className="flex min-h-0 flex-col">{column1}</div>
+          {/* Column 2 - Hidden on mobile, visible on xl+, 60% on xl+ */}
+          {column2 && (
+            <div className="hidden h-full max-h-full min-h-0 flex-col overflow-hidden xl:flex">{column2}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer with progress dots and sign out */}
+      <div className="flex w-full flex-col items-center justify-center gap-4 px-10 py-8">
+        <div className="flex items-center gap-2">
+          {[1, 2, 3].map((step) => (
+            <div key={step} className="relative flex h-2 w-2 shrink-0 items-center justify-center">
+              <div
+                className={`absolute inset-0 rounded-full ${
+                  step <= currentStep ? "bg-emphasis" : "bg-muted"
+                }`}
+              />
+              {step <= currentStep && <div className="bg-emphasis absolute h-1 w-1 rounded-full" />}
+            </div>
+          ))}
+        </div>
+        <Button onClick={handleSignOut} color="minimal" className="text-subtle h-7">
+          {t("sign_out")}
+        </Button>
+      </div>
+    </div>
+  );
+};
+

--- a/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
+++ b/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Button } from "@calcom/ui/components/button";
+import { Icon, type IconName } from "@calcom/ui/components/icon";
+
+type OnboardingBrowserViewProps = {
+  avatar?: string | null;
+  name?: string;
+  bio?: string;
+  username?: string | null;
+  teamSlug?: string;
+};
+
+export const OnboardingBrowserView = ({
+  avatar,
+  name,
+  bio,
+  username,
+  teamSlug,
+}: OnboardingBrowserViewProps) => {
+  const { t } = useLocale();
+  const webappUrl = WEBAPP_URL.replace(/^https?:\/\//, "");
+  const displayUrl =
+    teamSlug !== undefined ? `${webappUrl}/team/${teamSlug || ""}` : `${webappUrl}/${username || ""}`;
+
+  const events: Array<{
+    title: string;
+    description: string;
+    duration: number;
+    icon: IconName;
+  }> = [
+    {
+      title: t("onboarding_browser_view_demo"),
+      description: t("onboarding_browser_view_demo_description"),
+      duration: 15,
+      icon: "bell",
+    },
+    {
+      title: t("onboarding_browser_view_quick_meeting"),
+      description: t("onboarding_browser_view_quick_meeting_description"),
+      duration: 15,
+      icon: "bell",
+    },
+    {
+      title: t("onboarding_browser_view_longer_meeting"),
+      description: t("onboarding_browser_view_longer_meeting_description"),
+      duration: 30,
+      icon: "clock",
+    },
+    {
+      title: t("in_person_meeting"),
+      description: t("onboarding_browser_view_in_person_description"),
+      duration: 120,
+      icon: "map-pin",
+    },
+    {
+      title: t("onboarding_browser_view_ask_question"),
+      description: t("onboarding_browser_view_ask_question_description"),
+      duration: 15,
+      icon: "message-circle",
+    },
+  ];
+  return (
+    <div className="bg-default border-subtle hidden h-full w-full flex-col rounded-l-2xl border xl:flex">
+      {/* Browser header */}
+      <div className="border-subtle flex min-w-0 shrink-0 items-center gap-3 rounded-t-2xl border-b bg-white p-3">
+        {/* Navigation buttons */}
+        <div className="flex shrink-0 items-center gap-4 opacity-50">
+          <Icon name="arrow-left" className="text-subtle h-4 w-4" />
+          <Icon name="arrow-right" className="text-subtle h-4 w-4" />
+          <Icon name="rotate-cw" className="text-subtle h-4 w-4" />
+        </div>
+        <div className="bg-muted flex w-full items-center gap-2 rounded-[32px] px-3 py-2">
+          <Icon name="lock" className="text-subtle h-4 w-4" />
+          <p className="text-default text-sm font-medium leading-tight">{displayUrl}</p>
+        </div>
+        <Icon name="ellipsis-vertical" className="text-subtle h-4 w-4" />
+      </div>
+      {/* Content */}
+      <div className="bg-muted h-full pl-11 pt-11">
+        <div className="bg-default border-muted flex h-full w-full flex-col overflow-hidden rounded-xl border">
+          {/* Profile Header */}
+          <div className="border-subtle flex flex-col gap-4 border-b p-4">
+            <div className="flex flex-col items-start gap-4">
+              <Avatar
+                size="lg"
+                imageSrc={avatar || undefined}
+                alt={name || ""}
+                className="border-2 border-white"
+              />
+              <div className="flex flex-col gap-2">
+                <h2 className="text-emphasis text-xl font-semibold leading-tight">
+                  {name || t("your_name")}
+                </h2>
+                <p className="text-default text-sm leading-normal">
+                  {bio || t("onboarding_browser_view_default_bio")}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Events List */}
+          <div className="flex flex-col overflow-y-auto">
+            {events.map((event, index) => (
+              <div key={event.title} className="opacity-30">
+                {index > 0 && <div className="border-subtle h-px border-t" />}
+                <div className="flex items-center justify-between gap-3 px-5 py-4">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <div className="flex items-center gap-1">
+                      <h3 className="text-default text-sm font-semibold leading-none">{event.title}</h3>
+                      <div className="bg-emphasis flex h-4 items-center justify-center gap-1 rounded-md px-1">
+                        <Icon name={event.icon} className="text-emphasis h-3 w-3" />
+                        <span className="text-emphasis text-xs font-medium leading-none">
+                          {event.duration} {t("minute_timeUnit")}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-subtle text-sm font-medium leading-tight">{event.description}</p>
+                  </div>
+                  <Button color="secondary" size="sm" EndIcon="arrow-right">
+                    {t("book_now")}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/modules/onboarding/components/onboarding-invite-browser-view.tsx
+++ b/apps/web/modules/onboarding/components/onboarding-invite-browser-view.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { trpc } from "@calcom/trpc/react";
+import { Avatar } from "@calcom/ui/components/avatar";
+
+import { useOnboardingStore } from "../store/onboarding-store";
+
+type OnboardingInviteBrowserViewProps = {
+  teamName?: string;
+};
+
+export const OnboardingInviteBrowserView = ({ teamName }: OnboardingInviteBrowserViewProps) => {
+  const { data: user } = trpc.viewer.me.get.useQuery();
+  const { teamBrand } = useOnboardingStore();
+
+  // Use default values if not provided
+  const rawInviterName = user?.name || user?.username || "Alex";
+  const displayInviterName = rawInviterName.charAt(0).toUpperCase() + rawInviterName.slice(1);
+  const displayTeamName = teamName || "Deel";
+  const teamAvatar = teamBrand.logo || null;
+
+  return (
+    <div className="bg-default border-subtle hidden h-full w-full flex-col rounded-l-2xl border xl:flex">
+      {/* Browser header */}
+      <div className="border-subtle flex min-w-0 shrink-0 items-center gap-3 rounded-t-2xl border-b bg-white p-3">
+        {/* Navigation buttons */}
+        <div className="flex shrink-0 items-center gap-4 opacity-50">
+          <div className="h-3 w-3 rounded-full bg-gray-300" />
+          <div className="h-3 w-3 rounded-full bg-gray-300" />
+          <div className="h-3 w-3 rounded-full bg-gray-300" />
+        </div>
+        <div className="bg-muted flex w-full items-center gap-2 rounded-[32px] px-3 py-2">
+          <div className="h-3 w-3 rounded-full bg-gray-400" />
+          <p className="text-subtle text-xs font-medium leading-tight">mail.example.com</p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="bg-muted h-full pl-8 pt-8">
+        <div className="bg-default border-subtle flex h-full w-full flex-col overflow-hidden rounded-tl-2xl border-l border-t">
+          {/* Email Header */}
+          <div className="border-subtle bg-muted flex flex-col gap-4 border-b p-8">
+            <div className="flex flex-col items-start gap-4">
+              <Avatar
+                size="lg"
+                imageSrc={teamAvatar || undefined}
+                alt={displayTeamName}
+                className="border-default h-12 w-12 border-2"
+              />
+              <div className="flex w-full flex-col items-start gap-1">
+                <h2 className="text-emphasis font-cal w-full text-left text-xl font-semibold leading-tight">
+                  {displayInviterName} invited you to join {displayTeamName}
+                </h2>
+                <p className="text-subtle text-left text-sm font-normal leading-tight">
+                  We're emailing you all the details
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Email Body */}
+          <div className="bg-default flex-1 rounded-bl-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
+++ b/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
@@ -10,9 +10,9 @@ import { Button } from "@calcom/ui/components/button";
 import { type IconName } from "@calcom/ui/components/icon";
 import { RadioAreaGroup } from "@calcom/ui/components/radio";
 
+import { OnboardingLayout } from "../components/OnboardingLayout";
 import { OnboardingContinuationPrompt } from "../components/onboarding-continuation-prompt";
 import { PlanIcon } from "../components/plan-icon";
-import { OnboardingLayout } from "../personal/_components/OnboardingLayout";
 import { useOnboardingStore, type PlanType } from "../store/onboarding-store";
 
 type OnboardingViewProps = {
@@ -64,7 +64,7 @@ export const OnboardingView = ({ userName, userEmail }: OnboardingViewProps) => 
       badge: t("onboarding_plan_organization_badge"),
       description: t("onboarding_plan_organization_description"),
       icon: planIconByType.organization,
-      variant: "double" as const,
+      variant: "organization" as const,
     },
   ];
 


### PR DESCRIPTION
## What does this PR do?

Creates new onboarding UI components for the user onboarding flow, including:

- `OnboardingCard` - A reusable card component with title, subtitle, content, and footer sections
- `OnboardingLayout` - A layout component with progress indicators and sign-out functionality
- `OnboardingBrowserView` - A browser preview showing how the user's booking page will look
- `OnboardingCalendarBrowserView` - A calendar preview showing sample events
- `OnboardingInviteBrowserView` - A preview of the team invitation email
- Enhanced `PlanIcon` component with new variants and animations for organization and team plans

## Visual Demo (For contributors especially)

#### Image Demo:
The PR adds several visual components for the onboarding flow, including browser previews, calendar views, and animated plan icons with concentric rings and user avatars.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Navigate to the onboarding flow to see the new components in action
- Test the layout with different screen sizes to ensure responsive behavior
- Verify that the browser previews render correctly with sample data
- Check that the plan icon animations work properly for different variants (single, team, organization)
- Ensure the calendar view displays sample events correctly

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings