### PR TITLE
chore(logging): log availability snapshot on round robin reassignment

### DIFF
--- a/packages/lib/server/repository/SelectedCalendarRepository.interface.ts
+++ b/packages/lib/server/repository/SelectedCalendarRepository.interface.ts
@@ -59,4 +59,11 @@ export interface ISelectedCalendarRepository {
       | "syncSubscribedAt"
     >
   ): Promise<SelectedCalendar>;
+
+  /**
+   * Find selected calendars by user id
+   *
+   * @param userId
+   */
+  findByUserId(userId: number): Promise<SelectedCalendar[]>;
 }

--- a/packages/lib/server/repository/SelectedCalendarRepository.ts
+++ b/packages/lib/server/repository/SelectedCalendarRepository.ts
@@ -73,4 +73,10 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
       data,
     });
   }
+
+  async findByUserId(userId: number) {
+    return this.prismaClient.selectedCalendar.findMany({
+      where: { userId },
+    });
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Adds detailed logging to the round robin reassignment flow to track the chosen host's availability snapshot and selected calendar IDs, matching the format used in the "booking created" log in `handleNewBooking`.

**Context**: This improves observability for round robin reassignments by logging the same availability information that's logged during initial booking creation, making it easier to debug reassignment decisions.

**Changes**:
- Added `formatAvailabilitySnapshot` helper function to format availability data (dateRanges and oooExcludedDateRanges) for logging
- Added critical log entry after host selection with booking UID, selected calendar IDs, and availability snapshot
- Extended `SelectedCalendarRepository` with `findByUserId` method to fetch calendars following the repository pattern (avoiding direct Prisma usage outside repositories)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - This is an internal logging change that doesn't affect public APIs or user-facing behavior.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **Note**: No automated tests added for this logging change. Manual verification would be needed to confirm logs appear correctly.

## How should this be tested?

**Manual Testing**:
1. Set up a round robin event type with multiple hosts
2. Create a booking and trigger a round robin reassignment
3. Check application logs for the "Round robin host reassigned" log entry
4. Verify the log includes:
   - `bookingUid`: The booking's UID
   - `selectedCalendarIds`: Array of calendar IDs for the reassigned host
   - `availabilitySnapshot`: Object with `dateRanges` and `oooExcludedDateRanges` in ISO format

**Expected Output**:
```
Round robin host reassigned {
  bookingUid: "abc123...",
  selectedCalendarIds: ["cal_123", "cal_456"],
  availabilitySnapshot: {
    dateRanges: [{ start: "2025-01-01T09:00:00Z", end: "2025-01-01T17:00:00Z" }],
    oooExcludedDateRanges: []
  }
}
```

## Human Review Checklist

**Critical Items to Review**:
- [ ] Does the log format match the "booking created" log in `RegularBookingService.ts:1736-1742`?
- [ ] Is the `SelectedCalendarRepository.findByUserId` method implemented correctly and following repository conventions?
- [ ] Are both `selectedCalendarIds` and `availabilitySnapshot` necessary, or would just the availability snapshot suffice?
- [ ] Does the additional database query for selected calendars impact performance during reassignment?
- [ ] Should this logging be behind a feature flag or log level check?

**Notes**:
- The `formatAvailabilitySnapshot` function is duplicated from `RegularBookingService.ts` - consider extracting to a shared utility if this pattern is used elsewhere
- No tests were added for the new repository method or logging functionality

---

**Link to Devin run**: https://app.devin.ai/sessions/2ac11edb95874d269ce3bd7b4b36b055  
**Requested by**: joe@cal.com (@joeauyeung)