### PR TITLE
feat: add calendar cache telemetry

### DIFF
--- a/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
+++ b/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
@@ -34,10 +34,10 @@ function extractAndValidateProviderFromParams(params: Params): CalendarSubscript
  * If the provider is unsupported, it returns a 400 response.
  * If the webhook is processed successfully, it returns a 200 response.
  * In case of errors during processing, it returns a 500 response with the error message.
- * @param {NextRequest} request - The incoming request object.
- * @param {Object} context - The context object containing route parameters.
- * @param {Promise<Params>} context.params - A promise that resolves to the route parameters.
- * @returns {Promise<NextResponse>} - A promise that resolves to the response object.
+ * @param request - The incoming request object.
+ * @param context - The context object containing route parameters.
+ * @param context.params - A promise that resolves to the route parameters.
+ * @returns A promise that resolves to the response object.
  */
 async function postHandler(request: NextRequest, ctx: { params: Promise<Params> }) {
   const providerFromParams = extractAndValidateProviderFromParams(await ctx.params);

--- a/packages/lib/telemetry.ts
+++ b/packages/lib/telemetry.ts
@@ -21,6 +21,7 @@ export const telemetryEventTypes = {
   slugReplacementAction: "slug_replacement_action",
   org_created: "org_created",
   license_key_created: "license_key_created",
+  calendar_cache_events: "calendar_cache_events",
 };
 
 export function collectPageParameters(
@@ -85,7 +86,7 @@ export const nextCollectBasicSettings: CollectOpts = {
 
 export const extendEventData = (
   req: NextRequest | NextApiRequest,
-  res: NextResponse | NextApiResponse,
+  _res: NextResponse | NextApiResponse,
   original: { page_url: string; isTeamBooking: boolean }
 ) => {
   const onVercel =


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add telemetry for calendar subscription cache. Compute average staleness of fetched events and report it.

- **New Features**
  - Compute average milliseconds since event.updatedAt across fetched items in CalendarSubscriptionService.
  - Introduce telemetry event type: calendar_cache_events.

- **Refactors**
  - Promote fetch errors to error level; log “no events fetched” at info.
  - Tidy JSDoc/param types in webhook route and mark unused response param in telemetry utils.

<sup>Written for commit 3abfdc446870e4e9b0af3b30edbb04481fd75aba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

