### PR TITLE
fix: make routing form identifier field less intrusive

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -237,7 +237,6 @@ const FormEdit = ({
 
   const addField = () => {
     const newFieldId = uuidv4();
-    const fieldCount = hookFormFields.length;
     appendHookFormField({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
@@ -245,7 +244,7 @@ const FormEdit = ({
       // This is same type from react-awesome-query-builder
       type: "text",
       label: "",
-      identifier: `field_${fieldCount + 1}`,
+      identifier: "",
     });
   };
 

--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/FormEdit.tsx
@@ -67,11 +67,6 @@ function Field({
     name: `${hookFieldNamespace}.label`,
   });
 
-  const identifier = useWatch({
-    control: hookForm.control,
-    name: `${hookFieldNamespace}.identifier`,
-  });
-
   const fieldType = useWatch({
     control: hookForm.control,
     name: `${hookFieldNamespace}.type`,
@@ -110,13 +105,11 @@ function Field({
             <TextField
               disabled={!!router}
               label="Identifier"
-              name={`${hookFieldNamespace}.identifier`}
+              placeholder={label || routerField?.label || t("identifies_name_field")}
               required
-              placeholder={t("identifies_name_field")}
-              value={identifier || routerField?.identifier || label || routerField?.label || ""}
-              onChange={(e) => {
-                hookForm.setValue(`${hookFieldNamespace}.identifier`, e.target.value, { shouldDirty: true });
-              }}
+              {...hookForm.register(`${hookFieldNamespace}.identifier`, {
+                required: t("identifier_is_required"),
+              })}
             />
           </div>
           <div className="mb-3 w-full">
@@ -243,13 +236,16 @@ const FormEdit = ({
   const [animationRef] = useAutoAnimate<HTMLDivElement>();
 
   const addField = () => {
+    const newFieldId = uuidv4();
+    const fieldCount = hookFormFields.length;
     appendHookFormField({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      id: uuidv4(),
+      id: newFieldId,
       // This is same type from react-awesome-query-builder
       type: "text",
       label: "",
+      identifier: `field_${fieldCount + 1}`,
     });
   };
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2280,6 +2280,7 @@
   "responses_collection_waiting_description": "Wait for some time for responses to be collected. You can go and submit the form yourself as well.",
   "this_is_what_your_users_would_see": "This is what your users would see",
   "identifies_name_field": "Identifies field by this name.",
+  "identifier_is_required": "Identifier is required",
   "add_1_option_per_line": "Add 1 option per line",
   "select_a_router": "Select a router",
   "add_a_new_route": "Add a new Route",


### PR DESCRIPTION
## What does this PR do?

Makes the routing form question identifier field less intrusive by allowing users to clear the field content and showing validation errors on save instead of preventing deletion.

Previously, the identifier field used controlled input with fallback values that prevented users from deleting its content entirely. Now it behaves like a standard form field users can freely edit or clear it, and validation only triggers when attempting to save the form with an empty identifier.

- Fixes #25116
- Fixes [CAL-6741](https://linear.app/calcom/issue/CAL-6741/make-routing-edit-question-form-less-intrusive-on-how-it-handles-the)

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

Before: 

https://github.com/user-attachments/assets/2e53ca1c-ea0d-4bcd-bbbe-5c8b7bca0253

After: 

https://github.com/user-attachments/assets/da82fa94-6254-4e7f-b9bf-67db4055d698



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to Routing Forms in Cal.com
2. Create a new routing form or edit an existing one
3. Add a new question or edit an existing question
4. Try to clear the "Identifier" field completely
5. Verify you can delete all content
6. Try to save the form with an empty identifier
7. Verify validation error "Identifier is required" appears
8. Fill in the identifier and save successfully

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings