### PR TITLE
fix: prevent Avatar component from flashing on every render

### DIFF
--- a/packages/ui/components/avatar/AvatarGroup.tsx
+++ b/packages/ui/components/avatar/AvatarGroup.tsx
@@ -9,6 +9,7 @@ export type AvatarGroupProps = {
     title?: string;
     alt?: string;
     href?: string | null;
+    key?: string;
   }[];
   className?: string;
   truncateAfter?: number;
@@ -30,19 +31,22 @@ export const AvatarGroup = function AvatarGroup(props: AvatarGroupProps) {
 
   return (
     <ul className={classNames("flex items-center", props.className)}>
-      {displayedAvatars.map((item, idx) => (
-        <li key={idx} className="-mr-1 inline-block">
-          <Avatar
-            data-testid="avatar"
-            className="border-subtle"
-            imageSrc={item.image}
-            title={item.title}
-            alt={item.alt || ""}
-            size={props.size}
-            href={item.href}
-          />
-        </li>
-      ))}
+      {displayedAvatars.map((item) => {
+        const stableKey = item.key ?? `${item.href ?? ""}|${item.image}|${item.title ?? ""}`;
+        return (
+          <li key={stableKey} className="-mr-1 inline-block">
+            <Avatar
+              data-testid="avatar"
+              className="border-subtle"
+              imageSrc={item.image}
+              title={item.title}
+              alt={item.alt || ""}
+              size={props.size}
+              href={item.href}
+            />
+          </li>
+        );
+      })}
       {numTruncatedAvatars > 0 && (
         <li
           className={classNames(


### PR DESCRIPTION
## What does this PR do?

Fixes the Avatar component flashing issue reported in Slack (#talk-to-devin) where avatars would flash/flicker on every render.

**Root Causes Identified:**
1. **Index-based keys in AvatarGroup**: Using `key={idx}` caused React to remount avatar components when the array changed, retriggering the Radix Avatar loading sequence
2. **No loaded state persistence**: When Avatar components remounted (e.g., in virtualized lists), they would re-enter the loading state and show the fallback again, even for already-loaded images

**Changes Made:**
1. Replaced index-based keys with stable keys in `AvatarGroup.tsx` (combination of href, image, and title)
2. Added a module-level cache (`loadedImageCache`) to track which image URLs have successfully loaded
3. Implemented `onLoadingStatusChange` handler to update the cache when images finish loading
4. Conditionally render the Fallback only when the image hasn't loaded yet (`!isLoaded`)
5. Wrapped Avatar component with `React.memo` to reduce unnecessary re-renders

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a bug fix with no API changes
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: This fix addresses a visual rendering issue that's difficult to test automatically. Manual testing recommended.

## How should this be tested?

**Manual Testing Steps:**
1. Navigate to pages with avatars (event types list, bookings list, team views, settings)
2. Observe that avatars no longer flash/flicker when:
   - The page initially loads
   - Filtering or searching the list
   - Scrolling through virtualized lists
   - Switching between tabs

**Key Areas to Test:**
- Event types listing page (`/event-types`)
- Bookings listing page (`/bookings`)
- Team member lists
- User settings pages with avatar displays
- Header user avatar

**Expected Behavior:**
- Avatars should load smoothly without flashing
- Once an avatar image is loaded, it should not show the fallback again even if the component remounts
- Fallback should still appear for new images that haven't loaded yet

## Important Review Points

⚠️ **Potential Issues to Review:**

1. **Memory Leak Risk**: The `loadedImageCache` Map grows indefinitely and never clears. In long-running sessions with many different users/avatars, this could accumulate. Consider if we need cache eviction or clearing on logout.

2. **Empty String Cache Key**: When `imageSrc` is null/undefined, the cache key becomes `""`. This means all avatars without images share the same cache entry, which could cause unexpected behavior.

3. **Stable Key Collisions**: The fallback key generation uses `${item.href ?? ""}|${item.image}|${item.title ?? ""}`. While better than index-based keys, verify this doesn't cause collisions with real data.

4. **Version Mismatch**: The codebase uses `@radix-ui/react-avatar` v1.1.3 in `packages/ui` but v1.0.4 in `apps/web`. Confirm `onLoadingStatusChange` is available in both versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] I have run type checks and lint checks locally

---

**Link to Devin run**: https://app.devin.ai/sessions/45283c3652b3480e8318de11686b04b1    
**Requested by**: eunjae@cal.com (@eunjae-lee)