### PR TITLE
fix: Add orgSlug to slots.getSchedule call

### DIFF
--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -163,7 +163,7 @@ const BookerPlatformWrapperComponent = (props: BookerWebWrapperAtomProps) => {
     fromRedirectOfNonOrgLink: props.entity.fromRedirectOfNonOrgLink,
     isTeamEvent: props.isTeamEvent ?? !!event.data?.team,
     useApiV2: props.useApiV2,
-    orgSlug: props.entity.orgSlug,
+    ...(props.entity.orgSlug ? { orgSlug: props.entity.orgSlug } : {}),
   });
   const bookings = useBookings({
     event,

--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -163,6 +163,7 @@ const BookerPlatformWrapperComponent = (props: BookerWebWrapperAtomProps) => {
     fromRedirectOfNonOrgLink: props.entity.fromRedirectOfNonOrgLink,
     isTeamEvent: props.isTeamEvent ?? !!event.data?.team,
     useApiV2: props.useApiV2,
+    orgSlug: props.entity.orgSlug,
   });
   const bookings = useBookings({
     event,
@@ -213,7 +214,6 @@ const BookerPlatformWrapperComponent = (props: BookerWebWrapperAtomProps) => {
 
   useEffect(() => {
     if (hasSession) onOverlaySwitchStateChange(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasSession]);
 
   return (


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passes orgSlug to slots.getSchedule in BookerWebWrapper (when available) so the correct schedule loads for org-scoped events.
Also removes an unnecessary eslint-disable comment.

<sup>Written for commit 2ed4d77244495525355d09d40a2fb20f112e9203. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



