### PR TITLE
fix: sign up upsert error

### DIFF
--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -154,6 +154,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
       },
     });
     if (team) {
+      const organizationId = team.isOrganization ? team.id : team.parent?.id ?? null;
       const user = await prisma.user.upsert({
         where: { email },
         update: {
@@ -166,12 +167,14 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
               update: { hash: hashedPassword },
             },
           },
+          organizationId,
         },
         create: {
           username,
           email,
           identityProvider: IdentityProvider.CAL,
           password: { create: { hash: hashedPassword } },
+          organizationId,
         },
       });
       // Wrapping in a transaction as if one fails we want to rollback the whole thing to preventa any data inconsistencies

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -88,6 +88,7 @@ export default async function handler(body: Record<string, string>) {
         }
       }
 
+      const organizationId = team.isOrganization ? team.id : team.parent?.id ?? null;
       const user = await prisma.user.upsert({
         where: { email: userEmail },
         update: {
@@ -100,12 +101,14 @@ export default async function handler(body: Record<string, string>) {
           },
           emailVerified: new Date(Date.now()),
           identityProvider: IdentityProvider.CAL,
+          organizationId,
         },
         create: {
           username: correctedUsername,
           email: userEmail,
           password: { create: { hash: hashedPassword } },
           identityProvider: IdentityProvider.CAL,
+          organizationId,
         },
       });
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes:-

prisma:error 
Invalid `prisma.user.upsert()` invocation:


Unique constraint failed on the fields: (`username`, `("organizationId" IS NULL`)

on sign up page

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes signup failures by setting organizationId during user upsert. Users can now sign up without unique constraint errors on username.

- **Bug Fixes**
  - Set organizationId on both update and create paths in calcomHandler and selfHostedHandler, derived from team (org or parent).

<sup>Written for commit c3c73c8e2dd9e18b1a7a4bfbc4ae6fb6ff6485b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

