### PR TITLE
fix(organizations): upload organization logos to storage instead of saving base64 data

### DIFF
--- a/packages/features/ee/organizations/repositories/OrganizationRepository.ts
+++ b/packages/features/ee/organizations/repositories/OrganizationRepository.ts
@@ -504,4 +504,26 @@ export class OrganizationRepository {
 
     return org?.organizationSettings ?? null;
   }
+
+  async updateBrandAssets({
+    id,
+    logoUrl,
+    bannerUrl,
+  }: {
+    id: number;
+    logoUrl?: string | null;
+    bannerUrl?: string | null;
+  }) {
+    return await this.prismaClient.team.update({
+      where: { id, isOrganization: true },
+      data: {
+        logoUrl,
+        bannerUrl,
+      },
+      select: {
+        logoUrl: true,
+        bannerUrl: true,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where organization logos were being saved as base64-encoded data directly in the database instead of being uploaded to storage and saved as URLs.

**Root cause**: The `isBase64Image()` function only detects PNG and JPEG data URLs (`data:image/(png|jpeg);base64,`), causing SVG, WebP, and other image formats to bypass the upload logic and be stored as raw base64 data in the `Team.logoUrl` field.

**Changes**:
- Updated image detection in `uploadImageAsset()` to catch ALL data URL formats using `startsWith("data:image/")` instead of format-specific regex
- Added defensive error handling that prevents persisting data URLs to the database
- Moved database update logic to follow repository pattern via new `OrganizationRepository.updateBrandAssets()` method
- Removed unused `isBase64Image` import

## Visual Demo

N/A - This is a backend fix with no visual changes to the UI.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - No documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: No new tests added yet - existing upload flow should be tested.

## How should this be tested?

### Manual Testing:
1. Go through the organization wizard onboarding flow
2. Upload various image formats (PNG, JPEG, SVG, WebP) as the organization logo
3. After organization creation, check the database:
   - Query: `SELECT id, name, logoUrl FROM team WHERE id = <org_id>`
   - ✅ Expected: `logoUrl` should start with `/api/avatar/` (e.g., `/api/avatar/abc123.png`)
   - ❌ Bug would show: `logoUrl` starts with `data:image/` (base64 encoded data)

### Important Test Cases:
- PNG logo upload
- JPEG logo upload  
- **SVG logo upload** (most likely to have been affected by the bug)
- WebP logo upload
- Banner upload (same logic applies)

### Environment:
- No special environment variables needed
- Standard org onboarding flow setup

## Human Review Checklist

**Critical items to review:**

1. **Image format handling**: Verify that `uploadLogo()` can properly handle all image formats, especially SVG. The change now routes ALL data:image/* URLs through upload, not just PNG/JPEG.

2. **Error handling**: The added safeguards throw errors if data URLs persist after upload. Verify this is appropriate behavior vs. silent fallback.

3. **Repository pattern**: New `updateBrandAssets()` method in OrganizationRepository - verify it follows established patterns and conventions in the codebase.

4. **Testing**: This fix has not been tested end-to-end. Manual verification with actual org wizard flow is essential before merging.

5. **uploadLogo behavior**: Verify `uploadLogo()` doesn't silently fail and return the original base64 data (which would trigger the new error handling).

---

**Session Info**: 
- Devin session: https://app.devin.ai/sessions/4b6770e7e5b04de8b714ae0a555ac0f7
- Requested by: joe@cal.com (@joeauyeung)