### PR TITLE
chore: Docker builds access tokens

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -34,7 +34,7 @@ jobs:
           platform-suffix: ""
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}
@@ -80,7 +80,7 @@ jobs:
           platform-suffix: "-arm"
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the Docker release workflow to use GH_ACCESS_TOKEN instead of GITHUB_TOKEN for GitHub access during builds. This avoids permission and rate-limit issues from the default token.

- **Migration**
  - Ensure a GH_ACCESS_TOKEN secret (PAT) is configured in GitHub with the scopes needed by the release-docker workflow.

<sup>Written for commit f400bdd4d3219ff5976bf17946e5a3f83701f13b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

