### PR TITLE
fix: make identifier url safe 2

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -101,7 +101,7 @@ const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   try {
     await checkRateLimitAndThrowError({
       rateLimitingType: "common",
-      identifier: `${encodeURIComponent(req.nextUrl.pathname)}-${piiHasher.hash(requestorIp)}`,
+      identifier: piiHasher.hash(`${req.nextUrl.pathname}-${requestorIp}`),
     });
   } catch (error) {
     if (error instanceof HttpError) {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -101,7 +101,7 @@ const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   try {
     await checkRateLimitAndThrowError({
       rateLimitingType: "common",
-      identifier: `${req.nextUrl.pathname}-${piiHasher.hash(requestorIp)}`,
+      identifier: `${encodeURIComponent(req.nextUrl.pathname)}-${piiHasher.hash(requestorIp)}`,
     });
   } catch (error) {
     if (error instanceof HttpError) {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the rate-limit identifier URL-safe by hashing the combined pathname and requestor IP before use. This prevents invalid keys from special characters and ensures consistent rate limiting.

<sup>Written for commit 18f2a17cd879cf97b775317ec73fac78be2b4477. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



