### PR TITLE
fix: german-translation-link-meeting

### DIFF
--- a/apps/web/public/static/locales/de/common.json
+++ b/apps/web/public/static/locales/de/common.json
@@ -683,7 +683,7 @@
   "booking_reschedule_confirmation": "Planen Sie Ihr {{eventTypeTitle}} mit {{profileName}} um",
   "in_person_meeting": "Vor-Ort-Termin",
   "in_person": "Vor Ort (Organisator-Adresse)",
-  "link_meeting": "Termin verknüpfen",
+  "link_meeting": "Online Termin",
   "phone_number": "Telefonnummer",
   "attendee_phone_number": "Telefonnummer",
   "organizer_phone_number": "Telefonnummer des Organisators",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #25209 (GitHub issue number)
- Fixes CAL-6769 (Linear issue number - should be visible at the bottom of the GitHub issue description)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the German label for the meeting type: “link_meeting” now shows “Online Termin” to clearly indicate an online meeting in the booking flow. Resolves GitHub #25209 and aligns with Linear CAL-6769.

<sup>Written for commit b205340f815a511662db3c2e6724de85ee32ba69. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



