### PR TITLE
feat: add UI to move standalone teams to organization

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3959,5 +3959,8 @@
   "team_invite": "Team Invite",
   "team_invite_subtitle": "Invite team members to collaborate and schedule together",
   "team_onboarding_details_subtitle": "Add your team's name and create a unique URL for your team",
+  "teams_not_in_organization": "Teams not in organization",
+  "move_team_to_organization": "Move team to organization",
+  "team_moved_to_organization_successfully": "Team successfully moved to organization",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/ee/teams/components/TeamList.tsx
+++ b/packages/features/ee/teams/components/TeamList.tsx
@@ -22,6 +22,10 @@ interface Props {
    * True for teams that are pending invite acceptance
    */
   pending?: boolean;
+  /**
+   * True to show "Move to Organization" action
+   */
+  showMoveToOrg?: boolean;
 }
 
 export default function TeamList(props: Props) {
@@ -121,6 +125,7 @@ export default function TeamList(props: Props) {
           isPending={deleteTeamMutation.isPending}
           hideDropdown={hideDropdown}
           setHideDropdown={setHideDropdown}
+          showMoveToOrg={props.showMoveToOrg}
         />
       ))}
       {/* only show recommended steps when there is only one team */}

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -42,6 +42,7 @@ interface Props {
   isPending?: boolean;
   hideDropdown: boolean;
   setHideDropdown: (value: boolean) => void;
+  showMoveToOrg?: boolean;
 }
 
 export default function TeamListItem(props: Props) {
@@ -70,6 +71,19 @@ export default function TeamListItem(props: Props) {
       if (variables.accept && (isSubTeamOfDifferentOrg || isDifferentOrg)) {
         refreshData();
       }
+    },
+  });
+
+  const moveToOrganizationMutation = trpc.viewer.teams.moveToOrganization.useMutation({
+    onSuccess: () => {
+      showToast(t("team_moved_to_organization_successfully"), "success");
+      utils.viewer.teams.list.invalidate();
+      utils.viewer.teams.listStandalone.invalidate();
+      revalidateTeamsList();
+      refreshData();
+    },
+    onError: (error) => {
+      showToast(error.message, "error");
     },
   });
 
@@ -196,6 +210,21 @@ export default function TeamListItem(props: Props) {
           ) : (
             <div className="flex space-x-2 rtl:space-x-reverse">
               <TeamRole role={team.role} />
+              {props.showMoveToOrg && (
+                <Tooltip content={t("move_team_to_organization")}>
+                  <Button
+                    color="secondary"
+                    onClick={() => {
+                      moveToOrganizationMutation.mutate({
+                        teamId: team.id,
+                      });
+                    }}
+                    loading={moveToOrganizationMutation.isPending}
+                    variant="icon"
+                    StartIcon="arrow-right"
+                  />
+                </Tooltip>
+              )}
               <ButtonGroup combined>
                 {team.slug && (
                   <Tooltip content={t("copy_link_team")}>

--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -22,8 +22,10 @@ type TeamsListingProps = {
   orgId: number | null;
   permissions: {
     canCreateTeam: boolean;
+    canMoveTeams?: boolean;
   };
   teams: RouterOutputs["viewer"]["teams"]["list"];
+  standaloneTeams?: RouterOutputs["viewer"]["teams"]["list"];
   teamNameFromInvite: string | null;
   errorMsgFromInvite: string | null;
 };
@@ -33,6 +35,7 @@ export function TeamsListing({
   orgId,
   permissions,
   teams: data,
+  standaloneTeams = [],
   teamNameFromInvite,
   errorMsgFromInvite,
 }: TeamsListingProps) {
@@ -128,6 +131,13 @@ export function TeamsListing({
       )}
 
       {teams.length > 0 && <TeamList orgId={orgId} teams={teams} />}
+
+      {standaloneTeams.length > 0 && orgId && permissions.canMoveTeams && (
+        <div className="bg-subtle mb-6 rounded-md p-5">
+          <Label className="text-emphasis pb-2  font-semibold">{t("teams_not_in_organization")}</Label>
+          <TeamList orgId={orgId} teams={standaloneTeams} showMoveToOrg />
+        </div>
+      )}
 
       {teams.length === 0 && (
         <UpgradeTip

--- a/packages/features/ee/teams/repositories/TeamRepository.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.ts
@@ -560,24 +560,22 @@ export class TeamRepository {
             logoUrl: true,
             isOrganization: true,
             metadata: true,
+            inviteTokens: true,
+            parent: true,
             parentId: true,
-            _count: {
-              select: {
-                members: true,
-              },
-            },
           },
         },
       },
       orderBy: { role: "desc" },
     });
 
-    return memberships.map(({ team, ...membership }) => ({
+    return memberships.map(({ team: { inviteTokens, ...team }, ...membership }) => ({
       role: membership.role,
       accepted: membership.accepted,
       ...team,
       metadata: teamMetadataSchema.parse(team.metadata),
-      memberCount: team._count.members,
+      /** To prevent breaking we only return non-email attached token here, if we have one */
+      inviteToken: inviteTokens.find((token) => token.identifier === `invite-link-for-teamId-${team.id}`),
     }));
   }
 

--- a/packages/trpc/server/routers/viewer/teams/_router.tsx
+++ b/packages/trpc/server/routers/viewer/teams/_router.tsx
@@ -20,6 +20,8 @@ import { ZInviteMemberByTokenSchemaInputSchema } from "./inviteMemberByToken.sch
 import { ZLegacyListMembersInputSchema } from "./legacyListMembers.schema";
 import { ZGetListSchema } from "./list.schema";
 import { ZListMembersInputSchema } from "./listMembers.schema";
+import { ZListStandaloneSchema } from "./listStandalone.schema";
+import { ZMoveToOrganizationSchema } from "./moveToOrganization.schema";
 import { hasTeamPlan } from "./procedures/hasTeamPlan";
 import { ZPublishInputSchema } from "./publish.schema";
 import { ZRemoveHostsFromEventTypes } from "./removeHostsFromEventTypes.schema";
@@ -33,9 +35,6 @@ import { ZSkipTeamTrialsInputSchema } from "./skipTeamTrials.schema";
 import { ZUpdateInputSchema } from "./update.schema";
 import { ZUpdateInternalNotesPresetsInputSchema } from "./updateInternalNotesPresets.schema";
 import { ZUpdateMembershipInputSchema } from "./updateMembership.schema";
-
-const NAMESPACE = "teams";
-const namespaced = (s: string) => `${NAMESPACE}.${s}`;
 
 export const viewerTeamsRouter = router({
   // Retrieves team by id
@@ -51,6 +50,15 @@ export const viewerTeamsRouter = router({
   // Returns Teams I am a owner/admin of
   listOwnedTeams: authedProcedure.query(async (opts) => {
     const { default: handler } = await import("./list.handler");
+    return handler(opts);
+  }),
+  // Returns standalone teams (not in any organization)
+  listStandalone: authedProcedure.input(ZListStandaloneSchema).query(async (opts) => {
+    const { default: handler } = await import("./listStandalone.handler");
+    return handler(opts);
+  }),
+  moveToOrganization: authedProcedure.input(ZMoveToOrganizationSchema).mutation(async (opts) => {
+    const { default: handler } = await import("./moveToOrganization.handler");
     return handler(opts);
   }),
   create: authedProcedure.input(ZCreateInputSchema).mutation(async (opts) => {

--- a/packages/trpc/server/routers/viewer/teams/listStandalone.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listStandalone.handler.ts
@@ -1,0 +1,20 @@
+import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
+import { prisma } from "@calcom/prisma";
+
+import type { TrpcSessionUser } from "../../../../trpc";
+import type { TListStandaloneSchema } from "./listStandalone.schema";
+
+type ListStandaloneOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TListStandaloneSchema;
+};
+
+export const listStandaloneHandler = async ({ ctx }: ListStandaloneOptions) => {
+  const teamRepo = new TeamRepository(prisma);
+  const teams = await teamRepo.findStandaloneTeamsByUserId({ userId: ctx.user.id });
+  return teams;
+};
+
+export default listStandaloneHandler;

--- a/packages/trpc/server/routers/viewer/teams/listStandalone.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/listStandalone.handler.ts
@@ -1,7 +1,7 @@
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { prisma } from "@calcom/prisma";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 
-import type { TrpcSessionUser } from "../../../../trpc";
 import type { TListStandaloneSchema } from "./listStandalone.schema";
 
 type ListStandaloneOptions = {

--- a/packages/trpc/server/routers/viewer/teams/listStandalone.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/listStandalone.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const ZListStandaloneSchema = z.object({});
+
+export type TListStandaloneSchema = z.infer<typeof ZListStandaloneSchema>;

--- a/packages/trpc/server/routers/viewer/teams/moveToOrganization.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/moveToOrganization.handler.ts
@@ -1,0 +1,139 @@
+import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
+import slugify from "@calcom/lib/slugify";
+import { prisma } from "@calcom/prisma";
+import { CreationSource, MembershipRole } from "@calcom/prisma/enums";
+import { createTeamsHandler } from "@calcom/trpc/server/routers/viewer/organizations/createTeams.handler";
+
+import { TRPCError } from "@trpc/server";
+
+import type { TrpcSessionUser } from "../../../../trpc";
+import type { TMoveToOrganizationSchema } from "./moveToOrganization.schema";
+
+type MoveToOrganizationOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TMoveToOrganizationSchema;
+};
+
+export const moveToOrganizationHandler = async ({ ctx, input }: MoveToOrganizationOptions) => {
+  const { teamId, newSlug } = input;
+  const userId = ctx.user.id;
+
+  const orgId = ctx.user.organizationId || ctx.user.organization?.id;
+
+  if (!orgId) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "You must be part of an organization to move teams",
+    });
+  }
+
+  const orgMembership = await prisma.membership.findFirst({
+    where: {
+      userId,
+      teamId: orgId,
+      accepted: true,
+      role: {
+        in: [MembershipRole.ADMIN, MembershipRole.OWNER],
+      },
+    },
+  });
+
+  if (!orgMembership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You must be an admin or owner of the organization to move teams",
+    });
+  }
+
+  const teamMembership = await prisma.membership.findFirst({
+    where: {
+      userId,
+      teamId,
+      accepted: true,
+      role: {
+        in: [MembershipRole.ADMIN, MembershipRole.OWNER],
+      },
+    },
+  });
+
+  if (!teamMembership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You must be an admin or owner of the team to move it",
+    });
+  }
+
+  const teamRepo = new TeamRepository(prisma);
+  const team = await teamRepo.findById({ id: teamId });
+
+  if (!team) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Team not found",
+    });
+  }
+
+  if (team.parentId !== null) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Team is already part of an organization",
+    });
+  }
+
+  if (team.isOrganization) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Cannot move an organization",
+    });
+  }
+
+  const orgOwnerMembership = await prisma.membership.findFirst({
+    where: {
+      teamId: orgId,
+      accepted: true,
+      role: MembershipRole.OWNER,
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  if (!orgOwnerMembership) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Organization owner not found",
+    });
+  }
+
+  const finalSlug = newSlug ? slugify(newSlug) : team.slug;
+
+  await createTeamsHandler({
+    ctx: {
+      user: {
+        id: orgOwnerMembership.user.id,
+        organizationId: orgId,
+      },
+    },
+    input: {
+      teamNames: [],
+      orgId,
+      moveTeams: [
+        {
+          id: teamId,
+          newSlug: finalSlug,
+          shouldMove: true,
+        },
+      ],
+      creationSource: CreationSource.WEBAPP,
+    },
+  });
+
+  return {
+    success: true,
+    message: "Team successfully moved to organization",
+  };
+};
+
+export default moveToOrganizationHandler;

--- a/packages/trpc/server/routers/viewer/teams/moveToOrganization.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/moveToOrganization.handler.ts
@@ -2,11 +2,11 @@ import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepos
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import { CreationSource, MembershipRole } from "@calcom/prisma/enums";
+import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 import { createTeamsHandler } from "@calcom/trpc/server/routers/viewer/organizations/createTeams.handler";
 
 import { TRPCError } from "@trpc/server";
 
-import type { TrpcSessionUser } from "../../../../trpc";
 import type { TMoveToOrganizationSchema } from "./moveToOrganization.schema";
 
 type MoveToOrganizationOptions = {

--- a/packages/trpc/server/routers/viewer/teams/moveToOrganization.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/moveToOrganization.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ZMoveToOrganizationSchema = z.object({
+  teamId: z.number(),
+  newSlug: z.string().optional(),
+});
+
+export type TMoveToOrganizationSchema = z.infer<typeof ZMoveToOrganizationSchema>;


### PR DESCRIPTION
## What does this PR do?

Adds a UI feature on the `/teams` page that allows organization admins/owners to move standalone teams (teams not part of any organization) into their organization. This replaces the need for admin-only endpoints by giving org admins direct control over team migration.

**Key changes:**
- New tRPC query `viewer.teams.listStandalone` to fetch teams without a parent organization
- New tRPC mutation `viewer.teams.moveToOrganization` to migrate teams to the user's organization
- UI section on `/teams` page showing standalone teams with a "Move to Organization" button
- Reuses existing `createTeamsHandler` logic from organization onboarding flow

**Link to Devin run:** https://app.devin.ai/sessions/e702d18071bf4638a73773fbf587c21a  
**Requested by:** hariom@cal.com (@hariombalhara)

## Visual Demo

The feature adds a new section below the regular teams list that displays teams not in any organization:

```
┌─────────────────────────────────────┐
│ Teams not in organization           │
├─────────────────────────────────────┤
│ Team A    [→]  [Copy] [Settings]   │
│ Team B    [→]  [Copy] [Settings]   │
└─────────────────────────────────────┘
```

This section only appears when:
1. User is an admin/owner of an organization
2. User has teams that aren't part of any organization

## Important Review Points

⚠️ **Security & Permissions:**
- The `moveToOrganization.handler.ts` impersonates the org owner to call `createTeamsHandler` (lines 92-130). Please verify this pattern is secure and appropriate.
- Permission checks use direct Prisma queries instead of `PermissionCheckService` - this may need refactoring for consistency.

⚠️ **Code Quality:**
- The handler uses direct Prisma imports (lines 32-41, 50-59, 92-101) which violates the "No prisma outside repositories" guideline. Consider refactoring to use repository methods or services.

⚠️ **Type Safety:**
- `server-page.tsx` fetches `standaloneTeams` from repository and passes to `TeamsListing` which types it as `RouterOutputs["viewer"]["teams"]["list"]`. The shapes match now, but this coupling could be fragile.

⚠️ **Merge Conflict Fix:**
- Fixed React Hooks rule violation in `BookingDetailsSheet.tsx` (moved `useBookingLocation` hook before early return). This was from the main branch merge and is unrelated to the feature.

## How should this be tested?

**Prerequisites:**
1. Have an organization with admin/owner role
2. Have at least one team that is NOT part of any organization (parentId = null, isOrganization = false)

**Test Steps:**
1. Navigate to `/teams` page as an org admin/owner
2. Verify "Teams not in organization" section appears with standalone teams
3. Click the arrow button (→) on a standalone team
4. Verify success toast appears
5. Verify team now appears in regular teams list (not in standalone section)
6. Verify team's parentId is now set to the organization ID

**Edge Cases to Test:**
- User without org membership should not see the section
- User with org but no standalone teams should not see the section
- Slug collision handling (if team slug already exists in org)
- Permission denied scenarios (non-admin trying to move teams)

**Environment Variables:**
- Standard Cal.com database setup required
- No additional environment variables needed

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a UI feature that doesn't require documentation changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **⚠️ No automated tests added** - Manual testing required.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (with noted exceptions for Prisma usage)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings (lint and type checks pass)

## Known Issues / Follow-ups

1. **Prisma usage**: Handler uses direct Prisma queries instead of repositories - should be refactored to use `PermissionCheckService` for org role checks and repository methods for team admin checks
2. **No automated tests**: Feature needs integration tests for permission checks and team migration logic
3. **Cache invalidation**: Verify cache invalidation strategy is comprehensive across all affected queries