### PR TITLE
fix: Add all attendees to HubSpot CRM for seated events

### DIFF
--- a/packages/app-store/hubspot/lib/CrmService.ts
+++ b/packages/app-store/hubspot/lib/CrmService.ts
@@ -306,4 +306,15 @@ export default class HubspotCalendarService implements CRM {
   async handleAttendeeNoShow() {
     console.log("Not implemented");
   }
+
+  async addContacts(uid: string, contacts: Contact[]) {
+    const auth = await this.auth;
+    await auth.getToken();
+
+    const contactIds: { id: string }[] = contacts.map((contact) => ({ id: contact.id }));
+    const meeting = { id: uid } as SimplePublicObject;
+
+    await this.hubspotAssociate(meeting, contactIds);
+    this.log.debug("association:addContacts:ok", { meetingId: uid, contacts });
+  }
 }

--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -56,7 +56,7 @@ const delegatedCredentialFirst = <T extends { delegatedToId?: string | null }>(a
   return (b.delegatedToId ? 1 : 0) - (a.delegatedToId ? 1 : 0);
 };
 
-const _delegatedCredentialLast = <T extends { delegatedToId?: string | null }>(a: T, b: T) => {
+const delegatedCredentialLast = <T extends { delegatedToId?: string | null }>(a: T, b: T) => {
   return (a.delegatedToId ? 1 : 0) - (b.delegatedToId ? 1 : 0);
 };
 
@@ -127,20 +127,20 @@ type createdEventSchema = z.infer<typeof createdEventSchema>;
 
 export type EventManagerInitParams = {
   user: EventManagerUser;
-  eventTypeAppMetadata?: Record<string, unknown>;
+  eventTypeAppMetadata?: Record<string, any>;
 };
 
 export default class EventManager {
   calendarCredentials: CredentialForCalendarService[];
   videoCredentials: CredentialForCalendarService[];
   crmCredentials: CredentialForCalendarService[];
-  appOptions?: Record<string, unknown>;
+  appOptions?: Record<string, any>;
   /**
    * Takes an array of credentials and initializes a new instance of the EventManager.
    *
    * @param user
    */
-  constructor(user: EventManagerUser, eventTypeAppMetadata?: Record<string, unknown>) {
+  constructor(user: EventManagerUser, eventTypeAppMetadata?: Record<string, any>) {
     log.silly("Initializing EventManager", safeStringify({ user: getPiiFreeUser(user) }));
     const appCredentials = getApps(user.credentials, true).flatMap((app) =>
       app.credentials.map((creds) => ({ ...creds, appName: app.name }))
@@ -853,7 +853,10 @@ export default class EventManager {
           const currentAppOption = this.getAppOptionsFromEventMetadata(credential);
           const crm = new CrmManager(credential, currentAppOption);
           await crm.addContacts(reference.uid, event).catch((error) => {
-            log.warn(`Error adding contacts to CRM event for ${credential.type} for booking ${event?.uid}`, error);
+            log.warn(
+              `Error adding contacts to CRM event for ${credential.type} for booking ${event?.uid}`,
+              error
+            );
           });
         }
       }
@@ -1210,9 +1213,9 @@ export default class EventManager {
 
       return Promise.all(result);
     } catch (error) {
-      let _message = `Tried to 'updateAllCalendarEvents' but there was no '{thing}' for '${credential?.type}', userId: '${credential?.userId}', bookingId: '${booking?.id}'`;
+      let message = `Tried to 'updateAllCalendarEvents' but there was no '{thing}' for '${credential?.type}', userId: '${credential?.userId}', bookingId: '${booking?.id}'`;
       if (error instanceof Error) {
-        _message = _message.replace("{thing}", error.message);
+        message = message.replace("{thing}", error.message);
       }
 
       return Promise.resolve(

--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -155,6 +155,7 @@ const createNewSeat = async (
   const apps = eventTypeAppMetadataOptionalSchema.parse(eventType?.metadata?.apps);
   const eventManager = new EventManager({ ...organizerUser, credentials }, apps);
   await eventManager.updateCalendarAttendees(evt, seatedBooking);
+  await eventManager.updateCRMAttendees(evt, seatedBooking);
 
   const foundBooking = await findBookingQuery(seatedBooking.id);
 

--- a/packages/features/crmManager/crmManager.ts
+++ b/packages/features/crmManager/crmManager.ts
@@ -8,9 +8,7 @@ const log = logger.getSubLogger({ prefix: ["CrmManager"] });
 export default class CrmManager {
   crmService: CRM | null | undefined = null;
   credential: CredentialPayload;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   appOptions: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(credential: CredentialPayload, appOptions?: any) {
     this.credential = credential;
     this.appOptions = appOptions;

--- a/packages/types/CrmService.d.ts
+++ b/packages/types/CrmService.d.ts
@@ -27,7 +27,6 @@ export interface CrmEvent {
   type?: string;
   password?: string;
   url?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   additionalInfo?: any;
 }
 
@@ -49,7 +48,6 @@ export interface CRM {
     organizerEmail?: string,
     calEventResponses?: CalEventResponses | null
   ) => Promise<Contact[]>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getAppOptions: () => any;
   handleAttendeeNoShow?: (
     bookingUid: string,

--- a/packages/types/CrmService.d.ts
+++ b/packages/types/CrmService.d.ts
@@ -27,6 +27,7 @@ export interface CrmEvent {
   type?: string;
   password?: string;
   url?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   additionalInfo?: any;
 }
 
@@ -48,9 +49,11 @@ export interface CRM {
     organizerEmail?: string,
     calEventResponses?: CalEventResponses | null
   ) => Promise<Contact[]>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getAppOptions: () => any;
   handleAttendeeNoShow?: (
     bookingUid: string,
     attendees: { email: string; noShow: boolean }[]
   ) => Promise<void>;
+  addContacts?: (uid: string, contacts: Contact[]) => Promise<void>;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where only the first attendee was recorded in HubSpot CRM when multiple users booked seats in a seated event. Previously, `createNewSeat()` only called `updateCalendarAttendees()` but not CRM updates, so subsequent seat bookings were not reflected in the CRM.

