### PR TITLE
fix: seated events with paid bookings expose attendee emails despite privacy settings

### DIFF
--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -18,7 +18,7 @@ export default class AttendeeScheduledEmail extends BaseEmail {
 
   constructor(calEvent: CalendarEvent, attendee: Person, showAttendees?: boolean | undefined) {
     super();
-    if (!showAttendees && calEvent.seatsPerTimeSlot) {
+    if (showAttendees === false && calEvent.seatsPerTimeSlot) {
       this.calEvent = cloneDeep(calEvent);
       this.calEvent.attendees = [attendee];
     } else {

--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -18,7 +18,11 @@ export default class AttendeeScheduledEmail extends BaseEmail {
 
   constructor(calEvent: CalendarEvent, attendee: Person, showAttendees?: boolean | undefined) {
     super();
-    if (showAttendees === false && calEvent.seatsPerTimeSlot) {
+    const effectiveShowAttendees = typeof showAttendees === 'boolean' 
+      ? showAttendees 
+      : calEvent.seatsShowAttendees;
+    
+    if (effectiveShowAttendees === false) {
       this.calEvent = cloneDeep(calEvent);
       this.calEvent.attendees = [attendee];
     } else {

--- a/packages/features/bookings/lib/payment/getBooking.ts
+++ b/packages/features/bookings/lib/payment/getBooking.ts
@@ -33,6 +33,15 @@ export async function getBooking(bookingId: number) {
     select: {
       ...bookingMinimalSelect,
       responses: true,
+      attendees: {
+        include: {
+          bookingSeat: {
+            select: {
+              referenceUid: true,
+            },
+          },
+        },
+      },
       eventType: {
         select: {
           owner: {
@@ -72,6 +81,8 @@ export async function getBooking(bookingId: number) {
             },
           },
           slug: true,
+          seatsPerTimeSlot: true,
+          seatsShowAttendees: true,
           workflows: {
             select: {
               workflow: {
@@ -195,6 +206,8 @@ export async function getBooking(bookingId: number) {
     destinationCalendar: selectedDestinationCalendar ? [selectedDestinationCalendar] : [],
     recurringEvent: parseRecurringEvent(eventType?.recurringEvent),
     customReplyToEmail: booking.eventType?.customReplyToEmail,
+    seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
+    seatsShowAttendees: booking.eventType?.seatsShowAttendees,
   };
 
   return {


### PR DESCRIPTION
## What does this PR do?

Fixes a privacy bug where seated events with paid bookings expose all attendee emails to each other, even when "show attendees" (seatsShowAttendees) is disabled.

**Two bugs fixed:**

1. **Privacy Bug**: Attendee emails were visible to other attendees despite seatsShowAttendees being disabled
2. **Recipients Bug**: ALL attendees received confirmation emails when only the current booker should receive them

### Root Causes

**Bug 1**: The `AttendeeScheduledEmail` constructor had a flawed condition `!showAttendees && calEvent.seatsPerTimeSlot` that failed when:
- `showAttendees` was `undefined` (paid booking path doesn't pass this parameter)
- `seatsPerTimeSlot` was `null` (unlimited seats configuration)

**Bug 2**: `handlePaymentSuccess` called `sendScheduledEmailsAndSMS` which loops over ALL attendees in `evt.attendees`, but for seated events only the current booker should receive the email.

### Changes Made

1. **AttendeeScheduledEmail** (`packages/emails/templates/attendee-scheduled-email.ts`):
   - Added `effectiveShowAttendees` that falls back to `calEvent.seatsShowAttendees` when parameter is undefined
   - Changed condition to `effectiveShowAttendees === false` (strict check)
   - Removed `seatsPerTimeSlot` dependency so unlimited seats also respect privacy

2. **handlePaymentSuccess** (`packages/app-store/_utils/payments/handlePaymentSuccess.ts`):
   - Detects seated events using `evt.seatsPerTimeSlot`
   - Identifies current attendee by finding the one with `bookingSeat.referenceUid`
   - Calls `sendScheduledSeatsEmailsAndSMS` with only the current attendee
   - Falls back to `attendees[0]` defensively if no bookingSeat found

3. **getBooking** (`packages/features/bookings/lib/payment/getBooking.ts`):
   - Added `attendees.bookingSeat.referenceUid` to select
   - Added `seatsPerTimeSlot` and `seatsShowAttendees` to eventType select
   - Added these fields to the returned CalendarEvent object

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - no documentation changes needed
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: Manual testing required - see below

## How should this be tested?

### Test Scenario: Seated Event with Paid Bookings

1. **Setup**:
   - Create an event type with seats enabled (e.g., 5 seats per time slot)
   - Make it a paid event (e.g., $10)
   - **Disable** "Show attendees" (seatsShowAttendees = false)

2. **Test Steps**:
   - Book the event with email A and complete payment
   - Book the same time slot with email B and complete payment
   - Check email B's confirmation email

3. **Expected Results**:
   - ✅ Only email B receives a confirmation email (not email A)
   - ✅ Email B's confirmation does NOT show email A in the attendees list
   - ✅ Email A does NOT receive a duplicate confirmation email

4. **Additional Test Cases**:
   - Test with unlimited seats (seatsPerTimeSlot = null)
   - Test with seatsShowAttendees = true (should show all attendees)
   - Test with non-seated events (should work as before)

### Environment Variables
No special environment variables required beyond standard Cal.com setup with Stripe payment integration.


## Important Review Notes

⚠️ **Critical Areas to Review**:

1. **Attendee Identification Logic**: The logic `evt.attendees.find((attendee) => attendee.bookingSeat?.referenceUid) || evt.attendees[0]` assumes the attendee with a bookingSeat is the current one. Please verify this is correct for all payment flows.

2. **Potential Gap**: The smart friend mentioned that `handleConfirmation` might also need the same fix (when booking requires confirmation but payment succeeds). This PR only fixes the direct payment success path.

3. **Backward Compatibility**: Verify that non-seated events still work correctly with these changes.

4. **Privacy Logic Change**: Removed the `seatsPerTimeSlot` gate, so now unlimited seats also respect the privacy setting. This is intentional but changes existing behavior.

---

**Link to Devin run**: https://app.devin.ai/sessions/95797e94ec054f7dbdc5e3e4aa4c1e80  
**Requested by**: anik@cal.com (@anikdhabal)

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings (284 type errors exist on main, same on this branch - no new errors introduced)