### PR TITLE
fix: `Connect` atoms not working inside iframe

### DIFF
--- a/.changeset/long-ties-obey.md
+++ b/.changeset/long-ties-obey.md
@@ -2,4 +2,4 @@
 "@calcom/atoms": patch
 ---
 
-This PR fixes the issue of connect atoms not working inside iframes.
+This PR fixes the issue of connect atoms not working inside iframes. It also updates the atoms exports to include the `useAvailableSlots` hook.

--- a/.changeset/long-ties-obey.md
+++ b/.changeset/long-ties-obey.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": patch
+---
+
+This PR fixes the issue of connect atoms not working inside iframes.

--- a/packages/platform/atoms/hooks/connect/useConnect.ts
+++ b/packages/platform/atoms/hooks/connect/useConnect.ts
@@ -18,7 +18,7 @@ export const useGetRedirectUrl = (
   redir?: string,
   isDryRun?: boolean
 ) => {
-  const redirectUrl = !!redir ? encodeURIComponent(redir) : "";
+  const redirectUrl = redir ? encodeURIComponent(redir) : "";
 
   const authUrl = useQuery({
     queryKey: getQueryKey(calendar),
@@ -49,7 +49,15 @@ export const useConnect = (calendar: (typeof CALENDARS)[number], redir?: string,
     const redirectUri = await refetch();
 
     if (redirectUri.data) {
-      window.location.href = redirectUri.data;
+      let targetWindow;
+      if (window !== window.top && window.top) {
+        // if its an iframe, the target window should be the parent window
+        targetWindow = window.top;
+      } else {
+        targetWindow = window;
+      }
+
+      targetWindow.location.href = redirectUri.data;
     }
   };
 

--- a/packages/platform/atoms/index.ts
+++ b/packages/platform/atoms/index.ts
@@ -48,3 +48,5 @@ export { CreateSchedulePlatformWrapper as CreateSchedule } from "./create-schedu
 export { CreateScheduleForm } from "./create-schedule/CreateScheduleForm";
 
 export { ListSchedulesPlatformWrapper as ListSchedules } from "./list-schedules/index";
+
+export { useAvailableSlots } from "./hooks/useAvailableSlots";


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR fixes the issue of connect atoms (google connect specifically) not working inside iframes

## Visual Demo (For contributors especially)

Before: 



https://github.com/user-attachments/assets/ee7f7a98-d0bd-47a0-ab31-f57a611ab7fe

After:


https://github.com/user-attachments/assets/20ddf413-bd34-4015-8b0d-f19f8c7ba3ab

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] (N/A) I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
This can be tested in the examples app in packages/platform/atoms
