### PR TITLE
feat: make status parameter truly optional in bookings get handler

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -40,8 +40,7 @@ export const getHandler = async ({ ctx, input }: GetOptions) => {
   const take = input.limit;
   const skip = input.offset;
   const { prisma, user } = ctx;
-  const defaultStatus = "upcoming";
-  const bookingListingByStatus = [input.filters.status || defaultStatus];
+  const bookingListingByStatus = input.filters.status ? [input.filters.status] : [];
 
   const { bookings, recurringInfo, totalCount } = await getAllUserBookings({
     ctx: {


### PR DESCRIPTION
## What does this PR do?

This PR removes the default status value in the bookings get handler, making the status filter parameter truly optional. Previously, when no status was provided, it defaulted to "upcoming". Now, when status is not provided, no status condition is applied to the query, allowing all bookings to be returned regardless of their status.

**⚠️ Breaking Change**: This changes the default behavior when status is not specified. Existing API consumers that rely on the implicit "upcoming" default will now receive all bookings instead.

### Changes Made:
- Removed `defaultStatus = "upcoming"` constant
- Changed `bookingListingByStatus` to only include status if explicitly provided: `input.filters.status ? [input.filters.status] : []`
- When the array is empty, `addStatusesQueryFilters` skips adding any status conditions

## Requested By

- **User**: eunjae@cal.com (@eunjae-lee)
- **Devin Session**: https://app.devin.ai/sessions/26eb81537e234a03878a4fd9da91caa8
- **Slack Thread**: https://calendso.slack.com/archives/C08LT9BLEET/p1763396030528429

## How should this be tested?

### Test Scenarios:

1. **With status filter** (existing behavior should remain unchanged):
   ```
   GET /api/trpc/viewer.bookings.get?filters.status=upcoming
   ```
   Should return only upcoming bookings.

2. **Without status filter** (NEW behavior):
   ```
   GET /api/trpc/viewer.bookings.get
   ```
   Should now return ALL bookings (upcoming, past, cancelled, unconfirmed, recurring) instead of just upcoming.

3. **Performance consideration**: Test with users who have many bookings to ensure query performance is acceptable when no status filter is applied.

### Environment Setup:
- No special environment variables required
- Test with a user account that has bookings in multiple statuses (upcoming, past, cancelled)

## Human Review Checklist

**Critical items to verify:**

- [ ] **Breaking change impact**: Confirm that removing the default "upcoming" status is intentional and won't break existing API consumers
- [ ] **Performance**: Verify that returning all bookings when no status is provided doesn't cause performance issues for users with many bookings
- [ ] **Test coverage**: Check if existing tests need to be updated to account for the new behavior
- [ ] **API documentation**: Confirm whether API docs need to be updated to reflect this behavioral change
- [ ] **Backward compatibility**: Consider if this needs to be versioned or if a migration path is needed for existing consumers

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). **Needs review**: May need to document the behavioral change.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Needs review**: Existing tests may need updates.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (N/A - change is straightforward)
- [x] I have checked if my changes generate no new warnings (lint passed with only pre-existing warnings)

## Notes

- Type check failures in CI are pre-existing issues on main branch, confirmed by running type checks on main
- This is a minimal, focused change that only affects the status filtering logic
- The `addStatusesQueryFilters` function already handles empty arrays correctly by returning the query unchanged