### PR TITLE
fix: Make identifier for rate limit URL safe

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -101,7 +101,7 @@ const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   try {
     await checkRateLimitAndThrowError({
       rateLimitingType: "common",
-      identifier: `${req.nextUrl.pathname}-${piiHasher.hash(requestorIp)}`,
+      identifier: `${encodeURIComponent(req.nextUrl.pathname)}-${piiHasher.hash(requestorIp)}`,
     });
   } catch (error) {
     if (error instanceof HttpError) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the rate limit identifier URL-safe by encoding req.nextUrl.pathname. This prevents malformed keys and inconsistent throttling on paths with special characters.

<sup>Written for commit f9667d11e8274d2082155d29856fc13c24ee135b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

