### PR TITLE
fix: api v2 empty event type array if no username

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/event-types.service.ts
@@ -263,6 +263,10 @@ export class EventTypesService_2024_06_14 {
       return [dynamicEventType];
     }
 
+    if (authUser?.id) {
+      return await this.getUserEventTypes(authUser.id);
+    }
+
     return [];
   }
 

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -22678,7 +22678,8 @@
               "OOO_CREATED",
               "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
               "AFTER_GUESTS_CAL_VIDEO_NO_SHOW",
-              "FORM_SUBMITTED_NO_EVENT"
+              "FORM_SUBMITTED_NO_EVENT",
+              "DELEGATION_CREDENTIAL_ERROR"
             ]
           },
           "secret": {
@@ -22745,7 +22746,8 @@
               "OOO_CREATED",
               "AFTER_HOSTS_CAL_VIDEO_NO_SHOW",
               "AFTER_GUESTS_CAL_VIDEO_NO_SHOW",
-              "FORM_SUBMITTED_NO_EVENT"
+              "FORM_SUBMITTED_NO_EVENT",
+              "DELEGATION_CREDENTIAL_ERROR"
             ]
           },
           "secret": {
@@ -27394,6 +27396,10 @@
           "email": {
             "type": "string"
           },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
           "timeFormat": {
             "type": "number"
           },
@@ -27419,6 +27425,7 @@
           "id",
           "username",
           "email",
+          "name",
           "timeFormat",
           "defaultScheduleId",
           "weekStart",


### PR DESCRIPTION
## What does this PR do?

I was using Get all event types (/v2/event-types) endpoint and noticed it returns empty array with 200 status code if no username (query parameter) is provided, with username query parameter it works as expected.

### Before:
https://github.com/user-attachments/assets/babb5bd4-9850-4e09-8caa-7422a91d0263



### After: 
https://github.com/user-attachments/assets/2f4c9013-6db1-48cf-8a71-eadbeffc41af





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /v2/event-types to return the authenticated user's event types when no username is provided, instead of an empty array. Updates the v2 OpenAPI spec with a new webhook event type and a nullable, required name field on the user object.

- **Bug Fixes**
  - /v2/event-types: when username is missing, return event types for authUser.id instead of [].

- **New Features**
  - OpenAPI: added DELEGATION_CREDENTIAL_ERROR to webhook event types.
  - OpenAPI: added a nullable, required name field to the User schema.

<sup>Written for commit d783ccc6eecbfb55d80ed82ca3c5520dac8ad853. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



