### PR TITLE
fix: strip internal $RCH$ prefix from cancellation reason in ICS files

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -223,8 +223,9 @@ export const getPlatformCancelLink = (
   if (calEvent.platformCancelUrl) {
     const platformCancelLink = new URL(`${calEvent.platformCancelUrl}/${bookingUid}`);
     platformCancelLink.searchParams.append("slug", calEvent.type);
-    calEvent.organizer.username &&
+    if (calEvent.organizer.username) {
       platformCancelLink.searchParams.append("username", calEvent.organizer.username);
+    }
     platformCancelLink.searchParams.append("cancel", "true");
     platformCancelLink.searchParams.append("allRemainingBookings", String(!!calEvent.recurringEvent));
     if (seatUid) platformCancelLink.searchParams.append("seatReferenceUid", seatUid);
@@ -267,8 +268,9 @@ export const getPlatformRescheduleLink = (
       `${calEvent.platformRescheduleUrl}/${seatUid ? seatUid : bookingUid}`
     );
     platformRescheduleLink.searchParams.append("slug", calEvent.type);
-    calEvent.organizer.username &&
+    if (calEvent.organizer.username) {
       platformRescheduleLink.searchParams.append("username", calEvent.organizer.username);
+    }
     platformRescheduleLink.searchParams.append("reschedule", "true");
     if (calEvent?.team) platformRescheduleLink.searchParams.append("teamId", calEvent.team.id.toString());
     return platformRescheduleLink.toString();
@@ -408,7 +410,8 @@ export const getRichDescription = (
 
 export const getCancellationReason = (calEvent: Pick<CalendarEvent, "cancellationReason">, t: TFunction) => {
   if (!calEvent.cancellationReason) return "";
-  return `${t("cancellation_reason")}:\n${calEvent.cancellationReason}`;
+  const sanitized = calEvent.cancellationReason.replace("$RCH$", "").trim();
+  return `${t("cancellation_reason")}:\n${sanitized}`;
 };
 
 export const isDailyVideoCall = (calEvent: Pick<CalendarEvent, "videoCallData">): boolean => {

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -412,7 +412,7 @@ export const getCancellationReason = (calEvent: Pick<CalendarEvent, "cancellatio
   if (!calEvent.cancellationReason) return "";
   const sanitized = calEvent.cancellationReason.startsWith("$RCH$")
     ? calEvent.cancellationReason.substring(5).trim()
-    : calEvent.cancellationReason;
+    : calEvent.cancellationReason.trim();
   return `${t("cancellation_reason")}:\n${sanitized}`;
 };
 

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -410,7 +410,9 @@ export const getRichDescription = (
 
 export const getCancellationReason = (calEvent: Pick<CalendarEvent, "cancellationReason">, t: TFunction) => {
   if (!calEvent.cancellationReason) return "";
-  const sanitized = calEvent.cancellationReason.replace("$RCH$", "").trim();
+  const sanitized = calEvent.cancellationReason.startsWith("$RCH$")
+    ? calEvent.cancellationReason.substring(5).trim()
+    : calEvent.cancellationReason;
   return `${t("cancellation_reason")}:\n${sanitized}`;
 };
 


### PR DESCRIPTION
## What does this PR do?

Strips the internal `$RCH$` prefix from cancellation reasons in ICS files. The `$RCH$` marker is used internally to differentiate reschedules from cancellations, but it was appearing in user-facing ICS attachments. This fix sanitizes the cancellation reason before including it in generated descriptions and ICS files.

- Fixes #25000
- Fixes [CAL-6716](https://linear.app/calcom/issue/CAL-6716/ics-file-contains-dollarrchdollar-in-front-of-cancellation-reason)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Before:**
<img width="626" height="252" alt="Screenshot from 2025-11-08 12-08-11" src="https://github.com/user-attachments/assets/d8d9062d-1be8-46b4-b544-2d147718d16b" />

**After:**
<img width="626" height="252" alt="Screenshot from 2025-11-08 12-09-17" src="https://github.com/user-attachments/assets/2621b608-38ec-4115-b46b-c71fbd114570" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - This is a bug fix that doesn't require documentation changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set? **No**
- What are the minimal test data to have? **A booking that can be rescheduled with a reschedule reason**
- What is expected (happy path) to have (input and output)? 
  1. Create a booking
  2. Reschedule it with a reason (e.g., "As discussed :)")
  3. Check the ICS file in the email - it should show `Cancellation reason: As discussed :)` instead of `Cancellation reason: $RCH$As discussed :)`
- Any other important info that could help to test that PR: **The fix also corrected pre-existing ESLint warnings in the same file**
