### PR TITLE
feat: POC to send multiple ratelimit checks in one request

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -141,10 +141,19 @@ const shouldEnforceCsp = (url: URL) => {
 const middleware = async (req: NextRequest): Promise<NextResponse<unknown>> => {
   const requestorIp = getIP(req);
   try {
-    await checkRateLimitAndThrowError({
-      rateLimitingType: "common",
-      identifier: piiHasher.hash(`${req.nextUrl.pathname}-${requestorIp}`),
-    });
+    await checkRateLimitAndThrowError([
+      {
+        rateLimitingType: "common",
+        identifier: piiHasher.hash(req.nextUrl.pathname),
+      },
+      {
+        rateLimitingType: "common",
+        identifier: piiHasher.hash(`${req.nextUrl.pathname}-${requestorIp}`),
+        opts: {
+          limit: 5000,
+        },
+      },
+    ]);
   } catch (error) {
     if (error instanceof HttpError) {
       return new NextResponse(error.message, { status: error.statusCode });

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@daily-co/daily-js": "^0.83.1",
     "@evyweb/ioctopus": "^1.2.0",
     "@next/third-parties": "^14.2.5",
+    "@unkey/api": "^2.1.1",
     "@vercel/functions": "^1.4.0",
     "city-timezones": "^1.2.1",
     "date-fns-tz": "^3.2.0",

--- a/packages/lib/checkRateLimitAndThrowError.ts
+++ b/packages/lib/checkRateLimitAndThrowError.ts
@@ -2,18 +2,29 @@ import { HttpError } from "./http-error";
 import type { RateLimitHelper } from "./rateLimit";
 import { rateLimiter } from "./rateLimit";
 
-export async function checkRateLimitAndThrowError({
-  rateLimitingType = "core",
-  identifier,
-  onRateLimiterResponse,
-  opts,
-}: RateLimitHelper) {
-  const response = await rateLimiter()({ rateLimitingType, identifier, opts });
-  if (onRateLimiterResponse) onRateLimiterResponse(response);
-  const { success, reset } = response;
-  if (!success) {
+export async function checkRateLimitAndThrowError(req: RateLimitHelper | RateLimitHelper[]) {
+  const reqs = Array.isArray(req) ? req : [req];
+
+  const response = await rateLimiter()(...reqs);
+
+  for (const req of reqs) {
+    req.onRateLimiterResponse?.(response);
+  }
+
+  if (!response.passed) {
     const convertToSeconds = (ms: number) => Math.floor(ms / 1000);
-    const secondsToWait = convertToSeconds(reset - Date.now());
+    const rejected = response.limits.find((limit) => !limit.passed);
+
+    if (!rejected) {
+      // This should never happen, but if the top level `.passed` is false there
+      // was an exceeded ratelimit, so we can throw the same error
+      throw new HttpError({
+        statusCode: 429,
+        message: "Rate limit exceeded. Try again in a minute.",
+      });
+    }
+
+    const secondsToWait = convertToSeconds(rejected.reset - Date.now());
     throw new HttpError({
       statusCode: 429,
       message: `Rate limit exceeded. Try again in ${secondsToWait} seconds.`,

--- a/packages/lib/rateLimit.ts
+++ b/packages/lib/rateLimit.ts
@@ -1,24 +1,59 @@
-import { Ratelimit, type LimitOptions, type RatelimitResponse } from "@unkey/ratelimit";
+import { Unkey } from "@unkey/api";
+import * as errors from "@unkey/api/models/errors";
 
 import { isIpInBanListString } from "./getIP";
 import logger from "./logger";
 
 const log = logger.getSubLogger({ prefix: ["RateLimit"] });
 
-export { type RatelimitResponse };
+export const API_KEY_RATE_LIMIT = 30;
+
+const configs = {
+  core: {
+    limit: 10,
+    duration: 60 * 1000, // 60m
+  },
+  instantMeeting: {
+    limit: 1,
+    duration: 10 * 60 * 1000, // 10m
+  },
+  common: {
+    limit: 200,
+    duration: 60 * 1000, // 60s
+  },
+  forcedSlowMode: {
+    limit: 1,
+    duration: 30 * 1000, // 30s
+  },
+  api: {
+    limit: API_KEY_RATE_LIMIT,
+    duration: 60 * 1000, // 60s
+  },
+  ai: {
+    limit: 20,
+    duration: 24 * 60 * 60 * 1000, // 1d
+  },
+  sms: {
+    limit: 50,
+    duration: 5 * 60 * 1000, // 5m
+  },
+  smsMonth: {
+    limit: 250,
+    duration: 30 * 24 * 60 * 60 * 1000, // 30d
+  },
+} as const;
 
 export type RateLimitHelper = {
-  rateLimitingType?:
-    | "core"
-    | "forcedSlowMode"
-    | "common"
-    | "api"
-    | "ai"
-    | "sms"
-    | "smsMonth"
-    | "instantMeeting";
+  // defaults to "core"
+  rateLimitingType?: keyof typeof configs;
   identifier: string;
-  opts?: LimitOptions;
+  // Override limit or duration
+  opts?: {
+    limit?: number;
+
+    // milliseconds
+    duration?: number;
+  };
   /**
    * Using a callback instead of a regular return to provide headers even
    * when the rate limit is reached and an error is thrown.
@@ -26,104 +61,116 @@ export type RateLimitHelper = {
   onRateLimiterResponse?: (response: RatelimitResponse) => void;
 };
 
-export const API_KEY_RATE_LIMIT = 30;
+// I couldn't quite get the import from @unkey/api/models/components to work, so I copied it here
+export type RatelimitResponse = {
+  passed: boolean;
+  limits: {
+    namespace: string;
+    identifier: string;
+    passed: boolean;
+    limit: number;
+    remaining: number;
+    reset: number;
+  }[];
+};
 
-export function rateLimiter() {
+export function rateLimiter(): (
+  ...reqs: RateLimitHelper[]
+) => RatelimitResponse | Promise<RatelimitResponse> {
   const { UNKEY_ROOT_KEY } = process.env;
 
   if (!UNKEY_ROOT_KEY) {
     log.warn("Disabled because the UNKEY_ROOT_KEY environment variable was not found.");
-    return () => ({ success: true, limit: 10, remaining: 999, reset: 0 } as RatelimitResponse);
-  }
-  const timeout = {
-    fallback: { success: true, limit: 10, remaining: 999, reset: 0 },
-    ms: 5000,
-  };
-
-  const onError = (err: Error, identifier: string) => {
-    log.error("Unkey rate limiter encountered unknown error", {
-      error: err.message,
-      stack: err.stack,
-      identifier,
-      timestamp: new Date().toISOString(),
+    return () => ({
+      passed: true,
+      limits: [{ namespace: "core", identifier: "", passed: true, limit: 10, remaining: 999, reset: 0 }],
     });
-    return { success: true, limit: 10, remaining: 999, reset: 0 };
-  };
-
-  const limiter = {
-    core: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "core",
-      limit: 10,
-      duration: "60s",
-      timeout,
-      onError,
-    }),
-    instantMeeting: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "instantMeeting",
-      limit: 1,
-      duration: "10m",
-      timeout,
-      onError,
-    }),
-    common: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "common",
-      limit: 200,
-      duration: "60s",
-      timeout,
-      onError,
-    }),
-    forcedSlowMode: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "forcedSlowMode",
-      limit: 1,
-      duration: "30s",
-      timeout,
-      onError,
-    }),
-    api: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "api",
-      limit: API_KEY_RATE_LIMIT,
-      duration: "60s",
-      timeout,
-      onError,
-    }),
-    ai: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "ai",
-      limit: 20,
-      duration: "1d",
-      timeout,
-      onError,
-    }),
-    sms: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "sms",
-      limit: 50,
-      duration: "5m",
-      timeout,
-      onError,
-    }),
-    smsMonth: new Ratelimit({
-      rootKey: UNKEY_ROOT_KEY,
-      namespace: "smsMonth",
-      limit: 250,
-      duration: "30d",
-      timeout,
-      onError,
-    }),
-  };
-
-  async function rateLimit({ rateLimitingType = "core", identifier, opts }: RateLimitHelper) {
-    if (isIpInBanListString(identifier)) {
-      return await limiter.forcedSlowMode.limit(identifier, opts);
-    }
-
-    return await limiter[rateLimitingType].limit(identifier, opts);
   }
 
-  return rateLimit;
+  const unkey = new Unkey({
+    rootKey: UNKEY_ROOT_KEY,
+    timeoutMs: 5000,
+    retryConfig: {
+      strategy: "backoff",
+      backoff: {
+        initialInterval: 10,
+        maxInterval: 100,
+        exponent: 1.5,
+        maxElapsedTime: 500,
+      },
+      retryConnectionErrors: true,
+    },
+  });
+
+  return async function rateLimit(...reqs: RateLimitHelper[]): Promise<RatelimitResponse> {
+    try {
+      if (reqs.length === 0) {
+        return {
+          passed: true,
+          limits: [],
+        };
+      }
+
+      // If any of the identifiers is on the ban list, we do a single forced-slow-mode check
+      for (const req of reqs) {
+        if (isIpInBanListString(req.identifier)) {
+          return await unkey.ratelimit
+            .multiLimit([
+              {
+                namespace: "forcedSlowMode",
+                limit: req.opts?.limit ?? configs.forcedSlowMode.limit,
+                duration: req.opts?.duration ?? configs.forcedSlowMode.duration,
+                identifier: req.identifier,
+              },
+            ])
+            .then((res) => res.data);
+        }
+      }
+
+      return await unkey.ratelimit
+        .multiLimit(
+          reqs.map((req) => {
+            const namespace = req.rateLimitingType ?? "core";
+            return {
+              namespace,
+              limit: req.opts?.limit ?? configs[namespace].limit,
+              duration: req.opts?.duration ?? configs[namespace].duration,
+              identifier: req.identifier,
+            };
+          })
+        )
+        .then((res) => res.data);
+    } catch (err: unknown) {
+      if (err instanceof errors.UnkeyError) {
+        log.error("Unkey rate limiter encountered a known error", {
+          error: err.message,
+          stack: err.stack,
+          status: err.statusCode,
+          body: err.body, // contains request ids and hints on how to fix the issue
+          identifiers: reqs.map((req) => req.identifier),
+          timestamp: new Date().toISOString(),
+        });
+      } else if (err instanceof Error) {
+        log.error("Unkey rate limiter encountered unknown error", {
+          error: err.message,
+          stack: err.stack,
+          identifiers: reqs.map((req) => req.identifier),
+          timestamp: new Date().toISOString(),
+        });
+      } else {
+        // should never happen but typescript was sad
+        log.error("Unkey rate limiter encountered something other than an error", {
+          error: err,
+          identifiers: reqs.map((req) => req.identifier),
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      // This is the fallback response in case of an error or timeout.
+      return {
+        passed: true,
+        limits: [],
+      };
+    }
+  };
 }

--- a/packages/lib/smsLockState.ts
+++ b/packages/lib/smsLockState.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@calcom/prisma";
 import { SMSLockState } from "@calcom/prisma/enums";
+
 import type { RateLimitHelper } from "./rateLimit";
 import { rateLimiter } from "./rateLimit";
 
@@ -10,11 +11,10 @@ export async function checkSMSRateLimit({
   opts,
 }: RateLimitHelper) {
   const response = await rateLimiter()({ rateLimitingType, identifier, opts });
-  const { success } = response;
 
   if (onRateLimiterResponse) onRateLimiterResponse(response);
 
-  if (!success) {
+  if (!response.passed) {
     await changeSMSLockState(
       identifier,
       rateLimitingType === "sms" ? SMSLockState.LOCKED : SMSLockState.REVIEW_NEEDED

--- a/yarn.lock
+++ b/yarn.lock
@@ -19437,6 +19437,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unkey/api@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@unkey/api@npm:2.1.1"
+  dependencies:
+    zod: ^3.25.0 || ^4.0.0
+  peerDependencies:
+    "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0"
+  peerDependenciesMeta:
+    "@modelcontextprotocol/sdk":
+      optional: true
+  bin:
+    mcp: bin/mcp-server.js
+  checksum: 06c99c2efa161b6cfe8ef261ecfb47c6be44e18214c96a2178bd81b72475c316f05e8b4d31e0d04b3425e47356e272c106d6ce3dd737b1f9fb1a8d6bcd7779d3
+  languageName: node
+  linkType: hard
+
 "@unkey/ratelimit@npm:^2.1.3":
   version: 2.1.3
   resolution: "@unkey/ratelimit@npm:2.1.3"
@@ -22387,6 +22403,7 @@ __metadata:
     "@snaplet/copycat": ^4.1.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^16.0.1
+    "@unkey/api": ^2.1.1
     "@vercel/functions": ^1.4.0
     "@vitest/ui": ^2.1.9
     c8: ^7.13.0
@@ -49871,6 +49888,13 @@ __metadata:
   version: 3.24.2
   resolution: "zod@npm:3.24.2"
   checksum: c02455c09678c5055c636d64f9fcda2424fea0aa46ac7d9681e7f41990bc55f488bcd84b9d7cfef0f6e906f51f55b245239d92a9f726248aa74c5b84edf00c2d
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0 || ^4.0.0":
+  version: 4.1.12
+  resolution: "zod@npm:4.1.12"
+  checksum: 91174acc7d2ca5572ad522643474ddd60640cf6877b5d76e5d583eb25e3c4072c6f5eb92ab94f231ec5ce61c6acdfc3e0166de45fb1005b1ea54986b026b765f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Add a possible implementation of using unkey's multiratelimiting. (https://www.unkey.com/docs/api-reference/v2/ratelimit/apply-multiple-rate-limit-checks)

To application developers this just allows specifying multiple checks in the `checkRateLimitAndThrowError` function:
```ts
await checkRateLimitAndThrowError([
      {
        rateLimitingType: "common",
        identifier: piiHasher.hash(req.nextUrl.pathname),
      },
      {
        rateLimitingType: "common",
        identifier: piiHasher.hash(`${req.nextUrl.pathname}-${requestorIp}`),
        opts: {
          limit: 5000,
        },
      },
    ]);
 ```
 
Under the hood this replaces the `@unkey/ratelimit` sdk with the underlying `@unkey/api` sdk while preserving the same behavior around timeouts and fallbacks.

___

It's not really finished and can be cleaned up some more, but I wanted to get some feedback on the direction first before spending time on that.
For API keys I left the original code for now, cause it's irrelevant to show what I have in mind.

I also don't care if you close this cause you want to do it differently :)



I'll leave some more comments throughout this PR.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

It should just work as before. The check in the middleware now does 2 checks, one for path and one for path+ip

## Checklist

<!-- Remove bullet points below that don't apply to you -->

