### PR TITLE
fix: exclude attendee responses from calendar for seated event

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1574,7 +1574,7 @@ async function handler(
       rescheduleUid,
       reqBookingUid: reqBody.bookingUid,
       eventType,
-      evt: { ...evt, bookerUrl },
+      evt: { ...evt, seatsPerTimeSlot: eventType.seatsPerTimeSlot, bookerUrl },
       invitee,
       allCredentials,
       organizerUser,

--- a/packages/features/calendars/lib/CalendarManager.ts
+++ b/packages/features/calendars/lib/CalendarManager.ts
@@ -500,6 +500,11 @@ export const deleteEvent = async ({
  * Process the calendar event by generating description and removing attendees if needed
  */
 const processEvent = (calEvent: CalendarEvent): CalendarServiceEvent => {
+  if (calEvent.seatsPerTimeSlot){
+    calEvent.responses = null;
+    calEvent.userFieldsResponses = null;
+    calEvent.additionalNotes = null;
+  }
   // Generate the calendar event description
   const calendarEvent: CalendarServiceEvent = {
     ...calEvent,
@@ -515,11 +520,6 @@ const processEvent = (calEvent: CalendarEvent): CalendarServiceEvent => {
 
   if (calEvent.hideOrganizerEmail && !isOrganizerExempt && !isMeetLocationType) {
     calendarEvent.attendees = [];
-  }
-
-  if (calEvent.seatsPerTimeSlot){
-    calendarEvent.responses = null;
-    calendarEvent.userFieldsResponses = null;
   }
 
   return calendarEvent;

--- a/packages/features/calendars/lib/CalendarManager.ts
+++ b/packages/features/calendars/lib/CalendarManager.ts
@@ -504,6 +504,7 @@ const processEvent = (calEvent: CalendarEvent): CalendarServiceEvent => {
     calEvent.responses = null;
     calEvent.userFieldsResponses = null;
     calEvent.additionalNotes = null;
+    calEvent.customInputs = null;
   }
   // Generate the calendar event description
   const calendarEvent: CalendarServiceEvent = {


### PR DESCRIPTION
## What does this PR do?

## Summary by cubic
Hide attendee responses, custom field answers, and notes from calendar entries for seated events. We now pass seatsPerTimeSlot through so the calendar layer can detect and sanitize these events.

- **Bug Fixes**
  - Pass seatsPerTimeSlot from eventType into evt.
  - Strip responses, userFieldsResponses, and additionalNotes in processEvent when seatsPerTimeSlot is set.

<sup>Written for commit 94f2f1686780d8b8b7e0329d10642753443c18db. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

