### PR TITLE
chore: No more clientside markdown when importing Checkbox

### DIFF
--- a/packages/ui/components/form/checkbox/Checkbox.test.tsx
+++ b/packages/ui/components/form/checkbox/Checkbox.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/missing-playwright-await */
 import { render, fireEvent } from "@testing-library/react";
 import React from "react";
 import { vi } from "vitest";

--- a/packages/ui/components/form/checkbox/Checkbox.tsx
+++ b/packages/ui/components/form/checkbox/Checkbox.tsx
@@ -2,8 +2,6 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { useId } from "@radix-ui/react-id";
 import type { InputHTMLAttributes } from "react";
 import React, { forwardRef } from "react";
-
-import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import classNames from "@calcom/ui/classNames";
 
 import { Icon } from "../../icon";
@@ -100,7 +98,7 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
                       rest.descriptionClassName
                     )}
                     dangerouslySetInnerHTML={{
-                      __html: markdownToSafeHTML(descriptionAsSafeHtml),
+                      __html: descriptionAsSafeHtml,
                     }}
                   />
                 ) : (


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checkbox no longer converts markdown on the client; it renders pre-sanitized HTML (descriptionAsSafeHtml) directly. This reduces bundle size and improves performance.

<sup>Written for commit 7d504abf3823ac5718e07835da558f93e845a913. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

