### PR TITLE
feat: Enable ACH Direct Debit for team/org subscription checkout

### DIFF
--- a/apps/api/v1/pages/api/teams/_post.ts
+++ b/apps/api/v1/pages/api/teams/_post.ts
@@ -201,6 +201,8 @@ const generateTeamCheckoutSession = async ({
   const session = await stripe.checkout.sessions.create({
     customer,
     mode: "subscription",
+    payment_method_types: ["card", "us_bank_account"],
+    billing_address_collection: "required",
     ...(dubCustomer?.discount?.couponId
       ? {
           discounts: [

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -20,8 +20,7 @@ import { SUCCESS_STATUS } from "@calcom/platform-constants";
 import type { Prisma, Credential, User } from "@calcom/prisma/client";
 
 import { stripeKeysResponseSchema } from "./utils/stripeDataSchemas";
-
-import stringify = require("qs-stringify");
+import stringify from "qs-stringify";
 
 export type OAuthCallbackState = {
   accessToken: string;
@@ -179,6 +178,8 @@ export class StripeService {
     const session = await stripe.checkout.sessions.create({
       customer,
       mode: "subscription",
+      payment_method_types: ["card", "us_bank_account"],
+      billing_address_collection: "required",
       allow_promotion_codes: true,
       success_url: `${this.webAppUrl}/api/teams/api/create?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${this.webAppUrl}/settings/my-account/profile`,
@@ -243,7 +244,7 @@ export class StripeService {
       });
 
       customerId = customersResponse.data[0].id;
-    } catch (error) {
+    } catch {
       const customer = await stripe.customers.create({ email: user.email });
       customerId = customer.id;
     }

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -63,6 +63,8 @@ export const generateTeamCheckoutSession = async ({
   const session = await stripe.checkout.sessions.create({
     customer,
     mode: "subscription",
+    payment_method_types: ["card", "us_bank_account"],
+    billing_address_collection: "required",
     ...(dubCustomer?.discount?.couponId
       ? {
           discounts: [
@@ -174,6 +176,8 @@ export const purchaseTeamOrOrgSubscription = async (input: {
   const session = await stripe.checkout.sessions.create({
     customer,
     mode: "subscription",
+    payment_method_types: ["card", "us_bank_account"],
+    billing_address_collection: "required",
     allow_promotion_codes: true,
     success_url: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${WEBAPP_URL}/settings/my-account/profile`,


### PR DESCRIPTION
## What does this PR do?

Enables ACH Direct Debit (US bank account) payment option for team and organization subscription checkout flows. When enabled in Stripe Dashboard, customers will now see "Bank account" alongside "Card" as a payment option during team/org subscription checkout.

**Context**: User had ACH Direct Debit, SEPA Direct Debit, and Bank transfer enabled in Stripe Dashboard but none were appearing in checkout. Investigation revealed that omitting `payment_method_types` in Stripe Checkout defaults to card-only for subscriptions.

**Link to Devin run**: https://app.devin.ai/sessions/15ee4ed3e9bb44849095391400caecb2  
**Requested by**: joe@cal.com (@joeauyeung)

## Changes Made

1. **Added ACH Direct Debit support** to all team/org subscription checkout sessions:
   - `payment_method_types: ["card", "us_bank_account"]` explicitly enables both payment methods
   - `billing_address_collection: "required"` helps Stripe determine customer region for method eligibility

2. **Updated 4 checkout locations** for consistency:
   - `packages/features/ee/teams/lib/payments.ts` - `generateTeamCheckoutSession()` and `purchaseTeamOrOrgSubscription()`
   - `apps/api/v1/pages/api/teams/_post.ts` - `generateTeamCheckoutSession()`
   - `apps/api/v2/src/modules/stripe/stripe.service.ts` - `generateTeamCheckoutSession()`

3. **Fixed unrelated lint warnings** in API v2 Stripe service (require import style, unused error variable)

## Important Limitations & Considerations

⚠️ **This only works with USD prices**
- ACH Direct Debit requires USD currency
- SEPA Direct Debit (for EUR) would require adding `sepa_debit` to payment_method_types
- Verify team/org subscription prices are in USD

⚠️ **ACH verification can be asynchronous**
- Some customers may need micro-deposit verification
- Checkout session may not be "paid" immediately
- Existing "pending team" logic should handle this, but worth testing

⚠️ **Billing address now required**
- Adds an extra form step to checkout
- Necessary for Stripe to determine payment method eligibility

⚠️ **Scope limited to team/org subscriptions**
- Premium username subscriptions unchanged (intentional)
- Other checkout flows unchanged (intentional)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a configuration change that doesn't require docs updates
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Needs manual testing** - Stripe payment methods require live testing with test accounts

## How should this be tested?

### Environment Setup
1. Ensure Stripe test mode has ACH Direct Debit enabled in Dashboard
2. Verify `STRIPE_TEAM_MONTHLY_PRICE_ID` and `STRIPE_ORG_MONTHLY_PRICE_ID` are USD prices

### Test Steps
1. Navigate to team creation flow that requires payment
2. Click through to checkout
3. **Expected**: See both "Card" and "Bank account" payment options
4. Select "Bank account" and complete flow using [Stripe test bank account](https://docs.stripe.com/testing#bank-accounts)
5. Verify team is created successfully after payment
6. **Test async flow**: Use test account that triggers micro-deposit verification
7. Verify team provisioning handles pending/incomplete payment status

### Critical Checks
- [ ] ACH option appears in checkout UI
- [ ] Can complete payment with test bank account
- [ ] Team/org is provisioned after successful payment
- [ ] Async verification flow works (if applicable)
- [ ] Billing address collection doesn't break checkout UX
- [ ] Card payments still work normally

## Human Review Checklist

Please pay special attention to:
- [ ] Currency assumption - all team/org prices must be USD for this to work
- [ ] Async payment handling - verify logic handles non-immediate "paid" status
- [ ] UX impact of required billing address collection
- [ ] Consistent implementation across all 4 checkout locations
- [ ] Test thoroughly in Stripe test mode before production

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **N/A** - Simple configuration change
- [x] I have checked if my changes generate no new warnings