### PR TITLE
fix: flaky integartion test due to beforeAll

### DIFF
--- a/apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts
+++ b/apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts
@@ -6,34 +6,14 @@ import { describe, it, expect, beforeAll } from "vitest";
 import prisma from "@calcom/prisma";
 
 import handler from "../../../../pages/api/bookings/[id]/_patch";
+import { setupOrganizationSettings } from "../../utils/setupOrganizationSettings";
 
 type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
 
 describe("PATCH /api/bookings", () => {
   beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
+    await setupOrganizationSettings();
   });
   it("Returns 403 when user has no permission to the booking", async () => {
     const memberUser = await prisma.user.findFirstOrThrow({ where: { email: "member2-acme@example.com" } });

--- a/apps/api/v1/test/lib/bookings/_get.integration-test.ts
+++ b/apps/api/v1/test/lib/bookings/_get.integration-test.ts
@@ -7,6 +7,7 @@ import { ZodError } from "zod";
 import { prisma } from "@calcom/prisma";
 
 import { handler } from "../../../pages/api/bookings/_get";
+import { setupOrganizationSettings } from "../utils/setupOrganizationSettings";
 
 type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
@@ -18,28 +19,7 @@ const DefaultPagination = {
 
 describe("GET /api/bookings", async () => {
   beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
+    await setupOrganizationSettings();
   });
   const proUser = await prisma.user.findFirstOrThrow({ where: { email: "pro@example.com" } });
   const proUserBooking = await prisma.booking.findFirstOrThrow({ where: { userId: proUser.id } });

--- a/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
@@ -7,57 +7,14 @@ import prisma from "@calcom/prisma";
 
 import { isAdminGuard } from "../../../lib/utils/isAdmin";
 import { ScopeOfAdmin } from "../../../lib/utils/scopeOfAdmin";
+import { setupOrganizationSettings } from "./setupOrganizationSettings";
 
 type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
 
 describe("isAdmin guard", () => {
   beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-
-    const dunderOrg = await prisma.team.findFirst({
-      where: {
-        slug: "dunder-mifflin",
-        isOrganization: true,
-      },
-    });
-
-    if (dunderOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: dunderOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: false,
-        },
-        create: {
-          organizationId: dunderOrg.id,
-          orgAutoAcceptEmail: "dunder-mifflin.com",
-          isAdminAPIEnabled: false,
-        },
-      });
-    }
+    await setupOrganizationSettings();
   });
   it("Returns false when user does not exist in the system", async () => {
     const { req } = createMocks<CustomNextApiRequest, CustomNextApiResponse>({

--- a/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
@@ -6,31 +6,11 @@ import {
   getAccessibleUsers,
   retrieveOrgScopedAccessibleUsers,
 } from "../../../lib/utils/retrieveScopedAccessibleUsers";
+import { setupOrganizationSettings } from "./setupOrganizationSettings";
 
 describe("retrieveScopedAccessibleUsers tests", () => {
   beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
+    await setupOrganizationSettings();
   });
   describe("getAccessibleUsers", () => {
     it("Does not return members when only admin user ID is supplied", async () => {

--- a/apps/api/v1/test/lib/utils/setupOrganizationSettings.ts
+++ b/apps/api/v1/test/lib/utils/setupOrganizationSettings.ts
@@ -1,0 +1,53 @@
+import prisma from "@calcom/prisma";
+
+/**
+ * Safe to call multiple times - it's idempotent.
+ * Prevents race conditions which was causing falky tests
+ */
+export async function setupOrganizationSettings() {
+  const acmeOrg = await prisma.team.findFirst({
+    where: {
+      slug: "acme",
+      isOrganization: true,
+    },
+  });
+
+  if (acmeOrg) {
+    await prisma.organizationSettings.upsert({
+      where: {
+        organizationId: acmeOrg.id,
+      },
+      update: {
+        isAdminAPIEnabled: true,
+      },
+      create: {
+        organizationId: acmeOrg.id,
+        orgAutoAcceptEmail: "acme.com",
+        isAdminAPIEnabled: true,
+      },
+    });
+  }
+
+  const dunderOrg = await prisma.team.findFirst({
+    where: {
+      slug: "dunder-mifflin",
+      isOrganization: true,
+    },
+  });
+
+  if (dunderOrg) {
+    await prisma.organizationSettings.upsert({
+      where: {
+        organizationId: dunderOrg.id,
+      },
+      update: {
+        isAdminAPIEnabled: false,
+      },
+      create: {
+        organizationId: dunderOrg.id,
+        orgAutoAcceptEmail: "dunder-mifflin.com",
+        isAdminAPIEnabled: false,
+      },
+    });
+  }
+}

--- a/apps/api/v1/test/lib/utils/setupOrganizationSettings.ts
+++ b/apps/api/v1/test/lib/utils/setupOrganizationSettings.ts
@@ -1,4 +1,4 @@
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 
 /**
  * Safe to call multiple times - it's idempotent.


### PR DESCRIPTION
## What does this PR do?
The flakiness comes from a race condition: multiple test files have beforeAll hooks that update organizationSettings in parallel, causing inconsistent database state.

Centralizes organization settings configuration
Is idempotent (safe to call multiple times)
Ensures both "acme" and "dunder-mifflin" organizations are configured

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
