### PR TITLE
fix: video page dialog bg in light mode

### DIFF
--- a/apps/web/modules/videos/views/videos-single-view.tsx
+++ b/apps/web/modules/videos/views/videos-single-view.tsx
@@ -445,7 +445,7 @@ export function LogInOverlay(props: LogInOverlayProps) {
       <DialogContent
         title={t("join_video_call")}
         description={t("choose_how_you_d_like_to_appear_on_the_call")}
-        className="bg-black/80 p-6 sm:max-w-lg">
+        className="p-6 sm:max-w-lg">
         <div className="mt-2 pb-4">
           <div className="stack-y-4">
             <div>
@@ -568,7 +568,7 @@ export function VideoMeetingInfo(props: VideoMeetingInfo) {
           "no-scrollbar fixed left-0 top-0 z-30 flex h-full w-64 transform justify-between overflow-x-hidden overflow-y-scroll transition-all duration-300 ease-in-out",
           open ? "translate-x-0" : "-translate-x-[232px]"
         )}>
-        <main className="prose-sm prose max-w-64 prose-a:text-white prose-h3:text-white prose-h3:font-cal scroll-bar scrollbar-track-w-20 w-full overflow-scroll overflow-x-hidden! border-r border-gray-300/20 bg-black/80 p-4 text-white shadow-sm backdrop-blur-lg">
+        <main className="prose-sm prose max-w-64 prose-a:text-white prose-h3:text-white prose-h3:font-cal scroll-bar scrollbar-track-w-20 w-full overflow-scroll overflow-x-hidden! border-r border-gray-300/20 bg-default p-4 text-white shadow-sm backdrop-blur-lg">
           <h3>{t("what")}:</h3>
           <p>{booking.title}</p>
           <h3>{t("invitee_timezone")}:</h3>


### PR DESCRIPTION
## What does this PR do?

#### Image Demo

Before:
<img width="884" height="617" alt="Screenshot 2025-11-28 at 13 25 55" src="https://github.com/user-attachments/assets/c826797f-3e9b-4723-bc0e-d1def20d6080" />

After:
<img width="968" height="662" alt="Screenshot 2025-11-28 at 13 26 15" src="https://github.com/user-attachments/assets/0dde9ea2-0801-4e1b-81a5-21d6328ce805" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed light mode backgrounds on the video page. The login dialog and meeting info sidebar now use the theme default instead of a semi-transparent black, improving contrast and readability.

<sup>Written for commit 4f84d74f5f5326f6819408858bbaeea2cd4a741a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

