### PR TITLE
 fix: calendar events not syncing with v2 api bookings

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts
@@ -125,7 +125,7 @@ export class InputBookingsService_2024_08_13 {
         creationSource: CreationSource.API_V2,
       };
     } else {
-      Object.assign(newRequest, { userId });
+      Object.assign(newRequest, { userId, areCalendarEventsEnabled: true });
       newRequest.body = { ...bodyTransformed, noEmail: false, creationSource: CreationSource.API_V2 };
     }
 


### PR DESCRIPTION
Closes https://github.com/calcom/cal.com/issues/25009

### Issue Summary

**API v2 POST /bookings creates ACCEPTED bookings but fails to sync to calendar or send emails - Regression of #16512**

When creating bookings via the Cal.com API v2 (`POST /v2/bookings`), bookings were created successfully with `status: "ACCEPTED"` and appeared on the dashboard, but **did not sync to the connected calendar** (Google/Outlook) and **no confirmation emails were sent**.  
The API response contained an empty `references: []` array, indicating that no calendar event was created.

---

## What does this PR do?

- Fixes #25009  
- Fixes CAL-XXXX (Linear issue reference)

**Summary of changes:**
- Added the missing `areCalendarEventsEnabled: true` flag when creating new requests from the API.  
- This ensures both calendar sync and email notifications are triggered properly for bookings created via API v2.

**Files changed:**
- `apps/api/v2/src/ee/bookings/2024-08-13/services/input.service.ts`  
  - **1 addition, 1 deletion**

```diff
- Object.assign(newRequest, { userId });
+ Object.assign(newRequest, { userId, areCalendarEventsEnabled: true });
```

---

## Visual Demo

**Before:**  
- Booking created via API appears in dashboard but not on connected calendar.  
- No confirmation email sent.

**After:**  
- Booking appears in both dashboard and connected calendar.  
- Confirmation email is sent to attendee and host.

---

## Mandatory Tasks

- [x] I have self-reviewed the code.  
- [x] N/A (no documentation changes needed).  
- [x] Verified fix manually via API and connected Google Calendar.

---

## How should this be tested?

1. Connect a Google Calendar integration.  
2. Send a `POST /v2/bookings` request with a valid booking payload.  
3. Verify:
   - Booking status: `ACCEPTED`
   - Calendar event is created in Google Calendar
   - Confirmation emails are sent to both host and attendee
   - API response contains non-empty `references`

**Expected:**  
Calendar sync and email notifications now function correctly for API v2 bookings.

---