### PR TITLE
feat: auto-navigate to first sub-item when clicking parent menu items

### DIFF
--- a/packages/features/shell/navigation/NavigationItem.tsx
+++ b/packages/features/shell/navigation/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import React, { Fragment, useState, useEffect, useRef } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -92,6 +92,7 @@ export const NavigationItem: React.FC<{
   const { item, isChild } = props;
   const { t, isLocaleReady } = useLocale();
   const pathname = usePathname();
+  const router = useRouter();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;
   const current = isCurrent({ isChild: !!isChild, item, pathname });
   const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
@@ -160,6 +161,11 @@ export const NavigationItem: React.FC<{
               setIsExpanded(!isExpanded);
               if (isTablet && hasChildren) {
                 setIsTooltipOpen(!isTooltipOpen);
+              }
+              if (hasChildren && item.child && item.child.length > 0) {
+                const firstChild = item.child[0];
+                const href = buildHref(firstChild);
+                router.push(href);
               }
             }}
             className={classNames(
@@ -292,6 +298,7 @@ export const MobileNavigationMoreItem: React.FC<{
 }> = (props) => {
   const { item } = props;
   const { t, isLocaleReady } = useLocale();
+  const router = useRouter();
   const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
   const buildHref = useBuildHref();
@@ -305,7 +312,14 @@ export const MobileNavigationMoreItem: React.FC<{
       {hasChildren ? (
         <>
           <button
-            onClick={() => setIsExpanded(!isExpanded)}
+            onClick={() => {
+              setIsExpanded(!isExpanded);
+              if (item.child && item.child.length > 0) {
+                const firstChild = item.child[0];
+                const href = buildHref(firstChild);
+                router.push(href);
+              }
+            }}
             className="hover:bg-subtle flex w-full items-center justify-between p-5 text-left transition">
             <span className="text-default flex items-center font-semibold">
               {item.icon && (


### PR DESCRIPTION
## What does this PR do?

Updates the sidebar navigation behavior for menu items with sub-items (Bookings, Apps, Insights) to automatically navigate to the first sub-item when clicked, while still expanding the submenu.

**Previous behavior**: Clicking "Bookings", "Apps", or "Insights" only expanded/collapsed the submenu
**New behavior**: Clicking these items now expands the submenu AND navigates to the first sub-item

This change affects both desktop navigation (`NavigationItem`) and mobile "More" menu navigation (`MobileNavigationMoreItem`).

## Changes Made

- Added `useRouter` hook to `NavigationItem` and `MobileNavigationMoreItem` components
- Modified click handlers to call `router.push()` with the first child's href when a parent item with children is clicked
- Preserved existing expansion state behavior and query parameter handling via `buildHref`

## Important Review Points

⚠️ **UX Consideration**: The navigation now performs two actions on click (expand + navigate). Please verify this matches the intended user experience, especially:
- On tablets where tooltips are involved
- On mobile where the "More" menu behavior might differ
- Whether users might want to expand without navigating

⚠️ **Untested**: This PR has not been tested in a running application. Manual testing is required to verify:
- Navigation works correctly for all three menu items (Bookings, Apps, Insights)
- Query parameters are preserved correctly (especially for Bookings)
- Tablet and mobile behaviors feel natural
- No conflicts with existing expansion state management

## How should this be tested?

1. **Desktop Navigation**:
   - Click "Bookings" - should navigate to `/bookings/upcoming` and expand submenu
   - Click "Apps" - should navigate to `/apps` and expand submenu
   - Click "Insights" - should navigate to `/insights` and expand submenu
   - Verify clicking again collapses the submenu but still navigates

2. **Mobile Navigation** (More menu):
   - Open the "More" menu on mobile
   - Click items with children and verify navigation + expansion

3. **Query Parameters**:
   - Navigate to `/bookings/upcoming?filter=something`
   - Click another booking sub-item and verify query params are preserved where appropriate

## Checklist

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - UI behavior change only
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **No automated tests added** - manual testing required

---

**Link to Devin run**: https://app.devin.ai/sessions/80df2e3b407c437c959bbb0504a6d2a2  
**Requested by**: @eunjae-lee (eunjae@cal.com)