### PR TITLE
fix: google meet link is disappear when a seat is cancelled

### DIFF
--- a/packages/features/bookings/lib/getBookingToDelete.ts
+++ b/packages/features/bookings/lib/getBookingToDelete.ts
@@ -34,8 +34,12 @@ export async function getBookingToDelete(id: number | undefined, uid: string | u
           credentialId: true,
           thirdPartyRecurringEventId: true,
           delegationCredentialId: true,
+          meetingUrl: true,
+          meetingId: true,
+          meetingPassword: true,
         },
       },
+      metadata: true,
       payment: true,
       paid: true,
       eventType: {

--- a/packages/features/bookings/lib/handleSeats/cancel/cancelAttendeeSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/cancel/cancelAttendeeSeat.ts
@@ -94,12 +94,24 @@ async function cancelAttendeeSeat(
         });
 
         if (credential) {
+          const videoCallReference = bookingToDelete.references.find((reference) =>
+            reference.type.includes("_video")
+          );
+
+          if (videoCallReference) {
+            evt.videoCallData = {
+              type: videoCallReference.type,
+              id: videoCallReference.meetingId,
+              password: videoCallReference?.meetingPassword,
+              url: videoCallReference.meetingUrl,
+            };
+          }
           const updatedEvt = {
             ...evt,
             attendees: evt.attendees.filter((evtAttendee) => attendee.email !== evtAttendee.email),
             calendarDescription: getRichDescription(evt),
           };
-          if (reference.type.includes("_video")) {
+          if (reference.type.includes("_video") && reference.type !== "google_meet_video") {
             integrationsToUpdate.push(updateMeeting(credential, updatedEvt, reference));
           }
           if (reference.type.includes("_calendar")) {


### PR DESCRIPTION
## What does this PR do?

## Summary by cubic
Fixes loss of Google Meet link when cancelling a single attendee seat. Seat cancellations no longer modify the Google Meet conference, and video call details are preserved for other providers.

- **Bug Fixes**
  - Skip updateMeeting for google_meet_video during seat cancellation to prevent Meet link removal.
  - Populate evt.videoCallData from the stored video reference (type, id, password, url) for correct updates with other providers.
  - Fetch meetingUrl, meetingId, meetingPassword, and metadata in getBookingToDelete for downstream use.

<sup>Written for commit 979c2682c8884f5235b8c92a14343737b11652bb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

