### PR TITLE
fix: prevent double-encoding of bookingFields and locations in API v2

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/output-event-types.service.ts
@@ -247,7 +247,31 @@ export class OutputEventTypesService_2024_06_14 {
       if (result.success) {
         knownLocations.push(result.data);
       } else {
-        unknownLocations.push({ type: "unknown", location: JSON.stringify(location) });
+        let locationString: string;
+
+        // If location is already a string, try to parse it first to avoid double-encoding
+        if (typeof location === "string") {
+          try {
+            const parsed = JSON.parse(location);
+            // Try to validate the parsed object
+            const retryResult = InternalLocationSchema.safeParse(parsed);
+            if (retryResult.success) {
+              // It was a stringified valid location! Add to known locations and skip unknown
+              knownLocations.push(retryResult.data);
+              continue;
+            }
+            // Parsing succeeded but still doesn't match schema, use the original string
+            locationString = location;
+          } catch {
+            // Not valid JSON, use the string as-is
+            locationString = location;
+          }
+        } else {
+          // It's an object, stringify it
+          locationString = JSON.stringify(location);
+        }
+
+        unknownLocations.push({ type: "unknown", location: locationString });
       }
     }
 
@@ -274,10 +298,34 @@ export class OutputEventTypesService_2024_06_14 {
       if (result.success) {
         knownBookingFields.push(result.data);
       } else {
+        let bookingFieldString: string;
+
+        // If bookingField is already a string, try to parse it first to avoid double-encoding
+        if (typeof bookingField === "string") {
+          try {
+            const parsed = JSON.parse(bookingField);
+            // Try to validate the parsed object
+            const retryResult = BookingFieldSchema.safeParse(parsed);
+            if (retryResult.success) {
+              // It was a stringified valid field! Add to known fields and skip unknown
+              knownBookingFields.push(retryResult.data);
+              continue;
+            }
+            // Parsing succeeded but still doesn't match schema, use the original string
+            bookingFieldString = bookingField;
+          } catch {
+            // Not valid JSON, use the string as-is
+            bookingFieldString = bookingField;
+          }
+        } else {
+          // It's an object, stringify it
+          bookingFieldString = JSON.stringify(bookingField);
+        }
+
         unknownBookingFields.push({
           type: "unknown",
           slug: "unknown",
-          bookingField: JSON.stringify(bookingField),
+          bookingField: bookingFieldString,
         } satisfies OutputUnknownBookingField_2024_06_14);
       }
     }


### PR DESCRIPTION
Fixes #25429

When the event type API endpoint returns custom fields, the bookingField property was being double-encoded. This happened when legacy or malformed data stored booking fields as strings instead of objects.

Previously, when a booking field failed schema validation, the code would JSON.stringify it without checking if it was already a string. This caused double-encoding and fields to be returned with type="unknown" and slug="unknown" instead of their actual values.

Changes:
- Check if bookingField/location is already a string before stringifying
- If it's a string, try to JSON.parse and re-validate it
- If parsing succeeds and validation passes, add to known fields (not unknown)
- Only stringify if it's an object
- Use the original string if parsing fails to avoid double-encoding

This fix ensures that API responses return properly formatted JSON for bookingFields and locations with correct type/slug values, preventing the "unknown" type with malformed data.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
