### PR TITLE
feat: Add organization feature flags assignment modal

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/feature-flags/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/feature-flags/page.tsx
@@ -1,0 +1,37 @@
+import { _generateMetadata, getTranslate } from "app/_utils";
+
+import { OrganizationFeatureFlagsView } from "@calcom/features/flags/pages/organization-feature-flags-view";
+import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
+
+import { validateUserHasOrg } from "../actions/validateUserHasOrg";
+
+export const generateMetadata = async () =>
+  await _generateMetadata(
+    (t) => t("feature_flags"),
+    (t) => t("organization_feature_flags_description"),
+    undefined,
+    undefined,
+    "/settings/organizations/feature-flags"
+  );
+
+const Page = async () => {
+  const session = await validateUserHasOrg();
+  const t = await getTranslate();
+
+  const organizationId = session.user.profile.organizationId;
+
+  if (!organizationId) {
+    return null;
+  }
+
+  return (
+    <SettingsHeader
+      title={t("feature_flags")}
+      description={t("organization_feature_flags_description")}
+      borderInShellHeader={true}>
+      <OrganizationFeatureFlagsView organizationId={organizationId} />
+    </SettingsHeader>
+  );
+};
+
+export default Page;

--- a/packages/features/flags/components/OrganizationAssignFeatureSheet.tsx
+++ b/packages/features/flags/components/OrganizationAssignFeatureSheet.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+import { useDebounce } from "@calcom/lib/hooks/useDebounce";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Button } from "@calcom/ui/components/button";
+import { Checkbox, TextField } from "@calcom/ui/components/form";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetBody,
+  SheetFooter,
+} from "@calcom/ui/components/sheet";
+import { SkeletonContainer, SkeletonText } from "@calcom/ui/components/skeleton";
+import { showToast } from "@calcom/ui/components/toast";
+
+type Flag = RouterOutputs["viewer"]["organizations"]["listTeamFeatures"][number];
+
+interface OrganizationAssignFeatureSheetProps {
+  flag: Flag;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: number;
+}
+
+export function OrganizationAssignFeatureSheet({
+  flag,
+  open,
+  onOpenChange,
+  organizationId,
+}: OrganizationAssignFeatureSheetProps) {
+  const { t } = useLocale();
+  const utils = trpc.useUtils();
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    trpc.viewer.organizations.getTeamsForFeature.useInfiniteQuery(
+      {
+        featureId: flag.slug,
+        limit: 20,
+        searchTerm: debouncedSearchTerm || undefined,
+      },
+      {
+        enabled: open,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      }
+    );
+
+  const teams = data?.pages.flatMap((page) => page.teams) ?? [];
+
+  useEffect(() => {
+    if (!open) {
+      setSearchTerm("");
+    }
+  }, [open]);
+
+  const assignMutation = trpc.viewer.organizations.assignFeatureToTeam.useMutation({
+    onSuccess: () => {
+      utils.viewer.organizations.getTeamsForFeature.invalidate({ featureId: flag.slug });
+      utils.viewer.organizations.listTeamFeatures.invalidate({ orgId: organizationId });
+      showToast(t("feature_assigned_successfully"), "success");
+    },
+    onError: (err) => {
+      showToast(err.message, "error");
+    },
+  });
+
+  const unassignMutation = trpc.viewer.organizations.unassignFeatureFromTeam.useMutation({
+    onSuccess: () => {
+      utils.viewer.organizations.getTeamsForFeature.invalidate({ featureId: flag.slug });
+      utils.viewer.organizations.listTeamFeatures.invalidate({ orgId: organizationId });
+      showToast(t("feature_unassigned_successfully"), "success");
+    },
+    onError: (err) => {
+      showToast(err.message, "error");
+    },
+  });
+
+  const handleToggleTeam = (teamId: number, currentlyHasFeature: boolean) => {
+    if (currentlyHasFeature) {
+      unassignMutation.mutate({
+        teamId,
+        featureId: flag.slug,
+      });
+    } else {
+      assignMutation.mutate({
+        teamId,
+        featureId: flag.slug,
+      });
+    }
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const isLoading = assignMutation.isPending || unassignMutation.isPending;
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent className="bg-muted">
+        <SheetHeader>
+          <SheetTitle>Assign: {flag.slug}</SheetTitle>
+        </SheetHeader>
+        <SheetBody>
+          <div className="mb-4">
+            <TextField
+              type="text"
+              placeholder={t("search")}
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+          </div>
+          {isPending ? (
+            <SkeletonContainer>
+              <div className="space-y-3">
+                {[...Array(5)].map((_, i) => (
+                  <SkeletonText key={i} className="h-16 w-full" />
+                ))}
+              </div>
+            </SkeletonContainer>
+          ) : teams && teams.length > 0 ? (
+            <>
+              <div className="space-y-2">
+                {teams.map((team) => (
+                  <button
+                    key={team.id}
+                    type="button"
+                    onClick={() => handleToggleTeam(team.id, team.hasFeature)}
+                    disabled={isLoading}
+                    className="bg-default border-subtle hover:bg-muted flex w-full items-center justify-between rounded-lg border p-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50">
+                    <div className="flex items-center gap-3">
+                      <div className="relative">
+                        {team.isOrganization ? (
+                          <div className="h-8 w-8 overflow-hidden rounded">
+                            {team.logoUrl ? (
+                              <img
+                                src={team.logoUrl}
+                                alt={team.name || ""}
+                                className="h-full w-full object-cover"
+                              />
+                            ) : (
+                              <div className="bg-emphasis text-default flex h-full w-full items-center justify-center text-xs font-semibold">
+                                {team.name?.charAt(0).toUpperCase()}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <Avatar size="sm" alt={team.name || ""} imageSrc={team.logoUrl} />
+                        )}
+                        {team.parent && (
+                          <div className="border-emphasis absolute -bottom-1 -right-1 h-4 w-4 overflow-hidden rounded border">
+                            {team.parent.logoUrl ? (
+                              <img
+                                src={team.parent.logoUrl}
+                                alt={team.parent.name || ""}
+                                className="h-full w-full object-cover"
+                              />
+                            ) : (
+                              <div className="bg-emphasis text-default flex h-full w-full items-center justify-center text-[8px] font-semibold">
+                                {team.parent.name?.charAt(0).toUpperCase()}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <p className="text-emphasis text-sm font-medium">{team.name}</p>
+                        {team.slug && <p className="text-subtle text-xs">{team.slug}</p>}
+                        {team.parent && (
+                          <p className="text-subtle text-xs">
+                            {t("organization")}: {team.parent.name}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <Checkbox
+                      checked={team.hasFeature}
+                      disabled={isLoading}
+                      onCheckedChange={() => {}}
+                    />
+                  </button>
+                ))}
+              </div>
+              {hasNextPage && (
+                <div className="mt-4 flex justify-center">
+                  <Button
+                    color="secondary"
+                    onClick={() => fetchNextPage()}
+                    loading={isFetchingNextPage}
+                    disabled={isFetchingNextPage}>
+                    {t("load_more")}
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-subtle text-center text-sm">{t("no_teams_found")}</p>
+          )}
+        </SheetBody>
+        <SheetFooter>
+          <Button color="secondary" onClick={handleClose}>
+            {t("close")}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
+++ b/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
@@ -1,8 +1,13 @@
+import { useState } from "react";
+
 import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
+import { Button } from "@calcom/ui/components/button";
 import { PanelCard } from "@calcom/ui/components/card";
+import { Switch } from "@calcom/ui/components/form";
 import { ListItem, ListItemText, ListItemTitle } from "@calcom/ui/components/list";
 import { List } from "@calcom/ui/components/list";
+import { showToast } from "@calcom/ui/components/toast";
 
 type OrganizationFeatureFlagsListProps = {
   organizationId: number;
@@ -10,6 +15,7 @@ type OrganizationFeatureFlagsListProps = {
 
 export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFeatureFlagsListProps) => {
   const [data] = trpc.viewer.organizations.listTeamFeatures.useSuspenseQuery({ orgId: organizationId });
+  const [expandedFlags, setExpandedFlags] = useState<Set<string>>(new Set());
 
   const groupedFlags = data.reduce((acc, flag) => {
     const type = flag.type || "OTHER";
@@ -22,6 +28,18 @@ export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFea
 
   const sortedTypes = Object.keys(groupedFlags).sort();
 
+  const toggleExpanded = (slug: string) => {
+    setExpandedFlags((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) {
+        next.delete(slug);
+      } else {
+        next.add(slug);
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="space-y-4">
       {sortedTypes.map((type) => (
@@ -32,6 +50,11 @@ export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFea
                 <div className="flex flex-1 flex-col">
                   <ListItemTitle component="h3">{flag.slug}</ListItemTitle>
                   <ListItemText component="p">{flag.description}</ListItemText>
+                  {expandedFlags.has(flag.slug) && (
+                    <div className="mt-2 space-y-2">
+                      <TeamFeatureToggles featureSlug={flag.slug} assignedTeams={flag.teams} />
+                    </div>
+                  )}
                 </div>
                 <div className="flex items-center gap-2 py-2">
                   {flag.teams.length === 0 ? (
@@ -41,6 +64,13 @@ export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFea
                       {flag.teams.map((team) => team.name).join(", ")}
                     </span>
                   )}
+                  <Button
+                    color="secondary"
+                    size="sm"
+                    variant="icon"
+                    onClick={() => toggleExpanded(flag.slug)}
+                    StartIcon={expandedFlags.has(flag.slug) ? "chevron-up" : "chevron-down"}
+                  />
                 </div>
               </ListItem>
             ))}
@@ -52,3 +82,49 @@ export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFea
 };
 
 type Flag = RouterOutputs["viewer"]["organizations"]["listTeamFeatures"][number];
+
+type TeamFeatureTogglesProps = {
+  featureSlug: string;
+  assignedTeams: Array<{ id: number; name: string }>;
+};
+
+const TeamFeatureToggles = ({ featureSlug, assignedTeams }: TeamFeatureTogglesProps) => {
+  const utils = trpc.useUtils();
+  const { data: allTeams } = trpc.viewer.organizations.getTeams.useQuery();
+
+  const mutation = trpc.viewer.organizations.toggleTeamFeature.useMutation({
+    onSuccess: () => {
+      showToast("Feature flag updated successfully", "success");
+      utils.viewer.organizations.listTeamFeatures.invalidate();
+    },
+    onError: (error) => {
+      showToast(error.message || "Failed to update feature flag", "error");
+    },
+  });
+
+  if (!allTeams) {
+    return null;
+  }
+
+  const assignedTeamIds = new Set(assignedTeams.map((t) => t.id));
+
+  return (
+    <div className="space-y-2 rounded-md border border-subtle p-3">
+      {allTeams.map((team) => (
+        <div key={team.id} className="flex items-center justify-between">
+          <span className="text-sm">{team.name}</span>
+          <Switch
+            checked={assignedTeamIds.has(team.id)}
+            onCheckedChange={(checked) => {
+              mutation.mutate({
+                teamId: team.id,
+                featureSlug,
+                enabled: checked,
+              });
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
+++ b/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
@@ -1,0 +1,54 @@
+import { trpc } from "@calcom/trpc/react";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { PanelCard } from "@calcom/ui/components/card";
+import { ListItem, ListItemText, ListItemTitle } from "@calcom/ui/components/list";
+import { List } from "@calcom/ui/components/list";
+
+type OrganizationFeatureFlagsListProps = {
+  organizationId: number;
+};
+
+export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFeatureFlagsListProps) => {
+  const [data] = trpc.viewer.organizations.listTeamFeatures.useSuspenseQuery({ orgId: organizationId });
+
+  const groupedFlags = data.reduce((acc, flag) => {
+    const type = flag.type || "OTHER";
+    if (!acc[type]) {
+      acc[type] = [];
+    }
+    acc[type].push(flag);
+    return acc;
+  }, {} as Record<string, typeof data>);
+
+  const sortedTypes = Object.keys(groupedFlags).sort();
+
+  return (
+    <div className="space-y-4">
+      {sortedTypes.map((type) => (
+        <PanelCard key={type} title={type.replace(/_/g, " ")} collapsible defaultCollapsed={false}>
+          <List roundContainer noBorderTreatment>
+            {groupedFlags[type].map((flag: Flag, index: number) => (
+              <ListItem key={flag.slug} rounded={index === 0 || index === groupedFlags[type].length - 1}>
+                <div className="flex flex-1 flex-col">
+                  <ListItemTitle component="h3">{flag.slug}</ListItemTitle>
+                  <ListItemText component="p">{flag.description}</ListItemText>
+                </div>
+                <div className="flex items-center gap-2 py-2">
+                  {flag.teams.length === 0 ? (
+                    <span className="text-subtle text-sm">Nobody</span>
+                  ) : (
+                    <span className="text-default text-sm">
+                      {flag.teams.map((team) => team.name).join(", ")}
+                    </span>
+                  )}
+                </div>
+              </ListItem>
+            ))}
+          </List>
+        </PanelCard>
+      ))}
+    </div>
+  );
+};
+
+type Flag = RouterOutputs["viewer"]["organizations"]["listTeamFeatures"][number];

--- a/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
+++ b/packages/features/flags/components/OrganizationFeatureFlagsList.tsx
@@ -4,10 +4,10 @@ import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
 import { PanelCard } from "@calcom/ui/components/card";
-import { Switch } from "@calcom/ui/components/form";
 import { ListItem, ListItemText, ListItemTitle } from "@calcom/ui/components/list";
 import { List } from "@calcom/ui/components/list";
-import { showToast } from "@calcom/ui/components/toast";
+
+import { OrganizationAssignFeatureSheet } from "./OrganizationAssignFeatureSheet";
 
 type OrganizationFeatureFlagsListProps = {
   organizationId: number;
@@ -15,7 +15,8 @@ type OrganizationFeatureFlagsListProps = {
 
 export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFeatureFlagsListProps) => {
   const [data] = trpc.viewer.organizations.listTeamFeatures.useSuspenseQuery({ orgId: organizationId });
-  const [expandedFlags, setExpandedFlags] = useState<Set<string>>(new Set());
+  const [selectedFlag, setSelectedFlag] = useState<Flag | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
 
   const groupedFlags = data.reduce((acc, flag) => {
     const type = flag.type || "OTHER";
@@ -28,103 +29,55 @@ export const OrganizationFeatureFlagsList = ({ organizationId }: OrganizationFea
 
   const sortedTypes = Object.keys(groupedFlags).sort();
 
-  const toggleExpanded = (slug: string) => {
-    setExpandedFlags((prev) => {
-      const next = new Set(prev);
-      if (next.has(slug)) {
-        next.delete(slug);
-      } else {
-        next.add(slug);
-      }
-      return next;
-    });
+  const handleAssignClick = (flag: Flag) => {
+    setSelectedFlag(flag);
+    setSheetOpen(true);
   };
 
   return (
-    <div className="space-y-4">
-      {sortedTypes.map((type) => (
-        <PanelCard key={type} title={type.replace(/_/g, " ")} collapsible defaultCollapsed={false}>
-          <List roundContainer noBorderTreatment>
-            {groupedFlags[type].map((flag: Flag, index: number) => (
-              <ListItem key={flag.slug} rounded={index === 0 || index === groupedFlags[type].length - 1}>
-                <div className="flex flex-1 flex-col">
-                  <ListItemTitle component="h3">{flag.slug}</ListItemTitle>
-                  <ListItemText component="p">{flag.description}</ListItemText>
-                  {expandedFlags.has(flag.slug) && (
-                    <div className="mt-2 space-y-2">
-                      <TeamFeatureToggles featureSlug={flag.slug} assignedTeams={flag.teams} />
-                    </div>
-                  )}
-                </div>
-                <div className="flex items-center gap-2 py-2">
-                  {flag.teams.length === 0 ? (
-                    <span className="text-subtle text-sm">Nobody</span>
-                  ) : (
-                    <span className="text-default text-sm">
-                      {flag.teams.map((team) => team.name).join(", ")}
-                    </span>
-                  )}
-                  <Button
-                    color="secondary"
-                    size="sm"
-                    variant="icon"
-                    onClick={() => toggleExpanded(flag.slug)}
-                    StartIcon={expandedFlags.has(flag.slug) ? "chevron-up" : "chevron-down"}
-                  />
-                </div>
-              </ListItem>
-            ))}
-          </List>
-        </PanelCard>
-      ))}
-    </div>
+    <>
+      <div className="space-y-4">
+        {sortedTypes.map((type) => (
+          <PanelCard key={type} title={type.replace(/_/g, " ")} collapsible defaultCollapsed={false}>
+            <List roundContainer noBorderTreatment>
+              {groupedFlags[type].map((flag: Flag, index: number) => (
+                <ListItem key={flag.slug} rounded={index === 0 || index === groupedFlags[type].length - 1}>
+                  <div className="flex flex-1 flex-col">
+                    <ListItemTitle component="h3">{flag.slug}</ListItemTitle>
+                    <ListItemText component="p">{flag.description}</ListItemText>
+                  </div>
+                  <div className="flex items-center gap-2 py-2">
+                    {flag.teams.length === 0 ? (
+                      <span className="text-subtle text-sm">Nobody</span>
+                    ) : (
+                      <span className="text-default text-sm">
+                        {flag.teams.map((team) => team.name).join(", ")}
+                      </span>
+                    )}
+                    <Button
+                      color="secondary"
+                      size="sm"
+                      variant="icon"
+                      onClick={() => handleAssignClick(flag)}
+                      StartIcon="users"
+                    />
+                  </div>
+                </ListItem>
+              ))}
+            </List>
+          </PanelCard>
+        ))}
+      </div>
+      {selectedFlag && (
+        <OrganizationAssignFeatureSheet
+          flag={selectedFlag}
+          open={sheetOpen}
+          onOpenChange={setSheetOpen}
+          organizationId={organizationId}
+        />
+      )}
+    </>
   );
 };
 
 type Flag = RouterOutputs["viewer"]["organizations"]["listTeamFeatures"][number];
-
-type TeamFeatureTogglesProps = {
-  featureSlug: string;
-  assignedTeams: Array<{ id: number; name: string }>;
-};
-
-const TeamFeatureToggles = ({ featureSlug, assignedTeams }: TeamFeatureTogglesProps) => {
-  const utils = trpc.useUtils();
-  const { data: allTeams } = trpc.viewer.organizations.getTeams.useQuery();
-
-  const mutation = trpc.viewer.organizations.toggleTeamFeature.useMutation({
-    onSuccess: () => {
-      showToast("Feature flag updated successfully", "success");
-      utils.viewer.organizations.listTeamFeatures.invalidate();
-    },
-    onError: (error) => {
-      showToast(error.message || "Failed to update feature flag", "error");
-    },
-  });
-
-  if (!allTeams) {
-    return null;
-  }
-
-  const assignedTeamIds = new Set(assignedTeams.map((t) => t.id));
-
-  return (
-    <div className="space-y-2 rounded-md border border-subtle p-3">
-      {allTeams.map((team) => (
-        <div key={team.id} className="flex items-center justify-between">
-          <span className="text-sm">{team.name}</span>
-          <Switch
-            checked={assignedTeamIds.has(team.id)}
-            onCheckedChange={(checked) => {
-              mutation.mutate({
-                teamId: team.id,
-                featureSlug,
-                enabled: checked,
-              });
-            }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-};

--- a/packages/features/flags/pages/organization-feature-flags-view.tsx
+++ b/packages/features/flags/pages/organization-feature-flags-view.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Suspense } from "react";
+
+import NoSSR from "@calcom/lib/components/NoSSR";
+import { SkeletonText, SkeletonContainer } from "@calcom/ui/components/skeleton";
+
+import { OrganizationFeatureFlagsList } from "../components/OrganizationFeatureFlagsList";
+
+const SkeletonLoader = () => {
+  return (
+    <SkeletonContainer>
+      <div className="divide-subtle mb-8 mt-6 space-y-6">
+        <SkeletonText className="h-8 w-full" />
+        <SkeletonText className="h-8 w-full" />
+      </div>
+    </SkeletonContainer>
+  );
+};
+
+type OrganizationFeatureFlagsViewProps = {
+  organizationId: number;
+};
+
+export const OrganizationFeatureFlagsView = ({ organizationId }: OrganizationFeatureFlagsViewProps) => {
+  return (
+    <NoSSR>
+      <Suspense fallback={<SkeletonLoader />}>
+        <OrganizationFeatureFlagsList organizationId={organizationId} />
+      </Suspense>
+    </NoSSR>
+  );
+};

--- a/packages/trpc/server/routers/viewer/organizations/_router.tsx
+++ b/packages/trpc/server/routers/viewer/organizations/_router.tsx
@@ -36,6 +36,7 @@ import { ZRemoveHostsFromEventTypes } from "./removeHostsFromEventTypes.schema";
 import { ZSetPasswordSchema } from "./setPassword.schema";
 import { ZUpdateInputSchema } from "./update.schema";
 import { ZUpdateUserInputSchema } from "./updateUser.schema";
+import { ZListTeamFeaturesSchema } from "./listTeamFeatures.schema";
 
 export const viewerOrganizationsRouter = router({
   getOrganizationOnboarding: authedProcedure.query(async (opts) => {
@@ -214,6 +215,10 @@ export const viewerOrganizationsRouter = router({
     }),
   pendingReportsCount: authedOrgAdminProcedure.query(async (opts) => {
     const { default: handler } = await import("./pendingReportsCount.handler");
+    return handler(opts);
+  }),
+  listTeamFeatures: authedOrgAdminProcedure.input(ZListTeamFeaturesSchema).query(async (opts) => {
+    const { default: handler } = await import("./listTeamFeatures.handler");
     return handler(opts);
   }),
 

--- a/packages/trpc/server/routers/viewer/organizations/_router.tsx
+++ b/packages/trpc/server/routers/viewer/organizations/_router.tsx
@@ -38,6 +38,9 @@ import { ZUpdateInputSchema } from "./update.schema";
 import { ZUpdateUserInputSchema } from "./updateUser.schema";
 import { ZListTeamFeaturesSchema } from "./listTeamFeatures.schema";
 import { ZToggleTeamFeatureSchema } from "./toggleTeamFeature.schema";
+import { ZGetTeamsForFeatureSchema } from "./getTeamsForFeature.schema";
+import { ZAssignFeatureToTeamSchema } from "./assignFeatureToTeam.schema";
+import { ZUnassignFeatureFromTeamSchema } from "./unassignFeatureFromTeam.schema";
 
 export const viewerOrganizationsRouter = router({
   getOrganizationOnboarding: authedProcedure.query(async (opts) => {
@@ -226,5 +229,23 @@ export const viewerOrganizationsRouter = router({
     const { default: handler } = await import("./toggleTeamFeature.handler");
     return handler(opts);
   }),
+  getTeamsForFeature: authedOrgAdminProcedure
+    .input(ZGetTeamsForFeatureSchema)
+    .query(async (opts) => {
+      const { default: handler } = await import("./getTeamsForFeature.handler");
+      return handler(opts);
+    }),
+  assignFeatureToTeam: authedOrgAdminProcedure
+    .input(ZAssignFeatureToTeamSchema)
+    .mutation(async (opts) => {
+      const { default: handler } = await import("./assignFeatureToTeam.handler");
+      return handler(opts);
+    }),
+  unassignFeatureFromTeam: authedOrgAdminProcedure
+    .input(ZUnassignFeatureFromTeamSchema)
+    .mutation(async (opts) => {
+      const { default: handler } = await import("./unassignFeatureFromTeam.handler");
+      return handler(opts);
+    }),
 
 });

--- a/packages/trpc/server/routers/viewer/organizations/_router.tsx
+++ b/packages/trpc/server/routers/viewer/organizations/_router.tsx
@@ -37,6 +37,7 @@ import { ZSetPasswordSchema } from "./setPassword.schema";
 import { ZUpdateInputSchema } from "./update.schema";
 import { ZUpdateUserInputSchema } from "./updateUser.schema";
 import { ZListTeamFeaturesSchema } from "./listTeamFeatures.schema";
+import { ZToggleTeamFeatureSchema } from "./toggleTeamFeature.schema";
 
 export const viewerOrganizationsRouter = router({
   getOrganizationOnboarding: authedProcedure.query(async (opts) => {
@@ -219,6 +220,10 @@ export const viewerOrganizationsRouter = router({
   }),
   listTeamFeatures: authedOrgAdminProcedure.input(ZListTeamFeaturesSchema).query(async (opts) => {
     const { default: handler } = await import("./listTeamFeatures.handler");
+    return handler(opts);
+  }),
+  toggleTeamFeature: authedOrgAdminProcedure.input(ZToggleTeamFeatureSchema).mutation(async (opts) => {
+    const { default: handler } = await import("./toggleTeamFeature.handler");
     return handler(opts);
   }),
 

--- a/packages/trpc/server/routers/viewer/organizations/assignFeatureToTeam.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/assignFeatureToTeam.handler.ts
@@ -1,0 +1,44 @@
+import { TRPCError } from "@trpc/server";
+
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TAssignFeatureToTeamSchema } from "./assignFeatureToTeam.schema";
+
+type AssignFeatureToTeamOptions = {
+  ctx: {
+    user: { id: number; organizationId: number | null };
+    prisma: PrismaClient;
+  };
+  input: TAssignFeatureToTeamSchema;
+};
+
+export const assignFeatureToTeamHandler = async (opts: AssignFeatureToTeamOptions) => {
+  const { ctx, input } = opts;
+  const { prisma, user } = ctx;
+  const { teamId, featureId } = input;
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { parentId: true },
+  });
+
+  if (!team) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Team not found",
+    });
+  }
+
+  if (team.parentId !== user.organizationId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Team does not belong to your organization",
+    });
+  }
+
+  const featuresRepository = new FeaturesRepository(prisma);
+  await featuresRepository.toggleFeatureForTeam(teamId, featureId, true, user.id.toString());
+};
+
+export default assignFeatureToTeamHandler;

--- a/packages/trpc/server/routers/viewer/organizations/assignFeatureToTeam.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/assignFeatureToTeam.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ZAssignFeatureToTeamSchema = z.object({
+  teamId: z.number(),
+  featureId: z.string(),
+});
+
+export type TAssignFeatureToTeamSchema = z.infer<typeof ZAssignFeatureToTeamSchema>;

--- a/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.handler.ts
@@ -52,7 +52,7 @@ export const getTeamsForFeatureHandler = async (opts: GetTeamsForFeatureOptions)
           logoUrl: true,
         },
       },
-      teamFeatures: {
+      features: {
         where: {
           featureId,
         },
@@ -76,7 +76,7 @@ export const getTeamsForFeatureHandler = async (opts: GetTeamsForFeatureOptions)
     logoUrl: team.logoUrl,
     isOrganization: team.isOrganization,
     parent: team.parent,
-    hasFeature: team.teamFeatures.length > 0,
+    hasFeature: team.features.length > 0,
   }));
 
   return {

--- a/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.handler.ts
@@ -1,0 +1,88 @@
+import { TRPCError } from "@trpc/server";
+
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TGetTeamsForFeatureSchema } from "./getTeamsForFeature.schema";
+
+type GetTeamsForFeatureOptions = {
+  ctx: {
+    user: { id: number; organizationId: number | null };
+    prisma: PrismaClient;
+  };
+  input: TGetTeamsForFeatureSchema;
+};
+
+export const getTeamsForFeatureHandler = async (opts: GetTeamsForFeatureOptions) => {
+  const { ctx, input } = opts;
+  const { prisma, user } = ctx;
+  const { featureId, limit, cursor, searchTerm } = input;
+
+  if (!user.organizationId) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "You must be part of an organization",
+    });
+  }
+
+  const where = {
+    parentId: user.organizationId,
+    ...(searchTerm && {
+      OR: [
+        { name: { contains: searchTerm, mode: "insensitive" as const } },
+        { slug: { contains: searchTerm, mode: "insensitive" as const } },
+      ],
+    }),
+  };
+
+  const teams = await prisma.team.findMany({
+    where,
+    take: limit + 1,
+    ...(cursor && { skip: 1, cursor: { id: cursor } }),
+    orderBy: { id: "asc" },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      logoUrl: true,
+      isOrganization: true,
+      parent: {
+        select: {
+          id: true,
+          name: true,
+          logoUrl: true,
+        },
+      },
+      teamFeatures: {
+        where: {
+          featureId,
+        },
+        select: {
+          featureId: true,
+        },
+      },
+    },
+  });
+
+  let nextCursor: number | undefined = undefined;
+  if (teams.length > limit) {
+    const nextItem = teams.pop();
+    nextCursor = nextItem?.id;
+  }
+
+  const teamsWithFeature = teams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    slug: team.slug,
+    logoUrl: team.logoUrl,
+    isOrganization: team.isOrganization,
+    parent: team.parent,
+    hasFeature: team.teamFeatures.length > 0,
+  }));
+
+  return {
+    teams: teamsWithFeature,
+    nextCursor,
+  };
+};
+
+export default getTeamsForFeatureHandler;

--- a/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/getTeamsForFeature.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ZGetTeamsForFeatureSchema = z.object({
+  featureId: z.string(),
+  limit: z.number().min(1).max(100).default(20),
+  cursor: z.number().optional(),
+  searchTerm: z.string().optional(),
+});
+
+export type TGetTeamsForFeatureSchema = z.infer<typeof ZGetTeamsForFeatureSchema>;

--- a/packages/trpc/server/routers/viewer/organizations/listTeamFeatures.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listTeamFeatures.handler.ts
@@ -1,0 +1,25 @@
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TListTeamFeaturesSchema } from "./listTeamFeatures.schema";
+
+type ListTeamFeaturesOptions = {
+  ctx: {
+    user: { id: number };
+    prisma: PrismaClient;
+  };
+  input: TListTeamFeaturesSchema;
+};
+
+export const listTeamFeaturesHandler = async (opts: ListTeamFeaturesOptions) => {
+  const { ctx, input } = opts;
+  const { prisma } = ctx;
+  const { orgId } = input;
+
+  const featuresRepository = new FeaturesRepository(prisma);
+  const organizationTeamFeatures = await featuresRepository.getOrganizationTeamFeatures(orgId);
+
+  return organizationTeamFeatures;
+};
+
+export default listTeamFeaturesHandler;

--- a/packages/trpc/server/routers/viewer/organizations/listTeamFeatures.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listTeamFeatures.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const ZListTeamFeaturesSchema = z.object({
+  orgId: z.number(),
+});
+
+export type TListTeamFeaturesSchema = z.infer<typeof ZListTeamFeaturesSchema>;

--- a/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.handler.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TToggleTeamFeatureSchema } from "./toggleTeamFeature.schema";
+
+type ToggleTeamFeatureOptions = {
+  ctx: {
+    user: { id: number };
+    prisma: PrismaClient;
+  };
+  input: TToggleTeamFeatureSchema;
+};
+
+export const toggleTeamFeatureHandler = async (opts: ToggleTeamFeatureOptions) => {
+  const { ctx, input } = opts;
+  const { prisma, user } = ctx;
+  const { teamId, featureSlug, enabled } = input;
+
+  if (enabled) {
+    return prisma.teamFeatures.upsert({
+      where: {
+        teamId_featureId: {
+          teamId,
+          featureId: featureSlug,
+        },
+      },
+      create: {
+        teamId,
+        featureId: featureSlug,
+        assignedBy: user.id.toString(),
+      },
+      update: {
+        assignedBy: user.id.toString(),
+      },
+    });
+  } else {
+    return prisma.teamFeatures.delete({
+      where: {
+        teamId_featureId: {
+          teamId,
+          featureId: featureSlug,
+        },
+      },
+    });
+  }
+};
+
+export default toggleTeamFeatureHandler;

--- a/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.handler.ts
@@ -1,10 +1,13 @@
+import { TRPCError } from "@trpc/server";
+
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import type { PrismaClient } from "@calcom/prisma";
 
 import type { TToggleTeamFeatureSchema } from "./toggleTeamFeature.schema";
 
 type ToggleTeamFeatureOptions = {
   ctx: {
-    user: { id: number };
+    user: { id: number; organizationId: number | null };
     prisma: PrismaClient;
   };
   input: TToggleTeamFeatureSchema;
@@ -15,33 +18,27 @@ export const toggleTeamFeatureHandler = async (opts: ToggleTeamFeatureOptions) =
   const { prisma, user } = ctx;
   const { teamId, featureSlug, enabled } = input;
 
-  if (enabled) {
-    return prisma.teamFeatures.upsert({
-      where: {
-        teamId_featureId: {
-          teamId,
-          featureId: featureSlug,
-        },
-      },
-      create: {
-        teamId,
-        featureId: featureSlug,
-        assignedBy: user.id.toString(),
-      },
-      update: {
-        assignedBy: user.id.toString(),
-      },
-    });
-  } else {
-    return prisma.teamFeatures.delete({
-      where: {
-        teamId_featureId: {
-          teamId,
-          featureId: featureSlug,
-        },
-      },
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { parentId: true },
+  });
+
+  if (!team) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Team not found",
     });
   }
+
+  if (team.parentId !== user.organizationId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Team does not belong to your organization",
+    });
+  }
+
+  const featuresRepository = new FeaturesRepository(prisma);
+  await featuresRepository.toggleFeatureForTeam(teamId, featureSlug, enabled, user.id.toString());
 };
 
 export default toggleTeamFeatureHandler;

--- a/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/toggleTeamFeature.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ZToggleTeamFeatureSchema = z.object({
+  teamId: z.number(),
+  featureSlug: z.string(),
+  enabled: z.boolean(),
+});
+
+export type TToggleTeamFeatureSchema = z.infer<typeof ZToggleTeamFeatureSchema>;

--- a/packages/trpc/server/routers/viewer/organizations/unassignFeatureFromTeam.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/unassignFeatureFromTeam.handler.ts
@@ -1,0 +1,44 @@
+import { TRPCError } from "@trpc/server";
+
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TUnassignFeatureFromTeamSchema } from "./unassignFeatureFromTeam.schema";
+
+type UnassignFeatureFromTeamOptions = {
+  ctx: {
+    user: { id: number; organizationId: number | null };
+    prisma: PrismaClient;
+  };
+  input: TUnassignFeatureFromTeamSchema;
+};
+
+export const unassignFeatureFromTeamHandler = async (opts: UnassignFeatureFromTeamOptions) => {
+  const { ctx, input } = opts;
+  const { prisma, user } = ctx;
+  const { teamId, featureId } = input;
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { parentId: true },
+  });
+
+  if (!team) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Team not found",
+    });
+  }
+
+  if (team.parentId !== user.organizationId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Team does not belong to your organization",
+    });
+  }
+
+  const featuresRepository = new FeaturesRepository(prisma);
+  await featuresRepository.disableFeatureForTeam(teamId, featureId);
+};
+
+export default unassignFeatureFromTeamHandler;

--- a/packages/trpc/server/routers/viewer/organizations/unassignFeatureFromTeam.schema.ts
+++ b/packages/trpc/server/routers/viewer/organizations/unassignFeatureFromTeam.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ZUnassignFeatureFromTeamSchema = z.object({
+  teamId: z.number(),
+  featureId: z.string(),
+});
+
+export type TUnassignFeatureFromTeamSchema = z.infer<typeof ZUnassignFeatureFromTeamSchema>;


### PR DESCRIPTION
## What does this PR do?

Adds an organization-scoped feature flags management page that allows organization admins to view and assign team feature flags to teams within their organization. Replaces the previous expandable toggle UI with an assignment modal pattern matching the admin flags page.

**Key changes:**
- New hidden page at `/settings/organizations/feature-flags` (not in navigation, direct URL access only)
- Assignment modal with searchable team list and checkboxes for enabling/disabling features
- Organization-scoped tRPC endpoints with proper permission validation
- Infinite scroll pagination for teams list
- Cache invalidation to keep UI in sync after assignments

**Link to Devin run:** https://app.devin.ai/sessions/8f5ccf43ae7c4b36bcb8652818c18a17  
**Requested by:** alex@cal.com (@emrysal)

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A - internal feature, not documented**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **⚠️ No automated tests added - manual testing required**

## How should this be tested?

**Prerequisites:**
- Must be logged in as an organization admin
- Organization must have sub-teams
- Some feature flags should exist in the system

**Test steps:**
1. Navigate directly to `/settings/organizations/feature-flags`
2. Verify all feature flags are listed grouped by type
3. Click the "Assign" button (users icon) on any feature flag
4. Verify the assignment modal opens with a searchable list of teams
5. Test search functionality by typing team names
6. Toggle feature assignments by clicking on team rows
7. Verify checkboxes update to reflect assignment status
8. Verify "Nobody" / team names summary updates after assignment
9. Test pagination by scrolling if many teams exist
10. Verify only teams belonging to the current organization are shown

**Expected behavior:**
- Only organization admins can access the page
- Teams can only be assigned features if they belong to the current organization
- UI updates immediately after assignment changes
- Search filters teams by name and slug
- Toast notifications appear on success/error

## Important Review Points

**⚠️ Potential Issues:**

1. **Prisma usage outside repository**: `getTeamsForFeature.handler.ts` directly queries `prisma.team.findMany()`. This violates the "no Prisma outside repositories" guideline. Consider moving this query to `FeaturesRepository` or `TeamsRepository`.

2. **No automated tests**: This PR adds significant new functionality without automated tests. Permission checks, cache invalidation, and assignment logic should be tested.

3. **Cache invalidation**: Currently invalidates by `{ featureId: flag.slug }` which may not clear all cached pages with different search/limit parameters. Consider invalidating the entire procedure or testing thoroughly.

4. **Checkbox accessibility**: The checkbox has `onCheckedChange={() => {}}` making it non-functional for keyboard users. This matches the admin pattern but may need improvement.

5. **Permission validation**: While checks exist for `team.parentId === user.organizationId`, these haven't been tested to ensure they properly prevent unauthorized cross-organization access.

## Checklist

- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
- **⚠️ I haven't added automated tests for this feature**