### PR TITLE
feature: Allow org null for 'global' usernames

### DIFF
--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -6,7 +6,6 @@ import { v4 } from "uuid";
 
 import updateChildrenEventTypes from "@calcom/features/ee/managed-event-types/lib/handleChildrenEventTypes";
 import stripe from "@calcom/features/ee/payments/server/stripe";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";
@@ -207,7 +206,6 @@ const createTeamAndAddUser = async (
     ? {
         create: [
           {
-            uid: ProfileRepository.generateProfileUid(),
             username: user.username ?? user.email.split("@")[0],
             user: {
               connect: {
@@ -916,7 +914,6 @@ const createUser = (
       organizationId,
       profiles: {
         create: {
-          uid: ProfileRepository.generateProfileUid(),
           username: profileUsername ? `${profileUsername}${suffixToMakeUsernameUnique}` : uname,
           organization: {
             connect: {

--- a/apps/web/test/utils/bookingScenario/bookingScenario.ts
+++ b/apps/web/test/utils/bookingScenario/bookingScenario.ts
@@ -10,7 +10,6 @@ import type { z } from "zod";
 
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 import { handleStripePaymentSuccess } from "@calcom/features/ee/payments/api/webhook";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { weekdayToWeekIndex, type WeekDays } from "@calcom/lib/dayjs";
 import type { HttpError } from "@calcom/lib/http-error";
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
@@ -1653,7 +1652,6 @@ export function getScenarioData(
         {
           organizationId: orgId,
           username: profileUsername,
-          uid: ProfileRepository.generateProfileUid(),
         },
       ];
     });

--- a/packages/features/auth/signup/utils/createOrUpdateMemberships.ts
+++ b/packages/features/auth/signup/utils/createOrUpdateMemberships.ts
@@ -1,5 +1,4 @@
 import { updateNewTeamMemberEventTypes } from "@calcom/features/ee/teams/lib/queries";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { prisma } from "@calcom/prisma";
 import type { Team, User, OrganizationSettings } from "@calcom/prisma/client";
 import { MembershipRole } from "@calcom/prisma/enums";
@@ -37,7 +36,6 @@ export const createOrUpdateMemberships = async ({
         getOrgUsernameFromEmail(dbUser.email, team.organizationSettings?.orgAutoAcceptEmail ?? null);
       await tx.profile.upsert({
         create: {
-          uid: ProfileRepository.generateProfileUid(),
           userId: user.id,
           organizationId: team.id,
           username: orgUsername,

--- a/packages/features/auth/signup/utils/organization.ts
+++ b/packages/features/auth/signup/utils/organization.ts
@@ -1,5 +1,4 @@
 import { updateNewTeamMemberEventTypes } from "@calcom/features/ee/teams/lib/queries";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { prisma } from "@calcom/prisma";
 import type { Team, OrganizationSettings } from "@calcom/prisma/client";
 
@@ -39,7 +38,6 @@ export async function joinAnyChildTeamOnOrgInvite({
     }),
     prisma.profile.upsert({
       create: {
-        uid: ProfileRepository.generateProfileUid(),
         userId: userId,
         organizationId: org.id,
         username: orgUsername,

--- a/packages/features/profile/repositories/ProfileRepository.ts
+++ b/packages/features/profile/repositories/ProfileRepository.ts
@@ -152,7 +152,6 @@ export class ProfileRepository {
     log.debug("_create", safeStringify({ userId, organizationId, username, email }));
     return prisma.profile.create({
       data: {
-        uid: ProfileRepository.generateProfileUid(),
         user: {
           connect: {
             id: userId,
@@ -218,7 +217,6 @@ export class ProfileRepository {
   }) {
     return prisma.profile.upsert({
       create: {
-        uid: ProfileRepository.generateProfileUid(),
         user: {
           connect: {
             id: create.userId,
@@ -276,7 +274,6 @@ export class ProfileRepository {
   }) {
     await prisma.profile.createMany({
       data: users.map((user) => ({
-        uid: ProfileRepository.generateProfileUid(),
         userId: user.id,
         organizationId,
         username: user?.username || getOrgUsernameFromEmail(user.email, orgAutoAcceptEmail),
@@ -324,7 +321,6 @@ export class ProfileRepository {
   }) {
     return await prisma.profile.createMany({
       data: users.map((user) => ({
-        uid: ProfileRepository.generateProfileUid(),
         userId: user.id,
         organizationId,
         username: user?.username || getOrgUsernameFromEmail(user.email, orgAutoAcceptEmail),
@@ -344,7 +340,6 @@ export class ProfileRepository {
   }) {
     return prisma.profile.createMany({
       data: users.map((user) => ({
-        uid: ProfileRepository.generateProfileUid(),
         userId: user.id,
         organizationId,
         username: user?.username || getOrgUsernameFromEmail(user.email, orgAutoAcceptEmail),

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -719,7 +719,6 @@ export class UserRepository {
                 create: {
                   username,
                   organizationId: organizationIdValue,
-                  uid: ProfileRepository.generateProfileUid(),
                 },
               },
             }

--- a/packages/prisma/migrations/20251107151738_allow_nullable_org_and_set_uid_as_uuid_default/migration.sql
+++ b/packages/prisma/migrations/20251107151738_allow_nullable_org_and_set_uid_as_uuid_default/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[uid]` on the table `Profile` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Profile" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_uid_key" ON "public"."Profile"("uid");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -503,11 +503,11 @@ model NotificationsSubscriptions {
 model Profile {
   id             Int         @id @default(autoincrement())
   // uid allows us to set an identifier chosen by us which is helpful in migration when we create the Profile from User directly.
-  uid            String
+  uid            String      @unique @default(uuid())
   userId         Int
   user           User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organizationId Int
-  organization   Team        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId Int?
+  organization   Team?       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   username       String
   eventTypes     EventType[]
   movedFromUser  User?       @relation("moved_to_profile")

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -7,7 +7,6 @@ import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
 import { updateNewTeamMemberEventTypes } from "@calcom/features/ee/teams/lib/queries";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { createAProfileForAnExistingUser } from "@calcom/features/profile/lib/createAProfileForAnExistingUser";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { OnboardingPathService } from "@calcom/features/onboarding/lib/onboarding-path.service";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
@@ -360,7 +359,6 @@ export async function createNewUsersConnectToOrgIfExists({
                     createMany: {
                       data: [
                         {
-                          uid: ProfileRepository.generateProfileUid(),
                           username: orgMemberUsername,
                           organizationId: orgId,
                         },

--- a/scripts/seed-pbac-organization.ts
+++ b/scripts/seed-pbac-organization.ts
@@ -594,7 +594,6 @@ async function createProfile({
 }) {
   const profile = await prisma.profile.create({
     data: {
-      uid: uuid(),
       userId,
       organizationId,
       username,

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -131,7 +131,6 @@ const associateUserAndOrg = async ({ teamId, userId, role, username }: Associate
 
   const profile = await prisma.profile.create({
     data: {
-      uid: uuid(),
       username,
       organizationId: teamId,
       userId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allows profiles with global usernames to exist without an organization. Profile.uid is now auto-generated as a unique UUID, and manual uid generation is removed.

- **Migration**
  - Run Prisma migration to make Profile.organizationId nullable and add a unique index on Profile.uid.
  - Ensure existing profiles have unique uid values before migrating.

- **Refactors**
  - Removed all uses of ProfileRepository.generateProfileUid; rely on database defaults.
  - Updated schema: organizationId is optional; uid is unique with default uuid().
  - Cleaned org migration utilities and removed unused team revert logic.
  - Updated seeds, tests, and invite flows to stop passing uid explicitly.

<sup>Written for commit 770ca97e698f3a69bcdb1d86b3545bda6cfa73da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

