### PR TITLE
fix: Skip Prisma pooling in CI to fix test flakiness

### DIFF
--- a/.github/actions/cache-db/action.yml
+++ b/.github/actions/cache-db/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         path: ${{ inputs.path }}
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.path }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
-    - run: USE_POOL=true yarn db-seed
+    - run: yarn db-seed
       if: steps.cache-db.outputs.cache-hit != 'true'
       shell: bash
     - name: Postgres Dump Backup

--- a/apps/api/v1/lib/utils/isAdmin.ts
+++ b/apps/api/v1/lib/utils/isAdmin.ts
@@ -16,13 +16,15 @@ export const isAdminGuard = async (req: NextApiRequest) => {
     where: {
       userId: userId,
       accepted: true,
+      role: {
+        in: [MembershipRole.OWNER, MembershipRole.ADMIN],
+      },
       team: {
         isOrganization: true,
         organizationSettings: {
           isAdminAPIEnabled: true,
         },
       },
-      OR: [{ role: MembershipRole.OWNER }, { role: MembershipRole.ADMIN }],
     },
     select: {
       team: {

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -8,9 +8,8 @@ import { excludePendingPaymentsExtension } from "./extensions/exclude-pending-pa
 import { PrismaClient, type Prisma } from "./generated/prisma/client";
 
 const connectionString = process.env.DATABASE_URL || "";
-const isIntegrationTest = process.env.INTEGRATION_TESTS === "true";
 const pool =
-  !isIntegrationTest && (process.env.USE_POOL === "true" || process.env.USE_POOL === "1")
+  process.env.USE_POOL === "true" || process.env.USE_POOL === "1"
     ? new Pool({
         connectionString: connectionString,
         max: 5,


### PR DESCRIPTION
## What does this PR do?





















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Prisma pooling opt-in to prevent connection issues and flaky runs. Also tighten the isAdmin guard role filter.

- **Bug Fixes**
  - Make pooling strictly opt-in via USE_POOL and remove integration test checks; stop forcing pooling during db-seed in CI.
  - Replace OR role checks with role: { in: [OWNER, ADMIN] } in isAdminGuard.

<sup>Written for commit 65d8457a35d8beba5d9ebe56db030a11a0427e68. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->























