### PR TITLE
docs: update the app store doc regarding seed

### DIFF
--- a/docs/self-hosting/apps/install-apps/google.mdx
+++ b/docs/self-hosting/apps/install-apps/google.mdx
@@ -53,5 +53,5 @@ title: "Google"
 After adding Google credentials, you can now add the Google Calendar App to the app store. Repopulate the App store by running:
 
 <Step title="Repopulate App Store">
-    Run `pnpm db-seed` to update the app store and include the newly added Google Calendar integration.
+    Run `yarn workspace @calcom/prisma seed-app-store` to update the app store and include the newly added Google Calendar integration.
 </Step>


### PR DESCRIPTION
## What does this PR do?

This PR updates the app store doc. Replacing `db-seed` with `seed-app-store`.