### PR TITLE
fix: change edge runtime to prevent weird header override in unkey sdk

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -225,6 +225,7 @@ function enrichRequestWithHeaders({ req }: { req: NextRequest }) {
 }
 
 export const config = {
+  runtime: "nodejs",
   matcher: ["/((?!_next(?:/|$)|static(?:/|$)|public(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$).*)"],
 };
 


### PR DESCRIPTION
Testing with a different runtime

