### PR TITLE
fix: removed prefix $RCH$ from the cancellation reason data

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -408,7 +408,8 @@ export const getRichDescription = (
 
 export const getCancellationReason = (calEvent: Pick<CalendarEvent, "cancellationReason">, t: TFunction) => {
   if (!calEvent.cancellationReason) return "";
-  return `${t("cancellation_reason")}:\n${calEvent.cancellationReason}`;
+  const cleanedReason = calEvent.cancellationReason.replace(/^\$RCH\$/, "");
+  return `${t("cancellation_reason")}:\n${cleanedReason}`;
 };
 
 export const isDailyVideoCall = (calEvent: Pick<CalendarEvent, "videoCallData">): boolean => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #25000.
- Fixes [CAL-XXXX](https://linear.app/calcom/issue/CAL-6716/ics-file-contains-dollarrchdollar-in-front-of-cancellation-reason) 
## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

Before

<img width="587" height="314" alt="Screenshot from 2025-11-08 18-40-05" src="https://github.com/user-attachments/assets/4e74ec15-9986-42a5-bc12-6c99b951ace0" />

After

<img width="1551" height="322" alt="Screenshot from 2025-11-08 18-13-50" src="https://github.com/user-attachments/assets/f3dbd2f4-6e25-427c-9978-74fc1321b387" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize cancellation reason by stripping the "$RCH$" prefix in CalEventParser so users see clean text. Fixes ICS files and UI showing the marker before the reason (Linear CAL-6716).

<sup>Written for commit 065d451e57f18455ce19c192727cad9837bb3045. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

