### PR TITLE
feat: require label for checkbox type booking questions

### DIFF
--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -4,6 +4,7 @@ import type { SubmitHandler, UseFormReturn } from "react-hook-form";
 import { Controller, useFieldArray, useForm, useFormContext } from "react-hook-form";
 import type { z } from "zod";
 import { ZodError } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
@@ -34,6 +35,7 @@ import { showToast } from "@calcom/ui/components/toast";
 import { fieldTypesConfigMap } from "./fieldTypes";
 import { fieldsThatSupportLabelAsSafeHtml } from "./fieldsThatSupportLabelAsSafeHtml";
 import type { fieldsSchema } from "./schema";
+import { fieldEditDialogSchema } from "./schema";
 import { getFieldIdentifier } from "./utils/getFieldIdentifier";
 import { getConfig as getVariantsConfig } from "./utils/variantsConfig";
 
@@ -584,7 +586,7 @@ function FieldEditDialog({
   const isPlatform = useIsPlatform();
   const fieldForm = useForm<RhfFormField>({
     defaultValues: dialog.data || {},
-    //resolver: zodResolver(fieldSchema),
+    resolver: zodResolver(fieldEditDialogSchema),
   });
   const formFieldType = fieldForm.getValues("type");
 
@@ -608,7 +610,6 @@ function FieldEditDialog({
   const variantsConfig = fieldForm.watch("variantsConfig");
 
   const fieldTypes = Object.values(fieldTypesConfigMap);
-  const fieldName = fieldForm.getValues("name");
 
   return (
     <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>


### PR DESCRIPTION
## What does this PR do?

This PR enforces that checkbox type booking questions must have a label before they can be saved. Previously, the UI showed a validation message but still allowed saving checkbox fields without labels, creating invalid booking questions.

**Changes:**
- Added UI validation in the FormBuilder dialog using zod resolver
- Added server-side validation in the event type update mutation
- Both validations prevent saving checkbox fields without labels at UI and API level

**Requested by:** hariom@cal.com (@hariombalhara)
**Devin Session:** https://app.devin.ai/sessions/ce0601e815004dd1af5798b8252361d1

## Visual Demo

### Before:
![Before - checkbox without label can be saved](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_oJuTJ80VM9letuVV/4b13ff0e-8c18-409b-9ac5-948996144ca5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7TP6AJ5PO%2F20251111%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20251111T061932Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEE4aCXVzLWVhc3QtMSJIMEYCIQChFjJfieQOMPIjiWRo1aLBR8dNFhg2gRtYrnHd6kIV%2FQIhAMQrbqMD640LOvsyZJG%2BNzZ4ZThEKBalH4zNUSK2BU8DKrkFCBcQARoMMjcyNTA2NDk4MzAzIgx4CuimZszxI1OGjowqlgUl1AGR8lFUb4mSIEh2PUK1Xt1EnJrvaZBWsGA3d7rKq%2BiRj18M5yBdh5hRmEYcnNh6kruyOksBBdh9F4bur7tNSVFSlA%2B6wuLYextqh3DnWsBX2A%2F2BhBBqUx5rSRemlXU93wh0OJJkSFwusdbQHGjiqDW6NK7ThuAX9f9WBjJUYdPb5%2FZ1ZIEJyHRjW0geSFrmL1lb%2BveEqzOND7qvTCEIClJ0NL3pe91tgJR8SC9Pame25stGkwjBAHuXT7tG9%2BqPvfpWo6ZGt6uKTjUuxAS9Gf2jjSphT1%2FxPSih2bAUAuOVa0YfhtyOxzPbUKu8Sl0rLS7EGD%2Bws%2B0FzGmrY2enO1avCwdwhZfQCJS%2BaGNbnfyitjNJOIcV2XQGQdpy0HKXnkru8KhlMq%2BOeMPjGA4Qb3kyenrJfu6RSoOxI8njdugGrgmtmOWQBgSwMFGOMmlbhuFBWqY3NmKl7xoKK1RXJ1VmwN5egfHYiR8oFr1fDJZucNo6jqLbn6Rp7bBitm6%2Fj%2BvBPpU1F0a6dUzMJBaD90tjyxRlQxNDMc2oBoRcojy%2BIPNncEikaWeCWE0uLVPR4w%2FMIevGZZMdLvQbHRuE88wkS%2FcrJyVVxn5yDzi9dksS1Sy0eEhtC7ZqutZX3UisKQuoEizPsrsADHLfO47XNvEgpY%2BwR5y%2FMZQBfoEfuhre74qj3ZQgfhrnSt235z%2FYOqy6RiAs7AKp2kH6iHnjzJsKOWhl7LBF5HXPVi7aE6uODyaHLbu5fxm8blUES2651ZYnJm11zHtyRtPDYDY8Xj%2Fjbb8fWmoDtnZE2gj5UFz0XV%2BEt1i3L%2B4xq6BrmLDVL%2BqjKw0o4MCvH6DX%2FTXnDLvxshk%2Fhl27wnDyb3qc%2B25kQ38MTDWo8vIBjqVATfMUO872LDFIrfuYJ3DVzEhHyY1XwXalEJ9lZ4AXb5hsYw1uYyKUrYqtRB3mRLWlW9rpOFrdIlE4OuSm%2FPhFKAZpN0Y3pNEsuBnnGqFkwz41kCn%2FPNK2k%2BhMKI5p3JvdbjEAqRjeGvGucW18P1Y%2FRIrlp9RVmjysMrWGrxVzf6DF99C45nnXYm42YExzQ1mrwuayrER&X-Amz-Signature=31d16731fca52cccd4e60d06a0eb73e5568068a91b7adf5f375dd0ac1170fb53)

The "Add a question" dialog shows a validation message "Please fill in this field" but the Save button is still clickable and allows saving without a label.

### After:
With this PR, the form validation will prevent submission when the label is empty for checkbox type fields, and the server will reject any attempts to save checkbox fields without labels even if UI validation is bypassed.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a validation fix, no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note:** No new tests added, but existing validation framework is used.

## How should this be tested?

**Manual Testing:**
1. Navigate to Event Types settings
2. Click on an event type to edit it
3. Go to the "Advanced" tab
4. Click "Add a question"
5. Select "Checkbox" as the input type
6. Try to save without entering a label
7. **Expected:** Form validation should prevent submission with an error message
8. Enter a label and save
9. **Expected:** Field should save successfully

**Edge Cases to Test:**
- Editing existing checkbox fields that might not have labels (should force adding a label)
- System fields with defaultLabel (should not require explicit label)
- Attempting to bypass UI validation via API (should be rejected by server)

## Important Review Points

⚠️ **Please review carefully:**

1. **Backward Compatibility**: Existing checkbox fields without labels can still be read, but editing them will now require adding a label. Is this the intended behavior?

2. **Error Message Internationalization**: The validation error message "Label is required for checkbox fields" is hardcoded in English. Should this use the i18n system instead?

3. **System Fields Logic**: The validation exempts system fields that have a `defaultLabel`. Please verify this logic is correct for all system field scenarios.

4. **Validation Duplication**: The same validation logic exists in both `packages/features/form-builder/schema.ts` and `packages/trpc/server/routers/viewer/eventTypes/types.ts`. This is intentional for defense in depth, but future changes need to update both locations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings (pre-existing lint warning in FormBuilder.tsx is unrelated to these changes)