### PR TITLE
fix: prevent 500 errors in round-robin scheduling from OOO calibration for single host

### DIFF
--- a/packages/features/bookings/lib/getLuckyUser.ts
+++ b/packages/features/bookings/lib/getLuckyUser.ts
@@ -300,6 +300,11 @@ export class LuckyUserService implements ILuckyUserService {
     const oooCalibration = new Map<number, number>();
 
     oooData.forEach(({ userId, oooEntries }) => {
+      // Skip OOO calibration if there's only one host (division by zero would occur)
+      if (hosts.length <= 1) {
+        return;
+      }
+
       let calibration = 0;
 
       oooEntries.forEach((oooEntry) => {


### PR DESCRIPTION
## What does this PR do?

Fixes 500 error (`"Internal Error: Weight filter should never return length=0."`) in round-robin scheduling caused by 

1. **Division by zero in OOO calibration**: When a single host has out-of-office entries, the calibration calculation `bookingsInTimeframe.length / (hosts.length - 1)` causes division by zero


This issues causes NaN to propagate through booking shortfall calculations, resulting in `Math.max(...NaN values) = NaN`, and the filter `user.bookingShortfall === NaN` returns an empty array (since `NaN !== NaN`), triggering the error `"Internal Error: Weight filter should never return length=0."`

**Solutions implemented:**
1. **OOO calibration guard**: Skip OOO calibration when `hosts.length <= 1` (conceptually meaningless with a single host)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change - **N/A** (internal bug fix, no API changes)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works

