### PR TITLE
fix: recurring events not visible on mobile devices

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookFormAsModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useEventTypeById } from "@calcom/atoms/hooks/event-types/private/useEventTypeById";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
+import { EventOccurences } from "@calcom/features/bookings/components/event-meta/Occurences";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui/components/badge";
@@ -16,8 +17,25 @@ import { useBookerTime } from "../hooks/useBookerTime";
 
 const BookEventFormWrapper = ({ children, onCancel }: { onCancel: () => void; children: ReactNode }) => {
   const { data } = useEvent();
+  const rescheduleUid = useBookerStoreContext((state) => state.rescheduleUid);
+  const recurringEvent = (
+    data as { recurringEvent?: Parameters<typeof EventOccurences>[0]["event"]["recurringEvent"] }
+  )?.recurringEvent;
+  const recurringEventContent =
+    recurringEvent && !rescheduleUid ? (
+      <div className="mb-4 mt-2 max-h-[40vh] overflow-y-auto pr-1 sm:hidden">
+        <EventOccurences event={{ recurringEvent }} />
+      </div>
+    ) : null;
 
-  return <BookEventFormWrapperComponent child={children} eventLength={data?.length} onCancel={onCancel} />;
+  return (
+    <BookEventFormWrapperComponent
+      child={children}
+      eventLength={data?.length}
+      onCancel={onCancel}
+      recurringEventContent={recurringEventContent}
+    />
+  );
 };
 
 const PlatformBookEventFormWrapper = ({
@@ -29,19 +47,36 @@ const PlatformBookEventFormWrapper = ({
 }) => {
   const eventId = useBookerStoreContext((state) => state.eventId);
   const { data } = useEventTypeById(eventId);
+  const rescheduleUid = useBookerStoreContext((state) => state.rescheduleUid);
+  const recurringEvent = (
+    data as { recurringEvent?: Parameters<typeof EventOccurences>[0]["event"]["recurringEvent"] }
+  )?.recurringEvent;
+  const recurringEventContent =
+    recurringEvent && !rescheduleUid ? (
+      <div className="mb-4 mt-2 max-h-[40vh] overflow-y-auto pr-1 sm:hidden">
+        <EventOccurences event={{ recurringEvent }} />
+      </div>
+    ) : null;
 
   return (
-    <BookEventFormWrapperComponent child={children} eventLength={data?.lengthInMinutes} onCancel={onCancel} />
+    <BookEventFormWrapperComponent
+      child={children}
+      eventLength={data?.lengthInMinutes}
+      onCancel={onCancel}
+      recurringEventContent={recurringEventContent}
+    />
   );
 };
 
 export const BookEventFormWrapperComponent = ({
   child,
   eventLength,
+  recurringEventContent,
 }: {
   onCancel: () => void;
   child: ReactNode;
   eventLength?: number;
+  recurringEventContent?: ReactNode;
 }) => {
   const { i18n, t } = useLocale();
   const selectedTimeslot = useBookerStoreContext((state) => state.selectedTimeslot);
@@ -68,6 +103,7 @@ export const BookEventFormWrapperComponent = ({
           </Badge>
         )}
       </div>
+      {recurringEventContent}
       {child}
     </>
   );


### PR DESCRIPTION
## What does this PR do?

- Fixes #21352 
- Fixes CAL-5778 

## Visual Demo (For contributors especially)


https://github.com/user-attachments/assets/5d304393-e344-4f6b-9b78-47234ecd52b0

### If there are many recurring events, we also see +19 count

<img width="2560" height="1440" alt="Screenshot 2025-11-07 at 5 35 15 PM (2)" src="https://github.com/user-attachments/assets/95675421-0256-4c8f-b091-acbe53962874" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recurring event occurrences are now visible in the booking modal on mobile devices, so users can review upcoming dates before booking. Fixes #21352 and CAL-5778.

- **Bug Fixes**
  - Render EventOccurences in BookEventForm for mobile (visible below sm).
  - Hide occurrences during rescheduling (checks rescheduleUid).
  - Add a scrollable container with max height to prevent overflow.

<sup>Written for commit 96d88a9390874e8d741515eb2f03a1928c1160ab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

