### PR TITLE
refactor: separate bookings columns into filter and display columns

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/ViewToggleButton.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/ViewToggleButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useQueryState } from "nuqs";
+import { useEffect } from "react";
+
+import { activeFiltersParser } from "@calcom/features/data-table/lib/parsers";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
+import { ToggleGroup } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
+
+import { viewParser, type BookingView } from "~/bookings/lib/viewParser";
+
+export function ViewToggleButton() {
+  const { t } = useLocale();
+  const [view, setView] = useQueryState(
+    "view",
+    viewParser.withDefault("list").withOptions({ clearOnDefault: true })
+  );
+  const [, setActiveFilters] = useQueryState("activeFilters", activeFiltersParser);
+  const isMobile = !useMediaQuery("(min-width: 640px)");
+
+  useEffect(() => {
+    // Force list view on mobile
+    if (isMobile && view !== "list") {
+      setView("list");
+    }
+  }, [isMobile, view, setView]);
+
+  return (
+    <div className="hidden sm:block">
+      <ToggleGroup
+        value={view}
+        onValueChange={(value) => {
+          if (!value) return;
+          const newView = value as BookingView;
+
+          // When switching from calendar to list view, remove the dateRange filter
+          if (view === "calendar" && newView === "list") {
+            setActiveFilters((prev) => prev?.filter((filter) => filter.f !== "dateRange") ?? []);
+          }
+
+          setView(newView);
+        }}
+        options={[
+          {
+            value: "list",
+            label: "",
+            tooltip: t("list_view"),
+            iconLeft: <Icon name="menu" className="h-4 w-4" />,
+          },
+          {
+            value: "calendar",
+            label: "",
+            tooltip: t("calendar_view"),
+            iconLeft: <Icon name="calendar" className="h-4 w-4" />,
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -6,15 +6,15 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
-import { prisma } from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
 import { validStatuses } from "~/bookings/lib/validStatuses";
 import BookingsList from "~/bookings/views/bookings-view";
+
+import { ViewToggleButton } from "./ViewToggleButton";
 
 const querySchema = z.object({
   status: z.enum(validStatuses),
@@ -54,18 +54,12 @@ const Page = async ({ params }: PageProps) => {
     canReadOthersBookings = teamIdsWithPermission.length > 0;
   }
 
-  const featuresRepository = new FeaturesRepository(prisma);
-  const isCalendarViewEnabled = await featuresRepository.checkIfFeatureIsEnabledGlobally(
-    "booking-calendar-view"
-  );
-
   return (
-    <ShellMainAppDir heading={t("bookings")}>
+    <ShellMainAppDir heading={t("bookings")} CTA={<ViewToggleButton />}>
       <BookingsList
         status={parsed.data.status}
         userId={session?.user?.id}
         permissions={{ canReadOthersBookings }}
-        isCalendarViewEnabled={isCalendarViewEnabled}
       />
     </ShellMainAppDir>
   );

--- a/apps/web/components/booking/SkeletonLoader.tsx
+++ b/apps/web/components/booking/SkeletonLoader.tsx
@@ -1,36 +1,83 @@
 import React from "react";
 
-import { SkeletonText } from "@calcom/ui/components/skeleton";
+import classNames from "@calcom/ui/classNames";
+import { SkeletonAvatar, SkeletonText } from "@calcom/ui/components/skeleton";
 
 function SkeletonLoader() {
   return (
-    <ul className="divide-subtle border-subtle bg-default animate-pulse divide-y rounded-md border sm:overflow-hidden">
-      <SkeletonItem />
-      <SkeletonItem />
-      <SkeletonItem />
-    </ul>
+    <div className="animate-pulse">
+      {/* Table rows with separator at the beginning */}
+      <div className="divide-subtle divide-y">
+        {/* Month separator skeleton */}
+        <div className="bg-muted rounded-t py-2">
+          <SkeletonItem isHeader={true} />
+        </div>
+        <div className="bg-muted">
+          <SkeletonText className="ml-2 mt-3 h-4 w-28 rounded" />
+        </div>
+
+        <SkeletonItem />
+        <SkeletonItem />
+        <SkeletonItem />
+        <SkeletonItem />
+        <SkeletonItem />
+      </div>
+    </div>
   );
 }
 
 export default SkeletonLoader;
 
-function SkeletonItem() {
+function SkeletonItem({ isHeader = false }: { isHeader?: boolean }) {
   return (
-    <li className="group flex w-full items-center justify-between px-4 py-4 sm:px-6">
-      <div className="flex-grow truncate text-sm">
-        <div className="flex">
-          <div className="flex flex-col space-y-2">
-            <SkeletonText className="h-5 w-16" />
-            <SkeletonText className="h-4 w-32" />
-          </div>
-        </div>
+    <div
+      className={classNames(
+        "grid grid-cols-[132px_130px_185px_150px_140px_280px] gap-6 px-2",
+        isHeader ? "py-2" : "py-2.5"
+      )}>
+      {/* Date column - 140px */}
+      <div className="flex items-center">
+        <SkeletonText className={classNames("h-4 rounded", isHeader ? "w-12" : "w-20")} />
       </div>
-      <div className="mt-4 hidden flex-shrink-0 sm:ml-5 sm:mt-0 lg:flex">
-        <div className="flex justify-between space-x-2 rtl:space-x-reverse">
-          <SkeletonText className="h-6 w-16" />
-          <SkeletonText className="h-6 w-32" />
-        </div>
+
+      {/* Time column - 140px */}
+      <div className="flex items-center">
+        <SkeletonText className={classNames("h-4 rounded", isHeader ? "w-12" : "w-28")} />
       </div>
-    </li>
+
+      {/* Event column - 200px */}
+      <div className="flex items-center">
+        <SkeletonText className={classNames("h-4 rounded", isHeader ? "w-16" : "w-full")} />
+      </div>
+
+      {/* Who column - 160px, Avatar group */}
+      <div className="flex items-center -space-x-1">
+        {isHeader && <SkeletonText className="h-4 w-20 rounded" />}
+        {!isHeader && (
+          <>
+            <SkeletonAvatar className="h-6 w-6 rounded-full" />
+            <SkeletonAvatar className="h-6 w-6 rounded-full" />
+            <SkeletonAvatar className="h-6 w-6 rounded-full" />
+          </>
+        )}
+      </div>
+
+      {/* Team column - 140px */}
+      <div className="flex items-center">
+        <SkeletonText className="h-4 w-20 rounded-md" />
+      </div>
+
+      {/* Actions column - 280px */}
+      <div className="mr-2 flex items-center justify-end gap-2">
+        {isHeader && <SkeletonText className="h-4 w-16 rounded-md" />}
+        {!isHeader && (
+          <>
+            <SkeletonText className="h-4 w-16 rounded-md" />
+            <SkeletonText className="h-4 w-20 rounded-md" />
+            <SkeletonText className="h-4 w-8 rounded-md" />
+          </>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/web/components/booking/_BookingListItem.tsx
+++ b/apps/web/components/booking/_BookingListItem.tsx
@@ -499,7 +499,7 @@ function BookingListItem(booking: BookingItemProps) {
           </div>
           <div className="flex w-full flex-col flex-wrap items-end justify-end space-x-2 space-y-2 py-4 pl-4 text-right text-sm font-medium ltr:pr-4 rtl:pl-4 sm:flex-row sm:flex-nowrap sm:items-start sm:space-y-0 sm:pl-0">
             {shouldShowPendingActions(actionContext) && <TableActions actions={pendingActions} />}
-            <BookingActionsDropdown booking={booking} context="booking-list-item" />
+            <BookingActionsDropdown booking={booking} />
             {shouldShowRecurringCancelAction(actionContext) && <TableActions actions={[cancelEventAction]} />}
             {shouldShowIndividualReportButton(actionContext) && (
               <div className="flex items-center space-x-2">

--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -15,9 +15,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  DropdownMenuPortal,
 } from "@calcom/ui/components/dropdown";
 import { TextAreaField } from "@calcom/ui/components/form";
 import type { ActionType } from "@calcom/ui/components/table";
@@ -31,6 +31,7 @@ import { ReportBookingDialog } from "@components/dialog/ReportBookingDialog";
 import { RerouteDialog } from "@components/dialog/RerouteDialog";
 import { RescheduleDialog } from "@components/dialog/RescheduleDialog";
 
+import { buildBookingLink } from "../../../modules/bookings/lib/buildBookingLink";
 import type { BookingItemProps } from "../types";
 import { useBookingActionsStoreContext } from "./BookingActionsStoreProvider";
 import {
@@ -39,16 +40,29 @@ import {
   getAfterEventActions,
   getReportAction,
   shouldShowEditActions,
+  shouldShowPendingActions,
+  getPendingActions,
   type BookingActionContext,
 } from "./bookingActions";
 
 interface BookingActionsDropdownProps {
   booking: BookingItemProps;
-  context: "booking-list-item" | "booking-details-sheet";
   size?: "xs" | "sm" | "base" | "lg";
+  className?: string;
+  /**
+   * Whether to use a portal for the dropdown menu.
+   * Set to false when rendering inside a Sheet/Dialog to keep the dropdown within the modal's stacking context.
+   * @default true
+   */
+  usePortal?: boolean;
 }
 
-export function BookingActionsDropdown({ booking, context, size = "base" }: BookingActionsDropdownProps) {
+export function BookingActionsDropdown({
+  booking,
+  size = "base",
+  className,
+  usePortal = true,
+}: BookingActionsDropdownProps) {
   const { t } = useLocale();
   const utils = trpc.useUtils();
 
@@ -164,6 +178,13 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
 
   const isBookingFromRoutingForm = !!booking.routedFromRoutingFormReponse && !!booking.eventType?.team;
 
+  // Build booking confirmation link
+  const bookingLink = buildBookingLink({
+    bookingUid: booking.uid,
+    allRemainingBookings: isRecurring,
+    email: booking.attendees?.[0]?.email,
+  });
+
   const userEmail = booking.loggedInUser.userEmail;
   const userSeat = booking.seatsReferences.find((seat) => !!userEmail && seat.attendee?.email === userEmail);
   const isAttendee = !!userSeat;
@@ -211,6 +232,10 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
     }
   };
 
+  // Calculate showPendingPayment based on payment logic
+  const hasPayment = booking.payment.length > 0;
+  const showPendingPayment = hasPayment;
+
   const actionContext: BookingActionContext = {
     booking,
     isUpcoming,
@@ -228,7 +253,7 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
     isDisabledCancelling,
     isDisabledRescheduling,
     isCalVideoLocation,
-    showPendingPayment: false, // This will be calculated below
+    showPendingPayment,
     isAttendee,
     cardCharged,
     attendeeList,
@@ -237,6 +262,20 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
   } as BookingActionContext;
 
   const cancelEventAction = getCancelEventAction(actionContext);
+
+  // Get pending actions (accept/reject)
+  const shouldShowPending = shouldShowPendingActions(actionContext);
+  const basePendingActions = shouldShowPending ? getPendingActions(actionContext) : [];
+  const pendingActions: ActionType[] = basePendingActions.map((action) => ({
+    ...action,
+    disabled: mutation.isPending,
+    onClick:
+      action.id === "confirm"
+        ? () => bookingConfirm(true)
+        : action.id === "reject"
+        ? () => setRejectionDialogIsOpen(true)
+        : undefined,
+  })) as ActionType[];
 
   const shouldShowEdit = shouldShowEditActions(actionContext);
   const baseEditEventActions = getEditEventActions(actionContext);
@@ -500,22 +539,26 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
 
   // Check if there are any available actions across all action groups
   const hasAnyAvailableActions = () => {
+    // Check if any pending action is available
+    const hasAvailablePendingAction = pendingActions.some((action) => !action.disabled);
+
     // Check if any edit action is available
     const hasAvailableEditAction = editEventActions.some((action) => !action.disabled);
 
     // Check if any after event action is available
     const hasAvailableAfterAction = afterEventActions.some((action) => !action.disabled);
 
-    // For booking-list-item context, only check edit and after event actions
-    if (context === "booking-list-item") {
-      return hasAvailableEditAction || hasAvailableAfterAction;
-    }
-
-    // For booking-details-sheet context, also check report and cancel actions
+    // Check report and cancel actions
     const isReportAvailable = !reportActionWithHandler.disabled;
     const isCancelAvailable = !cancelEventAction.disabled;
 
-    return hasAvailableEditAction || hasAvailableAfterAction || isReportAvailable || isCancelAvailable;
+    return (
+      hasAvailablePendingAction ||
+      hasAvailableEditAction ||
+      hasAvailableAfterAction ||
+      isReportAvailable ||
+      isCancelAvailable
+    );
   };
 
   // Don't render dropdown if no actions are available
@@ -523,94 +566,134 @@ export function BookingActionsDropdown({ booking, context, size = "base" }: Book
     return dialogs;
   }
 
-  const menuContent = (
-    <DropdownMenuContent>
-      <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("edit_event")}</DropdownMenuLabel>
-      {editEventActions.map((action) => (
-        <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
-          <DropdownItem
-            type="button"
-            color={action.color}
-            StartIcon={action.icon}
-            href={action.href}
-            disabled={action.disabled}
-            onClick={action.onClick}
-            data-bookingid={action.bookingId}
-            data-testid={action.id}
-            className={action.disabled ? "text-muted" : undefined}>
-            {action.label}
-          </DropdownItem>
-        </DropdownMenuItem>
-      ))}
-      <DropdownMenuSeparator />
-      <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("after_event")}</DropdownMenuLabel>
-      {afterEventActions.map((action) => (
-        <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
-          <DropdownItem
-            type="button"
-            color={action.color}
-            StartIcon={action.icon}
-            href={action.href}
-            onClick={action.onClick}
-            disabled={action.disabled}
-            data-bookingid={action.bookingId}
-            data-testid={action.id}
-            className={action.disabled ? "text-muted" : undefined}>
-            {action.label}
-          </DropdownItem>
-        </DropdownMenuItem>
-      ))}
-      <>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="rounded-lg"
-          key={reportActionWithHandler.id}
-          disabled={reportActionWithHandler.disabled}>
-          <DropdownItem
-            type="button"
-            color={reportActionWithHandler.color}
-            StartIcon={reportActionWithHandler.icon}
-            onClick={reportActionWithHandler.onClick}
-            disabled={reportActionWithHandler.disabled}
-            data-testid={reportActionWithHandler.id}
-            className={reportActionWithHandler.disabled ? "text-muted" : undefined}>
-            {reportActionWithHandler.label}
-          </DropdownItem>
-        </DropdownMenuItem>
-      </>
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        className="rounded-lg"
-        key={cancelEventAction.id}
-        disabled={cancelEventAction.disabled}>
-        <DropdownItem
-          type="button"
-          color={cancelEventAction.color}
-          StartIcon={cancelEventAction.icon}
-          href={cancelEventAction.disabled ? undefined : cancelEventAction.href}
-          onClick={cancelEventAction.onClick}
-          disabled={cancelEventAction.disabled}
-          data-bookingid={cancelEventAction.bookingId}
-          data-testid={cancelEventAction.id}
-          className={cancelEventAction.disabled ? "text-muted" : undefined}>
-          {cancelEventAction.label}
-        </DropdownItem>
-      </DropdownMenuItem>
-    </DropdownMenuContent>
-  );
+  // Conditional portal wrapper to avoid portal when inside Sheet/Dialog
+  const ConditionalPortal = usePortal
+    ? DropdownMenuPortal
+    : ({ children }: { children: React.ReactNode }) => <>{children}</>;
 
   return (
     <>
       {dialogs}
-      <Dropdown modal={context === "booking-details-sheet" ? false : undefined}>
+      <Dropdown modal={false}>
         <DropdownMenuTrigger asChild data-testid="booking-actions-dropdown">
-          <Button type="button" color="secondary" variant="icon" size={size} StartIcon="ellipsis" />
+          <Button
+            type="button"
+            color="secondary"
+            size={size}
+            StartIcon="ellipsis"
+            className={className}
+            // Prevent click from bubbling to parent row/container click handlers
+            onClick={(e) => e.stopPropagation()}
+          />
         </DropdownMenuTrigger>
-        {context === "booking-details-sheet" ? (
-          menuContent
-        ) : (
-          <DropdownMenuPortal>{menuContent}</DropdownMenuPortal>
-        )}
+        <ConditionalPortal>
+          <DropdownMenuContent>
+            <DropdownMenuItem className="rounded-lg">
+              <DropdownItem
+                type="button"
+                StartIcon="external-link"
+                href={bookingLink}
+                target="_blank"
+                data-testid="view-booking">
+                {t("view")}
+              </DropdownItem>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {pendingActions.length > 0 && (
+              <>
+                <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("booking_response")}</DropdownMenuLabel>
+                {pendingActions.map((action) => (
+                  <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
+                    <DropdownItem
+                      type="button"
+                      color={action.color}
+                      StartIcon={action.icon}
+                      href={action.href}
+                      disabled={action.disabled}
+                      onClick={action.onClick}
+                      data-bookingid={action.bookingId}
+                      data-testid={action.id}
+                      className={action.disabled ? "text-muted" : undefined}>
+                      {action.label}
+                    </DropdownItem>
+                  </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("edit_event")}</DropdownMenuLabel>
+            {editEventActions.map((action) => (
+              <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={action.color}
+                  StartIcon={action.icon}
+                  href={action.href}
+                  disabled={action.disabled}
+                  onClick={action.onClick}
+                  data-bookingid={action.bookingId}
+                  data-testid={action.id}
+                  className={action.disabled ? "text-muted" : undefined}>
+                  {action.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="px-2 pb-1 pt-1.5">{t("after_event")}</DropdownMenuLabel>
+            {afterEventActions.map((action) => (
+              <DropdownMenuItem className="rounded-lg" key={action.id} disabled={action.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={action.color}
+                  StartIcon={action.icon}
+                  href={action.href}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  data-bookingid={action.bookingId}
+                  data-testid={action.id}
+                  className={action.disabled ? "text-muted" : undefined}>
+                  {action.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            ))}
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="rounded-lg"
+                key={reportActionWithHandler.id}
+                disabled={reportActionWithHandler.disabled}>
+                <DropdownItem
+                  type="button"
+                  color={reportActionWithHandler.color}
+                  StartIcon={reportActionWithHandler.icon}
+                  onClick={reportActionWithHandler.onClick}
+                  disabled={reportActionWithHandler.disabled}
+                  data-testid={reportActionWithHandler.id}
+                  className={reportActionWithHandler.disabled ? "text-muted" : undefined}>
+                  {reportActionWithHandler.label}
+                </DropdownItem>
+              </DropdownMenuItem>
+            </>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="rounded-lg"
+              key={cancelEventAction.id}
+              disabled={cancelEventAction.disabled}>
+              <DropdownItem
+                type="button"
+                color={cancelEventAction.color}
+                StartIcon={cancelEventAction.icon}
+                href={cancelEventAction.disabled ? undefined : cancelEventAction.href}
+                onClick={cancelEventAction.onClick}
+                disabled={cancelEventAction.disabled}
+                data-bookingid={cancelEventAction.bookingId}
+                data-testid={cancelEventAction.id}
+                className={cancelEventAction.disabled ? "text-muted" : undefined}>
+                {cancelEventAction.label}
+              </DropdownItem>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </ConditionalPortal>
       </Dropdown>
     </>
   );

--- a/apps/web/components/booking/actions/bookingActions.ts
+++ b/apps/web/components/booking/actions/bookingActions.ts
@@ -38,14 +38,7 @@ export function getPendingActions(context: BookingActionContext): ActionType[] {
   const { booking, isPending, isTabRecurring, isTabUnconfirmed, isRecurring, showPendingPayment, t } =
     context;
 
-  const actions: ActionType[] = [
-    {
-      id: "reject",
-      label: (isTabRecurring || isTabUnconfirmed) && isRecurring ? t("reject_all") : t("reject"),
-      icon: "ban",
-      disabled: false, // This would be controlled by mutation state in the component
-    },
-  ];
+  const actions: ActionType[] = [];
 
   // For bookings with payment, only confirm if the booking is paid for
   // Original logic: (isPending && !paymentAppData.enabled) || (paymentAppData.enabled && !!paymentAppData.price && booking.paid)
@@ -58,6 +51,13 @@ export function getPendingActions(context: BookingActionContext): ActionType[] {
       disabled: false, // This would be controlled by mutation state in the component
     });
   }
+
+  actions.push({
+    id: "reject",
+    label: (isTabRecurring || isTabUnconfirmed) && isRecurring ? t("reject_all") : t("reject"),
+    icon: "ban",
+    disabled: false, // This would be controlled by mutation state in the component
+  });
 
   return actions;
 }

--- a/apps/web/lib/hooks/useMediaQuery.ts
+++ b/apps/web/lib/hooks/useMediaQuery.ts
@@ -2,7 +2,13 @@
 import { useState, useEffect } from "react";
 
 const useMediaQuery = (query: string) => {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => {
+    // Initialize with actual media query value on client
+    if (typeof window !== "undefined") {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
 
   useEffect(() => {
     const media = window.matchMedia(query);
@@ -10,8 +16,8 @@ const useMediaQuery = (query: string) => {
       setMatches(media.matches);
     }
     const listener = () => setMatches(media.matches);
-    window.addEventListener("resize", listener);
-    return () => window.removeEventListener("resize", listener);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
   }, [matches, query]);
 
   return matches;

--- a/apps/web/modules/bookings/columns/filterColumns.ts
+++ b/apps/web/modules/bookings/columns/filterColumns.ts
@@ -16,7 +16,7 @@ export function buildFilterColumns({ t, permissions, status }: BuildFilterColumn
   const columnHelper = createColumnHelper<RowData>();
 
   return [
-    columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.id, {
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.eventType.id : null), {
       id: "eventTypeId",
       header: t("event_type"),
       enableColumnFilter: true,
@@ -28,7 +28,7 @@ export function buildFilterColumns({ t, permissions, status }: BuildFilterColumn
         },
       },
     }),
-    columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.team?.id, {
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.eventType.team?.id ?? null : null), {
       id: "teamId",
       header: t("team"),
       enableColumnFilter: true,
@@ -40,7 +40,7 @@ export function buildFilterColumns({ t, permissions, status }: BuildFilterColumn
         },
       },
     }),
-    columnHelper.accessor((row) => row.type === "data" && row.booking.user?.id, {
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.user?.id ?? null : null), {
       id: "userId",
       header: t("member"),
       enableColumnFilter: permissions.canReadOthersBookings,
@@ -91,7 +91,7 @@ export function buildFilterColumns({ t, permissions, status }: BuildFilterColumn
         },
       },
     }),
-    columnHelper.accessor((row) => row.type === "data" && row.booking.uid, {
+    columnHelper.accessor((row) => (row.type === "data" ? row.booking.uid : null), {
       id: "bookingUid",
       header: t("booking_uid"),
       enableColumnFilter: true,

--- a/apps/web/modules/bookings/columns/filterColumns.ts
+++ b/apps/web/modules/bookings/columns/filterColumns.ts
@@ -1,0 +1,110 @@
+import { createColumnHelper } from "@tanstack/react-table";
+
+import { ColumnFilterType } from "@calcom/features/data-table";
+
+import type { RowData } from "../types";
+
+interface BuildFilterColumnsParams {
+  t: (key: string) => string;
+  permissions: {
+    canReadOthersBookings: boolean;
+  };
+  status: string;
+}
+
+export function buildFilterColumns({ t, permissions, status }: BuildFilterColumnsParams) {
+  const columnHelper = createColumnHelper<RowData>();
+
+  return [
+    columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.id, {
+      id: "eventTypeId",
+      header: t("event_type"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.MULTI_SELECT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.team?.id, {
+      id: "teamId",
+      header: t("team"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.MULTI_SELECT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row.type === "data" && row.booking.user?.id, {
+      id: "userId",
+      header: t("member"),
+      enableColumnFilter: permissions.canReadOthersBookings,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.MULTI_SELECT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row, {
+      id: "attendeeName",
+      header: t("attendee_name"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row, {
+      id: "attendeeEmail",
+      header: t("attendee_email_variable"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row, {
+      id: "dateRange",
+      header: t("date_range"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.DATE_RANGE,
+          dateRangeOptions: {
+            range: status === "past" ? "past" : "custom",
+          },
+        },
+      },
+    }),
+    columnHelper.accessor((row) => row.type === "data" && row.booking.uid, {
+      id: "bookingUid",
+      header: t("booking_uid"),
+      enableColumnFilter: true,
+      enableSorting: false,
+      cell: () => null,
+      meta: {
+        filter: {
+          type: ColumnFilterType.TEXT,
+          textOptions: {
+            allowedOperators: ["equals"],
+          },
+        },
+      },
+    }),
+  ];
+}

--- a/apps/web/modules/bookings/columns/filterColumns.ts
+++ b/apps/web/modules/bookings/columns/filterColumns.ts
@@ -1,3 +1,4 @@
+import type { VisibilityState } from "@tanstack/react-table";
 import { createColumnHelper } from "@tanstack/react-table";
 
 import { ColumnFilterType } from "@calcom/features/data-table";
@@ -10,6 +11,28 @@ interface BuildFilterColumnsParams {
     canReadOthersBookings: boolean;
   };
   status: string;
+}
+
+/**
+ * IDs of filter columns that should be hidden in the UI
+ * These columns are used for filtering but not displayed
+ */
+const FILTER_COLUMN_IDS = [
+  "eventTypeId",
+  "teamId",
+  "userId",
+  "attendeeName",
+  "attendeeEmail",
+  "dateRange",
+  "bookingUid",
+] as const;
+
+/**
+ * Gets the column visibility state for filter columns
+ * All filter columns are hidden by default as they only provide filtering functionality
+ */
+export function getFilterColumnVisibility(): VisibilityState {
+  return Object.fromEntries(FILTER_COLUMN_IDS.map((id) => [id, false]));
 }
 
 export function buildFilterColumns({ t, permissions, status }: BuildFilterColumnsParams) {

--- a/apps/web/modules/bookings/columns/listColumns.tsx
+++ b/apps/web/modules/bookings/columns/listColumns.tsx
@@ -1,0 +1,104 @@
+import { createColumnHelper } from "@tanstack/react-table";
+
+import dayjs from "@calcom/dayjs";
+import { isSeparatorRow } from "@calcom/features/data-table/lib/separator";
+import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+import { AvatarGroup } from "@calcom/ui/components/avatar";
+import { Badge } from "@calcom/ui/components/badge";
+
+import type { RowData } from "../types";
+
+interface BuildListDisplayColumnsParams {
+  t: (key: string) => string;
+  user?: {
+    timeZone?: string;
+    timeFormat?: number | null;
+  } | null;
+}
+
+export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsParams) {
+  const columnHelper = createColumnHelper<RowData>();
+
+  return [
+    columnHelper.display({
+      id: "date",
+      header: () => <span className="text-subtle text-sm font-medium">{t("date")}</span>,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        return (
+          <div className="text-default text-sm font-medium">
+            {dayjs(row.booking.startTime).tz(user?.timeZone).format("ddd, DD MMM")}
+          </div>
+        );
+      },
+    }),
+    columnHelper.display({
+      id: "time",
+      header: () => <span className="text-subtle text-sm font-medium">{t("time")}</span>,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        const startTime = dayjs(row.booking.startTime).tz(user?.timeZone);
+        const endTime = dayjs(row.booking.endTime).tz(user?.timeZone);
+        return (
+          <div className="text-default text-sm font-medium">
+            {startTime.format(user?.timeFormat === 12 ? "h:mma" : "HH:mm")} -{" "}
+            {endTime.format(user?.timeFormat === 12 ? "h:mma" : "HH:mm")}
+          </div>
+        );
+      },
+    }),
+    columnHelper.display({
+      id: "event",
+      header: () => <span className="text-subtle text-sm font-medium">{t("event")}</span>,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        return <div className="text-emphasis flex-1 truncate text-sm font-medium">{row.booking.title}</div>;
+      },
+    }),
+    columnHelper.display({
+      id: "who",
+      header: () => <span className="text-subtle text-sm font-medium">{t("who")}</span>,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        const items = row.booking.attendees.map((attendee) => ({
+          image: getPlaceholderAvatar(null, attendee.name),
+          alt: attendee.name,
+          title: attendee.name,
+          href: null,
+        }));
+
+        return <AvatarGroup size="sm" truncateAfter={4} items={items} />;
+      },
+    }),
+    columnHelper.display({
+      id: "team",
+      header: () => <span className="text-subtle text-sm font-medium">{t("team")}</span>,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        if (row.booking.eventType.team) {
+          return (
+            <Badge variant="gray" size="sm">
+              {row.booking.eventType.team.name}
+            </Badge>
+          );
+        }
+        return null;
+      },
+    }),
+    columnHelper.display({
+      id: "actions",
+      header: () => null,
+      cell: () => null,
+    }),
+  ];
+}

--- a/apps/web/modules/bookings/columns/listColumns.tsx
+++ b/apps/web/modules/bookings/columns/listColumns.tsx
@@ -5,23 +5,41 @@ import { isSeparatorRow } from "@calcom/features/data-table/lib/separator";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { AvatarGroup } from "@calcom/ui/components/avatar";
 import { Badge } from "@calcom/ui/components/badge";
+import { Button } from "@calcom/ui/components/button";
 
+import { BookingActionsDropdown } from "../../../components/booking/actions/BookingActionsDropdown";
+import { BookingActionsStoreProvider } from "../../../components/booking/actions/BookingActionsStoreProvider";
+import type { BookingListingStatus } from "../../../components/booking/types";
+import { JoinMeetingButton } from "../components/JoinMeetingButton";
 import type { RowData } from "../types";
+
+interface PendingActionHandlers {
+  onAccept: (bookingId: number, recurringEventId?: string | null) => void;
+  onReject: (bookingId: number, recurringEventId?: string | null) => void;
+  isLoading?: boolean;
+}
 
 interface BuildListDisplayColumnsParams {
   t: (key: string) => string;
   user?: {
+    id?: number;
+    email?: string;
     timeZone?: string;
     timeFormat?: number | null;
-  } | null;
+  };
+  pendingActionHandlers: PendingActionHandlers;
 }
 
-export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsParams) {
+export function buildListDisplayColumns({ t, user, pendingActionHandlers }: BuildListDisplayColumnsParams) {
   const columnHelper = createColumnHelper<RowData>();
 
   return [
     columnHelper.display({
       id: "date",
+      size: 140,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => <span className="text-subtle text-sm font-medium">{t("date")}</span>,
       cell: (props) => {
         const row = props.row.original;
@@ -36,6 +54,10 @@ export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsPara
     }),
     columnHelper.display({
       id: "time",
+      size: 140,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => <span className="text-subtle text-sm font-medium">{t("time")}</span>,
       cell: (props) => {
         const row = props.row.original;
@@ -53,16 +75,28 @@ export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsPara
     }),
     columnHelper.display({
       id: "event",
+      minSize: 200,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => <span className="text-subtle text-sm font-medium">{t("event")}</span>,
       cell: (props) => {
         const row = props.row.original;
         if (isSeparatorRow(row)) return null;
 
-        return <div className="text-emphasis flex-1 truncate text-sm font-medium">{row.booking.title}</div>;
+        return (
+          <div className="text-emphasis flex-1 truncate text-sm font-medium" data-testid="title">
+            {row.booking.title}
+          </div>
+        );
       },
     }),
     columnHelper.display({
       id: "who",
+      size: 160,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => <span className="text-subtle text-sm font-medium">{t("who")}</span>,
       cell: (props) => {
         const row = props.row.original;
@@ -80,6 +114,10 @@ export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsPara
     }),
     columnHelper.display({
       id: "team",
+      size: 140,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => <span className="text-subtle text-sm font-medium">{t("team")}</span>,
       cell: (props) => {
         const row = props.row.original;
@@ -97,8 +135,102 @@ export function buildListDisplayColumns({ t, user }: BuildListDisplayColumnsPara
     }),
     columnHelper.display({
       id: "actions",
+      size: 280,
+      enableColumnFilter: true,
+      enableSorting: false,
+      enableHiding: false,
       header: () => null,
-      cell: () => null,
+      cell: (props) => {
+        const row = props.row.original;
+        if (isSeparatorRow(row)) return null;
+
+        const booking = row.booking;
+        const isPending = booking.status === "PENDING";
+        const isUpcoming = new Date(booking.endTime) >= new Date();
+        const isCancelled = booking.status === "CANCELLED";
+        const isRejected = booking.status === "REJECTED";
+        const isAccepted = booking.status === "ACCEPTED";
+
+        // Determine if we should show pending actions
+        const shouldShowPendingActions = isPending && isUpcoming && !isCancelled;
+
+        // Determine which buttons to show based on payment status
+        const hasPayment = Array.isArray(booking.payment) && booking.payment.length > 0;
+        const isPaid = booking.paid;
+        const shouldShowAccept = shouldShowPendingActions && (!hasPayment || isPaid);
+        const shouldShowReject = shouldShowPendingActions;
+
+        // Show join meeting button only for upcoming accepted/confirmed bookings
+        const shouldShowJoinButton = isAccepted && isUpcoming && !isCancelled && !isRejected;
+
+        // Determine if this is a recurring booking for the label
+        const isRecurring = booking.recurringEventId !== null;
+        const isTabRecurring = row.type === "data" && row.recurringInfo !== undefined;
+        const isTabUnconfirmed = booking.status === "PENDING";
+        const showAllLabel = (isTabRecurring || isTabUnconfirmed) && isRecurring;
+
+        return (
+          <div className="flex w-full items-center justify-end gap-2">
+            {shouldShowReject && (
+              <Button
+                color="minimal"
+                size="sm"
+                StartIcon="ban"
+                disabled={pendingActionHandlers.isLoading}
+                data-testid="reject"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const recurringEventId = showAllLabel ? booking.recurringEventId : null;
+                  pendingActionHandlers.onReject(booking.id, recurringEventId);
+                }}>
+                {showAllLabel ? t("reject_all") : t("reject")}
+              </Button>
+            )}
+            {shouldShowAccept && (
+              <Button
+                color="secondary"
+                size="sm"
+                StartIcon="check"
+                disabled={pendingActionHandlers.isLoading}
+                data-testid="confirm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const recurringEventId = showAllLabel ? booking.recurringEventId : null;
+                  pendingActionHandlers.onAccept(booking.id, recurringEventId);
+                }}>
+                {showAllLabel ? t("confirm_all") : t("confirm")}
+              </Button>
+            )}
+            {shouldShowJoinButton && (
+              <JoinMeetingButton
+                size="sm"
+                location={booking.location}
+                metadata={booking.metadata}
+                bookingStatus={booking.status}
+                t={t}
+              />
+            )}
+            <BookingActionsStoreProvider>
+              <BookingActionsDropdown
+                booking={{
+                  ...booking,
+                  listingStatus: booking.status.toLowerCase() as BookingListingStatus,
+                  recurringInfo: row.type === "data" ? row.recurringInfo : undefined,
+                  loggedInUser: {
+                    userId: user?.id,
+                    userTimeZone: user?.timeZone,
+                    userTimeFormat: user?.timeFormat,
+                    userEmail: user?.email,
+                  },
+                  isToday: row.type === "data" ? row.isToday : false,
+                }}
+                className="px-1.5"
+                size="sm"
+              />
+            </BookingActionsStoreProvider>
+          </div>
+        );
+      },
     }),
   ];
 }

--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -29,8 +29,8 @@ import {
 import { BookingActionsDropdown } from "../../../components/booking/actions/BookingActionsDropdown";
 import { BookingActionsStoreProvider } from "../../../components/booking/actions/BookingActionsStoreProvider";
 import type { BookingListingStatus } from "../../../components/booking/types";
-import { buildBookingLink } from "../lib/buildBookingLink";
 import type { BookingOutput } from "../types";
+import { JoinMeetingButton } from "./JoinMeetingButton";
 
 type BookingMetaData = z.infer<typeof bookingMetadataSchema>;
 
@@ -80,14 +80,6 @@ function BookingDetailsSheetInner({
   const startTime = dayjs(booking.startTime).tz(userTimeZone);
   const endTime = dayjs(booking.endTime).tz(userTimeZone);
 
-  // Build booking confirmation link
-  const isRecurring = booking.recurringEventId !== null;
-  const bookingLink = buildBookingLink({
-    bookingUid: booking.uid,
-    allRemainingBookings: isRecurring,
-    email: booking.attendees?.[0]?.email,
-  });
-
   const getStatusBadge = () => {
     switch (booking.status) {
       case "ACCEPTED":
@@ -107,14 +99,6 @@ function BookingDetailsSheetInner({
 
   const parsedMetadata = bookingMetadataSchema.safeParse(booking.metadata ?? null);
   const bookingMetadata = parsedMetadata.success ? parsedMetadata.data : null;
-
-  // Get conference link info for Join button
-  const { locationToDisplay, provider, isLocationURL } = useBookingLocation({
-    location: booking.location,
-    videoCallUrl: bookingMetadata?.videoCallUrl,
-    t,
-    bookingStatus: booking.status,
-  });
 
   const recurringInfo =
     booking.recurringEventId && booking.eventType?.recurringEvent
@@ -203,49 +187,35 @@ function BookingDetailsSheetInner({
         </SheetBody>
 
         <SheetFooter className="bg-muted border-subtle -mx-4 -mb-4 border-t pt-0 sm:-mx-6 sm:-my-6">
-          <div className="flex w-full flex-row items-center justify-end gap-2 px-4 pb-4 pt-4">
-            {isLocationURL && locationToDisplay && (
-              <>
-                <Button
-                  color="secondary"
-                  size="sm"
-                  href={locationToDisplay}
-                  target="_blank"
-                  className="flex items-center gap-2">
-                  {provider?.iconUrl && (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={provider.iconUrl}
-                      className="h-4 w-4 flex-shrink-0 rounded-sm"
-                      alt={`${provider.label} logo`}
-                    />
-                  )}
-                  {provider?.label
-                    ? t("join_event_location", { eventLocationType: provider.label })
-                    : t("join_meeting")}
-                </Button>
-                <div className="border-subtle h-3 w-px border-r" />
-              </>
-            )}
-            <Button color="secondary" size="sm" EndIcon="external-link" href={bookingLink} target="_blank">
-              {t("view")}
+          <div className="flex w-full flex-row items-center justify-between gap-2 px-4 pb-4 pt-4">
+            <Button color="secondary" StartIcon="x" onClick={onClose}>
+              {t("close")}
             </Button>
-            <BookingActionsDropdown
-              context="booking-details-sheet"
-              size="sm"
-              booking={{
-                ...booking,
-                listingStatus: booking.status.toLowerCase() as BookingListingStatus,
-                recurringInfo: undefined,
-                loggedInUser: {
-                  userId,
-                  userTimeZone,
-                  userTimeFormat: userTimeFormat ?? null,
-                  userEmail,
-                },
-                isToday: false,
-              }}
-            />
+
+            <div className="flex gap-2">
+              <JoinMeetingButton
+                location={booking.location}
+                metadata={booking.metadata}
+                bookingStatus={booking.status}
+                t={t}
+              />
+
+              <BookingActionsDropdown
+                booking={{
+                  ...booking,
+                  listingStatus: booking.status.toLowerCase() as BookingListingStatus,
+                  recurringInfo: undefined,
+                  loggedInUser: {
+                    userId,
+                    userTimeZone,
+                    userTimeFormat: userTimeFormat ?? null,
+                    userEmail,
+                  },
+                  isToday: false,
+                }}
+                usePortal={false}
+              />
+            </div>
           </div>
         </SheetFooter>
       </SheetContent>

--- a/apps/web/modules/bookings/components/BookingsCalendar.tsx
+++ b/apps/web/modules/bookings/components/BookingsCalendar.tsx
@@ -1,89 +1,62 @@
 "use client";
 
 import type { Table as ReactTable } from "@tanstack/react-table";
-import { createParser, useQueryState } from "nuqs";
-import { useMemo, useCallback } from "react";
+import { useCallback } from "react";
 
 import dayjs from "@calcom/dayjs";
 import {
   DataTableFilters,
   DataTableSegment,
   useDataTable,
-  useFilterValue,
-  ZDateRangeFilterValue,
   ColumnFilterType,
 } from "@calcom/features/data-table";
 import { CUSTOM_PRESET } from "@calcom/features/data-table/lib/dateRange";
 
-import type { RowData, BookingListingStatus } from "../types";
+import type { RowData, BookingListingStatus, BookingOutput } from "../types";
 import { BookingsCalendarView } from "./BookingsCalendarView";
 
-type BookingsCalendarViewProps = {
+type BookingsCalendarProps = {
   status: BookingListingStatus;
   table: ReactTable<RowData>;
+  isPending?: boolean;
+  onOpenDetails: (bookingId: number) => void;
+  currentWeekStart: dayjs.Dayjs;
+  setCurrentWeekStart: (
+    value: dayjs.Dayjs | ((old: dayjs.Dayjs) => dayjs.Dayjs | null) | null
+  ) => Promise<URLSearchParams>;
+  bookings: BookingOutput[];
 };
 
 const COLUMN_IDS_TO_HIDE = ["dateRange"];
 
-const weekStartParser = createParser({
-  parse: (value: string) => {
-    const parsed = dayjs(value);
-    return parsed.isValid() ? parsed.startOf("week") : dayjs().startOf("week");
-  },
-  serialize: (value: dayjs.Dayjs) => value.format("YYYY-MM-DD"),
-});
-
-export function BookingsCalendar({ table }: BookingsCalendarViewProps) {
-  const { rows } = table.getRowModel();
+export function BookingsCalendar({
+  table,
+  isPending = false,
+  onOpenDetails,
+  currentWeekStart,
+  setCurrentWeekStart,
+  bookings,
+}: BookingsCalendarProps) {
   const { updateFilter } = useDataTable();
-  const dateRange = useFilterValue("dateRange", ZDateRangeFilterValue)?.data;
-
-  const [currentWeekStart, setCurrentWeekStart] = useQueryState(
-    "weekStart",
-    weekStartParser.withDefault(dayjs().startOf("week"))
-  );
-
-  const bookings = useMemo(() => {
-    return rows
-      .filter((row) => row.original.type === "data")
-      .map((row) => (row.original.type === "data" ? row.original.booking : null))
-      .filter((booking): booking is NonNullable<typeof booking> => booking !== null);
-  }, [rows]);
 
   const handleWeekStartChange = useCallback(
     (newWeekStart: dayjs.Dayjs) => {
       setCurrentWeekStart(newWeekStart);
 
+      // Always set the date range to match the current week exactly
       const startDate = newWeekStart.toDate();
       const endDate = newWeekStart.add(6, "day").toDate();
-
-      if (!dateRange) {
-        return;
-      }
-
-      const rangeStart = dateRange.startDate ? new Date(dateRange.startDate) : null;
-      const rangeEnd = dateRange.endDate ? new Date(dateRange.endDate) : null;
-
-      const needsStartUpdate = !rangeStart || startDate < rangeStart;
-      const needsEndUpdate = !rangeEnd || endDate > rangeEnd;
-
-      if (!needsStartUpdate && !needsEndUpdate) {
-        return;
-      }
-
-      const newStartDate = needsStartUpdate ? startDate : rangeStart;
-      const newEndDate = needsEndUpdate ? endDate : rangeEnd;
 
       updateFilter("dateRange", {
         type: ColumnFilterType.DATE_RANGE,
         data: {
-          startDate: newStartDate.toISOString(),
-          endDate: newEndDate.toISOString(),
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
           preset: CUSTOM_PRESET.value,
         },
       });
     },
-    [dateRange, updateFilter, setCurrentWeekStart]
+    [updateFilter, setCurrentWeekStart]
   );
 
   return (
@@ -103,6 +76,8 @@ export function BookingsCalendar({ table }: BookingsCalendarViewProps) {
         bookings={bookings}
         currentWeekStart={currentWeekStart}
         onWeekStartChange={handleWeekStartChange}
+        isPending={isPending}
+        onOpenDetails={onOpenDetails}
       />
     </>
   );

--- a/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+
+import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
+
+import { buildFilterColumns } from "../columns/filterColumns";
+import type { RowData, BookingListingStatus } from "../types";
+import { BookingsCalendar } from "./BookingsCalendar";
+
+interface BookingsCalendarContainerProps {
+  status: BookingListingStatus;
+  permissions: {
+    canReadOthersBookings: boolean;
+  };
+  data: RowData[];
+}
+
+export function BookingsCalendarContainer({ status, permissions, data }: BookingsCalendarContainerProps) {
+  const { t } = useLocale();
+
+  const columns = useMemo(() => {
+    return buildFilterColumns({ t, permissions, status });
+  }, [t, permissions, status]);
+
+  const getFacetedUniqueValues = useFacetedUniqueValues();
+
+  const table = useReactTable<RowData>({
+    data,
+    columns,
+    initialState: {
+      columnVisibility: {
+        eventTypeId: false,
+        teamId: false,
+        userId: false,
+        attendeeName: false,
+        attendeeEmail: false,
+        dateRange: false,
+        bookingUid: false,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedUniqueValues,
+  });
+
+  return <BookingsCalendar status={status} table={table} />;
+}

--- a/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
@@ -7,7 +7,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 
-import { buildFilterColumns } from "../columns/filterColumns";
+import { buildFilterColumns, getFilterColumnVisibility } from "../columns/filterColumns";
 import type { RowData, BookingListingStatus } from "../types";
 import { BookingsCalendar } from "./BookingsCalendar";
 
@@ -32,15 +32,7 @@ export function BookingsCalendarContainer({ status, permissions, data }: Booking
     data,
     columns,
     initialState: {
-      columnVisibility: {
-        eventTypeId: false,
-        teamId: false,
-        userId: false,
-        attendeeName: false,
-        attendeeEmail: false,
-        dateRange: false,
-        bookingUid: false,
-      },
+      columnVisibility: getFilterColumnVisibility(),
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsCalendarContainer.tsx
@@ -1,15 +1,29 @@
 "use client";
 
 import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { createParser, useQueryState } from "nuqs";
+import { useCallback, useMemo } from "react";
 
+import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 
 import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 
 import { buildFilterColumns, getFilterColumnVisibility } from "../columns/filterColumns";
+import { useBookingCursor } from "../hooks/useBookingCursor";
+import { useSelectedBookingId } from "../hooks/useSelectedBookingId";
 import type { RowData, BookingListingStatus } from "../types";
+import { BookingDetailsSheet } from "./BookingDetailsSheet";
 import { BookingsCalendar } from "./BookingsCalendar";
+
+const weekStartParser = createParser({
+  parse: (value: string) => {
+    const parsed = dayjs(value);
+    return parsed.isValid() ? parsed.startOf("week") : dayjs().startOf("week");
+  },
+  serialize: (value: dayjs.Dayjs) => value.format("YYYY-MM-DD"),
+});
 
 interface BookingsCalendarContainerProps {
   status: BookingListingStatus;
@@ -17,10 +31,30 @@ interface BookingsCalendarContainerProps {
     canReadOthersBookings: boolean;
   };
   data: RowData[];
+  isPending?: boolean;
 }
 
-export function BookingsCalendarContainer({ status, permissions, data }: BookingsCalendarContainerProps) {
+export function BookingsCalendarContainer({
+  status,
+  permissions,
+  data,
+  isPending = false,
+}: BookingsCalendarContainerProps) {
   const { t } = useLocale();
+  const user = useMeQuery().data;
+
+  const [selectedBookingId, setSelectedBookingId] = useSelectedBookingId();
+  const [currentWeekStart, setCurrentWeekStart] = useQueryState(
+    "weekStart",
+    weekStartParser.withDefault(dayjs().startOf("week"))
+  );
+
+  const onOpenDetails = useCallback(
+    (bookingId: number) => {
+      setSelectedBookingId(bookingId);
+    },
+    [setSelectedBookingId]
+  );
 
   const columns = useMemo(() => {
     return buildFilterColumns({ t, permissions, status });
@@ -39,5 +73,59 @@ export function BookingsCalendarContainer({ status, permissions, data }: Booking
     getFacetedUniqueValues,
   });
 
-  return <BookingsCalendar status={status} table={table} />;
+  // Extract bookings from table data and filter by current week
+  const bookings = useMemo(() => {
+    const weekStart = currentWeekStart;
+    const weekEnd = currentWeekStart.add(6, "day");
+
+    return data
+      .filter((row): row is Extract<RowData, { type: "data" }> => row.type === "data")
+      .map((row) => row.booking)
+      .filter((booking) => {
+        const bookingStart = dayjs(booking.startTime);
+        return (
+          (bookingStart.isAfter(weekStart) || bookingStart.isSame(weekStart, "day")) &&
+          bookingStart.isBefore(weekEnd.endOf("day"))
+        );
+      });
+  }, [data, currentWeekStart]);
+
+  const selectedBooking = useMemo(() => {
+    if (!selectedBookingId) return null;
+    return bookings.find((booking) => booking.id === selectedBookingId) ?? null;
+  }, [selectedBookingId, bookings]);
+
+  const bookingNavigation = useBookingCursor({
+    bookings,
+    selectedBookingId,
+    setSelectedBookingId,
+  });
+
+  return (
+    <>
+      <BookingsCalendar
+        status={status}
+        table={table}
+        isPending={isPending}
+        onOpenDetails={onOpenDetails}
+        currentWeekStart={currentWeekStart}
+        setCurrentWeekStart={setCurrentWeekStart}
+        bookings={bookings}
+      />
+
+      <BookingDetailsSheet
+        booking={selectedBooking}
+        isOpen={!!selectedBooking}
+        onClose={() => setSelectedBookingId(null)}
+        userTimeZone={user?.timeZone}
+        userTimeFormat={user?.timeFormat === null ? undefined : user?.timeFormat}
+        userId={user?.id}
+        userEmail={user?.email}
+        onPrevious={bookingNavigation.onPrevious}
+        hasPrevious={bookingNavigation.hasPrevious}
+        onNext={bookingNavigation.onNext}
+        hasNext={bookingNavigation.hasNext}
+      />
+    </>
+  );
 }

--- a/apps/web/modules/bookings/components/BookingsCalendarView.tsx
+++ b/apps/web/modules/bookings/components/BookingsCalendarView.tsx
@@ -18,12 +18,16 @@ type BookingsCalendarViewProps = {
   bookings: BookingOutput[];
   currentWeekStart: dayjs.Dayjs;
   onWeekStartChange: (weekStart: dayjs.Dayjs) => void;
+  isPending?: boolean;
+  onOpenDetails: (bookingId: number) => void;
 };
 
 export function BookingsCalendarView({
   bookings,
   currentWeekStart,
   onWeekStartChange,
+  isPending = false,
+  onOpenDetails,
 }: BookingsCalendarViewProps) {
   const { t } = useLocale();
   const { timezone } = useTimePreferences();
@@ -44,8 +48,10 @@ export function BookingsCalendarView({
   const startDate = useMemo(() => currentWeekStart.toDate(), [currentWeekStart]);
   const endDate = useMemo(() => currentWeekStart.add(6, "day").toDate(), [currentWeekStart]);
 
+  // Intentionally only runs on mount to trigger the initial currentWeekStart
   useEffect(() => {
     onWeekStartChange(currentWeekStart);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const events = useMemo<CalendarEvent[]>(() => {
@@ -78,6 +84,7 @@ export function BookingsCalendarView({
           options: {
             status: booking.status,
             ...(eventTypeColor && { color: eventTypeColor }),
+            bookingId: booking.id,
           },
         };
       });
@@ -109,6 +116,7 @@ export function BookingsCalendarView({
       <div className="mx-4 mt-4 flex items-center justify-between py-1.5">
         <div className="flex items-center gap-2">
           <h2 className="text-xl font-semibold">{weekRange}</h2>
+          {isPending && <Icon name="refresh-cw" className="text-muted h-4 w-4 animate-spin" />}
         </div>
         <div className="flex items-center gap-2">
           <Button color="secondary" onClick={goToToday} className="capitalize leading-4">
@@ -141,7 +149,12 @@ export function BookingsCalendarView({
           showBackgroundPattern={false}
           showBorder={false}
           borderColor="subtle"
-          onEventClick={(_event) => {}}
+          onEventClick={(event) => {
+            const bookingId = event.options?.bookingId;
+            if (bookingId) {
+              onOpenDetails(bookingId);
+            }
+          }}
           hideHeader
         />
       </div>

--- a/apps/web/modules/bookings/components/BookingsList.tsx
+++ b/apps/web/modules/bookings/components/BookingsList.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { Row, Table as ReactTable } from "@tanstack/react-table";
+import { useCallback } from "react";
 
 import { DataTableWrapper, DataTableFilters, DataTableSegment } from "@calcom/features/data-table";
+import { isSeparatorRow } from "@calcom/features/data-table/lib/separator";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 
@@ -23,11 +25,26 @@ type BookingsListViewProps = {
   table: ReactTable<RowData>;
   isPending: boolean;
   totalRowCount?: number;
-  onRowClick?: (row: Row<RowData>) => void;
+  onOpenDetails: (bookingId: number) => void;
 };
 
-export function BookingsList({ status, table, isPending, totalRowCount, onRowClick }: BookingsListViewProps) {
+export function BookingsList({
+  status,
+  table,
+  isPending,
+  totalRowCount,
+  onOpenDetails,
+}: BookingsListViewProps) {
   const { t } = useLocale();
+
+  const handleRowClick = useCallback(
+    (row: Row<RowData>) => {
+      if (!isSeparatorRow(row.original)) {
+        onOpenDetails(row.original.booking.id);
+      }
+    },
+    [onOpenDetails]
+  );
 
   return (
     <DataTableWrapper
@@ -35,11 +52,21 @@ export function BookingsList({ status, table, isPending, totalRowCount, onRowCli
       table={table}
       testId={`${status}-bookings`}
       bodyTestId="bookings"
+      rowTestId={(row) => {
+        if (isSeparatorRow(row.original)) return undefined;
+        return "booking-item";
+      }}
+      rowDataAttributes={(row) => {
+        if (isSeparatorRow(row.original)) return undefined;
+        return {
+          "data-today": String(row.original.isToday),
+        };
+      }}
       isPending={isPending}
       totalRowCount={totalRowCount}
       variant="default"
       paginationMode="standard"
-      onRowMouseclick={onRowClick}
+      onRowMouseclick={handleRowClick}
       hideSeparatorsOnSort={true}
       ToolbarLeft={
         <>

--- a/apps/web/modules/bookings/components/BookingsListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsListContainer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { Row } from "@tanstack/react-table";
+import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
+
+import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
+
+import { buildFilterColumns } from "../columns/filterColumns";
+import { buildListDisplayColumns } from "../columns/listColumns";
+import type { RowData, BookingListingStatus } from "../types";
+import { BookingsList } from "./BookingsList";
+
+interface BookingsListContainerProps {
+  status: BookingListingStatus;
+  permissions: {
+    canReadOthersBookings: boolean;
+  };
+  data: RowData[];
+  isPending: boolean;
+  totalRowCount?: number;
+  onRowClick?: (row: Row<RowData>) => void;
+}
+
+export function BookingsListContainer({
+  status,
+  permissions,
+  data,
+  isPending,
+  totalRowCount,
+  onRowClick,
+}: BookingsListContainerProps) {
+  const { t } = useLocale();
+  const user = useMeQuery().data;
+
+  const columns = useMemo(() => {
+    const filterCols = buildFilterColumns({ t, permissions, status });
+    const listCols = buildListDisplayColumns({ t, user });
+    return [...filterCols, ...listCols];
+  }, [t, permissions, status, user]);
+
+  const getFacetedUniqueValues = useFacetedUniqueValues();
+
+  const table = useReactTable<RowData>({
+    data,
+    columns,
+    initialState: {
+      columnVisibility: {
+        eventTypeId: false,
+        teamId: false,
+        userId: false,
+        attendeeName: false,
+        attendeeEmail: false,
+        dateRange: false,
+        bookingUid: false,
+        date: true,
+        time: true,
+        event: true,
+        who: true,
+        team: true,
+        actions: true,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedUniqueValues,
+  });
+
+  return (
+    <BookingsList
+      status={status}
+      table={table}
+      isPending={isPending}
+      totalRowCount={totalRowCount}
+      onRowClick={onRowClick}
+    />
+  );
+}

--- a/apps/web/modules/bookings/components/BookingsListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsListContainer.tsx
@@ -9,7 +9,7 @@ import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 
 import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 
-import { buildFilterColumns } from "../columns/filterColumns";
+import { buildFilterColumns, getFilterColumnVisibility } from "../columns/filterColumns";
 import { buildListDisplayColumns } from "../columns/listColumns";
 import type { RowData, BookingListingStatus } from "../types";
 import { BookingsList } from "./BookingsList";
@@ -48,21 +48,7 @@ export function BookingsListContainer({
     data,
     columns,
     initialState: {
-      columnVisibility: {
-        eventTypeId: false,
-        teamId: false,
-        userId: false,
-        attendeeName: false,
-        attendeeEmail: false,
-        dateRange: false,
-        bookingUid: false,
-        date: true,
-        time: true,
-        event: true,
-        who: true,
-        team: true,
-        actions: true,
-      },
+      columnVisibility: getFilterColumnVisibility(),
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/web/modules/bookings/components/BookingsListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsListContainer.tsx
@@ -1,17 +1,25 @@
 "use client";
 
-import type { Row } from "@tanstack/react-table";
 import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
+import { Button } from "@calcom/ui/components/button";
+import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
+import { TextAreaField } from "@calcom/ui/components/form";
+import { showToast } from "@calcom/ui/components/toast";
 
 import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 
 import { buildFilterColumns, getFilterColumnVisibility } from "../columns/filterColumns";
 import { buildListDisplayColumns } from "../columns/listColumns";
+import { useBookingCursor } from "../hooks/useBookingCursor";
+import { useSelectedBookingId } from "../hooks/useSelectedBookingId";
 import type { RowData, BookingListingStatus } from "../types";
+import { BookingDetailsSheet } from "./BookingDetailsSheet";
 import { BookingsList } from "./BookingsList";
 
 interface BookingsListContainerProps {
@@ -22,7 +30,6 @@ interface BookingsListContainerProps {
   data: RowData[];
   isPending: boolean;
   totalRowCount?: number;
-  onRowClick?: (row: Row<RowData>) => void;
 }
 
 export function BookingsListContainer({
@@ -31,16 +38,105 @@ export function BookingsListContainer({
   data,
   isPending,
   totalRowCount,
-  onRowClick,
 }: BookingsListContainerProps) {
   const { t } = useLocale();
   const user = useMeQuery().data;
+  const utils = trpc.useUtils();
+
+  const [selectedBookingId, setSelectedBookingId] = useSelectedBookingId();
+
+  // Filter out separator rows and extract bookings
+  const bookings = useMemo(() => {
+    return data
+      .filter((row): row is Extract<RowData, { type: "data" }> => row.type === "data")
+      .map((row) => row.booking);
+  }, [data]);
+
+  const selectedBooking = useMemo(() => {
+    if (!selectedBookingId) return null;
+    return bookings.find((booking) => booking.id === selectedBookingId) ?? null;
+  }, [selectedBookingId, bookings]);
+
+  const bookingNavigation = useBookingCursor({
+    bookings,
+    selectedBookingId,
+    setSelectedBookingId,
+  });
+
+  const [rejectionDialogIsOpen, setRejectionDialogIsOpen] = useState(false);
+  const [rejectionReason, setRejectionReason] = useState<string>("");
+  const [pendingRejection, setPendingRejection] = useState<{
+    bookingId: number;
+    recurringEventId?: string | null;
+  } | null>(null);
+
+  const confirmMutation = trpc.viewer.bookings.confirm.useMutation({
+    onSuccess: (data) => {
+      if (data?.status === "REJECTED") {
+        setRejectionDialogIsOpen(false);
+        setRejectionReason("");
+        setPendingRejection(null);
+        showToast(t("booking_rejection_success"), "success");
+      } else {
+        showToast(t("booking_confirmation_success"), "success");
+      }
+      utils.viewer.bookings.invalidate();
+      utils.viewer.me.bookingUnconfirmedCount.invalidate();
+    },
+    onError: () => {
+      showToast(t("booking_confirmation_failed"), "error");
+      utils.viewer.bookings.invalidate();
+    },
+  });
+
+  const handleAccept = useCallback(
+    (bookingId: number, recurringEventId?: string | null) => {
+      confirmMutation.mutate({
+        bookingId,
+        confirmed: true,
+        reason: "",
+        ...(recurringEventId && { recurringEventId }),
+      });
+    },
+    [confirmMutation]
+  );
+
+  const handleReject = useCallback((bookingId: number, recurringEventId?: string | null) => {
+    setPendingRejection({ bookingId, recurringEventId });
+    setRejectionDialogIsOpen(true);
+  }, []);
+
+  const handleConfirmRejection = useCallback(() => {
+    if (!pendingRejection) return;
+
+    confirmMutation.mutate({
+      bookingId: pendingRejection.bookingId,
+      confirmed: false,
+      reason: rejectionReason,
+      ...(pendingRejection.recurringEventId && { recurringEventId: pendingRejection.recurringEventId }),
+    });
+  }, [pendingRejection, rejectionReason, confirmMutation]);
+
+  const onOpenDetails = useCallback(
+    (bookingId: number) => {
+      setSelectedBookingId(bookingId);
+    },
+    [setSelectedBookingId]
+  );
 
   const columns = useMemo(() => {
     const filterCols = buildFilterColumns({ t, permissions, status });
-    const listCols = buildListDisplayColumns({ t, user });
+    const listCols = buildListDisplayColumns({
+      t,
+      user,
+      pendingActionHandlers: {
+        onAccept: handleAccept,
+        onReject: handleReject,
+        isLoading: confirmMutation.isPending,
+      },
+    });
     return [...filterCols, ...listCols];
-  }, [t, permissions, status, user]);
+  }, [t, permissions, status, user, handleAccept, handleReject, confirmMutation.isPending]);
 
   const getFacetedUniqueValues = useFacetedUniqueValues();
 
@@ -49,19 +145,74 @@ export function BookingsListContainer({
     columns,
     initialState: {
       columnVisibility: getFilterColumnVisibility(),
+      columnPinning: {
+        right: ["actions"],
+      },
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFacetedUniqueValues,
   });
 
+  const handleRejectionDialogChange = useCallback((open: boolean) => {
+    setRejectionDialogIsOpen(open);
+    if (!open) {
+      setRejectionReason("");
+      setPendingRejection(null);
+    }
+  }, []);
+
   return (
-    <BookingsList
-      status={status}
-      table={table}
-      isPending={isPending}
-      totalRowCount={totalRowCount}
-      onRowClick={onRowClick}
-    />
+    <>
+      <Dialog open={rejectionDialogIsOpen} onOpenChange={handleRejectionDialogChange}>
+        <DialogContent title={t("rejection_reason_title")} description={t("rejection_reason_description")}>
+          <div>
+            <TextAreaField
+              name="rejectionReason"
+              label={
+                <>
+                  {t("rejection_reason")}
+                  <span className="text-subtle font-normal"> (Optional)</span>
+                </>
+              }
+              value={rejectionReason}
+              onChange={(e) => setRejectionReason(e.target.value)}
+            />
+          </div>
+
+          <DialogFooter>
+            <DialogClose />
+            <Button
+              disabled={confirmMutation.isPending}
+              data-testid="rejection-confirm"
+              onClick={handleConfirmRejection}>
+              {t("rejection_confirmation")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <BookingsList
+        status={status}
+        table={table}
+        isPending={isPending}
+        totalRowCount={totalRowCount}
+        onOpenDetails={onOpenDetails}
+      />
+
+      <BookingDetailsSheet
+        booking={selectedBooking}
+        isOpen={!!selectedBooking}
+        onClose={() => setSelectedBookingId(null)}
+        userTimeZone={user?.timeZone}
+        userTimeFormat={user?.timeFormat === null ? undefined : user?.timeFormat}
+        userId={user?.id}
+        userEmail={user?.email}
+        onPrevious={bookingNavigation.onPrevious}
+        hasPrevious={bookingNavigation.hasPrevious}
+        onNext={bookingNavigation.onNext}
+        hasNext={bookingNavigation.hasNext}
+      />
+    </>
   );
 }

--- a/apps/web/modules/bookings/components/JoinMeetingButton.tsx
+++ b/apps/web/modules/bookings/components/JoinMeetingButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { BookingStatus } from "@calcom/prisma/enums";
+import classNames from "@calcom/ui/classNames";
+import { Button } from "@calcom/ui/components/button";
+
+import { useJoinableLocation } from "./useJoinableLocation";
+
+interface JoinMeetingButtonProps {
+  location: string | null;
+  metadata?: unknown;
+  bookingStatus: BookingStatus;
+  t: (key: string, options?: Record<string, unknown>) => string;
+  size?: "sm" | "base" | "lg";
+  color?: "primary" | "secondary" | "minimal" | "destructive";
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+export function JoinMeetingButton({
+  location,
+  metadata,
+  bookingStatus,
+  t,
+  size = "base",
+  color = "secondary",
+  className,
+  onClick,
+}: JoinMeetingButtonProps) {
+  const { isJoinable, locationToDisplay, provider } = useJoinableLocation({
+    location,
+    metadata,
+    bookingStatus,
+    t,
+  });
+
+  if (!isJoinable || !locationToDisplay) {
+    return null;
+  }
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick?.(e);
+  };
+
+  return (
+    <Button
+      color={color}
+      size={size}
+      href={locationToDisplay}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={classNames("flex items-center gap-2", className)}
+      onClick={handleClick}>
+      {provider?.iconUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={provider.iconUrl}
+          className="h-4 w-4 flex-shrink-0 rounded-sm"
+          alt={`${provider.label} logo`}
+        />
+      )}
+      {provider?.label ? t("join_event_location", { eventLocationType: provider.label }) : t("join_meeting")}
+    </Button>
+  );
+}

--- a/apps/web/modules/bookings/components/useJoinableLocation.tsx
+++ b/apps/web/modules/bookings/components/useJoinableLocation.tsx
@@ -1,0 +1,46 @@
+import type { TFunction } from "i18next";
+import { useMemo } from "react";
+
+import { useBookingLocation } from "@calcom/features/bookings/hooks";
+import type { BookingStatus } from "@calcom/prisma/enums";
+import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
+
+interface UseJoinableLocationParams {
+  location: string | null;
+  metadata?: unknown;
+  bookingStatus: BookingStatus;
+  t: TFunction;
+}
+
+/**
+ * Custom hook to determine if a booking location is joinable (i.e., has a clickable URL).
+ * This hook is used to show/hide the join meeting button and related UI elements.
+ *
+ * @returns An object containing:
+ * - `isJoinable`: Whether the location is joinable (has a valid URL)
+ * - `locationToDisplay`: The location URL or text to display
+ * - `provider`: Provider information (label, iconUrl, etc.)
+ * - `isLocationURL`: Whether the location is a URL
+ */
+export function useJoinableLocation({ location, metadata, bookingStatus, t }: UseJoinableLocationParams) {
+  const bookingMetadata = useMemo(() => {
+    const parsedMetadata = bookingMetadataSchema.safeParse(metadata ?? null);
+    return parsedMetadata.success ? parsedMetadata.data : null;
+  }, [metadata]);
+
+  const { locationToDisplay, provider, isLocationURL } = useBookingLocation({
+    location,
+    videoCallUrl: bookingMetadata?.videoCallUrl,
+    t,
+    bookingStatus,
+  });
+
+  const isJoinable = isLocationURL && !!locationToDisplay;
+
+  return {
+    isJoinable,
+    locationToDisplay,
+    provider,
+    isLocationURL,
+  };
+}

--- a/apps/web/modules/bookings/hooks/useBookingCursor.ts
+++ b/apps/web/modules/bookings/hooks/useBookingCursor.ts
@@ -1,43 +1,37 @@
 import { useMemo, useCallback } from "react";
 
-import type { RowData } from "../types";
-
-function isDataRow(row: RowData): row is Extract<RowData, { type: "data" }> {
-  return row.type === "data";
-}
+import type { BookingOutput } from "../types";
 
 export function useBookingCursor({
   bookings,
   selectedBookingId,
   setSelectedBookingId,
 }: {
-  bookings: RowData[];
+  bookings: BookingOutput[];
   selectedBookingId: number | null;
   setSelectedBookingId: (bookingId: number | null) => void;
 }) {
-  const bookingRows = useMemo(() => bookings.filter(isDataRow), [bookings]);
-
   const currentIndex = useMemo(
-    () => bookingRows.findIndex((row) => selectedBookingId && row.booking.id === selectedBookingId),
-    [bookingRows, selectedBookingId]
+    () => bookings.findIndex((booking) => selectedBookingId && booking.id === selectedBookingId),
+    [bookings, selectedBookingId]
   );
 
   const onPrevious = useCallback(() => {
     if (currentIndex >= 1) {
-      setSelectedBookingId(bookingRows[currentIndex - 1].booking.id);
+      setSelectedBookingId(bookings[currentIndex - 1].id);
     }
-  }, [bookingRows, currentIndex, setSelectedBookingId]);
+  }, [bookings, currentIndex, setSelectedBookingId]);
 
   const onNext = useCallback(() => {
-    if (currentIndex >= 0 && currentIndex < bookingRows.length - 1) {
-      setSelectedBookingId(bookingRows[currentIndex + 1].booking.id);
+    if (currentIndex >= 0 && currentIndex < bookings.length - 1) {
+      setSelectedBookingId(bookings[currentIndex + 1].id);
     }
-  }, [bookingRows, currentIndex, setSelectedBookingId]);
+  }, [bookings, currentIndex, setSelectedBookingId]);
 
   return {
     onPrevious,
     onNext,
     hasPrevious: currentIndex > 0,
-    hasNext: currentIndex < bookingRows.length - 1 && currentIndex >= 0,
+    hasNext: currentIndex < bookings.length - 1 && currentIndex >= 0,
   };
 }

--- a/apps/web/modules/bookings/hooks/useSelectedBookingId.ts
+++ b/apps/web/modules/bookings/hooks/useSelectedBookingId.ts
@@ -1,0 +1,10 @@
+import { useQueryState } from "nuqs";
+
+export function useSelectedBookingId() {
+  return useQueryState("selectedId", {
+    defaultValue: null,
+    parse: (value) => (value ? parseInt(value, 10) : null),
+    serialize: (value) => (value ? String(value) : ""),
+    clearOnDefault: true,
+  });
+}

--- a/apps/web/modules/bookings/lib/viewParser.ts
+++ b/apps/web/modules/bookings/lib/viewParser.ts
@@ -1,0 +1,11 @@
+import { createParser } from "nuqs";
+
+export const viewParser = createParser({
+  parse: (value: string) => {
+    if (value === "calendar") return "calendar";
+    return "list";
+  },
+  serialize: (value: "list" | "calendar") => value,
+});
+
+export type BookingView = "list" | "calendar";

--- a/apps/web/modules/bookings/views/bookings-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReactTable, getCoreRowModel, getSortedRowModel, createColumnHelper } from "@tanstack/react-table";
+import dynamic from "next/dynamic";
 import { useSearchParams, usePathname } from "next/navigation";
 import { createParser, useQueryState } from "nuqs";
 import { useMemo } from "react";
@@ -8,8 +8,6 @@ import { useMemo } from "react";
 import dayjs from "@calcom/dayjs";
 import {
   DataTableProvider,
-  DataTableFilters,
-  DataTableSegment,
   type SystemFilterSegment,
   useDataTable,
   ColumnFilterType,
@@ -19,26 +17,26 @@ import {
   ZTextFilterValue,
 } from "@calcom/features/data-table";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
-import { isSeparatorRow } from "@calcom/features/data-table/lib/separator";
-import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { Alert } from "@calcom/ui/components/alert";
-import { AvatarGroup } from "@calcom/ui/components/avatar";
-import { Badge } from "@calcom/ui/components/badge";
 import type { HorizontalTabItemProps } from "@calcom/ui/components/navigation";
 import { HorizontalTabs } from "@calcom/ui/components/navigation";
 import { WipeMyCalActionButton } from "@calcom/web/components/apps/wipemycalother/wipeMyCalActionButton";
 
-import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
 import type { validStatuses } from "~/bookings/lib/validStatuses";
 
 import { BookingDetailsSheet } from "../components/BookingDetailsSheet";
-import { BookingsCalendar } from "../components/BookingsCalendar";
-import { BookingsList } from "../components/BookingsList";
 import { useBookingCursor } from "../hooks/useBookingCursor";
 import type { RowData, BookingOutput } from "../types";
+
+const BookingsListContainer = dynamic(() =>
+  import("../components/BookingsListContainer").then((mod) => ({ default: mod.BookingsListContainer }))
+);
+const BookingsCalendarContainer = dynamic(() =>
+  import("../components/BookingsCalendarContainer").then((mod) => ({ default: mod.BookingsCalendarContainer }))
+);
 
 type BookingsProps = {
   status: (typeof validStatuses)[number];
@@ -176,183 +174,6 @@ function BookingsContent({ status, permissions, isCalendarViewEnabled }: Booking
     },
   });
 
-  const columns = useMemo(() => {
-    const columnHelper = createColumnHelper<RowData>();
-
-    return [
-      columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.id, {
-        id: "eventTypeId",
-        header: t("event_type"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.MULTI_SELECT,
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row.type === "data" && row.booking.eventType.team?.id, {
-        id: "teamId",
-        header: t("team"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.MULTI_SELECT,
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row.type === "data" && row.booking.user?.id, {
-        id: "userId",
-        header: t("member"),
-        enableColumnFilter: permissions.canReadOthersBookings,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.MULTI_SELECT,
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row, {
-        id: "attendeeName",
-        header: t("attendee_name"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.TEXT,
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row, {
-        id: "attendeeEmail",
-        header: t("attendee_email_variable"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.TEXT,
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row, {
-        id: "dateRange",
-        header: t("date_range"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.DATE_RANGE,
-            dateRangeOptions: {
-              range: status === "past" ? "past" : "custom",
-            },
-          },
-        },
-      }),
-      columnHelper.accessor((row) => row.type === "data" && row.booking.uid, {
-        id: "bookingUid",
-        header: t("booking_uid"),
-        enableColumnFilter: true,
-        enableSorting: false,
-        cell: () => null,
-        meta: {
-          filter: {
-            type: ColumnFilterType.TEXT,
-            textOptions: {
-              allowedOperators: ["equals"],
-            },
-          },
-        },
-      }),
-      columnHelper.display({
-        id: "date",
-        header: () => <span className="text-subtle text-sm font-medium">{t("date")}</span>,
-        cell: (props) => {
-          const row = props.row.original;
-          if (isSeparatorRow(row)) return null;
-
-          return (
-            <div className="text-default text-sm font-medium">
-              {dayjs(row.booking.startTime).tz(user?.timeZone).format("ddd, DD MMM")}
-            </div>
-          );
-        },
-      }),
-      columnHelper.display({
-        id: "time",
-        header: () => <span className="text-subtle text-sm font-medium">{t("time")}</span>,
-        cell: (props) => {
-          const row = props.row.original;
-          if (isSeparatorRow(row)) return null;
-
-          const startTime = dayjs(row.booking.startTime).tz(user?.timeZone);
-          const endTime = dayjs(row.booking.endTime).tz(user?.timeZone);
-          return (
-            <div className="text-default text-sm font-medium">
-              {startTime.format(user?.timeFormat === 12 ? "h:mma" : "HH:mm")} -{" "}
-              {endTime.format(user?.timeFormat === 12 ? "h:mma" : "HH:mm")}
-            </div>
-          );
-        },
-      }),
-      columnHelper.display({
-        id: "event",
-        header: () => <span className="text-subtle text-sm font-medium">{t("event")}</span>,
-        cell: (props) => {
-          const row = props.row.original;
-          if (isSeparatorRow(row)) return null;
-
-          return <div className="text-emphasis flex-1 truncate text-sm font-medium">{row.booking.title}</div>;
-        },
-      }),
-      columnHelper.display({
-        id: "who",
-        header: () => <span className="text-subtle text-sm font-medium">{t("who")}</span>,
-        cell: (props) => {
-          const row = props.row.original;
-          if (isSeparatorRow(row)) return null;
-
-          const items = row.booking.attendees.map((attendee) => ({
-            image: getPlaceholderAvatar(null, attendee.name),
-            alt: attendee.name,
-            title: attendee.name,
-            href: null,
-          }));
-
-          return <AvatarGroup size="sm" truncateAfter={4} items={items} />;
-        },
-      }),
-      columnHelper.display({
-        id: "team",
-        header: () => <span className="text-subtle text-sm font-medium">{t("team")}</span>,
-        cell: (props) => {
-          const row = props.row.original;
-          if (isSeparatorRow(row)) return null;
-
-          if (row.booking.eventType.team) {
-            return (
-              <Badge variant="gray" size="sm">
-                {row.booking.eventType.team.name}
-              </Badge>
-            );
-          }
-          return null;
-        },
-      }),
-      columnHelper.display({
-        id: "actions",
-        header: () => null,
-        cell: () => null,
-      }),
-    ];
-  }, [user, status, t, permissions.canReadOthersBookings]);
-
   const isEmpty = useMemo(() => !query.data?.bookings.length, [query.data]);
 
   const groupedBookings = useMemo(() => {
@@ -469,35 +290,14 @@ function BookingsContent({ status, permissions, isCalendarViewEnabled }: Booking
     setSelectedBookingId,
   });
 
-  const getFacetedUniqueValues = useFacetedUniqueValues();
-
-  const table = useReactTable<RowData>({
-    data: finalData,
-    columns,
-    initialState: {
-      columnVisibility: {
-        eventTypeId: false,
-        teamId: false,
-        userId: false,
-        attendeeName: false,
-        attendeeEmail: false,
-        dateRange: false,
-        bookingUid: false,
-        date: true,
-        time: true,
-        event: true,
-        who: true,
-        team: true,
-        actions: true,
-      },
-    },
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFacetedUniqueValues,
-  });
-
   const isPending = query.isPending;
   const totalRowCount = query.data?.totalCount;
+
+  const handleRowClick = (row: { original: RowData }) => {
+    if (row.original.type === "data") {
+      setSelectedBookingId(row.original.booking.id);
+    }
+  };
 
   return (
     <div className="flex flex-col">
@@ -512,37 +312,23 @@ function BookingsContent({ status, permissions, isCalendarViewEnabled }: Booking
       <main className="w-full">
         <div className="flex w-full flex-col">
           {query.status === "error" ? (
-            <>
-              <div className="grid w-full items-center gap-2 pb-4">
-                <div className="flex w-full flex-col gap-2">
-                  <div className="flex w-full flex-wrap justify-between gap-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <DataTableFilters.FilterBar table={table} />
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <DataTableFilters.ClearFiltersButton />
-                      <DataTableSegment.SaveButton />
-                      <DataTableSegment.Select />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <Alert severity="error" title={t("something_went_wrong")} message={query.error.message} />
-            </>
+            <Alert severity="error" title={t("something_went_wrong")} message={query.error.message} />
           ) : (
             <>
               {!!bookingsToday.length && status === "upcoming" && (
                 <WipeMyCalActionButton bookingStatus={status} bookingsEmpty={isEmpty} />
               )}
               {view === "list" ? (
-                <BookingsList
+                <BookingsListContainer
                   status={status}
-                  table={table}
+                  permissions={permissions}
+                  data={finalData}
                   isPending={isPending}
                   totalRowCount={totalRowCount}
+                  onRowClick={handleRowClick}
                 />
               ) : (
-                <BookingsCalendar status={status} table={table} />
+                <BookingsCalendarContainer status={status} permissions={permissions} data={finalData} />
               )}
             </>
           )}

--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -10,6 +10,7 @@ import {
   confirmReschedule,
   createNewSeatedEventType,
   createUserWithSeatedEventAndAttendees,
+  openBookingActionsDropdown,
   selectFirstAvailableTimeSlotNextMonth,
   submitAndWaitForResponse,
 } from "./lib/testUtils";
@@ -496,7 +497,7 @@ test.describe("Reschedule for booking with seats", () => {
     await page.goto("/bookings/upcoming");
     await page.waitForSelector('[data-testid="bookings"]');
 
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    await openBookingActionsDropdown(page, 0);
     await page.locator('[data-testid="reschedule"]').click();
 
     await page.waitForURL((url) => {
@@ -554,15 +555,15 @@ test.describe("Reschedule for booking with seats", () => {
     await page.goto("/bookings/upcoming");
     await page.waitForSelector('[data-testid="bookings"]');
 
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    await openBookingActionsDropdown(page, 0);
     await page.waitForTimeout(2000);
     const href = await page.locator('[data-testid="reschedule"]').getAttribute("href");
     const url = new URL(href!, page.url());
-    const seatReferenceUid = url.searchParams.get('seatReferenceUid');
-    if(!seatReferenceUid) {
+    const seatReferenceUid = url.searchParams.get("seatReferenceUid");
+    if (!seatReferenceUid) {
       await page.reload();
       await page.waitForSelector('[data-testid="bookings"]');
-      await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+      await openBookingActionsDropdown(page, 0);
       await page.waitForTimeout(2000);
     }
     await page.locator('[data-testid="reschedule"]').click();

--- a/apps/web/playwright/bookings-list.e2e.ts
+++ b/apps/web/playwright/bookings-list.e2e.ts
@@ -8,7 +8,7 @@ import { addFilter } from "./filter-helpers";
 import { createTeamEventType } from "./fixtures/users";
 import type { Fixtures } from "./lib/fixtures";
 import { test } from "./lib/fixtures";
-import { setupManagedEvent } from "./lib/testUtils";
+import { openBookingActionsDropdown, setupManagedEvent } from "./lib/testUtils";
 
 test.afterEach(({ users }) => users.deleteAll());
 
@@ -67,7 +67,7 @@ test.describe("Bookings", () => {
       ).toBeVisible();
     });
 
-    test("Cannot choose date range presets", async ({ page, users, bookings, webhooks }) => {
+    test("Cannot choose date range presets", async ({ page, users }) => {
       const firstUser = await users.create();
       await firstUser.apiLogin();
       const bookingsGetResponse = page.waitForResponse((response) =>
@@ -91,7 +91,7 @@ test.describe("Bookings", () => {
   test.describe("Past bookings", () => {
     test("Mark first guest as no-show", async ({ page, users, bookings, webhooks }) => {
       const firstUser = await users.create();
-      const secondUser = await users.create();
+      await users.create();
 
       const bookingWhereFirstUserIsOrganizerFixture = await createBooking({
         title: "Booking as organizer",
@@ -112,7 +112,6 @@ test.describe("Bookings", () => {
       await page.goto(`/bookings/past`);
       const pastBookings = page.locator('[data-testid="past-bookings"]');
       const firstPastBooking = pastBookings.locator('[data-testid="booking-item"]').nth(0);
-      const titleAndAttendees = firstPastBooking.locator('[data-testid="title-and-attendees"]');
       const firstGuest = firstPastBooking.locator('[data-testid="guest"]').nth(0);
       await firstGuest.click();
       await expect(page.locator('[data-testid="unmark-no-show"]')).toBeHidden();
@@ -142,7 +141,7 @@ test.describe("Bookings", () => {
     });
     test("Mark 3rd attendee as no-show", async ({ page, users, bookings }) => {
       const firstUser = await users.create();
-      const secondUser = await users.create();
+      await users.create();
 
       const bookingWhereFirstUserIsOrganizerFixture = await createBooking({
         title: "Booking as organizer",
@@ -158,13 +157,12 @@ test.describe("Bookings", () => {
           { name: "Fourth", email: "fourth@cal.com", timeZone: "Europe/Berlin" },
         ],
       });
-      const bookingWhereFirstUserIsOrganizer = await bookingWhereFirstUserIsOrganizerFixture.self();
+      await bookingWhereFirstUserIsOrganizerFixture.self();
 
       await firstUser.apiLogin();
       await page.goto(`/bookings/past`);
       const pastBookings = page.locator('[data-testid="past-bookings"]');
       const firstPastBooking = pastBookings.locator('[data-testid="booking-item"]').nth(0);
-      const titleAndAttendees = firstPastBooking.locator('[data-testid="title-and-attendees"]');
       const moreGuests = firstPastBooking.locator('[data-testid="more-guests"]');
       await moreGuests.click();
       const firstGuestInMore = page.getByRole("menuitemcheckbox").nth(0);
@@ -199,11 +197,10 @@ test.describe("Bookings", () => {
       });
       const booking = await bookingFixture.self();
       await adminUser.apiLogin();
-      const { webhookReceiver, teamId } = await webhooks.createTeamReceiver();
+      const { webhookReceiver } = await webhooks.createTeamReceiver();
       await page.goto(`/bookings/past`);
       const pastBookings = page.locator('[data-testid="past-bookings"]');
       const firstPastBooking = pastBookings.locator('[data-testid="booking-item"]').nth(0);
-      const titleAndAttendees = firstPastBooking.locator('[data-testid="title-and-attendees"]');
       const firstGuest = firstPastBooking.locator('[data-testid="guest"]').nth(0);
       await firstGuest.click();
       await expect(page.locator('[data-testid="mark-no-show"]')).toBeVisible();
@@ -232,7 +229,7 @@ test.describe("Bookings", () => {
       webhookReceiver.close();
     });
 
-    test("Can choose date range presets", async ({ page, users, bookings, webhooks }) => {
+    test("Can choose date range presets", async ({ page, users }) => {
       const firstUser = await users.create();
       await firstUser.apiLogin();
       const bookingsGetResponse = page.waitForResponse((response) =>
@@ -359,8 +356,8 @@ test.describe("Bookings", () => {
       .locator(`[data-testid="select-filter-options-userId"] [role="option"]:has-text("${thirdUser.name}")`)
       .click();
     await bookingsGetResponse2;
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
     // Check that the cancel option is visible in the dropdown
     await expect(page.locator('[data-testid="cancel"]')).toBeVisible();
 
@@ -414,7 +411,7 @@ test.describe("Bookings", () => {
 
     const { team } = await owner.getFirstTeamMembership();
     const eventType = await owner.getFirstTeamEvent(team.id);
-    const { id: eventTypeId, title: teamEventTitle, slug: teamEventSlug } = eventType;
+    const { id: eventTypeId } = eventType;
 
     // remove myself from host of this event type
     await prisma.host.delete({

--- a/apps/web/playwright/dynamic-booking-pages.e2e.ts
+++ b/apps/web/playwright/dynamic-booking-pages.e2e.ts
@@ -8,6 +8,7 @@ import {
   confirmReschedule,
   confirmBooking,
   doOnOrgDomain,
+  openBookingActionsDropdown,
   selectFirstAvailableTimeSlotNextMonth,
   selectSecondAvailableTimeSlotNextMonth,
 } from "./lib/testUtils";
@@ -37,8 +38,8 @@ test("dynamic booking", async ({ page, users }) => {
   await test.step("can reschedule a booking", async () => {
     // Logged in
     await page.goto("/bookings/upcoming");
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
     // Click the reschedule option in the dropdown
     await page.locator('[data-testid="reschedule"]').click();
     await page.waitForURL((url) => {
@@ -57,8 +58,8 @@ test("dynamic booking", async ({ page, users }) => {
 
   await test.step("Can cancel the recently created booking", async () => {
     await page.goto("/bookings/upcoming");
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
     // Click the cancel option in the dropdown
     await page.locator('[data-testid="cancel"]').click();
     await page.waitForURL((url) => {
@@ -148,7 +149,6 @@ test("multiple duration selection updates event length correctly", async ({ page
   });
 });
 
-// eslint-disable-next-line playwright/no-skipped-test
 test.skip("it contains the right event details", async ({ page }) => {
   const response = await page.goto(`http://acme.cal.local:3000/owner1+member1`);
   expect(response?.status()).toBe(200);
@@ -193,9 +193,9 @@ test.describe("Organization:", () => {
         });
         await expect(page.getByTestId("success-page")).toBeVisible();
         // All the teammates should be in the booking
-         
+
         await expect(page.getByText(user1.name!, { exact: true })).toBeVisible();
-         
+
         await expect(page.getByText(user2.name!, { exact: true })).toBeVisible();
       }
     );

--- a/apps/web/playwright/reschedule.e2e.ts
+++ b/apps/web/playwright/reschedule.e2e.ts
@@ -14,6 +14,7 @@ import {
   doOnOrgDomain,
   goToUrlWithErrorHandling,
   IS_STRIPE_ENABLED,
+  openBookingActionsDropdown,
   selectFirstAvailableTimeSlotNextMonth,
   submitAndWaitForResponse,
 } from "./lib/testUtils";
@@ -33,8 +34,8 @@ test.describe("Reschedule Tests", async () => {
     await user.apiLogin();
     await page.goto("/bookings/upcoming");
 
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
 
     await page.locator('[data-testid="reschedule_request"]').click();
 
@@ -58,7 +59,7 @@ test.describe("Reschedule Tests", async () => {
   }) => {
     const user = await users.create();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const booking = await bookings.create(user.id, user.username, user.eventTypes[0].id!, {
+    await bookings.create(user.id, user.username, user.eventTypes[0].id!, {
       status: BookingStatus.ACCEPTED,
       startTime: dayjs().subtract(2, "day").toDate(),
       endTime: dayjs().subtract(2, "day").add(30, "minutes").toDate(),
@@ -76,8 +77,8 @@ test.describe("Reschedule Tests", async () => {
     await user.apiLogin();
     await page.goto("/bookings/past");
 
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
 
     await expect(page.locator('[data-testid="reschedule"]')).toBeVisible();
     await expect(page.locator('[data-testid="reschedule_request"]')).toBeVisible();
@@ -93,8 +94,8 @@ test.describe("Reschedule Tests", async () => {
 
     await page.reload();
 
-    // Click the ellipsis menu button to open the dropdown
-    await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
+    // Open the booking actions dropdown
+    await openBookingActionsDropdown(page, 0);
 
     // Check that the reschedule options are visible but disabled
     await expect(page.locator('[data-testid="reschedule"]')).toBeVisible();
@@ -196,7 +197,7 @@ test.describe("Reschedule Tests", async () => {
         },
       },
     });
-    const payment = await payments.create(booking.id);
+    await payments.create(booking.id);
     await page.goto(`/reschedule/${booking.uid}`);
 
     await selectFirstAvailableTimeSlotNextMonth(page);
@@ -226,7 +227,7 @@ test.describe("Reschedule Tests", async () => {
       paid: true,
     });
 
-    const payment = await payments.create(booking.id);
+    await payments.create(booking.id);
     await page.goto(`/reschedule/${booking?.uid}`);
 
     await selectFirstAvailableTimeSlotNextMonth(page);
@@ -330,7 +331,6 @@ test.describe("Reschedule Tests", async () => {
   test("Should load Valid Cal video url after rescheduling Opt in events", async ({
     page,
     users,
-    bookings,
     browser,
   }) => {
     // eslint-disable-next-line playwright/no-skipped-test

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3975,7 +3975,6 @@
   "team_onboarding_details_subtitle": "Add your team's name and create a unique URL for your team",
   "repeats_num_times": "Repeats {{count}} times",
   "view_booking_details": "View Booking Details",
-  "view": "View",
   "recurring_booking_description": "Recurring {{frequency}} event with {{count}} occurrences",
   "team_bio": "Team Bio",
   "team_bio_placeholder": "Tell us about your team...",
@@ -4005,5 +4004,9 @@
   "onboarding_browser_view_ask_question_description": "Ask a question",
   "onboarding_browser_view_default_bio": "Find a time that suits you",
   "book_now": "Book now",
+  "view": "View",
+  "booking_response": "Booking Response",
+  "list_view": "List view",
+  "calendar_view": "Calendar view",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/calendars/weeklyview/types/events.ts
+++ b/packages/features/calendars/weeklyview/types/events.ts
@@ -13,6 +13,7 @@ export interface CalendarEvent {
     allDay?: boolean;
     color?: string;
     className?: string;
+    bookingId?: number;
     "data-test-id"?: string;
   };
 }

--- a/packages/features/data-table/components/DataTable.tsx
+++ b/packages/features/data-table/components/DataTable.tsx
@@ -39,6 +39,8 @@ export type DataTablePropsFromWrapper<TData> = {
   containerClassName?: string;
   headerClassName?: string;
   rowClassName?: string | ((row: Row<TData>) => string);
+  rowTestId?: string | ((row: Row<TData>) => string | undefined);
+  rowDataAttributes?: (row: Row<TData>) => Record<string, string> | undefined;
   paginationMode?: "infinite" | "standard";
   hasWrapperContext?: boolean;
   hideSeparatorsOnSort?: boolean;
@@ -68,6 +70,8 @@ export function DataTable<TData>({
   containerClassName,
   headerClassName,
   rowClassName,
+  rowTestId,
+  rowDataAttributes,
   paginationMode = "infinite",
   hasWrapperContext = false,
   hideSeparatorsOnSort = true,
@@ -203,6 +207,8 @@ export function DataTable<TData>({
               onRowMouseclick={onRowMouseclick}
               paginationMode={paginationMode}
               rowClassName={rowClassName}
+              rowTestId={rowTestId}
+              rowDataAttributes={rowDataAttributes}
               hideSeparatorsOnSort={hideSeparatorsOnSort}
               hideSeparatorsOnFilter={hideSeparatorsOnFilter}
               separatorClassName={separatorClassName}
@@ -219,6 +225,8 @@ export function DataTable<TData>({
               onRowMouseclick={onRowMouseclick}
               paginationMode={paginationMode}
               rowClassName={rowClassName}
+              rowTestId={rowTestId}
+              rowDataAttributes={rowDataAttributes}
               hideSeparatorsOnSort={hideSeparatorsOnSort}
               hideSeparatorsOnFilter={hideSeparatorsOnFilter}
               separatorClassName={separatorClassName}
@@ -244,6 +252,8 @@ const MemoizedTableBody = memo(
     prev.onRowMouseclick === next.onRowMouseclick &&
     prev.paginationMode === next.paginationMode &&
     prev.rowClassName === next.rowClassName &&
+    prev.rowTestId === next.rowTestId &&
+    prev.rowDataAttributes === next.rowDataAttributes &&
     prev.hideSeparatorsOnSort === next.hideSeparatorsOnSort &&
     prev.hideSeparatorsOnFilter === next.hideSeparatorsOnFilter &&
     prev.separatorClassName === next.separatorClassName &&
@@ -260,6 +270,8 @@ type DataTableBodyProps<TData> = {
   onRowMouseclick?: (row: Row<TData>) => void;
   paginationMode?: "infinite" | "standard";
   rowClassName?: string | ((row: Row<TData>) => string);
+  rowTestId?: string | ((row: Row<TData>) => string | undefined);
+  rowDataAttributes?: (row: Row<TData>) => Record<string, string> | undefined;
   hideSeparatorsOnSort?: boolean;
   hideSeparatorsOnFilter?: boolean;
   separatorClassName?: string;
@@ -294,6 +306,8 @@ function DataTableBody<TData>({
   onRowMouseclick,
   paginationMode,
   rowClassName,
+  rowTestId,
+  rowDataAttributes,
   hideSeparatorsOnSort = true,
   hideSeparatorsOnFilter = false,
   separatorClassName,
@@ -374,10 +388,16 @@ function DataTableBody<TData>({
           );
         }
 
+        const computedRowTestId = typeof rowTestId === "function" ? rowTestId(row) : rowTestId;
+        const computedRowClassName = typeof rowClassName === "function" ? rowClassName(row) : rowClassName;
+        const computedDataAttributes = rowDataAttributes?.(row);
+
         return (
           <TableRow
             ref={virtualItem ? (node) => filteredRowVirtualizer.measureElement(node) : undefined}
             key={row.id}
+            data-testid={computedRowTestId}
+            {...computedDataAttributes}
             data-index={virtualItem?.index} // needed for dynamic row height measurement
             data-state={row.getIsSelected() && "selected"}
             onClick={() => onRowMouseclick && onRowMouseclick(row)}
@@ -389,11 +409,7 @@ function DataTableBody<TData>({
                 width: "100%",
               }),
             }}
-            className={classNames(
-              onRowMouseclick && "hover:cursor-pointer",
-              "group",
-              typeof rowClassName === "function" ? rowClassName(row) : rowClassName
-            )}>
+            className={classNames(onRowMouseclick && "hover:cursor-pointer", "group", computedRowClassName)}>
             {row.getVisibleCells().map((cell) => {
               const column = cell.column;
               return (

--- a/packages/features/data-table/components/DataTableWrapper.tsx
+++ b/packages/features/data-table/components/DataTableWrapper.tsx
@@ -22,6 +22,8 @@ type BaseDataTableWrapperProps<TData> = Omit<
   LoaderView?: React.ReactNode;
   tableContainerRef?: React.RefObject<HTMLDivElement>;
   onRowMouseclick?: (row: Row<TData>) => void;
+  rowTestId?: string | ((row: Row<TData>) => string | undefined);
+  rowDataAttributes?: (row: Row<TData>) => Record<string, string> | undefined;
 };
 
 type InfinitePaginationProps<TData> = BaseDataTableWrapperProps<TData> & {
@@ -58,6 +60,8 @@ export function DataTableWrapper<TData>({
   containerClassName,
   headerClassName,
   rowClassName,
+  rowTestId,
+  rowDataAttributes,
   children,
   tableContainerRef: externalRef,
   paginationMode,
@@ -133,6 +137,8 @@ export function DataTableWrapper<TData>({
           containerClassName={containerClassName}
           headerClassName={headerClassName}
           rowClassName={rowClassName}
+          rowTestId={rowTestId}
+          rowDataAttributes={rowDataAttributes}
           paginationMode={paginationMode}
           onRowMouseclick={onRowMouseclick}
           hasWrapperContext={true}

--- a/packages/lib/hooks/useMediaQuery.ts
+++ b/packages/lib/hooks/useMediaQuery.ts
@@ -1,7 +1,13 @@
 import { useState, useEffect } from "react";
 
 const useMediaQuery = (query: string) => {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => {
+    // Initialize with actual media query value on client
+    if (typeof window !== "undefined") {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
 
   useEffect(() => {
     const media = window.matchMedia(query);
@@ -9,8 +15,8 @@ const useMediaQuery = (query: string) => {
       setMatches(media.matches);
     }
     const listener = () => setMatches(media.matches);
-    window.addEventListener("resize", listener);
-    return () => window.removeEventListener("resize", listener);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
   }, [matches, query]);
 
   return matches;

--- a/packages/ui/components/sheet/Sheet.tsx
+++ b/packages/ui/components/sheet/Sheet.tsx
@@ -70,7 +70,7 @@ const SheetContent = React.forwardRef<
           ref={forwardedRef}
           className={classNames(
             // base
-            "fixed inset-y-4 mx-auto flex w-[95vw] flex-1 flex-col overflow-y-auto rounded-xl border p-4 shadow-lg focus:outline-none sm:right-2 sm:max-w-lg sm:p-6",
+            "fixed inset-x-0 inset-y-4 mx-auto flex w-[95vw] flex-1 flex-col overflow-y-auto rounded-xl border p-4 shadow-lg focus:outline-none sm:inset-x-auto sm:right-2 sm:max-w-lg sm:p-6",
             // "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm sm:p-6 p-4 shadow-lg rounded-xl border ",
             // border color
             "border-subtle",


### PR DESCRIPTION
## What does this PR do?

This PR refactors the bookings page column definitions to separate filter-only columns from display columns, ensuring the calendar view doesn't unnecessarily import list-specific UI components.

**Stacked on:** #24664 (feat(CAL-5374): bookings page redesign v3)

### Changes Made

1. **Created `filterColumns.ts`** - Shared builder for 7 filter-only columns (eventTypeId, teamId, userId, attendeeName, attendeeEmail, dateRange, bookingUid)
2. **Created `listColumns.tsx`** - Builder for 6 list-specific display columns (date, time, event, who, team, actions) with React components
3. **Created `BookingsListContainer.tsx`** - Imports both filter and display columns, creates table for list view
4. **Created `BookingsCalendarContainer.tsx`** - Imports only filter columns, creates table for calendar view
5. **Updated `bookings-view.tsx`** - Uses dynamic imports for containers, removed inline column/table creation

### Bug Fix (Second Commit)

Fixed filter accessor functions to return `null` instead of `false` for separator rows, preventing bogus "false" values from appearing in multi-select filters.

### Benefits

- **Smaller bundle for calendar view** - List-specific UI components (`AvatarGroup`, `Badge`) are not bundled when `view === "calendar"` (via Next.js dynamic imports)
- **Clear separation of concerns** - Filter columns vs display columns in separate files
- **Better maintainability** - Columns organized by purpose and view

---

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - Internal refactoring only
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **TODO** - Need to add tests for column builders

---

## How should this be tested?

### Prerequisites
- PR #24664 must be merged first (this PR is stacked on top)
- Standard Cal.com dev environment

### Test Cases

1. **List View Functionality**
   - Navigate to `/bookings?view=list`
   - Verify all columns render (date, time, event, who, team)
   - Test filtering by event type, team, user, attendee, date range
   - Click booking rows - verify details sheet opens
   - Check pagination works

2. **Calendar View Functionality**
   - Switch to `/bookings?view=calendar`
   - Verify calendar renders correctly
   - Test all filters work (event type, team, user, date range)
   - Verify filters affect calendar display

3. **Filter Bug Fix Verification**
   - Apply filters in both views
   - Check that multi-select filters don't show "false" as an option
   - Verify separator rows don't pollute filter values

4. **Bundle Size Verification** ⚠️ **Important**
   - Run production build: `yarn build`
   - Analyze bundle for calendar route
   - Verify `AvatarGroup` and `Badge` components are NOT in calendar bundle
   - Compare before/after bundle sizes

---

## Review Checklist

**⚠️ Critical Items:**

- [ ] **Error state regression**: cubic AI reviewer flagged that when query fails, users can no longer access filter controls to clear filters and recover. This is a known limitation that would require architectural changes to fix properly. Should we address this now or accept it?
- [ ] **Bundle splitting verification**: Confirm via bundle analyzer that list-specific components aren't imported for calendar view
- [ ] **Filtering works correctly**: Test all filter types in both views, especially after the null vs false fix
- [ ] **Row interactions work**: Clicking rows in list view opens details sheet correctly
- [ ] **Pagination and sorting**: Verify these still work in list view

**Additional Items:**

- [ ] Column definitions match original implementation exactly
- [ ] `useFacetedUniqueValues` hook works in both containers
- [ ] Dynamic imports load without hydration issues
- [ ] `handleRowClick` type (`{ original: RowData }`) is acceptable vs full `Row<RowData>` type
- [ ] No console errors in browser

---

**Link to Devin run:** https://app.devin.ai/sessions/e325ce15c9104c5a9fb607327bccb79d  
**Requested by:** eunjae@cal.com (@eunjae-lee)

**Known Issues:**
- The error state no longer shows filter controls, making it harder for users to clear filters when queries fail (raised by cubic AI reviewer)