### PR TITLE
fix: change confirm-reschedule-button testid condition to depend only on rescheduleUid

### DIFF
--- a/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookEventForm.tsx
@@ -255,9 +255,7 @@ export const BookEventForm = ({
                   isVerificationCodeSending
                 }
                 className={classNames?.confirmButton}
-                data-testid={
-                  rescheduleUid && bookingData ? "confirm-reschedule-button" : "confirm-book-button"
-                }>
+                data-testid={rescheduleUid ? "confirm-reschedule-button" : "confirm-book-button"}>
                 {rescheduleUid && bookingData
                   ? t("reschedule")
                   : renderConfirmNotVerifyEmailButtonCond


### PR DESCRIPTION
## What does this PR do?

Fixes e2e test failures for `confirm-reschedule-button` by changing the button's testid condition to depend only on `rescheduleUid` instead of both `rescheduleUid && bookingData`.

**Context:** Two recent commits (452729f4ab and 228fbaf72e from Nov 11, 2025) modified the reschedule flow to skip email verification. These changes introduced a condition `Boolean(rescheduleUid && bookingData)` to determine if a booking is being rescheduled. However, the button's testid used the same condition, which caused issues when `rescheduleUid` was present (from URL params) but `bookingData` wasn't set yet (not populated until form interaction). This caused the button to render with testid `confirm-book-button` instead of `confirm-reschedule-button`, breaking e2e tests.

**The Fix:** Changed the testid condition from `rescheduleUid && bookingData` to just `rescheduleUid`, making it more resilient to timing issues with form state initialization.

**Note:** The button label still depends on `rescheduleUid && bookingData` (unchanged), so it will show "Confirm" when `bookingData` isn't set, but the testid will correctly identify it as a reschedule flow.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a bug fix that doesn't require documentation changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note:** I was unable to run the failing e2e test locally due to environment issues, but the logic change should fix the test failure based on my analysis.

## How should this be tested?

Run the failing e2e test:
```bash
yarn e2e booking-seats.e2e.ts --grep "be able to reschedule when going directly to booking"
```

**Expected behavior:**
- The test "Owner shouldn't be able to reschedule when going directly to booking/rescheduleUid" should pass
- When an owner navigates directly to a reschedule URL and logs in, the button should have testid `confirm-reschedule-button`

**Additional tests to verify:**
- Check other e2e tests that use `confirm-reschedule-button` testid still pass
- Verify the reschedule flow works correctly end-to-end

## Important Review Points

⚠️ **Please review carefully:**
1. The button label logic (line 259-267) still depends on `rescheduleUid && bookingData`, so the button might show "Confirm" text but have testid "confirm-reschedule-button" when `bookingData` isn't set. Is this the intended behavior?
2. Verify no other code relies on the old testid condition (`rescheduleUid && bookingData`)
3. Confirm this aligns with the intended behavior of the recent email verification changes (commits 452729f4ab and 228fbaf72e)

---

**Link to Devin run:** https://app.devin.ai/sessions/f7caa33055ca46809ad9a94ded3fb650  
**Requested by:** eunjae@cal.com (@eunjae-lee)