### PR TITLE
feat: add recurring event count badge for mobile

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3958,5 +3958,6 @@
   "team_invite": "Team Invite",
   "team_invite_subtitle": "Invite team members to collaborate and schedule together",
   "team_onboarding_details_subtitle": "Add your team's name and create a unique URL for your team",
+  "repeats_num_times": "Repeats {{count}} times",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -46,6 +46,7 @@ export const BookEventFormWrapperComponent = ({
   const { i18n, t } = useLocale();
   const selectedTimeslot = useBookerStoreContext((state) => state.selectedTimeslot);
   const selectedDuration = useBookerStoreContext((state) => state.selectedDuration);
+  const recurringEventCount = useBookerStoreContext((state) => state.recurringEventCount);
   const { timeFormat, timezone } = useBookerTime();
   if (!selectedTimeslot) {
     return null;
@@ -65,6 +66,16 @@ export const BookEventFormWrapperComponent = ({
         {(selectedDuration || eventLength) && (
           <Badge variant="grayWithoutHover" startIcon="clock" size="lg">
             <span>{getDurationFormatted(selectedDuration || eventLength, t)}</span>
+          </Badge>
+        )}
+
+        {recurringEventCount && recurringEventCount > 1 && (
+          <Badge variant="grayWithoutHover" startIcon="refresh-ccw" size="lg">
+            <span>
+              {t("repeats_up_to", {
+                count: recurringEventCount,
+              })}
+            </span>
           </Badge>
         )}
       </div>

--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -72,7 +72,7 @@ export const BookEventFormWrapperComponent = ({
         {recurringEventCount && recurringEventCount > 1 && (
           <Badge variant="grayWithoutHover" startIcon="refresh-ccw" size="lg">
             <span>
-              {t("repeats_up_to", {
+              {t("repeats_num_times", {
                 count: recurringEventCount,
               })}
             </span>


### PR DESCRIPTION
## What does this PR do?

- Fixes #21352 (GitHub issue number)


based on #24986
should be mergead after it


## Visual Demo
![Screenshot 2025-11-07 at 5 11 36 PM](https://github.com/user-attachments/assets/bca78934-8a62-423b-8f81-d65c2c057de6)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recurring event count badge in the mobile booking form and makes the count from URL params reliable. The count now reads from the recurringEventCount query param, validates against max occurrences, and avoids clobbering other query params.

- **New Features**
  - Show a “Repeats {count} times” badge in the mobile booking modal when count > 1.

- **Bug Fixes**
  - Initialize and validate recurringEventCount from the URL (bounds: 1..max); ignore invalid/NaN and default to max.
  - Preserve existing URL query params when toggling the overlay calendar.
  - Rename occurenceCount to recurringEventCountQueryParam and switch the public query param to recurringEventCount (update any links using the old name).

<sup>Written for commit 084e767a3197dc8559eb5c51e3aff7cb585bec21. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



