### PR TITLE
fix: APIv1 race conditions re. permissions checking

### DIFF
--- a/apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts
+++ b/apps/api/v1/test/lib/bookings/[id]/_patch.integration-test.ts
@@ -1,9 +1,9 @@
 import type { Request, Response } from "express";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 
-import prisma from "@calcom/prisma";
+import { prisma } from "@calcom/prisma";
 
 import handler from "../../../../pages/api/bookings/[id]/_patch";
 
@@ -11,30 +11,7 @@ type CustomNextApiRequest = NextApiRequest & Request;
 type CustomNextApiResponse = NextApiResponse & Response;
 
 describe("PATCH /api/bookings", () => {
-  beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
 
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-  });
   it("Returns 403 when user has no permission to the booking", async () => {
     const memberUser = await prisma.user.findFirstOrThrow({ where: { email: "member2-acme@example.com" } });
     const proUser = await prisma.user.findFirstOrThrow({ where: { email: "pro@example.com" } });

--- a/apps/api/v1/test/lib/bookings/_get.integration-test.ts
+++ b/apps/api/v1/test/lib/bookings/_get.integration-test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { describe, expect, it, beforeAll } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
 
 import { prisma } from "@calcom/prisma";
@@ -17,30 +17,7 @@ const DefaultPagination = {
 };
 
 describe("GET /api/bookings", async () => {
-  beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
 
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-  });
   const proUser = await prisma.user.findFirstOrThrow({ where: { email: "pro@example.com" } });
   const proUserBooking = await prisma.booking.findFirstOrThrow({ where: { userId: proUser.id } });
 

--- a/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/isAdmin.integration-test.ts
@@ -13,29 +13,6 @@ type CustomNextApiResponse = NextApiResponse & Response;
 
 describe("isAdmin guard", () => {
   beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-
     const dunderOrg = await prisma.team.findFirst({
       where: {
         slug: "dunder-mifflin",

--- a/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
+++ b/apps/api/v1/test/lib/utils/retrieveScopedAccessibleUsers.integration-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import prisma from "@calcom/prisma";
 
@@ -8,30 +8,6 @@ import {
 } from "../../../lib/utils/retrieveScopedAccessibleUsers";
 
 describe("retrieveScopedAccessibleUsers tests", () => {
-  beforeAll(async () => {
-    const acmeOrg = await prisma.team.findFirst({
-      where: {
-        slug: "acme",
-        isOrganization: true,
-      },
-    });
-
-    if (acmeOrg) {
-      await prisma.organizationSettings.upsert({
-        where: {
-          organizationId: acmeOrg.id,
-        },
-        update: {
-          isAdminAPIEnabled: true,
-        },
-        create: {
-          organizationId: acmeOrg.id,
-          orgAutoAcceptEmail: "acme.com",
-          isAdminAPIEnabled: true,
-        },
-      });
-    }
-  });
   describe("getAccessibleUsers", () => {
     it("Does not return members when only admin user ID is supplied", async () => {
       const adminUser = await prisma.user.findFirstOrThrow({ where: { email: "owner1-acme@example.com" } });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed side-effecting test setup that toggled org admin settings to eliminate race conditions in API v1 permission checks. Tests now rely on seeded data for consistent, deterministic results.

- **Bug Fixes**
  - Removed beforeAll orgSettings.upsert from four v1 integration tests (bookings GET/PATCH, isAdmin guard, retrieveScopedAccessibleUsers) to prevent cross-test config drift and flaky outcomes.
  - Switched to the named prisma import in the bookings PATCH test for consistency with the current prisma export.

<sup>Written for commit 8090168f7089fbd55e726cece2a85aa624e73ccb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

