### PR TITLE
fix: allow non-booking routes to be used as booking pages on org domains

### DIFF
--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const glob = require("glob");
 const { nextJsOrgRewriteConfig } = require("./getNextjsOrgRewriteConfig");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
@@ -9,6 +10,7 @@ let pages = (exports.pages = glob
       cwd: __dirname,
     }
   )
+  .filter((filename) => !filename.includes("(use-page-wrapper)"))
   .map((filename) =>
     filename
       .replace(

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -1,5 +1,7 @@
-/* eslint-disable @typescript-eslint/no-require-imports, no-undef, no-useless-escape */
+/* global require, exports, __dirname */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const glob = require("glob");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { nextJsOrgRewriteConfig } = require("./getNextjsOrgRewriteConfig");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
 // Pages found here are excluded from redirects in beforeFiles in next.config.js
@@ -10,7 +12,7 @@ const bookingRoutes = glob.sync("app/(booking-page-wrapper)/**/[^_]*.{tsx,js,ts}
 
 const nonWrapperRoutes = glob.sync("{pages,app}/**/[^_]*.{tsx,js,ts}", {
   cwd: __dirname,
-  ignore: ["app/(*)/**"],
+  ignore: ["app/\\(*/**"],
 });
 
 let pages = (exports.pages = [...new Set([...bookingRoutes, ...nonWrapperRoutes])]
@@ -72,11 +74,11 @@ function getRegExpMatchingAllReservedRoutes(suffix) {
 }
 
 // To handle /something
-exports.orgUserRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes("/?$")})[a-zA-Z0-9\-_]+)`;
+exports.orgUserRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes("/?$")})[a-zA-Z0-9_-]+)`;
 // To handle /something/somethingelse
 exports.orgUserTypeRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes(
   "/"
-)})[^/]+)/:type((?!avatar\.png)[^/]+)`;
+)})[^/]+)/:type((?!avatar[.]png)[^/]+)`;
 
 // To handle /something/somethingelse/embed
 exports.orgUserTypeEmbedRoutePath = `/:user((?!${getRegExpMatchingAllReservedRoutes("/")})[^/]+)/:type/embed`;

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -3,14 +3,17 @@ const glob = require("glob");
 const { nextJsOrgRewriteConfig } = require("./getNextjsOrgRewriteConfig");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
 // Pages found here are excluded from redirects in beforeFiles in next.config.js
-let pages = (exports.pages = glob
-  .sync(
-    "{pages,app,app/(booking-page-wrapper),app/(use-page-wrapper),app/(use-page-wrapper)/(main-nav)}/**/[^_]*.{tsx,js,ts}",
-    {
-      cwd: __dirname,
-    }
-  )
-  .filter((filename) => !filename.includes("(use-page-wrapper)"))
+
+const bookingRoutes = glob.sync("app/(booking-page-wrapper)/**/[^_]*.{tsx,js,ts}", {
+  cwd: __dirname,
+});
+
+const nonWrapperRoutes = glob.sync("{pages,app}/**/[^_]*.{tsx,js,ts}", {
+  cwd: __dirname,
+  ignore: ["app/(*)/**"], // Exclude all wrapper groups like (use-page-wrapper), (booking-page-wrapper)
+});
+
+let pages = (exports.pages = [...new Set([...bookingRoutes, ...nonWrapperRoutes])]
   .map((filename) =>
     filename
       .replace(

--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef, no-useless-escape */
 const glob = require("glob");
 const { nextJsOrgRewriteConfig } = require("./getNextjsOrgRewriteConfig");
 /** Needed to rewrite public booking page, gets all static pages but [user] */
@@ -10,7 +10,7 @@ const bookingRoutes = glob.sync("app/(booking-page-wrapper)/**/[^_]*.{tsx,js,ts}
 
 const nonWrapperRoutes = glob.sync("{pages,app}/**/[^_]*.{tsx,js,ts}", {
   cwd: __dirname,
-  ignore: ["app/(*)/**"], // Exclude all wrapper groups like (use-page-wrapper), (booking-page-wrapper)
+  ignore: ["app/(*)/**"],
 });
 
 let pages = (exports.pages = [...new Set([...bookingRoutes, ...nonWrapperRoutes])]

--- a/apps/web/test/lib/next-config.test.ts
+++ b/apps/web/test/lib/next-config.test.ts
@@ -2,7 +2,7 @@ import { it, expect, describe, beforeAll } from "vitest";
 
 import { getRegExpThatMatchesAllOrgDomains } from "../../getNextjsOrgRewriteConfig";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { match, pathToRegexp } = require("next/dist/compiled/path-to-regexp");
 type MatcherRes = (path: string) => { params: Record<string, string> };
 let orgUserTypeRouteMatch: MatcherRes;
@@ -15,7 +15,7 @@ beforeAll(async () => {
   const {
     orgUserRoutePath,
     orgUserTypeRoutePath,
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
   } = require("../../pagesAndRewritePaths");
 
   orgUserTypeRouteMatch = match(orgUserTypeRoutePath);
@@ -144,23 +144,109 @@ describe("next.config.js - Org Rewrite", () => {
       expect(orgUserRouteMatch("/_next/")).toEqual(false);
       expect(orgUserRouteMatch("/public/")).toEqual(false);
 
-      expect(orgUserRouteMatch("/event-types/")).toEqual(false);
-      expect(orgUserTypeRouteMatch("/event-types/")).toEqual(false);
-
-      expect(orgUserRouteMatch("/event-types/?abc=1")).toEqual(false);
-      expect(orgUserTypeRouteMatch("/event-types/?abc=1")).toEqual(false);
-
-      expect(orgUserRouteMatch("/event-types")).toEqual(false);
-      expect(orgUserTypeRouteMatch("/event-types")).toEqual(false);
-
-      expect(orgUserRouteMatch("/event-types?abc=1")).toEqual(false);
-      expect(orgUserTypeRouteMatch("/event-types?abc=1")).toEqual(false);
-
       expect(orgUserTypeRouteMatch("/john/avatar.png")).toEqual(false);
       expect(orgUserTypeRouteMatch("/cancel/abcd")).toEqual(false);
       expect(orgUserTypeRouteMatch("/success/abcd")).toEqual(false);
       expect(orgUserRouteMatch("/forms/xdsdf-sd")).toEqual(false);
       expect(orgUserRouteMatch("/router?form=")).toEqual(false);
+    });
+
+    it("Non-booking routes from (use-page-wrapper) should be treated as booking pages on org domains", () => {
+      
+      // /onboarding should match as a booking page
+      expect(orgUserRouteMatch("/onboarding")?.params).toEqual({
+        user: "onboarding",
+      });
+
+      // /settings should match as a booking page
+      expect(orgUserRouteMatch("/settings")?.params).toEqual({
+        user: "settings",
+      });
+
+      // /availability should match as a booking page
+      expect(orgUserRouteMatch("/availability")?.params).toEqual({
+        user: "availability",
+      });
+
+      // /workflows should match as a booking page
+      expect(orgUserRouteMatch("/workflows")?.params).toEqual({
+        user: "workflows",
+      });
+
+      // /insights should match as a booking page
+      expect(orgUserRouteMatch("/insights")?.params).toEqual({
+        user: "insights",
+      });
+
+      // /bookings should match as a booking page
+      expect(orgUserRouteMatch("/bookings")?.params).toEqual({
+        user: "bookings",
+      });
+
+      // /teams should match as a booking page
+      expect(orgUserRouteMatch("/teams")?.params).toEqual({
+        user: "teams",
+      });
+
+      // /video should match as a booking page
+      expect(orgUserRouteMatch("/video")?.params).toEqual({
+        user: "video",
+      });
+
+      // /getting-started should match as a booking page
+      expect(orgUserRouteMatch("/getting-started")?.params).toEqual({
+        user: "getting-started",
+      });
+
+      // /payment should match as a booking page
+      expect(orgUserRouteMatch("/payment")?.params).toEqual({
+        user: "payment",
+      });
+
+      // /signup should match as a booking page
+      expect(orgUserRouteMatch("/signup")?.params).toEqual({
+        user: "signup",
+      });
+
+      // /enterprise should match as a booking page
+      expect(orgUserRouteMatch("/enterprise")?.params).toEqual({
+        user: "enterprise",
+      });
+
+      // /connect-and-join should match as a booking page
+      expect(orgUserRouteMatch("/connect-and-join")?.params).toEqual({
+        user: "connect-and-join",
+      });
+
+      // /maintenance should match as a booking page
+      expect(orgUserRouteMatch("/maintenance")?.params).toEqual({
+        user: "maintenance",
+      });
+
+      // /more should match as a booking page
+      expect(orgUserRouteMatch("/more")?.params).toEqual({
+        user: "more",
+      });
+
+      // /upgrade should match as a booking page
+      expect(orgUserRouteMatch("/upgrade")?.params).toEqual({
+        user: "upgrade",
+      });
+
+      // /refer should match as a booking page
+      expect(orgUserRouteMatch("/refer")?.params).toEqual({
+        user: "refer",
+      });
+
+      // /auth should match as a booking page
+      expect(orgUserRouteMatch("/auth")?.params).toEqual({
+        user: "auth",
+      });
+
+      // /apps should match as a booking page
+      expect(orgUserRouteMatch("/apps")?.params).toEqual({
+        user: "apps",
+      });
     });
   });
 });

--- a/apps/web/test/lib/pagesAndRewritePaths.test.ts
+++ b/apps/web/test/lib/pagesAndRewritePaths.test.ts
@@ -5,37 +5,68 @@ import { pages } from "../../pagesAndRewritePaths.js";
 describe("pagesAndRewritePaths", () => {
   describe("beforeFiles must exclude routes in pages/app router", () => {
     const BEFORE_REWRITE_EXCLUDE_PAGES = [
-      "apps",
-      "availability",
       "booking",
-      "connect-and-join",
-      "enterprise",
+      "booking-successful",
       "error",
-      "getting-started",
-      "insights",
-      "maintenance",
-      "more",
       "not-found",
       "reschedule",
-      "settings",
-      "teams",
-      "upgrade",
-      "video",
-      "workflows",
-      "bookings",
-      "event-types",
       "icons",
       "org",
-      "payment",
       "routing-forms",
-      "signup",
       "team",
       "d",
+      "api",
+      "cache",
     ];
 
     it("should include all required routes", () => {
       BEFORE_REWRITE_EXCLUDE_PAGES.forEach((route) => {
         expect(pages).toContain(route);
+      });
+    });
+  });
+
+  describe("Only booking routes should be excluded from org rewrites", () => {
+    const BOOKING_ROUTES = [
+      "booking",
+      "booking-successful",
+      "d",
+      "org",
+      "team",
+    ];
+
+    const NON_BOOKING_ROUTES = [
+      "onboarding",
+      "settings",
+      "event-types",
+      "availability",
+      "apps",
+      "workflows",
+      "insights",
+      "bookings",
+      "teams",
+      "video",
+      "getting-started",
+      "payment",
+      "signup",
+      "enterprise",
+      "connect-and-join",
+      "maintenance",
+      "more",
+      "upgrade",
+      "refer",
+      "auth",
+    ];
+
+    it("should include booking routes from (booking-page-wrapper)", () => {
+      BOOKING_ROUTES.forEach((route) => {
+        expect(pages, `Expected booking route '${route}' to be in pages array`).toContain(route);
+      });
+    });
+
+    it("should NOT include non-booking routes from (use-page-wrapper)", () => {
+      NON_BOOKING_ROUTES.forEach((route) => {
+        expect(pages, `Non-booking route '${route}' should NOT be in pages array to allow org domain rewrites`).not.toContain(route);
       });
     });
   });

--- a/apps/web/test/lib/pagesAndRewritePaths.test.ts
+++ b/apps/web/test/lib/pagesAndRewritePaths.test.ts
@@ -26,6 +26,27 @@ describe("pagesAndRewritePaths", () => {
     });
   });
 
+  describe("Top-level app routes must be reserved (not treated as booking pages)", () => {
+    const TOP_LEVEL_APP_ROUTES = [
+      "api",
+      "icons",
+      "cache",
+      "routing-forms",
+      "reschedule",
+      "error",
+      "not-found",
+    ];
+
+    it("should include top-level app routes to prevent them from being treated as user slugs on org domains", () => {
+      TOP_LEVEL_APP_ROUTES.forEach((route) => {
+        expect(
+          pages,
+          `Top-level app route '${route}' must be in pages array to prevent /acme.cal.com/${route} from being treated as a booking page`
+        ).toContain(route);
+      });
+    });
+  });
+
   describe("Only booking routes should be excluded from org rewrites", () => {
     const BOOKING_ROUTES = [
       "booking",


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where non-booking routes (like `/onboarding`, `/settings`, `/event-types`) from `(use-page-wrapper)` were incorrectly added to the reserved routes list, preventing users from having booking pages with those slugs on org domains.

**Problem**: `acme.cal.com/onboarding` returned 404 even when a user with slug "onboarding" exists  
**Solution**: Modified `pagesAndRewritePaths.js` to only include actual booking routes from `(booking-page-wrapper)` and top-level app routes (api, icons, cache, etc.) in the reserved list, allowing non-booking routes to work as user slugs on org domains

### Implementation Approach

Refactored the glob pattern logic to use two separate scans:
1. **bookingRoutes** - Explicitly gathers routes from `app/(booking-page-wrapper)/**`
2. **nonWrapperRoutes** - Gathers `pages/**` and `app/**` while ignoring ALL wrapper groups via `ignore: ["app/(*)/**"]`

This ensures:
- Booking routes (team, org, d, booking, booking-successful) remain reserved ✓
- Top-level app routes (api, _trpc, icons, cache, routing-forms) remain reserved ✓  
- Non-booking routes (onboarding, settings, event-types, etc.) can now match as user slugs ✓

### Test Coverage

Added comprehensive test suites verifying:
1. Top-level app routes must be in pages array to prevent them being treated as user slugs
2. Booking routes from (booking-page-wrapper) are correctly included
3. Non-booking routes from (use-page-wrapper) are correctly excluded
4. Non-booking routes can match as booking pages on org domains (next-config.test.ts)

---

**Link to Devin run**: https://app.devin.ai/sessions/4328ca36ef7e4895bd128d2df76bb676  
**Requested by**: @hariombalhara (hariom@cal.com)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - no documentation changes needed
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works

## How should this be tested?

### Environment Setup
- Set `ORGANIZATIONS_ENABLED=1` in environment variables
- Configure an organization with a custom domain (e.g., `acme.cal.com`)

### Test Scenario
1. Create a user with slug `onboarding` in an organization
2. Visit `{org-domain}/onboarding` (e.g., `acme.cal.com/onboarding`)
3. **Expected**: Should display the booking page for user "onboarding"
4. **Previous behavior**: Would return 404

### Additional Routes to Verify
Test that these non-booking routes now work as user slugs on org domains:
- `/settings`, `/event-types`, `/availability`, `/apps`, `/workflows`
- `/insights`, `/bookings`, `/teams`, `/video`, `/payment`
- `/signup`, `/enterprise`, `/maintenance`, `/more`, `/upgrade`

### Verify No Regressions
Ensure these routes still work correctly and are NOT treated as user slugs:
- `/api` - API endpoints
- `/icons` - Icon assets
- `/cache` - Cache directory
- `/routing-forms` - Routing forms feature
- `/{username}` - user booking page
- `/{username}/{event-type}` - specific event type
- `/team/{team-slug}` - team booking page
- `/d/{link}` - dynamic link

## Human Review Checklist

### 🔴 Critical
1. **Glob ignore pattern**: Verify that `ignore: ["app/(*)/**"]` correctly excludes all wrapper groups. Test by checking the generated `pages` array contains no routes from `(use-page-wrapper)` but does contain routes from `(booking-page-wrapper)` and top-level app routes.

2. **Top-level app routes preserved**: Confirm routes like `/api`, `/icons`, `/cache`, `/routing-forms`, `/reschedule`, `/error`, `/not-found` are in the pages array. These must remain reserved or they could be matched as user slugs, breaking core functionality.

3. **Generated regex patterns**: Review the negative lookahead regex in `orgUserRoutePath` and `orgUserTypeRoutePath` to ensure they correctly exclude booking routes and top-level app routes while allowing non-booking routes.

### 🟡 Important
4. **ESLint configuration**: The `eslint-disable` comment disables CommonJS-specific rules for the entire file. This is acceptable for a CommonJS module but worth noting.

5. **Future wrapper groups**: The ignore pattern is generic and will exclude ANY wrapper group under `app/`. If a future wrapper group needs to be included in reserved routes, it must be explicitly added to the bookingRoutes glob.

### Manual Testing Recommended
6. Testing on an actual org domain setup with various user slugs matching non-booking route names would provide the strongest validation of this fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my changes generate no new warnings
- [x] Local tests pass: `TZ=UTC yarn test`