### PR TITLE
feat: v2 api allow switching event type between collective and round robin

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
@@ -257,7 +257,8 @@ export class InputOrganizationsEventTypesService {
     if (assignAllTeamMembers) {
       return await this.getAllTeamMembers(teamId, nextSchedulingType);
     }
-    return this.transformInputHosts(hosts, nextSchedulingType);
+    const nextHosts = hosts || [];
+    return this.transformInputHosts(nextHosts, nextSchedulingType);
   }
 
   async getChildEventTypesForManagedEventTypeUpdate(

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
@@ -1337,64 +1337,6 @@ describe("Organizations Event Types Endpoints", () => {
 
         await eventTypesRepositoryFixture.delete(roundRobinEventType.id);
       });
-
-      it("should update managed event type hosts and return array with parent and child event types", async () => {
-        const managedEventType = await eventTypesRepositoryFixture.create(
-          {
-            title: `managed-update-hosts-${randomString()}`,
-            slug: `managed-update-hosts-${randomString()}`,
-            length: 60,
-            team: {
-              connect: {
-                id: team.id,
-              },
-            },
-            schedulingType: "MANAGED",
-            hosts: {
-              create: [
-                {
-                  userId: teamMember1.id,
-                  isFixed: true,
-                },
-              ],
-            },
-          },
-          userAdmin.id
-        );
-
-        const updateBody = {
-          hosts: [
-            {
-              userId: teamMember2.id,
-            },
-          ],
-        };
-
-        const response = await request(app.getHttpServer())
-          .patch(`/v2/teams/${team.id}/event-types/${managedEventType.id}`)
-          .send(updateBody)
-          .expect(200);
-
-        const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14[]> = response.body;
-        expect(responseBody.status).toEqual(SUCCESS_STATUS);
-        expect(Array.isArray(responseBody.data)).toBe(true);
-        // note(Lauris): 1 parent managed event type + 1 child event type
-        expect(responseBody.data).toHaveLength(2);
-
-        const parentEventType = responseBody.data[0];
-        expect(parentEventType.schedulingType).toEqual("managed");
-        expect(parentEventType.hosts).toHaveLength(1);
-        expect(parentEventType.hosts[0].userId).toEqual(teamMember2.id);
-        expect(parentEventType.parentEventTypeId).toBeNull();
-
-        const childEventType = responseBody.data[1];
-        expect(childEventType.parentEventTypeId).toEqual(parentEventType.id);
-        expect(childEventType.schedulingType).toBeNull();
-        expect(childEventType.hosts).toHaveLength(0);
-        expect(childEventType.ownerId).toEqual(teamMember2.id);
-
-        await eventTypesRepositoryFixture.delete(managedEventType.id);
-      });
     });
 
     afterAll(async () => {

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.e2e-spec.ts
@@ -758,6 +758,345 @@ describe("Organizations Event Types Endpoints", () => {
       expect(expected.priority).toEqual(received?.priority);
     }
 
+    describe("updating scheduling type", () => {
+
+    it("should return 400 error if schedulingType: managed is passed", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-collective-${randomString()}`,
+        slug: `teams-event-types-scheduling-collective-${randomString()}`,
+        description: "Test collective event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "COLLECTIVE",
+        hosts: [
+          {
+            userId: teamMember1.id,
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody = {
+        schedulingType: "MANAGED",
+      } as unknown as UpdateTeamEventTypeInput_2024_06_14;
+
+      await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(400);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change round robin event type to collective and hosts should be empty array", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        slug: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        description: "Test round robin event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "ROUND_ROBIN",
+        hosts: [
+          {
+            userId: teamMember1.id,
+            priority: "high",
+          },
+          {
+            userId: teamMember2.id,
+            priority: "low",
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "COLLECTIVE",
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("collective");
+      expect(responseBody.data.hosts).toEqual([]);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change collective event type to roundRobin and hosts should be empty array", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-collective-${randomString()}`,
+        slug: `teams-event-types-scheduling-collective-${randomString()}`,
+        description: "Test collective event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "COLLECTIVE",
+        hosts: [
+          {
+            userId: teamMember1.id,
+          },
+          {
+            userId: teamMember2.id,
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "ROUND_ROBIN",
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("roundRobin");
+      expect(responseBody.data.hosts).toEqual([]);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change round robin event type to collective and pass new hosts", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        slug: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        description: "Test round robin event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "ROUND_ROBIN",
+        hosts: [
+          {
+            userId: teamMember1.id,
+            priority: "high",
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "COLLECTIVE",
+        hosts: [
+          {
+            userId: teamMember2.id,
+          },
+        ],
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("collective");
+      expect(responseBody.data.hosts).toHaveLength(1);
+      expect(responseBody.data.hosts[0].userId).toEqual(teamMember2.id);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change collective event type to roundRobin and pass new hosts", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-collective-${randomString()}`,
+        slug: `teams-event-types-scheduling-collective-${randomString()}`,
+        description: "Test collective event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "COLLECTIVE",
+        hosts: [
+          {
+            userId: teamMember1.id,
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "ROUND_ROBIN",
+        hosts: [
+          {
+            userId: teamMember2.id,
+            priority: "medium",
+          },
+        ],
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("roundRobin");
+      expect(responseBody.data.hosts).toHaveLength(1);
+      expect(responseBody.data.hosts[0].userId).toEqual(teamMember2.id);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change collective event type to roundRobin with assignAllTeamMembers: true", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-collective-${randomString()}`,
+        slug: `teams-event-types-scheduling-collective-${randomString()}`,
+        description: "Test collective event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "COLLECTIVE",
+        hosts: [
+          {
+            userId: teamMember1.id,
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "ROUND_ROBIN",
+        assignAllTeamMembers: true,
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("roundRobin");
+      expect(responseBody.data.hosts).toHaveLength(3);
+      const hostUserIds = responseBody.data.hosts.map((host) => host.userId);
+      expect(hostUserIds).toContain(teamMember1.id);
+      expect(hostUserIds).toContain(teamMember2.id);
+      expect(hostUserIds).toContain(userAdmin.id);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+
+    it("should change round robin event type to collective with assignAllTeamMembers: true", async () => {
+      const createBody: CreateTeamEventTypeInput_2024_06_14 = {
+        title: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        slug: `teams-event-types-scheduling-roundrobin-${randomString()}`,
+        description: "Test round robin event type",
+        lengthInMinutes: 60,
+        locations: [
+          {
+            type: "integration",
+            integration: "cal-video",
+          },
+        ],
+        schedulingType: "ROUND_ROBIN",
+        hosts: [
+          {
+            userId: teamMember1.id,
+            priority: "high",
+          },
+        ],
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/event-types`)
+        .send(createBody)
+        .expect(201);
+
+      const createdEventType: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = createResponse.body;
+
+      const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
+        schedulingType: "COLLECTIVE",
+        assignAllTeamMembers: true,
+      };
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/event-types/${createdEventType.data.id}`)
+        .send(updateBody)
+        .expect(200);
+
+      const responseBody: ApiSuccessResponse<TeamEventTypeOutput_2024_06_14> = updateResponse.body;
+      expect(responseBody.status).toEqual(SUCCESS_STATUS);
+      expect(responseBody.data.schedulingType).toEqual("collective");
+      expect(responseBody.data.hosts).toHaveLength(3);
+      const hostUserIds = responseBody.data.hosts.map((host) => host.userId);
+      expect(hostUserIds).toContain(teamMember1.id);
+      expect(hostUserIds).toContain(teamMember2.id);
+      expect(hostUserIds).toContain(userAdmin.id);
+
+      await eventTypesRepositoryFixture.delete(createdEventType.data.id);
+    });
+    });
+
     afterAll(async () => {
       await userRepositoryFixture.deleteByEmail(userAdmin.email);
       await userRepositoryFixture.deleteByEmail(teamMember1.email);

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -3865,6 +3865,16 @@
             }
           },
           {
+            "name": "bookingUid",
+            "required": false,
+            "in": "query",
+            "description": "Filter bookings by the booking Uid.",
+            "example": "2NtaeaVcKfpmSZ4CthFdfk",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "eventTypeIds",
             "required": false,
             "in": "query",
@@ -21927,6 +21937,12 @@
             "type": "boolean",
             "default": false,
             "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+          },
+          "schedulingType": {
+            "type": "string",
+            "enum": ["collective", "roundRobin"],
+            "example": "collective",
+            "description": "The scheduling type for the team event - collective or roundRobin. ❗If you change scheduling type you must also provide `hosts` or `assignAllTeamMembers` in the request body, otherwise the event type will have no hosts - this is required because\n      in case of collective event type all hosts are mandatory but in case of round robin some or non can be mandatory so we can't predict how you want the hosts to be setup which is why you must provide that information.  If you want to convert round robin or collective into managed or managed into round robin or collective then you will have to create a new team event type and delete old one."
           },
           "hosts": {
             "description": "Hosts contain specific team members you want to assign to this event type, but if you want to assign all team members, use `assignAllTeamMembers: true` instead and omit this field. For platform customers the hosts can include userIds only of managed users. Provide either hosts or assignAllTeamMembers but not both",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
@@ -489,6 +489,7 @@ export class UpdateTeamEventTypeInput_2024_06_14 extends BaseUpdateEventTypeInpu
     return value;
   })
   @IsEnum(SchedulingType)
+  @IsOptional()
   @DocsPropertyOptional({
     enum: ["collective", "roundRobin"],
     example: "collective",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
@@ -11,7 +11,10 @@ import {
   ArrayNotEmpty,
   ArrayUnique,
   IsUrl,
+  IsEnum,
 } from "class-validator";
+
+import { SchedulingType } from "@calcom/platform-enums";
 
 import { RequiresAtLeastOnePropertyWhenNotDisabled } from "../../../utils/RequiresOneOfPropertiesWhenNotDisabled";
 import { BookerActiveBookingsLimit_2024_06_14 } from "./booker-active-booking-limit.input";
@@ -476,6 +479,24 @@ export class UpdateEventTypeInput_2024_06_14 extends BaseUpdateEventTypeInput {
 }
 
 export class UpdateTeamEventTypeInput_2024_06_14 extends BaseUpdateEventTypeInput {
+  @Transform(({ value }) => {
+    if (value === "collective") {
+      return SchedulingType.COLLECTIVE;
+    }
+    if (value === "roundRobin") {
+      return SchedulingType.ROUND_ROBIN;
+    }
+    return value;
+  })
+  @IsEnum(SchedulingType)
+  @DocsPropertyOptional({
+    enum: ["collective", "roundRobin"],
+    example: "collective",
+    description: `The scheduling type for the team event - collective or roundRobin. ❗If you change scheduling type you must also provide \`hosts\` or \`assignAllTeamMembers\` in the request body, otherwise the event type will have no hosts - this is required because
+      in case of collective event type all hosts are mandatory but in case of round robin some or non can be mandatory so we can't predict how you want the hosts to be setup which is why you must provide that information.  If you want to convert round robin or collective into managed or managed into round robin or collective then you will have to create a new team event type and delete old one.`,
+  })
+  schedulingType?: "COLLECTIVE" | "ROUND_ROBIN";
+
   @ValidateNested({ each: true })
   @Type(() => Host)
   @IsArray()

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/update-event-type.input.ts
@@ -11,7 +11,7 @@ import {
   ArrayNotEmpty,
   ArrayUnique,
   IsUrl,
-  IsEnum,
+  IsIn,
 } from "class-validator";
 
 import { SchedulingType } from "@calcom/platform-enums";
@@ -488,7 +488,7 @@ export class UpdateTeamEventTypeInput_2024_06_14 extends BaseUpdateEventTypeInpu
     }
     return value;
   })
-  @IsEnum(SchedulingType)
+  @IsIn([SchedulingType.COLLECTIVE, SchedulingType.ROUND_ROBIN])
   @IsOptional()
   @DocsPropertyOptional({
     enum: ["collective", "roundRobin"],


### PR DESCRIPTION
Fixes #25034









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow switching a team event type between collective and round robin in the v2 API. Adds strict validation for host handling and blocks switching to managed via update.

- **New Features**
  - PATCH /v2/teams/:id/event-types/:eventTypeId supports schedulingType: collective or roundRobin.
  - When switching schedulingType, you must provide hosts or assignAllTeamMembers; otherwise returns 400.
  - Setting schedulingType to managed via update returns 400.
  - OpenAPI updated and e2e tests cover all switch scenarios and host behavior.

- **Refactors**
  - Centralized host population for create/update, using the next scheduling type and skipping hosts for managed event types.

<sup>Written for commit 32c64eb966fc99a34edbda502e2e41580c32161d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









