### PR TITLE
chore: Fix circular dependency in tanstack-table.d.ts

### DIFF
--- a/apps/web/modules/insights/insights-view.tsx
+++ b/apps/web/modules/insights/insights-view.tsx
@@ -10,6 +10,7 @@ import {
   ColumnFilterType,
   type FilterableColumn,
 } from "@calcom/features/data-table";
+import type { FilterType } from "@calcom/types/data-table";
 import { useDataTable } from "@calcom/features/data-table/hooks/useDataTable";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import {
@@ -53,13 +54,13 @@ export default function InsightsPage({ timeZone }: { timeZone: string }) {
   );
 }
 
-const createdAtColumn: Extract<FilterableColumn, { type: ColumnFilterType.DATE_RANGE }> = {
+const createdAtColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }> = {
   id: "createdAt",
   title: "createdAt",
   type: ColumnFilterType.DATE_RANGE,
 };
 
-const startTimeColumn: Extract<FilterableColumn, { type: ColumnFilterType.DATE_RANGE }> = {
+const startTimeColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }> = {
   id: "startTime",
   title: "startTime",
   type: ColumnFilterType.DATE_RANGE,

--- a/packages/features/data-table/components/filters/BaseSelectFilterOptions.tsx
+++ b/packages/features/data-table/components/filters/BaseSelectFilterOptions.tsx
@@ -18,26 +18,26 @@ import { Icon } from "@calcom/ui/components/icon";
 
 import { useDataTable, useFilterValue } from "../../hooks";
 import type {
-  ColumnFilterType,
   FacetedValue,
   FilterableColumn as _FilterableColumn,
   FilterValueSchema,
 } from "../../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 
 type FilterableColumn = Extract<
   _FilterableColumn,
-  { type: ColumnFilterType.MULTI_SELECT | ColumnFilterType.SINGLE_SELECT }
+  { type: Extract<FilterType, "ms" | "ss"> }
 >;
 
-type FilterableSelectColumn<T extends ColumnFilterType.MULTI_SELECT | ColumnFilterType.SINGLE_SELECT> =
+type FilterableSelectColumn<T extends Extract<FilterType, "ms" | "ss">> =
   Extract<FilterableColumn, { type: T }>;
 
-type FilterValue<T extends ColumnFilterType.MULTI_SELECT | ColumnFilterType.SINGLE_SELECT> = ReturnType<
+type FilterValue<T extends Extract<FilterType, "ms" | "ss">> = ReturnType<
   typeof useFilterValue<T, FilterValueSchema<T>>
 >;
 
 export type BaseSelectFilterOptionsProps<
-  T extends ColumnFilterType.MULTI_SELECT | ColumnFilterType.SINGLE_SELECT
+  T extends Extract<FilterType, "ms" | "ss">
 > = {
   column: FilterableSelectColumn<T>;
   filterValueSchema: FilterValueSchema<T>;
@@ -88,7 +88,7 @@ function getSectionedOptions(options: FacetedValue[]) {
 }
 
 export function BaseSelectFilterOptions<
-  T extends ColumnFilterType.MULTI_SELECT | ColumnFilterType.SINGLE_SELECT
+  T extends Extract<FilterType, "ms" | "ss">
 >({
   column,
   filterValueSchema,

--- a/packages/features/data-table/components/filters/DateRangeFilter.tsx
+++ b/packages/features/data-table/components/filters/DateRangeFilter.tsx
@@ -33,10 +33,11 @@ import {
 import { preserveLocalTime } from "../../lib/preserveLocalTime";
 import type { FilterableColumn, DateRangeFilterOptions } from "../../lib/types";
 import { ZDateRangeFilterValue, ColumnFilterType } from "../../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { useFilterPopoverOpen } from "./useFilterPopoverOpen";
 
 type DateRangeFilterProps = {
-  column: Extract<FilterableColumn, { type: ColumnFilterType.DATE_RANGE }>;
+  column: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }>;
   options?: DateRangeFilterOptions;
   showColumnName?: boolean;
   showClearButton?: boolean;

--- a/packages/features/data-table/components/filters/FilterPopover.tsx
+++ b/packages/features/data-table/components/filters/FilterPopover.tsx
@@ -1,6 +1,7 @@
-// eslint-disable-next-line no-restricted-imports
+ 
 import startCase from "lodash/startCase";
 
+import type { FilterType } from "@calcom/types/data-table";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import type { IconName } from "@calcom/ui/components/icon";
@@ -18,7 +19,7 @@ import { FilterOptions } from "./FilterOptions";
 import { useFilterPopoverOpen } from "./useFilterPopoverOpen";
 import { numberFilterOperatorOptions, useTextFilterOperatorOptions } from "./utils";
 
-const FILTER_ICONS: Record<ColumnFilterType, IconName> = {
+const FILTER_ICONS: Record<FilterType, IconName> = {
   [ColumnFilterType.TEXT]: "file-text",
   [ColumnFilterType.NUMBER]: "binary",
   [ColumnFilterType.MULTI_SELECT]: "layers",
@@ -84,11 +85,11 @@ function AppliedSelectFilterValue({ column, filterValue }: SelectedLabelsProps) 
   let moreCount = 0;
 
   if (isSingleSelectFilterValue(filterValue)) {
-    const options = (column as Extract<FilterableColumn, { type: ColumnFilterType.SINGLE_SELECT }>).options;
+    const options = (column as FilterableColumn & { type: "ss" }).options;
     text = options.find((opt) => opt.value === filterValue.data)?.label;
     moreCount = 0;
   } else if (isMultiSelectFilterValue(filterValue)) {
-    const options = (column as Extract<FilterableColumn, { type: ColumnFilterType.MULTI_SELECT }>).options;
+    const options = (column as FilterableColumn & { type: "ms" }).options;
     text = options.find((opt) => opt.value === filterValue.data[0])?.label;
     moreCount = filterValue.data.length - 1;
   }

--- a/packages/features/data-table/components/filters/MultiSelectFilterOptions.tsx
+++ b/packages/features/data-table/components/filters/MultiSelectFilterOptions.tsx
@@ -3,17 +3,18 @@
 import { useDataTable } from "../../hooks";
 import type { FilterableColumn } from "../../lib/types";
 import { ZMultiSelectFilterValue, ColumnFilterType } from "../../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { BaseSelectFilterOptions } from "./BaseSelectFilterOptions";
 
 export type MultiSelectFilterOptionsProps = {
-  column: Extract<FilterableColumn, { type: ColumnFilterType.MULTI_SELECT }>;
+  column: Extract<FilterableColumn, { type: Extract<FilterType, "ms"> }>;
 };
 
 export function MultiSelectFilterOptions({ column }: MultiSelectFilterOptionsProps) {
   const { updateFilter } = useDataTable();
 
   return (
-    <BaseSelectFilterOptions<ColumnFilterType.MULTI_SELECT>
+    <BaseSelectFilterOptions<Extract<FilterType, "ms">>
       column={column}
       filterValueSchema={ZMultiSelectFilterValue}
       testIdPrefix="select-filter-options"

--- a/packages/features/data-table/components/filters/NumberFilterOptions.tsx
+++ b/packages/features/data-table/components/filters/NumberFilterOptions.tsx
@@ -9,10 +9,11 @@ import { Form, Select, NumberInput } from "@calcom/ui/components/form";
 import { useFilterValue, useDataTable } from "../../hooks";
 import type { FilterableColumn } from "../../lib/types";
 import { ZNumberFilterValue, ColumnFilterType } from "../../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { numberFilterOperatorOptions } from "./utils";
 
 export type NumberFilterOptionsProps = {
-  column: Extract<FilterableColumn, { type: ColumnFilterType.NUMBER }>;
+  column: Extract<FilterableColumn, { type: Extract<FilterType, "n"> }>;
 };
 
 export function NumberFilterOptions({ column }: NumberFilterOptionsProps) {

--- a/packages/features/data-table/components/filters/SingleSelectFilterOptions.tsx
+++ b/packages/features/data-table/components/filters/SingleSelectFilterOptions.tsx
@@ -1,19 +1,21 @@
 "use client";
 
+import type { FilterType } from "@calcom/types/data-table";
+
 import { useDataTable } from "../../hooks";
 import type { FilterableColumn } from "../../lib/types";
 import { ZSingleSelectFilterValue, ColumnFilterType } from "../../lib/types";
 import { BaseSelectFilterOptions } from "./BaseSelectFilterOptions";
 
 export type SingleSelectFilterOptionsProps = {
-  column: Extract<FilterableColumn, { type: ColumnFilterType.SINGLE_SELECT }>;
+  column: Extract<FilterableColumn, { type: Extract<FilterType, "ss"> }>;
 };
 
 export function SingleSelectFilterOptions({ column }: SingleSelectFilterOptionsProps) {
   const { updateFilter } = useDataTable();
 
   return (
-    <BaseSelectFilterOptions<ColumnFilterType.SINGLE_SELECT>
+    <BaseSelectFilterOptions<Extract<FilterType, "ss">>
       column={column}
       filterValueSchema={ZSingleSelectFilterValue}
       testIdPrefix="select-filter-options"

--- a/packages/features/data-table/components/filters/TextFilterOptions.tsx
+++ b/packages/features/data-table/components/filters/TextFilterOptions.tsx
@@ -9,10 +9,11 @@ import { Form, Select, Input } from "@calcom/ui/components/form";
 import { useFilterValue, useDataTable } from "../../hooks";
 import type { FilterableColumn } from "../../lib/types";
 import { ZTextFilterValue, ColumnFilterType } from "../../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { useTextFilterOperatorOptions } from "./utils";
 
 export type TextFilterOptionsProps = {
-  column: Extract<FilterableColumn, { type: ColumnFilterType.TEXT }>;
+  column: Extract<FilterableColumn, { type: Extract<FilterType, "t"> }>;
 };
 
 export function TextFilterOptions({ column }: TextFilterOptionsProps) {

--- a/packages/features/data-table/hooks/useFilterValue.ts
+++ b/packages/features/data-table/hooks/useFilterValue.ts
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import type { z } from "zod";
 
-import type { FilterValueSchema, ColumnFilterType, ZFilterValue } from "../lib/types";
+import type { FilterValueSchema, ZFilterValue } from "../lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { useDataTable } from "./useDataTable";
 
 export function useFilterValue<
-  T extends ColumnFilterType,
+  T extends FilterType,
   TSchema extends FilterValueSchema<T> | typeof ZFilterValue
 >(columnId: string, schema: TSchema) {
   const { activeFilters } = useDataTable();

--- a/packages/features/data-table/lib/types.ts
+++ b/packages/features/data-table/lib/types.ts
@@ -1,19 +1,15 @@
 import type { SortingState, ColumnSort } from "@tanstack/react-table";
 import { z } from "zod";
 
-import type { IconName } from "@calcom/ui/components/icon";
+import type { TextFilterOperator } from "@calcom/types/data-table";
+export type { ColumnFilterMeta, FilterableColumn } from "@calcom/types/data-table";
+import { ColumnFilterType } from "@calcom/types/data-table";
 
 export type { SortingState } from "@tanstack/react-table";
 
 export const SYSTEM_SEGMENT_PREFIX = "system_";
 
-export enum ColumnFilterType {
-  SINGLE_SELECT = "ss",
-  MULTI_SELECT = "ms",
-  TEXT = "t",
-  NUMBER = "n",
-  DATE_RANGE = "dr",
-}
+export { ColumnFilterType };
 
 export const textFilterOperators = [
   "equals",
@@ -25,8 +21,6 @@ export const textFilterOperators = [
   "isEmpty",
   "isNotEmpty",
 ] as const;
-
-export type TextFilterOperator = (typeof textFilterOperators)[number];
 
 export const ZTextFilterOperator = z.enum(textFilterOperators);
 
@@ -123,48 +117,6 @@ export type TextFilterOptions = {
   allowedOperators?: TextFilterOperator[];
   placeholder?: string;
 };
-
-export type ColumnFilterMeta =
-  | {
-      type: ColumnFilterType.DATE_RANGE;
-      icon?: IconName;
-      dateRangeOptions?: DateRangeFilterOptions;
-    }
-  | {
-      type: ColumnFilterType.TEXT;
-      icon?: IconName;
-      textOptions?: TextFilterOptions;
-    }
-  | {
-      type?: Exclude<ColumnFilterType, ColumnFilterType.DATE_RANGE | ColumnFilterType.TEXT>;
-      icon?: IconName;
-    };
-
-export type FilterableColumn = {
-  id: string;
-  title: string;
-  icon?: IconName;
-} & (
-  | {
-      type: ColumnFilterType.SINGLE_SELECT;
-      options: FacetedValue[];
-    }
-  | {
-      type: ColumnFilterType.MULTI_SELECT;
-      options: FacetedValue[];
-    }
-  | {
-      type: ColumnFilterType.TEXT;
-      textOptions?: TextFilterOptions;
-    }
-  | {
-      type: ColumnFilterType.NUMBER;
-    }
-  | {
-      type: ColumnFilterType.DATE_RANGE;
-      dateRangeOptions?: DateRangeFilterOptions;
-    }
-);
 
 export type ColumnFilter = {
   id: string;

--- a/packages/features/data-table/lib/types.ts
+++ b/packages/features/data-table/lib/types.ts
@@ -9,7 +9,7 @@ export type { SortingState } from "@tanstack/react-table";
 
 export const SYSTEM_SEGMENT_PREFIX = "system_";
 
-export { ColumnFilterType };
+export { ColumnFilterType, TextFilterOperator };
 
 export const textFilterOperators = [
   "equals",

--- a/packages/features/data-table/lib/types.ts
+++ b/packages/features/data-table/lib/types.ts
@@ -3,7 +3,14 @@ import { z } from "zod";
 
 import type { TextFilterOperator } from "@calcom/types/data-table";
 export type { ColumnFilterMeta, FilterableColumn } from "@calcom/types/data-table";
-import { ColumnFilterType } from "@calcom/types/data-table";
+
+enum ColumnFilterType {
+  SINGLE_SELECT = "ss",
+  MULTI_SELECT = "ms",
+  TEXT = "t",
+  NUMBER = "n",
+  DATE_RANGE = "dr",
+}
 
 export type { SortingState } from "@tanstack/react-table";
 

--- a/packages/features/data-table/lib/types.ts
+++ b/packages/features/data-table/lib/types.ts
@@ -1,16 +1,18 @@
 import type { SortingState, ColumnSort } from "@tanstack/react-table";
 import { z } from "zod";
 
-import type { TextFilterOperator } from "@calcom/types/data-table";
+import type { TextFilterOperator, FilterType } from "@calcom/types/data-table";
 export type { ColumnFilterMeta, FilterableColumn } from "@calcom/types/data-table";
 
-enum ColumnFilterType {
-  SINGLE_SELECT = "ss",
-  MULTI_SELECT = "ms",
-  TEXT = "t",
-  NUMBER = "n",
-  DATE_RANGE = "dr",
-}
+const ColumnFilterType = {
+  SINGLE_SELECT: "ss",
+  MULTI_SELECT: "ms",
+  TEXT: "t",
+  NUMBER: "n",
+  DATE_RANGE: "dr",
+} as const satisfies Record<string, FilterType>;
+
+type ColumnFilterTypeValues = typeof ColumnFilterType;
 
 export type { SortingState } from "@tanstack/react-table";
 
@@ -32,7 +34,7 @@ export const textFilterOperators = [
 export const ZTextFilterOperator = z.enum(textFilterOperators);
 
 export type SingleSelectFilterValue = {
-  type: ColumnFilterType.SINGLE_SELECT;
+  type: ColumnFilterTypeValues["SINGLE_SELECT"];
   data: string | number;
 };
 
@@ -42,7 +44,7 @@ export const ZSingleSelectFilterValue = z.object({
 }) satisfies z.ZodType<SingleSelectFilterValue>;
 
 export type MultiSelectFilterValue = {
-  type: ColumnFilterType.MULTI_SELECT;
+  type: ColumnFilterTypeValues["MULTI_SELECT"];
   data: Array<string | number>;
 };
 
@@ -52,7 +54,7 @@ export const ZMultiSelectFilterValue = z.object({
 }) satisfies z.ZodType<MultiSelectFilterValue>;
 
 export type TextFilterValue = {
-  type: ColumnFilterType.TEXT;
+  type: ColumnFilterTypeValues["TEXT"];
   data: {
     operator: TextFilterOperator;
     operand: string;
@@ -74,7 +76,7 @@ export type NumberFilterOperator = (typeof numberFilterOperators)[number];
 export const ZNumberFilterOperator = z.enum(numberFilterOperators);
 
 export type NumberFilterValue = {
-  type: ColumnFilterType.NUMBER;
+  type: ColumnFilterTypeValues["NUMBER"];
   data: {
     operator: NumberFilterOperator;
     operand: number;
@@ -90,7 +92,7 @@ export const ZNumberFilterValue = z.object({
 }) satisfies z.ZodType<NumberFilterValue>;
 
 export type DateRangeFilterValue = {
-  type: ColumnFilterType.DATE_RANGE;
+  type: ColumnFilterTypeValues["DATE_RANGE"];
   data: {
     startDate: string | null;
     endDate: string | null;
@@ -135,32 +137,32 @@ export const ZColumnFilter = z.object({
   value: ZFilterValue,
 }) satisfies z.ZodType<ColumnFilter>;
 
-export type FilterValueSchema<T extends ColumnFilterType> = T extends ColumnFilterType.SINGLE_SELECT
+export type FilterValueSchema<T extends FilterType> = T extends ColumnFilterTypeValues["SINGLE_SELECT"]
   ? typeof ZSingleSelectFilterValue
-  : T extends ColumnFilterType.MULTI_SELECT
+  : T extends ColumnFilterTypeValues["MULTI_SELECT"]
   ? typeof ZMultiSelectFilterValue
-  : T extends ColumnFilterType.TEXT
+  : T extends ColumnFilterTypeValues["TEXT"]
   ? typeof ZTextFilterValue
-  : T extends ColumnFilterType.NUMBER
+  : T extends ColumnFilterTypeValues["NUMBER"]
   ? typeof ZNumberFilterValue
-  : T extends ColumnFilterType.DATE_RANGE
+  : T extends ColumnFilterTypeValues["DATE_RANGE"]
   ? typeof ZDateRangeFilterValue
   : never;
 
-export type FilterValue<T extends ColumnFilterType = ColumnFilterType> =
-  T extends ColumnFilterType.SINGLE_SELECT
+export type FilterValue<T extends FilterType = FilterType> =
+  T extends ColumnFilterTypeValues["SINGLE_SELECT"]
     ? SingleSelectFilterValue
-    : T extends ColumnFilterType.MULTI_SELECT
+    : T extends ColumnFilterTypeValues["MULTI_SELECT"]
     ? MultiSelectFilterValue
-    : T extends ColumnFilterType.TEXT
+    : T extends ColumnFilterTypeValues["TEXT"]
     ? TextFilterValue
-    : T extends ColumnFilterType.NUMBER
+    : T extends ColumnFilterTypeValues["NUMBER"]
     ? NumberFilterValue
-    : T extends ColumnFilterType.DATE_RANGE
+    : T extends ColumnFilterTypeValues["DATE_RANGE"]
     ? DateRangeFilterValue
     : never;
 
-export type TypedColumnFilter<T extends ColumnFilterType> = {
+export type TypedColumnFilter<T extends FilterType> = {
   id: string;
   value: FilterValue<T>;
 };

--- a/packages/features/insights/components/routing/RoutingFormResponsesTable.tsx
+++ b/packages/features/insights/components/routing/RoutingFormResponsesTable.tsx
@@ -19,6 +19,7 @@ import {
   ZSingleSelectFilterValue,
   type FilterableColumn,
 } from "@calcom/features/data-table";
+import type { FilterType } from "@calcom/types/data-table";
 import { useInsightsRoutingParameters } from "@calcom/features/insights/hooks/useInsightsRoutingParameters";
 import { trpc } from "@calcom/trpc";
 
@@ -34,7 +35,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 export type RoutingFormTableType = ReturnType<typeof useReactTable<RoutingFormTableRow>>;
 
-const createdAtColumn: Extract<FilterableColumn, { type: ColumnFilterType.DATE_RANGE }> = {
+const createdAtColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }> = {
   id: "createdAt",
   title: "createdAt",
   type: ColumnFilterType.DATE_RANGE,

--- a/packages/features/insights/lib/bookingUtils.ts
+++ b/packages/features/insights/lib/bookingUtils.ts
@@ -1,6 +1,7 @@
 import { ColumnFilterType } from "@calcom/features/data-table/lib/types";
 import { type ColumnFilter } from "@calcom/features/data-table/lib/types";
 import { isDateRangeFilterValue } from "@calcom/features/data-table/lib/utils";
+import type { FilterType } from "@calcom/types/data-table";
 
 export function extractDateRangeFromColumnFilters(columnFilters?: ColumnFilter[]) {
   if (!columnFilters) throw new Error("No date range filter found");
@@ -9,7 +10,7 @@ export function extractDateRangeFromColumnFilters(columnFilters?: ColumnFilter[]
     if ((filter.id === "startTime" || filter.id === "createdAt") && isDateRangeFilterValue(filter.value)) {
       const dateFilter = filter.value as Extract<
         ColumnFilter["value"],
-        { type: ColumnFilterType.DATE_RANGE }
+        { type: Extract<FilterType, "dr"> }
       >;
       if (dateFilter.data.startDate && dateFilter.data.endDate) {
         return {

--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import dayjs from "@calcom/dayjs";
 import { makeSqlCondition } from "@calcom/features/data-table/lib/server";
 import type { FilterValue, TextFilterValue, TypedColumnFilter } from "@calcom/features/data-table/lib/types";
-import type { ColumnFilterType } from "@calcom/features/data-table/lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import {
   isMultiSelectFilterValue,
   isTextFilterValue,
@@ -49,7 +49,7 @@ export type InsightsRoutingServiceOptions = z.infer<typeof insightsRoutingServic
 export type InsightsRoutingServiceFilterOptions = {
   startDate: string;
   endDate: string;
-  columnFilters?: TypedColumnFilter<ColumnFilterType>[];
+  columnFilters?: TypedColumnFilter<FilterType>[];
 };
 
 export type InsightsRoutingTableItem = {
@@ -705,7 +705,7 @@ export class InsightsRoutingBaseService {
       columnFilters.reduce((acc, filter) => {
         acc[filter.id] = filter;
         return acc;
-      }, {} as Record<string, TypedColumnFilter<ColumnFilterType>>) || {};
+      }, {} as Record<string, TypedColumnFilter<FilterType>>) || {};
 
     // Extract booking status order filter
     const bookingStatusOrder = filtersMap["bookingStatusOrder"];

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@calcom/prisma/__mocks__/prisma";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { type TypedColumnFilter, ColumnFilterType } from "@calcom/features/data-table/lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 
 import { listMembersHandler } from "./listMembers.handler";
 
@@ -76,6 +77,7 @@ describe("listMembersHandler", () => {
     prisma.membership.count.mockResolvedValue(0);
     prisma.membership.findFirst.mockResolvedValue({ role: "ADMIN" });
     // Mock team.findUnique to return only isPrivate field since that's what the handler selects
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prisma.team.findUnique.mockResolvedValue({ isPrivate: false } as any);
   });
 
@@ -83,7 +85,7 @@ describe("listMembersHandler", () => {
     // Mock PBAC enabled
     mockCheckIfTeamHasFeature.mockResolvedValue(true);
 
-    const roleFilter: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const roleFilter: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "role",
       value: {
         type: ColumnFilterType.MULTI_SELECT,
@@ -122,7 +124,7 @@ describe("listMembersHandler", () => {
     // Mock PBAC disabled
     mockCheckIfTeamHasFeature.mockResolvedValue(false);
 
-    const roleFilter: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const roleFilter: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "role",
       value: {
         type: ColumnFilterType.MULTI_SELECT,
@@ -157,7 +159,7 @@ describe("listMembersHandler", () => {
     // Mock PBAC disabled for this test
     mockCheckIfTeamHasFeature.mockResolvedValue(false);
 
-    const roleFilter: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const roleFilter: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "role",
       value: {
         type: ColumnFilterType.MULTI_SELECT,
@@ -165,7 +167,7 @@ describe("listMembersHandler", () => {
       },
     };
 
-    const teamFilter: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const teamFilter: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "teams",
       value: {
         type: ColumnFilterType.MULTI_SELECT,
@@ -173,7 +175,7 @@ describe("listMembersHandler", () => {
       },
     };
 
-    const attributeFilter1: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const attributeFilter1: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "1",
       value: {
         type: ColumnFilterType.MULTI_SELECT,
@@ -181,7 +183,7 @@ describe("listMembersHandler", () => {
       },
     };
 
-    const attributeFilter2: TypedColumnFilter<ColumnFilterType.MULTI_SELECT> = {
+    const attributeFilter2: TypedColumnFilter<Extract<FilterType, "ms">> = {
       id: "2",
       value: {
         type: ColumnFilterType.MULTI_SELECT,

--- a/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/listMembers.handler.ts
@@ -1,8 +1,7 @@
 import { makeWhereClause } from "@calcom/features/data-table/lib/server";
 import { type TypedColumnFilter, ColumnFilterType } from "@calcom/features/data-table/lib/types";
+import type { FilterType } from "@calcom/types/data-table";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
-import { Resource, CustomAction } from "@calcom/features/pbac/domain/types/permission-registry";
-import { getSpecificPermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { prisma } from "@calcom/prisma";
@@ -113,19 +112,19 @@ export const listMembersHandler = async ({ ctx, input }: GetOptions) => {
   const { limit, offset } = input;
 
   const roleFilter = filters.find((filter) => filter.id === "role") as
-    | TypedColumnFilter<ColumnFilterType.MULTI_SELECT>
+    | TypedColumnFilter<Extract<FilterType, "ms">>
     | undefined;
   const teamFilter = filters.find((filter) => filter.id === "teams") as
-    | TypedColumnFilter<ColumnFilterType.MULTI_SELECT>
+    | TypedColumnFilter<Extract<FilterType, "ms">>
     | undefined;
   const lastActiveAtFilter = filters.find((filter) => filter.id === "lastActiveAt") as
-    | TypedColumnFilter<ColumnFilterType.DATE_RANGE>
+    | TypedColumnFilter<Extract<FilterType, "dr">>
     | undefined;
   const createdAtFilter = filters.find((filter) => filter.id === "createdAt") as
-    | TypedColumnFilter<ColumnFilterType.DATE_RANGE>
+    | TypedColumnFilter<Extract<FilterType, "dr">>
     | undefined;
   const updatedAtFilter = filters.find((filter) => filter.id === "updatedAt") as
-    | TypedColumnFilter<ColumnFilterType.DATE_RANGE>
+    | TypedColumnFilter<Extract<FilterType, "dr">>
     | undefined;
 
   const roleWhereClause = roleFilter

--- a/packages/types/data-table.d.ts
+++ b/packages/types/data-table.d.ts
@@ -1,12 +1,10 @@
 import type { IconName } from "@calcom/ui/components/icon/icon-names";
 
-export enum ColumnFilterType {
-  SINGLE_SELECT = "ss",
-  MULTI_SELECT = "ms",
-  TEXT = "t",
-  NUMBER = "n",
-  DATE_RANGE = "dr",
-}
+export type FilterTypeSingleSelect = "ss";
+export type FilterTypeMultiSelect = "ms";
+export type FilterTypeText = "t";
+export type FilterTypeNumber = "n";
+export type FilterTypeDateRange = "dr";
 
 export type TextFilterOperator = "equals" | "notEquals" | "contains" | "notContains" | "startsWith" | "endsWith" | "isEmpty" | "isNotEmpty";
 
@@ -22,17 +20,17 @@ export type DateRangeFilterOptions = {
 
 export type ColumnFilterMeta =
   | {
-      type: ColumnFilterType.DATE_RANGE;
+      type: FilterTypeDateRange;
       icon?: IconName;
       dateRangeOptions?: DateRangeFilterOptions;
     }
   | {
-      type: ColumnFilterType.TEXT;
+      type: FilterTypeText;
       icon?: IconName;
       textOptions?: TextFilterOptions;
     }
   | {
-      type?: Exclude<ColumnFilterType, ColumnFilterType.DATE_RANGE | ColumnFilterType.TEXT>;
+      type?: FilterTypeMultiSelect | FilterTypeNumber | FilterTypeSingleSelect;
       icon?: IconName;
     };
 
@@ -42,22 +40,22 @@ export type FilterableColumn = {
     icon?: IconName;
 } & (
     | {
-        type: ColumnFilterType.SINGLE_SELECT;
+        type: FilterTypeSingleSelect;
         options: FacetedValue[];
     }
     | {
-        type: ColumnFilterType.MULTI_SELECT;
+        type: FilterTypeMultiSelect;
         options: FacetedValue[];
     }
     | {
-        type: ColumnFilterType.TEXT;
+        type: FilterTypeText;
         textOptions?: TextFilterOptions;
     }
     | {
-        type: ColumnFilterType.NUMBER;
+        type: FilterTypeNumber;
     }
     | {
-        type: ColumnFilterType.DATE_RANGE;
+        type: FilterTypeDateRange;
         dateRangeOptions?: DateRangeFilterOptions;
     }
 );

--- a/packages/types/data-table.d.ts
+++ b/packages/types/data-table.d.ts
@@ -1,10 +1,6 @@
 import type { IconName } from "@calcom/ui/components/icon/icon-names";
 
-export type FilterTypeSingleSelect = "ss";
-export type FilterTypeMultiSelect = "ms";
-export type FilterTypeText = "t";
-export type FilterTypeNumber = "n";
-export type FilterTypeDateRange = "dr";
+export type FilterType = "ss" | "ms" | "t" | "n" | "dr";
 
 export type TextFilterOperator = "equals" | "notEquals" | "contains" | "notContains" | "startsWith" | "endsWith" | "isEmpty" | "isNotEmpty";
 
@@ -20,17 +16,17 @@ export type DateRangeFilterOptions = {
 
 export type ColumnFilterMeta =
   | {
-      type: FilterTypeDateRange;
+      type: Extract<FilterType, "dr">;
       icon?: IconName;
       dateRangeOptions?: DateRangeFilterOptions;
     }
   | {
-      type: FilterTypeText;
+      type: Extract<FilterType, "t">;
       icon?: IconName;
       textOptions?: TextFilterOptions;
     }
   | {
-      type?: FilterTypeMultiSelect | FilterTypeNumber | FilterTypeSingleSelect;
+      type?: Extract<FilterType, "ms" | "n" | "ss">;
       icon?: IconName;
     };
 
@@ -40,22 +36,22 @@ export type FilterableColumn = {
     icon?: IconName;
 } & (
     | {
-        type: FilterTypeSingleSelect;
+        type: Extract<FilterType, "ss">;
         options: FacetedValue[];
     }
     | {
-        type: FilterTypeMultiSelect;
+        type: Extract<FilterType, "ms">;
         options: FacetedValue[];
     }
     | {
-        type: FilterTypeText;
+        type: Extract<FilterType, "t">;
         textOptions?: TextFilterOptions;
     }
     | {
-        type: FilterTypeNumber;
+        type: Extract<FilterType, "n">;
     }
     | {
-        type: FilterTypeDateRange;
+        type: Extract<FilterType, "dr">;
         dateRangeOptions?: DateRangeFilterOptions;
     }
 );

--- a/packages/types/data-table.d.ts
+++ b/packages/types/data-table.d.ts
@@ -1,0 +1,63 @@
+import type { IconName } from "@calcom/ui/components/icon/icon-names";
+
+export enum ColumnFilterType {
+  SINGLE_SELECT = "ss",
+  MULTI_SELECT = "ms",
+  TEXT = "t",
+  NUMBER = "n",
+  DATE_RANGE = "dr",
+}
+
+export type TextFilterOperator = "equals" | "notEquals" | "contains" | "notContains" | "startsWith" | "endsWith" | "isEmpty" | "isNotEmpty";
+
+export type TextFilterOptions = {
+  allowedOperators?: TextFilterOperator[];
+  placeholder?: string;
+};
+
+export type DateRangeFilterOptions = {
+  range?: "past" | "custom";
+  convertToTimeZone?: boolean;
+};
+
+export type ColumnFilterMeta =
+  | {
+      type: ColumnFilterType.DATE_RANGE;
+      icon?: IconName;
+      dateRangeOptions?: DateRangeFilterOptions;
+    }
+  | {
+      type: ColumnFilterType.TEXT;
+      icon?: IconName;
+      textOptions?: TextFilterOptions;
+    }
+  | {
+      type?: Exclude<ColumnFilterType, ColumnFilterType.DATE_RANGE | ColumnFilterType.TEXT>;
+      icon?: IconName;
+    };
+
+export type FilterableColumn = {
+    id: string;
+    title: string;
+    icon?: IconName;
+} & (
+    | {
+        type: ColumnFilterType.SINGLE_SELECT;
+        options: FacetedValue[];
+    }
+    | {
+        type: ColumnFilterType.MULTI_SELECT;
+        options: FacetedValue[];
+    }
+    | {
+        type: ColumnFilterType.TEXT;
+        textOptions?: TextFilterOptions;
+    }
+    | {
+        type: ColumnFilterType.NUMBER;
+    }
+    | {
+        type: ColumnFilterType.DATE_RANGE;
+        dateRangeOptions?: DateRangeFilterOptions;
+    }
+);

--- a/packages/types/tanstack-table.d.ts
+++ b/packages/types/tanstack-table.d.ts
@@ -1,9 +1,9 @@
 import "@tanstack/react-table";
 
-import type { ColumnFilterMeta } from "@calcom/features/data-table/lib/types";
+import type { ColumnFilterMeta } from "./data-table";
 
 declare module "@tanstack/table-core" {
-  interface ColumnMeta<TData extends RowData, TValue> {
+  interface ColumnMeta {
     filter?: ColumnFilterMeta;
 
     // `autoWidth` can make the column size dynamic,


### PR DESCRIPTION
















<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a circular dependency in table typings by moving shared filter types to packages/types/data-table.d.ts and updating tanstack-table.d.ts to import from it. This stabilizes type augmentation and removes build issues.

- **Refactors**
  - Centralized ColumnFilterMeta, FilterableColumn, and TextFilterOperator in packages/types/data-table.d.ts; introduced a FilterType union.
  - Updated tanstack-table.d.ts to import ColumnFilterMeta from "./data-table" and simplified ColumnMeta (removed generics).
  - Cleaned up features/data-table/lib/types.ts to re-export ColumnFilterMeta, FilterableColumn, and TextFilterOperator, switch enum to const and generics to FilterType; updated filter components, insights-view, server handlers, and tests to use Extract<FilterType, "...">.

<sup>Written for commit 1fde0960f75a20e10c98f9da6f5ec796dec2908e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















