### PR TITLE
fix: delegation credential error webhooks + refactor repeated code

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarAuth.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarAuth.ts
@@ -140,7 +140,7 @@ export class CalendarAuth {
         delegationError = new CalendarAppDelegationCredentialError("Error authorizing delegation credential");
       }
 
-      if (user && user.email && this.credential.appId) {
+      if (user && user.email && this.credential.appId && this.credential.delegatedToId) {
         await triggerDelegationCredentialErrorWebhook({
           error: delegationError,
           credential: {
@@ -152,7 +152,7 @@ export class CalendarAuth {
             id: this.credential.userId ?? 0,
             email: user.email,
           },
-          orgId: this.credential.teamId,
+          delegationCredentialId: this.credential.delegatedToId,
         });
       }
 

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -124,6 +124,29 @@ export default class Office365CalendarService implements Calendar {
     this.log = logger.getSubLogger({ prefix: [`[[lib] ${this.integrationName}`] });
   }
 
+  private async triggerDelegationCredentialError(error: Error): Promise<void> {
+    if (
+      this.credential.userId &&
+      this.credential.user &&
+      this.credential.appId &&
+      this.credential.delegatedToId
+    ) {
+      await triggerDelegationCredentialErrorWebhook({
+        error,
+        credential: {
+          id: this.credential.id,
+          type: this.credential.type,
+          appId: this.credential.appId,
+        },
+        user: {
+          id: this.credential.userId,
+          email: this.credential.user.email,
+        },
+        delegationCredentialId: this.credential.delegatedToId,
+      });
+    }
+  }
+
   private async getAuthUrl(delegatedTo: boolean, tenantId?: string): Promise<string> {
     if (delegatedTo) {
       if (!tenantId) {
@@ -131,26 +154,7 @@ export default class Office365CalendarService implements Calendar {
           "Invalid DelegationCredential Settings: tenantId is missing"
         );
 
-        if (
-          this.credential.userId &&
-          this.credential.user &&
-          this.credential.appId &&
-          this.credential.delegatedToId
-        ) {
-          await triggerDelegationCredentialErrorWebhook({
-            error,
-            credential: {
-              id: this.credential.id,
-              type: this.credential.type,
-              appId: this.credential.appId,
-            },
-            user: {
-              id: this.credential.userId,
-              email: this.credential.user.email,
-            },
-            delegationCredentialId: this.credential.delegatedToId,
-          });
-        }
+        await this.triggerDelegationCredentialError(error);
 
         throw error;
       }
@@ -170,26 +174,7 @@ export default class Office365CalendarService implements Calendar {
           "Delegation credential without clientId or Secret"
         );
 
-        if (
-          this.credential.userId &&
-          this.credential.user &&
-          this.credential.appId &&
-          this.credential.delegatedToId
-        ) {
-          await triggerDelegationCredentialErrorWebhook({
-            error,
-            credential: {
-              id: this.credential.id,
-              type: this.credential.type,
-              appId: this.credential.appId,
-            },
-            user: {
-              id: this.credential.userId,
-              email: this.credential.user.email,
-            },
-            delegationCredentialId: this.credential.delegatedToId,
-          });
-        }
+        await this.triggerDelegationCredentialError(error);
 
         throw error;
       }
@@ -217,26 +202,7 @@ export default class Office365CalendarService implements Calendar {
         "Delegation credential without clientId or Secret"
       );
 
-      if (
-        this.credential.userId &&
-        this.credential.user &&
-        this.credential.appId &&
-        this.credential.delegatedToId
-      ) {
-        await triggerDelegationCredentialErrorWebhook({
-          error,
-          credential: {
-            id: this.credential.id,
-            type: this.credential.type,
-            appId: this.credential.appId,
-          },
-          user: {
-            id: this.credential.userId,
-            email: this.credential.user.email,
-          },
-          delegationCredentialId: this.credential.delegatedToId,
-        });
-      }
+      await this.triggerDelegationCredentialError(error);
 
       throw error;
     }
@@ -275,26 +241,7 @@ export default class Office365CalendarService implements Calendar {
           "User might not exist in Microsoft Azure Active Directory"
         );
 
-        if (
-          this.credential.userId &&
-          this.credential.user &&
-          this.credential.appId &&
-          this.credential.delegatedToId
-        ) {
-          await triggerDelegationCredentialErrorWebhook({
-            error,
-            credential: {
-              id: this.credential.id,
-              type: this.credential.type,
-              appId: this.credential.appId,
-            },
-            user: {
-              id: this.credential.userId ?? 0,
-              email: this.credential.user.email,
-            },
-            delegationCredentialId: this.credential.delegatedToId,
-          });
-        }
+        await this.triggerDelegationCredentialError(error);
 
         throw error;
       }

--- a/packages/app-store/office365calendar/lib/CalendarService.ts
+++ b/packages/app-store/office365calendar/lib/CalendarService.ts
@@ -131,7 +131,12 @@ export default class Office365CalendarService implements Calendar {
           "Invalid DelegationCredential Settings: tenantId is missing"
         );
 
-        if (this.credential.userId && this.credential.user && this.credential.appId) {
+        if (
+          this.credential.userId &&
+          this.credential.user &&
+          this.credential.appId &&
+          this.credential.delegatedToId
+        ) {
           await triggerDelegationCredentialErrorWebhook({
             error,
             credential: {
@@ -143,7 +148,7 @@ export default class Office365CalendarService implements Calendar {
               id: this.credential.userId,
               email: this.credential.user.email,
             },
-            orgId: this.credential.teamId,
+            delegationCredentialId: this.credential.delegatedToId,
           });
         }
 
@@ -165,7 +170,12 @@ export default class Office365CalendarService implements Calendar {
           "Delegation credential without clientId or Secret"
         );
 
-        if (this.credential.userId && this.credential.user && this.credential.appId) {
+        if (
+          this.credential.userId &&
+          this.credential.user &&
+          this.credential.appId &&
+          this.credential.delegatedToId
+        ) {
           await triggerDelegationCredentialErrorWebhook({
             error,
             credential: {
@@ -177,7 +187,7 @@ export default class Office365CalendarService implements Calendar {
               id: this.credential.userId,
               email: this.credential.user.email,
             },
-            orgId: this.credential.teamId,
+            delegationCredentialId: this.credential.delegatedToId,
           });
         }
 
@@ -207,7 +217,12 @@ export default class Office365CalendarService implements Calendar {
         "Delegation credential without clientId or Secret"
       );
 
-      if (this.credential.userId && this.credential.user && this.credential.appId) {
+      if (
+        this.credential.userId &&
+        this.credential.user &&
+        this.credential.appId &&
+        this.credential.delegatedToId
+      ) {
         await triggerDelegationCredentialErrorWebhook({
           error,
           credential: {
@@ -219,7 +234,7 @@ export default class Office365CalendarService implements Calendar {
             id: this.credential.userId,
             email: this.credential.user.email,
           },
-          orgId: this.credential.teamId,
+          delegationCredentialId: this.credential.delegatedToId,
         });
       }
 
@@ -260,7 +275,12 @@ export default class Office365CalendarService implements Calendar {
           "User might not exist in Microsoft Azure Active Directory"
         );
 
-        if (this.credential.userId && this.credential.user && this.credential.appId) {
+        if (
+          this.credential.userId &&
+          this.credential.user &&
+          this.credential.appId &&
+          this.credential.delegatedToId
+        ) {
           await triggerDelegationCredentialErrorWebhook({
             error,
             credential: {
@@ -272,7 +292,7 @@ export default class Office365CalendarService implements Calendar {
               id: this.credential.userId ?? 0,
               email: this.credential.user.email,
             },
-            orgId: this.credential.teamId,
+            delegationCredentialId: this.credential.delegatedToId,
           });
         }
 

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -42,6 +42,24 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
   let azureUserId: string | null;
   const tokenResponse = oAuthManagerHelper.getTokenObjectFromCredential(credential);
 
+  async function triggerDelegationCredentialError(error: Error): Promise<void> {
+    if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
+      await triggerDelegationCredentialErrorWebhook({
+        error,
+        credential: {
+          id: credential.id,
+          type: credential.type,
+          appId: credential.appId,
+        },
+        user: {
+          id: credential.userId ?? 0,
+          email: credential.user.email,
+        },
+        delegationCredentialId: credential.delegatedToId,
+      });
+    }
+  }
+
   const auth = new OAuthManager({
     credentialSyncVariables: oAuthManagerHelper.credentialSyncVariables,
     resourceOwner: {
@@ -68,21 +86,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           "Delegation credential without clientId or Secret"
         );
 
-        if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
-          await triggerDelegationCredentialErrorWebhook({
-            error,
-            credential: {
-              id: credential.id,
-              type: credential.type,
-              appId: credential.appId,
-            },
-            user: {
-              id: credential.userId ?? 0,
-              email: credential.user.email,
-            },
-            delegationCredentialId: credential.delegatedToId,
-          });
-        }
+        await triggerDelegationCredentialError(error);
 
         throw error;
       }
@@ -130,21 +134,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           "Invalid DelegationCredential Settings: tenantId is missing"
         );
 
-        if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
-          await triggerDelegationCredentialErrorWebhook({
-            error,
-            credential: {
-              id: credential.id,
-              type: credential.type,
-              appId: credential.appId,
-            },
-            user: {
-              id: credential.userId ?? 0,
-              email: credential.user.email,
-            },
-            delegationCredentialId: credential.delegatedToId,
-          });
-        }
+        await triggerDelegationCredentialError(error);
 
         throw error;
       }
@@ -179,21 +169,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         "Delegation credential without clientId or Secret"
       );
 
-      if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
-        await triggerDelegationCredentialErrorWebhook({
-          error,
-          credential: {
-            id: credential.id,
-            type: credential.type,
-            appId: credential.appId,
-          },
-          user: {
-            id: credential.userId ?? 0,
-            email: credential.user.email,
-          },
-          delegationCredentialId: credential.delegatedToId,
-        });
-      }
+      await triggerDelegationCredentialError(error);
 
       throw error;
     }
@@ -231,21 +207,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         "User might not exist in Microsoft Azure Active Directory"
       );
 
-      if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
-        await triggerDelegationCredentialErrorWebhook({
-          error,
-          credential: {
-            id: credential.id,
-            type: credential.type,
-            appId: credential.appId,
-          },
-          user: {
-            id: credential.userId ?? 0,
-            email: credential.user.email,
-          },
-          delegationCredentialId: credential.delegatedToId,
-        });
-      }
+      await triggerDelegationCredentialError(error);
 
       throw error;
     }

--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -68,7 +68,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           "Delegation credential without clientId or Secret"
         );
 
-        if (credential.userId && credential.user && credential.appId) {
+        if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
           await triggerDelegationCredentialErrorWebhook({
             error,
             credential: {
@@ -80,7 +80,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
               id: credential.userId ?? 0,
               email: credential.user.email,
             },
-            orgId: credential.teamId,
+            delegationCredentialId: credential.delegatedToId,
           });
         }
 
@@ -130,7 +130,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
           "Invalid DelegationCredential Settings: tenantId is missing"
         );
 
-        if (credential.userId && credential.user && credential.appId) {
+        if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
           await triggerDelegationCredentialErrorWebhook({
             error,
             credential: {
@@ -142,7 +142,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
               id: credential.userId ?? 0,
               email: credential.user.email,
             },
-            orgId: credential.teamId,
+            delegationCredentialId: credential.delegatedToId,
           });
         }
 
@@ -179,7 +179,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         "Delegation credential without clientId or Secret"
       );
 
-      if (credential.userId && credential.user && credential.appId) {
+      if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
         await triggerDelegationCredentialErrorWebhook({
           error,
           credential: {
@@ -191,7 +191,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
             id: credential.userId ?? 0,
             email: credential.user.email,
           },
-          orgId: credential.teamId,
+          delegationCredentialId: credential.delegatedToId,
         });
       }
 
@@ -231,7 +231,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         "User might not exist in Microsoft Azure Active Directory"
       );
 
-      if (credential.userId && credential.user && credential.appId) {
+      if (credential.userId && credential.user && credential.appId && credential.delegatedToId) {
         await triggerDelegationCredentialErrorWebhook({
           error,
           credential: {
@@ -243,7 +243,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
             id: credential.userId ?? 0,
             email: credential.user.email,
           },
-          orgId: credential.teamId,
+          delegationCredentialId: credential.delegatedToId,
         });
       }
 

--- a/packages/features/webhooks/lib/dto/types.ts
+++ b/packages/features/webhooks/lib/dto/types.ts
@@ -498,10 +498,12 @@ export type DelegationCredentialErrorPayloadType = {
     id: number;
     type: string;
     appId: string;
+    delegationCredentialId?: string;
   };
   user: {
     id: number;
     email: string;
+    organizationId?: number;
   };
 };
 

--- a/packages/features/webhooks/lib/repository/WebhookRepository.ts
+++ b/packages/features/webhooks/lib/repository/WebhookRepository.ts
@@ -261,6 +261,36 @@ export class WebhookRepository implements IWebhookRepository {
     });
   }
 
+  async findByOrgIdAndTrigger({
+    orgId,
+    triggerEvent,
+  }: {
+    orgId: number;
+    triggerEvent: WebhookTriggerEvents;
+  }): Promise<WebhookSubscriber[]> {
+    return await this.prisma.webhook.findMany({
+      where: {
+        teamId: orgId,
+        platform: false,
+        eventTriggers: { has: triggerEvent },
+      },
+      select: {
+        id: true,
+        subscriberUrl: true,
+        payloadTemplate: true,
+        active: true,
+        eventTriggers: true,
+        secret: true,
+        teamId: true,
+        userId: true,
+        platform: true,
+        time: true,
+        timeUnit: true,
+        appId: true,
+      },
+    });
+  }
+
   async getFilteredWebhooksForUser({ userId, userRole }: { userId: number; userRole?: UserPermissionRole }) {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },

--- a/packages/features/webhooks/lib/triggerDelegationCredentialErrorWebhook.ts
+++ b/packages/features/webhooks/lib/triggerDelegationCredentialErrorWebhook.ts
@@ -1,3 +1,4 @@
+import { DelegationCredentialRepository } from "@calcom/features/delegation-credentials/repositories/DelegationCredentialRepository";
 import { DelegationCredentialErrorPayloadType } from "@calcom/features/webhooks/lib/dto/types";
 import type { CalendarAppDelegationCredentialError } from "@calcom/lib/CalendarAppError";
 import logger from "@calcom/lib/logger";
@@ -15,24 +16,30 @@ export async function triggerDelegationCredentialErrorWebhook(params: {
   error: CalendarAppDelegationCredentialError;
   credential: DelegationCredentialErrorPayloadType["credential"];
   user: DelegationCredentialErrorPayloadType["user"];
-  orgId?: number | null;
+  delegationCredentialId: string;
 }): Promise<void> {
   try {
-    const { error, credential, user, orgId } = params;
+    const { error, credential, user, delegationCredentialId } = params;
 
-    if (!orgId) {
-      log.debug("Skipping webhook emission - no organization context");
+    const delegationCredential = await DelegationCredentialRepository.findById({
+      id: delegationCredentialId,
+    });
+
+    if (!delegationCredential) {
+      log.debug("No delegation credential found", { delegationCredentialId });
       return;
     }
 
     const webhookRepository = WebhookRepository.getInstance();
-    const webhooks = await webhookRepository.getSubscribers({
-      teamId: orgId,
+    const webhooks = await webhookRepository.findByOrgIdAndTrigger({
+      orgId: delegationCredential.organizationId,
       triggerEvent: WebhookTriggerEvents.DELEGATION_CREDENTIAL_ERROR,
     });
 
     if (webhooks.length === 0) {
-      log.debug("No webhooks subscribed to DELEGATION_CREDENTIAL_ERROR for organization", { orgId });
+      log.debug("No webhooks subscribed to DELEGATION_CREDENTIAL_ERROR for organization", {
+        orgId: delegationCredential.organizationId,
+      });
       return;
     }
 
@@ -45,10 +52,12 @@ export async function triggerDelegationCredentialErrorWebhook(params: {
         id: credential.id,
         type: credential.type,
         appId: credential.appId || "unknown",
+        delegationCredentialId: delegationCredential.id,
       },
       user: {
         id: user.id,
         email: user.email,
+        organizationId: delegationCredential.organizationId,
       },
     } satisfies DelegationCredentialErrorPayloadType;
 


### PR DESCRIPTION
## What does this PR do?

This PR contains two sets of changes:

### 1. Original Changes (Delegation Credential Error Webhook Fixes)
- Fixes the delegation credential error webhook system to properly resolve organizations from delegation credentials
- Changes webhook trigger parameter from `orgId` to `delegationCredentialId` for more accurate organization resolution
- Adds new `WebhookRepository.findByOrgIdAndTrigger()` method for fetching webhooks by organization and trigger event
- Enriches webhook payload with `delegationCredentialId` and `organizationId` fields
- Fixes GoogleCalendar to include `delegatedToId` check before triggering webhooks

### 2. Refactoring Changes (Code DRY Improvements)
- Extracts repeated delegation credential error webhook triggering logic into helper methods
- Adds `triggerDelegationCredentialError()` private method in `Office365CalendarService` class
- Adds `triggerDelegationCredentialError()` helper function in `TeamsVideoApiAdapter`
- Replaces 4 instances of repeated code in each file with calls to the helper methods

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] N/A - No documentation changes required (internal refactoring and bug fix)
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works

## How should this be tested?

**Testing the webhook fixes:**
1. Set up a delegation credential for Office365 or Google Calendar
2. Configure a webhook subscriber for `DELEGATION_CREDENTIAL_ERROR` trigger at the organization level
3. Trigger a delegation credential error (e.g., invalid tenant ID, missing client credentials, or non-existent Azure user)
4. Verify the webhook is fired with the correct payload including `delegationCredentialId` and `organizationId`

**Testing the refactoring:**
1. Run existing tests for Office365Calendar and Office365Video integrations
2. Verify delegation credential error scenarios still trigger webhooks correctly
3. Check that all 4 error scenarios in each file still work as expected

## Human Review Checklist

**Critical items to review:**

1. **Webhook Logic Change**: Verify the change from passing `orgId` directly to looking up the delegation credential first is correct. Does this properly handle all edge cases?

2. **New Repository Method**: Review `WebhookRepository.findByOrgIdAndTrigger()` - is the query correct? Does it properly filter by organization and trigger event?

3. **Payload Changes**: The webhook payload now includes `delegationCredentialId` and `organizationId`. Is this a breaking change for existing webhook consumers? Should this be documented?

4. **GoogleCalendar Fix**: Verify the addition of `credential.delegatedToId` check in GoogleCalendar is correct and consistent with other integrations.

5. **Refactoring Correctness**: Verify the extracted helper methods maintain exactly the same behavior as the original repeated code. Check that:
   - All conditional checks are preserved
   - The webhook payload structure is identical
   - Error handling remains the same

6. **Edge Cases**: What happens if `delegationCredential` is not found in the database? The code returns early, but is this the correct behavior?

---

**Session Info:**
- Requested by: morgan@cal.com (@ThyMinimalDev)
- Devin session: https://app.devin.ai/sessions/445bdf27097648ab8eaf91d7cac2af57