### PR TITLE
revert: "chore: Rate limit top level of public booking pages (#25055)"

### DIFF
--- a/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/org/[orgSlug]/[user]/[type]/getServerSideProps.tsx
@@ -2,9 +2,6 @@ import type { GetServerSidePropsContext } from "next";
 import z from "zod";
 
 import { getSlugOrRequestedSlug } from "@calcom/features/ee/organizations/lib/orgDomains";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
-import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 
@@ -19,12 +16,6 @@ const paramsSchema = z.object({
 });
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const requestorIp = getIP(ctx.req as unknown as Request);
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: `[orgSlug]/[user]/[type]-${piiHasher.hash(requestorIp)}`,
-  });
-
   const { user: teamOrUserSlugOrDynamicGroup, orgSlug, type } = paramsSchema.parse(ctx.params);
   const team = await prisma.team.findFirst({
     where: {

--- a/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/[type]/getServerSideProps.tsx
@@ -9,10 +9,7 @@ import { getOrganizationSEOSettings } from "@calcom/features/ee/organizations/li
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { getBrandingForEventType } from "@calcom/features/profile/lib/getBranding";
 import { shouldHideBrandingForTeamEvent } from "@calcom/features/profile/lib/hideBranding";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
-import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import type { User } from "@calcom/prisma/client";
@@ -31,11 +28,6 @@ function hasApiV2RouteInEnv() {
 }
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req as unknown as Request);
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: `team/[slug]/[type]-${piiHasher.hash(requestorIp)}`,
-  });
   const { req, params, query } = context;
   const session = await getServerSession({ req });
   const { slug: teamSlug, type: meetingSlug } = paramsSchema.parse(params);

--- a/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/[type]/getServerSideProps.ts
@@ -11,9 +11,6 @@ import type { getPublicEvent } from "@calcom/features/eventtypes/lib/getPublicEv
 import { EventRepository } from "@calcom/features/eventtypes/repositories/EventRepository";
 import { shouldHideBrandingForUserEvent } from "@calcom/features/profile/lib/hideBranding";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
-import getIP from "@calcom/lib/getIP";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import slugify from "@calcom/lib/slugify";
 import { prisma } from "@calcom/prisma";
 import { BookingStatus, RedirectType } from "@calcom/prisma/enums";
@@ -66,7 +63,6 @@ async function processReschedule({
     (booking?.eventTypeId === props.eventData?.id &&
       (booking.status !== BookingStatus.CANCELLED ||
         allowRescheduleForCancelledBooking ||
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         !!(props.eventData as any)?.allowReschedulingCancelledBookings))
   ) {
     props.booking = booking;
@@ -318,12 +314,6 @@ const paramsSchema = z.object({
 // Booker page fetches a tiny bit of data server side, to determine early
 // whether the page should show an away state or dynamic booking not allowed.
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const requestorIp = getIP(context.req as unknown as Request);
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: `[user]/[type]-${piiHasher.hash(requestorIp)}`,
-  });
-
   const { user } = paramsSchema.parse(context.params);
   const isDynamicGroup = user.length > 1;
 

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -8,14 +8,11 @@ import { getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { getEventTypesPublic } from "@calcom/features/eventtypes/lib/getEventTypesPublic";
 import { getBrandingForUser } from "@calcom/features/profile/lib/getBranding";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
-import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { DEFAULT_DARK_BRAND_COLOR, DEFAULT_LIGHT_BRAND_COLOR } from "@calcom/lib/constants";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
-import getIP from "@calcom/lib/getIP";
 import logger from "@calcom/lib/logger";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { safeStringify } from "@calcom/lib/safeStringify";
-import { piiHasher } from "@calcom/lib/server/PiiHasher";
 import { stripMarkdown } from "@calcom/lib/stripMarkdown";
 import { prisma } from "@calcom/prisma";
 import type { EventType, User } from "@calcom/prisma/client";
@@ -82,12 +79,6 @@ type UserPageProps = {
 } & EmbedProps;
 
 export const getServerSideProps: GetServerSideProps<UserPageProps> = async (context) => {
-  // handle IP based rate limiting
-  const requestorIp = getIP(context.req as unknown as Request);
-  await checkRateLimitAndThrowError({
-    rateLimitingType: "core",
-    identifier: `[user]-${piiHasher.hash(requestorIp)}`,
-  });
   const { currentOrgDomain, isValidOrgDomain } = orgDomainConfig(context.req, context.params?.orgSlug);
   const usernameList = getUsernameList(context.query.user as string);
   const isARedirectFromNonOrgLink = context.query.orgRedirection === "true";
@@ -153,7 +144,8 @@ export const getServerSideProps: GetServerSideProps<UserPageProps> = async (cont
     theme: branding.theme,
     brandColor: branding.brandColor ?? DEFAULT_LIGHT_BRAND_COLOR,
     avatarUrl: user.avatarUrl,
-    darkBrandColor: branding.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
+    darkBrandColor:
+      branding.darkBrandColor ?? DEFAULT_DARK_BRAND_COLOR,
     allowSEOIndexing: user.allowSEOIndexing ?? true,
     username: user.username,
     organization: user.profile.organization,


### PR DESCRIPTION
This reverts commit e239b6717131b019212f7e50ae5ec9d0c051ba83.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts IP-based rate limiting on public booking pages to restore normal access and prevent unexpected 429s for legitimate visitors.

- **Bug Fixes**
  - Removed rate limit checks from getServerSideProps on user, team, and org booking routes.
  - Dropped IP and PII hashing tied to the rate limiter.

<sup>Written for commit a4059d734c46baa0efe8850665ff726eccdc19a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

