### PR TITLE
fix: signup username collision

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -15,8 +15,8 @@ import { LicenseKeySingleton } from "@calcom/ee/common/server/LicenseKeyService"
 import { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
 import createUsersAndConnectToOrg from "@calcom/features/ee/dsync/lib/users/createUsersAndConnectToOrg";
 import ImpersonationProvider from "@calcom/features/ee/impersonation/lib/ImpersonationProvider";
-import { getOrgFullOrigin, subdomainSuffix } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { getOrganizationRepository } from "@calcom/features/ee/organizations/di/OrganizationRepository.container";
+import { getOrgFullOrigin, subdomainSuffix } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { clientSecretVerifier, hostedCal, isSAMLLoginEnabled } from "@calcom/features/ee/sso/lib/saml";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
@@ -962,7 +962,7 @@ export const getOptions = ({
                 email: user.email,
                 // Slugify the incoming name and append a few random characters to
                 // prevent conflicts for users with the same name.
-                username: getOrgUsernameFromEmail(user.name, getDomainFromEmail(user.email)),
+                username: getOrgUsernameFromEmail(user.email, getDomainFromEmail(user.email)),
                 emailVerified: new Date(Date.now()),
                 name: user.name,
                 identityProvider: idP,

--- a/packages/features/auth/signup/utils/getOrgUsernameFromEmail.test.ts
+++ b/packages/features/auth/signup/utils/getOrgUsernameFromEmail.test.ts
@@ -16,6 +16,30 @@ describe("getOrgUsernameFromEmail", () => {
     const result = getOrgUsernameFromEmail(email, autoAcceptEmailDomain);
     expect(result).toBe("john.doe-example");
   });
+
+  it("should generate unique usernames for different emails even with same name", () => {
+    const email1 = "alice@acme.com";
+    const email2 = "alice+work@corp.com";
+
+    const username1 = getOrgUsernameFromEmail(email1, null);
+    const username2 = getOrgUsernameFromEmail(email2, null);
+
+    expect(username1).toBe("alice-acme");
+    expect(username2).toBe("alice-work-corp");
+    expect(username1).not.toBe(username2);
+  });
+
+  it("should handle email with plus sign correctly", () => {
+    const email = "bob+test@example.com";
+    const result = getOrgUsernameFromEmail(email, "example.com");
+    expect(result).toBe("bob-test");
+  });
+
+  it("should handle null autoAcceptEmailDomain", () => {
+    const email = "user@company.com";
+    const result = getOrgUsernameFromEmail(email, null);
+    expect(result).toBe("user-company");
+  });
 });
 
 describe("deriveNameFromOrgUsername", () => {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes 

[GET]/api/auth/error?error=
Invalid `prisma.user.update()` invocation:
Unique constraint failed on the fields: (`username`, `("organizationId" IS NULL`)status=200



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate org usernames from the user's email (with domain) during signup instead of from the display name. This prevents username collisions for same-name users and avoids failed signups.

<sup>Written for commit a0878dfeff04ddb9292a9fe0f4d706b3aaaa0593. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





