### PR TITLE
fix: exclude AWAITING_HOST from seed-insights random status selection

### DIFF
--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -15,7 +15,7 @@ import { seedAttributes, seedRoutingFormResponses, seedRoutingForms } from "./se
 // - Requires InstantMeetingToken to be created
 // - Only used for actual instant meetings via InstantBookingCreateService
 // See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
-const validStatusesForSeed = Object.values(BookingStatus).filter(
+const VALID_STATUSES_FOR_SEED = Object.values(BookingStatus).filter(
   (status) => status !== BookingStatus.AWAITING_HOST
 );
 
@@ -61,9 +61,9 @@ const shuffle = (
   booking.endTime = endTime.toISOString();
   booking.createdAt = startTime.subtract(1, "day").toISOString();
 
-  // Pick a random status from validStatusesForSeed (defined at module level)
-  const randomStatusIndex = Math.floor(Math.random() * validStatusesForSeed.length);
-  booking.status = validStatusesForSeed[randomStatusIndex];
+  // Pick a random status from VALID_STATUSES_FOR_SEED (defined at module level)
+  const randomStatusIndex = Math.floor(Math.random() * VALID_STATUSES_FOR_SEED.length);
+  booking.status = VALID_STATUSES_FOR_SEED[randomStatusIndex];
 
   booking.rescheduled = Math.random() > 0.5 && Math.random() > 0.5 && Math.random() > 0.5;
 

--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -51,11 +51,20 @@ const shuffle = (
   booking.endTime = endTime.toISOString();
   booking.createdAt = startTime.subtract(1, "day").toISOString();
 
-  // Pick a random status
-  const randomStatusIndex = Math.floor(Math.random() * Object.keys(BookingStatus).length);
-  const statusKey = Object.keys(BookingStatus)[randomStatusIndex];
-
-  booking.status = BookingStatus[statusKey];
+  // Pick a random status from valid statuses for seed data.
+  // AWAITING_HOST is excluded because it requires special handling:
+  // - userId must be NULL (not assigned until host joins)
+  // - Requires InstantMeetingToken to be created
+  // - Only used for actual instant meetings via InstantBookingCreateService
+  // See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
+  const validStatusesForSeed = [
+    BookingStatus.ACCEPTED,
+    BookingStatus.PENDING,
+    BookingStatus.CANCELLED,
+    BookingStatus.REJECTED,
+  ];
+  const randomStatusIndex = Math.floor(Math.random() * validStatusesForSeed.length);
+  booking.status = validStatusesForSeed[randomStatusIndex];
 
   booking.rescheduled = Math.random() > 0.5 && Math.random() > 0.5 && Math.random() > 0.5;
 

--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -51,18 +51,14 @@ const shuffle = (
   booking.endTime = endTime.toISOString();
   booking.createdAt = startTime.subtract(1, "day").toISOString();
 
-  // Pick a random status from valid statuses for seed data.
-  // AWAITING_HOST is excluded because it requires special handling:
+  // Pick a random status, excluding AWAITING_HOST which requires special handling:
   // - userId must be NULL (not assigned until host joins)
   // - Requires InstantMeetingToken to be created
   // - Only used for actual instant meetings via InstantBookingCreateService
   // See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
-  const validStatusesForSeed = [
-    BookingStatus.ACCEPTED,
-    BookingStatus.PENDING,
-    BookingStatus.CANCELLED,
-    BookingStatus.REJECTED,
-  ];
+  const validStatusesForSeed = Object.values(BookingStatus).filter(
+    (status) => status !== BookingStatus.AWAITING_HOST
+  );
   const randomStatusIndex = Math.floor(Math.random() * validStatusesForSeed.length);
   booking.status = validStatusesForSeed[randomStatusIndex];
 

--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -9,15 +9,19 @@ import { BookingStatus, AssignmentReasonEnum } from "@calcom/prisma/enums";
 
 import { seedAttributes, seedRoutingFormResponses, seedRoutingForms } from "./seed-utils";
 
-// Valid statuses for seed data - calculated once at module load.
+// Valid statuses for seed data
 // AWAITING_HOST is excluded because it requires special handling:
 // - userId must be NULL (not assigned until host joins)
 // - Requires InstantMeetingToken to be created
 // - Only used for actual instant meetings via InstantBookingCreateService
-// See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
 const VALID_STATUSES_FOR_SEED = Object.values(BookingStatus).filter(
   (status) => status !== BookingStatus.AWAITING_HOST
 );
+
+function getRandomBookingStatus() {
+  const randomStatusIndex = Math.floor(Math.random() * VALID_STATUSES_FOR_SEED.length);
+  return VALID_STATUSES_FOR_SEED[randomStatusIndex];
+}
 
 function getRandomRatingFeedback() {
   const feedbacks = [
@@ -61,9 +65,7 @@ const shuffle = (
   booking.endTime = endTime.toISOString();
   booking.createdAt = startTime.subtract(1, "day").toISOString();
 
-  // Pick a random status from VALID_STATUSES_FOR_SEED (defined at module level)
-  const randomStatusIndex = Math.floor(Math.random() * VALID_STATUSES_FOR_SEED.length);
-  booking.status = VALID_STATUSES_FOR_SEED[randomStatusIndex];
+  booking.status = getRandomBookingStatus();
 
   booking.rescheduled = Math.random() > 0.5 && Math.random() > 0.5 && Math.random() > 0.5;
 

--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -9,6 +9,16 @@ import { BookingStatus, AssignmentReasonEnum } from "@calcom/prisma/enums";
 
 import { seedAttributes, seedRoutingFormResponses, seedRoutingForms } from "./seed-utils";
 
+// Valid statuses for seed data - calculated once at module load.
+// AWAITING_HOST is excluded because it requires special handling:
+// - userId must be NULL (not assigned until host joins)
+// - Requires InstantMeetingToken to be created
+// - Only used for actual instant meetings via InstantBookingCreateService
+// See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
+const validStatusesForSeed = Object.values(BookingStatus).filter(
+  (status) => status !== BookingStatus.AWAITING_HOST
+);
+
 function getRandomRatingFeedback() {
   const feedbacks = [
     "Great chat!",
@@ -51,14 +61,7 @@ const shuffle = (
   booking.endTime = endTime.toISOString();
   booking.createdAt = startTime.subtract(1, "day").toISOString();
 
-  // Pick a random status, excluding AWAITING_HOST which requires special handling:
-  // - userId must be NULL (not assigned until host joins)
-  // - Requires InstantMeetingToken to be created
-  // - Only used for actual instant meetings via InstantBookingCreateService
-  // See: packages/features/bookings/lib/service/InstantBookingCreateService.ts
-  const validStatusesForSeed = Object.values(BookingStatus).filter(
-    (status) => status !== BookingStatus.AWAITING_HOST
-  );
+  // Pick a random status from validStatusesForSeed (defined at module level)
   const randomStatusIndex = Math.floor(Math.random() * validStatusesForSeed.length);
   booking.status = validStatusesForSeed[randomStatusIndex];
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the seed-insights script where `AWAITING_HOST` status was randomly assigned to bookings along with a `userId`, which violates the correct behavior of instant meetings.

**Problem:**
- The seed script randomly picked from all 5 booking statuses (including `AWAITING_HOST`)
- When `AWAITING_HOST` was selected, the script still assigned a `userId`
- Real instant meetings with `AWAITING_HOST` status should have `userId = NULL` until a host joins
- This created incorrect test data that doesn't match production behavior

**Solution:**
- Filter out `AWAITING_HOST` from `BookingStatus` values using `Object.values(BookingStatus).filter()`
- This approach is more maintainable than listing valid statuses explicitly - if new statuses are added in the future, they will automatically be included
- Moved `validStatusesForSeed` to module level so it's calculated once at load time instead of on every shuffle call
- Added comments explaining why this status requires special handling

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - seed script only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a seed script for test data generation.

## How should this be tested?

1. Run the seed script: `yarn seed-insights`
2. Verify no `AWAITING_HOST` bookings are created with a `userId`:
```sql
SELECT COUNT(*) FROM "Booking" 
WHERE status = 'awaiting_host' AND "userId" IS NOT NULL 
AND "createdAt" > NOW() - INTERVAL '1 day';
-- Should return 0 for newly seeded data
```
3. Verify other statuses are still generated:
```sql
SELECT status, COUNT(*) FROM "Booking" 
WHERE "createdAt" > NOW() - INTERVAL '1 day' 
GROUP BY status;
-- Should show ACCEPTED, PENDING, CANCELLED, REJECTED (but not AWAITING_HOST)
```

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run:** https://app.devin.ai/sessions/08f634e7210d415982d71c8f687b4468
> **Requested by:** eunjae@cal.com (@eunjae-lee)