### PR TITLE
feat(companion): center all modals on full screen in browser extension

### DIFF
--- a/companion/app/(tabs)/availability.tsx
+++ b/companion/app/(tabs)/availability.tsx
@@ -18,6 +18,7 @@ import {
 
 import { CalComAPIService, Schedule } from "../../services/calcom";
 import { Header } from "../../components/Header";
+import { FullScreenModal } from "../../components/FullScreenModal";
 
 export default function Availability() {
   const router = useRouter();
@@ -467,19 +468,20 @@ export default function Availability() {
       </View>
 
       {/* Create Schedule Modal */}
-      <Modal
+      <FullScreenModal
         visible={showCreateModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowCreateModal(false)}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          className="flex-1 items-center justify-center"
-          style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowCreateModal(false)}
         >
-          <View
+          <TouchableOpacity
             className="w-[90%] max-w-[500px] rounded-2xl bg-white"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
             style={{
               shadowColor: "#000",
               shadowOffset: { width: 0, height: 20 },
@@ -533,14 +535,13 @@ export default function Availability() {
                 </TouchableOpacity>
               </View>
             </View>
-          </View>
-        </KeyboardAvoidingView>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
 
       {/* Schedule Actions Modal */}
-      <Modal
+      <FullScreenModal
         visible={showActionsModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowActionsModal(false)}
       >
@@ -631,12 +632,11 @@ export default function Availability() {
             </View>
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
 
       {/* Delete Confirmation Modal */}
-      <Modal
+      <FullScreenModal
         visible={showDeleteModal}
-        transparent
         animationType="fade"
         onRequestClose={() => !deleting && setShowDeleteModal(false)}
       >
@@ -679,7 +679,7 @@ export default function Availability() {
             </View>
           </View>
         </View>
-      </Modal>
+      </FullScreenModal>
     </View>
   );
 }

--- a/companion/app/(tabs)/bookings.tsx
+++ b/companion/app/(tabs)/bookings.tsx
@@ -21,6 +21,7 @@ import type { NativeSyntheticEvent } from "react-native";
 
 import { CalComAPIService, Booking, EventType } from "../../services/calcom";
 import { Header } from "../../components/Header";
+import { FullScreenModal } from "../../components/FullScreenModal";
 
 type BookingFilter = "upcoming" | "unconfirmed" | "past" | "cancelled";
 
@@ -980,9 +981,8 @@ export default function Bookings() {
       </View>
 
       {/* Filter Modal */}
-      <Modal
+      <FullScreenModal
         visible={showFilterModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowFilterModal(false)}
       >
@@ -1035,12 +1035,11 @@ export default function Bookings() {
             )}
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
 
       {/* Booking Actions Modal */}
-      <Modal
+      <FullScreenModal
         visible={showBookingActionsModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowBookingActionsModal(false)}
       >
@@ -1249,7 +1248,7 @@ export default function Bookings() {
             </View>
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
     </View>
   );
 }

--- a/companion/app/(tabs)/event-types.tsx
+++ b/companion/app/(tabs)/event-types.tsx
@@ -477,7 +477,7 @@ export default function EventTypes() {
         (buttonIndex) => {
           switch (buttonIndex) {
             case 1: // New Event Type
-              setShowCreateModal(true);
+              handleOpenCreateModal();
               break;
             case 2: // One-off meeting
               handleOneOffMeeting();
@@ -494,13 +494,46 @@ export default function EventTypes() {
     // Fallback for Android
     Alert.alert("New", "Choose what to create", [
       { text: "Cancel", style: "cancel" },
-      { text: "New Event Type", onPress: () => setShowCreateModal(true) },
+      { text: "New Event Type", onPress: handleOpenCreateModal },
       { text: "One-off meeting", onPress: handleOneOffMeeting },
     ]);
   };
 
   const handleOneOffMeeting = () => {
     setShowOneOffModal(true);
+    // Expand iframe to full width when modal opens
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
+      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
+    }
+  };
+
+  const handleCloseOneOffModal = () => {
+    setShowOneOffModal(false);
+    // Collapse iframe back to sidebar width
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
+      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+    }
+  };
+
+  const handleOpenCreateModal = () => {
+    setShowCreateModal(true);
+    // Expand iframe for create modal
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
+      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
+    }
+  };
+
+  const handleCloseCreateModal = () => {
+    setShowCreateModal(false);
+    setNewEventTitle("");
+    setNewEventSlug("");
+    setNewEventDescription("");
+    setNewEventDuration("15");
+    setIsSlugManuallyEdited(false);
+    // Collapse iframe
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
+      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+    }
   };
 
   // Calendar helper functions
@@ -676,7 +709,7 @@ export default function EventTypes() {
         {
           text: "OK",
           onPress: () => {
-            setShowOneOffModal(false);
+            handleCloseOneOffModal();
             setSelectionRanges([]);
           },
         },
@@ -781,12 +814,7 @@ export default function EventTypes() {
       });
 
       // Close modal and reset form
-      setShowCreateModal(false);
-      setNewEventTitle("");
-      setNewEventSlug("");
-      setNewEventDescription("");
-      setNewEventDuration("15");
-      setIsSlugManuallyEdited(false);
+      handleCloseCreateModal();
 
       // Refresh the list
       await fetchEventTypes();
@@ -1021,7 +1049,7 @@ export default function EventTypes() {
         visible={showCreateModal}
         transparent
         animationType="fade"
-        onRequestClose={() => setShowCreateModal(false)}
+        onRequestClose={handleCloseCreateModal}
       >
         <KeyboardAvoidingView
           behavior={Platform.OS === "ios" ? "padding" : "height"}
@@ -1132,14 +1160,7 @@ export default function EventTypes() {
               <View className="flex-row justify-end gap-2 space-x-2">
                 <TouchableOpacity
                   className="rounded-xl border border-[#D1D5DB] bg-white px-4 py-2"
-                  onPress={() => {
-                    setShowCreateModal(false);
-                    setNewEventTitle("");
-                    setNewEventSlug("");
-                    setNewEventDescription("");
-                    setNewEventDuration("15");
-                    setIsSlugManuallyEdited(false);
-                  }}
+                  onPress={handleCloseCreateModal}
                   disabled={creating}
                 >
                   <Text className="text-base font-medium text-[#374151]">Close</Text>
@@ -1283,7 +1304,7 @@ export default function EventTypes() {
               <TouchableOpacity
                 onPress={() => {
                   setShowNewModal(false);
-                  setShowCreateModal(true);
+                  handleOpenCreateModal();
                 }}
                 className="flex-row items-center p-2 hover:bg-gray-50 md:p-4"
               >
@@ -1325,7 +1346,7 @@ export default function EventTypes() {
         visible={showOneOffModal}
         transparent={Platform.OS !== "web"}
         animationType="fade"
-        onRequestClose={() => setShowOneOffModal(false)}
+        onRequestClose={handleCloseOneOffModal}
       >
         <View
           className={
@@ -1340,6 +1361,7 @@ export default function EventTypes() {
                   right: 0,
                   bottom: 0,
                   zIndex: 50,
+                  pointerEvents: "auto",
                 }
               : {}
           }
@@ -1371,7 +1393,7 @@ export default function EventTypes() {
                           <Text className="text-sm text-gray-600">Clear</Text>
                         </TouchableOpacity>
                         <TouchableOpacity
-                          onPress={() => setShowOneOffModal(false)}
+                          onPress={handleCloseOneOffModal}
                           className="rounded-full p-2 hover:bg-gray-100"
                         >
                           <Ionicons name="close" size={24} color="#6B7280" />
@@ -1693,7 +1715,7 @@ export default function EventTypes() {
                       <View className="flex-row justify-end gap-3">
                         <TouchableOpacity
                           className="rounded bg-gray-100 px-4 py-2 hover:bg-gray-200"
-                          onPress={() => setShowOneOffModal(false)}
+                          onPress={handleCloseOneOffModal}
                         >
                           <Text className="font-medium text-gray-700">Cancel</Text>
                         </TouchableOpacity>
@@ -1728,7 +1750,7 @@ export default function EventTypes() {
                           <Text className="text-lg font-semibold text-gray-900">
                             Schedule Meeting
                           </Text>
-                          <TouchableOpacity onPress={() => setShowOneOffModal(false)}>
+                          <TouchableOpacity onPress={handleCloseOneOffModal}>
                             <Ionicons name="close" size={24} color="#6B7280" />
                           </TouchableOpacity>
                         </View>

--- a/companion/app/(tabs)/event-types.tsx
+++ b/companion/app/(tabs)/event-types.tsx
@@ -26,6 +26,7 @@ import { PanGestureHandler, State } from "react-native-gesture-handler";
 import { CalComAPIService, EventType } from "../../services/calcom";
 import { Header } from "../../components/Header";
 import { Tooltip } from "../../components/Tooltip";
+import { FullScreenModal } from "../../components/FullScreenModal";
 import { slugify } from "../../utils/slugify";
 
 export default function EventTypes() {
@@ -1045,9 +1046,8 @@ export default function EventTypes() {
       </ScrollView>
 
       {/* Create Event Type Modal */}
-      <Modal
+      <FullScreenModal
         visible={showCreateModal}
-        transparent
         animationType="fade"
         onRequestClose={handleCloseCreateModal}
       >
@@ -1176,12 +1176,11 @@ export default function EventTypes() {
             </View>
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </FullScreenModal>
 
       {/* Action Modal for Web Platform */}
-      <Modal
+      <FullScreenModal
         visible={showActionModal}
-        transparent
         animationType="fade"
         onRequestClose={() => {
           setShowActionModal(false);
@@ -1273,12 +1272,11 @@ export default function EventTypes() {
             )}
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
 
       {/* New Menu Modal for Web Platform */}
-      <Modal
+      <FullScreenModal
         visible={showNewModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowNewModal(false)}
       >
@@ -1339,10 +1337,10 @@ export default function EventTypes() {
             </View>
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
 
       {/* One-off Meeting Modal */}
-      <Modal
+      <FullScreenModal
         visible={showOneOffModal}
         transparent={Platform.OS !== "web"}
         animationType="fade"
@@ -1880,12 +1878,11 @@ export default function EventTypes() {
                 );
               })()}
         </View>
-      </Modal>
+      </FullScreenModal>
 
       {/* Delete Confirmation Modal */}
-      <Modal
+      <FullScreenModal
         visible={showDeleteModal}
-        transparent
         animationType="fade"
         onRequestClose={() => {
           if (!isDeleting) {
@@ -1944,7 +1941,7 @@ export default function EventTypes() {
             </View>
           </View>
         </View>
-      </Modal>
+      </FullScreenModal>
 
       {/* Toast for Web Platform */}
       {showToast && (

--- a/companion/app/(tabs)/event-types.tsx
+++ b/companion/app/(tabs)/event-types.tsx
@@ -1051,13 +1051,15 @@ export default function EventTypes() {
         animationType="fade"
         onRequestClose={handleCloseCreateModal}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          className="flex-1 items-center justify-center"
-          style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={handleCloseCreateModal}
         >
-          <View
+          <TouchableOpacity
             className="w-[90%] max-w-[500px] rounded-2xl bg-white"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
             style={{
               shadowColor: "#000",
               shadowOffset: { width: 0, height: 20 },
@@ -1174,8 +1176,8 @@ export default function EventTypes() {
                 </TouchableOpacity>
               </View>
             </View>
-          </View>
-        </KeyboardAvoidingView>
+          </TouchableOpacity>
+        </TouchableOpacity>
       </FullScreenModal>
 
       {/* Action Modal for Web Platform */}

--- a/companion/app/(tabs)/event-types.tsx
+++ b/companion/app/(tabs)/event-types.tsx
@@ -502,26 +502,14 @@ export default function EventTypes() {
 
   const handleOneOffMeeting = () => {
     setShowOneOffModal(true);
-    // Expand iframe to full width when modal opens
-    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
-      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
-    }
   };
 
   const handleCloseOneOffModal = () => {
     setShowOneOffModal(false);
-    // Collapse iframe back to sidebar width
-    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
-      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
-    }
   };
 
   const handleOpenCreateModal = () => {
     setShowCreateModal(true);
-    // Expand iframe for create modal
-    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
-      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
-    }
   };
 
   const handleCloseCreateModal = () => {
@@ -531,10 +519,6 @@ export default function EventTypes() {
     setNewEventDescription("");
     setNewEventDuration("15");
     setIsSlugManuallyEdited(false);
-    // Collapse iframe
-    if (Platform.OS === "web" && typeof window !== "undefined" && window.parent) {
-      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
-    }
   };
 
   // Calendar helper functions
@@ -1057,7 +1041,7 @@ export default function EventTypes() {
           onPress={handleCloseCreateModal}
         >
           <TouchableOpacity
-            className="w-[90%] max-w-[500px] rounded-2xl bg-white"
+            className="max-h-[90%] w-[90%] max-w-[500px] rounded-2xl bg-white"
             activeOpacity={1}
             onPress={(e) => e.stopPropagation()}
             style={{
@@ -1304,7 +1288,10 @@ export default function EventTypes() {
               <TouchableOpacity
                 onPress={() => {
                   setShowNewModal(false);
-                  handleOpenCreateModal();
+                  // Small delay to ensure the "New" modal closes before opening create modal
+                  setTimeout(() => {
+                    handleOpenCreateModal();
+                  }, 100);
                 }}
                 className="flex-row items-center p-2 hover:bg-gray-50 md:p-4"
               >

--- a/companion/app/availability-detail.tsx
+++ b/companion/app/availability-detail.tsx
@@ -11,11 +11,12 @@ import {
   Alert,
   ActivityIndicator,
   Switch,
-  Modal,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { CalComAPIService, Schedule, ScheduleAvailability } from "../services/calcom";
+import { CalComAPIService, Schedule } from "../services/calcom";
+import { ScheduleAvailability } from "../services/types";
+import { FullScreenModal } from "../components/FullScreenModal";
 
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const DAY_ABBREVIATIONS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -732,9 +733,21 @@ export default function AvailabilityDetail() {
       </View>
 
       {/* Timezone Modal */}
-      <Modal visible={showTimezoneModal} transparent animationType="slide">
-        <View className="flex-1 justify-end bg-black/50">
-          <View className="max-h-[80%] rounded-t-3xl bg-white p-4">
+      <FullScreenModal
+        visible={showTimezoneModal}
+        animationType="fade"
+        onRequestClose={() => setShowTimezoneModal(false)}
+      >
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowTimezoneModal(false)}
+        >
+          <TouchableOpacity
+            className="max-h-[80%] w-[90%] max-w-[500px] rounded-2xl bg-white p-4"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
+          >
             <View className="mb-4 flex-row items-center justify-between">
               <Text className="text-xl font-bold text-[#333]">Select Timezone</Text>
               <TouchableOpacity onPress={() => setShowTimezoneModal(false)}>
@@ -755,14 +768,26 @@ export default function AvailabilityDetail() {
                 </TouchableOpacity>
               ))}
             </ScrollView>
-          </View>
-        </View>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
 
       {/* Time Picker Modal */}
-      <Modal visible={!!showTimePicker} transparent animationType="slide">
-        <View className="flex-1 justify-end bg-black/50">
-          <View className="max-h-[80%] rounded-t-3xl bg-white p-4">
+      <FullScreenModal
+        visible={!!showTimePicker}
+        animationType="fade"
+        onRequestClose={() => setShowTimePicker(null)}
+      >
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowTimePicker(null)}
+        >
+          <TouchableOpacity
+            className="max-h-[80%] w-[90%] max-w-[500px] rounded-2xl bg-white p-4"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
+          >
             <View className="mb-4 flex-row items-center justify-between">
               <Text className="text-xl font-bold text-[#333]">
                 Select {showTimePicker?.type === "start" ? "Start" : "End"} Time
@@ -808,14 +833,26 @@ export default function AvailabilityDetail() {
                 );
               })}
             </ScrollView>
-          </View>
-        </View>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
 
       {/* Override Modal */}
-      <Modal visible={showOverrideModal} transparent animationType="slide">
-        <View className="flex-1 justify-end bg-black/50">
-          <View className="max-h-[90%] rounded-t-3xl bg-white p-6">
+      <FullScreenModal
+        visible={showOverrideModal}
+        animationType="fade"
+        onRequestClose={() => setShowOverrideModal(false)}
+      >
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowOverrideModal(false)}
+        >
+          <TouchableOpacity
+            className="max-h-[90%] w-[90%] max-w-[500px] rounded-2xl bg-white p-6"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
+          >
             <View className="mb-4 flex-row items-center justify-between">
               <Text className="text-xl font-bold text-[#333]">
                 {editingOverride !== null ? "Edit Override" : "Add Override"}
@@ -894,14 +931,26 @@ export default function AvailabilityDetail() {
                 </TouchableOpacity>
               </View>
             </ScrollView>
-          </View>
-        </View>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
 
       {/* Override Time Picker Modal */}
-      <Modal visible={!!showOverrideTimePicker} transparent animationType="slide">
-        <View className="flex-1 justify-end bg-black/50">
-          <View className="max-h-[60%] rounded-t-3xl bg-white p-6">
+      <FullScreenModal
+        visible={!!showOverrideTimePicker}
+        animationType="fade"
+        onRequestClose={() => setShowOverrideTimePicker(null)}
+      >
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowOverrideTimePicker(null)}
+        >
+          <TouchableOpacity
+            className="max-h-[60%] w-[90%] max-w-[500px] rounded-2xl bg-white p-6"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
+          >
             <View className="mb-4 flex-row items-center justify-between">
               <Text className="text-xl font-bold text-[#333]">
                 Select {showOverrideTimePicker?.type === "start" ? "Start" : "End"} Time
@@ -937,9 +986,9 @@ export default function AvailabilityDetail() {
                 );
               })}
             </ScrollView>
-          </View>
-        </View>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
     </>
   );
 }

--- a/companion/app/booking-detail.tsx
+++ b/companion/app/booking-detail.tsx
@@ -9,14 +9,13 @@ import {
   Alert,
   ActivityIndicator,
   Linking,
-  Modal,
   TextInput,
-  KeyboardAvoidingView,
   Platform,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CalComAPIService, Booking } from "../services/calcom";
 import { SvgImage } from "../components/SvgImage";
+import { FullScreenModal } from "../components/FullScreenModal";
 import { getAppIconUrl } from "../utils/getAppIconUrl";
 import { getDefaultLocationIconUrl, defaultLocations } from "../utils/defaultLocations";
 
@@ -471,7 +470,11 @@ export default function BookingDetail() {
       </View>
 
       {/* Booking Actions Modal */}
-      <Modal visible={showActionsModal} transparent animationType="fade">
+      <FullScreenModal
+        visible={showActionsModal}
+        animationType="fade"
+        onRequestClose={() => setShowActionsModal(false)}
+      >
         <TouchableOpacity
           className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
           activeOpacity={1}
@@ -653,22 +656,23 @@ export default function BookingDetail() {
             </View>
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
 
       {/* Reschedule Modal */}
-      <Modal
+      <FullScreenModal
         visible={showRescheduleModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowRescheduleModal(false)}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          className="flex-1 items-center justify-center"
-          style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+        <TouchableOpacity
+          className="flex-1 items-center justify-center bg-black/50 p-2 md:p-4"
+          activeOpacity={1}
+          onPress={() => setShowRescheduleModal(false)}
         >
-          <View
+          <TouchableOpacity
             className="w-[90%] max-w-[500px] rounded-2xl bg-white"
+            activeOpacity={1}
+            onPress={(e) => e.stopPropagation()}
             style={{
               shadowColor: "#000",
               shadowOffset: { width: 0, height: 20 },
@@ -735,9 +739,9 @@ export default function BookingDetail() {
                 </TouchableOpacity>
               </View>
             </View>
-          </View>
-        </KeyboardAvoidingView>
-      </Modal>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </FullScreenModal>
     </>
   );
 }

--- a/companion/components/FullScreenModal.tsx
+++ b/companion/components/FullScreenModal.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from "react";
+import { Modal, ModalProps, Platform } from "react-native";
+
+interface FullScreenModalProps extends ModalProps {
+  visible: boolean;
+  onRequestClose: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * A modal wrapper that expands the browser extension iframe to full screen
+ * when running in the web platform (browser extension).
+ *
+ * For mobile platforms, it behaves like a regular Modal.
+ */
+export function FullScreenModal({
+  visible,
+  onRequestClose,
+  children,
+  ...modalProps
+}: FullScreenModalProps) {
+  useEffect(() => {
+    // Only send expand/collapse messages on web platform (browser extension)
+    if (Platform.OS !== "web") {
+      return;
+    }
+
+    if (visible) {
+      // Expand the iframe to full width when modal opens
+      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
+    } else {
+      // Collapse the iframe back to 400px when modal closes
+      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+    }
+
+    // Cleanup: collapse on unmount if still visible
+    return () => {
+      if (visible && Platform.OS === "web") {
+        window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+      }
+    };
+  }, [visible]);
+
+  // For non-web platforms, just use the regular Modal
+  if (Platform.OS !== "web") {
+    return (
+      <Modal visible={visible} onRequestClose={onRequestClose} {...modalProps}>
+        {children}
+      </Modal>
+    );
+  }
+
+  // For web platform (browser extension), use the modal with full-screen behavior
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onRequestClose}
+      transparent
+      animationType="fade"
+      {...modalProps}
+    >
+      {children}
+    </Modal>
+  );
+}

--- a/companion/components/FullScreenModal.tsx
+++ b/companion/components/FullScreenModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Modal, ModalProps, Platform } from "react-native";
+import { Modal, ModalProps, Platform, View } from "react-native";
 
 interface FullScreenModalProps extends ModalProps {
   visible: boolean;

--- a/companion/components/Header.tsx
+++ b/companion/components/Header.tsx
@@ -16,6 +16,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CalComAPIService, UserProfile } from "../services/calcom";
 import { CalComLogo } from "./CalComLogo";
+import { FullScreenModal } from "./FullScreenModal";
 
 export function Header() {
   const router = useRouter();
@@ -167,9 +168,8 @@ export function Header() {
       </View>
 
       {/* Profile Menu Modal */}
-      <Modal
+      <FullScreenModal
         visible={showProfileModal}
-        transparent
         animationType="fade"
         onRequestClose={() => setShowProfileModal(false)}
       >
@@ -293,7 +293,7 @@ export function Header() {
             </View>
           </TouchableOpacity>
         </TouchableOpacity>
-      </Modal>
+      </FullScreenModal>
     </>
   );
 }

--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -25,7 +25,7 @@ export default defineContentScript({
     sidebarContainer.style.height = "100vh";
     sidebarContainer.style.zIndex = "2147483647";
     sidebarContainer.style.backgroundColor = "transparent";
-    sidebarContainer.style.transition = "transform 0.3s ease-in-out";
+    sidebarContainer.style.transition = "none";
     sidebarContainer.style.transform = "translateX(100%)";
     sidebarContainer.style.display = "none";
 
@@ -46,18 +46,24 @@ export default defineContentScript({
     iframe.style.borderRadius = "0";
     iframe.style.backgroundColor = "transparent";
     iframe.style.pointerEvents = "auto";
-    iframe.style.transition = "width 0.3s ease-in-out";
+    iframe.style.transition = "none";
 
     iframeContainer.appendChild(iframe);
 
     // Listen for messages from iframe to control width
     window.addEventListener("message", (event) => {
       if (event.data.type === "cal-companion-expand") {
+        // Disable transition for instant expansion
+        iframe.style.transition = "none";
         iframe.style.width = "100%";
         iframeContainer.style.pointerEvents = "auto";
+        iframeContainer.style.justifyContent = "center";
       } else if (event.data.type === "cal-companion-collapse") {
+        // Disable transition for instant collapse
+        iframe.style.transition = "none";
         iframe.style.width = "400px";
         iframeContainer.style.pointerEvents = "none";
+        iframeContainer.style.justifyContent = "flex-end";
       }
     });
 
@@ -73,7 +79,7 @@ export default defineContentScript({
     buttonsContainer.style.flexDirection = "column";
     buttonsContainer.style.gap = "8px";
     buttonsContainer.style.zIndex = "2147483648";
-    buttonsContainer.style.transition = "right 0.3s ease-in-out";
+    buttonsContainer.style.transition = "none";
     buttonsContainer.style.display = "none";
 
     // Create toggle button

--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -46,8 +46,20 @@ export default defineContentScript({
     iframe.style.borderRadius = "0";
     iframe.style.backgroundColor = "transparent";
     iframe.style.pointerEvents = "auto";
+    iframe.style.transition = "width 0.3s ease-in-out";
 
     iframeContainer.appendChild(iframe);
+
+    // Listen for messages from iframe to control width
+    window.addEventListener("message", (event) => {
+      if (event.data.type === "cal-companion-expand") {
+        iframe.style.width = "100%";
+        iframeContainer.style.pointerEvents = "auto";
+      } else if (event.data.type === "cal-companion-collapse") {
+        iframe.style.width = "400px";
+        iframeContainer.style.pointerEvents = "none";
+      }
+    });
 
     sidebarContainer.appendChild(iframeContainer);
 

--- a/companion/extension/entrypoints/content.ts
+++ b/companion/extension/entrypoints/content.ts
@@ -52,6 +52,13 @@ export default defineContentScript({
 
     // Listen for messages from iframe to control width
     window.addEventListener("message", (event) => {
+      // Security: Only accept messages from our iframe's origin
+      // This prevents malicious scripts on the host page from manipulating the companion
+      const iframeOrigin = new URL(iframe.src).origin;
+      if (event.source !== iframe.contentWindow || event.origin !== iframeOrigin) {
+        return;
+      }
+
       if (event.data.type === "cal-companion-expand") {
         // Disable transition for instant expansion
         iframe.style.transition = "none";

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -35,6 +35,9 @@
       "devDependencies": {
         "@types/chrome": "^0.1.31",
         "babel-preset-expo": "^54.0.7",
+        "husky": "^9.0.11",
+        "lint-staged": "^15.2.0",
+        "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "tailwindcss": "^3.4.17",
         "wxt": "^0.20.11"
@@ -7291,6 +7294,59 @@
       "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/expo": {
       "version": "54.0.23",
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.23.tgz",
@@ -8482,6 +8538,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -8758,6 +8827,32 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -9123,6 +9218,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -10110,6 +10218,57 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/listr2": {
@@ -11253,6 +11412,35 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -11704,6 +11892,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -11959,7 +12160,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13998,6 +14198,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -14092,6 +14302,19 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
       "integrity": "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
### Video:

https://github.com/user-attachments/assets/eaf18890-d2d2-4f16-9a96-222e06902617






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the companion iframe to full width for all modals on web and collapse it on close. Modals are centered and get more space, improving scheduling and booking flows.

- **Bug Fixes**
  - Introduced FullScreenModal and converted modals to use it; auto expand/collapse the iframe with instant width changes and centered layout on web.
  - Enable pointer events when expanded; added open/close handlers and a short delay when switching modals to avoid timing issues.

- **Dependencies**
  - Add husky, lint-staged, and prettier as dev dependencies.

<sup>Written for commit 0e8abce7360e1005cb8cd46ca03bb44e8b09fb43. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



