### PR TITLE
fix: normalize eventSlug before lookup to avoid 404 on repeated hyphens

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.test.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Normalize incoming slug because URL slugs may contain repeated hyphens but DB slugs are stored normalized.
+ * Collapses multiple consecutive hyphens to single hyphens and trims leading/trailing hyphens.
+ */
+function normalizeSlug(s: string): string {
+  return s.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+describe("normalizeSlug", () => {
+  it("should collapse multiple consecutive hyphens to single hyphen", () => {
+    expect(normalizeSlug("some--team---wow")).toBe("some-team-wow");
+  });
+
+  it("should trim leading and trailing hyphens", () => {
+    expect(normalizeSlug("--hello--")).toBe("hello");
+  });
+
+  it("should collapse triple hyphens in the middle", () => {
+    expect(normalizeSlug("wow---ok")).toBe("wow-ok");
+  });
+
+  it("should handle already normalized slugs", () => {
+    expect(normalizeSlug("normal-slug")).toBe("normal-slug");
+  });
+
+  it("should handle single word slugs", () => {
+    expect(normalizeSlug("hello")).toBe("hello");
+  });
+
+  it("should handle slugs with only hyphens", () => {
+    expect(normalizeSlug("---")).toBe("");
+  });
+
+  it("should trim leading hyphens only", () => {
+    expect(normalizeSlug("---hello")).toBe("hello");
+  });
+
+  it("should trim trailing hyphens only", () => {
+    expect(normalizeSlug("hello---")).toBe("hello");
+  });
+
+  it("should handle mixed consecutive hyphens", () => {
+    expect(normalizeSlug("a--b---c----d")).toBe("a-b-c-d");
+  });
+
+  it("should preserve single hyphens between words", () => {
+    expect(normalizeSlug("hello-world-test")).toBe("hello-world-test");
+  });
+});

--- a/packages/features/eventtypes/lib/getPublicEvent.test.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect } from "vitest";
 
-/**
- * Normalize incoming slug because URL slugs may contain repeated hyphens but DB slugs are stored normalized.
- * Collapses multiple consecutive hyphens to single hyphens and trims leading/trailing hyphens.
- */
-function normalizeSlug(s: string): string {
-  return s.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
-}
+import { normalizeSlug } from "./getPublicEvent";
+
 
 describe("normalizeSlug", () => {
   it("should collapse multiple consecutive hyphens to single hyphen", () => {

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -28,6 +28,14 @@ import {
 } from "@calcom/prisma/zod-utils";
 import type { UserProfile } from "@calcom/types/UserProfile";
 
+/**
+ * Normalize incoming slug because URL slugs may contain repeated hyphens but DB slugs are stored normalized.
+ * Collapses multiple consecutive hyphens to single hyphens and trims leading/trailing hyphens.
+ */
+function normalizeSlug(s: string): string {
+  return s.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+}
+
 const userSelect = {
   id: true,
   avatarUrl: true,
@@ -271,6 +279,9 @@ export const getPublicEvent = async (
   currentUserId?: number,
   fetchAllUsers = false
 ) => {
+  // Normalize incoming slug because URL slugs may contain repeated hyphens but DB slugs are stored normalized.
+  eventSlug = normalizeSlug(eventSlug);
+
   const usernameList = getUsernameList(username);
   const orgQuery = org ? getSlugOrRequestedSlug(org) : null;
   // In case of dynamic group event, we fetch user's data and use the default event.

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -32,7 +32,7 @@ import type { UserProfile } from "@calcom/types/UserProfile";
  * Normalize incoming slug because URL slugs may contain repeated hyphens but DB slugs are stored normalized.
  * Collapses multiple consecutive hyphens to single hyphens and trims leading/trailing hyphens.
  */
-function normalizeSlug(s: string): string {
+export function normalizeSlug(s: string): string {
   return s.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
 }
 


### PR DESCRIPTION
Fixes #25121
I ran into an issue where event pages return a 404 if the slug in the URL contains repeated hyphens (for example: some--team---wow). The database stores the normalized version of the slug, so the lookup fails when the incoming value doesn’t match the stored one.

This update adds a small helper to normalize the slug by collapsing consecutive hyphens and trimming any leading or trailing ones. The normalized value is now used for both event lookups in getPublicEvent.

I also added a test covering the different cases to make sure the normalization behaves as expected.

This brings the incoming slugs in line with how they’re saved in the DB and resolves the mismatch that caused the 404.