### PR TITLE
fix: Excessive Re-renders in Column View Cause Flickering Date Range & Incorrect Week Calculation

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -39,7 +39,7 @@ import { RedirectToInstantMeetingModal } from "./components/RedirectToInstantMee
 import { BookerSection } from "./components/Section";
 import { NotFound } from "./components/Unavailable";
 import { useIsQuickAvailabilityCheckFeatureEnabled } from "./components/hooks/useIsQuickAvailabilityCheckFeatureEnabled";
-import { fadeInLeft, getBookerSizeClassNames, useBookerResizeAnimation } from "./config";
+import { extraDaysConfig, fadeInLeft, getBookerSizeClassNames, useBookerResizeAnimation } from "./config";
 import framerFeatures from "./framer-features";
 import type { BookerProps, WrappedBookerProps } from "./types";
 import { isBookingDryRun } from "./utils/isBookingDryRun";
@@ -103,6 +103,7 @@ const BookerComponent = ({
     hideEventTypeDetails,
     isEmbed,
     bookerLayouts,
+    isTablet,
   } = bookerLayout;
 
   const [seatedEventData, setSeatedEventData] = useBookerStoreContext(
@@ -128,9 +129,53 @@ const BookerComponent = ({
       : 0;
   // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
-  if (nonEmptyScheduleDays.length !== 0)
-    columnViewExtraDays.current =
-      Math.abs(dayjs(selectedDate).diff(availableSlots[availableSlots.length - 2], "day")) + addonDays;
+
+  const columnViewExtraDaysConfig = isTablet
+    ? extraDaysConfig[BookerLayouts.COLUMN_VIEW].tablet
+    : extraDaysConfig[BookerLayouts.COLUMN_VIEW].desktop;
+
+  const relevantDates = nonEmptyScheduleDays.slice(0, columnViewExtraDaysConfig + 1).join(",");
+
+  const calculatedColumnViewExtraDays = useMemo(() => {
+    if (layout !== BookerLayouts.COLUMN_VIEW) {
+      return columnViewExtraDays.current;
+    }
+
+    if (nonEmptyScheduleDays.length === 0) {
+      return columnViewExtraDaysConfig;
+    }
+
+    const columnAddonDays =
+      nonEmptyScheduleDays.length < columnViewExtraDaysConfig
+        ? (columnViewExtraDaysConfig - nonEmptyScheduleDays.length + 1) * totalWeekDays
+        : nonEmptyScheduleDays.length === columnViewExtraDaysConfig
+        ? totalWeekDays
+        : 0;
+
+    const columnAvailableSlots = nonEmptyScheduleDays.slice(0, columnViewExtraDaysConfig + 1);
+
+    if (columnAvailableSlots.length < 2) {
+      return columnViewExtraDaysConfig;
+    }
+
+    const calculated =
+      Math.abs(dayjs(selectedDate).diff(columnAvailableSlots[columnAvailableSlots.length - 2], "day")) +
+      columnAddonDays;
+
+    return calculated;
+  }, [
+    layout,
+    selectedDate,
+    relevantDates,
+    nonEmptyScheduleDays.length,
+    isTablet,
+    columnViewExtraDays,
+    columnViewExtraDaysConfig,
+  ]);
+
+  if (layout === BookerLayouts.COLUMN_VIEW) {
+    columnViewExtraDays.current = calculatedColumnViewExtraDays;
+  }
 
   const nextSlots =
     Math.abs(dayjs(selectedDate).diff(availableSlots[availableSlots.length - 1], "day")) + addonDays;

--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -39,7 +39,7 @@ import { RedirectToInstantMeetingModal } from "./components/RedirectToInstantMee
 import { BookerSection } from "./components/Section";
 import { NotFound } from "./components/Unavailable";
 import { useIsQuickAvailabilityCheckFeatureEnabled } from "./components/hooks/useIsQuickAvailabilityCheckFeatureEnabled";
-import { extraDaysConfig, fadeInLeft, getBookerSizeClassNames, useBookerResizeAnimation } from "./config";
+import { fadeInLeft, getBookerSizeClassNames, useBookerResizeAnimation } from "./config";
 import framerFeatures from "./framer-features";
 import type { BookerProps, WrappedBookerProps } from "./types";
 import { isBookingDryRun } from "./utils/isBookingDryRun";
@@ -103,7 +103,6 @@ const BookerComponent = ({
     hideEventTypeDetails,
     isEmbed,
     bookerLayouts,
-    isTablet,
   } = bookerLayout;
 
   const [seatedEventData, setSeatedEventData] = useBookerStoreContext(
@@ -130,11 +129,7 @@ const BookerComponent = ({
   // Taking one more available slot(extraDays + 1) to calculate the no of days in between, that next and prev button need to shift.
   const availableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
 
-  const columnViewExtraDaysConfig = isTablet
-    ? extraDaysConfig[BookerLayouts.COLUMN_VIEW].tablet
-    : extraDaysConfig[BookerLayouts.COLUMN_VIEW].desktop;
-
-  const relevantDates = nonEmptyScheduleDays.slice(0, columnViewExtraDaysConfig + 1).join(",");
+  const relevantDates = nonEmptyScheduleDays.slice(0, extraDays + 1).join(",");
 
   const calculatedColumnViewExtraDays = useMemo(() => {
     if (layout !== BookerLayouts.COLUMN_VIEW) {
@@ -142,20 +137,20 @@ const BookerComponent = ({
     }
 
     if (nonEmptyScheduleDays.length === 0) {
-      return columnViewExtraDaysConfig;
+      return extraDays;
     }
 
     const columnAddonDays =
-      nonEmptyScheduleDays.length < columnViewExtraDaysConfig
-        ? (columnViewExtraDaysConfig - nonEmptyScheduleDays.length + 1) * totalWeekDays
-        : nonEmptyScheduleDays.length === columnViewExtraDaysConfig
+      nonEmptyScheduleDays.length < extraDays
+        ? (extraDays - nonEmptyScheduleDays.length + 1) * totalWeekDays
+        : nonEmptyScheduleDays.length === extraDays
         ? totalWeekDays
         : 0;
 
-    const columnAvailableSlots = nonEmptyScheduleDays.slice(0, columnViewExtraDaysConfig + 1);
+    const columnAvailableSlots = nonEmptyScheduleDays.slice(0, extraDays + 1);
 
     if (columnAvailableSlots.length < 2) {
-      return columnViewExtraDaysConfig;
+      return extraDays;
     }
 
     const calculated =
@@ -163,15 +158,7 @@ const BookerComponent = ({
       columnAddonDays;
 
     return calculated;
-  }, [
-    layout,
-    selectedDate,
-    relevantDates,
-    nonEmptyScheduleDays.length,
-    isTablet,
-    columnViewExtraDays,
-    columnViewExtraDaysConfig,
-  ]);
+  }, [layout, selectedDate, relevantDates, nonEmptyScheduleDays.length, extraDays, columnViewExtraDays]);
 
   if (layout === BookerLayouts.COLUMN_VIEW) {
     columnViewExtraDays.current = calculatedColumnViewExtraDays;

--- a/packages/features/bookings/Booker/__mocks__/config.ts
+++ b/packages/features/bookings/Booker/__mocks__/config.ts
@@ -1,5 +1,25 @@
+import { BookerLayouts } from "@calcom/prisma/zod-utils";
+
 vi.mock("../config", () => ({
   useBookerResizeAnimation: () => ({ current: document.createElement("div") }),
   getBookerSizeClassNames: () => [],
   fadeInLeft: {},
+  extraDaysConfig: {
+    mobile: {
+      desktop: 0,
+      tablet: 0,
+    },
+    [BookerLayouts.MONTH_VIEW]: {
+      desktop: 0,
+      tablet: 0,
+    },
+    [BookerLayouts.WEEK_VIEW]: {
+      desktop: 7,
+      tablet: 4,
+    },
+    [BookerLayouts.COLUMN_VIEW]: {
+      desktop: 6,
+      tablet: 2,
+    },
+  },
 }));

--- a/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
+++ b/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
@@ -1,4 +1,5 @@
 import dayjs from "@calcom/dayjs";
+import { BookerLayouts } from "@calcom/prisma/zod-utils";
 import type { BookerState } from "@calcom/features/bookings/Booker/types";
 
 import { getPrefetchMonthCount } from "../../utils/getPrefetchMonthCount";
@@ -19,9 +20,18 @@ export const usePrefetch = ({ date, month, bookerLayout, bookerState }: UsePrefe
   const dateMonth = dayjs(date).month();
   const monthAfterAdding1Month = dayjs(date).add(1, "month").month();
   const monthAfterAddingExtraDays = dayjs(date).add(bookerLayout.extraDays, "day").month();
-  const monthAfterAddingExtraDaysColumnView = dayjs(date)
-    .add(bookerLayout.columnViewExtraDays.current, "day")
-    .month();
+
+  // We use a buffer to ensure we prefetch next month if the slots might extend into it.
+  // Since column view shows a number of *slots*, not days, we might need more days than 'extraDays'
+  // if there are unavailable days (like weekends).
+  // Adding 7 days (1 week) buffer covers most cases where weekends/holidays push the needed dates into next month.
+  // This prevents oscillation where fetching more data shrinks columnViewExtraDays, causing us to stop fetching, which expands it again.
+  const columnViewExtraDays =
+    bookerLayout.layout === BookerLayouts.COLUMN_VIEW
+      ? Math.max(bookerLayout.columnViewExtraDays.current, bookerLayout.extraDays + 7)
+      : bookerLayout.columnViewExtraDays.current;
+
+  const monthAfterAddingExtraDaysColumnView = dayjs(date).add(columnViewExtraDays, "day").month();
 
   const prefetchNextMonth = isPrefetchNextMonthEnabled(
     bookerLayout.layout,

--- a/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
+++ b/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
@@ -21,11 +21,7 @@ export const usePrefetch = ({ date, month, bookerLayout, bookerState }: UsePrefe
   const monthAfterAdding1Month = dayjs(date).add(1, "month").month();
   const monthAfterAddingExtraDays = dayjs(date).add(bookerLayout.extraDays, "day").month();
 
-  // We use a buffer to ensure we prefetch next month if the slots might extend into it.
-  // Since column view shows a number of *slots*, not days, we might need more days than 'extraDays'
-  // if there are unavailable days (like weekends).
-  // Adding 7 days (1 week) buffer covers most cases where weekends/holidays push the needed dates into next month.
-  // This prevents oscillation where fetching more data shrinks columnViewExtraDays, causing us to stop fetching, which expands it again.
+  // Add extra week buffer for column view to handle weekends/unavailable days
   const columnViewExtraDays =
     bookerLayout.layout === BookerLayouts.COLUMN_VIEW
       ? Math.max(bookerLayout.columnViewExtraDays.current, bookerLayout.extraDays + 7)

--- a/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
+++ b/packages/features/bookings/Booker/components/hooks/usePrefetch.ts
@@ -1,6 +1,6 @@
 import dayjs from "@calcom/dayjs";
-import { BookerLayouts } from "@calcom/prisma/zod-utils";
 import type { BookerState } from "@calcom/features/bookings/Booker/types";
+import { BookerLayouts } from "@calcom/prisma/zod-utils";
 
 import { getPrefetchMonthCount } from "../../utils/getPrefetchMonthCount";
 import { isPrefetchNextMonthEnabled } from "../../utils/isPrefetchNextMonthEnabled";


### PR DESCRIPTION
## What does this PR do?

This PR fixes the date range header flickering and excessive re-rendering issues in the column view of the booking calendar. The problem occurred when navigating between dates near month boundaries, where the header would flicker between different week ranges and cause performance issues due to unnecessary component re-renders.

- Fixes #25354
- Fixes [CAL-6805](https://linear.app/calcom/issue/CAL-6805/booker-excessive-re-renders-in-column-view-cause-flickering-date-range)

Fixed two issues:

1. **Prevent unnecessary re-renders:** Wrapped `columnViewExtraDays` calculation in `useMemo` with stable dependencies to ensure recalculation only happens when relevant data changes (selected date, schedule data, layout)
2. **Stabilize prefetch behavior:** Added 7-day buffer to prefetch logic to ensure sufficient data is always fetched, even when weekends/unavailable days create gaps, preventing the oscillation cycle

## Visual Demo (For contributors especially)
- Before:

https://github.com/user-attachments/assets/974bf599-f19b-4a12-8af7-58a88e1295c0



- After:

https://github.com/user-attachments/assets/a5bccad8-0a57-4656-8a77-7338b580e7af






## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Standard Cal.com development environment with database running
- Test user with a typical weekly schedule (e.g., Monday-Friday 9am-5pm with weekends unavailable)
- No special environment variables required beyond standard setup

