### PR TITLE
fix: enable api v2 sms

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/providers/twilioProvider.ts
+++ b/packages/features/ee/workflows/lib/reminders/providers/twilioProvider.ts
@@ -2,16 +2,16 @@ import type { NextRequest } from "next/server";
 import TwilioClient from "twilio";
 import { v4 as uuidv4 } from "uuid";
 
-import { checkSMSRateLimit } from "@calcom/lib/smsLockState";
-import { WEBAPP_URL } from "@calcom/lib/constants";
+import { IS_API_V2_E2E, WEBAPP_URL } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
+import { checkSMSRateLimit } from "@calcom/lib/smsLockState";
 import { setTestSMS } from "@calcom/lib/testSMS";
 import prisma from "@calcom/prisma";
 import { SMSLockState } from "@calcom/prisma/enums";
 
 const log = logger.getSubLogger({ prefix: ["[twilioProvider]"] });
 
-const testMode = process.env.NEXT_PUBLIC_IS_E2E || process.env.INTEGRATION_TEST_MODE || process.env.IS_E2E;
+const testMode = process.env.NEXT_PUBLIC_IS_E2E || process.env.INTEGRATION_TEST_MODE || IS_API_V2_E2E;
 
 function createTwilioClient() {
   if (process.env.TWILIO_SID && process.env.TWILIO_TOKEN && process.env.TWILIO_MESSAGING_SID) {

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -258,3 +258,5 @@ export const ENV_PAST_BOOKING_RESCHEDULE_CHANGE_TEAM_IDS =
 export const ORG_TRIAL_DAYS = process.env.STRIPE_ORG_TRIAL_DAYS
   ? Math.max(0, parseInt(process.env.STRIPE_ORG_TRIAL_DAYS, 10))
   : null;
+
+export const IS_API_V2_E2E = process.env.IS_E2E === "true";


### PR DESCRIPTION
Fixing SMS not being triggered via apiv2 because of how IS_E2E is treated on API v2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables SMS sending in API v2 by fixing E2E test-mode detection in the Twilio provider. Test mode now only activates when IS_E2E is exactly "true", preventing accidental suppression of real SMS.

- **Bug Fixes**
  - Added IS_API_V2_E2E constant and used it in Twilio provider.
  - Prevented test mode from enabling when IS_E2E="false", restoring SMS delivery in API v2.

<sup>Written for commit 37b065c79e2cf74c1af7b46731675f2a18a02d11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

