### PR TITLE
fix: Use different GitHub access token for ghcr pushes

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -80,7 +80,7 @@ jobs:
           platform-suffix: "-arm"
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches GHCR push auth in the release-docker workflow to use secrets.GH_ACCESS_TOKEN instead of GITHUB_TOKEN. Fixes permission failures so image publishing succeeds.

- **Bug Fixes**
  - Uses a token with the required package write scope for GHCR pushes.

<sup>Written for commit 393c06cd088a08b5f2c5e9c496f8c4b37d09f899. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

