### PR TITLE
fix: Remove square enforcing in resizeBase64Image

### DIFF
--- a/packages/lib/server/resizeBase64Image.ts
+++ b/packages/lib/server/resizeBase64Image.ts
@@ -26,10 +26,6 @@ export async function resizeBase64Image(
     maxSize = 96 * 4,
   } = opts ?? {};
   const image = await jimp.read(buffer);
-  if (image.getHeight() !== image.getWidth()) {
-    // this could be handled later
-    throw new Error("Image is not a square");
-  }
   const currentSize = Math.max(image.getWidth(), image.getHeight());
   if (currentSize > maxSize) {
     image.resize(jimp.AUTO, maxSize);


### PR DESCRIPTION
## What does this PR do?
Allows you to upload banners again. We dont have a reason to force a square - i PR was made recently to fix this behaviour that was not working (4 years its been an issue for) but as a result - we actually were using the broken behaviour 

Fixes #25388 

## How should this be tested?

Upload a banner to an organization. 

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
