### PR TITLE
fix: correct assignment reason badge mapping

### DIFF
--- a/apps/web/lib/booking/assignmentReasonBadgeTitleMap.ts
+++ b/apps/web/lib/booking/assignmentReasonBadgeTitleMap.ts
@@ -2,9 +2,11 @@ import { AssignmentReasonEnum } from "@calcom/prisma/enums";
 
 const assignmentReasonBadgeTitleMap = (assignmentReason: AssignmentReasonEnum) => {
   switch (assignmentReason) {
-    case AssignmentReasonEnum.ROUTING_FORM_ROUTING || AssignmentReasonEnum.ROUTING_FORM_ROUTING_FALLBACK:
+    case AssignmentReasonEnum.ROUTING_FORM_ROUTING:
+    case AssignmentReasonEnum.ROUTING_FORM_ROUTING_FALLBACK:
       return "routed";
     case AssignmentReasonEnum.REASSIGNED:
+    case AssignmentReasonEnum.RR_REASSIGNED:
       return "reassigned";
     case AssignmentReasonEnum.REROUTED:
       return "rerouted";


### PR DESCRIPTION
## What does this PR do?
## Summary by cubic
Fixed incorrect badge titles for assignment reasons in the booking UI. Routing form routing and fallback now map to “routed,” and RR_REASSIGNED maps to “reassigned,” preventing mislabeling.

<sup>Written for commit 599c152ac6bfc0f2eb9dcdd7e21f860dab677c8c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

