### PR TITLE
chore: Upgrade typescript to 5.9.3

### DIFF
--- a/apps/api/v1/package.json
+++ b/apps/api/v1/package.json
@@ -21,7 +21,8 @@
     "@calcom/eslint-config": "workspace:*",
     "@calcom/tsconfig": "workspace:*",
     "@calcom/types": "workspace:*",
-    "node-mocks-http": "^1.11.0"
+    "node-mocks-http": "^1.11.0",
+    "typescript": "5.9.3"
   },
   "dependencies": {
     "@calcom/app-store": "workspace:*",
@@ -40,7 +41,6 @@
     "next-axiom": "^0.17.0",
     "next-swagger-doc": "^0.3.6",
     "next-validations": "^0.2.0",
-    "typescript": "^5.9.0-beta",
     "tzdata": "^1.0.30",
     "uuid": "^8.3.2",
     "zod": "^3.22.4"

--- a/apps/api/v2/package.json
+++ b/apps/api/v2/package.json
@@ -111,8 +111,7 @@
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.1.0",
-    "typescript": "^5.9.0-beta"
+    "tsconfig-paths": "^4.1.0"
   },
   "prisma": {
     "schema": "../../../packages/prisma/schema.prisma"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -201,7 +201,7 @@
     "tailwindcss-animate": "^1.0.6",
     "ts-node": "^10.9.1",
     "turbo": "^2.5.5",
-    "typescript": "^5.9.0-beta"
+    "typescript": "5.9.3"
   },
   "nextBundleAnalysis": {
     "budget": 358400,

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "resize-observer-polyfill": "^1.5.1",
     "tsc-absolute": "^1.0.0",
     "turbo": "^2.5.5",
-    "typescript": "5.9.0-beta",
     "vitest": "^2.1.9",
     "vitest-fetch-mock": "^0.3.0",
     "vitest-mock-extended": "^2.0.2"

--- a/packages/app-store-cli/package.json
+++ b/packages/app-store-cli/package.json
@@ -30,7 +30,6 @@
     "chokidar": "^3.5.3",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.9.0-beta"
+    "ts-node": "^10.9.1"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,7 +29,6 @@
     "prettier": "^2.8.6",
     "prettier-plugin-tailwindcss": "^0.2.5",
     "tailwind-scrollbar": "^2.0.1",
-    "tailwindcss": "^3.3.3",
-    "typescript": "^5.9.0-beta"
+    "tailwindcss": "^3.3.3"
   }
 }

--- a/packages/embeds/embed-core/package.json
+++ b/packages/embeds/embed-core/package.json
@@ -54,7 +54,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.18",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.9.0-beta",
+    "typescript": "5.9.3",
     "vite": "^4.1.2",
     "vite-plugin-environment": "^1.1.3"
   }

--- a/packages/embeds/embed-react/package.json
+++ b/packages/embeds/embed-react/package.json
@@ -29,10 +29,6 @@
   "main": "./dist/Cal.umd.js",
   "module": "./dist/Cal.es.mjs",
   "types": "./dist/embed-react/src/index.d.ts",
-  "peerDependencies": {
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0"
-  },
   "files": [
     "dist"
   ],
@@ -50,11 +46,15 @@
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^2.2.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.9.0-beta",
     "vite": "^4.5.2"
   },
   "dependencies": {
     "@calcom/embed-core": "workspace:*",
     "@calcom/embed-snippet": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/embeds/embed-snippet/package.json
+++ b/packages/embeds/embed-snippet/package.json
@@ -26,10 +26,12 @@
   "types": "./dist/index.d.ts",
   "devDependencies": {
     "@calcom/eslint-config": "workspace:*",
-    "typescript": "^5.9.0-beta",
     "vite": "^4.1.2"
   },
   "dependencies": {
     "@calcom/embed-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,9 @@
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-turbo": "2.5.5",
     "globals": "15.15.0",
-    "typescript": "5.9.2",
     "typescript-eslint": "8.40.0"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "@typescript-eslint/parser": "^5.52.0",
     "@typescript-eslint/utils": "^5.52.0",
-    "ts-node-maintained": "^10.9.5",
-    "typescript": "^5.9.0-beta"
+    "ts-node-maintained": "^10.9.5"
   },
   "devDependencies": {
-    "@types/eslint": "^8.4.5"
+    "@types/eslint": "^8.4.5",
+    "typescript": "5.9.3"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -25,7 +25,6 @@
     "lingo.dev": "^0.111.1",
     "rrule": "^2.7.1",
     "sharp": "0.33.5",
-    "sonner": "^1.7.4",
     "tsdav": "2.0.3",
     "tslog": "^4.9.2",
     "uuid": "^8.3.2"
@@ -35,6 +34,6 @@
     "@calcom/tsconfig": "workspace:*",
     "@calcom/types": "workspace:*",
     "@faker-js/faker": "^7.3.0",
-    "typescript": "^5.9.0-beta"
+    "typescript": "5.9.3"
   }
 }

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -33,7 +33,6 @@
     "postcss-prefixwrap": "1.46.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.9.0-beta",
     "vite": "^5.0.10",
     "vite-plugin-dts": "^3.7.3",
     "vite-plugin-inspect": "^0.8.4",
@@ -88,6 +87,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "typescript": "^5.0.0"
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "typescript": "^5.1.0"
   }
 }

--- a/packages/platform/constants/package.json
+++ b/packages/platform/constants/package.json
@@ -8,5 +8,8 @@
     "build": "tsc --build --force tsconfig.json",
     "build:watch": "tsc --build --force ./tsconfig.json --watch",
     "post-install": "yarn build"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
   }
 }

--- a/packages/platform/enums/package.json
+++ b/packages/platform/enums/package.json
@@ -23,5 +23,8 @@
   },
   "dependencies": {
     "@calcom/platform-constants": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
   }
 }

--- a/packages/platform/examples/base/package.json
+++ b/packages/platform/examples/base/package.json
@@ -30,6 +30,6 @@
     "dotenv": "^17.2.1",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.9.0-beta"
+    "typescript": "5.9.3"
   }
 }

--- a/packages/platform/libraries/package.json
+++ b/packages/platform/libraries/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/node": "^20.3.1",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.9.0-beta",
+    "typescript": "5.9.3",
     "vite": "^5.0.12",
     "vite-plugin-dts": "^3.7.2",
     "vite-plugin-environment": "^1.1.3"

--- a/packages/platform/types/package.json
+++ b/packages/platform/types/package.json
@@ -16,5 +16,8 @@
     "@types/express": "^4.17.21",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
   }
 }

--- a/packages/platform/utils/package.json
+++ b/packages/platform/utils/package.json
@@ -16,5 +16,8 @@
     "@types/jest": "^29.5.10",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
   }
 }

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -22,7 +22,12 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@calcom/eslint-config": "workspace:*",
-    "typescript": "^5.9.0-beta"
+    "@calcom/eslint-config": "workspace:*"
+  },
+  "peerDependencies": {
+    "next": "^15.4.5",
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "typescript": "^5.1.0"
   }
 }

--- a/packages/ui/components/test-setup.tsx
+++ b/packages/ui/components/test-setup.tsx
@@ -17,12 +17,6 @@ vi.mock("framer-motion", () => ({
   useAnimate: () => [null, vi.fn()],
 }));
 
-// Add new mocks
-vi.mock("next-seo", () => ({
-  NextSeo: () => null,
-  LogoJsonLd: () => null,
-}));
-
 vi.mock("@calcom/features/ee/organizations/hooks", () => ({
   useOrgBrandingValues() {
     return {};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -92,10 +92,9 @@
     "cmk": "^0.1.1",
     "date-fns": "^3.6.0",
     "downshift": "^6.1.9",
-    "next-seo": "^6.0.0",
-    "react": "^18.2.0",
     "react-colorful": "^5.6.0",
     "react-day-picker": "^8.10.1",
+    "react-dom": "18.2.0",
     "react-hook-form": "^7.43.3",
     "react-inlinesvg": "^4.1.3",
     "react-select": "^5.7.0",
@@ -113,7 +112,10 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "lucide-static": "^0.424.0",
-    "node-html-parser": "^6.1.13",
-    "typescript": "^5.9.0-beta"
+    "node-html-parser": "^6.1.13"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "typescript": "^5.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,7 +2780,6 @@ __metadata:
     ts-loader: ^9.4.3
     ts-node: ^10.9.1
     tsconfig-paths: ^4.1.0
-    typescript: ^5.9.0-beta
     uuid: ^8.3.2
     winston: ^3.13.0
     winston-transport: ^4.7.0
@@ -2812,7 +2811,7 @@ __metadata:
     next-swagger-doc: ^0.3.6
     next-validations: ^0.2.0
     node-mocks-http: ^1.11.0
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
     tzdata: ^1.0.30
     uuid: ^8.3.2
     zod: ^3.22.4
@@ -2834,7 +2833,6 @@ __metadata:
     meow: ^9.0.0
     react: ^18.2.0
     ts-node: ^10.9.1
-    typescript: ^5.9.0-beta
   bin:
     app-store-cli: dist/cli.js
   languageName: unknown
@@ -2903,14 +2901,14 @@ __metadata:
     tailwindcss: ^3.3.3
     tailwindcss-animate: ^1.0.6
     ts-jest: ^29.1.2
-    typescript: ^5.9.0-beta
     vite: ^5.0.10
     vite-plugin-dts: ^3.7.3
     vite-plugin-inspect: ^0.8.4
     vite-plugin-node-polyfills: ^0.22.0
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
-    typescript: ^5.0.0
+    react-dom: ^18.2.0 || ^19.0.0
+    typescript: ^5.1.0
   languageName: unknown
   linkType: soft
 
@@ -2961,7 +2959,7 @@ __metadata:
     react-dom: ^18
     react-select: ^5.8.0
     tailwindcss: ^3.3.0
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3063,7 +3061,6 @@ __metadata:
     prettier-plugin-tailwindcss: ^0.2.5
     tailwind-scrollbar: ^2.0.1
     tailwindcss: ^3.3.3
-    typescript: ^5.9.0-beta
   languageName: unknown
   linkType: soft
 
@@ -3214,7 +3211,7 @@ __metadata:
     npm-run-all: ^4.1.5
     postcss: ^8.4.18
     tailwindcss: ^3.3.3
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
     vite: ^4.1.2
     vite-plugin-environment: ^1.1.3
   languageName: unknown
@@ -3232,11 +3229,11 @@ __metadata:
     "@types/react-dom": ^18.0.9
     "@vitejs/plugin-react": ^2.2.0
     npm-run-all: ^4.1.5
-    typescript: ^5.9.0-beta
     vite: ^4.5.2
   peerDependencies:
     react: ^18.2.0 || ^19.0.0
     react-dom: ^18.2.0 || ^19.0.0
+    typescript: ^5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3246,8 +3243,9 @@ __metadata:
   dependencies:
     "@calcom/embed-core": "workspace:*"
     "@calcom/eslint-config": "workspace:*"
-    typescript: ^5.9.0-beta
     vite: ^4.1.2
+  peerDependencies:
+    typescript: ^5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3268,7 +3266,7 @@ __metadata:
     eslint-plugin-react-hooks: 5.2.0
     eslint-plugin-turbo: 2.5.5
     globals: 15.15.0
-    typescript: 5.9.2
+    typescript: 5.9.3
     typescript-eslint: 8.40.0
   languageName: unknown
   linkType: soft
@@ -3281,7 +3279,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.52.0
     "@typescript-eslint/utils": ^5.52.0
     ts-node-maintained: ^10.9.5
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3633,10 +3631,9 @@ __metadata:
     lingo.dev: ^0.111.1
     rrule: ^2.7.1
     sharp: 0.33.5
-    sonner: ^1.7.4
     tsdav: 2.0.3
     tslog: ^4.9.2
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -3802,6 +3799,8 @@ __metadata:
 "@calcom/platform-constants@workspace:*, @calcom/platform-constants@workspace:packages/platform/constants":
   version: 0.0.0-use.local
   resolution: "@calcom/platform-constants@workspace:packages/platform/constants"
+  dependencies:
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3810,6 +3809,7 @@ __metadata:
   resolution: "@calcom/platform-enums@workspace:packages/platform/enums"
   dependencies:
     "@calcom/platform-constants": "workspace:*"
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3821,7 +3821,7 @@ __metadata:
     "@calcom/lib": "workspace:*"
     "@types/node": ^20.3.1
     "@vitejs/plugin-react": ^4.2.1
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
     vite: ^5.0.12
     vite-plugin-dts: ^3.7.2
     vite-plugin-environment: ^1.1.3
@@ -3837,6 +3837,7 @@ __metadata:
     "@types/express": ^4.17.21
     class-transformer: ^0.5.1
     class-validator: ^0.14.0
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -3849,6 +3850,7 @@ __metadata:
     "@types/jest": ^29.5.10
     jest: ^29.7.0
     ts-jest: ^29.1.1
+    typescript: 5.9.3
   languageName: unknown
   linkType: soft
 
@@ -4098,8 +4100,12 @@ __metadata:
     "@trpc/react-query": 11.0.0-next-beta.222
     "@trpc/server": 11.0.0-next-beta.222
     superjson: 1.9.1
-    typescript: ^5.9.0-beta
     zod: ^3.22.4
+  peerDependencies:
+    next: ^15.4.5
+    react: ^18.2.0 || ^19.0.0
+    react-dom: ^18.2.0 || ^19.0.0
+    typescript: ^5.1.0
   languageName: unknown
   linkType: soft
 
@@ -4162,17 +4168,18 @@ __metadata:
     fast-glob: ^3.3.2
     fs-extra: ^11.2.0
     lucide-static: ^0.424.0
-    next-seo: ^6.0.0
     node-html-parser: ^6.1.13
-    react: ^18.2.0
     react-colorful: ^5.6.0
     react-day-picker: ^8.10.1
+    react-dom: 18.2.0
     react-hook-form: ^7.43.3
     react-inlinesvg: ^4.1.3
     react-select: ^5.7.0
     tailwind-merge: ^1.13.2
-    typescript: ^5.9.0-beta
     uuid: ^11.1.0
+  peerDependencies:
+    react: ^18.2.0
+    typescript: ^5.1.0
   languageName: unknown
   linkType: soft
 
@@ -4384,7 +4391,7 @@ __metadata:
     ts-node: ^10.9.1
     turbo: ^2.5.5
     turndown: ^7.1.3
-    typescript: ^5.9.0-beta
+    typescript: 5.9.3
     uuid: ^8.3.2
     zod: ^3.22.4
   languageName: unknown
@@ -21287,7 +21294,6 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     tsc-absolute: ^1.0.0
     turbo: ^2.5.5
-    typescript: 5.9.0-beta
     vitest: ^2.1.9
     vitest-fetch-mock: ^0.3.0
     vitest-mock-extended: ^2.0.2
@@ -39208,7 +39214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18, react-dom@npm:^18.2.0":
+"react-dom@npm:18.2.0, react-dom@npm:^18, react-dom@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
   dependencies:
@@ -45192,23 +45198,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.0-beta":
-  version: 5.9.0-beta
-  resolution: "typescript@npm:5.9.0-beta"
+"typescript@npm:5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 42564de845d58e611b774b6222eec4aa75eaf88c79dde2b6e4d2366e2e9da344af0cdb1cc5a8fc2300dc8f33a794fafd1f7aa3ffea63caefe61f2745cb471ab8
-  languageName: node
-  linkType: hard
-
-"typescript@npm:5.9.2, typescript@npm:^5.9.0-beta, typescript@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "typescript@npm:5.9.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: f619cf6773cfe31409279711afd68cdf0859780006c50bc2a7a0c3227f85dea89a3b97248846326f3a17dad72ea90ec27cf61a8387772c680b2252fd02d8497b
+  checksum: 0d0ffb84f2cd072c3e164c79a2e5a1a1f4f168e84cb2882ff8967b92afe1def6c2a91f6838fb58b168428f9458c57a2ba06a6737711fdd87a256bbe83e9a217f
   languageName: node
   linkType: hard
 
@@ -45222,6 +45218,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: f619cf6773cfe31409279711afd68cdf0859780006c50bc2a7a0c3227f85dea89a3b97248846326f3a17dad72ea90ec27cf61a8387772c680b2252fd02d8497b
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@5.3.3#~builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=1f5320"
@@ -45232,23 +45238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.9.0-beta#~builtin<compat/typescript>":
-  version: 5.9.0-beta
-  resolution: "typescript@patch:typescript@npm%3A5.9.0-beta#~builtin<compat/typescript>::version=5.9.0-beta&hash=1f5320"
+"typescript@patch:typescript@5.9.3#~builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4a3a8b55e8b64f01ae92bab8b93771817e716e4956a07fe16d8ce33a0078da11e2ab5402f4ea8db6820dc4dbe13ca5affabfa57da9f7176e753f6e9f80ed79db
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@5.9.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.0-beta#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
-  version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#~builtin<compat/typescript>::version=5.9.2&hash=1f5320"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e42a701947325500008334622321a6ad073f842f5e7d5e7b588a6346b31fdf51d56082b9ce5cef24312ecd3e48d6c0d4d44da7555f65e2feec18cf62ec540385
+  checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
   languageName: node
   linkType: hard
 
@@ -45259,6 +45255,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#~builtin<compat/typescript>::version=5.9.2&hash=1f5320"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: e42a701947325500008334622321a6ad073f842f5e7d5e7b588a6346b31fdf51d56082b9ce5cef24312ecd3e48d6c0d4d44da7555f65e2feec18cf62ec540385
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade TypeScript to 5.9.3 across the monorepo for consistent builds and newer compiler features. Also aligns where TypeScript lives (dev vs peer) and tidies related deps.

- **Dependencies**
  - Replace all TypeScript beta refs with 5.9.3 and remove root TypeScript.
  - Move TypeScript to peerDependencies where appropriate (e.g., trpc, ui, atoms: ^5.1.0; embed-react/snippet: ^5.9.3) and add devDependencies in platform and eslint packages.
  - Normalize React peer deps (add react-dom where missing; move react to peer in ui) and remove next-seo from ui.
  - Update yarn.lock accordingly.

- **Migration**
  - Ensure TypeScript >=5.1 is installed for packages declaring it as a peer (embed-react/snippet need ^5.9.3).
  - Ensure react and react-dom ^18 or ^19 are present where required.
  - Run a fresh install; no runtime code changes expected.

<sup>Written for commit a49585b7c7f41e26e01a9c30959218be199a25ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

