### PR TITLE
fix: added icon and description in team event type empty page

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -877,12 +877,15 @@ const EmptyEventTypeList = ({
   return (
     <>
       <EmptyScreen
+        Icon="link"
         headline={searchTerm ? t("no_result_found_for", { searchTerm }) : t("team_no_event_types")}
+        description={t("new_team_event_type_description")}
+        className="mb-16"
         buttonRaw={
           <Button
             href={`?dialog=new&eventPage=${group.profile.slug}&teamId=${group.teamId}`}
             variant="button"
-            className="mt-5">
+          >
             {t("create")}
           </Button>
         }
@@ -1003,7 +1006,7 @@ const EventTypesPage = ({ userEventGroupsData, user }: Props) => {
     if (redirectUrl) {
       router.push(redirectUrl);
     }
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     setShowProfileBanner(

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -942,6 +942,7 @@
   "new_event_type_btn": "New event type",
   "new_event_type_heading": "Create your first event type",
   "new_event_type_description": "Event types enable you to share links that show available times on your calendar and allow people to make bookings with you.",
+  "new_team_event_type_description": "Event types enable the team to share links that show available times on their calendars and allow people to make bookings with the team.",
   "event_type_created_successfully": "{{eventTypeTitle}} event type created successfully",
   "no_call_history": "No call history",
   "no_call_history_description": "No matching call history found for the particular account/search query.",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #24950 
- Fixes CAL-6702
- added icon and description for the empty team event type page

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before:

<img width="1584" height="738" alt="Screenshot from 2025-11-05 14-52-33" src="https://github.com/user-attachments/assets/381bd78b-8743-4d39-8ee4-58ccc564af52" />
<img width="1584" height="738" alt="Screenshot from 2025-11-05 14-52-43" src="https://github.com/user-attachments/assets/502e77ca-c6d7-4179-bc02-868fd4642743" />

After:

<img width="1613" height="701" alt="Screenshot from 2025-11-05 16-00-46" src="https://github.com/user-attachments/assets/deb26a99-e2ba-43b9-a536-047436f11ae5" />
<img width="1613" height="701" alt="Screenshot from 2025-11-05 16-01-00" src="https://github.com/user-attachments/assets/84c5ec81-4771-4efc-a596-30c3544440c7" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Create a team
- Go to event types page for the team
- Check that the empty team event type page is same as the empty event type page of personal account


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Team Event Types empty state with the personal view: adds a link icon, a team-specific description, and consistent spacing to guide creating the first event type (CAL-6702, #24950). Also updates the useEffect to depend on router to avoid a stale reference and ensure redirects work reliably.

<sup>Written for commit cfb9828f375500e7cb2d9123401792c198caa6a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

