### PR TITLE
feat: add tRPC handler for booking details

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -2,20 +2,11 @@ import { createRouterCaller } from "app/_trpc/context";
 import type { GetServerSidePropsContext } from "next";
 import { z } from "zod";
 
-import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-utils";
 import { orgDomainConfig } from "@calcom/ee/organizations/lib/orgDomains";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import getBookingInfo from "@calcom/features/bookings/lib/getBookingInfo";
-import { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
-import { isTeamMember } from "@calcom/features/ee/teams/lib/queries";
-import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
-import { getBrandingForEventType } from "@calcom/features/profile/lib/getBranding";
+import { getBookingDetailsForViewer } from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
 import { shouldHideBrandingForEvent } from "@calcom/features/profile/lib/hideBranding";
-import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
-import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
-import { maybeGetBookingUidFromSeat } from "@calcom/lib/server/maybeGetBookingUidFromSeat";
 import prisma from "@calcom/prisma";
-import { customInputSchema } from "@calcom/prisma/zod-utils";
 import { meRouter } from "@calcom/trpc/server/routers/viewer/me/_router";
 
 import type { inferSSRProps } from "@lib/types/inferSSRProps";
@@ -52,7 +43,6 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const session = await getServerSession({ req: context.req });
   let tz: string | null = null;
   let userTimeFormat: number | null = null;
-  let requiresLoginToUpdate = false;
   if (session) {
     const caller = await createRouterCaller(meRouter);
     const user = await caller.get();
@@ -63,186 +53,52 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const parsedQuery = querySchema.safeParse(context.query);
 
   if (!parsedQuery.success) return { notFound: true } as const;
-  const { eventTypeSlug } = parsedQuery.data;
-  let { uid, seatReferenceUid } = parsedQuery.data;
+  const { uid, seatReferenceUid, eventTypeSlug } = parsedQuery.data;
 
-  const maybeBookingUidFromSeat = await maybeGetBookingUidFromSeat(prisma, uid);
-  if (maybeBookingUidFromSeat.uid) uid = maybeBookingUidFromSeat.uid;
-  if (maybeBookingUidFromSeat.seatReferenceUid) seatReferenceUid = maybeBookingUidFromSeat.seatReferenceUid;
+  const bookingDetails = await getBookingDetailsForViewer(
+    {
+      prisma,
+      uid,
+      seatReferenceUid,
+      eventTypeSlug,
+      userId: session?.user?.id ?? null,
+    },
+    {
+      getEventTypesFromDB,
+      handleSeatsEventTypeOnBooking,
+      getRecurringBookings,
+    }
+  );
 
-  const { bookingInfoRaw, bookingInfo } = await getBookingInfo(uid);
-
-  if (!bookingInfoRaw) {
-    return {
-      notFound: true,
-    } as const;
+  if (!bookingDetails) {
+    return { notFound: true } as const;
   }
 
-  let rescheduledToUid: string | null = null;
-  if (bookingInfo.rescheduled) {
-    const bookingRepo = new BookingRepository(prisma);
-    const rescheduledTo = await bookingRepo.findFirstBookingByReschedule({
-      originalBookingUid: bookingInfo.uid,
-    });
-    rescheduledToUid = rescheduledTo?.uid ?? null;
-  }
-
-  let previousBooking: {
-    rescheduledBy: string | null;
-    uid: string;
-  } | null = null;
-
-  if (bookingInfo.fromReschedule) {
-    const bookingRepo = new BookingRepository(prisma);
-    previousBooking = await bookingRepo.findReschedulerByUid({
-      uid: bookingInfo.fromReschedule,
-    });
-  }
-
-  const eventTypeRaw = !bookingInfoRaw.eventTypeId
-    ? getDefaultEvent(eventTypeSlug || "")
-    : await getEventTypesFromDB(bookingInfoRaw.eventTypeId);
-  if (!eventTypeRaw) {
-    return {
-      notFound: true,
-    } as const;
-  }
-
-  if (eventTypeRaw.seatsPerTimeSlot && !seatReferenceUid && !session) {
-    requiresLoginToUpdate = true;
-  }
+  const {
+    profile,
+    eventType,
+    recurringBookings,
+    dynamicEventName,
+    bookingInfo,
+    previousBooking,
+    paymentStatus,
+    requiresLoginToUpdate,
+    rescheduledToUid,
+    isLoggedInUserHost,
+    canViewHiddenData,
+    internalNotePresets,
+    isPlatformBooking,
+  } = bookingDetails;
 
   // @NOTE: had to do this because Server side cant return [Object objects]
   // probably fixable with json.stringify -> json.parse
-  bookingInfo["startTime"] = (bookingInfo?.startTime as Date)?.toISOString() as unknown as Date;
-  bookingInfo["endTime"] = (bookingInfo?.endTime as Date)?.toISOString() as unknown as Date;
-
-  eventTypeRaw.users = eventTypeRaw.hosts?.length
-    ? eventTypeRaw.hosts.map((host) => host.user)
-    : eventTypeRaw.users;
-
-  if (!eventTypeRaw.users.length) {
-    if (!eventTypeRaw.owner) {
-      if (bookingInfoRaw.user) {
-        eventTypeRaw.users.push({
-          ...bookingInfoRaw.user,
-          hideBranding: false,
-          theme: null,
-          brandColor: null,
-          darkBrandColor: null,
-          isPlatformManaged: false,
-        });
-      } else {
-        return { notFound: true } as const;
-      }
-    } else {
-      eventTypeRaw.users.push({ ...eventTypeRaw.owner });
-    }
-  }
-
-  const eventType = {
-    ...eventTypeRaw,
-    periodStartDate: eventTypeRaw.periodStartDate?.toString() ?? null,
-    periodEndDate: eventTypeRaw.periodEndDate?.toString() ?? null,
-    metadata: eventTypeMetaDataSchemaWithTypedApps.parse(eventTypeRaw.metadata),
-    recurringEvent: parseRecurringEvent(eventTypeRaw.recurringEvent),
-    customInputs: customInputSchema.array().parse(eventTypeRaw.customInputs),
-    hideOrganizerEmail: eventTypeRaw.hideOrganizerEmail,
-    bookingFields: eventTypeRaw.bookingFields.map((field) => {
-      return {
-        ...field,
-        label: field.type === "boolean" ? markdownToSafeHTML(field.label || "") : field.label || "",
-        defaultLabel:
-          field.type === "boolean" ? markdownToSafeHTML(field.defaultLabel || "") : field.defaultLabel || "",
-      };
-    }),
+  const bookingInfoForPage = {
+    ...bookingInfo,
+    startTime: (bookingInfo?.startTime as Date)?.toISOString() as unknown as Date,
+    endTime: (bookingInfo?.endTime as Date)?.toISOString() as unknown as Date,
   };
-
-  const profile = {
-    name: eventType.team?.name || eventType.users[0]?.name || null,
-    email: eventType.team ? null : eventType.users[0].email || null,
-    ...getBrandingForEventType({ eventType: eventTypeRaw }),
-    slug: eventType.team?.slug || eventType.users[0]?.username || null,
-  };
-
-  const userId = session?.user?.id;
-
-  const checkIfUserIsHost = (userId?: number | null) => {
-    if (!userId) return false;
-
-    return (
-      bookingInfo?.user?.id === userId ||
-      eventType.users.some(
-        (user) =>
-          user.id === userId && bookingInfo.attendees.some((attendee) => attendee.email === user.email)
-      ) ||
-      eventType.hosts.some(
-        ({ user }) =>
-          user.id === userId && bookingInfo.attendees.some((attendee) => attendee.email === user.email)
-      )
-    );
-  };
-
-  const isLoggedInUserHost = checkIfUserIsHost(userId);
-  const eventTeamId = eventType.team?.id ?? eventType.parent?.teamId;
-  const isLoggedInUserTeamMember = !!(userId && eventTeamId && (await isTeamMember(userId, eventTeamId)));
-
-  const canViewHiddenData = isLoggedInUserHost || isLoggedInUserTeamMember;
-
-  if (bookingInfo !== null && eventType.seatsPerTimeSlot) {
-    await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
-  }
-
-  const payment = await prisma.payment.findFirst({
-    where: {
-      bookingId: bookingInfo.id,
-    },
-    select: {
-      appId: true,
-      success: true,
-      refunded: true,
-      currency: true,
-      amount: true,
-      paymentOption: true,
-    },
-  });
-
-  if (!canViewHiddenData) {
-    for (const key in bookingInfo.responses) {
-      const field = eventTypeRaw.bookingFields.find((field) => field.name === key);
-      if (field && !!field.hidden) {
-        delete bookingInfo.responses[key];
-      }
-    }
-  }
 
   const { currentOrgDomain } = orgDomainConfig(context.req);
-
-  async function getInternalNotePresets(teamId: number | null) {
-    if (!teamId || !canViewHiddenData) return [];
-    return await prisma.internalNotePreset.findMany({
-      where: {
-        teamId,
-      },
-      select: {
-        id: true,
-        name: true,
-        cancellationReason: true,
-      },
-    });
-  }
-
-  const internalNotes = await getInternalNotePresets(eventType.team?.id ?? eventType.parent?.teamId ?? null);
-
-  // Filter out organizer information if hideOrganizerEmail is true
-  const sanitizedPreviousBooking =
-    eventType.hideOrganizerEmail &&
-      previousBooking &&
-      previousBooking.rescheduledBy === bookingInfo.user?.email
-      ? { ...previousBooking, rescheduledBy: bookingInfo.user?.name }
-      : previousBooking;
-
-  const isPlatformBooking = eventType.users[0]?.isPlatformManaged || eventType.team?.createdByOAuthClientId;
 
   return {
     props: {
@@ -251,25 +107,25 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       hideBranding: isPlatformBooking
         ? true
         : await shouldHideBrandingForEvent({
-          eventTypeId: eventType.id,
-          team: eventType?.parent?.team ?? eventType?.team,
-          owner: eventType.users[0] ?? null,
-          organizationId: session?.user?.profile?.organizationId ?? session?.user?.org?.id ?? null,
-        }),
+            eventTypeId: eventType.id,
+            team: eventType?.parent?.team ?? eventType?.team,
+            owner: eventType.users[0] ?? null,
+            organizationId: session?.user?.profile?.organizationId ?? session?.user?.org?.id ?? null,
+          }),
       profile,
       eventType,
-      recurringBookings: await getRecurringBookings(bookingInfo.recurringEventId),
-      dynamicEventName: bookingInfo?.eventType?.eventName || "",
-      bookingInfo,
-      previousBooking: sanitizedPreviousBooking,
-      paymentStatus: payment,
+      recurringBookings,
+      dynamicEventName,
+      bookingInfo: bookingInfoForPage,
+      previousBooking,
+      paymentStatus,
       ...(tz && { tz }),
       userTimeFormat,
       requiresLoginToUpdate,
       rescheduledToUid,
       isLoggedInUserHost,
       canViewHiddenData,
-      internalNotePresets: internalNotes,
+      internalNotePresets,
     },
   };
 }

--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -4,7 +4,10 @@ import { z } from "zod";
 
 import { orgDomainConfig } from "@calcom/ee/organizations/lib/orgDomains";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import { getBookingDetailsForViewer } from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
+import {
+  getBookingDetailsForViewer,
+  type GetEventTypesFromDBFn,
+} from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
 import { shouldHideBrandingForEvent } from "@calcom/features/profile/lib/hideBranding";
 import prisma from "@calcom/prisma";
 import { meRouter } from "@calcom/trpc/server/routers/viewer/me/_router";
@@ -55,6 +58,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   if (!parsedQuery.success) return { notFound: true } as const;
   const { uid, seatReferenceUid, eventTypeSlug } = parsedQuery.data;
 
+  // Cast getEventTypesFromDB to the expected type - the branded bookingFields array
+  // from getBookingFieldsWithSystemFields is structurally compatible with the base type
+  const getEventTypesFromDBTyped = getEventTypesFromDB as GetEventTypesFromDBFn;
+
   const bookingDetails = await getBookingDetailsForViewer(
     {
       prisma,
@@ -64,7 +71,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       userId: session?.user?.id ?? null,
     },
     {
-      getEventTypesFromDB,
+      getEventTypesFromDB: getEventTypesFromDBTyped,
       handleSeatsEventTypeOnBooking,
       getRecurringBookings,
     }

--- a/packages/features/bookings/lib/getBookingDetailsForViewer.ts
+++ b/packages/features/bookings/lib/getBookingDetailsForViewer.ts
@@ -59,6 +59,61 @@ type BookingFieldBase = {
   defaultLabel?: string;
 };
 
+// Type for the processed eventType that getCalendarLinks expects
+// This ensures the eventType returned from the shared service is compatible
+type ProcessedEventType = {
+  id: number;
+  title: string;
+  description: string | null;
+  length: number;
+  eventName: string | null;
+  recurringEvent: Prisma.JsonObject | null;
+  isDynamic: boolean;
+  team: {
+    id: number;
+    slug: string | null;
+    name: string | null;
+    hideBranding: boolean;
+    brandColor: string | null;
+    darkBrandColor: string | null;
+    theme: string | null;
+    parent: {
+      hideBranding: boolean;
+      brandColor: string | null;
+      darkBrandColor: string | null;
+      theme: string | null;
+    } | null;
+    createdByOAuthClientId: string | null;
+  } | null;
+  users: UserSelect[];
+  hosts: { user: UserSelect }[];
+  seatsPerTimeSlot: number | null;
+  seatsShowAttendees: boolean | null;
+  seatsShowAvailabilityCount: boolean | null;
+  hideOrganizerEmail: boolean | null;
+  periodStartDate: string | null;
+  periodEndDate: string | null;
+  metadata: ReturnType<typeof eventTypeMetaDataSchemaWithTypedApps.parse>;
+  customInputs: ReturnType<typeof customInputSchema.array.prototype.parse>;
+  bookingFields: {
+    name: string;
+    type: string;
+    hidden?: boolean;
+    label: string;
+    defaultLabel: string;
+  }[];
+  parent: {
+    teamId: number | null;
+    team: {
+      hideBranding: boolean;
+      parent: {
+        hideBranding: boolean;
+      } | null;
+    } | null;
+  } | null;
+  [key: string]: unknown;
+};
+
 // Base type for event type data - uses structural typing to be compatible with both
 // getEventTypesFromDB return type and DefaultEvent
 type EventTypeBase = {
@@ -379,7 +434,7 @@ export async function getBookingDetailsForViewer(
 
   return {
     profile,
-    eventType,
+    eventType: eventType as ProcessedEventType,
     recurringBookings,
     dynamicEventName: bookingInfo?.eventType?.eventName || "",
     bookingInfo,

--- a/packages/features/bookings/lib/getBookingDetailsForViewer.ts
+++ b/packages/features/bookings/lib/getBookingDetailsForViewer.ts
@@ -1,0 +1,279 @@
+import type { z } from "zod";
+
+import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-utils";
+import { getDefaultEvent } from "@calcom/features/eventtypes/lib/defaultEvents";
+import { getBrandingForEventType } from "@calcom/features/profile/lib/getBranding";
+import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
+import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
+import { maybeGetBookingUidFromSeat } from "@calcom/lib/server/maybeGetBookingUidFromSeat";
+import type { PrismaClient } from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
+import { customInputSchema, eventTypeBookingFields } from "@calcom/prisma/zod-utils";
+
+import { BookingRepository } from "../repositories/BookingRepository";
+import getBookingInfo from "./getBookingInfo";
+
+type GetBookingDetailsParams = {
+  prisma: PrismaClient;
+  uid: string;
+  seatReferenceUid?: string;
+  eventTypeSlug?: string;
+  userId?: number | null;
+};
+
+type UserSelect = {
+  id: number;
+  name: string | null;
+  username: string | null;
+  hideBranding: boolean;
+  theme: string | null;
+  brandColor: string | null;
+  darkBrandColor: string | null;
+  email: string;
+  timeZone: string;
+  isPlatformManaged: boolean;
+};
+
+type BookingField = z.infer<typeof eventTypeBookingFields>[number];
+
+type BookingInfoType = Partial<
+  Prisma.BookingGetPayload<{
+    include: {
+      attendees: { select: { name: true; email: true; phoneNumber: true } };
+      seatsReferences: { select: { referenceUid: true } };
+      user: {
+        select: {
+          id: true;
+          name: true;
+          email: true;
+          username: true;
+          timeZone: true;
+        };
+      };
+    };
+  }>
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type GetEventTypesFromDBFn = (id: number) => Promise<any>;
+type HandleSeatsEventTypeOnBookingFn = (
+  eventType: {
+    seatsPerTimeSlot?: number | null;
+    seatsShowAttendees: boolean | null;
+    seatsShowAvailabilityCount: boolean | null;
+    [x: string | number | symbol]: unknown;
+  },
+  bookingInfo: BookingInfoType,
+  seatReferenceUid?: string,
+  isHost?: boolean
+) => Promise<BookingInfoType>;
+type GetRecurringBookingsFn = (recurringEventId: string | null) => Promise<string[] | null>;
+
+export type BookingDetailsResult = Awaited<ReturnType<typeof getBookingDetailsForViewer>>;
+
+export async function getBookingDetailsForViewer(
+  params: GetBookingDetailsParams,
+  helpers: {
+    getEventTypesFromDB: GetEventTypesFromDBFn;
+    handleSeatsEventTypeOnBooking: HandleSeatsEventTypeOnBookingFn;
+    getRecurringBookings: GetRecurringBookingsFn;
+  }
+) {
+  const { prisma, eventTypeSlug, userId } = params;
+  let { uid, seatReferenceUid } = params;
+
+  const maybeBookingUidFromSeat = await maybeGetBookingUidFromSeat(prisma, uid);
+  if (maybeBookingUidFromSeat.uid) uid = maybeBookingUidFromSeat.uid;
+  if (maybeBookingUidFromSeat.seatReferenceUid) seatReferenceUid = maybeBookingUidFromSeat.seatReferenceUid;
+
+  const { bookingInfoRaw, bookingInfo } = await getBookingInfo(uid);
+
+  if (!bookingInfoRaw || !bookingInfo) {
+    return null;
+  }
+
+  let rescheduledToUid: string | null = null;
+  if (bookingInfo.rescheduled) {
+    const bookingRepo = new BookingRepository(prisma);
+    const rescheduledTo = await bookingRepo.findFirstBookingByReschedule({
+      originalBookingUid: bookingInfo.uid,
+    });
+    rescheduledToUid = rescheduledTo?.uid ?? null;
+  }
+
+  let previousBooking: {
+    rescheduledBy: string | null;
+    uid: string;
+  } | null = null;
+
+  if (bookingInfo.fromReschedule) {
+    const bookingRepo = new BookingRepository(prisma);
+    previousBooking = await bookingRepo.findReschedulerByUid({
+      uid: bookingInfo.fromReschedule,
+    });
+  }
+
+  const eventTypeRaw = !bookingInfoRaw.eventTypeId
+    ? getDefaultEvent(eventTypeSlug || "")
+    : await helpers.getEventTypesFromDB(bookingInfoRaw.eventTypeId);
+
+  if (!eventTypeRaw) {
+    return null;
+  }
+
+  let requiresLoginToUpdate = false;
+  if (eventTypeRaw.seatsPerTimeSlot && !seatReferenceUid && !userId) {
+    requiresLoginToUpdate = true;
+  }
+
+  eventTypeRaw.users = eventTypeRaw.hosts?.length
+    ? eventTypeRaw.hosts.map((host: { user: UserSelect }) => host.user)
+    : eventTypeRaw.users;
+
+  if (!eventTypeRaw.users.length) {
+    if (!eventTypeRaw.owner) {
+      if (bookingInfoRaw.user) {
+        eventTypeRaw.users.push({
+          ...bookingInfoRaw.user,
+          hideBranding: false,
+          theme: null,
+          brandColor: null,
+          darkBrandColor: null,
+          isPlatformManaged: false,
+        });
+      } else {
+        return null;
+      }
+    } else {
+      eventTypeRaw.users.push({ ...eventTypeRaw.owner });
+    }
+  }
+
+  const eventType = {
+    ...eventTypeRaw,
+    periodStartDate: eventTypeRaw.periodStartDate?.toString() ?? null,
+    periodEndDate: eventTypeRaw.periodEndDate?.toString() ?? null,
+    metadata: eventTypeMetaDataSchemaWithTypedApps.parse(eventTypeRaw.metadata),
+    recurringEvent: parseRecurringEvent(eventTypeRaw.recurringEvent),
+    customInputs: customInputSchema.array().parse(eventTypeRaw.customInputs),
+    hideOrganizerEmail: eventTypeRaw.hideOrganizerEmail,
+    bookingFields: eventTypeRaw.bookingFields.map((field: BookingField) => {
+      return {
+        ...field,
+        label: field.type === "boolean" ? markdownToSafeHTML(field.label || "") : field.label || "",
+        defaultLabel:
+          field.type === "boolean" ? markdownToSafeHTML(field.defaultLabel || "") : field.defaultLabel || "",
+      };
+    }),
+  };
+
+  const profile = {
+    name: eventType.team?.name || eventType.users[0]?.name || null,
+    email: eventType.team ? null : eventType.users[0].email || null,
+    ...getBrandingForEventType({ eventType: eventTypeRaw }),
+    slug: eventType.team?.slug || eventType.users[0]?.username || null,
+  };
+
+  const checkIfUserIsHost = (checkUserId?: number | null) => {
+    if (!checkUserId) return false;
+
+    return (
+      bookingInfo?.user?.id === checkUserId ||
+      eventType.users.some(
+        (user: UserSelect) =>
+          user.id === checkUserId && bookingInfo.attendees.some((attendee) => attendee.email === user.email)
+      ) ||
+      eventType.hosts.some(
+        ({ user }: { user: UserSelect }) =>
+          user.id === checkUserId && bookingInfo.attendees.some((attendee) => attendee.email === user.email)
+      )
+    );
+  };
+
+  const isLoggedInUserHost = checkIfUserIsHost(userId);
+  const eventTeamId = eventType.team?.id ?? eventType.parent?.teamId;
+
+  let isLoggedInUserTeamMember = false;
+  if (userId && eventTeamId) {
+    const membership = await prisma.membership.findFirst({
+      where: {
+        userId,
+        teamId: eventTeamId,
+        accepted: true,
+      },
+    });
+    isLoggedInUserTeamMember = !!membership;
+  }
+
+  const canViewHiddenData = isLoggedInUserHost || isLoggedInUserTeamMember;
+
+  if (bookingInfo !== null && eventType.seatsPerTimeSlot) {
+    await helpers.handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
+  }
+
+  const payment = await prisma.payment.findFirst({
+    where: {
+      bookingId: bookingInfo.id,
+    },
+    select: {
+      appId: true,
+      success: true,
+      refunded: true,
+      currency: true,
+      amount: true,
+      paymentOption: true,
+    },
+  });
+
+  if (!canViewHiddenData) {
+    for (const key in bookingInfo.responses) {
+      const field = eventTypeRaw.bookingFields.find((field: BookingField) => field.name === key);
+      if (field && !!field.hidden) {
+        delete bookingInfo.responses[key];
+      }
+    }
+  }
+
+  async function getInternalNotePresets(teamId: number | null) {
+    if (!teamId || !canViewHiddenData) return [];
+    return await prisma.internalNotePreset.findMany({
+      where: {
+        teamId,
+      },
+      select: {
+        id: true,
+        name: true,
+        cancellationReason: true,
+      },
+    });
+  }
+
+  const internalNotes = await getInternalNotePresets(eventType.team?.id ?? eventType.parent?.teamId ?? null);
+
+  const sanitizedPreviousBooking =
+    eventType.hideOrganizerEmail &&
+    previousBooking &&
+    previousBooking.rescheduledBy === bookingInfo.user?.email
+      ? { ...previousBooking, rescheduledBy: bookingInfo.user?.name }
+      : previousBooking;
+
+  const isPlatformBooking = eventType.users[0]?.isPlatformManaged || eventType.team?.createdByOAuthClientId;
+
+  const recurringBookings = await helpers.getRecurringBookings(bookingInfo.recurringEventId);
+
+  return {
+    profile,
+    eventType,
+    recurringBookings,
+    dynamicEventName: bookingInfo?.eventType?.eventName || "",
+    bookingInfo,
+    previousBooking: sanitizedPreviousBooking,
+    paymentStatus: payment,
+    requiresLoginToUpdate,
+    rescheduledToUid,
+    isLoggedInUserHost,
+    canViewHiddenData,
+    internalNotePresets: internalNotes,
+    isPlatformBooking,
+  };
+}

--- a/packages/trpc/server/routers/viewer/bookings/_router.tsx
+++ b/packages/trpc/server/routers/viewer/bookings/_router.tsx
@@ -7,13 +7,15 @@ import { ZEditLocationInputSchema } from "./editLocation.schema";
 import { ZFindInputSchema } from "./find.schema";
 import { ZGetInputSchema } from "./get.schema";
 import { ZGetBookingAttendeesInputSchema } from "./getBookingAttendees.schema";
+import { ZGetDetailsInputSchema } from "./getDetails.schema";
 import { ZInstantBookingInputSchema } from "./getInstantBookingLocation.schema";
 import { ZReportBookingInputSchema } from "./reportBooking.schema";
 import { ZRequestRescheduleInputSchema } from "./requestReschedule.schema";
 import { bookingsProcedure } from "./util";
 
-type BookingsRouterHandlerCache = {
+type _BookingsRouterHandlerCache = {
   get?: typeof import("./get.handler").getHandler;
+  getDetails?: typeof import("./getDetails.handler").getDetailsHandler;
   requestReschedule?: typeof import("./requestReschedule.handler").requestRescheduleHandler;
   editLocation?: typeof import("./editLocation.handler").editLocationHandler;
   addGuests?: typeof import("./addGuests.handler").addGuestsHandler;
@@ -29,6 +31,15 @@ export const bookingsRouter = router({
     const { getHandler } = await import("./get.handler");
 
     return getHandler({
+      ctx,
+      input,
+    });
+  }),
+
+  getDetails: authedProcedure.input(ZGetDetailsInputSchema).query(async ({ input, ctx }) => {
+    const { getDetailsHandler } = await import("./getDetails.handler");
+
+    return getDetailsHandler({
       ctx,
       input,
     });

--- a/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
@@ -1,0 +1,41 @@
+import { getBookingDetailsForViewer } from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
+import type { PrismaClient } from "@calcom/prisma";
+
+import type { TrpcSessionUser } from "../../../types";
+import type { TGetDetailsInputSchema } from "./getDetails.schema";
+
+type GetDetailsOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+    prisma: PrismaClient;
+  };
+  input: TGetDetailsInputSchema;
+};
+
+export const getDetailsHandler = async ({ ctx, input }: GetDetailsOptions) => {
+  const { prisma, user } = ctx;
+  const { uid, seatReferenceUid, eventTypeSlug } = input;
+
+  const { getRecurringBookings, handleSeatsEventTypeOnBooking, getEventTypesFromDB } = await import(
+    "@calcom/web/lib/booking"
+  );
+
+  const result = await getBookingDetailsForViewer(
+    {
+      prisma,
+      uid,
+      seatReferenceUid,
+      eventTypeSlug,
+      userId: user.id,
+      userEmail: user.email,
+      userOrgId: user.organizationId,
+    },
+    {
+      getEventTypesFromDB,
+      handleSeatsEventTypeOnBooking,
+      getRecurringBookings,
+    }
+  );
+
+  return result;
+};

--- a/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
@@ -1,4 +1,7 @@
-import { getBookingDetailsForViewer } from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
+import {
+  getBookingDetailsForViewer,
+  type GetEventTypesFromDBFn,
+} from "@calcom/features/bookings/lib/getBookingDetailsForViewer";
 import type { PrismaClient } from "@calcom/prisma";
 
 import type { TrpcSessionUser } from "../../../types";
@@ -20,6 +23,10 @@ export const getDetailsHandler = async ({ ctx, input }: GetDetailsOptions) => {
     "@calcom/web/lib/booking"
   );
 
+  // Cast getEventTypesFromDB to the expected type - the branded bookingFields array
+  // from getBookingFieldsWithSystemFields is structurally compatible with the base type
+  const getEventTypesFromDBTyped = getEventTypesFromDB as GetEventTypesFromDBFn;
+
   const result = await getBookingDetailsForViewer(
     {
       prisma,
@@ -29,7 +36,7 @@ export const getDetailsHandler = async ({ ctx, input }: GetDetailsOptions) => {
       userId: user.id,
     },
     {
-      getEventTypesFromDB,
+      getEventTypesFromDB: getEventTypesFromDBTyped,
       handleSeatsEventTypeOnBooking,
       getRecurringBookings,
     }

--- a/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getDetails.handler.ts
@@ -27,8 +27,6 @@ export const getDetailsHandler = async ({ ctx, input }: GetDetailsOptions) => {
       seatReferenceUid,
       eventTypeSlug,
       userId: user.id,
-      userEmail: user.email,
-      userOrgId: user.organizationId,
     },
     {
       getEventTypesFromDB,

--- a/packages/trpc/server/routers/viewer/bookings/getDetails.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/getDetails.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ZGetDetailsInputSchema = z.object({
+  uid: z.string(),
+  seatReferenceUid: z.string().optional(),
+  eventTypeSlug: z.string().optional(),
+});
+
+export type TGetDetailsInputSchema = z.infer<typeof ZGetDetailsInputSchema>;


### PR DESCRIPTION
## What does this PR do?

This PR creates a new tRPC endpoint `viewer.bookings.getDetails` that enables fetching booking details via tRPC. This is a prerequisite for improving `BookingDetailsSheet` so it can fetch data client-side instead of relying on server-side props.

**Changes:**
- Creates a shared service function `getBookingDetailsForViewer` in `packages/features/bookings/lib/`
- Adds tRPC schema and handler for the new `getDetails` endpoint
- Registers the handler in the bookings router
- **Refactors `getServerSideProps` to use the shared service** - the logic is now truly shared between SSR and tRPC

This is part of the work for #25251 - once this PR is merged, the existing PR can be updated to use this new endpoint in `BookingDetailsSheet`.

## Updates since last revision

- **Fixed: `getServerSideProps` now uses `getBookingDetailsForViewer`** - Previously the shared service was created but `getServerSideProps` still had duplicated logic. Now it properly calls the shared function.
- **Fixed: Removed `any` type usage** - Added proper `EventTypeBase` and `BookingFieldBase` type definitions
- **Fixed: Type compatibility with branded arrays** - The `getEventTypesFromDB` function returns a branded `bookingFields` array from `getBookingFieldsWithSystemFields`. The handler now uses a targeted type assertion (`as GetEventTypesFromDBFn`) to handle this, since the branded array is structurally compatible with the base type.
- **Fixed: Removed unused parameters** - `userEmail` and `userOrgId` are no longer passed to the service

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal API change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. The new tRPC endpoint can be tested by calling `trpc.viewer.bookings.getDetails.useQuery({ uid: "booking-uid" })` from a client component
2. **Verify the `/booking/[uid]` page still works correctly** - since `getServerSideProps` now uses the shared service
3. Test with different user permissions:
   - As the booking host
   - As a team member
   - As a non-host/non-team-member (should have hidden fields filtered)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Important items for human review

1. **Type assertion in handler** - Line 28 of `getDetails.handler.ts` uses `as GetEventTypesFromDBFn` to cast the branded bookingFields array. This is necessary because `getBookingFieldsWithSystemFields` returns a Zod branded type that TypeScript won't automatically accept as compatible with the base type, even though it's structurally compatible.
2. **`EventTypeBase` type compatibility** - Verify the type definition in `getBookingDetailsForViewer.ts` correctly handles both `getEventTypesFromDB` return type and `DefaultEvent`
3. **Permission logic** - Verify `canViewHiddenData` logic correctly filters hidden booking fields for non-hosts/non-team-members
4. **SSR date handling** - `getServerSideProps` converts dates to ISO strings (lines 95-99 of the refactored file), while tRPC returns Date objects directly

---

Link to Devin run: https://app.devin.ai/sessions/629ee5793e7b4a62a01cee0ab8774524
Requested by: @eunjae-lee (eunjae@cal.com)