### PR TITLE
fix: Lazy loaded Stripe proxy to avoid crash on BillingService setup

### DIFF
--- a/packages/features/ee/billing/di/modules/StripeClient.ts
+++ b/packages/features/ee/billing/di/modules/StripeClient.ts
@@ -6,9 +6,33 @@ import { DI_TOKENS } from "../tokens";
 
 export const stripeClientModule = createModule();
 const token = DI_TOKENS.STRIPE_CLIENT;
+
+/**
+ * Creates a deep proxy that only throws when a Stripe function is invoked.
+ * Property access (e.g. stripe.customers, stripe.customers.create) returns another proxy so that
+ * code doing capability checks (typeof stripe.customers?.create === "function") does not immediately throw.
+ */
+function createLazyThrowingStripeStub(error: Error): Stripe {
+  // Using unknown instead of any to satisfy lint while still allowing broad proxying.
+  function makeDeepProxy(): unknown {
+    return new Proxy(function () {}, {
+      get() {
+        // Return another proxy for any nested property (resources/methods)
+        return makeDeepProxy();
+      },
+      apply() {
+        throw error; // Throw only when a function is actually called
+      },
+    });
+  }
+  return makeDeepProxy() as Stripe;
+}
+
 stripeClientModule.bind(token).toFactory(() => {
   if (!process.env.STRIPE_PRIVATE_KEY) {
-    throw new Error("STRIPE_PRIVATE_KEY is not set");
+    const error = new Error("STRIPE_PRIVATE_KEY is not set");
+    // Inject a stub that defers throwing until a method invocation
+    return createLazyThrowingStripeStub(error);
   }
 
   return new Stripe(process.env.STRIPE_PRIVATE_KEY!, {


### PR DESCRIPTION
Fixes https://github.com/calcom/cal.com/issues/25399

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents BillingService from crashing at setup when Stripe isn’t configured by returning a lazy Stripe proxy that only throws on method calls. This lets capability checks run without errors and defers failure until a Stripe API is used.

- **Bug Fixes**
  - In StripeClient DI module, when STRIPE_PRIVATE_KEY is missing, inject a deep proxy stub that throws only on invocation.
  - Allows checks like typeof stripe.customers?.create === "function" during initialization without immediate errors.

<sup>Written for commit 068238473b9c0e2b32824436488e9f5b2b0b3eac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

