### PR TITLE
fix: prevent buttons from looking active when interacting with parent…

### DIFF
--- a/packages/ui/components/button/Button.tsx
+++ b/packages/ui/components/button/Button.tsx
@@ -273,7 +273,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
                 name={StartIcon}
                 className={classNames(
                   loading ? "invisible" : "visible",
-                  "button-icon group-active:translate-y-[0.5px]",
+                  "button-icon group-[:not(div):active]:translate-y-[0.5px]",
                   variant === "icon" && "h-4 w-4",
                   variant === "button" && "h-4 w-4 stroke-[1.5px] "
                 )}
@@ -286,7 +286,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
           "contents", // This makes the div behave like it doesn't exist in the layout
           loading ? "invisible" : "visible",
           variant === "fab" ? "hidden md:contents" : "",
-          "group-active:translate-y-[0.5px]"
+          "group-[:not(div):active]:translate-y-[0.5px]"
         )}>
         {props.children}
       </div>
@@ -321,7 +321,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
               name={EndIcon}
               className={classNames(
                 loading ? "invisible" : "visible",
-                "group-active:translate-y-[0.5px]",
+                "group-[:not(div):active]:translate-y-[0.5px]",
                 variant === "icon" && "h-4 w-4",
                 variant === "button" && "h-4 w-4 stroke-[1.5px] "
               )}


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/edbb018d-d006-497d-ada5-01117eac2a7b

After:

https://github.com/user-attachments/assets/e1596d70-4426-4b73-8e68-e12e079cca96



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop buttons from looking pressed when interacting with parent divs in button groups. The active translate effect now only triggers for non-div parents, so only real button interactions show the pressed state.

- **Bug Fixes**
  - Replaced group-active with group-[:not(div):active] for icon and content wrappers in Button.tsx.

<sup>Written for commit 52d6667dc4b06025220f16de0b6f63ce1d4a6647. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

