### PR TITLE
docs: add no show updated docs

### DIFF
--- a/docs/developing/guides/automation/webhooks.mdx
+++ b/docs/developing/guides/automation/webhooks.mdx
@@ -34,6 +34,7 @@ To create a new webhook subscription, visit `/settings/developer/webhooks` and p
         - `Form Submitted`
         - `Meeting Ended`
         - `Instant Meeting Created`
+        - `Booking No-show Updated`
     </Step>
     <Step title="Secret">
         You can provide a secret key with this webhook to [verify it](/docs/core-features/webhooks#verifying-the-authenticity-of-the-received-payload) on the subscriber URL when receiving a payload. This helps confirm whether the payload is authentic or has been tampered with. You can leave it blank if you don't wish to secure the webhook with a secret key.
@@ -144,6 +145,50 @@ To create a new webhook subscription, visit `/settings/developer/webhooks` and p
 
 ```
 
+### Booking No-show Updated webhook payload
+
+This webhook is triggered when an attendee is manually marked or unmarked as no-show on the `/bookings/past` page.
+
+**Example payload when marking an attendee as no-show:**
+
+```json
+{
+  "triggerEvent": "BOOKING_NO_SHOW_UPDATED",
+  "createdAt": "2025-12-01T12:34:34.774Z",
+  "payload": {
+    "message": "test@example.com marked as no-show",
+    "attendees": [
+      {
+        "email": "test@example.com",
+        "noShow": true
+      }
+    ],
+    "bookingUid": "5vQFqxDFMjdgKGMijqtqRw",
+    "bookingId": 31
+  }
+}
+```
+
+**Example payload when unmarking an attendee as no-show:**
+
+```json
+{
+  "triggerEvent": "BOOKING_NO_SHOW_UPDATED",
+  "createdAt": "2025-12-01T12:38:31.663Z",
+  "payload": {
+    "message": "test@example.com unmarked as no-show",
+    "attendees": [
+      {
+        "email": "test@example.com",
+        "noShow": false
+      }
+    ],
+    "bookingUid": "5vQFqxDFMjdgKGMijqtqRw",
+    "bookingId": 31
+  }
+}
+```
+
 ### Verifying the authenticity of the received payload
 <Steps>
     <Step title="Add a new secret key to your webhook">
@@ -182,7 +227,7 @@ where `{{type}}` represents the event type slug and `{{title}}` represents the t
 
 | Variable           | Type         | Description                                                                                                                                                   |
 |--------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| triggerEvent       | String       | The name of the trigger event [BOOKING_CREATED, BOOKING_RESCHEDULED, BOOKING_CANCELLED, MEETING_ENDED, BOOKING_REJECTED, BOOKING_REQUESTED, BOOKING_PAYMENT_INITIATED, BOOKING_PAID, MEETING_STARTED, RECORDING_READY, FORM_SUBMITTED] |
+| triggerEvent       | String       | The name of the trigger event [BOOKING_CREATED, BOOKING_RESCHEDULED, BOOKING_CANCELLED, MEETING_ENDED, BOOKING_REJECTED, BOOKING_REQUESTED, BOOKING_PAYMENT_INITIATED, BOOKING_PAID, MEETING_STARTED, RECORDING_READY, FORM_SUBMITTED, BOOKING_NO_SHOW_UPDATED] |
 | createdAt          | Datetime     | The time of the webhook                                                                                                                                       |
 | type               | String       | The event type slug                                                                                                                                           |
 | title              | String       | The event type name                                                                                                                                           |


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds documentation for "Booking No show updated" webhook trigger event with example payload.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added documentation for the Booking No-show Updated webhook event. Covers when it triggers (mark/unmark no-show on /bookings/past), provides example payloads, and adds the event to the supported triggerEvent list.

<sup>Written for commit 21b01c0bfd05013470e0619e1fd55a361fc6e1f7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

