### PR TITLE
refactor: remove HttpError from features layer in CredentialAccessService

### DIFF
--- a/packages/features/credentials/errors.ts
+++ b/packages/features/credentials/errors.ts
@@ -1,0 +1,13 @@
+export class CredentialNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialNotFoundError";
+  }
+}
+
+export class CredentialAccessDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialAccessDeniedError";
+  }
+}

--- a/packages/features/credentials/services/CredentialAccessService.test.ts
+++ b/packages/features/credentials/services/CredentialAccessService.test.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, test, vi, beforeEach } from "vitest";
 
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
+import { CredentialNotFoundError, CredentialAccessDeniedError } from "@calcom/features/credentials/errors";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
-import { HttpError } from "@calcom/lib/http-error";
 import { prisma } from "@calcom/prisma";
 
 import { CredentialAccessService } from "./CredentialAccessService";
@@ -57,7 +58,7 @@ describe("CredentialAccessService", () => {
       delegationCredentialId: null,
     } as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,
@@ -86,7 +87,7 @@ describe("CredentialAccessService", () => {
       delegationCredentialId: null,
     } as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,
@@ -125,7 +126,7 @@ describe("CredentialAccessService", () => {
 
     vi.mocked(UserRepository).mockImplementation(() => mockUserRepo as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,
@@ -170,7 +171,7 @@ describe("CredentialAccessService", () => {
 
     vi.mocked(UserRepository).mockImplementation(() => mockUserRepo as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,
@@ -209,7 +210,7 @@ describe("CredentialAccessService", () => {
 
     vi.mocked(UserRepository).mockImplementation(() => mockUserRepo as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,
@@ -226,7 +227,7 @@ describe("CredentialAccessService", () => {
 
     vi.mocked(CredentialRepository.findFirstByIdWithKeyAndUser).mockResolvedValue(null);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     const error = await service
       .ensureAccessible({
         credentialId,
@@ -235,8 +236,7 @@ describe("CredentialAccessService", () => {
       })
       .catch((e) => e);
 
-    expect(error).toBeInstanceOf(HttpError);
-    expect(error.statusCode).toBe(404);
+    expect(error).toBeInstanceOf(CredentialNotFoundError);
     expect(error.message).toBe("Credential not found");
   });
 
@@ -275,7 +275,7 @@ describe("CredentialAccessService", () => {
 
     vi.mocked(UserRepository).mockImplementation(() => mockUserRepo as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     const error = await service
       .ensureAccessible({
         credentialId,
@@ -284,8 +284,7 @@ describe("CredentialAccessService", () => {
       })
       .catch((e) => e);
 
-    expect(error).toBeInstanceOf(HttpError);
-    expect(error.statusCode).toBe(403);
+    expect(error).toBeInstanceOf(CredentialAccessDeniedError);
     expect(error.message).toBe("You do not have access to this credential");
   });
 
@@ -308,7 +307,7 @@ describe("CredentialAccessService", () => {
       delegationCredentialId: null,
     } as any);
 
-    const service = new CredentialAccessService();
+    const service = new CredentialAccessService(prisma as any);
     await expect(
       service.ensureAccessible({
         credentialId,

--- a/packages/features/credentials/services/CredentialAccessService.ts
+++ b/packages/features/credentials/services/CredentialAccessService.ts
@@ -1,8 +1,7 @@
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
+import { CredentialNotFoundError, CredentialAccessDeniedError } from "@calcom/features/credentials/errors";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
-import { HttpError } from "@calcom/lib/http-error";
 import type { PrismaClient } from "@calcom/prisma";
-import { prisma } from "@calcom/prisma";
 
 type CredentialAccessInput = {
   credentialId: number;
@@ -18,7 +17,7 @@ type UserTeamsData = {
 export class CredentialAccessService {
   private readonly userRepository: UserRepository;
 
-  constructor(private readonly prismaClient: PrismaClient = prisma) {
+  constructor(private readonly prismaClient: PrismaClient) {
     this.userRepository = new UserRepository(this.prismaClient);
   }
 
@@ -45,10 +44,7 @@ export class CredentialAccessService {
     });
 
     if (!credential) {
-      throw new HttpError({
-        statusCode: 404,
-        message: "Credential not found",
-      });
+      throw new CredentialNotFoundError("Credential not found");
     }
 
     return credential;
@@ -122,9 +118,6 @@ export class CredentialAccessService {
   }
 
   private throwForbiddenError(): never {
-    throw new HttpError({
-      statusCode: 403,
-      message: "You do not have access to this credential",
-    });
+    throw new CredentialAccessDeniedError("You do not have access to this credential");
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR addresses the architectural concern raised in https://github.com/calcom/cal.com/pull/25315#discussion_r2549903406 about using `HttpError` within the `features` layer. The changes ensure that the features layer remains transport-agnostic by using domain errors instead of HTTP-specific errors.

**Key Changes:**
- Created domain error classes (`CredentialNotFoundError`, `CredentialAccessDeniedError`) in `packages/features/credentials/errors.ts`
- Updated `CredentialAccessService` to throw domain errors instead of `HttpError`
- Removed prisma singleton import from service, now requires `PrismaClient` in constructor (aligns with "no prisma outside of repositories" principle)
- Added error mapping in `editLocation.handler.ts` to convert domain errors to `TRPCError` at the boundary layer
- Updated all tests to expect domain errors and pass prisma to constructor

**Architectural Benefits:**
- Features layer is now transport-agnostic (no HTTP concerns)
- Error handling follows proper layering: domain errors in features → HTTP/tRPC errors at boundaries
- Service no longer depends on prisma singleton, improving testability

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. **N/A** - No documentation changes needed
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Prerequisites:**
- No special environment variables needed
- Standard Cal.com development setup

**Test Scenarios:**
1. **Credential not found (404):**
   - Try to edit a booking location with a non-existent credential ID
   - Expected: Should receive a NOT_FOUND error with message "Credential not found"

2. **Credential access denied (403):**
   - Try to edit a booking location with a credential that belongs to another user/team
   - Expected: Should receive a FORBIDDEN error with message "You do not have access to this credential"

3. **Successful credential access:**
   - Edit a booking location with a valid credential that the user owns
   - Expected: Location should update successfully

**Unit Tests:**
- Run `TZ=UTC yarn test packages/features/credentials/services/CredentialAccessService.test.ts`
- All 8 tests should pass

## Human Review Checklist

**Critical Items to Verify:**
- [ ] Confirm that `editLocation.handler.ts` is the ONLY call site for `CredentialAccessService.ensureAccessible` (search codebase for other usages)
- [ ] Verify error mapping preserves correct HTTP semantics (404 → NOT_FOUND, 403 → FORBIDDEN)
- [ ] Check if there are any other places where `CredentialAccessService` is instantiated that need updating
- [ ] Confirm the eslint-disable comment in test file is acceptable for test mocks

**Lower Priority:**
- [ ] Review domain error class naming and structure
- [ ] Verify test coverage is adequate

---

**Session Info:**
- Requested by: @sean-brydon (sean@cal.com)
- Devin Session: https://app.devin.ai/sessions/11836e4b2b0b427e9522abff12a6986a
- Addresses: https://github.com/calcom/cal.com/pull/25315#discussion_r2549903406

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings