### PR TITLE
feat: add hideHeader prop to Shell component for reusable header hiding

### DIFF
--- a/apps/web/app/(use-page-wrapper)/insights/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/layout.tsx
@@ -14,6 +14,7 @@ export default async function InsightsLayout({ children }: { children: React.Rea
         withoutMain={false}
         heading={t("insights")}
         subtitle={t("insights_subtitle")}
+        hideHeader={true}
         actions={<div className={`mb-2 flex items-center gap-2 ${CTA_CONTAINER_CLASS_NAME}`} />}>
         <UpgradeTipWrapper>{children}</UpgradeTipWrapper>
       </Shell>

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -85,6 +85,7 @@ export type LayoutProps = {
   afterHeading?: ReactNode;
   smallHeading?: boolean;
   isPlatformUser?: boolean;
+  hideHeader?: boolean;
 };
 
 const KBarWrapper = ({ children, withKBar = false }: { withKBar: boolean; children: React.ReactNode }) =>
@@ -127,7 +128,7 @@ export function ShellMain(props: LayoutProps) {
 
   return (
     <>
-      {(props.heading || !!props.backPath) && (
+      {!props.hideHeader && (props.heading || !!props.backPath) && (
         <div
           className={classNames(
             "bg-default sticky top-0 z-10 mb-0 flex items-center py-2 md:mb-6 md:mt-0",


### PR DESCRIPTION
## What does this PR do?

Adds a reusable `hideHeader` prop to the Shell component that allows pages to hide the sticky header section. This prop is now used on the insights page to hide the header containing the page title and subtitle.

**Context**: This change was requested to clean up the insights page UI by removing the redundant header section.

## Changes Made

- Added `hideHeader?: boolean` prop to `LayoutProps` interface in `packages/features/shell/Shell.tsx`
- Updated `ShellMain` component to conditionally render the header based on the `hideHeader` prop
- Set `hideHeader={true}` in the insights page layout (`apps/web/app/(use-page-wrapper)/insights/layout.tsx`)

## Important Review Points

⚠️ **Please verify the following**:

1. **Visual check**: The insights page (`/insights`) should no longer show the sticky header with "Insights" title and subtitle
2. **No regressions**: Other pages using the Shell component should be unaffected (header should still appear normally)
3. **Conditional logic**: The condition `!props.hideHeader && (props.heading || !!props.backPath)` correctly hides the entire header div when `hideHeader={true}`

## How should this be tested?

1. Navigate to `/insights` page
2. Verify the sticky header (with "Insights" title and subtitle) is no longer visible
3. Navigate to other pages (e.g., `/event-types`, `/bookings`) and verify their headers still display correctly
4. Check that the insights page content and filters are still functional

**Expected behavior**: The insights page should render without the sticky header section, while all other pages remain unchanged.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - This is a minor UI change that doesn't require documentation updates.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. **N/A** - This is a visual UI change that would require E2E tests, which are not included in this PR.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas **N/A** - Code is self-explanatory
- [x] I have checked if my changes generate no new warnings

---

**Devin run**: https://app.devin.ai/sessions/5f0e2a0dcd9b45079730e3e7820dd790  
**Requested by**: @PeerRich