### PR TITLE
chore: try to log headers via custom http client

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,5 +1,5 @@
 import { Unkey } from "@unkey/api";
-import { HTTPClient } from "@unkey/api/dist/esm/lib/http";
+import { HTTPClient } from "@unkey/api/lib/http";
 import { get } from "@vercel/edge-config";
 import { collectEvents } from "next-collect/server";
 import type { NextRequest } from "next/server";

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -26,10 +26,10 @@ const httpClient = new HTTPClient();
 
 httpClient.addHook("beforeRequest", (request) => {
   const headers: Record<string, string> = {};
-  for (const [key, value] of Object.entries(request.headers)) {
+  request.headers.forEach((value, key) => {
     headers[key] = value;
-  }
-  console.log(`[UNKEY_DEBUG_MIDDLEWARE] Before request ${request.url}`, JSON.stringify(headers));
+  });
+  console.log(`[UNKEY_DEBUG_MIDDLEWARE] Before request ${request.url}`, JSON.stringify(headers, null, 2));
 
   return request;
 });

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@daily-co/daily-js": "^0.83.1",
     "@evyweb/ioctopus": "^1.2.0",
     "@next/third-parties": "^14.2.5",
+    "@unkey/api": "latest",
     "@vercel/functions": "^1.4.0",
     "city-timezones": "^1.2.1",
     "date-fns-tz": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19437,6 +19437,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unkey/api@npm:latest":
+  version: 2.1.1
+  resolution: "@unkey/api@npm:2.1.1"
+  dependencies:
+    zod: ^3.25.0 || ^4.0.0
+  peerDependencies:
+    "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0"
+  peerDependenciesMeta:
+    "@modelcontextprotocol/sdk":
+      optional: true
+  bin:
+    mcp: bin/mcp-server.js
+  checksum: 06c99c2efa161b6cfe8ef261ecfb47c6be44e18214c96a2178bd81b72475c316f05e8b4d31e0d04b3425e47356e272c106d6ce3dd737b1f9fb1a8d6bcd7779d3
+  languageName: node
+  linkType: hard
+
 "@unkey/ratelimit@npm:^2.1.3":
   version: 2.1.3
   resolution: "@unkey/ratelimit@npm:2.1.3"
@@ -22387,6 +22403,7 @@ __metadata:
     "@snaplet/copycat": ^4.1.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^16.0.1
+    "@unkey/api": latest
     "@vercel/functions": ^1.4.0
     "@vitest/ui": ^2.1.9
     c8: ^7.13.0
@@ -49871,6 +49888,13 @@ __metadata:
   version: 3.24.2
   resolution: "zod@npm:3.24.2"
   checksum: c02455c09678c5055c636d64f9fcda2424fea0aa46ac7d9681e7f41990bc55f488bcd84b9d7cfef0f6e906f51f55b245239d92a9f726248aa74c5b84edf00c2d
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0 || ^4.0.0":
+  version: 4.1.12
+  resolution: "zod@npm:4.1.12"
+  checksum: 91174acc7d2ca5572ad522643474ddd60640cf6877b5d76e5d583eb25e3c4072c6f5eb92ab94f231ec5ce61c6acdfc3e0166de45fb1005b1ea54986b026b765f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
DO NOT MERGE THIS EVER, all we need is a preview deployment 

just debugging, see slack

this tries to hook into the underlying sdk and log headers before they are being sent, trying to get a step closer to figuring out where it goes south





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a custom Unkey HTTP client in the middleware to log outgoing request headers and debug rate limit behavior. Also adds a ratelimit call and logs its response.

- **New Features**
  - Log headers via a beforeRequest hook on Unkey’s HTTP client.
  - Call unkey.ratelimit.limit in middleware, log the result, and return 429 when exceeded.

- **Dependencies**
  - Add @unkey/api (latest).

<sup>Written for commit 0e6a629a297056e0694cae7a89f11b056ffa7a0a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





