### PR TITLE
fix: v2 get event type by id return type

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.e2e-spec.ts
@@ -1381,6 +1381,9 @@ describe("Event types Endpoints", () => {
       expect(fetchedEventType.locations).toEqual(eventType.locations);
       expect(fetchedEventType.bookingFields).toEqual(eventType.bookingFields);
       expect(fetchedEventType.ownerId).toEqual(user.id);
+      expect(Array.isArray(fetchedEventType.users)).toEqual(true);
+      expect(fetchedEventType.users.length).toEqual(1);
+      expect(fetchedEventType.users[0].id).toEqual(fetchedEventType.ownerId);
       expect(fetchedEventType.bookingLimitsCount).toEqual(eventType.bookingLimitsCount);
       expect(fetchedEventType.onlyShowFirstAvailableSlot).toEqual(eventType.onlyShowFirstAvailableSlot);
       expect(fetchedEventType.bookingLimitsDuration).toEqual(eventType.bookingLimitsDuration);

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/controllers/event-types.controller.ts
@@ -7,6 +7,7 @@ import { EventTypeResponseTransformPipe } from "@/ee/event-types/event-types_202
 import { EventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/event-types.service";
 import { InputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/input-event-types.service";
 import { OutputEventTypesService_2024_06_14 } from "@/ee/event-types/event-types_2024_06_14/services/output-event-types.service";
+import type { DatabaseEventType } from "@/ee/event-types/event-types_2024_06_14/services/output-event-types.service";
 import { VERSION_2024_06_14_VALUE } from "@/lib/api-versions";
 import {
   API_KEY_OR_ACCESS_TOKEN_HEADER,
@@ -25,6 +26,7 @@ import { OptionalApiAuthGuard } from "@/modules/auth/guards/optional-api-auth/op
 import { PermissionsGuard } from "@/modules/auth/guards/permissions/permissions.guard";
 import { ApiAuthGuardUser } from "@/modules/auth/strategies/api-auth/api-auth.strategy";
 import { OutputTeamEventTypesResponsePipe } from "@/modules/organizations/event-types/pipes/team-event-types-response.transformer";
+import type { DatabaseTeamEventType } from "@/modules/organizations/event-types/services/output.service";
 import { UserWithProfile } from "@/modules/users/users.repository";
 import {
   Controller,
@@ -132,15 +134,20 @@ export class EventTypesController_2024_06_14 {
       throw new NotFoundException(`Event type with id ${eventTypeId} not found`);
     }
 
-    const responseEventType =
-      "hosts" in eventType
-        ? await this.outputTeamEventTypesResponsePipe.transform(eventType)
-        : this.eventTypeResponseTransformPipe.transform(eventType);
+    const responseEventType = this.isTeamEventType(eventType)
+      ? await this.outputTeamEventTypesResponsePipe.transform(eventType)
+      : this.eventTypeResponseTransformPipe.transform(eventType);
 
     return {
       status: SUCCESS_STATUS,
       data: responseEventType,
     };
+  }
+
+  private isTeamEventType(
+    eventType: DatabaseTeamEventType | ({ ownerId: number } & DatabaseEventType)
+  ): eventType is DatabaseTeamEventType {
+    return !!eventType.teamId;
   }
 
   @Get("/")


### PR DESCRIPTION
Fixes #25089 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 “get event type by id” endpoint to return the correct response shape for team vs personal event types. Uses a clear type guard to pick the right transformer.

- **Bug Fixes**
  - Added isTeamEventType guard based on teamId to select the correct response pipe.
  - Team event types use OutputTeamEventTypesResponsePipe; personal event types use EventTypeResponseTransformPipe.

<sup>Written for commit 647385afc4e4e77a0b33ce578ffa4e1cd9d0b85f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



