### PR TITLE
feat: add a setting to change default home view

### DIFF
--- a/apps/web/modules/settings/my-account/general-view.tsx
+++ b/apps/web/modules/settings/my-account/general-view.tsx
@@ -39,6 +39,10 @@ export type FormValues = {
     value: string;
     label: string;
   };
+  defaultHomeView: {
+    value: "event-types" | "bookings";
+    label: string;
+  };
   travelSchedules: {
     id?: number;
     startDate: Date;
@@ -93,6 +97,11 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
     { value: 24, label: t("24_hour") },
   ];
 
+  const defaultHomeViewOptions = [
+    { value: "event-types" as const, label: t("event_types") },
+    { value: "bookings" as const, label: t("bookings") },
+  ];
+
   const weekStartOptions = [
     { value: "Sunday", label: nameOfDay(localeProp, 0) },
     { value: "Monday", label: nameOfDay(localeProp, 1) },
@@ -117,6 +126,12 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
       weekStart: {
         value: user.weekStart,
         label: weekStartOptions.find((option) => option.value === user.weekStart)?.label || "",
+      },
+      defaultHomeView: {
+        value: (user.metadata as { defaultHomeView?: "event-types" | "bookings" } | null)?.defaultHomeView ?? "event-types",
+        label: defaultHomeViewOptions.find(
+          (option) => option.value === ((user.metadata as { defaultHomeView?: "event-types" | "bookings" } | null)?.defaultHomeView ?? "event-types")
+        )?.label || t("event_types"),
       },
       travelSchedules:
         travelSchedules.map((schedule) => {
@@ -165,6 +180,9 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
               locale: values.locale.value,
               timeFormat: values.timeFormat.value,
               weekStart: values.weekStart.value,
+              metadata: {
+                defaultHomeView: values.defaultHomeView.value,
+              },
             });
           }}>
           <div className="border-subtle border-x border-y-0 px-4 py-8 sm:px-6">
@@ -298,6 +316,24 @@ const GeneralView = ({ user, travelSchedules }: GeneralViewProps) => {
                     options={weekStartOptions}
                     onChange={(event) => {
                       if (event) formMethods.setValue("weekStart", { ...event }, { shouldDirty: true });
+                    }}
+                  />
+                </>
+              )}
+            />
+            <Controller
+              name="defaultHomeView"
+              control={formMethods.control}
+              render={({ field: { value } }) => (
+                <>
+                  <Label className="text-emphasis mt-6">
+                    <>{t("default_home_view")}</>
+                  </Label>
+                  <Select
+                    value={value}
+                    options={defaultHomeViewOptions}
+                    onChange={(event) => {
+                      if (event) formMethods.setValue("defaultHomeView", { ...event }, { shouldDirty: true });
                     }}
                   />
                 </>

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -501,6 +501,8 @@
   "no_status_bookings_yet_description": "You have no {{status}} bookings. {{description}}",
   "event_between_users": "{{eventName}} between {{host}} and {{attendeeName}}",
   "bookings": "Bookings",
+  "event_types": "Event Types",
+  "default_home_view": "Default Home View",
   "booking_not_found": "Booking not found",
   "bookings_description": "See upcoming and past events booked through your event type links.",
   "upcoming_bookings": "As soon as someone books a time with you it will show up here.",

--- a/packages/platform/atoms/vite.config.ts.timestamp-1764224134365-f87732878db3e.mjs
+++ b/packages/platform/atoms/vite.config.ts.timestamp-1764224134365-f87732878db3e.mjs
@@ -1,0 +1,114 @@
+// vite.config.ts
+import react from "file:///Users/tombauer/workspace/github.com/TBau23/gauntlet/cal.com/node_modules/@vitejs/plugin-react-swc/index.mjs";
+import path from "path";
+import { resolve } from "path";
+import { defineConfig, loadEnv } from "file:///Users/tombauer/workspace/github.com/TBau23/gauntlet/cal.com/node_modules/vite/dist/node/index.js";
+import dts from "file:///Users/tombauer/workspace/github.com/TBau23/gauntlet/cal.com/packages/platform/atoms/node_modules/vite-plugin-dts/dist/index.mjs";
+var __vite_injected_original_dirname = "/Users/tombauer/workspace/github.com/TBau23/gauntlet/cal.com/packages/platform/atoms";
+var vite_config_default = defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const webAppUrl = env.NEXT_PUBLIC_WEBAPP_URL ?? "https://app.cal.com";
+  const calcomVersion = env.NEXT_PUBLIC_CALCOM_VERSION ?? "";
+  const vercelCommitSha = env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "";
+  return {
+    optimizeDeps: {
+      include: [
+        "@calcom/lib",
+        "@calcom/features",
+        "@calcom/prisma",
+        "@calcom/dayjs",
+        "@calcom/platform-constants",
+        "@calcom/platform-types",
+        "@calcom/platform-utils"
+      ]
+    },
+    plugins: [
+      react(),
+      dts({
+        insertTypesEntry: true,
+        beforeWriteFile: (filePath, content) => {
+          if (content.includes(`kysely/types.ts').$Enums`)) {
+            return {
+              filePath,
+              content: content.replaceAll(`kysely/types.ts').$Enums`, `kysely/types.ts')`)
+            };
+          }
+          return { filePath, content };
+        }
+      })
+    ],
+    define: {
+      "process.env.NEXT_PUBLIC_WEBAPP_URL": `"${webAppUrl}"`,
+      "process.env.NEXT_PUBLIC_CALCOM_VERSION": `"${calcomVersion}"`,
+      "process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA": `"${vercelCommitSha}"`,
+      "process.env.NODE_ENV": `"${mode}"`,
+      "process.env.__NEXT_ROUTER_BASEPATH": `""`,
+      "process.env.__NEXT_I18N_SUPPORT": `false`,
+      "process.env.__NEXT_MANUAL_TRAILING_SLASH": `false`,
+      "process.env.__NEXT_TRAILING_SLASH": `false`,
+      "process.env": "{}"
+    },
+    ssr: {
+      noExternal: ["turndown"]
+      // Example if you want to disable SSR for your library
+    },
+    build: {
+      lib: {
+        entry: [resolve(__vite_injected_original_dirname, "index.ts")],
+        name: "CalAtoms",
+        fileName: "cal-atoms"
+      },
+      rollupOptions: {
+        external: [
+          "react",
+          "fs",
+          "path",
+          "os",
+          "react/jsx-runtime",
+          "react-dom",
+          "react-dom/client",
+          "@prisma/client",
+          "react/jsx-dev-runtime",
+          ,
+          "react-awesome-query-builder",
+          "react-awesome-query-builder",
+          "react-awesome-query-builder"
+        ],
+        output: {
+          globals: {
+            react: "React",
+            "react-dom": "ReactDOM",
+            "react/jsx-runtime": "ReactJsxRuntime"
+          }
+        }
+      }
+    },
+    resolve: {
+      alias: {
+        fs: resolve("../../../node_modules/rollup-plugin-node-builtins"),
+        path: resolve("../../../node_modules/rollup-plugin-node-builtins"),
+        os: resolve("../../../node_modules/rollup-plugin-node-builtins"),
+        "@": path.resolve(__vite_injected_original_dirname, "./src"),
+        "@calcom/lib/markdownToSafeHTML": path.resolve(__vite_injected_original_dirname, "./lib/markdownToSafeHTML"),
+        "@calcom/lib/hooks/useLocale": path.resolve(__vite_injected_original_dirname, "./lib/useLocale"),
+        "@radix-ui/react-tooltip": path.resolve(__vite_injected_original_dirname, "./src/components/ui/tooltip.tsx"),
+        "@radix-ui/react-dialog": path.resolve(__vite_injected_original_dirname, "./src/components/ui/dialog.tsx"),
+        "@calcom/prisma/client/runtime/library": resolve("./prisma-types/index.ts"),
+        "@calcom/prisma/client": path.resolve(__vite_injected_original_dirname, "../../kysely/types.ts"),
+        kysely: path.resolve(__vite_injected_original_dirname, "./kysely-types/index.ts"),
+        "@calcom/dayjs": path.resolve(__vite_injected_original_dirname, "../../dayjs"),
+        "@calcom/platform-constants": path.resolve(__vite_injected_original_dirname, "../constants/index.ts"),
+        "@calcom/platform-types": path.resolve(__vite_injected_original_dirname, "../types/index.ts"),
+        "@calcom/platform-utils": path.resolve(__vite_injected_original_dirname, "../constants/index.ts"),
+        "@calcom/web/public/static/locales/en/common.json": path.resolve(
+          __vite_injected_original_dirname,
+          "../../../apps/web/public/static/locales/en/common.json"
+        )
+      }
+    }
+  };
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvVXNlcnMvdG9tYmF1ZXIvd29ya3NwYWNlL2dpdGh1Yi5jb20vVEJhdTIzL2dhdW50bGV0L2NhbC5jb20vcGFja2FnZXMvcGxhdGZvcm0vYXRvbXNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfZmlsZW5hbWUgPSBcIi9Vc2Vycy90b21iYXVlci93b3Jrc3BhY2UvZ2l0aHViLmNvbS9UQmF1MjMvZ2F1bnRsZXQvY2FsLmNvbS9wYWNrYWdlcy9wbGF0Zm9ybS9hdG9tcy92aXRlLmNvbmZpZy50c1wiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9pbXBvcnRfbWV0YV91cmwgPSBcImZpbGU6Ly8vVXNlcnMvdG9tYmF1ZXIvd29ya3NwYWNlL2dpdGh1Yi5jb20vVEJhdTIzL2dhdW50bGV0L2NhbC5jb20vcGFja2FnZXMvcGxhdGZvcm0vYXRvbXMvdml0ZS5jb25maWcudHNcIjtpbXBvcnQgcmVhY3QgZnJvbSBcIkB2aXRlanMvcGx1Z2luLXJlYWN0LXN3Y1wiO1xuaW1wb3J0IHBhdGggZnJvbSBcInBhdGhcIjtcbmltcG9ydCB7IHJlc29sdmUgfSBmcm9tIFwicGF0aFwiO1xuaW1wb3J0IHsgZGVmaW5lQ29uZmlnLCBsb2FkRW52IH0gZnJvbSBcInZpdGVcIjtcbmltcG9ydCBkdHMgZnJvbSBcInZpdGUtcGx1Z2luLWR0c1wiO1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoKHsgbW9kZSB9KSA9PiB7XG4gIGNvbnN0IGVudiA9IGxvYWRFbnYobW9kZSwgcHJvY2Vzcy5jd2QoKSwgXCJcIik7IC8vIC5lbnYgaW5zaWRlIG9mIHBhY2thZ2VzL3BsYXRmb3JtL2F0b21zXG4gIGNvbnN0IHdlYkFwcFVybCA9IGVudi5ORVhUX1BVQkxJQ19XRUJBUFBfVVJMID8/IFwiaHR0cHM6Ly9hcHAuY2FsLmNvbVwiO1xuICBjb25zdCBjYWxjb21WZXJzaW9uID0gZW52Lk5FWFRfUFVCTElDX0NBTENPTV9WRVJTSU9OID8/IFwiXCI7XG4gIGNvbnN0IHZlcmNlbENvbW1pdFNoYSA9IGVudi5ORVhUX1BVQkxJQ19WRVJDRUxfR0lUX0NPTU1JVF9TSEEgPz8gXCJcIjtcblxuICByZXR1cm4ge1xuICAgIG9wdGltaXplRGVwczoge1xuICAgICAgaW5jbHVkZTogW1xuICAgICAgICBcIkBjYWxjb20vbGliXCIsXG4gICAgICAgIFwiQGNhbGNvbS9mZWF0dXJlc1wiLFxuICAgICAgICBcIkBjYWxjb20vcHJpc21hXCIsXG4gICAgICAgIFwiQGNhbGNvbS9kYXlqc1wiLFxuICAgICAgICBcIkBjYWxjb20vcGxhdGZvcm0tY29uc3RhbnRzXCIsXG4gICAgICAgIFwiQGNhbGNvbS9wbGF0Zm9ybS10eXBlc1wiLFxuICAgICAgICBcIkBjYWxjb20vcGxhdGZvcm0tdXRpbHNcIixcbiAgICAgIF0sXG4gICAgfSxcbiAgICBwbHVnaW5zOiBbXG4gICAgICByZWFjdCgpLFxuICAgICAgZHRzKHtcbiAgICAgICAgaW5zZXJ0VHlwZXNFbnRyeTogdHJ1ZSxcbiAgICAgICAgYmVmb3JlV3JpdGVGaWxlOiAoZmlsZVBhdGgsIGNvbnRlbnQpID0+IHtcbiAgICAgICAgICAvLyBDaGVjayBpZiB0aGUgY29udGVudCBpbmNsdWRlcyB0aGUgYnJva2VuIHBhdGggZnJvbSBreXNlbHlcbiAgICAgICAgICBpZiAoY29udGVudC5pbmNsdWRlcyhga3lzZWx5L3R5cGVzLnRzJykuJEVudW1zYCkpIHtcbiAgICAgICAgICAgIC8vIFJlcGxhY2UgdGhlIGJyb2tlbiBwYXRoIHdpdGggdGhlIGNvcnJlY3QgaW1wb3J0XG4gICAgICAgICAgICByZXR1cm4ge1xuICAgICAgICAgICAgICBmaWxlUGF0aCxcbiAgICAgICAgICAgICAgY29udGVudDogY29udGVudC5yZXBsYWNlQWxsKGBreXNlbHkvdHlwZXMudHMnKS4kRW51bXNgLCBga3lzZWx5L3R5cGVzLnRzJylgKSxcbiAgICAgICAgICAgIH07XG4gICAgICAgICAgfVxuICAgICAgICAgIHJldHVybiB7IGZpbGVQYXRoLCBjb250ZW50IH07XG4gICAgICAgIH0sXG4gICAgICB9KSxcbiAgICBdLFxuICAgIGRlZmluZToge1xuICAgICAgXCJwcm9jZXNzLmVudi5ORVhUX1BVQkxJQ19XRUJBUFBfVVJMXCI6IGBcIiR7d2ViQXBwVXJsfVwiYCxcbiAgICAgIFwicHJvY2Vzcy5lbnYuTkVYVF9QVUJMSUNfQ0FMQ09NX1ZFUlNJT05cIjogYFwiJHtjYWxjb21WZXJzaW9ufVwiYCxcbiAgICAgIFwicHJvY2Vzcy5lbnYuTkVYVF9QVUJMSUNfVkVSQ0VMX0dJVF9DT01NSVRfU0hBXCI6IGBcIiR7dmVyY2VsQ29tbWl0U2hhfVwiYCxcbiAgICAgIFwicHJvY2Vzcy5lbnYuTk9ERV9FTlZcIjogYFwiJHttb2RlfVwiYCxcbiAgICAgIFwicHJvY2Vzcy5lbnYuX19ORVhUX1JPVVRFUl9CQVNFUEFUSFwiOiBgXCJcImAsXG4gICAgICBcInByb2Nlc3MuZW52Ll9fTkVYVF9JMThOX1NVUFBPUlRcIjogYGZhbHNlYCxcbiAgICAgIFwicHJvY2Vzcy5lbnYuX19ORVhUX01BTlVBTF9UUkFJTElOR19TTEFTSFwiOiBgZmFsc2VgLFxuICAgICAgXCJwcm9jZXNzLmVudi5fX05FWFRfVFJBSUxJTkdfU0xBU0hcIjogYGZhbHNlYCxcbiAgICAgIFwicHJvY2Vzcy5lbnZcIjogXCJ7fVwiLFxuICAgIH0sXG4gICAgc3NyOiB7XG4gICAgICBub0V4dGVybmFsOiBbXCJ0dXJuZG93blwiXSwgLy8gRXhhbXBsZSBpZiB5b3Ugd2FudCB0byBkaXNhYmxlIFNTUiBmb3IgeW91ciBsaWJyYXJ5XG4gICAgfSxcbiAgICBidWlsZDoge1xuICAgICAgbGliOiB7XG4gICAgICAgIGVudHJ5OiBbcmVzb2x2ZShfX2Rpcm5hbWUsIFwiaW5kZXgudHNcIildLFxuICAgICAgICBuYW1lOiBcIkNhbEF0b21zXCIsXG4gICAgICAgIGZpbGVOYW1lOiBcImNhbC1hdG9tc1wiLFxuICAgICAgICBcbiAgICAgIH0sXG4gICAgICByb2xsdXBPcHRpb25zOiB7XG4gICAgICAgIGV4dGVybmFsOiBbXG4gICAgICAgICAgXCJyZWFjdFwiLFxuICAgICAgICAgIFwiZnNcIixcbiAgICAgICAgICBcInBhdGhcIixcbiAgICAgICAgICBcIm9zXCIsXG4gICAgICAgICAgXCJyZWFjdC9qc3gtcnVudGltZVwiLFxuICAgICAgICAgIFwicmVhY3QtZG9tXCIsXG4gICAgICAgICAgXCJyZWFjdC1kb20vY2xpZW50XCIsXG4gICAgICAgICAgXCJAcHJpc21hL2NsaWVudFwiLFxuICAgICAgICAgIFwicmVhY3QvanN4LWRldi1ydW50aW1lXCIsXG4gICAgICAgICwgXCJyZWFjdC1hd2Vzb21lLXF1ZXJ5LWJ1aWxkZXJcIiwgXCJyZWFjdC1hd2Vzb21lLXF1ZXJ5LWJ1aWxkZXJcIiwgXCJyZWFjdC1hd2Vzb21lLXF1ZXJ5LWJ1aWxkZXJcIl0sXG4gICAgICAgIG91dHB1dDoge1xuICAgICAgICAgIGdsb2JhbHM6IHtcbiAgICAgICAgICAgIHJlYWN0OiBcIlJlYWN0XCIsXG4gICAgICAgICAgICBcInJlYWN0LWRvbVwiOiBcIlJlYWN0RE9NXCIsXG4gICAgICAgICAgICBcInJlYWN0L2pzeC1ydW50aW1lXCI6IFwiUmVhY3RKc3hSdW50aW1lXCIsXG4gICAgICAgICAgfSxcbiAgICAgICAgfSxcbiAgICAgIH0sXG4gICAgfSxcbiAgICByZXNvbHZlOiB7XG4gICAgICBhbGlhczoge1xuICAgICAgICBmczogcmVzb2x2ZShcIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9yb2xsdXAtcGx1Z2luLW5vZGUtYnVpbHRpbnNcIiksXG4gICAgICAgIHBhdGg6IHJlc29sdmUoXCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvcm9sbHVwLXBsdWdpbi1ub2RlLWJ1aWx0aW5zXCIpLFxuICAgICAgICBvczogcmVzb2x2ZShcIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9yb2xsdXAtcGx1Z2luLW5vZGUtYnVpbHRpbnNcIiksXG4gICAgICAgIFwiQFwiOiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCBcIi4vc3JjXCIpLFxuICAgICAgICBcIkBjYWxjb20vbGliL21hcmtkb3duVG9TYWZlSFRNTFwiOiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCBcIi4vbGliL21hcmtkb3duVG9TYWZlSFRNTFwiKSxcbiAgICAgICAgXCJAY2FsY29tL2xpYi9ob29rcy91c2VMb2NhbGVcIjogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgXCIuL2xpYi91c2VMb2NhbGVcIiksXG4gICAgICAgIFwiQHJhZGl4LXVpL3JlYWN0LXRvb2x0aXBcIjogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgXCIuL3NyYy9jb21wb25lbnRzL3VpL3Rvb2x0aXAudHN4XCIpLFxuICAgICAgICBcIkByYWRpeC11aS9yZWFjdC1kaWFsb2dcIjogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgXCIuL3NyYy9jb21wb25lbnRzL3VpL2RpYWxvZy50c3hcIiksXG4gICAgICAgIFwiQGNhbGNvbS9wcmlzbWEvY2xpZW50L3J1bnRpbWUvbGlicmFyeVwiOiByZXNvbHZlKFwiLi9wcmlzbWEtdHlwZXMvaW5kZXgudHNcIiksXG4gICAgICAgIFwiQGNhbGNvbS9wcmlzbWEvY2xpZW50XCI6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsIFwiLi4vLi4va3lzZWx5L3R5cGVzLnRzXCIpLFxuICAgICAgICBreXNlbHk6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsIFwiLi9reXNlbHktdHlwZXMvaW5kZXgudHNcIiksXG4gICAgICAgIFwiQGNhbGNvbS9kYXlqc1wiOiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCBcIi4uLy4uL2RheWpzXCIpLFxuICAgICAgICBcIkBjYWxjb20vcGxhdGZvcm0tY29uc3RhbnRzXCI6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsIFwiLi4vY29uc3RhbnRzL2luZGV4LnRzXCIpLFxuICAgICAgICBcIkBjYWxjb20vcGxhdGZvcm0tdHlwZXNcIjogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgXCIuLi90eXBlcy9pbmRleC50c1wiKSxcbiAgICAgICAgXCJAY2FsY29tL3BsYXRmb3JtLXV0aWxzXCI6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsIFwiLi4vY29uc3RhbnRzL2luZGV4LnRzXCIpLFxuICAgICAgICBcIkBjYWxjb20vd2ViL3B1YmxpYy9zdGF0aWMvbG9jYWxlcy9lbi9jb21tb24uanNvblwiOiBwYXRoLnJlc29sdmUoXG4gICAgICAgICAgX19kaXJuYW1lLFxuICAgICAgICAgIFwiLi4vLi4vLi4vYXBwcy93ZWIvcHVibGljL3N0YXRpYy9sb2NhbGVzL2VuL2NvbW1vbi5qc29uXCJcbiAgICAgICAgKSxcbiAgICAgIH0sXG4gICAgfSxcbiAgfTtcbn0pO1xuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUE4YSxPQUFPLFdBQVc7QUFDaGMsT0FBTyxVQUFVO0FBQ2pCLFNBQVMsZUFBZTtBQUN4QixTQUFTLGNBQWMsZUFBZTtBQUN0QyxPQUFPLFNBQVM7QUFKaEIsSUFBTSxtQ0FBbUM7QUFNekMsSUFBTyxzQkFBUSxhQUFhLENBQUMsRUFBRSxLQUFLLE1BQU07QUFDeEMsUUFBTSxNQUFNLFFBQVEsTUFBTSxRQUFRLElBQUksR0FBRyxFQUFFO0FBQzNDLFFBQU0sWUFBWSxJQUFJLDBCQUEwQjtBQUNoRCxRQUFNLGdCQUFnQixJQUFJLDhCQUE4QjtBQUN4RCxRQUFNLGtCQUFrQixJQUFJLHFDQUFxQztBQUVqRSxTQUFPO0FBQUEsSUFDTCxjQUFjO0FBQUEsTUFDWixTQUFTO0FBQUEsUUFDUDtBQUFBLFFBQ0E7QUFBQSxRQUNBO0FBQUEsUUFDQTtBQUFBLFFBQ0E7QUFBQSxRQUNBO0FBQUEsUUFDQTtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBQUEsSUFDQSxTQUFTO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixJQUFJO0FBQUEsUUFDRixrQkFBa0I7QUFBQSxRQUNsQixpQkFBaUIsQ0FBQyxVQUFVLFlBQVk7QUFFdEMsY0FBSSxRQUFRLFNBQVMsMEJBQTBCLEdBQUc7QUFFaEQsbUJBQU87QUFBQSxjQUNMO0FBQUEsY0FDQSxTQUFTLFFBQVEsV0FBVyw0QkFBNEIsbUJBQW1CO0FBQUEsWUFDN0U7QUFBQSxVQUNGO0FBQ0EsaUJBQU8sRUFBRSxVQUFVLFFBQVE7QUFBQSxRQUM3QjtBQUFBLE1BQ0YsQ0FBQztBQUFBLElBQ0g7QUFBQSxJQUNBLFFBQVE7QUFBQSxNQUNOLHNDQUFzQyxJQUFJLFNBQVM7QUFBQSxNQUNuRCwwQ0FBMEMsSUFBSSxhQUFhO0FBQUEsTUFDM0QsaURBQWlELElBQUksZUFBZTtBQUFBLE1BQ3BFLHdCQUF3QixJQUFJLElBQUk7QUFBQSxNQUNoQyxzQ0FBc0M7QUFBQSxNQUN0QyxtQ0FBbUM7QUFBQSxNQUNuQyw0Q0FBNEM7QUFBQSxNQUM1QyxxQ0FBcUM7QUFBQSxNQUNyQyxlQUFlO0FBQUEsSUFDakI7QUFBQSxJQUNBLEtBQUs7QUFBQSxNQUNILFlBQVksQ0FBQyxVQUFVO0FBQUE7QUFBQSxJQUN6QjtBQUFBLElBQ0EsT0FBTztBQUFBLE1BQ0wsS0FBSztBQUFBLFFBQ0gsT0FBTyxDQUFDLFFBQVEsa0NBQVcsVUFBVSxDQUFDO0FBQUEsUUFDdEMsTUFBTTtBQUFBLFFBQ04sVUFBVTtBQUFBLE1BRVo7QUFBQSxNQUNBLGVBQWU7QUFBQSxRQUNiLFVBQVU7QUFBQSxVQUNSO0FBQUEsVUFDQTtBQUFBLFVBQ0E7QUFBQSxVQUNBO0FBQUEsVUFDQTtBQUFBLFVBQ0E7QUFBQSxVQUNBO0FBQUEsVUFDQTtBQUFBLFVBQ0E7QUFBQSxVQUNGO0FBQUEsVUFBRTtBQUFBLFVBQStCO0FBQUEsVUFBK0I7QUFBQSxRQUE2QjtBQUFBLFFBQzdGLFFBQVE7QUFBQSxVQUNOLFNBQVM7QUFBQSxZQUNQLE9BQU87QUFBQSxZQUNQLGFBQWE7QUFBQSxZQUNiLHFCQUFxQjtBQUFBLFVBQ3ZCO0FBQUEsUUFDRjtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBQUEsSUFDQSxTQUFTO0FBQUEsTUFDUCxPQUFPO0FBQUEsUUFDTCxJQUFJLFFBQVEsbURBQW1EO0FBQUEsUUFDL0QsTUFBTSxRQUFRLG1EQUFtRDtBQUFBLFFBQ2pFLElBQUksUUFBUSxtREFBbUQ7QUFBQSxRQUMvRCxLQUFLLEtBQUssUUFBUSxrQ0FBVyxPQUFPO0FBQUEsUUFDcEMsa0NBQWtDLEtBQUssUUFBUSxrQ0FBVywwQkFBMEI7QUFBQSxRQUNwRiwrQkFBK0IsS0FBSyxRQUFRLGtDQUFXLGlCQUFpQjtBQUFBLFFBQ3hFLDJCQUEyQixLQUFLLFFBQVEsa0NBQVcsaUNBQWlDO0FBQUEsUUFDcEYsMEJBQTBCLEtBQUssUUFBUSxrQ0FBVyxnQ0FBZ0M7QUFBQSxRQUNsRix5Q0FBeUMsUUFBUSx5QkFBeUI7QUFBQSxRQUMxRSx5QkFBeUIsS0FBSyxRQUFRLGtDQUFXLHVCQUF1QjtBQUFBLFFBQ3hFLFFBQVEsS0FBSyxRQUFRLGtDQUFXLHlCQUF5QjtBQUFBLFFBQ3pELGlCQUFpQixLQUFLLFFBQVEsa0NBQVcsYUFBYTtBQUFBLFFBQ3RELDhCQUE4QixLQUFLLFFBQVEsa0NBQVcsdUJBQXVCO0FBQUEsUUFDN0UsMEJBQTBCLEtBQUssUUFBUSxrQ0FBVyxtQkFBbUI7QUFBQSxRQUNyRSwwQkFBMEIsS0FBSyxRQUFRLGtDQUFXLHVCQUF1QjtBQUFBLFFBQ3pFLG9EQUFvRCxLQUFLO0FBQUEsVUFDdkQ7QUFBQSxVQUNBO0FBQUEsUUFDRjtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUNGLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -510,6 +510,7 @@ export const userMetadata = z
         revertTime: z.string().optional(),
       })
       .optional(),
+    defaultHomeView: z.enum(["event-types", "bookings"]).optional(),
   })
   .nullable();
 

--- a/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
@@ -7,6 +7,7 @@ import { bookerLayouts, userMetadata } from "@calcom/prisma/zod-utils";
 export const updateUserMetadataAllowedKeys = z.object({
   sessionTimeout: z.number().optional(), // Minutes
   defaultBookerLayouts: bookerLayouts.optional(),
+  defaultHomeView: z.enum(["event-types", "bookings"]).optional(),
 });
 
 export const ZUpdateProfileInputSchema = z.object({


### PR DESCRIPTION

## What does this PR do?
Adds a user preference setting to choose their default home view (landing page). When users visit the root URL (`/`), they are automatically redirected to either Event Types or Bookings based on their saved preference.

**Key Changes:**
- Added `defaultHomeView` field to user metadata schema with values `"event-types"` | `"bookings"`
- Modified root redirect logic to respect user preference (defaults to "event-types" for backward compatibility)
- Added dropdown control in Settings → My Account → General for users to set their preference
- Preference is stored in existing `metadata` JSONB column (no migration required)

- Fixes 13778 (GitHub issue number)
- Fixes CAL-3176 (Linear issue number - should be visible at the bottom of the GitHub issue description)


## Mandatory Tasks (DO NOT REMOVE)
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write **N/A** - this is a user-facing feature change with no developer API impact.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Environment Setup:**
- No special environment variables required
- Requires a working database connection (standard Cal.com setup)

**Test Scenarios:**

1. **New User (No Preference Set)**
   - Login as a user who hasn't set a preference
   - Visit `/` → should redirect to `/event-types`

2. **Set Preference to Bookings**
   - Navigate to Settings → My Account → General
   - Find "Default Home View" dropdown
   - Select "Bookings"
   - Click "Update"
   - Verify success toast appears
   - Visit `/` → should redirect to `/bookings/upcoming`

3. **Set Preference to Event Types**
   - Navigate to Settings → My Account → General
   - Change "Default Home View" to "Event Types"
   - Click "Update"
   - Visit `/` → should redirect to `/event-types`

4. **Persistence Test**
   - Set preference to "Bookings"
   - Logout and login again
   - Visit `/` → should still redirect to `/bookings/upcoming`

5. **Onboarding Flow (Should Not Be Affected)**
   - Create a new user who needs onboarding
   - Verify onboarding redirect still takes precedence over home view preference

**Expected Behavior:**
- Dropdown appears in Settings → General after "Start of Week"
- Form's "Update" button enables when selection changes
- Success toast on save
- Root URL redirects to chosen view
- Preference persists across sessions
- Defaults to "event-types" for backward compatibility

## Checklist
- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

**Files Changed:**
- `packages/prisma/zod-utils.ts` - Added schema field
- `packages/trpc/server/routers/viewer/me/updateProfile.schema.ts` - Whitelisted field for updates
- `apps/web/app/page.tsx` - Added redirect logic
- `apps/web/modules/settings/my-account/general-view.tsx` - Added UI control
- `apps/web/public/static/locales/en/common.json` - Added translation keys

**Technical Notes:**
- Uses existing `metadata` JSONB column (no database migration needed)
- Type-safe with Zod validation
- Backward compatible (defaults to existing behavior)
- Integrates seamlessly with existing auth/onboarding flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user setting to choose the default home view. Users are redirected to Bookings or Event Types on sign-in based on this preference.
- **New Features**
  - Added "Default Home View" selector in My Account → General.
  - Saved preference in user metadata and allowed via updateProfile schema.
  - Updated app/page.tsx to redirect to /bookings/upcoming or /event-types based on the saved preference (defaults to Event Types).
  - Added i18n strings for the new setting.
<sup>Written for commit 477e8e47af5f97120ff3b140cb8a2b0c13af85bd. Summary will update automatically on new commits.</sup>
<!-- End of auto-generated description by cubic. -->