### PR TITLE
feat: given name and last name

### DIFF
--- a/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
+++ b/apps/web/modules/onboarding/personal/settings/personal-settings-view.tsx
@@ -115,7 +115,7 @@ export const PersonalSettingsView = ({ userEmail, userName }: PersonalSettingsVi
   // Profile mutation
   const mutation = trpc.viewer.me.updateProfile.useMutation({
     onSuccess: async () => {
-      await utils.viewer.me.invalidate();
+      await utils.viewer.me.get.invalidate();
     },
   });
 

--- a/apps/web/modules/onboarding/store/onboarding-store.ts
+++ b/apps/web/modules/onboarding/store/onboarding-store.ts
@@ -40,7 +40,8 @@ export interface TeamBrand {
 }
 
 export interface PersonalDetails {
-  name: string;
+  givenName: string;
+  lastName: string;
   username: string;
   timezone: string;
   bio: string;
@@ -113,7 +114,8 @@ const initialState = {
   },
   teamInvites: [],
   personalDetails: {
-    name: "",
+    givenName: "",
+    lastName: "",
     username: "",
     timezone: "",
     bio: "",

--- a/apps/web/playwright/profile.e2e.ts
+++ b/apps/web/playwright/profile.e2e.ts
@@ -34,6 +34,31 @@ test.describe("Teams", () => {
 });
 
 test.describe("Update Profile", () => {
+  test("allows editing given and last name separately", async ({ page, users }) => {
+    const user = await users.create({
+      name: "Jane Doe",
+    });
+
+    await user.apiLogin();
+    await page.goto("/settings/my-account/profile");
+
+    const givenNameInput = page.locator('input[name="givenName"]');
+    const lastNameInput = page.locator('input[name="lastName"]');
+
+    await expect(givenNameInput).toHaveValue("Jane");
+    await expect(lastNameInput).toHaveValue("Doe");
+
+    await givenNameInput.fill("Janet");
+    await lastNameInput.fill("Smith");
+
+    await submitAndWaitForResponse(page, "/api/trpc/me/updateProfile?batch=1", {
+      action: () => page.getByTestId("profile-submit-button").click(),
+    });
+
+    await expect(givenNameInput).toHaveValue("Janet");
+    await expect(lastNameInput).toHaveValue("Smith");
+  });
+
   test("Cannot update a users email when existing user has same email (verification enabled)", async ({
     page,
     users,

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -92,6 +92,8 @@ export async function getServerSession(options: {
     user: {
       id: user.id,
       name: user.name,
+      givenName: token.givenName,
+      lastName: token.lastName,
       username: user.username,
       email: user.email,
       emailVerified: user.emailVerified,

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -344,6 +344,8 @@ export class UserRepository {
         id: true,
         username: true,
         name: true,
+        givenName: true,
+        lastName: true,
         email: true,
         metadata: true,
         identityProvider: true,

--- a/packages/features/users/repositories/UserRepository.ts
+++ b/packages/features/users/repositories/UserRepository.ts
@@ -27,6 +27,8 @@ export type SessionUser = {
   id: number;
   username: string | null;
   name: string | null;
+  givenName: string;
+  lastName: string | null;
   email: string;
   emailVerified: Date | null;
   bio: string | null;
@@ -83,6 +85,8 @@ const userSelect = {
   id: true,
   username: true,
   name: true,
+  givenName: true,
+  lastName: true,
   email: true,
   emailVerified: true,
   bio: true,

--- a/packages/prisma/migrations/25236_given_last_name/migration.sql
+++ b/packages/prisma/migrations/25236_given_last_name/migration.sql
@@ -1,0 +1,25 @@
+-- Add Given/Last name columns and backfill from existing name data
+ALTER TABLE "users"
+  ADD COLUMN "givenName" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "users"
+  ADD COLUMN "lastName" TEXT;
+
+-- Backfill using the first whitespace split for legacy data
+UPDATE "users"
+SET
+  "givenName" = CASE
+    WHEN "name" IS NULL OR btrim("name") = '' THEN ''
+    WHEN strpos(btrim("name"), ' ') = 0 THEN btrim("name")
+    ELSE split_part(btrim("name"), ' ', 1)
+  END,
+  "lastName" = CASE
+    WHEN "name" IS NULL OR btrim("name") = '' THEN NULL
+    WHEN strpos(btrim("name"), ' ') = 0 THEN NULL
+    ELSE btrim(substr(btrim("name"), strpos(btrim("name"), ' ') + 1))
+  END;
+
+-- Keep legacy name column consistent with the new fields
+UPDATE "users"
+SET "name" = btrim(concat_ws(' ', NULLIF("givenName", ''), NULLIF("lastName", '')))
+WHERE "name" IS DISTINCT FROM btrim(concat_ws(' ', NULLIF("givenName", ''), NULLIF("lastName", '')));

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -367,6 +367,8 @@ model User {
   uuid                String               @unique @default(uuid()) @db.Uuid
   username            String?
   name                String?
+  givenName           String               @default("")
+  lastName            String?
   /// @zod.import(["import { emailSchema } from '../../zod-utils'"]).custom.use(emailSchema)
   email               String
   emailVerified       DateTime?

--- a/packages/trpc/server/middlewares/sessionMiddleware.ts
+++ b/packages/trpc/server/middlewares/sessionMiddleware.ts
@@ -83,6 +83,8 @@ export async function getUserFromSession(ctx: TRPCContextInner, session: Maybe<S
     locale,
     defaultBookerLayouts: userMetaData?.defaultBookerLayouts || null,
     requiresBookerEmailVerification: user.requiresBookerEmailVerification,
+    givenName: user.givenName,
+    lastName: user.lastName,
   };
 }
 

--- a/packages/trpc/server/routers/viewer/me/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/get.handler.ts
@@ -109,6 +109,8 @@ export const getHandler = async ({ ctx, input }: MeOptions) => {
   return {
     id: user.id,
     name: user.name,
+    givenName: user.givenName,
+    lastName: user.lastName,
     email: user.email,
     emailMd5: crypto.createHash("md5").update(user.email).digest("hex"),
     emailVerified: user.emailVerified,

--- a/packages/trpc/server/routers/viewer/me/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.handler.ts
@@ -40,7 +40,9 @@ const normalizeNamePart = (value?: string | null) => {
   return trimmed.length ? trimmed : undefined;
 };
 
-const splitLegacyFullName = (fullName?: string | null) => {
+const splitLegacyFullName = (
+  fullName?: string | null
+): { givenName: string | undefined; lastName: string | undefined } => {
   if (!fullName) {
     return {
       givenName: undefined,
@@ -101,7 +103,10 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
   const normalizedGivenName = normalizeNamePart(givenName);
   const normalizedLastName =
     lastName === undefined ? undefined : lastName.trim().length ? lastName.trim() : null;
-  const legacyNameParts = legacyName !== undefined ? splitLegacyFullName(legacyName) : {};
+  const legacyNameParts =
+    legacyName !== undefined
+      ? splitLegacyFullName(legacyName)
+      : { givenName: undefined, lastName: undefined };
 
   const effectiveGivenName =
     normalizedGivenName !== undefined
@@ -453,12 +458,13 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
   }
 
   return {
-    ...input,
     name: updatedUser.name,
     givenName: updatedUser.givenName,
     lastName: updatedUser.lastName,
     email: emailVerification && !secondaryEmail?.emailVerified ? user.email : input.email,
     avatarUrl: updatedUser.avatarUrl,
+    username: updatedUser.username,
+    locale: input.locale,
     hasEmailBeenChanged,
     sendEmailVerification: emailVerification && !secondaryEmail?.emailVerified,
   };

--- a/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
@@ -11,7 +11,9 @@ export const updateUserMetadataAllowedKeys = z.object({
 
 export const ZUpdateProfileInputSchema = z.object({
   username: z.string().optional(),
-  name: z.string().max(FULL_NAME_LENGTH_MAX_LIMIT).optional(),
+  name: z.string().max(FULL_NAME_LENGTH_MAX_LIMIT).optional(), // Legacy support until all clients send given/last name
+  givenName: z.string().trim().min(1).max(FULL_NAME_LENGTH_MAX_LIMIT).optional(),
+  lastName: z.string().trim().max(FULL_NAME_LENGTH_MAX_LIMIT).optional(),
   email: z.string().optional(),
   bio: z.string().optional(),
   avatarUrl: z.string().nullable().optional(),

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -18,6 +18,8 @@ declare module "next-auth" {
 
   interface User extends Omit<DefaultUser, "id"> {
     id: PrismaUser["id"];
+    givenName?: string;
+    lastName?: string | null;
     emailVerified?: PrismaUser["emailVerified"];
     email_verified?: boolean;
     completedOnboarding?: boolean;
@@ -48,6 +50,8 @@ declare module "next-auth/jwt" {
   interface JWT {
     id?: string | number;
     name?: string | null;
+    givenName?: string;
+    lastName?: string | null;
     username?: string | null;
     avatarUrl?: string | null;
     email?: string | null;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #25236 (GitHub issue number)
- Fixes CAL-6775 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the full name into givenName and lastName across the app to improve data accuracy and editing. Fulfills CAL-6775 by storing first and last names separately while keeping the legacy name in sync.

- **New Features**
  - Database: added givenName (required, default ""), lastName (nullable) with backfill; keeps name updated from the parts.
  - UI/API/Auth: onboarding and profile forms now use first/last name; TRPC schema and handler accept givenName/lastName; NextAuth JWT/session include them; OAuth signups capture given/last when available (fallback to splitting full name); sensible defaults derived from legacy name; e2e test added.

- **Migration**
  - Run Prisma migrations.
  - Clients should start sending givenName and lastName to me.updateProfile (lastName is optional). Legacy name is still accepted during transition and will be split.

<sup>Written for commit cc169dc2bc7bc94caf83c9505f9937652dbc890b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



