### PR TITLE
feat: add defaultPhoneCountry prop with ISO 3166-1 alpha-2 type safety

### DIFF
--- a/.changeset/little-rings-repeat.md
+++ b/.changeset/little-rings-repeat.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": minor
+---
+
+Add defaultPhoneCountry prop to BookerPlatformWrapper with ISO 3166-1 alpha-2 type safety

--- a/docs/platform/atoms/booker.mdx
+++ b/docs/platform/atoms/booker.mdx
@@ -131,6 +131,7 @@ Below is a list of props that can be passed to the booker atom.
 | showNoAvailabilityDialog        | No       | Boolean indicating if the no availability dialog should be shown, defaults to true.                                                                                                                            |
 | silentlyHandleCalendarFailures  | No       | Boolean when true the booker still displays slots when the third party calendars credentials are invalid or expired, Booker may show stale availability when enabled                                           |
 | hideEventMetadata               | No       | Boolean that controls the visibility of the event metadata sidebar. When `true`, hides the left sidebar containing event details like title, description, duration, and host information. Defaults to `false`. |
+| defaultPhoneCountry             | No       | Sets the default country code for phone number inputs in the booking form. Accepts ISO 3166-1 alpha-2 country codes (e.g., `"us"`, `"gb"`, `"in"`, `"ee"`). When set, phone inputs will default to the specified country's dialing code. |
 
 ## Styling
 

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -15,6 +15,36 @@ import type { GetBookingType } from "../lib/get-booking";
 import type { BookerState, BookerLayout } from "./types";
 import { updateQueryParam, getQueryParam, removeQueryParam } from "./utils/query-param";
 
+const _iso_3166_1_alpha_2_codes = [
+  "ad", "ae", "af", "ag", "ai", "al", "am", "ao", "aq", "ar", "as", "at", "au", "aw", "ax", "az",
+  "ba", "bb", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bl", "bm", "bn", "bo", "bq", "br", "bs", "bt", "bv", "bw", "by", "bz",
+  "ca", "cc", "cd", "cf", "cg", "ch", "ci", "ck", "cl", "cm", "cn", "co", "cr", "cu", "cv", "cw", "cx", "cy", "cz",
+  "de", "dj", "dk", "dm", "do", "dz",
+  "ec", "ee", "eg", "eh", "er", "es", "et",
+  "fi", "fj", "fk", "fm", "fo", "fr",
+  "ga", "gb", "gd", "ge", "gf", "gg", "gh", "gi", "gl", "gm", "gn", "gp", "gq", "gr", "gs", "gt", "gu", "gw", "gy",
+  "hk", "hm", "hn", "hr", "ht", "hu",
+  "id", "ie", "il", "im", "in", "io", "iq", "ir", "is", "it",
+  "je", "jm", "jo", "jp",
+  "ke", "kg", "kh", "ki", "km", "kn", "kp", "kr", "kw", "ky", "kz",
+  "la", "lb", "lc", "li", "lk", "lr", "ls", "lt", "lu", "lv", "ly",
+  "ma", "mc", "md", "me", "mf", "mg", "mh", "mk", "ml", "mm", "mn", "mo", "mp", "mq", "mr", "ms", "mt", "mu", "mv", "mw", "mx", "my", "mz",
+  "na", "nc", "ne", "nf", "ng", "ni", "nl", "no", "np", "nr", "nu", "nz",
+  "om",
+  "pa", "pe", "pf", "pg", "ph", "pk", "pl", "pm", "pn", "pr", "ps", "pt", "pw", "py",
+  "qa",
+  "re", "ro", "rs", "ru", "rw",
+  "sa", "sb", "sc", "sd", "se", "sg", "sh", "si", "sj", "sk", "sl", "sm", "sn", "so", "sr", "ss", "st", "sv", "sx", "sy",
+  "tc", "td", "tf", "tg", "th", "tj", "tk", "tl", "tm", "tn", "to", "tr", "tt", "tv", "tw", "tz",
+  "ua", "ug", "um", "us", "uy", "uz",
+  "va", "vc", "ve", "vg", "vi", "vn", "vu",
+  "wf", "ws",
+  "ye", "yt",
+  "za", "zm", "zw"
+] as const;
+
+type CountryCode = typeof _iso_3166_1_alpha_2_codes[number];
+
 
 /**
  * Arguments passed into store initializer, containing
@@ -44,7 +74,7 @@ export type StoreInitializeType = {
   crmRecordId?: string | null;
   isPlatform?: boolean;
   allowUpdatingUrlParams?: boolean;
-  defaultPhoneCountry?: string;
+  defaultPhoneCountry?: CountryCode;
 };
 
 type SeatedEventData = {
@@ -184,7 +214,7 @@ export type BookerStore = {
   crmRecordId?: string | null;
   isPlatform?: boolean;
   allowUpdatingUrlParams?: boolean;
-  defaultPhoneCountry?: string | null;
+  defaultPhoneCountry?: CountryCode | null;
 };
 
 /**

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -43,7 +43,7 @@ const _iso_3166_1_alpha_2_codes = [
   "za", "zm", "zw"
 ] as const;
 
-type CountryCode = typeof _iso_3166_1_alpha_2_codes[number];
+export type CountryCode = typeof _iso_3166_1_alpha_2_codes[number];
 
 
 /**

--- a/packages/features/bookings/Booker/store.ts
+++ b/packages/features/bookings/Booker/store.ts
@@ -44,6 +44,7 @@ export type StoreInitializeType = {
   crmRecordId?: string | null;
   isPlatform?: boolean;
   allowUpdatingUrlParams?: boolean;
+  defaultPhoneCountry?: string;
 };
 
 type SeatedEventData = {
@@ -183,6 +184,7 @@ export type BookerStore = {
   crmRecordId?: string | null;
   isPlatform?: boolean;
   allowUpdatingUrlParams?: boolean;
+  defaultPhoneCountry?: string | null;
 };
 
 /**
@@ -329,6 +331,7 @@ export const createBookerStore = () =>
       crmRecordId,
       isPlatform = false,
       allowUpdatingUrlParams = true,
+      defaultPhoneCountry,
     }: StoreInitializeType) => {
       const selectedDateInStore = get().selectedDate;
 
@@ -372,6 +375,7 @@ export const createBookerStore = () =>
         crmRecordId,
         isPlatform,
         allowUpdatingUrlParams,
+        defaultPhoneCountry,
       });
 
       if (durationConfig?.includes(Number(getQueryParam("duration")))) {
@@ -461,6 +465,7 @@ export const createBookerStore = () =>
     },
     isPlatform: false,
     allowUpdatingUrlParams: true,
+    defaultPhoneCountry: null,
   }));
 
 /**
@@ -489,6 +494,7 @@ export const useInitializeBookerStore = ({
   crmRecordId,
   isPlatform = false,
   allowUpdatingUrlParams = true,
+  defaultPhoneCountry,
 }: StoreInitializeType) => {
   const initializeStore = useBookerStore((state) => state.initialize);
   useEffect(() => {
@@ -513,6 +519,7 @@ export const useInitializeBookerStore = ({
       crmRecordId,
       isPlatform,
       allowUpdatingUrlParams,
+      defaultPhoneCountry,
     });
   }, [
     initializeStore,
@@ -536,5 +543,6 @@ export const useInitializeBookerStore = ({
     crmRecordId,
     isPlatform,
     allowUpdatingUrlParams,
+    defaultPhoneCountry,
   ]);
 };

--- a/packages/features/components/phone-input/PhoneInput.tsx
+++ b/packages/features/components/phone-input/PhoneInput.tsx
@@ -7,6 +7,7 @@ import PhoneInput from "react-phone-input-2";
 import "react-phone-input-2/lib/style.css";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
+import { useBookerStore } from "@calcom/features/bookings/Booker/store";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 
@@ -33,6 +34,8 @@ function BasePhoneInput({
   ...rest
 }: PhoneInputProps) {
   const isPlatform = useIsPlatform();
+  const defaultPhoneCountryFromStore = useBookerStore((state) => state.defaultPhoneCountry);
+  const effectiveDefaultCountry = defaultPhoneCountryFromStore || defaultCountry;
 
   // This is to trigger validation on prefill value changes
   useEffect(() => {
@@ -63,7 +66,7 @@ function BasePhoneInput({
       value={value ? value.trim().replace(/^\+?/, "+") : undefined}
       enableSearch
       disableSearchIcon
-      country={defaultCountry}
+      country={effectiveDefaultCountry}
       inputProps={{
         name,
         required: rest.required,
@@ -150,7 +153,8 @@ function BasePhoneInputWeb({
 }
 
 const useDefaultCountry = () => {
-  const [defaultCountry, setDefaultCountry] = useState("us");
+  const defaultPhoneCountryFromStore = useBookerStore((state) => state.defaultPhoneCountry);
+  const [defaultCountry, setDefaultCountry] = useState(defaultPhoneCountryFromStore || "us");
   const query = trpc.viewer.public.countryCode.useQuery(undefined, {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -159,16 +163,23 @@ const useDefaultCountry = () => {
 
   useEffect(
     function refactorMeWithoutEffect() {
+      if (defaultPhoneCountryFromStore) {
+        setDefaultCountry(defaultPhoneCountryFromStore);
+        return;
+      }
+
       const data = query.data;
       if (!data?.countryCode) {
         return;
       }
 
-      isSupportedCountry(data?.countryCode)
-        ? setDefaultCountry(data.countryCode.toLowerCase())
-        : setDefaultCountry(navigator.language.split("-")[1]?.toLowerCase() || "us");
+      if (isSupportedCountry(data?.countryCode)) {
+        setDefaultCountry(data.countryCode.toLowerCase());
+      } else {
+        setDefaultCountry(navigator.language.split("-")[1]?.toLowerCase() || "us");
+      }
     },
-    [query.data]
+    [query.data, defaultPhoneCountryFromStore]
   );
 
   return defaultCountry;

--- a/packages/features/components/phone-input/PhoneInput.tsx
+++ b/packages/features/components/phone-input/PhoneInput.tsx
@@ -7,7 +7,7 @@ import PhoneInput from "react-phone-input-2";
 import "react-phone-input-2/lib/style.css";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
-import { useBookerStore } from "@calcom/features/bookings/Booker/store";
+import { useBookerStore, type CountryCode } from "@calcom/features/bookings/Booker/store";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 
@@ -154,7 +154,7 @@ function BasePhoneInputWeb({
 
 const useDefaultCountry = () => {
   const defaultPhoneCountryFromStore = useBookerStore((state) => state.defaultPhoneCountry);
-  const [defaultCountry, setDefaultCountry] = useState(defaultPhoneCountryFromStore || "us");
+  const [defaultCountry, setDefaultCountry] = useState<CountryCode>(defaultPhoneCountryFromStore || "us");
   const query = trpc.viewer.public.countryCode.useQuery(undefined, {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -174,9 +174,14 @@ const useDefaultCountry = () => {
       }
 
       if (isSupportedCountry(data?.countryCode)) {
-        setDefaultCountry(data.countryCode.toLowerCase());
+        setDefaultCountry(data.countryCode.toLowerCase() as CountryCode);
       } else {
-        setDefaultCountry(navigator.language.split("-")[1]?.toLowerCase() || "us");
+        const navCountry = navigator.language.split("-")[1]?.toUpperCase();
+        if (navCountry && isSupportedCountry(navCountry)) {
+          setDefaultCountry(navCountry.toLowerCase() as CountryCode);
+        } else {
+          setDefaultCountry("us");
+        }
       }
     },
     [query.data, defaultPhoneCountryFromStore]

--- a/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerPlatformWrapper.tsx
@@ -70,6 +70,7 @@ const BookerPlatformWrapperComponent = (
     showNoAvailabilityDialog,
     silentlyHandleCalendarFailures = false,
     hideEventMetadata = false,
+    defaultPhoneCountry,
   } = props;
   const layout = BookerLayouts[view];
 
@@ -185,6 +186,7 @@ const BookerPlatformWrapperComponent = (
     bookingData,
     isPlatform: true,
     allowUpdatingUrlParams,
+    defaultPhoneCountry,
   });
   useInitializeBookerStoreContext({
     ...props,
@@ -201,6 +203,7 @@ const BookerPlatformWrapperComponent = (
     bookingData,
     isPlatform: true,
     allowUpdatingUrlParams,
+    defaultPhoneCountry,
   });
   const [dayCount] = useBookerStoreContext((state) => [state.dayCount, state.setDayCount], shallow);
   const selectedDate = useBookerStoreContext((state) => state.selectedDate);

--- a/packages/platform/atoms/booker/types.ts
+++ b/packages/platform/atoms/booker/types.ts
@@ -88,6 +88,7 @@ export type BookerPlatformWrapperAtomProps = Omit<
   roundRobinHideOrgAndTeam?: boolean;
   silentlyHandleCalendarFailures?: boolean;
   hideEventMetadata?: boolean;
+  defaultPhoneCountry?: string;
 };
 
 export type BookerPlatformWrapperAtomPropsForIndividual = BookerPlatformWrapperAtomProps & {

--- a/packages/platform/atoms/booker/types.ts
+++ b/packages/platform/atoms/booker/types.ts
@@ -14,6 +14,36 @@ import type { Slot } from "@calcom/trpc/server/routers/viewer/slots/types";
 
 import type { UseCreateBookingInput } from "../hooks/bookings/useCreateBooking";
 
+const _iso_3166_1_alpha_2_codes = [
+  "ad", "ae", "af", "ag", "ai", "al", "am", "ao", "aq", "ar", "as", "at", "au", "aw", "ax", "az",
+  "ba", "bb", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bl", "bm", "bn", "bo", "bq", "br", "bs", "bt", "bv", "bw", "by", "bz",
+  "ca", "cc", "cd", "cf", "cg", "ch", "ci", "ck", "cl", "cm", "cn", "co", "cr", "cu", "cv", "cw", "cx", "cy", "cz",
+  "de", "dj", "dk", "dm", "do", "dz",
+  "ec", "ee", "eg", "eh", "er", "es", "et",
+  "fi", "fj", "fk", "fm", "fo", "fr",
+  "ga", "gb", "gd", "ge", "gf", "gg", "gh", "gi", "gl", "gm", "gn", "gp", "gq", "gr", "gs", "gt", "gu", "gw", "gy",
+  "hk", "hm", "hn", "hr", "ht", "hu",
+  "id", "ie", "il", "im", "in", "io", "iq", "ir", "is", "it",
+  "je", "jm", "jo", "jp",
+  "ke", "kg", "kh", "ki", "km", "kn", "kp", "kr", "kw", "ky", "kz",
+  "la", "lb", "lc", "li", "lk", "lr", "ls", "lt", "lu", "lv", "ly",
+  "ma", "mc", "md", "me", "mf", "mg", "mh", "mk", "ml", "mm", "mn", "mo", "mp", "mq", "mr", "ms", "mt", "mu", "mv", "mw", "mx", "my", "mz",
+  "na", "nc", "ne", "nf", "ng", "ni", "nl", "no", "np", "nr", "nu", "nz",
+  "om",
+  "pa", "pe", "pf", "pg", "ph", "pk", "pl", "pm", "pn", "pr", "ps", "pt", "pw", "py",
+  "qa",
+  "re", "ro", "rs", "ru", "rw",
+  "sa", "sb", "sc", "sd", "se", "sg", "sh", "si", "sj", "sk", "sl", "sm", "sn", "so", "sr", "ss", "st", "sv", "sx", "sy",
+  "tc", "td", "tf", "tg", "th", "tj", "tk", "tl", "tm", "tn", "to", "tr", "tt", "tv", "tw", "tz",
+  "ua", "ug", "um", "us", "uy", "uz",
+  "va", "vc", "ve", "vg", "vi", "vn", "vu",
+  "wf", "ws",
+  "ye", "yt",
+  "za", "zm", "zw"
+] as const;
+
+type CountryCode = typeof _iso_3166_1_alpha_2_codes[number];
+
 
 // Type that includes only the data values from BookerStore (excluding functions)
 export type BookerStoreValues = Omit<
@@ -88,7 +118,7 @@ export type BookerPlatformWrapperAtomProps = Omit<
   roundRobinHideOrgAndTeam?: boolean;
   silentlyHandleCalendarFailures?: boolean;
   hideEventMetadata?: boolean;
-  defaultPhoneCountry?: string;
+  defaultPhoneCountry?: CountryCode;
 };
 
 export type BookerPlatformWrapperAtomPropsForIndividual = BookerPlatformWrapperAtomProps & {

--- a/packages/platform/atoms/booker/types.ts
+++ b/packages/platform/atoms/booker/types.ts
@@ -3,7 +3,7 @@ import type React from "react";
 
 
 import type { BookerProps } from "@calcom/features/bookings/Booker";
-import type { BookerStore } from "@calcom/features/bookings/Booker/store";
+import type { BookerStore, CountryCode } from "@calcom/features/bookings/Booker/store";
 import type { Timezone, VIEW_TYPE } from "@calcom/features/bookings/Booker/types";
 import type { BookingCreateBody } from "@calcom/features/bookings/lib/bookingCreateBodySchema";
 import type { BookingResponse } from "@calcom/platform-libraries";
@@ -13,36 +13,6 @@ import type { Slot } from "@calcom/trpc/server/routers/viewer/slots/types";
 
 
 import type { UseCreateBookingInput } from "../hooks/bookings/useCreateBooking";
-
-const _iso_3166_1_alpha_2_codes = [
-  "ad", "ae", "af", "ag", "ai", "al", "am", "ao", "aq", "ar", "as", "at", "au", "aw", "ax", "az",
-  "ba", "bb", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bl", "bm", "bn", "bo", "bq", "br", "bs", "bt", "bv", "bw", "by", "bz",
-  "ca", "cc", "cd", "cf", "cg", "ch", "ci", "ck", "cl", "cm", "cn", "co", "cr", "cu", "cv", "cw", "cx", "cy", "cz",
-  "de", "dj", "dk", "dm", "do", "dz",
-  "ec", "ee", "eg", "eh", "er", "es", "et",
-  "fi", "fj", "fk", "fm", "fo", "fr",
-  "ga", "gb", "gd", "ge", "gf", "gg", "gh", "gi", "gl", "gm", "gn", "gp", "gq", "gr", "gs", "gt", "gu", "gw", "gy",
-  "hk", "hm", "hn", "hr", "ht", "hu",
-  "id", "ie", "il", "im", "in", "io", "iq", "ir", "is", "it",
-  "je", "jm", "jo", "jp",
-  "ke", "kg", "kh", "ki", "km", "kn", "kp", "kr", "kw", "ky", "kz",
-  "la", "lb", "lc", "li", "lk", "lr", "ls", "lt", "lu", "lv", "ly",
-  "ma", "mc", "md", "me", "mf", "mg", "mh", "mk", "ml", "mm", "mn", "mo", "mp", "mq", "mr", "ms", "mt", "mu", "mv", "mw", "mx", "my", "mz",
-  "na", "nc", "ne", "nf", "ng", "ni", "nl", "no", "np", "nr", "nu", "nz",
-  "om",
-  "pa", "pe", "pf", "pg", "ph", "pk", "pl", "pm", "pn", "pr", "ps", "pt", "pw", "py",
-  "qa",
-  "re", "ro", "rs", "ru", "rw",
-  "sa", "sb", "sc", "sd", "se", "sg", "sh", "si", "sj", "sk", "sl", "sm", "sn", "so", "sr", "ss", "st", "sv", "sx", "sy",
-  "tc", "td", "tf", "tg", "th", "tj", "tk", "tl", "tm", "tn", "to", "tr", "tt", "tv", "tw", "tz",
-  "ua", "ug", "um", "us", "uy", "uz",
-  "va", "vc", "ve", "vg", "vi", "vn", "vu",
-  "wf", "ws",
-  "ye", "yt",
-  "za", "zm", "zw"
-] as const;
-
-type CountryCode = typeof _iso_3166_1_alpha_2_codes[number];
 
 
 // Type that includes only the data values from BookerStore (excluding functions)


### PR DESCRIPTION
## What does this PR do?

Adds a `defaultPhoneCountry` prop to `BookerPlatformWrapper` that allows setting a default phone country extension for PhoneInput components in the booker form. The prop is strictly typed to only accept valid ISO 3166-1 alpha-2 country codes (e.g., 'us', 'gb', 'ee').

**Context**: Requested by morgan@cal.com (@ThyMinimalDev) for 11x.ai integration
**Devin session**: https://app.devin.ai/sessions/4421590f6479455a9f8cad12fa5e1fe8

### Key Changes:
- Added `CountryCode` type using all 249 ISO 3166-1 alpha-2 country codes in `store.ts`
- Added `defaultPhoneCountry` prop to `BookerPlatformWrapper` and `BookerStore`
- Updated `PhoneInput` component to use `defaultPhoneCountry` from store (with fallback to existing logic)
- Exported `CountryCode` from store.ts and imported in types.ts to avoid duplication
- Added type-safe casts with `isSupportedCountry` validation in PhoneInput
- Added documentation in `docs/platform/atoms/booker.mdx`
- Added changeset for minor version bump

## Visual Demo

N/A - This is a type-safety improvement with no visual changes unless the prop is explicitly set.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works - **No automated tests added** (requires integration testing with phone input rendering)

## How should this be tested?

### Type Safety Testing:
1. Try passing an invalid country code: `defaultPhoneCountry="invalid"` - TypeScript should show compile error
2. Try passing a valid country code: `defaultPhoneCountry="ee"` - TypeScript should accept it

### Runtime Testing:
1. Create a `BookerPlatformWrapper` with `defaultPhoneCountry="ee"`
2. Open the booker form with a phone input field (either via phone location or booking field)
3. Verify the phone input defaults to Estonia (+372) country code
4. Test with other valid codes like "us", "gb", "fr"
5. Test without the prop to ensure backward compatibility (should use IP-based detection)

**Environment variables**: None required
**Test data**: Any event type with phone number location or booking fields requiring phone number

## Important Notes for Reviewers

⚠️ **PhoneInput Behavior Change**: The `PhoneInput` component now prioritizes `defaultPhoneCountry` from the store over the IP-based country detection. When `defaultPhoneCountry` is set, it will always use that value instead of detecting from IP. This is intentional for the 11x.ai use case.

⚠️ **Type Cast Safety**: The PhoneInput component uses `as CountryCode` type casts after validating with `isSupportedCountry()`. This assumes libphonenumber's supported country set matches our CountryCode union. Review the type cast logic in `packages/features/components/phone-input/PhoneInput.tsx:177` and `PhoneInput.tsx:181`.

⚠️ **Type Definition Location**: The `CountryCode` type is defined in `store.ts` (not `types.ts`) to avoid circular dependencies, since platform/atoms depends on features/bookings. The type is exported from store and imported in types.ts.

⚠️ **No Automated Tests**: This PR does not include automated tests. Manual testing is required to verify:
- Phone input correctly uses the default country when prop is set
- Backward compatibility when prop is not set
- Type safety prevents invalid country codes at compile time

⚠️ **Navigator.language Fallback**: The fallback logic for `navigator.language` now validates the country code with `isSupportedCountry` before using it, which is safer but changes existing behavior.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (N/A - straightforward prop passing)
- [x] I have checked if my changes generate no new warnings (pre-existing warnings in store.ts are unrelated)