### PR TITLE
chore: Rate limit top level of public booking pages

### DIFF
--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -2,6 +2,8 @@ import type { GetServerSidePropsContext } from "next";
 import z from "zod";
 
 import { getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 
@@ -16,6 +18,12 @@ const paramsSchema = z.object({
 });
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const requestorIp = getIP(context.req);
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: `[orgSlug]/[user]/[type]-${piiHasher.hash(requestorIp)}`,
+  });
+
   const { user: teamOrUserSlugOrDynamicGroup, orgSlug, type } = paramsSchema.parse(ctx.params);
   const team = await prisma.team.findFirst({
     where: {

--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -19,7 +19,7 @@ const paramsSchema = z.object({
 });
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const requestorIp = getIP(ctx.req as Request);
+  const requestorIp = getIP(ctx.req as unknown as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[orgSlug]/[user]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -19,7 +19,7 @@ const paramsSchema = z.object({
 });
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req);
+  const requestorIp = getIP(ctx.req);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[orgSlug]/[user]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -19,7 +19,7 @@ const paramsSchema = z.object({
 });
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const requestorIp = getIP(ctx.req);
+  const requestorIp = getIP(ctx.req as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[orgSlug]/[user]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -3,6 +3,7 @@ import z from "zod";
 
 import { getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import getIP from "@calcom/lib/getIP";
 import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -9,7 +9,9 @@ import { getOrganizationSEOSettings } from "@calcom/features/ee/organizations/li
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { getBrandingForEventType } from "@calcom/features/profile/lib/getBranding";
 import { shouldHideBrandingForTeamEvent } from "@calcom/features/profile/lib/hideBranding";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import type { User } from "@calcom/prisma/client";
@@ -28,6 +30,11 @@ function hasApiV2RouteInEnv() {
 }
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const requestorIp = getIP(context.req);
+  await checkRateLimitAndThrowError({
+    rateLimitingType: "core",
+    identifier: `team/[slug]/[type]-${piiHasher.hash(requestorIp)}`,
+  });
   const { req, params, query } = context;
   const session = await getServerSession({ req });
   const { slug: teamSlug, type: meetingSlug } = paramsSchema.parse(params);

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -11,6 +11,7 @@ import { getBrandingForEventType } from "@calcom/features/profile/lib/getBrandin
 import { shouldHideBrandingForTeamEvent } from "@calcom/features/profile/lib/hideBranding";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
+import getIP from "@calcom/lib/getIP";
 import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -31,7 +31,7 @@ function hasApiV2RouteInEnv() {
 }
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req);
+  const requestorIp = getIP(context.req as unknown as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `team/[slug]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -318,7 +318,7 @@ const paramsSchema = z.object({
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req);
+  const requestorIp = getIP(context.req as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[user]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -11,12 +11,12 @@ import type { getPublicEvent } from "@calcom/features/eventtypes/lib/getPublicEv
 import { EventRepository } from "@calcom/features/eventtypes/repositories/EventRepository";
 import { shouldHideBrandingForUserEvent } from "@calcom/features/profile/lib/hideBranding";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+import getIP from "@calcom/lib/getIP";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import { BookingStatus, RedirectType } from "@calcom/prisma/enums";
-import getIP from "@calcom/lib/getIP";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";
 
@@ -318,7 +318,6 @@ const paramsSchema = z.object({
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  // handle IP based rate limiting
   const requestorIp = getIP(context.req);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -318,7 +318,7 @@ const paramsSchema = z.object({
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req as Request);
+  const requestorIp = getIP(context.req as unknown as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[user]/[type]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -322,7 +322,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const requestorIp = getIP(context.req);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
-    identifier: piiHasher.hash(requestorIp),
+    identifier: `[user]/[type]-${piiHasher.hash(requestorIp)}`,
   });
 
   const { user } = paramsSchema.parse(context.params);

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -83,7 +83,7 @@ type UserPageProps = {
 
 export const getServerSideProps: GetServerSideProps<UserPageProps> = async (context) => {
   // handle IP based rate limiting
-  const requestorIp = getIP(context.req);
+  const requestorIp = getIP(context.req as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[user]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -83,7 +83,7 @@ type UserPageProps = {
 
 export const getServerSideProps: GetServerSideProps<UserPageProps> = async (context) => {
   // handle IP based rate limiting
-  const requestorIp = getIP(context.req as Request);
+  const requestorIp = getIP(context.req as unknown as Request);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
     identifier: `[user]-${piiHasher.hash(requestorIp)}`,

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -84,7 +84,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
   const requestorIp = getIP(context.req);
   await checkRateLimitAndThrowError({
     rateLimitingType: "core",
-    identifier: piiHasher.hash(requestorIp),
+    identifier: `[user]-${piiHasher.hash(requestorIp)}`,
   });
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
   const usernameList = getUsernameList(context.query.user as string);

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -8,20 +8,22 @@ import { getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { getEventTypesPublic } from "@calcom/features/eventtypes/lib/getEventTypesPublic";
 import { getBrandingForUser } from "@calcom/features/profile/lib/getBranding";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
+import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import getIP from "@calcom/lib/getIP";
 import logger from "@calcom/lib/logger";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { safeStringify } from "@calcom/lib/safeStringify";
+import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { stripMarkdown } from "@calcom/lib/stripMarkdown";
 import { prisma } from "@calcom/prisma";
 import type { EventType, User } from "@calcom/prisma/client";
 import { RedirectType } from "@calcom/prisma/enums";
 import type { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import type { UserProfile } from "@calcom/types/UserProfile";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
+
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 
 const log = logger.getSubLogger({ prefix: ["[[pages/[user]]]"] });
 type UserPageProps = {
@@ -151,8 +153,7 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     theme: branding.theme,
     brandColor: branding.brandColor ?? DEFAULT_LIGHT_BRAND_COLOR,
     avatarUrl: user.avatarUrl,
-    darkBrandColor:
-      branding.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
+    darkBrandColor: branding.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
     allowSEOIndexing: user.allowSEOIndexing ?? true,
     username: user.username,
     organization: user.profile.organization,


### PR DESCRIPTION


















<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add IP-based rate limiting to public booking pages to curb abuse and reduce load. Requests over the limit now fail early during server-side rendering.

- **New Features**
  - Apply rate limiting in getServerSideProps for /[user], /[user]/[type], team/[slug]/[type], and org/[orgSlug]/[user]/[type] using the "core" limiter.
  - Identify requestors by hashed IP (getIP + piiHasher) and prefix limiter keys per route via checkRateLimitAndThrowError.

<sup>Written for commit d8ab8f26a8a077984c1f16c77f4c0706b85f6fa4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















