### PR TITLE
fix: Attempt fix to explictly pass 'Accept/Content-Type' through opts

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -102,6 +102,12 @@ const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
     await checkRateLimitAndThrowError({
       rateLimitingType: "common",
       identifier: piiHasher.hash(`${req.nextUrl.pathname}-${requestorIp}`),
+      opts: {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        }
+      }
     });
   } catch (error) {
     if (error instanceof HttpError) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Explicitly set Accept and Content-Type to application/json when calling checkRateLimitAndThrowError in web middleware. This ensures the rate-limit request is treated as JSON and prevents upstream API rejections.

<sup>Written for commit 9d67fc1daa04d2bf3cec58bb93cd07a0e7cb947c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

