### PR TITLE
perf: Calendar Cache Improvements

### DIFF
--- a/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
+++ b/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
@@ -12,7 +12,7 @@ import type { CalendarSyncService } from "@calcom/features/calendar-subscription
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import logger from "@calcom/lib/logger";
 import type { ISelectedCalendarRepository } from "@calcom/lib/server/repository/SelectedCalendarRepository.interface";
-import { SelectedCalendar } from "@calcom/prisma/client";
+import type { SelectedCalendar } from "@calcom/prisma/client";
 
 const log = logger.getSubLogger({ prefix: ["CalendarSubscriptionService"] });
 
@@ -204,6 +204,10 @@ export class CalendarSubscriptionService {
    * Subscribe periodically to new calendars
    */
   async checkForNewSubscriptions() {
+    const calendarSubscriptionTeamsEnabled = await this.deps.featuresRepository.getTeamsWithFeatureEnabled(
+      CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE
+    );
+
     const rows = await this.deps.selectedCalendarRepository.findNextSubscriptionBatch({
       take: 100,
       integrations: this.deps.adapterFactory.getProviders(),

--- a/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
+++ b/packages/features/calendar-subscription/lib/CalendarSubscriptionService.ts
@@ -204,13 +204,14 @@ export class CalendarSubscriptionService {
    * Subscribe periodically to new calendars
    */
   async checkForNewSubscriptions() {
-    const calendarSubscriptionTeamsEnabled = await this.deps.featuresRepository.getTeamsWithFeatureEnabled(
+    const teamIds = await this.deps.featuresRepository.getTeamsWithFeatureEnabled(
       CalendarSubscriptionService.CALENDAR_SUBSCRIPTION_CACHE_FEATURE
     );
 
     const rows = await this.deps.selectedCalendarRepository.findNextSubscriptionBatch({
       take: 100,
       integrations: this.deps.adapterFactory.getProviders(),
+      teamIds,
     });
     log.debug("checkForNewSubscriptions", { count: rows.length });
     await Promise.allSettled(rows.map(({ id }) => this.subscribe(id)));

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -4,4 +4,5 @@ export interface IFeaturesRepository {
   checkIfFeatureIsEnabledGlobally(slug: keyof AppFlags): Promise<boolean>;
   checkIfUserHasFeature(userId: number, slug: string): Promise<boolean>;
   checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags): Promise<boolean>;
+  getTeamsWithFeatureEnabled(slug: keyof AppFlags): Promise<number[]>;
 }

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -351,4 +351,23 @@ export class FeaturesRepository implements IFeaturesRepository {
       throw err;
     }
   }
+
+  async getTeamsWithFeatureEnabled(slug: keyof AppFlags): Promise<number[]> {
+    try {
+      // If globally disabled, treat as effectively disabled everywhere
+      const isGloballyEnabled = await this.checkIfFeatureIsEnabledGlobally(slug);
+      if (!isGloballyEnabled) return [];
+
+      const rows = await this.prismaClient.teamFeatures.findMany({
+        where: { featureId: slug },
+        select: { teamId: true },
+        orderBy: { teamId: "asc" },
+      });
+
+      return rows.map((r) => r.teamId);
+    } catch (err) {
+      captureException(err);
+      throw err;
+    }
+  }
 }

--- a/packages/lib/server/repository/SelectedCalendarRepository.interface.ts
+++ b/packages/lib/server/repository/SelectedCalendarRepository.interface.ts
@@ -24,9 +24,11 @@ export interface ISelectedCalendarRepository {
    */
   findNextSubscriptionBatch({
     take,
+    teamIds,
     integrations,
   }: {
     take: number;
+    teamIds: number[];
     integrations?: string[];
   }): Promise<SelectedCalendar[]>;
 

--- a/packages/lib/server/repository/SelectedCalendarRepository.ts
+++ b/packages/lib/server/repository/SelectedCalendarRepository.ts
@@ -15,26 +15,24 @@ export class SelectedCalendarRepository implements ISelectedCalendarRepository {
     return this.prismaClient.selectedCalendar.findFirst({ where: { channelId } });
   }
 
-  async findNextSubscriptionBatch({ take, integrations }: { take: number; integrations: string[] }) {
+  async findNextSubscriptionBatch({
+    take,
+    teamIds,
+    integrations,
+  }: {
+    take: number;
+    teamIds: number[];
+    integrations: string[];
+  }) {
     return this.prismaClient.selectedCalendar.findMany({
       where: {
         integration: { in: integrations },
         OR: [{ syncSubscribedAt: null }, { channelExpiration: { lte: new Date() } }],
-        // initially we will run subscription only for teams that have
-        // the feature flags enabled and it should be removed later
         user: {
           teams: {
             some: {
-              team: {
-                features: {
-                  some: {
-                    OR: [
-                      { featureId: "calendar-subscription-cache" },
-                      { featureId: "calendar-subscription-sync" },
-                    ],
-                  },
-                },
-              },
+              teamId: { in: teamIds },
+              accepted: true,
             },
           },
         },


### PR DESCRIPTION
## What does this PR do?




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits calendar subscription processing to teams with the cache feature enabled, reducing unnecessary work and improving job performance.

- **Performance**
  - Fetches team IDs with the feature enabled and filters subscription batches by those teams.
  - Adds FeaturesRepository.getTeamsWithFeatureEnabled and uses it in CalendarSubscriptionService.
  - Simplifies SelectedCalendarRepository query to filter by teamId and accepted membership.

<sup>Written for commit 070a3394c1a4f735733164948fdea265d9445b57. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



## Updates since last revision

- Fixed failing test by adding missing mock methods (`checkIfTeamHasFeature`, `getTeamsWithFeatureEnabled`) to the mock FeaturesRepository
- Updated test assertion to verify `teamIds` parameter is passed to `findNextSubscriptionBatch`
- Added new test scenarios:
  - Mixed cache scenario: verifies correct handling when some teams have cache enabled and some don't
  - Hierarchical isolation: verifies team feature flag doesn't enable for entire organization (only explicitly enabled teams are included)
  - Empty teams: verifies no calendars are processed when no teams have the feature enabled

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/calendar-subscription/lib/__tests__/CalendarSubscriptionService.test.ts`
2. All 24 tests should pass, including the 3 new test scenarios

## Human Review Checklist

- [ ] Verify the non-hierarchical team filtering is the intended behavior (enabling feature for a team should NOT enable it for parent org or child teams)
- [ ] Confirm the `accepted: true` membership requirement is correct for filtering calendars
- [ ] Review that the `getTeamsWithFeatureEnabled` query correctly returns only teams with explicit feature flags

---
**Link to Devin run:** https://app.devin.ai/sessions/a96c3e9e3d2b4718ada5bf9c30ff4d78
**Requested by:** Volnei Munhoz (volnei@cal.com) (@volnei)