### PR TITLE
fix: markdown rendering

### DIFF
--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -10,6 +10,7 @@ import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { getBrandingForEventType } from "@calcom/features/profile/lib/getBranding";
 import { shouldHideBrandingForTeamEvent } from "@calcom/features/profile/lib/hideBranding";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import type { User } from "@calcom/prisma/client";
@@ -197,6 +198,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
           ...branding,
         },
         title: eventData.title,
+        descriptionAsSafeHTML: markdownToSafeHTML(eventData.description),
         users: eventHostsUserData,
         hidden: eventData.hidden,
         interfaceLanguage: eventData.interfaceLanguage,
@@ -269,6 +271,7 @@ const getTeamWithEventsData = async (
         select: {
           id: true,
           title: true,
+          description: true,
           isInstantEvent: true,
           schedulingType: true,
           metadata: true,

--- a/apps/web/modules/event-types/components/EventTypeDescription.tsx
+++ b/apps/web/modules/event-types/components/EventTypeDescription.tsx
@@ -6,7 +6,6 @@ import { Price } from "@calcom/features/bookings/components/event-meta/Price";
 import { PriceIcon } from "@calcom/web/modules/bookings/components/event-meta/PriceIcon";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
-import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import type { baseEventTypeSelect } from "@calcom/prisma";
 import type { Prisma, EventType } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
@@ -32,9 +31,9 @@ export const EventTypeDescription = ({
   eventType,
   className,
   shortenDescription,
-  isPublic,
+  isPublic: _isPublic,
 }: EventTypeDescriptionProps) => {
-  const { t, i18n } = useLocale();
+  const { t } = useLocale();
 
   const recurringEvent = useMemo(
     () => parseRecurringEvent(eventType.recurringEvent),
@@ -60,7 +59,7 @@ export const EventTypeDescription = ({
             // eslint-disable-next-line react/no-danger
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is sanitized via markdownToSafeHTML
             dangerouslySetInnerHTML={{
-              __html: markdownToSafeHTML(eventType.descriptionAsSafeHTML || ""),
+              __html: eventType.descriptionAsSafeHTML,
             }}
           />
         )}

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -552,6 +552,7 @@ export const getPublicEvent = async (
   return {
     ...eventWithUserProfiles,
     bookerLayouts: bookerLayoutsSchema.parse(eventMetaData?.bookerLayouts || null),
+    description: markdownToSafeHTML(eventWithUserProfiles.description),
     descriptionAsSafeHTML: markdownToSafeHTML(eventWithUserProfiles.description),
     metadata: eventMetaData,
     customInputs: customInputSchema.array().parse(event.customInputs || []),
@@ -762,6 +763,7 @@ export const processEventDataShared = async ({
   return {
     ...eventData,
     bookerLayouts: bookerLayoutsSchema.parse(metadata?.bookerLayouts || null),
+    description: markdownToSafeHTML(eventData.description),
     descriptionAsSafeHTML: markdownToSafeHTML(eventData.description),
     metadata,
     customInputs: customInputSchema.array().parse(eventData.customInputs || []),

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -552,7 +552,7 @@ export const getPublicEvent = async (
   return {
     ...eventWithUserProfiles,
     bookerLayouts: bookerLayoutsSchema.parse(eventMetaData?.bookerLayouts || null),
-    description: markdownToSafeHTML(eventWithUserProfiles.description),
+    descriptionAsSafeHTML: markdownToSafeHTML(eventWithUserProfiles.description),
     metadata: eventMetaData,
     customInputs: customInputSchema.array().parse(event.customInputs || []),
     locations: privacyFilteredLocations((eventWithUserProfiles.locations || []) as LocationObject[]),
@@ -601,9 +601,9 @@ export const getPublicEvent = async (
   };
 };
 
-const eventData = getPublicEventSelect(true);
+const _eventData = getPublicEventSelect(true);
 
-type Event = Prisma.EventTypeGetPayload<{ select: typeof eventData }>;
+type Event = Prisma.EventTypeGetPayload<{ select: typeof _eventData }>;
 
 type GetProfileFromEventInput = Omit<Event, "hosts"> & {
   hosts?: Event["hosts"];
@@ -762,7 +762,7 @@ export const processEventDataShared = async ({
   return {
     ...eventData,
     bookerLayouts: bookerLayoutsSchema.parse(metadata?.bookerLayouts || null),
-    description: markdownToSafeHTML(eventData.description),
+    descriptionAsSafeHTML: markdownToSafeHTML(eventData.description),
     metadata,
     customInputs: customInputSchema.array().parse(eventData.customInputs || []),
     locations: privacyFilteredLocations((eventData.locations || []) as LocationObject[]),

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -498,7 +498,7 @@ export const getRichDescriptionHTML = (
   // Helper function to render markdown content to safe HTML
   const markdownContentToHTML = (title: string, content: string | null | undefined) => {
     if (!content) return "";
-    const html = markdownToSafeHTML(content as string | null);
+    const html = markdownToSafeHTML(content);
     return `<p><strong>${title}</strong></p>${html}`;
   };
 

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -186,10 +186,14 @@ export const getDescription = (t: TFunction, description?: string | null, stripM
   if (!description) {
     return "";
   }
-  const text = stripMarkdownForIcs
-    ? stripMarkdown(description, { preserveNewlines: true })
-    : htmlToPlainText(description);
-  return `${t("description")}:\n${text}`;
+
+  let plainText = htmlToPlainText(description);
+
+  if (stripMarkdownForIcs) {
+    plainText = stripMarkdown(plainText, { preserveNewlines: true });
+  }
+
+  return `${t("description")}:\n${plainText}`;
 };
 
 export const getLocation = (calEvent: {

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -1,8 +1,5 @@
-import type { TFunction } from "i18next";
-import short from "short-uuid";
-
 import getLabelValueMapFromResponses from "@calcom/lib/bookings/getLabelValueMapFromResponses";
-import { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "@calcom/prisma/client";
 import type {
   AdditionalInformation,
   AppsStatus,
@@ -12,7 +9,8 @@ import type {
   TeamMember,
   VideoCallData,
 } from "@calcom/types/Calendar";
-
+import type { TFunction } from "i18next";
+import short from "short-uuid";
 import { WEBAPP_URL } from "./constants";
 import isSmsCalEmail from "./isSmsCalEmail";
 import {
@@ -21,6 +19,8 @@ import {
   buildStandardCancelLink,
   buildStandardRescheduleLink,
 } from "./LinkBuilder";
+import { markdownToSafeHTML } from "./markdownToSafeHTML";
+import { stripMarkdown } from "./stripMarkdown";
 
 const translator = short();
 
@@ -93,11 +93,18 @@ export const getWho = (
   }`;
 };
 
-export const getAdditionalNotes = (t: TFunction, additionalNotes?: string | null) => {
+export const getAdditionalNotes = (
+  t: TFunction,
+  additionalNotes?: string | null,
+  stripMarkdownForIcs = false
+) => {
   if (!additionalNotes) {
     return "";
   }
-  return `${t("additional_notes")}:\n${additionalNotes}`;
+  const text = stripMarkdownForIcs
+    ? stripMarkdown(additionalNotes, { preserveNewlines: true })
+    : additionalNotes;
+  return `${t("additional_notes")}:\n${text}`;
 };
 
 export const getUserFieldsResponses = (
@@ -175,12 +182,14 @@ const htmlToPlainText = (html: string): string => {
   );
 };
 
-export const getDescription = (t: TFunction, description?: string | null) => {
+export const getDescription = (t: TFunction, description?: string | null, stripMarkdownForIcs = false) => {
   if (!description) {
     return "";
   }
-  const plainText = htmlToPlainText(description);
-  return `${t("description")}\n${plainText}`;
+  const text = stripMarkdownForIcs
+    ? stripMarkdown(description, { preserveNewlines: true })
+    : htmlToPlainText(description);
+  return `${t("description")}:\n${text}`;
 };
 
 export const getLocation = (calEvent: {
@@ -477,14 +486,20 @@ export const getRichDescriptionHTML = (
   const textToHtml = (text: string) => {
     if (!text) return "";
     const lines = text.split("\n").filter(Boolean);
-    return lines
-      .map((line, index) => {
-        if (index === 0) {
-          return `<p><strong>${line}</strong></p>`;
-        }
-        return `<p>${line}</p>`;
-      })
-      .join("");
+    const firstLine = lines.shift();
+    if (!firstLine) return "";
+    let html = `<p><strong>${firstLine}</strong></p>`;
+    if (lines.length > 0) {
+      html += `<p>${lines.join("<br>")}</p>`;
+    }
+    return html;
+  };
+
+  // Helper function to render markdown content to safe HTML
+  const markdownContentToHTML = (title: string, content: string | null) => {
+    if (!content) return "";
+    const html = markdownToSafeHTML(content);
+    return `<p><strong>${title}</strong></p>${html}`;
   };
 
   // Convert the manage link to a clickable hyperlink
@@ -528,8 +543,8 @@ export const getRichDescriptionHTML = (
         t
       )
     ),
-    textToHtml(getDescription(t, calEvent.description)),
-    textToHtml(getAdditionalNotes(t, calEvent.additionalNotes)),
+    markdownContentToHTML(t("description"), calEvent.description),
+    markdownContentToHTML(t("additional_notes"), calEvent.additionalNotes),
     textToHtml(
       getUserFieldsResponses(
         {
@@ -563,6 +578,7 @@ export const getRichDescription = (
   const t = t_ ?? calEvent.organizer.language.translate;
 
   // Join all parts with single newlines and remove extra whitespace
+  // NOTE: We pass true to strip markdown since this is used for ICS files and plain text emails
   const parts = [
     getCancellationReason(t, calEvent.cancellationReason),
     getWhat(calEvent.title, t),
@@ -591,9 +607,17 @@ export const getRichDescription = (
       location: calEvent.location,
       uid: calEvent.uid,
     })}`,
-    getDescription(t, calEvent.description),
-    getAdditionalNotes(t, calEvent.additionalNotes),
-    getUserFieldsResponses(calEvent, t),
+    getDescription(t, calEvent.description, true),
+    getAdditionalNotes(t, calEvent.additionalNotes, true),
+    getUserFieldsResponses(
+      {
+        customInputs: calEvent.customInputs,
+        userFieldsResponses: calEvent.userFieldsResponses,
+        responses: calEvent.responses,
+        eventTypeId: calEvent.eventTypeId,
+      },
+      t
+    ),
     includeAppStatus ? getAppsStatus(t, calEvent.appsStatus) : "",
     // TODO: Only the original attendee can make changes to the event
     // Guests cannot

--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -496,9 +496,9 @@ export const getRichDescriptionHTML = (
   };
 
   // Helper function to render markdown content to safe HTML
-  const markdownContentToHTML = (title: string, content: string | null) => {
+  const markdownContentToHTML = (title: string, content: string | null | undefined) => {
     if (!content) return "";
-    const html = markdownToSafeHTML(content);
+    const html = markdownToSafeHTML(content as string | null);
     return `<p><strong>${title}</strong></p>${html}`;
   };
 

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -30,12 +30,12 @@ export const md = new MarkdownIt({ html: true, breaks: true, linkify: true });
  * Inline styles are required because many email clients don't support external CSS
  */
 const STYLES = {
-  text: "color: #101010; font-weight: 400; line-height: 24px; margin: 8px 0;",
-  list: "list-style-type: disc; list-style-position: outside; padding-left: 20px; margin-left: 1.5em; color: #101010; line-height: 24px;",
+  text: "font-weight: 400; line-height: 24px; margin: 8px 0;",
+  list: "list-style-type: disc; list-style-position: outside; padding-left: 20px; margin-left: 1.5em; line-height: 24px;",
   orderedList:
-    "list-style-type: decimal; list-style-position: outside; padding-left: 20px; margin-left: 1.5em; color: #101010; line-height: 24px;",
-  listItem: "color: #101010; font-weight: 400; line-height: 24px; margin: 4px 0;",
-  header: "color: #101010; font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
+    "list-style-type: decimal; list-style-position: outside; padding-left: 20px; margin-left: 1.5em; line-height: 24px;",
+  listItem: "font-weight: 400; line-height: 24px; margin: 4px 0;",
+  header: "font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
   h1: "font-size: 2em;",
   h2: "font-size: 1.5em;",
   h3: "font-size: 1.25em;",

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -192,7 +192,7 @@ export function unescapeMarkdown(markdown: string): string {
   // The negative character class avoids matching emphasis/bold like `**` or `--`.
   const unorderedListRegex = /^(\s*)([-*])([^\s*-])/gm;
   // For numbered lists: `  1.item` -> `  1. item`
-  const orderedListRegex = /^(\s*\d+\.)(\S)/gm;
+  const orderedListRegex = /^(\s*\d+\.)([^\d\s])/gm;
 
   result = result.replace(unorderedListRegex, "$1$2 $3").replace(orderedListRegex, "$1 $2");
 

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -1,3 +1,24 @@
 import MarkdownIt from "markdown-it";
 
-export const md = new MarkdownIt("default", { html: true, breaks: true, linkify: true });
+export const md = new MarkdownIt({ html: true, breaks: true, linkify: true });
+
+/**
+ * Unescapes markdown characters that may have been escaped by turndown
+ * This handles legacy data where turndown escaped markdown syntax
+ */
+export function unescapeMarkdown(markdown: string): string {
+  if (!markdown) return "";
+
+  return markdown
+    .replace(/\\#/g, "#")
+    .replace(/\\\*/g, "*")
+    .replace(/\\_/g, "_")
+    .replace(/\\`/g, "`")
+    .replace(/\\\[/g, "[")
+    .replace(/\\\]/g, "]")
+    .replace(/\\\(/g, "(")
+    .replace(/\\\)/g, ")")
+    .replace(/\\-/g, "-")
+    .replace(/\\~/g, "~")
+    .replace(/\\>/g, ">");
+}

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -120,7 +120,7 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
  * Unescapes markdown characters that may have been escaped by turndown.
  * This handles legacy data where turndown escaped markdown syntax.
  * It also normalizes list markers to ensure they have proper spacing.
- * 
+ *
  * Note: Only unescapes if input appears to be legacy data (has multiple escaped
  * markdown characters), to avoid corrupting fresh input with intentional escapes.
  */
@@ -131,12 +131,12 @@ export function unescapeMarkdown(markdown: string): string {
   // Look for patterns that suggest Turndown escaping:
   // - Escaped headers at start of line: \#header
   // - Escaped blockquotes: \> quote
-  // - Multiple escaped formatting chars in a row
+  // - Multiple escaped formatting chars (2+ to catch cases like \*Important\*)
   const hasEscapedHeaders = /^\\#+\s/m.test(markdown);
   const hasEscapedBlockquotes = /^\\>\s/m.test(markdown);
   const escapedMarkdownChars = (markdown.match(/\\([*_`#[\]()~>-])/g) || []).length;
-  // Only treat as legacy if we see clear Turndown patterns or many escaped chars
-  const isLikelyLegacyData = hasEscapedHeaders || hasEscapedBlockquotes || escapedMarkdownChars >= 3;
+  // Only treat as legacy if we see clear Turndown patterns or 2+ escaped chars
+  const isLikelyLegacyData = hasEscapedHeaders || hasEscapedBlockquotes || escapedMarkdownChars >= 2;
 
   let result = markdown;
 

--- a/packages/lib/markdownIt.ts
+++ b/packages/lib/markdownIt.ts
@@ -136,7 +136,7 @@ export function unescapeMarkdown(markdown: string): string {
   const hasEscapedBlockquotes = /^\\>\s/m.test(markdown);
   const escapedMarkdownChars = (markdown.match(/\\([*_`#[\]()~>-])/g) || []).length;
   // Only treat as legacy if we see clear Turndown patterns or 2+ escaped chars
-  const isLikelyLegacyData = hasEscapedHeaders || hasEscapedBlockquotes || escapedMarkdownChars >= 2;
+  const isLikelyLegacyData = hasEscapedHeaders || hasEscapedBlockquotes || escapedMarkdownChars >= 3;
 
   let result = markdown;
 

--- a/packages/lib/markdownToSafeHTML.test.ts
+++ b/packages/lib/markdownToSafeHTML.test.ts
@@ -1123,11 +1123,6 @@ describe("markdownToSafeHTMLClient (Client-side)", () => {
     markdownToSafeHTMLClient = module.markdownToSafeHTMLClient;
   });
 
-  afterEach(() => {
-    // Clean up window mock to prevent affecting other tests
-    delete (global as { window?: unknown }).window;
-  });
-
   describe("XSS Prevention", () => {
     it("should remove script tags", () => {
       const malicious = "Hello <script>alert('XSS')</script> world";

--- a/packages/lib/markdownToSafeHTML.test.ts
+++ b/packages/lib/markdownToSafeHTML.test.ts
@@ -1123,6 +1123,11 @@ describe("markdownToSafeHTMLClient (Client-side)", () => {
     markdownToSafeHTMLClient = module.markdownToSafeHTMLClient;
   });
 
+  afterEach(() => {
+    // Clean up window mock to prevent affecting other tests
+    delete (global as { window?: unknown }).window;
+  });
+
   describe("XSS Prevention", () => {
     it("should remove script tags", () => {
       const malicious = "Hello <script>alert('XSS')</script> world";

--- a/packages/lib/markdownToSafeHTML.test.ts
+++ b/packages/lib/markdownToSafeHTML.test.ts
@@ -1,0 +1,1203 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { markdownToSafeHTML } from "./markdownToSafeHTML";
+
+/**
+ * TEST SUITE OVERVIEW
+ *
+ * This comprehensive test suite validates:
+ *
+ * 1. XSS PREVENTION: Ensures malicious code cannot be injected through markdown
+ *    - Script injection, event handlers, dangerous URLs, HTML tags, etc.
+ *
+ * 2. MARKDOWN EDGE CASES: Tests all markdown features and edge cases
+ *    - Lists (ordered, unordered, nested, non-consecutive numbering)
+ *    - Links, code blocks, blockquotes, headers, formatting
+ *    - Special characters, Unicode, encoding, legacy data
+ *    - Malformed input, empty/null values, whitespace
+ *
+ * 3. SANITIZATION CONSISTENCY: Ensures server and client produce safe output
+ *
+ * NOTE ON DOMPURIFY MOCKING:
+ * DOMPurify is the gold standard for client-side HTML sanitization because it uses
+ * a real browser DOM to parse and clean HTML. However, these tests run in Vitest
+ * (Node.js environment), which doesn't have a DOM. Therefore, we mock DOMPurify
+ * with a simplified simulation that removes dangerous content (scripts, event handlers,
+ * dangerous URLs, etc.). This allows tests to run quickly in Node.js while still
+ * verifying that the sanitization logic is being called correctly.
+ *
+ * In production, the real DOMPurify runs in the browser with full DOM capabilities.
+ */
+
+// Mock DOMPurify for client-side tests
+// This mock simulates DOMPurify's sanitization behavior
+const mockSanitize = vi.fn((html: string, config: Record<string, unknown>) => {
+  // Simulate DOMPurify's sanitization
+  let sanitized = html;
+
+  // Remove script tags
+  sanitized = sanitized.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+
+  // Remove dangerous event handlers
+  sanitized = sanitized.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, "");
+
+  // Remove javascript: URLs
+  sanitized = sanitized.replace(/javascript:/gi, "");
+  sanitized = sanitized.replace(/vbscript:/gi, "");
+  sanitized = sanitized.replace(/data:/gi, "");
+
+  // Remove dangerous tags (not in ALLOWED_TAGS)
+  const allowedTags = (config?.ALLOWED_TAGS as string[]) || [];
+  const dangerousTags = ["iframe", "embed", "object", "form", "input", "style", "meta", "script"];
+  dangerousTags.forEach((tag) => {
+    if (!allowedTags.includes(tag)) {
+      sanitized = sanitized.replace(new RegExp(`<${tag}[^>]*>[\\s\\S]*?</${tag}>`, "gi"), "");
+      sanitized = sanitized.replace(new RegExp(`<${tag}[^>]*/?>`, "gi"), "");
+    }
+  });
+
+  return sanitized;
+});
+
+const mockAddHook = vi.fn();
+const mockRemoveHook = vi.fn();
+
+vi.mock("dompurify", () => ({
+  default: {
+    sanitize: mockSanitize,
+    addHook: mockAddHook,
+    removeHook: mockRemoveHook,
+    isSupported: true,
+  },
+}));
+
+// Import after mocking - use dynamic import in tests that need it
+
+describe("markdownToSafeHTML (Server-side)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("XSS Prevention", () => {
+    describe("Script injection attacks", () => {
+      it("should remove script tags from markdown", () => {
+        const malicious = "Hello <script>alert('XSS')</script> world";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<script>");
+        expect(result).not.toContain("alert('XSS')");
+      });
+
+      it("should remove script tags even when embedded in markdown", () => {
+        const malicious = "# Heading\n<script src='evil.js'></script>\nNormal text";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<script");
+        expect(result).toContain("Heading");
+        expect(result).toContain("Normal text");
+      });
+
+      it("should remove script tags with various attributes", () => {
+        const cases = [
+          '<script type="text/javascript">alert(1)</script>',
+          "<script async defer>alert(1)</script>",
+          '<script src="https://evil.com/script.js"></script>',
+        ];
+
+        for (const malicious of cases) {
+          const result = markdownToSafeHTML(malicious);
+          expect(result).not.toContain("<script");
+          expect(result).not.toContain("alert");
+        }
+      });
+    });
+
+    describe("Event handler injection", () => {
+      it("should remove onclick handlers from HTML", () => {
+        const malicious = '<a href="#" onclick="alert(1)">Click me</a>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("onclick");
+        expect(result).not.toContain("alert(1)");
+      });
+
+      it("should remove onerror handlers from HTML", () => {
+        const malicious = '<img src="image.jpg" onerror="alert(1)">';
+        // Images are not in allowed tags, so img tag should be removed
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<img");
+        expect(result).not.toContain("onerror");
+      });
+
+      it("should remove onmouseover and other event handlers", () => {
+        const malicious = '<p onmouseover="alert(1)">Hover me</p>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("onmouseover");
+        expect(result).not.toContain("alert(1)");
+      });
+    });
+
+    describe("JavaScript URL schemes", () => {
+      it("should sanitize javascript: URLs in links", () => {
+        const malicious = "[Click](javascript:alert('XSS'))";
+        const result = markdownToSafeHTML(malicious);
+        // sanitize-html should remove the href or the entire link when scheme is not allowed
+        // The link text might remain, but the href should be removed
+        expect(result).not.toMatch(/href=["']javascript:/i);
+        // If the link is removed entirely, that's also acceptable
+        if (result.includes("Click")) {
+          // Link text might remain but href should be sanitized
+          expect(result).not.toMatch(/href=["']javascript:/i);
+        }
+      });
+
+      it("should sanitize javascript: URLs with encoded characters", () => {
+        const malicious = "[Click](javascript%3Aalert('XSS'))";
+        const result = markdownToSafeHTML(malicious);
+        // URL encoding is decoded by markdown-it, then sanitized
+        expect(result).not.toMatch(/href=["']javascript:/i);
+      });
+
+      it("should allow safe URL schemes only", () => {
+        const safe = "[Link](https://example.com)";
+        const result = markdownToSafeHTML(safe);
+        expect(result).toContain("https://example.com");
+        expect(result).toContain('target="_blank"');
+        expect(result).toContain('rel="noopener noreferrer"');
+      });
+
+      it("should allow mailto: and tel: schemes", () => {
+        const email = "[Email](mailto:test@example.com)";
+        const phone = "[Phone](tel:+1234567890)";
+        const emailResult = markdownToSafeHTML(email);
+        const phoneResult = markdownToSafeHTML(phone);
+
+        expect(emailResult).toContain("mailto:test@example.com");
+        expect(phoneResult).toContain("tel:+1234567890");
+      });
+
+      it("should block data: URLs", () => {
+        const malicious = "[Click](data:text/html,<script>alert(1)</script>)";
+        const result = markdownToSafeHTML(malicious);
+        // data: scheme is not in allowedSchemes, so href should be removed
+        expect(result).not.toMatch(/href=["']data:/i);
+      });
+
+      it("should block vbscript: URLs", () => {
+        const malicious = "[Click](vbscript:alert('XSS'))";
+        const result = markdownToSafeHTML(malicious);
+        // vbscript: scheme is not in allowedSchemes
+        expect(result).not.toMatch(/href=["']vbscript:/i);
+      });
+    });
+
+    describe("Dangerous HTML tags", () => {
+      it("should remove input tags", () => {
+        const malicious = "Text <input type='text' value='XSS'> more text";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<input");
+        expect(result).toContain("Text");
+        expect(result).toContain("more text");
+      });
+
+      it("should remove iframe tags", () => {
+        const malicious = "<iframe src='evil.com'></iframe>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<iframe");
+      });
+
+      it("should remove embed tags", () => {
+        const malicious = "<embed src='evil.swf'>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<embed");
+      });
+
+      it("should remove object tags", () => {
+        const malicious = "<object data='evil.swf'></object>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<object");
+      });
+
+      it("should remove form tags", () => {
+        const malicious = "<form><input name='xss'></form>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<form");
+        expect(result).not.toContain("<input");
+      });
+
+      it("should remove style tags", () => {
+        const malicious = "<style>body { background: red; }</style>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<style");
+      });
+
+      it("should remove meta tags", () => {
+        const malicious = "<meta http-equiv='refresh' content='0;url=evil.com'>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<meta");
+      });
+    });
+
+    describe("Style attribute injection", () => {
+      it("should only allow style on permitted tags", () => {
+        const malicious =
+          '<div style="position:fixed;top:0;left:0;width:100%;height:100%;background:red;z-index:9999">Overlay</div>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<div");
+        expect(result).not.toContain("position:fixed");
+      });
+
+      it("should allow style on allowed tags like p, h1, etc", () => {
+        const safe = "# Heading\n\nParagraph text";
+        const result = markdownToSafeHTML(safe);
+        // Should contain style attributes from our renderer
+        expect(result).toContain("style=");
+      });
+
+      it("should prevent CSS expression injection", () => {
+        const malicious = '<p style="background: expression(alert(1))">Text</p>';
+        const result = markdownToSafeHTML(malicious);
+        // Even if style is allowed, dangerous CSS should be filtered
+        expect(result).not.toContain("expression");
+      });
+    });
+
+    describe("Attribute injection", () => {
+      it("should remove dangerous attributes from allowed tags", () => {
+        const malicious = '<p id="xss" class="evil" data-xss="alert(1)">Text</p>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain('id="xss"');
+        expect(result).not.toContain('class="evil"');
+        expect(result).not.toContain("data-xss");
+      });
+
+      it("should only allow href, target, rel, style on anchor tags", () => {
+        const malicious = '<a href="#" onclick="alert(1)" onmouseover="alert(2)">Link</a>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("onclick");
+        expect(result).not.toContain("onmouseover");
+      });
+    });
+
+    describe("Nested attack vectors", () => {
+      it("should handle deeply nested malicious content", () => {
+        const malicious = "<div><script><iframe><embed>XSS</embed></iframe></script></div>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<script");
+        expect(result).not.toContain("<iframe");
+        expect(result).not.toContain("<embed");
+        expect(result).not.toContain("<div");
+      });
+
+      it("should sanitize markdown mixed with HTML attacks", () => {
+        const malicious = "# Heading\n\n<script>alert(1)</script>\n\n**Bold** text";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).toContain("Heading");
+        expect(result).toContain("Bold");
+        expect(result).not.toContain("<script");
+      });
+    });
+  });
+
+  describe("Markdown Edge Cases", () => {
+    describe("Ordered list numbering", () => {
+      it("should preserve non-consecutive ordered list numbers", () => {
+        const markdown = "1. First item\n3. Third item\n2. Second item";
+        const result = markdownToSafeHTML(markdown);
+        // First item is 1, so start attribute won't be added
+        // But value attributes should be preserved on each li
+        expect(result).toContain('value="1"');
+        expect(result).toContain('value="3"');
+        expect(result).toContain('value="2"');
+        expect(result).toContain("<ol");
+        expect(result).toContain("<li");
+      });
+
+      it("should add start attribute when list doesn't start at 1", () => {
+        const markdown = "3. Third\n4. Fourth\n5. Fifth";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain('start="3"');
+        expect(result).toContain('value="3"');
+        expect(result).toContain('value="4"');
+        expect(result).toContain('value="5"');
+      });
+
+      it("should not add start attribute when list starts at 1", () => {
+        const markdown = "1. First\n2. Second\n3. Third";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).not.toContain('start="1"');
+        expect(result).toContain("<ol");
+      });
+
+      it("should handle large start numbers", () => {
+        const markdown = "100. Item one hundred\n101. Item one hundred one";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain('start="100"');
+        expect(result).toContain('value="100"');
+        expect(result).toContain('value="101"');
+      });
+
+      it("should handle single item lists", () => {
+        const markdown = "1. Only item";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<li");
+        expect(result).not.toContain('start="1"');
+      });
+    });
+
+    describe("Nested lists", () => {
+      it("should handle nested unordered lists", () => {
+        const markdown = "- Item 1\n  - Nested 1\n  - Nested 2\n- Item 2";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ul");
+        expect(result).toContain("<li");
+        // Should have proper nesting structure
+        expect(result.split("<ul").length).toBeGreaterThan(2);
+      });
+
+      it("should handle nested ordered lists", () => {
+        const markdown = "1. Item 1\n   1. Nested 1\n   2. Nested 2\n2. Item 2";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<li");
+      });
+
+      it("should handle mixed nested lists", () => {
+        const markdown = "1. Ordered\n   - Unordered nested\n2. Another";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<ul");
+      });
+    });
+
+    describe("Empty and null inputs", () => {
+      it("should return empty string for null input", () => {
+        expect(markdownToSafeHTML(null)).toBe("");
+      });
+
+      it("should return empty string for undefined input", () => {
+        expect(markdownToSafeHTML(undefined)).toBe("");
+      });
+
+      it("should return empty string for empty string", () => {
+        expect(markdownToSafeHTML("")).toBe("");
+      });
+
+      it("should return empty string for whitespace-only input", () => {
+        expect(markdownToSafeHTML("   \n\t  ")).toBe("");
+      });
+    });
+
+    describe("Special characters and encoding", () => {
+      it("should handle HTML entities in markdown", () => {
+        const markdown = "Text with &amp; entities";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("&amp;");
+      });
+
+      it("should handle unicode characters", () => {
+        const markdown = "Hello 世界 🌍";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("世界");
+        expect(result).toContain("🌍");
+      });
+
+      it("should handle special markdown characters", () => {
+        const markdown = "Text with *asterisks* and _underscores_";
+        const result = markdownToSafeHTML(markdown);
+        // Markdown-it renders * as <em> by default, ** as <strong>
+        // Single * should be <em>, _ should also be <em>
+        expect(result).toMatch(/<em>asterisks<\/em>/i);
+        expect(result).toMatch(/<em>underscores<\/em>/i);
+      });
+    });
+
+    describe("Legacy turndown escaping", () => {
+      it("should unescape legacy turndown escapes", () => {
+        const legacy = "\\# Heading\n\\*Bold\\*\n\\> Quote";
+        const result = markdownToSafeHTML(legacy);
+        expect(result).toContain("Heading");
+        expect(result).toContain("Bold");
+        expect(result).toContain("Quote");
+      });
+
+      it("should not unescape intentional escapes in fresh content", () => {
+        const fresh = "Text with \\*one\\* escape";
+        const result = markdownToSafeHTML(fresh);
+        // Should preserve the escape if it's not legacy data
+        expect(result).toContain("Text");
+      });
+
+      it("should handle escaped list markers", () => {
+        const legacy = "\\- Item 1\n\\* Item 2";
+        const result = markdownToSafeHTML(legacy);
+        expect(result).toContain("Item 1");
+        expect(result).toContain("Item 2");
+      });
+    });
+
+    describe("Link handling", () => {
+      it("should add security attributes to links", () => {
+        const markdown = "[Link](https://example.com)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain('target="_blank"');
+        expect(result).toContain('rel="noopener noreferrer"');
+      });
+
+      it("should handle reference-style links", () => {
+        const markdown = "[Link][ref]\n\n[ref]: https://example.com";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+        expect(result).toContain('target="_blank"');
+      });
+
+      it("should handle autolinks", () => {
+        const markdown = "Visit https://example.com for more";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+        expect(result).toContain('target="_blank"');
+      });
+    });
+
+    describe("Code blocks and inline code", () => {
+      it("should preserve code blocks", () => {
+        const markdown = "```\nconst x = 1;\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+        expect(result).toContain("<code");
+        expect(result).toContain("const x = 1;");
+      });
+
+      it("should preserve inline code", () => {
+        const markdown = "Use `console.log()` to debug";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<code");
+        expect(result).toContain("console.log()");
+      });
+
+      it("should sanitize code blocks containing HTML", () => {
+        const markdown = "```\n<script>alert(1)</script>\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+        expect(result).not.toContain("<script");
+        // The script should be escaped or removed
+      });
+    });
+
+    describe("Blockquotes", () => {
+      it("should render blockquotes correctly", () => {
+        const markdown = "> This is a quote\n> Multiple lines";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+        expect(result).toContain("This is a quote");
+      });
+
+      it("should handle nested blockquotes", () => {
+        const markdown = "> Quote\n> > Nested quote";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+      });
+    });
+
+    describe("Headers", () => {
+      it("should render all header levels", () => {
+        const markdown = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6";
+        const result = markdownToSafeHTML(markdown);
+        // Headers have inline styles, so check for the tag and content
+        expect(result).toMatch(/<h1[^>]*>H1<\/h1>/i);
+        expect(result).toMatch(/<h2[^>]*>H2<\/h2>/i);
+        expect(result).toMatch(/<h3[^>]*>H3<\/h3>/i);
+        expect(result).toMatch(/<h4[^>]*>H4<\/h4>/i);
+        expect(result).toMatch(/<h5[^>]*>H5<\/h5>/i);
+        expect(result).toMatch(/<h6[^>]*>H6<\/h6>/i);
+      });
+    });
+
+    describe("Text formatting", () => {
+      it("should handle bold text", () => {
+        const markdown = "**Bold** and __also bold__";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<strong>Bold</strong>");
+        expect(result).toContain("<strong>also bold</strong>");
+      });
+
+      it("should handle italic text", () => {
+        const markdown = "Text with *italic* and _also italic_";
+        const result = markdownToSafeHTML(markdown);
+        // Both * and _ should render as <em> when not at start of line
+        expect(result).toMatch(/<em>italic<\/em>/i);
+        expect(result).toMatch(/<em>also italic<\/em>/i);
+      });
+
+      it("should handle strikethrough", () => {
+        const markdown = "~~Strikethrough~~";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<s>Strikethrough</s>");
+      });
+
+      it("should handle mixed formatting", () => {
+        const markdown = "**Bold** with *italic* and ~~strike~~";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<strong>Bold</strong>");
+        expect(result).toContain("<em>italic</em>");
+        expect(result).toContain("<s>strike</s>");
+      });
+    });
+
+    describe("Horizontal rules", () => {
+      it("should render horizontal rules", () => {
+        const markdown = "Text\n\n---\n\nMore text";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<hr");
+      });
+    });
+
+    describe("Line breaks", () => {
+      it("should handle hard line breaks", () => {
+        const markdown = "Line one  \nLine two";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<br");
+      });
+
+      it("should handle soft line breaks with breaks option", () => {
+        const markdown = "Line one\nLine two";
+        const result = markdownToSafeHTML(markdown);
+        // With breaks: true, single newlines should create breaks
+        expect(result).toContain("<br");
+      });
+    });
+
+    describe("Complex markdown combinations", () => {
+      it("should handle complex nested structures", () => {
+        const markdown = `# Main Heading
+
+## Subheading
+
+1. First item
+   - Nested bullet
+   - Another nested
+2. Second item
+
+> Blockquote with **bold** text
+
+\`\`\`javascript
+const code = "example";
+\`\`\`
+
+[Link](https://example.com) with **bold** and *italic*.`;
+
+        const result = markdownToSafeHTML(markdown);
+        // Check for elements with their content (styles may be present)
+        expect(result).toMatch(/<h1[^>]*>Main Heading<\/h1>/i);
+        expect(result).toMatch(/<h2[^>]*>Subheading<\/h2>/i);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<ul");
+        expect(result).toContain("<blockquote");
+        expect(result).toContain("<pre");
+        expect(result).toMatch(/<strong>bold<\/strong>/i);
+        expect(result).toMatch(/<em>italic<\/em>/i);
+        expect(result).toMatch(/href=["']https:\/\/example\.com["']/i);
+      });
+    });
+
+    describe("Malformed and edge case markdown", () => {
+      it("should handle markdown with only punctuation", () => {
+        const markdown = "!!! ??? ... ---";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        expect(result).not.toContain("<script");
+      });
+
+      it("should handle markdown with only symbols", () => {
+        const markdown = "*** --- ___";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle markdown with only whitespace and newlines", () => {
+        const markdown = "   \n\n   \n\t\n";
+        const result = markdownToSafeHTML(markdown);
+        // Should return empty string (whitespace-only input is normalized to empty)
+        expect(result).toBe("");
+      });
+
+      it("should handle markdown with mixed line endings (CRLF, LF, CR)", () => {
+        const markdown = "Line 1\r\nLine 2\nLine 3\rLine 4";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        expect(result).toContain("Line 1");
+        expect(result).toContain("Line 4");
+      });
+
+      it("should handle markdown with excessive newlines", () => {
+        const markdown = "Text\n\n\n\n\nMore text";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        expect(result).toContain("Text");
+        expect(result).toContain("More text");
+      });
+
+      it("should handle markdown with excessive spaces", () => {
+        const markdown = "Text     with     many     spaces";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        expect(result).toContain("Text");
+      });
+
+      it("should handle markdown with tabs", () => {
+        const markdown = "Text\twith\ttabs";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        expect(result).toContain("Text");
+      });
+
+      it("should handle markdown with zero-width characters", () => {
+        const markdown = "Text\u200Bwith\u200Czero\u200Dwidth";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        // Should sanitize or handle gracefully
+      });
+
+      it("should handle markdown with control characters", () => {
+        const markdown = "Text\u0000with\u0001control\u0002chars";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        // Control chars should be removed or escaped
+      });
+    });
+
+    describe("List edge cases", () => {
+      it("should handle empty list items", () => {
+        const markdown = "1. \n2. Item\n3. ";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<li");
+      });
+
+      it("should handle list items with only whitespace", () => {
+        const markdown = "-   \n- Item\n-   ";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ul");
+      });
+
+      it("should handle lists with very large numbers", () => {
+        const markdown = "999999. Very large number\n1000000. Even larger";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain('value="999999"');
+      });
+
+      it("should handle lists starting with zero", () => {
+        const markdown = "0. Zero item\n1. First item";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain('value="0"');
+      });
+
+      it("should handle lists with negative numbers (should be treated as text)", () => {
+        const markdown = "-1. Negative\n1. Positive";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+      });
+
+      it("should handle deeply nested lists (5+ levels)", () => {
+        const markdown =
+          "1. Level 1\n    1. Level 2\n        1. Level 3\n            1. Level 4\n                1. Level 5";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result.split("<ol").length).toBeGreaterThan(4);
+      });
+
+      it("should handle lists with inconsistent spacing", () => {
+        const markdown = "1.Item one\n2.  Item two\n3.   Item three";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+      });
+
+      it("should handle lists with special characters in items", () => {
+        const markdown = "1. Item with *asterisk*\n2. Item with _underscore_\n3. Item with `code`";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).toContain("<li");
+      });
+
+      it("should handle lists with HTML in items (should be sanitized)", () => {
+        const markdown = "1. Item with <script>alert(1)</script>\n2. Safe item";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ol");
+        expect(result).not.toContain("<script");
+      });
+
+      it("should handle unordered lists with different markers", () => {
+        const markdown = "- Item 1\n* Item 2\n- Item 3";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<ul");
+      });
+    });
+
+    describe("Link edge cases", () => {
+      it("should handle links with very long URLs", () => {
+        const longUrl = "https://example.com/" + "a".repeat(1000);
+        const markdown = `[Link](${longUrl})`;
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+        expect(result).toContain('target="_blank"');
+      });
+
+      it("should handle links with special characters in URL", () => {
+        const markdown = "[Link](https://example.com/path?query=value&other=test)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+      });
+
+      it("should handle links with unicode in URL", () => {
+        const markdown = "[Link](https://example.com/路径/测试)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+      });
+
+      it("should handle links with empty text", () => {
+        const markdown = "[](https://example.com)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+      });
+
+      it("should handle links with only whitespace text", () => {
+        const markdown = "[   ](https://example.com)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+      });
+
+      it("should handle reference-style links with missing definition", () => {
+        const markdown = "[Link][missing]";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle autolinks in various formats", () => {
+        const markdown = "Visit https://example.com and http://test.com";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+        expect(result).toContain("http://test.com");
+      });
+
+      it("should handle email autolinks", () => {
+        const markdown = "Email test@example.com";
+        const result = markdownToSafeHTML(markdown);
+        // markdown-it with linkify should convert emails
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle links with title attributes", () => {
+        const markdown = '[Link](https://example.com "Link Title")';
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("https://example.com");
+      });
+
+      it("should handle malformed link syntax", () => {
+        const markdown = "[Unclosed link(https://example.com)";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+        // Should handle gracefully without breaking
+      });
+    });
+
+    describe("Code block edge cases", () => {
+      it("should handle empty code blocks", () => {
+        const markdown = "```\n\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+        expect(result).toContain("<code");
+      });
+
+      it("should handle code blocks with only whitespace", () => {
+        const markdown = "```\n   \n\t\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+      });
+
+      it("should handle code blocks with special characters", () => {
+        const markdown = "```\n<>&\"'\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+        // Special chars should be escaped
+      });
+
+      it("should handle code blocks with unclosed fences", () => {
+        const markdown = "```\nCode without closing fence";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle code blocks with language identifier", () => {
+        const markdown = "```javascript\nconst x = 1;\n```";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+        expect(result).toContain("const x = 1;");
+      });
+
+      it("should handle inline code with backticks", () => {
+        const markdown = "Code with ``double backticks``";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<code");
+      });
+
+      it("should handle inline code with special characters", () => {
+        const markdown = "Code: `<script>alert(1)</script>`";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<code");
+        // Script should be escaped in code
+      });
+
+      it("should handle code blocks with very long lines", () => {
+        const longLine = "a".repeat(10000);
+        const markdown = `\`\`\`\n${longLine}\n\`\`\``;
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<pre");
+      });
+    });
+
+    describe("Blockquote edge cases", () => {
+      it("should handle empty blockquotes", () => {
+        const markdown = ">\n> \n>";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+      });
+
+      it("should handle blockquotes with only whitespace", () => {
+        const markdown = ">   \n>   ";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+      });
+
+      it("should handle deeply nested blockquotes", () => {
+        const markdown = "> Quote\n> > Nested\n> > > Very nested";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+        expect(result.split("<blockquote").length).toBeGreaterThan(2);
+      });
+
+      it("should handle blockquotes with other markdown", () => {
+        const markdown = "> **Bold** and *italic*\n> - List item";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<blockquote");
+        expect(result).toContain("<strong>Bold</strong>");
+      });
+    });
+
+    describe("Header edge cases", () => {
+      it("should handle headers with only hashes", () => {
+        const markdown = "######";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle headers with only whitespace", () => {
+        const markdown = "#   \n##   ";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<h1");
+        expect(result).toContain("<h2");
+      });
+
+      it("should handle headers with special characters", () => {
+        const markdown = "# Header with <>&\"'";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toMatch(/<h1[^>]*>/i);
+        // Special chars should be escaped
+      });
+
+      it("should handle headers with unicode", () => {
+        const markdown = "# 标题 世界 🌍";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toMatch(/<h1[^>]*>标题/i);
+      });
+
+      it("should handle headers with very long text", () => {
+        const longText = "a".repeat(1000);
+        const markdown = `# ${longText}`;
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toMatch(/<h1[^>]*>/i);
+      });
+
+      it("should handle more than 6 hash marks (should be treated as text)", () => {
+        const markdown = "####### Too many hashes";
+        const result = markdownToSafeHTML(markdown);
+        // Should not be a header
+        expect(result).not.toMatch(/<h[1-6][^>]*>/i);
+      });
+
+      it("should handle headers with inline formatting", () => {
+        const markdown = "# Header with **bold** and *italic*";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toMatch(/<h1[^>]*>/i);
+        expect(result).toContain("<strong>bold</strong>");
+      });
+    });
+
+    describe("Text formatting edge cases", () => {
+      it("should handle bold with only asterisks", () => {
+        const markdown = "**";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle italic with only asterisk", () => {
+        const markdown = "*";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle strikethrough with only tildes", () => {
+        const markdown = "~~";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle mixed formatting", () => {
+        const markdown = "***bold and italic***";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle formatting with special characters", () => {
+        const markdown = "**Bold with <>&\"'**";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<strong>");
+        // Special chars should be escaped
+      });
+
+      it("should handle unclosed formatting", () => {
+        const markdown = "**Bold without closing";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toBeTruthy();
+      });
+
+      it("should handle formatting across lines", () => {
+        const markdown = "**Bold\nacross\nlines**";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("<strong>");
+      });
+    });
+
+    describe("Very long input edge cases", () => {
+      it("should handle very long markdown input", () => {
+        const longMarkdown = "# Header\n\n" + "Paragraph text. ".repeat(1000);
+        const result = markdownToSafeHTML(longMarkdown);
+        expect(result).toBeTruthy();
+        expect(result).toMatch(/<h1[^>]*>Header<\/h1>/i);
+      });
+
+      it("should handle markdown with many lists", () => {
+        const manyLists = Array.from({ length: 100 }, (_, i) => `${i + 1}. Item ${i + 1}`).join("\n");
+        const result = markdownToSafeHTML(manyLists);
+        expect(result).toContain("<ol");
+        expect(result.split("<li").length).toBeGreaterThan(50);
+      });
+
+      it("should handle markdown with many links", () => {
+        const manyLinks = Array.from({ length: 50 }, (_, i) => `[Link ${i}](https://example.com/${i})`).join(
+          "\n"
+        );
+        const result = markdownToSafeHTML(manyLinks);
+        expect(result).toContain("https://example.com");
+      });
+    });
+
+    describe("HTML mixed with markdown edge cases", () => {
+      it("should sanitize HTML while preserving markdown", () => {
+        const markdown = "# Heading\n\n<script>alert(1)</script>\n\n**Bold** text";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toMatch(/<h1[^>]*>Heading<\/h1>/i);
+        expect(result).not.toContain("<script");
+        expect(result).toContain("<strong>Bold</strong>");
+      });
+
+      it("should handle HTML comments in markdown", () => {
+        const markdown = "Text <!-- comment --> more text";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("Text");
+        expect(result).toContain("more text");
+        // HTML comments should be removed
+      });
+
+      it("should handle HTML entities in markdown", () => {
+        const markdown = "Text &amp; entities &lt;script&gt;";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).toContain("&amp;");
+        expect(result).toContain("&lt;");
+      });
+
+      it("should handle markdown inside HTML (should be sanitized)", () => {
+        const markdown = "<div># Not a header</div>";
+        const result = markdownToSafeHTML(markdown);
+        expect(result).not.toContain("<div");
+        // div is not in allowed tags
+      });
+    });
+
+    describe("Additional XSS edge cases", () => {
+      it("should handle script tags with mixed case", () => {
+        const malicious = "<ScRiPt>alert(1)</ScRiPt>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<script");
+        expect(result).not.toContain("<ScRiPt");
+      });
+
+      it("should handle script tags with null bytes", () => {
+        const malicious = "<script\u0000>alert(1)</script>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<script");
+      });
+
+      it("should handle event handlers with unicode", () => {
+        const malicious = '<p onclick="alert(1)">Click</p>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("onclick");
+      });
+
+      it("should handle CSS injection attempts", () => {
+        const malicious = '<p style="background: url(javascript:alert(1))">Text</p>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("javascript:");
+      });
+
+      it("should handle SVG with script", () => {
+        const malicious = "<svg><script>alert(1)</script></svg>";
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<svg");
+        expect(result).not.toContain("<script");
+      });
+
+      it("should handle iframe with various protocols", () => {
+        const cases = [
+          '<iframe src="javascript:alert(1)"></iframe>',
+          '<iframe src="data:text/html,<script>alert(1)</script>"></iframe>',
+        ];
+        for (const malicious of cases) {
+          const result = markdownToSafeHTML(malicious);
+          expect(result).not.toContain("<iframe");
+        }
+      });
+
+      it("should handle link with javascript: and encoded characters", () => {
+        const malicious =
+          '<a href="&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;alert(1)">Click</a>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toMatch(/href=["']javascript:/i);
+      });
+
+      it("should handle img with onerror", () => {
+        const malicious = '<img src="x" onerror="alert(1)">';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<img");
+        expect(result).not.toContain("onerror");
+      });
+
+      it("should handle form with action javascript", () => {
+        const malicious = '<form action="javascript:alert(1)"><input></form>';
+        const result = markdownToSafeHTML(malicious);
+        expect(result).not.toContain("<form");
+        expect(result).not.toContain("<input");
+      });
+    });
+  });
+});
+
+describe("markdownToSafeHTMLClient (Client-side)", () => {
+  let markdownToSafeHTMLClient: typeof import("./markdownToSafeHTMLClient").markdownToSafeHTMLClient;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Reset mocks
+    mockSanitize.mockClear();
+    mockAddHook.mockClear();
+    mockRemoveHook.mockClear();
+
+    // Set up window mock
+    Object.defineProperty(global, "window", {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    // Dynamically import after mocks are set up
+    const module = await import("./markdownToSafeHTMLClient");
+    markdownToSafeHTMLClient = module.markdownToSafeHTMLClient;
+  });
+
+  describe("XSS Prevention", () => {
+    it("should remove script tags", () => {
+      const malicious = "Hello <script>alert('XSS')</script> world";
+      const result = markdownToSafeHTMLClient(malicious);
+      expect(result).not.toContain("<script>");
+      expect(result).not.toContain("alert('XSS')");
+    });
+
+    it("should sanitize javascript: URLs", () => {
+      const malicious = "[Click](javascript:alert('XSS'))";
+      const result = markdownToSafeHTMLClient(malicious);
+      // The href with javascript: should be removed or sanitized
+      expect(result).not.toMatch(/href=["']javascript:/i);
+    });
+
+    it("should remove input tags", () => {
+      const malicious = "Text <input type='text'> more text";
+      const result = markdownToSafeHTMLClient(malicious);
+      expect(result).not.toContain("<input");
+    });
+
+    it("should remove dangerous HTML tags", () => {
+      const malicious = "<iframe src='evil.com'></iframe><embed src='evil.swf'>";
+      const result = markdownToSafeHTMLClient(malicious);
+      expect(result).not.toContain("<iframe");
+      expect(result).not.toContain("<embed");
+    });
+  });
+
+  describe("Markdown Edge Cases", () => {
+    it("should preserve ordered list numbering", () => {
+      const markdown = "1. First\n3. Third\n2. Second";
+      const result = markdownToSafeHTMLClient(markdown);
+      // First item is 1, so start won't be added, but values should be preserved
+      expect(result).toContain('value="1"');
+      expect(result).toContain('value="3"');
+      expect(result).toContain('value="2"');
+      expect(result).toContain("<ol");
+    });
+
+    it("should handle empty input", () => {
+      expect(markdownToSafeHTMLClient(null)).toBe("");
+      expect(markdownToSafeHTMLClient(undefined)).toBe("");
+      expect(markdownToSafeHTMLClient("")).toBe("");
+    });
+
+    it("should render basic markdown correctly", () => {
+      const markdown = "# Heading\n\n**Bold** text";
+      const result = markdownToSafeHTMLClient(markdown);
+      // Headers have inline styles
+      expect(result).toMatch(/<h1[^>]*>Heading<\/h1>/i);
+      expect(result).toContain("<strong>Bold</strong>");
+    });
+  });
+
+  describe("Consistency with server-side", () => {
+    it("should produce similar sanitized output for safe markdown", () => {
+      const markdown = "# Heading\n\n**Bold** text with [link](https://example.com)";
+      const serverResult = markdownToSafeHTML(markdown);
+      const clientResult = markdownToSafeHTMLClient(markdown);
+
+      // Both should contain the same safe elements (with possible style attributes)
+      expect(serverResult).toMatch(/<h1[^>]*>Heading<\/h1>/i);
+      expect(clientResult).toMatch(/<h1[^>]*>Heading<\/h1>/i);
+      expect(serverResult).toContain("<strong>Bold</strong>");
+      expect(clientResult).toContain("<strong>Bold</strong>");
+      expect(serverResult).toMatch(/https:\/\/example\.com/i);
+      expect(clientResult).toMatch(/https:\/\/example\.com/i);
+
+      // Both should sanitize dangerous content
+      const malicious = "<script>alert(1)</script>";
+      const serverSafe = markdownToSafeHTML(malicious);
+      const clientSafe = markdownToSafeHTMLClient(malicious);
+      expect(serverSafe).not.toContain("<script");
+      expect(clientSafe).not.toContain("<script");
+    });
+  });
+});

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -7,8 +7,12 @@ import { md, unescapeMarkdown } from "./markdownIt";
  * Converts markdown to safe HTML with inline styles for email compatibility
  * Uses the centralized markdown-it instance from @calcom/lib/markdownIt
  *
+ * ⚠️ SECURITY: This function sanitizes the output using sanitize-html to prevent XSS attacks.
+ * The underlying markdown-it instance has `html: true` enabled, which would be dangerous
+ * without this sanitization step.
+ *
  * @param markdown - The markdown string to convert
- * @returns Safe HTML string with inline styles
+ * @returns Safe HTML string with inline styles (sanitized to prevent XSS)
  */
 export function markdownToSafeHTML(markdown: string | null | undefined): string {
   if (typeof window !== "undefined") {
@@ -49,11 +53,9 @@ export function markdownToSafeHTML(markdown: string | null | undefined): string 
       "pre",
       "code",
       "hr",
-      "input",
     ],
     allowedAttributes: {
       a: ["href", "target", "rel", "style"],
-      input: ["type", "checked", "disabled", "style"],
       // Allow style attribute on specific tags that need inline styles
       p: ["style"],
       h1: ["style"],
@@ -63,7 +65,7 @@ export function markdownToSafeHTML(markdown: string | null | undefined): string 
       h5: ["style"],
       h6: ["style"],
       ul: ["style"],
-      ol: ["style"],
+      ol: ["style", "start"],
       li: ["style", "value"],
       blockquote: ["style"],
       pre: ["style"],

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -6,25 +6,30 @@ import sanitizeHtml from "sanitize-html";
 function processInlineFormatting(text: string): string {
   if (!text) return "";
 
-  // Escape HTML entities FIRST to prevent XSS in content
-  let processed = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  let processed = text;
 
-  // Process inline code FIRST (to protect content inside)
+  // Step 1: Process inline code FIRST (to protect content inside)
   const codeBlocks: string[] = [];
   processed = processed.replace(/`([^`]+)`/g, (match, code) => {
     const placeholder = `___CODE_${codeBlocks.length}___`;
-    // Escape HTML inside code
+    // Escape HTML inside the raw code content
     const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     codeBlocks.push(`<code>${escapedCode}</code>`);
     return placeholder;
   });
 
+  // Step 2: Escape the rest of the HTML entities to prevent XSS
+  processed = processed
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
   // Links [text](url) - process before bold/italic
   processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
-    // Unescape the URL and link text
-    const cleanUrl = url.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
-    const cleanText = linkText.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
-    return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer">${cleanText}</a>`;
+    // The linkText and url are already escaped from the previous step.
+    // We don't un-escape them, to avoid re-introducing vulnerabilities.
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
   });
 
   // Bold (**text**)
@@ -39,7 +44,7 @@ function processInlineFormatting(text: string): string {
   // Strikethrough (~~text~~)
   processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
 
-  // Restore code blocks
+  // Step 3: Restore code blocks
   codeBlocks.forEach((code, i) => {
     processed = processed.replace(`___CODE_${i}___`, code);
   });

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -142,7 +142,14 @@ function parseMarkdown(markdown: string | null): string {
 
     // Headers, HR, Blockquotes are not indented
     if (indent === 0) {
-      closeList(-1);
+      // Check if this is a list item before closing lists
+      const isListItem =
+        /^[-*•]\s+\[([ xX])\]\s+/.test(trimmed) || /^[-*•]\s+/.test(trimmed) || /^\d+\.\s+/.test(trimmed);
+
+      if (!isListItem) {
+        closeList(-1);
+      }
+
       if (trimmed === "") {
         result.push("");
         continue;

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -1,37 +1,312 @@
+import type { Attributes } from "sanitize-html";
 import sanitizeHtml from "sanitize-html";
 
-import { md } from "@calcom/lib/markdownIt";
+// --- HELPER FUNCTION ---
+// We only need one copy of this function, as it's identical for both client and server.
+function processInlineFormatting(text: string): string {
+  if (!text) return "";
 
-if (typeof window !== "undefined") {
-  // This file imports markdown parser which is a costly dependency, so we want to make sure it's not imported on the client side.
-  // It is still imported at some places on client in non-booker pages, we can gradually remove it from there and then convert it into an error
-  console.warn("`markdownToSafeHTML` should not be imported on the client side.");
+  // Escape HTML entities FIRST to prevent XSS in content
+  let processed = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  // Process inline code FIRST (to protect content inside)
+  const codeBlocks: string[] = [];
+  processed = processed.replace(/`([^`]+)`/g, (match, code) => {
+    const placeholder = `___CODE_${codeBlocks.length}___`;
+    // Escape HTML inside code
+    const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    codeBlocks.push(`<code>${escapedCode}</code>`);
+    return placeholder;
+  });
+
+  // Links [text](url) - process before bold/italic
+  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
+    // Unescape the URL and link text
+    const cleanUrl = url.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    const cleanText = linkText.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer">${cleanText}</a>`;
+  });
+
+  // Bold (**text**)
+  processed = processed.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Italic (__text__)
+  processed = processed.replace(/__(.+?)__/g, "<em>$1</em>");
+
+  // Italic (*text* or _text_) - must be careful not to conflict with bold
+  processed = processed.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
+  processed = processed.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "<em>$1</em>");
+
+  // Strikethrough (~~text~~)
+  processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
+
+  // Restore code blocks
+  codeBlocks.forEach((code, i) => {
+    processed = processed.replace(`___CODE_${i}___`, code);
+  });
+
+  return processed;
 }
 
+// --- SHARED STYLING ---
+// Define styles in one place
+const STYLES = {
+  text: "color: #101010; font-weight: 400; line-height: 24px; margin: 8px 0;",
+  list: "list-style-position: inside; margin-left: 12px; margin-bottom: 4px; color: #101010; line-height: 24px;",
+  listItem: "color: #101010; font-weight: 400; line-height: 24px; margin: 4px 0;",
+  header: "color: #101010; font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
+  h1: "font-size: 2em;",
+  h2: "font-size: 1.5em;",
+  h3: "font-size: 1.25em;",
+  h4: "font-size: 1.1em;",
+  h5: "font-size: 1em;",
+  h6: "font-size: 0.9em;",
+};
+
+// --- SHARED PARSER ---
+// The core logic that converts markdown string to raw HTML string.
+function parseMarkdown(markdown: string | null): string {
+  if (!markdown || typeof markdown !== "string") return "";
+
+  // Handle <br> tags - convert to newlines FIRST
+  markdown = markdown.replace(/<br\s*\/?>/gi, "\n");
+
+  // Remove escape backslashes. This is for legacy data, but be aware:
+  // this means users *cannot* escape markdown (e.g., "\# header" will become a header).
+  // For a more robust parser, escaping should be handled line-by-line.
+  markdown = markdown
+    .replace(/\\#/g, "#")
+    .replace(/\\\*/g, "*")
+    .replace(/\\_/g, "_")
+    .replace(/\\`/g, "`")
+    .replace(/\\\[/g, "[")
+    .replace(/\\\]/g, "]")
+    .replace(/\\\(/g, "(")
+    .replace(/\\\)/g, ")")
+    .replace(/\\-/g, "-")
+    .replace(/\\~/g, "~")
+    .replace(/\\>/g, ">")
+    .replace(/\\\./g, ".");
+
+  const lines = markdown.split("\n");
+  const result: string[] = [];
+  let inCodeBlock = false;
+  let codeBlockLines: string[] = [];
+  let currentListItems: string[] = [];
+  let currentListType: "ul" | "ol" | "task" | null = null;
+
+  function closeList() {
+    if (currentListItems.length > 0 && currentListType) {
+      const tag = currentListType === "ol" ? "ol" : "ul";
+      result.push(`<${tag}>${currentListItems.join("")}</${tag}>`);
+      currentListItems = [];
+      currentListType = null;
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Code blocks
+    if (trimmed.startsWith("```")) {
+      if (inCodeBlock) {
+        // End code block
+        const code = codeBlockLines.join("\n");
+        // Escape HTML entities inside the code block
+        const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        result.push(`<pre><code>${escaped}</code></pre>`);
+        codeBlockLines = [];
+        inCodeBlock = false;
+      } else {
+        // Start code block
+        closeList();
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockLines.push(line);
+      continue;
+    }
+
+    // Empty line - close list
+    if (trimmed === "") {
+      closeList();
+      result.push(""); // Add an empty line to preserve spacing, will be handled by sanitizer
+      continue;
+    }
+
+    // Headers (# ## ### etc.)
+    const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)$/) || trimmed.match(/^(#{1,6})$/);
+    if (headerMatch) {
+      closeList();
+      const level = headerMatch[1].length;
+      const content = headerMatch[2] ? processInlineFormatting(headerMatch[2]) : "";
+      result.push(`<h${level}>${content}</h${level}>`);
+      continue;
+    }
+
+    // Horizontal rules
+    if (trimmed === "---" || trimmed === "***" || trimmed === "___") {
+      closeList();
+      result.push("<hr>");
+      continue;
+    }
+
+    // Blockquotes
+    if (trimmed.startsWith("> ")) {
+      closeList();
+      // Handle multi-line blockquotes (simple version)
+      const content = processInlineFormatting(trimmed.substring(2));
+      result.push(`<blockquote>${content}</blockquote>`);
+      continue;
+    }
+
+    // Task lists (- [ ] or - [x])
+    const taskMatch = trimmed.match(/^[-*•]\s+\[([ xX])\]\s+(.+)$/);
+    if (taskMatch) {
+      const checked = taskMatch[1].toLowerCase() === "x";
+      const content = processInlineFormatting(taskMatch[2]);
+      const checkbox = `<input type="checkbox" disabled${checked ? " checked" : ""} />`;
+
+      if (currentListType !== "task") {
+        closeList();
+        currentListType = "task";
+      }
+      currentListItems.push(`<li>${checkbox} ${content}</li>`);
+      continue;
+    }
+
+    // Unordered lists (- or * or •)
+    const ulMatch = trimmed.match(/^[-*•]\s+(.+)$/);
+    if (ulMatch) {
+      const content = processInlineFormatting(ulMatch[1]);
+
+      if (currentListType !== "ul") {
+        closeList();
+        currentListType = "ul";
+      }
+      currentListItems.push(`<li>${content}</li>`);
+      continue;
+    }
+
+    // Ordered lists (1. 2. etc.)
+    // Fixed: Removed the redundant/buggy check for escaped periods.
+    const olMatch = trimmed.match(/^(\d+)\.\s+(.+)$/);
+    if (olMatch) {
+      const content = processInlineFormatting(olMatch[2] || "");
+      const startValue = olMatch[1]; // Capture the number
+
+      if (currentListType !== "ol") {
+        closeList();
+        currentListType = "ol";
+      }
+      // Add the "value" attribute to force the correct number
+      currentListItems.push(`<li value="${startValue}">${content}</li>`);
+      continue;
+    }
+
+    // Regular paragraph
+    closeList();
+    const processed = processInlineFormatting(trimmed);
+    result.push(`<p>${processed}</p>`);
+  }
+
+  // Close any remaining list or code block
+  closeList();
+  if (inCodeBlock && codeBlockLines.length > 0) {
+    const code = codeBlockLines.join("\n");
+    const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    result.push(`<pre><code>${escaped}</code></pre>`);
+  }
+
+  return result.join("\n");
+}
+
+// --- SHARED STYLER ---
+// Applies the inline styles to the raw HTML.
+function applyStyling(html: string): string {
+  return html
+    .replace(/<p>/g, `<p style="${STYLES.text}">`)
+    .replace(/<h1>/g, `<h1 style="${STYLES.header} ${STYLES.h1}">`)
+    .replace(/<h2>/g, `<h2 style="${STYLES.header} ${STYLES.h2}">`)
+    .replace(/<h3>/g, `<h3 style="${STYLES.header} ${STYLES.h3}">`)
+    .replace(/<h4>/g, `<h4 style="${STYLES.header} ${STYLES.h4}">`)
+    .replace(/<h5>/g, `<h5 style="${STYLES.header} ${STYLES.h5}">`)
+    .replace(/<h6>/g, `<h6 style="${STYLES.header} ${STYLES.h6}">`)
+    .replace(/<ul>/g, `<ul style="list-style-type: disc; ${STYLES.list}">`)
+    .replace(/<ol>/g, `<ol style="list-style-type: decimal; ${STYLES.list}">`)
+    .replace(/<li /g, `<li style="${STYLES.listItem}" `)
+    .replace(/<li>/g, `<li style="${STYLES.listItem}">`);
+}
+
+// --- SERVER-SIDE FUNCTION ---
+// Uses `sanitize-html` which is ideal for the backend.
 export function markdownToSafeHTML(markdown: string | null) {
-  if (!markdown) return "";
+  if (typeof window !== "undefined") {
+    console.warn("`markdownToSafeHTML` should not be imported on the client side.");
+  }
 
-  const html = md.render(markdown);
+  const rawHtml = parseMarkdown(markdown);
+  const styledHtml = applyStyling(rawHtml);
 
-  const safeHTML = sanitizeHtml(html);
+  const safeHTML = sanitizeHtml(styledHtml, {
+    allowedTags: [
+      "p",
+      "br",
+      "strong",
+      "em",
+      "b",
+      "i",
+      "u",
+      "s",
+      "strike",
+      "ul",
+      "ol",
+      "li",
+      "a",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "blockquote",
+      "pre",
+      "code",
+      "hr",
+      "input",
+    ],
+    allowedAttributes: {
+      a: ["href", "target", "rel"],
+      input: ["type", "checked", "disabled"],
+      // Allow the style attribute on all tags
+      p: ["style"],
+      h1: ["style"],
+      h2: ["style"],
+      h3: ["style"],
+      h4: ["style"],
+      h5: ["style"],
+      h6: ["style"],
+      ul: ["style"],
+      ol: ["style"],
+      li: ["style", "value"],
+    },
+    allowedSchemes: ["http", "https", "mailto", "tel"],
+    transformTags: {
+      a: (tagName: string, attribs: Attributes) => {
+        return {
+          tagName: "a",
+          attribs: {
+            ...attribs,
+            rel: "noopener noreferrer",
+            target: "_blank",
+          },
+        };
+      },
+    },
+  });
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li>
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return safeHTML;
 }

--- a/packages/lib/markdownToSafeHTML.ts
+++ b/packages/lib/markdownToSafeHTML.ts
@@ -1,300 +1,30 @@
 import type { Attributes } from "sanitize-html";
 import sanitizeHtml from "sanitize-html";
 
-// --- HELPER FUNCTION ---
-// We only need one copy of this function, as it's identical for both client and server.
-function processInlineFormatting(text: string): string {
-  if (!text) return "";
+import { md, unescapeMarkdown } from "./markdownIt";
 
-  let processed = text;
-
-  // Step 1: Process inline code FIRST (to protect content inside)
-  const codeBlocks: string[] = [];
-  processed = processed.replace(/`([^`]+)`/g, (match, code) => {
-    const placeholder = `___CODE_${codeBlocks.length}___`;
-    // Escape HTML inside the raw code content
-    const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    codeBlocks.push(`<code>${escapedCode}</code>`);
-    return placeholder;
-  });
-
-  // Step 2: Escape the rest of the HTML entities to prevent XSS
-  processed = processed
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-
-  // Links [text](url) - process before bold/italic
-  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
-    // The linkText and url are already escaped from the previous step.
-    // We don't un-escape them, to avoid re-introducing vulnerabilities.
-    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
-  });
-
-  // Bold (**text**)
-  processed = processed.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  // Bold (__text__)
-  processed = processed.replace(/__(.+?)__/g, "<strong>$1</strong>");
-
-  // Italic (*text* or _text_) - must be careful not to conflict with bold
-  processed = processed.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
-  processed = processed.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "<em>$1</em>");
-
-  // Strikethrough (~~text~~)
-  processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
-
-  // Step 3: Restore code blocks
-  codeBlocks.forEach((code, i) => {
-    processed = processed.replace(`___CODE_${i}___`, code);
-  });
-
-  return processed;
-}
-
-// --- SHARED STYLING ---
-// Define styles in one place
-const STYLES = {
-  text: "color: #101010; font-weight: 400; line-height: 24px; margin: 8px 0;",
-  list: "list-style-position: inside; margin-left: 12px; margin-bottom: 4px; color: #101010; line-height: 24px;",
-  listItem: "color: #101010; font-weight: 400; line-height: 24px; margin: 4px 0;",
-  header: "color: #101010; font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
-  h1: "font-size: 2em;",
-  h2: "font-size: 1.5em;",
-  h3: "font-size: 1.25em;",
-  h4: "font-size: 1.1em;",
-  h5: "font-size: 1em;",
-  h6: "font-size: 0.9em;",
-};
-
-// --- SHARED PARSER ---
-// The core logic that converts markdown string to raw HTML string.
-function parseMarkdown(markdown: string | null): string {
-  if (!markdown || typeof markdown !== "string") return "";
-
-  // Handle <br> tags - convert to newlines FIRST
-  markdown = markdown.replace(/<br\s*\/?>/gi, "\n");
-
-  // Remove escape backslashes. This is for legacy data, but be aware:
-  // this means users *cannot* escape markdown (e.g., "\# header" will become a header).
-  // For a more robust parser, escaping should be handled line-by-line.
-  markdown = markdown
-    .replace(/\\#/g, "#")
-    .replace(/\\\*/g, "*")
-    .replace(/\\_/g, "_")
-    .replace(/\\`/g, "`")
-    .replace(/\\\[/g, "[")
-    .replace(/\\\]/g, "]")
-    .replace(/\\\(/g, "(")
-    .replace(/\\\)/g, ")")
-    .replace(/\\-/g, "-")
-    .replace(/\\~/g, "~")
-    .replace(/\\>/g, ">")
-    .replace(/\\\./g, ".");
-
-  const lines = markdown.split("\n");
-  const result: string[] = [];
-  let inCodeBlock = false;
-  let codeBlockLines: string[] = [];
-  const listStack: { type: "ul" | "ol" | "task"; indent: number; loose?: boolean }[] = [];
-  let consecutiveBlankLines = 0;
-
-  function getIndent(line: string): number {
-    const match = line.match(/^(\s*)/);
-    return match ? match[1].length : 0;
-  }
-
-  function closeList(indent: number) {
-    while (listStack.length > 0 && indent <= listStack[listStack.length - 1].indent) {
-      const list = listStack.pop();
-      if (list) {
-        const tag = list.type === "ol" ? "ol" : "ul";
-        result.push(`${" ".repeat(list.indent)}</${tag}>`);
-      }
-    }
-  }
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const indent = getIndent(line);
-    const trimmed = line.trim();
-
-    // Code blocks
-    if (trimmed.startsWith("```")) {
-      consecutiveBlankLines = 0;
-      closeList(-1); // Close all lists
-      if (inCodeBlock) {
-        const code = codeBlockLines.join("\n");
-        const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        result.push(`<pre><code>${escaped}</code></pre>`);
-        codeBlockLines = [];
-        inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-      }
-      continue;
-    }
-
-    if (inCodeBlock) {
-      codeBlockLines.push(line);
-      continue;
-    }
-
-    // Headers, HR, Blockquotes are not indented
-    if (indent === 0) {
-      // Check if this is a list item before closing lists
-      const isListItem =
-        /^[-*•]\s+\[([ xX])\]\s+/.test(trimmed) || /^[-*•]\s+/.test(trimmed) || /^\d+\.\s+/.test(trimmed);
-
-      if (!isListItem) {
-        closeList(-1);
-      }
-
-      if (trimmed === "") {
-        result.push("");
-        continue;
-      }
-      const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)$/) || trimmed.match(/^(#{1,6})$/);
-      if (headerMatch) {
-        const level = headerMatch[1].length;
-        const content = headerMatch[2] ? processInlineFormatting(headerMatch[2]) : "";
-        result.push(`<h${level}>${content}</h${level}>`);
-        continue;
-      }
-      if (trimmed === "---" || trimmed === "***" || trimmed === "___") {
-        result.push("<hr>");
-        continue;
-      }
-      if (trimmed.startsWith("> ")) {
-        const content = processInlineFormatting(trimmed.substring(2));
-        result.push(`<blockquote>${content}</blockquote>`);
-        continue;
-      }
-    }
-
-    const taskMatch = trimmed.match(/^[-*•]\s+\[([ xX])\]\s+(.+)$/);
-    const ulMatch = !taskMatch && trimmed.match(/^[-*•]\s+(.+)$/);
-    const olMatch = trimmed.match(/^(\d+)\.\s+(.+)$/);
-
-    if (taskMatch || ulMatch || olMatch) {
-      consecutiveBlankLines = 0;
-      const listType = taskMatch ? "task" : ulMatch ? "ul" : "ol";
-      const currentIndent = listStack.length > 0 ? listStack[listStack.length - 1].indent : -1;
-      const currentType = listStack.length > 0 ? listStack[listStack.length - 1].type : null;
-
-      if (indent > currentIndent) {
-        // Start a new nested list
-        listStack.push({ type: listType, indent });
-        const tag = listType === "ol" ? "ol" : "ul";
-        result.push(`${" ".repeat(indent)}<${tag}>`);
-      } else if (indent < currentIndent) {
-        // Close nested lists
-        closeList(indent);
-        // Check if we need to start a new list of the same type
-        if (listStack.length === 0 || listStack[listStack.length - 1].indent !== indent) {
-          listStack.push({ type: listType, indent });
-          const tag = listType === "ol" ? "ol" : "ul";
-          result.push(`${" ".repeat(indent)}<${tag}>`);
-        }
-      } else if (listType !== currentType) {
-        // Same indent, but different list type
-        closeList(indent);
-        listStack.push({ type: listType, indent });
-        const tag = listType === "ol" ? "ol" : "ul";
-        result.push(`${" ".repeat(indent)}<${tag}>`);
-      }
-
-      let content = "";
-      let startValue = "";
-      if (taskMatch) {
-        const checked = taskMatch[1].toLowerCase() === "x";
-        content = processInlineFormatting(taskMatch[2]);
-        const checkbox = `<input type="checkbox" disabled${checked ? " checked" : ""} />`;
-        content = `${checkbox} ${content}`;
-      } else if (ulMatch) {
-        content = processInlineFormatting(ulMatch[1]);
-      } else if (olMatch) {
-        content = processInlineFormatting(olMatch[2] || "");
-        startValue = olMatch[1];
-      }
-      const isLoose = listStack.length > 0 && listStack[listStack.length - 1].loose;
-      const liTag = startValue ? `<li value="${startValue}">` : `<li>`;
-      result.push(`${" ".repeat(indent + 2)}${liTag}${isLoose ? `<p>${content}</p>` : content}</li>`);
-    } else if (trimmed !== "") {
-      consecutiveBlankLines = 0;
-      closeList(-1);
-      const processed = processInlineFormatting(trimmed);
-      result.push(`<p>${processed}</p>`);
-    } else {
-      consecutiveBlankLines++;
-      if (listStack.length > 0) {
-        if (consecutiveBlankLines === 1) {
-          const currentList = listStack[listStack.length - 1];
-          if (!currentList.loose) {
-            currentList.loose = true;
-            for (let j = result.length - 1; j >= 0; j--) {
-              const res = result[j];
-              const itemIndent = getIndent(res);
-              if (itemIndent > currentList.indent) {
-                if (res.trim().startsWith("<li")) {
-                  result[j] = res.replace(/<li>(.*)<\/li>/, "<li><p>$1</p></li>");
-                }
-              } else if (itemIndent <= currentList.indent) {
-                break;
-              }
-            }
-          }
-          result.push("");
-        } else {
-          closeList(-1);
-          result.push("");
-        }
-      } else {
-        closeList(-1);
-        result.push("");
-      }
-    }
-  }
-
-  // Close any remaining lists or code blocks
-  closeList(-1);
-  if (inCodeBlock && codeBlockLines.length > 0) {
-    const code = codeBlockLines.join("\n");
-    const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    result.push(`<pre><code>${escaped}</code></pre>`);
-  }
-
-  return result.join("\n");
-}
-
-// --- SHARED STYLER ---
-// Applies the inline styles to the raw HTML.
-function applyStyling(html: string): string {
-  return html
-    .replace(/<p>/g, `<p style="${STYLES.text}">`)
-    .replace(/<h1>/g, `<h1 style="${STYLES.header} ${STYLES.h1}">`)
-    .replace(/<h2>/g, `<h2 style="${STYLES.header} ${STYLES.h2}">`)
-    .replace(/<h3>/g, `<h3 style="${STYLES.header} ${STYLES.h3}">`)
-    .replace(/<h4>/g, `<h4 style="${STYLES.header} ${STYLES.h4}">`)
-    .replace(/<h5>/g, `<h5 style="${STYLES.header} ${STYLES.h5}">`)
-    .replace(/<h6>/g, `<h6 style="${STYLES.header} ${STYLES.h6}">`)
-    .replace(/<ul>/g, `<ul style="list-style-type: disc; ${STYLES.list}">`)
-    .replace(/<ol>/g, `<ol style="list-style-type: decimal; ${STYLES.list}">`)
-    .replace(/<li /g, `<li style="${STYLES.listItem}" `)
-    .replace(/<li>/g, `<li style="${STYLES.listItem}">`);
-}
-
-// --- SERVER-SIDE FUNCTION ---
-// Uses `sanitize-html` which is ideal for the backend.
-export function markdownToSafeHTML(markdown: string | null) {
+/**
+ * Converts markdown to safe HTML with inline styles for email compatibility
+ * Uses the centralized markdown-it instance from @calcom/lib/markdownIt
+ *
+ * @param markdown - The markdown string to convert
+ * @returns Safe HTML string with inline styles
+ */
+export function markdownToSafeHTML(markdown: string | null | undefined): string {
   if (typeof window !== "undefined") {
     console.warn("`markdownToSafeHTML` should not be imported on the client side.");
   }
 
-  const rawHtml = parseMarkdown(markdown);
-  const styledHtml = applyStyling(rawHtml);
+  if (!markdown) return "";
 
-  const safeHTML = sanitizeHtml(styledHtml, {
+  // Unescape legacy turndown escapes
+  const unescaped = unescapeMarkdown(markdown);
+
+  // Render markdown to HTML using markdown-it (with inline styles from renderer rules)
+  const rendered = md.render(unescaped);
+
+  // Sanitize the HTML to prevent XSS attacks
+  const safeHTML = sanitizeHtml(rendered, {
     allowedTags: [
       "p",
       "br",
@@ -322,9 +52,9 @@ export function markdownToSafeHTML(markdown: string | null) {
       "input",
     ],
     allowedAttributes: {
-      a: ["href", "target", "rel"],
-      input: ["type", "checked", "disabled"],
-      // Allow the style attribute on all tags
+      a: ["href", "target", "rel", "style"],
+      input: ["type", "checked", "disabled", "style"],
+      // Allow style attribute on specific tags that need inline styles
       p: ["style"],
       h1: ["style"],
       h2: ["style"],
@@ -335,10 +65,13 @@ export function markdownToSafeHTML(markdown: string | null) {
       ul: ["style"],
       ol: ["style"],
       li: ["style", "value"],
+      blockquote: ["style"],
+      pre: ["style"],
+      code: ["style"],
     },
     allowedStyles: {
       "*": {
-        // Allow all styles used in the STYLES object
+        // Allow all styles used in the STYLES object from markdownIt.ts
         color: [/.*/],
         "font-weight": [/.*/],
         "line-height": [/.*/],
@@ -348,6 +81,8 @@ export function markdownToSafeHTML(markdown: string | null) {
         "font-size": [/.*/],
         "list-style-position": [/.*/],
         "list-style-type": [/.*/],
+        padding: [/.*/],
+        "padding-left": [/.*/],
       },
     },
     allowedSchemes: ["http", "https", "mailto", "tel"],

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -6,8 +6,12 @@ import { md, unescapeMarkdown } from "./markdownIt";
  * Converts markdown to safe HTML with inline styles for client-side use
  * Uses the centralized markdown-it instance from @calcom/lib/markdownIt
  *
+ * ⚠️ SECURITY: This function sanitizes the output using DOMPurify to prevent XSS attacks.
+ * The underlying markdown-it instance has `html: true` enabled, which would be dangerous
+ * without this sanitization step.
+ *
  * @param markdown - The markdown string to convert
- * @returns Safe HTML string with inline styles
+ * @returns Safe HTML string with inline styles (sanitized to prevent XSS)
  */
 export function markdownToSafeHTMLClient(markdown: string | null | undefined): string {
   if (typeof window === "undefined") {
@@ -24,13 +28,36 @@ export function markdownToSafeHTMLClient(markdown: string | null | undefined): s
 
   // Sanitize the HTML to prevent XSS attacks using DOMPurify
   // Critical: Use hooks to preserve CSS properties that DOMPurify might filter
-  // DOMPurify filters CSS properties automatically, but we need list-style-type and padding-left
+  // DOMPurify filters CSS properties automatically; preserve allowed styles/attributes
+  const STYLE_ALLOWED_TAGS = new Set([
+    "A",
+    "P",
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "UL",
+    "OL",
+    "LI",
+    "BLOCKQUOTE",
+    "PRE",
+    "CODE",
+  ]);
+
   DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-    // Preserve style attributes on ul, ol, li tags
-    if (
-      data.attrName === "style" &&
-      (node.tagName === "UL" || node.tagName === "OL" || node.tagName === "LI")
-    ) {
+    if (data.attrName === "style" && STYLE_ALLOWED_TAGS.has(node.tagName)) {
+      data.keepAttr = true;
+      return;
+    }
+
+    if (data.attrName === "value" && node.tagName === "LI") {
+      data.keepAttr = true;
+      return;
+    }
+
+    if (data.attrName === "start" && node.tagName === "OL") {
       data.keepAttr = true;
     }
   });
@@ -53,7 +80,6 @@ export function markdownToSafeHTMLClient(markdown: string | null | undefined): s
       "a",
       "code",
       "pre",
-      "input",
       "blockquote",
       "hr",
       "s",
@@ -62,8 +88,8 @@ export function markdownToSafeHTMLClient(markdown: string | null | undefined): s
       "i",
       "u",
     ],
-    ALLOWED_ATTR: ["href", "target", "rel", "type", "checked", "disabled", "style", "value"],
-    ADD_ATTR: ["style"], // Explicitly preserve style attributes
+    ALLOWED_ATTR: ["href", "target", "rel"],
+    ADD_ATTR: ["style", "value", "start"], // Explicitly preserve supported attributes
     KEEP_CONTENT: true,
     // Ensure style attributes are not forbidden
     FORBID_ATTR: [],

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -1,37 +1,292 @@
 import DOMPurify from "dompurify";
 
-import { md } from "@calcom/lib/markdownIt";
+// --- HELPER FUNCTION ---
+// We only need one copy of this function, as it's identical for both client and server.
+function processInlineFormatting(text: string): string {
+  if (!text) return "";
 
-if (typeof window == "undefined") {
-  console.warn(
-    "`markdownToSafeHTMLClient` should not be used on the server side. use markdownToSafeHTML instead"
-  );
+  // Escape HTML entities FIRST to prevent XSS in content
+  let processed = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  // Process inline code FIRST (to protect content inside)
+  const codeBlocks: string[] = [];
+  processed = processed.replace(/`([^`]+)`/g, (match, code) => {
+    const placeholder = `___CODE_${codeBlocks.length}___`;
+    // Escape HTML inside code
+    const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    codeBlocks.push(`<code>${escapedCode}</code>`);
+    return placeholder;
+  });
+
+  // Links [text](url) - process before bold/italic
+  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
+    // Unescape the URL and link text
+    const cleanUrl = url.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    const cleanText = linkText.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+    return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer">${cleanText}</a>`;
+  });
+
+  // Bold (**text**)
+  processed = processed.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Italic (__text__)
+  processed = processed.replace(/__(.+?)__/g, "<em>$1</em>");
+
+  // Italic (*text* or _text_) - must be careful not to conflict with bold
+  processed = processed.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
+  processed = processed.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "<em>$1</em>");
+
+  // Strikethrough (~~text~~)
+  processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
+
+  // Restore code blocks
+  codeBlocks.forEach((code, i) => {
+    processed = processed.replace(`___CODE_${i}___`, code);
+  });
+
+  return processed;
 }
 
+// --- SHARED STYLING ---
+// Define styles in one place
+const STYLES = {
+  text: "color: #101010; font-weight: 400; line-height: 24px; margin: 8px 0;",
+  list: "list-style-position: inside; margin-left: 12px; margin-bottom: 4px; color: #101010; line-height: 24px;",
+  listItem: "color: #101010; font-weight: 400; line-height: 24px; margin: 4px 0;",
+  header: "color: #101010; font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
+  h1: "font-size: 2em;",
+  h2: "font-size: 1.5em;",
+  h3: "font-size: 1.25em;",
+  h4: "font-size: 1.1em;",
+  h5: "font-size: 1em;",
+  h6: "font-size: 0.9em;",
+};
+
+// --- SHARED PARSER ---
+// The core logic that converts markdown string to raw HTML string.
+function parseMarkdown(markdown: string | null): string {
+  if (!markdown || typeof markdown !== "string") return "";
+
+  // Handle <br> tags - convert to newlines FIRST
+  markdown = markdown.replace(/<br\s*\/?>/gi, "\n");
+
+  // Remove escape backslashes. This is for legacy data, but be aware:
+  // this means users *cannot* escape markdown (e.g., "\# header" will become a header).
+  // For a more robust parser, escaping should be handled line-by-line.
+  markdown = markdown
+    .replace(/\\#/g, "#")
+    .replace(/\\\*/g, "*")
+    .replace(/\\_/g, "_")
+    .replace(/\\`/g, "`")
+    .replace(/\\\[/g, "[")
+    .replace(/\\\]/g, "]")
+    .replace(/\\\(/g, "(")
+    .replace(/\\\)/g, ")")
+    .replace(/\\-/g, "-")
+    .replace(/\\~/g, "~")
+    .replace(/\\>/g, ">")
+    .replace(/\\\./g, ".");
+
+  const lines = markdown.split("\n");
+  const result: string[] = [];
+  let inCodeBlock = false;
+  let codeBlockLines: string[] = [];
+  let currentListItems: string[] = [];
+  let currentListType: "ul" | "ol" | "task" | null = null;
+
+  function closeList() {
+    if (currentListItems.length > 0 && currentListType) {
+      const tag = currentListType === "ol" ? "ol" : "ul";
+      result.push(`<${tag}>${currentListItems.join("")}</${tag}>`);
+      currentListItems = [];
+      currentListType = null;
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Code blocks
+    if (trimmed.startsWith("```")) {
+      if (inCodeBlock) {
+        // End code block
+        const code = codeBlockLines.join("\n");
+        // Escape HTML entities inside the code block
+        const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        result.push(`<pre><code>${escaped}</code></pre>`);
+        codeBlockLines = [];
+        inCodeBlock = false;
+      } else {
+        // Start code block
+        closeList();
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockLines.push(line);
+      continue;
+    }
+
+    // Empty line - close list
+    if (trimmed === "") {
+      closeList();
+      result.push(""); // Add an empty line to preserve spacing, will be handled by sanitizer
+      continue;
+    }
+
+    // Headers (# ## ### etc.)
+    const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)$/) || trimmed.match(/^(#{1,6})$/);
+    if (headerMatch) {
+      closeList();
+      const level = headerMatch[1].length;
+      const content = headerMatch[2] ? processInlineFormatting(headerMatch[2]) : "";
+      result.push(`<h${level}>${content}</h${level}>`);
+      continue;
+    }
+
+    // Horizontal rules
+    if (trimmed === "---" || trimmed === "***" || trimmed === "___") {
+      closeList();
+      result.push("<hr>");
+      continue;
+    }
+
+    // Blockquotes
+    if (trimmed.startsWith("> ")) {
+      closeList();
+      // Handle multi-line blockquotes (simple version)
+      const content = processInlineFormatting(trimmed.substring(2));
+      result.push(`<blockquote>${content}</blockquote>`);
+      continue;
+    }
+
+    // Task lists (- [ ] or - [x])
+    const taskMatch = trimmed.match(/^[-*•]\s+\[([ xX])\]\s+(.+)$/);
+    if (taskMatch) {
+      const checked = taskMatch[1].toLowerCase() === "x";
+      const content = processInlineFormatting(taskMatch[2]);
+      const checkbox = `<input type="checkbox" disabled${checked ? " checked" : ""}>`;
+
+      if (currentListType !== "task") {
+        closeList();
+        currentListType = "task";
+      }
+      currentListItems.push(`<li>${checkbox} ${content}</li>`);
+      continue;
+    }
+
+    // Unordered lists (- or * or •)
+    const ulMatch = trimmed.match(/^[-*•]\s+(.+)$/);
+    if (ulMatch) {
+      const content = processInlineFormatting(ulMatch[1]);
+
+      if (currentListType !== "ul") {
+        closeList();
+        currentListType = "ul";
+      }
+      currentListItems.push(`<li>${content}</li>`);
+      continue;
+    }
+
+    // Ordered lists (1. 2. etc.)
+    // Fixed: Removed the redundant/buggy check for escaped periods.
+    const olMatch = trimmed.match(/^(\d+)\.\s+(.+)$/);
+    if (olMatch) {
+      const content = processInlineFormatting(olMatch[2] || "");
+      const startValue = olMatch[1]; // Capture the number
+
+      if (currentListType !== "ol") {
+        closeList();
+        currentListType = "ol";
+      }
+      // Add the "value" attribute to force the correct number
+      currentListItems.push(`<li value="${startValue}">${content}</li>`);
+      continue;
+    }
+
+    // Regular paragraph
+    closeList();
+    const processed = processInlineFormatting(trimmed);
+    result.push(`<p>${processed}</p>`);
+  }
+
+  // Close any remaining list or code block
+  closeList();
+  if (inCodeBlock && codeBlockLines.length > 0) {
+    const code = codeBlockLines.join("\n");
+    const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    result.push(`<pre><code>${escaped}</code></pre>`);
+  }
+
+  return result.join("\n");
+}
+
+// --- SHARED STYLER ---
+// Applies the inline styles to the raw HTML.
+function applyStyling(html: string): string {
+  return html
+    .replace(/<p>/g, `<p style="${STYLES.text}">`)
+    .replace(/<h1>/g, `<h1 style="${STYLES.header} ${STYLES.h1}">`)
+    .replace(/<h2>/g, `<h2 style="${STYLES.header} ${STYLES.h2}">`)
+    .replace(/<h3>/g, `<h3 style="${STYLES.header} ${STYLES.h3}">`)
+    .replace(/<h4>/g, `<h4 style="${STYLES.header} ${STYLES.h4}">`)
+    .replace(/<h5>/g, `<h5 style="${STYLES.header} ${STYLES.h5}">`)
+    .replace(/<h6>/g, `<h6 style="${STYLES.header} ${STYLES.h6}">`)
+    .replace(/<ul>/g, `<ul style="list-style-type: disc; ${STYLES.list}">`)
+    .replace(/<ol>/g, `<ol style="list-style-type: decimal; ${STYLES.list}">`)
+    .replace(/<li /g, `<li style="${STYLES.listItem}" `)
+    .replace(/<li>/g, `<li style="${STYLES.listItem}">`);
+}
+
+// --- CLIENT-SIDE FUNCTION ---
+// Uses `DOMPurify` which is ideal for the frontend.
 export function markdownToSafeHTMLClient(markdown: string | null) {
-  if (!markdown) return "";
+  if (typeof window == "undefined") {
+    console.warn("`markdownToSafeHTMLClient` should not be used on the server side.");
+  }
 
-  const html = md.render(markdown);
+  const rawHtml = parseMarkdown(markdown);
+  const styledHtml = applyStyling(rawHtml);
 
-  const safeHTML = DOMPurify.sanitize(html);
+  // **THE FIX**: Configure DOMPurify to allow the `style` attribute.
+  const safeHTML = DOMPurify.sanitize(styledHtml, {
+    ALLOWED_TAGS: [
+      "p",
+      "br",
+      "strong",
+      "em",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "ul",
+      "ol",
+      "li",
+      "a",
+      "code",
+      "pre",
+      "input",
+      "blockquote",
+      "hr",
+      "s",
+      "strike",
+    ],
+    ALLOWED_ATTR: [
+      "href",
+      "target",
+      "rel",
+      "type",
+      "checked",
+      "disabled",
+      "style", // <-- THIS IS THE CRITICAL FIX
+      "value",
+    ],
+    KEEP_CONTENT: true,
+  });
 
-  let safeHTMLWithListFormatting = safeHTML
-    .replace(
-      /<ul>/g,
-      "<ul style='list-style-type: disc; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(
-      /<ol>/g,
-      "<ol style='list-style-type: decimal; list-style-position: inside; margin-left: 12px; margin-bottom: 4px'>"
-    )
-    .replace(/<a\s+href=/g, "<a target='_blank' class='text-blue-500 hover:text-blue-600' href=");
-
-  // Match: <li>Some text </li><li><ul>...</ul></li> or
-  // Convert to: <li>Some text <ul>...</ul></li>
-  safeHTMLWithListFormatting = safeHTMLWithListFormatting.replace(
-    /<li>([^<]+|<strong>.*?<\/strong>)<\/li>\s*<li>\s*<ul([^>]*)>([\s\S]*?)<\/ul>\s*<\/li>/g,
-    "<li>$1<ul$2>$3</ul></li>"
-  );
-
-  return safeHTMLWithListFormatting;
+  return safeHTML;
 }

--- a/packages/lib/markdownToSafeHTMLClient.ts
+++ b/packages/lib/markdownToSafeHTMLClient.ts
@@ -1,262 +1,41 @@
 import DOMPurify from "dompurify";
 
-// --- HELPER FUNCTION ---
-// We only need one copy of this function, as it's identical for both client and server.
-function processInlineFormatting(text: string): string {
-  if (!text) return "";
+import { md, unescapeMarkdown } from "./markdownIt";
 
-  let processed = text;
-
-  // Step 1: Process inline code FIRST (to protect content inside)
-  const codeBlocks: string[] = [];
-  processed = processed.replace(/`([^`]+)`/g, (match, code) => {
-    const placeholder = `___CODE_${codeBlocks.length}___`;
-    // Escape HTML inside the raw code content
-    const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    codeBlocks.push(`<code>${escapedCode}</code>`);
-    return placeholder;
-  });
-
-  // Step 2: Escape the rest of the HTML entities to prevent XSS
-  processed = processed
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-
-  // Links [text](url) - process before bold/italic
-  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
-    // The linkText and url are already escaped from the previous step.
-    // We don't un-escape them, to avoid re-introducing vulnerabilities.
-    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
-  });
-
-  // Bold (**text**)
-  processed = processed.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  // Italic (__text__)
-  processed = processed.replace(/__(.+?)__/g, "<em>$1</em>");
-
-  // Italic (*text* or _text_) - must be careful not to conflict with bold
-  processed = processed.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
-  processed = processed.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "<em>$1</em>");
-
-  // Strikethrough (~~text~~)
-  processed = processed.replace(/~~(.+?)~~/g, "<s>$1</s>");
-
-  // Step 3: Restore code blocks
-  codeBlocks.forEach((code, i) => {
-    processed = processed.replace(`___CODE_${i}___`, code);
-  });
-
-  return processed;
-}
-
-// --- SHARED STYLING ---
-// Define styles in one place
-const STYLES = {
-  text: "color: #101010; font-weight: 400; line-height: 24px; margin: 8px 0;",
-  list: "list-style-position: inside; margin-left: 12px; margin-bottom: 4px; color: #101010; line-height: 24px;",
-  listItem: "color: #101010; font-weight: 400; line-height: 24px; margin: 4px 0;",
-  header: "color: #101010; font-weight: 600; line-height: 1.4; margin: 16px 0 8px 0;",
-  h1: "font-size: 2em;",
-  h2: "font-size: 1.5em;",
-  h3: "font-size: 1.25em;",
-  h4: "font-size: 1.1em;",
-  h5: "font-size: 1em;",
-  h6: "font-size: 0.9em;",
-};
-
-// --- SHARED PARSER ---
-// The core logic that converts markdown string to raw HTML string.
-function parseMarkdown(markdown: string | null): string {
-  if (!markdown || typeof markdown !== "string") return "";
-
-  // Handle <br> tags - convert to newlines FIRST
-  markdown = markdown.replace(/<br\s*\/?>/gi, "\n");
-
-  // Remove escape backslashes. This is for legacy data, but be aware:
-  // this means users *cannot* escape markdown (e.g., "\# header" will become a header).
-  // For a more robust parser, escaping should be handled line-by-line.
-  markdown = markdown
-    .replace(/\\#/g, "#")
-    .replace(/\\\*/g, "*")
-    .replace(/\\_/g, "_")
-    .replace(/\\`/g, "`")
-    .replace(/\\\[/g, "[")
-    .replace(/\\\]/g, "]")
-    .replace(/\\\(/g, "(")
-    .replace(/\\\)/g, ")")
-    .replace(/\\-/g, "-")
-    .replace(/\\~/g, "~")
-    .replace(/\\>/g, ">")
-    .replace(/\\\./g, ".");
-
-  const lines = markdown.split("\n");
-  const result: string[] = [];
-  let inCodeBlock = false;
-  let codeBlockLines: string[] = [];
-  let currentListItems: string[] = [];
-  let currentListType: "ul" | "ol" | "task" | null = null;
-
-  function closeList() {
-    if (currentListItems.length > 0 && currentListType) {
-      const tag = currentListType === "ol" ? "ol" : "ul";
-      result.push(`<${tag}>${currentListItems.join("")}</${tag}>`);
-      currentListItems = [];
-      currentListType = null;
-    }
-  }
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const trimmed = line.trim();
-
-    // Code blocks
-    if (trimmed.startsWith("```")) {
-      if (inCodeBlock) {
-        // End code block
-        const code = codeBlockLines.join("\n");
-        // Escape HTML entities inside the code block
-        const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        result.push(`<pre><code>${escaped}</code></pre>`);
-        codeBlockLines = [];
-        inCodeBlock = false;
-      } else {
-        // Start code block
-        closeList();
-        inCodeBlock = true;
-      }
-      continue;
-    }
-
-    if (inCodeBlock) {
-      codeBlockLines.push(line);
-      continue;
-    }
-
-    // Empty line - close list
-    if (trimmed === "") {
-      closeList();
-      result.push(""); // Add an empty line to preserve spacing, will be handled by sanitizer
-      continue;
-    }
-
-    // Headers (# ## ### etc.)
-    const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)$/) || trimmed.match(/^(#{1,6})$/);
-    if (headerMatch) {
-      closeList();
-      const level = headerMatch[1].length;
-      const content = headerMatch[2] ? processInlineFormatting(headerMatch[2]) : "";
-      result.push(`<h${level}>${content}</h${level}>`);
-      continue;
-    }
-
-    // Horizontal rules
-    if (trimmed === "---" || trimmed === "***" || trimmed === "___") {
-      closeList();
-      result.push("<hr>");
-      continue;
-    }
-
-    // Blockquotes
-    if (trimmed.startsWith("> ")) {
-      closeList();
-      // Handle multi-line blockquotes (simple version)
-      const content = processInlineFormatting(trimmed.substring(2));
-      result.push(`<blockquote>${content}</blockquote>`);
-      continue;
-    }
-
-    // Task lists (- [ ] or - [x])
-    const taskMatch = trimmed.match(/^[-*•]\s+\[([ xX])\]\s+(.+)$/);
-    if (taskMatch) {
-      const checked = taskMatch[1].toLowerCase() === "x";
-      const content = processInlineFormatting(taskMatch[2]);
-      const checkbox = `<input type="checkbox" disabled${checked ? " checked" : ""}>`;
-
-      if (currentListType !== "task") {
-        closeList();
-        currentListType = "task";
-      }
-      currentListItems.push(`<li>${checkbox} ${content}</li>`);
-      continue;
-    }
-
-    // Unordered lists (- or * or •)
-    const ulMatch = trimmed.match(/^[-*•]\s+(.+)$/);
-    if (ulMatch) {
-      const content = processInlineFormatting(ulMatch[1]);
-
-      if (currentListType !== "ul") {
-        closeList();
-        currentListType = "ul";
-      }
-      currentListItems.push(`<li>${content}</li>`);
-      continue;
-    }
-
-    // Ordered lists (1. 2. etc.)
-    // Fixed: Removed the redundant/buggy check for escaped periods.
-    const olMatch = trimmed.match(/^(\d+)\.\s+(.+)$/);
-    if (olMatch) {
-      const content = processInlineFormatting(olMatch[2] || "");
-      const startValue = olMatch[1]; // Capture the number
-
-      if (currentListType !== "ol") {
-        closeList();
-        currentListType = "ol";
-      }
-      // Add the "value" attribute to force the correct number
-      currentListItems.push(`<li value="${startValue}">${content}</li>`);
-      continue;
-    }
-
-    // Regular paragraph
-    closeList();
-    const processed = processInlineFormatting(trimmed);
-    result.push(`<p>${processed}</p>`);
-  }
-
-  // Close any remaining list or code block
-  closeList();
-  if (inCodeBlock && codeBlockLines.length > 0) {
-    const code = codeBlockLines.join("\n");
-    const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    result.push(`<pre><code>${escaped}</code></pre>`);
-  }
-
-  return result.join("\n");
-}
-
-// --- SHARED STYLER ---
-// Applies the inline styles to the raw HTML.
-function applyStyling(html: string): string {
-  return html
-    .replace(/<p>/g, `<p style="${STYLES.text}">`)
-    .replace(/<h1>/g, `<h1 style="${STYLES.header} ${STYLES.h1}">`)
-    .replace(/<h2>/g, `<h2 style="${STYLES.header} ${STYLES.h2}">`)
-    .replace(/<h3>/g, `<h3 style="${STYLES.header} ${STYLES.h3}">`)
-    .replace(/<h4>/g, `<h4 style="${STYLES.header} ${STYLES.h4}">`)
-    .replace(/<h5>/g, `<h5 style="${STYLES.header} ${STYLES.h5}">`)
-    .replace(/<h6>/g, `<h6 style="${STYLES.header} ${STYLES.h6}">`)
-    .replace(/<ul>/g, `<ul style="list-style-type: disc; ${STYLES.list}">`)
-    .replace(/<ol>/g, `<ol style="list-style-type: decimal; ${STYLES.list}">`)
-    .replace(/<li /g, `<li style="${STYLES.listItem}" `)
-    .replace(/<li>/g, `<li style="${STYLES.listItem}">`);
-}
-
-// --- CLIENT-SIDE FUNCTION ---
-// Uses `DOMPurify` which is ideal for the frontend.
-export function markdownToSafeHTMLClient(markdown: string | null) {
-  if (typeof window == "undefined") {
+/**
+ * Converts markdown to safe HTML with inline styles for client-side use
+ * Uses the centralized markdown-it instance from @calcom/lib/markdownIt
+ *
+ * @param markdown - The markdown string to convert
+ * @returns Safe HTML string with inline styles
+ */
+export function markdownToSafeHTMLClient(markdown: string | null | undefined): string {
+  if (typeof window === "undefined") {
     console.warn("`markdownToSafeHTMLClient` should not be used on the server side.");
   }
 
-  const rawHtml = parseMarkdown(markdown);
-  const styledHtml = applyStyling(rawHtml);
+  if (!markdown) return "";
 
-  // **THE FIX**: Configure DOMPurify to allow the `style` attribute.
-  const safeHTML = DOMPurify.sanitize(styledHtml, {
+  // Unescape legacy turndown escapes
+  const unescaped = unescapeMarkdown(markdown);
+
+  // Render markdown to HTML using markdown-it (with inline styles from renderer rules)
+  const rendered = md.render(unescaped);
+
+  // Sanitize the HTML to prevent XSS attacks using DOMPurify
+  // Critical: Use hooks to preserve CSS properties that DOMPurify might filter
+  // DOMPurify filters CSS properties automatically, but we need list-style-type and padding-left
+  DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+    // Preserve style attributes on ul, ol, li tags
+    if (
+      data.attrName === "style" &&
+      (node.tagName === "UL" || node.tagName === "OL" || node.tagName === "LI")
+    ) {
+      data.keepAttr = true;
+    }
+  });
+
+  const safeHTML = DOMPurify.sanitize(rendered, {
     ALLOWED_TAGS: [
       "p",
       "br",
@@ -279,19 +58,19 @@ export function markdownToSafeHTMLClient(markdown: string | null) {
       "hr",
       "s",
       "strike",
+      "b",
+      "i",
+      "u",
     ],
-    ALLOWED_ATTR: [
-      "href",
-      "target",
-      "rel",
-      "type",
-      "checked",
-      "disabled",
-      "style", // <-- THIS IS THE CRITICAL FIX
-      "value",
-    ],
+    ALLOWED_ATTR: ["href", "target", "rel", "type", "checked", "disabled", "style", "value"],
+    ADD_ATTR: ["style"], // Explicitly preserve style attributes
     KEEP_CONTENT: true,
+    // Ensure style attributes are not forbidden
+    FORBID_ATTR: [],
   });
+
+  // Remove hook after sanitization to avoid affecting other uses
+  DOMPurify.removeHook("uponSanitizeAttribute");
 
   return safeHTML;
 }

--- a/packages/lib/stripMarkdown.ts
+++ b/packages/lib/stripMarkdown.ts
@@ -23,7 +23,7 @@ export function stripMarkdown(
     // Additional cleanup for any remaining markdown artifacts
     stripped = stripped.replace(/\\/g, ""); // Remove escape characters
     stripped = stripped.replace(/[*_~`#>]{1,}/g, " "); // Remove any remaining markdown syntax
-    stripped = stripped.replace(/[[\]()]/g, " "); // Remove brackets from links
+    stripped = stripped.replace(/[[\]]/g, " "); // Remove brackets from links
 
     // Restore newlines
     stripped = stripped
@@ -46,7 +46,7 @@ export function stripMarkdown(
   stripped = stripped
     .replace(/\\/g, "") // Remove escape characters
     .replace(/[*_~`#>]{1,}/g, " ") // Remove markdown syntax
-    .replace(/[[\]()]/g, " ") // Remove brackets
+    .replace(/[[\]]/g, " ") // Remove brackets
     .replace(/\s{2,}/g, " ") // Collapse whitespace
     .replace(/\r\n/g, "\n") // Normalize line endings
     .trim();

--- a/packages/lib/stripMarkdown.ts
+++ b/packages/lib/stripMarkdown.ts
@@ -22,7 +22,17 @@ export function stripMarkdown(
 
     // Additional cleanup for any remaining markdown artifacts
     stripped = stripped.replace(/\\/g, ""); // Remove escape characters
-    stripped = stripped.replace(/[*_~`#>]{1,}/g, " "); // Remove any remaining markdown syntax
+    // Only remove markdown syntax patterns, not all punctuation:
+    // - Headers: # at start of line
+    // - Blockquotes: > at start of line
+    // - Emphasis: * or _ when used as markdown (paired or at word boundaries)
+    stripped = stripped
+      .replace(/^#+\s/gm, "") // Remove header markers at start of line
+      .replace(/^>\s/gm, "") // Remove blockquote markers at start of line
+      .replace(/\*{2,}/g, " ") // Remove bold markers (multiple asterisks)
+      .replace(/_{2,}/g, " ") // Remove bold markers (multiple underscores)
+      .replace(/`+/g, " ") // Remove code markers (backticks)
+      .replace(/~{2,}/g, " "); // Remove strikethrough markers
     stripped = stripped.replace(/[[\]]/g, " "); // Remove brackets from links
 
     // Restore newlines
@@ -43,9 +53,15 @@ export function stripMarkdown(
   let stripped = removeMd(md);
 
   // Clean up any remaining markdown artifacts
+  stripped = stripped.replace(/\\/g, ""); // Remove escape characters
+  // Only remove markdown syntax patterns, not all punctuation:
   stripped = stripped
-    .replace(/\\/g, "") // Remove escape characters
-    .replace(/[*_~`#>]{1,}/g, " ") // Remove markdown syntax
+    .replace(/^#+\s/gm, "") // Remove header markers at start of line
+    .replace(/^>\s/gm, "") // Remove blockquote markers at start of line
+    .replace(/\*{2,}/g, " ") // Remove bold markers (multiple asterisks)
+    .replace(/_{2,}/g, " ") // Remove bold markers (multiple underscores)
+    .replace(/`+/g, " ") // Remove code markers (backticks)
+    .replace(/~{2,}/g, " ") // Remove strikethrough markers
     .replace(/[[\]]/g, " ") // Remove brackets
     .replace(/\s{2,}/g, " ") // Collapse whitespace
     .replace(/\r\n/g, "\n") // Normalize line endings

--- a/packages/lib/stripMarkdown.ts
+++ b/packages/lib/stripMarkdown.ts
@@ -1,5 +1,55 @@
 import removeMd from "remove-markdown";
 
-export function stripMarkdown(md: string) {
-  return removeMd(md);
+export function stripMarkdown(
+  md: string | null | undefined,
+  options?: { preserveNewlines?: boolean }
+): string {
+  if (!md) return "";
+
+  if (options?.preserveNewlines) {
+    // Use highly unique tokens that won't be affected by markdown cleanup
+    const PAR_TOKEN = "XXXCALPARABREAKXXX";
+    const LINE_TOKEN = "XXXCALLINEBREAKXXX";
+
+    // Normalize line endings and preserve structure with tokens
+    const withPlaceholders = md
+      .replace(/\r\n/g, "\n")
+      .replace(/\n{2,}/g, PAR_TOKEN)
+      .replace(/\n/g, LINE_TOKEN);
+
+    // Remove markdown syntax using the library
+    let stripped = removeMd(withPlaceholders);
+
+    // Additional cleanup for any remaining markdown artifacts
+    stripped = stripped.replace(/\\/g, ""); // Remove escape characters
+    stripped = stripped.replace(/[*_~`#>]{1,}/g, ""); // Remove any remaining markdown syntax
+    stripped = stripped.replace(/[[\]()]/g, " "); // Remove brackets from links
+
+    // Restore newlines
+    stripped = stripped
+      .replace(new RegExp(PAR_TOKEN, "g"), "\n\n")
+      .replace(new RegExp(LINE_TOKEN, "g"), "\n");
+
+    // Clean up excessive whitespace
+    stripped = stripped
+      .replace(/[ \t]{2,}/g, " ") // Collapse spaces
+      .replace(/\n{3,}/g, "\n\n") // Limit newlines
+      .trim();
+
+    return stripped;
+  }
+
+  // Without preserving newlines, collapse to single-line readable text
+  let stripped = removeMd(md);
+
+  // Clean up any remaining markdown artifacts
+  stripped = stripped
+    .replace(/\\/g, "") // Remove escape characters
+    .replace(/[*_~`#>]{1,}/g, " ") // Remove markdown syntax
+    .replace(/[[\]()]/g, " ") // Remove brackets
+    .replace(/\s{2,}/g, " ") // Collapse whitespace
+    .replace(/\r\n/g, "\n") // Normalize line endings
+    .trim();
+
+  return stripped;
 }

--- a/packages/lib/stripMarkdown.ts
+++ b/packages/lib/stripMarkdown.ts
@@ -22,7 +22,7 @@ export function stripMarkdown(
 
     // Additional cleanup for any remaining markdown artifacts
     stripped = stripped.replace(/\\/g, ""); // Remove escape characters
-    stripped = stripped.replace(/[*_~`#>]{1,}/g, ""); // Remove any remaining markdown syntax
+    stripped = stripped.replace(/[*_~`#>]{1,}/g, " "); // Remove any remaining markdown syntax
     stripped = stripped.replace(/[[\]()]/g, " "); // Remove brackets from links
 
     // Restore newlines

--- a/packages/lib/turndownService.ts
+++ b/packages/lib/turndownService.ts
@@ -1,6 +1,13 @@
 import TurndownService from "turndown";
 
-const turndownService = new TurndownService();
+const turndownService = new TurndownService({
+  headingStyle: "atx", // Use # for headers
+  hr: "---",
+  bulletListMarker: "-",
+  codeBlockStyle: "fenced",
+  emDelimiter: "_", // Use _ for italic
+  strongDelimiter: "**", // Use ** for bold
+});
 
 function turndown(html: string | TurndownService.Node): string {
   let result = turndownService.turndown(html);
@@ -28,13 +35,6 @@ turndownService.addRule("enter", {
   },
   replacement: function () {
     return "<p><br></p>";
-  },
-});
-
-turndownService.addRule("ignoreEmphasized", {
-  filter: "em",
-  replacement: function (content) {
-    return content;
   },
 });
 


### PR DESCRIPTION
- Fixes #24454 
- Fixes CAL-6573

## What does this PR do?

Fixes markdown rendering on public booking pages and in email notifications. Previously, markdown (headers, lists, bold, italic, links, etc.) was displayed as raw text instead of formatted HTML.

## Technical Changes:

Implemented custom markdown parser in markdownToSafeHTML.ts (server-side) and markdownToSafeHTMLClient.ts (client-side)
Added descriptionAsSafeHTML prop to event type queries (getPublicEvent.ts, getServerSideProps.tsx)
Updated CalEventParser.ts to render markdown in email descriptions using markdownToSafeHTML
Security: removed unsafe un-escaping of URLs, added double-quote escaping, fixed double-escaping in code blocks
Fixed ordered list numbering by using value attribute on list elements
Configured DOMPurify and sanitize-html to allow style attributes for inline CSS (email compatibility)

## Why This Matters:

Users often copy event descriptions from GPT/LLMs, which output markdown. Without rendering, headers, lists, and formatting appear as raw syntax, reducing readability. This fix ensures markdown is properly rendered on booking pages and in emails.

## Visual Demo (For contributors especially)
#### Video Demo (if applicable):

https://github.com/user-attachments/assets/a6cea20d-1c26-4ce2-a879-9e3ab91eb952





- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Environment Setup:
- No special environment variables required

- Ensure dev server is running: yarn dev
- Test Data:
- Create or edit an event type with a description containing:
- Headers: # H1, ## H2, ### H3
- Lists: - item or 1. item
- Bold: **text**
- Italic: *text* or _text_ or __text__
- Links: [text](https://example.com)

### Test Steps:

- Edit event type at /event-types/[id]?tabName=setup
- Add markdown in the description field
- Save and view the public booking page: /[username]/[event-slug]
- Verify markdown renders as formatted HTML
- Create a test booking and check the confirmation email
- Verify markdown renders correctly in the email HTML
- Expected Behavior:
- Markdown syntax is converted to styled HTML
- Headers display with appropriate font sizes
- Lists show proper bullets/numbers
- Links are clickable and open in new tabs
- Bold/italic text is formatted correctly
- No XSS vulnerabilities (malicious scripts are sanitized)

### Security Testing:

- Test with malicious markdown: [click](javascript:alert('xss')) - should be sanitized
- Test with HTML injection attempts - should be escaped

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/25052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
