### PR TITLE
fix: meeting ended page server component dto

### DIFF
--- a/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/video/meeting-ended/[uid]/getServerSideProps.ts
@@ -23,10 +23,15 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     return redirect;
   }
 
-  const bookingObj = Object.assign({}, booking, {
-    startTime: booking.startTime.toString(),
-    endTime: booking.endTime.toString(),
-  });
+  // Booking Object DTO, we should not expose any sensitive data through getServerSideProps + server components
+  const bookingObj = Object.assign(
+    {},
+    {
+      title: booking.title,
+      startTime: booking.startTime.toString(),
+      endTime: booking.endTime.toString(),
+    }
+  );
 
   return {
     props: {

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -640,18 +640,6 @@ export class BookingRepository {
       select: {
         ...bookingMinimalSelect,
         uid: true,
-        user: {
-          select: {
-            credentials: true,
-          },
-        },
-        references: {
-          select: {
-            uid: true,
-            type: true,
-            meetingUrl: true,
-          },
-        },
       },
     });
   }


### PR DESCRIPTION
## What does this PR do?

ensure meeting ended getServerSideProps only fetches and display the required data and nothing else

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
