### PR TITLE
feat: add UUID v7 and @db.Uuid to AuditActor model

### DIFF
--- a/packages/prisma/migrations/20251119115537_add_uuidv7_to_audit_actor/migration.sql
+++ b/packages/prisma/migrations/20251119115537_add_uuidv7_to_audit_actor/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - The primary key for the `AuditActor` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `id` on the `AuditActor` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `actorId` on the `BookingAudit` table to UUID.
+  - Changed the type of `bookingUid` on the `BookingAudit` table to UUID.
+
+*/
+
+ALTER TABLE "public"."BookingAudit" DROP CONSTRAINT "BookingAudit_actorId_fkey";
+
+ALTER TABLE "public"."BookingAudit" ALTER COLUMN "actorId" TYPE UUID USING "actorId"::UUID;
+ALTER TABLE "public"."BookingAudit" ALTER COLUMN "bookingUid" TYPE UUID USING "bookingUid"::UUID;
+
+ALTER TABLE "public"."AuditActor" DROP CONSTRAINT "AuditActor_pkey";
+
+ALTER TABLE "public"."AuditActor" ALTER COLUMN "id" TYPE UUID USING "id"::UUID;
+
+ALTER TABLE "public"."AuditActor" ADD CONSTRAINT "AuditActor_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE "public"."BookingAudit" ADD CONSTRAINT "BookingAudit_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "public"."AuditActor"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma/migrations/20251119124132_add_uuidv7_to_audit_actor/migration.sql
+++ b/packages/prisma/migrations/20251119124132_add_uuidv7_to_audit_actor/migration.sql
@@ -4,14 +4,12 @@
   - The primary key for the `AuditActor` table will be changed. If it partially fails, the table could be left without primary key constraint.
   - Changed the type of `id` on the `AuditActor` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
   - Changed the type of `actorId` on the `BookingAudit` table to UUID.
-  - Changed the type of `bookingUid` on the `BookingAudit` table to UUID.
 
 */
 
 ALTER TABLE "public"."BookingAudit" DROP CONSTRAINT "BookingAudit_actorId_fkey";
 
 ALTER TABLE "public"."BookingAudit" ALTER COLUMN "actorId" TYPE UUID USING "actorId"::UUID;
-ALTER TABLE "public"."BookingAudit" ALTER COLUMN "bookingUid" TYPE UUID USING "bookingUid"::UUID;
 
 ALTER TABLE "public"."AuditActor" DROP CONSTRAINT "AuditActor_pkey";
 

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2671,7 +2671,7 @@ enum AuditActorType {
 }
 
 model AuditActor {
-  id   String         @id @default(uuid())
+  id   String         @id @default(uuid(7)) @db.Uuid
   type AuditActorType
 
   // References for different actor types (soft references, no FK constraints)
@@ -2708,11 +2708,11 @@ model BookingAudit {
   // - When a booking is deleted, we still need to know which booking the audit log belonged to
   // - Using a plain string instead of a relation prevents bookingUid from becoming NULL on booking deletion
   // - This allows users to view complete audit history for deleted bookings
-  bookingUid String
+  bookingUid String @db.Uuid
 
   // Actor who performed the action (USER, GUEST, or SYSTEM)
   // Stored in AuditActor table to maintain audit trail even after user deletion
-  actorId String
+  actorId String     @db.Uuid
   // Restrict onDelete to prevent deletion of audit actor if there are any booking audits associated with it
   actor   AuditActor @relation(fields: [actorId], references: [id], onDelete: Restrict)
 

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2708,7 +2708,7 @@ model BookingAudit {
   // - When a booking is deleted, we still need to know which booking the audit log belonged to
   // - Using a plain string instead of a relation prevents bookingUid from becoming NULL on booking deletion
   // - This allows users to view complete audit history for deleted bookings
-  bookingUid String @db.Uuid
+  bookingUid String
 
   // Actor who performed the action (USER, GUEST, or SYSTEM)
   // Stored in AuditActor table to maintain audit trail even after user deletion


### PR DESCRIPTION
## What does this PR do?

This PR updates the audit logging models to use UUID v7 for ID generation and adds proper PostgreSQL UUID type annotations to ensure type consistency.

**Changes:**
- Updated `AuditActor.id` to use `uuid(7)` with `@db.Uuid` type annotation
- Added `@db.Uuid` type annotation to `BookingAudit.actorId` (which references `AuditActor.id`)
- Created migration to convert existing TEXT columns to PostgreSQL UUID type using CAST

**Important note:** `BookingAudit.bookingUid` intentionally remains as plain `String` (without `@db.Uuid`) because it references `Booking.uid`, which is a plain string, not a UUID.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - This is a database schema change that doesn't require documentation updates.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **N/A** - This is a schema change; existing tests will validate that the application continues to work correctly.

## How should this be tested?

**Prerequisites:**
- Ensure the database has the audit tables (`AuditActor` and `BookingAudit`) with existing data

**Test steps:**
1. Run the migration: `yarn workspace @calcom/prisma db-migrate`
2. Verify the migration completes successfully
3. Create a new booking and verify audit records are created correctly
4. Check that `AuditActor.id` and `BookingAudit.actorId` are now UUID type in the database
5. Verify that `BookingAudit.bookingUid` remains as TEXT type (not UUID)

**Expected behavior:**
- Migration should complete without errors
- New audit records should be created with UUID v7 IDs
- Existing audit records should have their IDs converted to UUID type
- Foreign key relationship between `BookingAudit.actorId` and `AuditActor.id` should remain intact

## Human Review Checklist

**Critical items to verify:**
1. ⚠️ **Data migration safety**: The migration assumes all existing `AuditActor.id` and `BookingAudit.actorId` values are valid UUIDs. If there's any non-UUID data, the migration will fail. Please verify this assumption is correct.
2. ⚠️ **Correct field selection**: Confirm that `BookingAudit.bookingUid` should NOT be a UUID (it references `Booking.uid` which is a plain string). This was initially incorrect in the first commit and was fixed.
3. **Foreign key handling**: Verify the migration correctly drops and re-adds the foreign key constraint between `BookingAudit.actorId` and `AuditActor.id`.
4. **UUID v7 generation**: Note that `@default(uuid(7))` is handled by Prisma at the application level, not at the database level (no `DEFAULT` clause in the migration).

---

**Link to Devin run:** https://app.devin.ai/sessions/c24d2b7490004aa2b0dac6ac79050826  
**Requested by:** hariom@cal.com (@hariombalhara)