### PR TITLE
fix: improve booking list stability by preventing unmount/remount on re-renders

### DIFF
--- a/apps/web/modules/bookings/components/BookingsListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingsListContainer.tsx
@@ -88,17 +88,18 @@ export function BookingsListContainer({
       utils.viewer.bookings.invalidate();
     },
   });
+  const confirmMutationMutate = confirmMutation.mutate;
 
   const handleAccept = useCallback(
     (bookingId: number, recurringEventId?: string | null) => {
-      confirmMutation.mutate({
+      confirmMutationMutate({
         bookingId,
         confirmed: true,
         reason: "",
         ...(recurringEventId && { recurringEventId }),
       });
     },
-    [confirmMutation]
+    [confirmMutationMutate]
   );
 
   const handleReject = useCallback((bookingId: number, recurringEventId?: string | null) => {
@@ -143,6 +144,12 @@ export function BookingsListContainer({
   const table = useReactTable<RowData>({
     data,
     columns,
+    getRowId: (row) => {
+      if (row.type === "data") {
+        return `booking-${row.booking.id}`;
+      }
+      return `separator-${row.label}`;
+    },
     initialState: {
       columnVisibility: getFilterColumnVisibility(),
       columnPinning: {


### PR DESCRIPTION
## What does this PR do?

This PR improves the stability of booking list items by preventing unnecessary unmount/remount cycles during re-renders, which was causing (avatar) flickering in the UI.

**Changes:**
1. Extracted `confirmMutation.mutate` to a stable reference to prevent the `handleAccept` callback from being recreated on every render
2. Added `getRowId` function to the table configuration to provide stable row identifiers, preventing React Table from unmounting and remounting rows unnecessarily

## Visual Demo

No visual demo provided - this fix addresses flickering that occurs during booking list updates (e.g., when accepting/rejecting bookings).

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change - **N/A** (internal optimization, no API changes)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works - **Note**: This is a UI stability fix that's difficult to test automatically

## How should this be tested?

1. Navigate to the bookings page with multiple bookings
2. Accept or reject a booking
3. Observe that the booking list items don't flicker or re-render unnecessarily
4. Verify that accepting/rejecting bookings still works correctly
5. Test with both data rows and separator rows in the list

**Key areas to verify:**
- No flickering when booking status changes
- Accept/reject functionality still works correctly
- Table rows maintain their state during updates

## Human Review Checklist

Please pay special attention to:

- [ ] **Row ID logic**: Verify the `getRowId` function handles all possible row types (currently handles "data" and "separator" types)
- [ ] **Mutation behavior**: Confirm that extracting `confirmMutation.mutate` doesn't cause stale closure issues or break tRPC mutation behavior
- [ ] **Dependency array**: Verify the change from `[confirmMutation]` to `[confirmMutationMutate]` in the `handleAccept` callback is correct
- [ ] **Visual testing**: Test the booking list to confirm flickering is resolved when accepting/rejecting bookings

---

**Link to Devin run**: https://app.devin.ai/sessions/1987c587ca07434a8025f85eded434da  
**Requested by**: eunjae@cal.com (@eunjae-lee)