### PR TITLE
fix: Remove hosts - verify event type belongs to event type

### DIFF
--- a/packages/features/membership/repositories/MembershipRepository.ts
+++ b/packages/features/membership/repositories/MembershipRepository.ts
@@ -134,6 +134,22 @@ export class MembershipRepository {
     });
   }
 
+  static async findAcceptedMembershipsByUserIdsInTeam({
+    userIds,
+    teamId,
+  }: {
+    userIds: number[];
+    teamId: number;
+  }) {
+    return prisma.membership.findMany({
+      where: {
+        userId: { in: userIds },
+        accetped: true,
+        teamId,
+      },
+    });
+  }
+
   static async createMany(data: IMembership[]) {
     return await prisma.membership.createMany({
       data: data.map((item) => ({

--- a/packages/features/membership/repositories/MembershipRepository.ts
+++ b/packages/features/membership/repositories/MembershipRepository.ts
@@ -144,7 +144,7 @@ export class MembershipRepository {
     return prisma.membership.findMany({
       where: {
         userId: { in: userIds },
-        accetped: true,
+        accepted: true,
         teamId,
       },
     });

--- a/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.test.ts
@@ -1,0 +1,346 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach, vi, expect } from "vitest";
+
+import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
+import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
+import prisma from "@calcom/prisma";
+
+import type { TrpcSessionUser } from "../../../types";
+import removeHostsFromEventTypesHandler from "./removeHostsFromEventTypes.handler";
+
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    host: {
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@calcom/features/pbac/services/permission-check.service", () => ({
+  PermissionCheckService: vi.fn(),
+}));
+
+vi.mock("@calcom/features/membership/repositories/MembershipRepository", () => ({
+  MembershipRepository: {
+    findAcceptedMembershipsByUserIdsInTeam: vi.fn(),
+  },
+}));
+
+describe("removeHostsFromEventTypesHandler", () => {
+  const mockUser = {
+    id: 1,
+    name: "Test User",
+  } as NonNullable<TrpcSessionUser>;
+
+  const mockInput = {
+    userIds: [101, 102],
+    eventTypeIds: [201, 202],
+    teamId: 300,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws UNAUTHORIZED if user does not have eventType.update permission", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(false);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    await expect(
+      removeHostsFromEventTypesHandler({
+        ctx: { user: mockUser },
+        input: mockInput,
+      })
+    ).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+
+    expect(mockCheckPermission).toHaveBeenCalledWith({
+      userId: mockUser.id,
+      teamId: mockInput.teamId,
+      permission: "eventType.update",
+      fallbackRoles: ["OWNER", "ADMIN"],
+    });
+
+    expect(MembershipRepository.findAcceptedMembershipsByUserIdsInTeam).not.toHaveBeenCalled();
+    expect(prisma.host.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes hosts when user has permission and all users are team members", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Mock that all userIds are valid team members
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 101 },
+      { userId: 102 },
+    ]);
+
+    const mockDeleteResult = { count: 3 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: mockInput,
+    });
+
+    expect(result).toEqual(mockDeleteResult);
+
+    expect(mockCheckPermission).toHaveBeenCalledWith({
+      userId: mockUser.id,
+      teamId: mockInput.teamId,
+      permission: "eventType.update",
+      fallbackRoles: ["OWNER", "ADMIN"],
+    });
+
+    expect(MembershipRepository.findAcceptedMembershipsByUserIdsInTeam).toHaveBeenCalledWith({
+      userIds: mockInput.userIds,
+      teamId: mockInput.teamId,
+    });
+
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: mockInput.eventTypeIds,
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: mockInput.userIds,
+        },
+      },
+    });
+  });
+
+  it("only removes hosts for userIds that are team members (filters out non-members)", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Mock that only userId 101 is a team member, 102 is not
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 101 },
+    ]);
+
+    const mockDeleteResult = { count: 1 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: mockInput,
+    });
+
+    expect(result).toEqual(mockDeleteResult);
+
+    expect(MembershipRepository.findAcceptedMembershipsByUserIdsInTeam).toHaveBeenCalledWith({
+      userIds: mockInput.userIds,
+      teamId: mockInput.teamId,
+    });
+
+    // Should only delete for userId 101, not 102
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: mockInput.eventTypeIds,
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: [101], // Only 101, not 102
+        },
+      },
+    });
+  });
+
+  it("handles empty userIds array", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Empty array means no memberships to validate
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([]);
+
+    const mockDeleteResult = { count: 0 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const emptyUsersInput = {
+      ...mockInput,
+      userIds: [],
+    };
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: emptyUsersInput,
+    });
+
+    expect(result).toEqual(mockDeleteResult);
+
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: mockInput.eventTypeIds,
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: [],
+        },
+      },
+    });
+  });
+
+  it("handles empty eventTypeIds array", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Mock that all userIds are valid team members
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 101 },
+      { userId: 102 },
+    ]);
+
+    const mockDeleteResult = { count: 0 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const emptyEventTypesInput = {
+      ...mockInput,
+      eventTypeIds: [],
+    };
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: emptyEventTypesInput,
+    });
+
+    expect(result).toEqual(mockDeleteResult);
+
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: [],
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: mockInput.userIds,
+        },
+      },
+    });
+  });
+
+  it("returns count of 0 when no hosts match the criteria", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Mock that all userIds are valid team members
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 101 },
+      { userId: 102 },
+    ]);
+
+    const mockDeleteResult = { count: 0 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: mockInput,
+    });
+
+    expect(result.count).toBe(0);
+  });
+
+  it("returns count of 0 when userId is a team member but not a host on the specified event types", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // User 999 is a valid team member
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 999 },
+    ]);
+
+    // But they're not a host on any of the event types
+    const mockDeleteResult = { count: 0 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const nonHostInput = {
+      ...mockInput,
+      userIds: [999],
+    };
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: nonHostInput,
+    });
+
+    expect(result.count).toBe(0);
+
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: mockInput.eventTypeIds,
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: [999],
+        },
+      },
+    });
+  });
+
+  it("returns count of 0 when event types do not belong to the specified team", async () => {
+    const mockCheckPermission = vi.fn().mockResolvedValue(true);
+    (PermissionCheckService as any).mockImplementation(() => ({
+      checkPermission: mockCheckPermission,
+    }));
+
+    // Mock that all userIds are valid team members
+    (MembershipRepository.findAcceptedMembershipsByUserIdsInTeam as any).mockResolvedValue([
+      { userId: 101 },
+      { userId: 102 },
+    ]);
+
+    // Event types belong to a different team, so no hosts should be deleted
+    const mockDeleteResult = { count: 0 };
+    (prisma.host.deleteMany as any).mockResolvedValue(mockDeleteResult);
+
+    const result = await removeHostsFromEventTypesHandler({
+      ctx: { user: mockUser },
+      input: mockInput,
+    });
+
+    expect(result.count).toBe(0);
+
+    // Verify the query includes the teamId check
+    expect(prisma.host.deleteMany).toHaveBeenCalledWith({
+      where: {
+        eventTypeId: {
+          in: mockInput.eventTypeIds,
+        },
+        eventType: {
+          teamId: mockInput.teamId,
+        },
+        userId: {
+          in: mockInput.userIds,
+        },
+      },
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.ts
@@ -1,3 +1,4 @@
+import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import prisma from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
@@ -28,6 +29,14 @@ export async function removeHostsFromEventTypesHandler({ ctx, input }: RemoveHos
   // check if user has permission to update event types
   if (!hasEventTypeUpdatePermission) throw new TRPCError({ code: "UNAUTHORIZED" });
 
+  // verify that all userIds are members of the team
+  const teamMemberIds = await MembershipRepository.findAcceptedMembershipsByUserIdsInTeam({
+    userIds,
+    teamId,
+  });
+
+  const filteredUserIds = teamMemberIds.map((teamMember) => teamMember.userId);
+
   return await prisma.host.deleteMany({
     where: {
       eventTypeId: {
@@ -37,7 +46,7 @@ export async function removeHostsFromEventTypesHandler({ ctx, input }: RemoveHos
         teamId: teamId,
       },
       userId: {
-        in: userIds,
+        in: filteredUserIds,
       },
     },
   });

--- a/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/removeHostsFromEventTypes.handler.ts
@@ -33,6 +33,9 @@ export async function removeHostsFromEventTypesHandler({ ctx, input }: RemoveHos
       eventTypeId: {
         in: eventTypeIds,
       },
+      eventType: {
+        teamId: teamId,
+      },
       userId: {
         in: userIds,
       },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When removing hosts from an event type, validate that the passed `eventTypeId` and `userIds` belong to the team

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict host removal to team-owned event types and users in the team. Adds a teamId check and filters userIds to accepted members to prevent cross-team changes.

<sup>Written for commit 16f3ebdb0f536d2707b70e60c44df84bf4906f6a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





