### PR TITLE
fix(calendar): Prevent date range header from flickering

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -130,14 +130,16 @@ const BookerComponent = ({
   // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
 
+  const columnViewExtraDaysConfig = isTablet
+    ? extraDaysConfig[BookerLayouts.COLUMN_VIEW].tablet
+    : extraDaysConfig[BookerLayouts.COLUMN_VIEW].desktop;
+  
+  const relevantDates = nonEmptyScheduleDays.slice(0, columnViewExtraDaysConfig + 1).join(",");
+
   const calculatedColumnViewExtraDays = useMemo(() => {
     if (layout !== BookerLayouts.COLUMN_VIEW) {
       return columnViewExtraDays.current;
     }
-
-    const columnViewExtraDaysConfig = isTablet
-      ? extraDaysConfig[BookerLayouts.COLUMN_VIEW].tablet
-      : extraDaysConfig[BookerLayouts.COLUMN_VIEW].desktop;
 
     if (nonEmptyScheduleDays.length === 0) {
       return columnViewExtraDaysConfig;
@@ -161,7 +163,15 @@ const BookerComponent = ({
       columnAddonDays;
 
     return calculated;
-  }, [layout, selectedDate, nonEmptyScheduleDays.length, isTablet, columnViewExtraDays]);
+  }, [
+    layout,
+    selectedDate,
+    relevantDates,
+    nonEmptyScheduleDays.length,
+    isTablet,
+    columnViewExtraDays,
+    columnViewExtraDaysConfig,
+  ]);
 
   if (layout === BookerLayouts.COLUMN_VIEW) {
     columnViewExtraDays.current = calculatedColumnViewExtraDays;

--- a/packages/features/bookings/Booker/__mocks__/config.ts
+++ b/packages/features/bookings/Booker/__mocks__/config.ts
@@ -2,4 +2,10 @@ vi.mock("../config", () => ({
   useBookerResizeAnimation: () => ({ current: document.createElement("div") }),
   getBookerSizeClassNames: () => [],
   fadeInLeft: {},
+  extraDaysConfig: {
+    mobile: {desktop: 0, tablet: 0},
+    month_view: {desktop: 0, tablet: 0},
+    week_view: {desktop: 7, tablet: 4},
+    column_view: {desktop: 6, tablet: 2},
+  }
 }));

--- a/packages/features/bookings/Booker/__tests__/Booker.test.tsx
+++ b/packages/features/bookings/Booker/__tests__/Booker.test.tsx
@@ -136,6 +136,7 @@ const defaultProps = {
     extraDays: 7,
     columnViewExtraDays: { current: 7 },
     isMobile: false,
+    isTablet: false,
     layout: "MONTH_VIEW",
     hideEventTypeDetails: false,
     isEmbed: false,


### PR DESCRIPTION
## What does this PR do?

The issue was caused by incorrect handling of columnViewExtraDays.current value in packages/features/bookings/Booker/Booker.tsx.

<img width="976" height="373" alt="Screenshot 2025-11-24 at 1 43 57 AM" src="https://github.com/user-attachments/assets/2dcfd54b-8550-4120-92e3-dc27c53a4b2c" />

**Problem:**
- nonEmptyScheduleDays array changes frequently as schedule data updates
- addonDays oscillates based on the array length
- The calculation ran for all layouts, not just column view
- This caused columnViewExtraDays.current to jump between values 5 and 11

**Solution:**
- Wrapped the calculation in useMemo with stable dependencies to prevent unnecessary recalculations.
- With memo , it only recalculates when dependencies actually change
- dependency uses nonEmptyScheduleDays.length instead of the array itself

<img width="675" height="663" alt="Screenshot 2025-11-24 at 3 00 19 AM" src="https://github.com/user-attachments/assets/140b9451-0881-479f-9269-9d9fc7df06c4" />

- Fixes #25350
- Fixes CAL-6804

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

**Reproducing the issue:**

https://github.com/user-attachments/assets/2289a6b3-8ff6-4d4f-98b3-5671c20df63f

**After fixing the issue:**

https://github.com/user-attachments/assets/9a548467-fcaf-41c1-81f6-762f8ba3ae94

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

The existing Booker component tests cover the logic.This fix is just an optimization (when the calculation runs), not a logic change.