### PR TITLE
fix: add legacy admin/owner fallback for roles tab visibility when PBAC is enabled

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
@@ -72,8 +72,9 @@ export default async function SettingsLayoutAppDir(props: SettingsLayoutProps) {
       ]);
 
       // Check if user has permission to read roles
+      // Fall back to legacy admin/owner check if no PBAC permissions are set
       const roleActions = PermissionMapper.toActionMap(rolePermissions, Resource.Role);
-      canViewRoles = roleActions[CrudAction.Read] ?? false;
+      canViewRoles = roleActions[CrudAction.Read] ?? isOrgAdminOrOwner;
       const orgActions = PermissionMapper.toActionMap(organizationPermissions, Resource.Organization);
       canViewOrganizationBilling = orgActions[CustomAction.ManageBilling] ?? isOrgAdminOrOwner;
       canUpdateOrganization = orgActions[CrudAction.Update] ?? isOrgAdminOrOwner;


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the roles tab disappears from the sidebar for a default admin in an organization when PBAC (roles) is enabled.

**Root cause:** When PBAC is enabled, the permission check only looks at `customRoleId` on the user's membership. For "default admins" (users who are ADMIN/OWNER by the legacy `role` field but don't have a custom role assigned yet), the permission check returns false because they don't have a `customRoleId`.

**Solution:** Add a fallback to check the legacy admin/owner role when no PBAC permissions are set. This is consistent with how `canViewOrganizationBilling` and `canUpdateOrganization` already work in the same codebase.

- Link to Devin run: https://app.devin.ai/sessions/6db9c9ee7c854edd903040006e1856a7
- Requested by: joe@cal.com (@joeauyeung)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create/use an organization with a user who is an ADMIN or OWNER (by legacy membership role)
2. Enable PBAC (roles) feature for the organization
3. Ensure the admin user does NOT have a custom role assigned (no `customRoleId` on their membership)
4. Navigate to Settings
5. **Before fix:** The "Roles" tab would be missing from the sidebar
6. **After fix:** The "Roles" tab should be visible and accessible

Also verify:
- Clicking the Roles tab should load the roles page (not 404)
- Admin should be able to create/read/update/delete roles
- Same behavior should work for team-level roles pages

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the fallback pattern (`?? isOrgAdminOrOwner`) is appropriate and consistent with existing patterns
- [ ] In `teams/[id]/roles/page.tsx`, verify that `team.members.find((member) => member.id === session.user.id)` correctly finds the current user's membership
- [ ] Consider if there are edge cases where a demoted user might incorrectly retain access