### PR TITLE
fix: ProgressBar styling is hardcoded in light mode

### DIFF
--- a/packages/ui/components/progress-bar/ProgressBar.tsx
+++ b/packages/ui/components/progress-bar/ProgressBar.tsx
@@ -29,10 +29,10 @@ export function ProgressBar({ color, percentageValue, label, className }: Progre
 
   return (
     <div className={classNames("flex w-full items-center gap-3", className)}>
-      <div className="h-2 flex-1 rounded-full bg-gray-200">
+      <div className="bg-subtle h-2 flex-1 rounded-full">
         <div className={progressBarStyles({ color })} style={{ width: `${clampedPercentage}%` }} />
       </div>
-      {label && <span className="text-sm font-medium text-gray-700">{label}</span>}
+      {label && <span className="text-default text-sm font-medium">{label}</span>}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

The `ProgressBar` component was using hardcoded Tailwind colors (`bg-gray-200` and `text-gray-700`) that don't adapt to dark mode. This caused the progress bar track to appear as a harsh light gray stripe in dark mode, making it look out of place.

This PR replaces those hardcoded colors with Cal.com's design system tokens (`bg-subtle` and `text-default`) which automatically adapt to both light and dark themes like the Slider component already does.

- Fixes #25515 
- Fixes [CAL-6850](https://linear.app/calcom/issue/CAL-6850/bug-progressbar-styling-is-dark-mode-is-hardcoded)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

## Before Fix:
<img width="1278" height="793" alt="Screenshot 2025-12-02 031123" src="https://github.com/user-attachments/assets/e59b9c65-2b8a-47a3-ae03-c56b981925c2" />

## After Fix:
<img width="1287" height="823" alt="Screenshot 2025-12-02 031247" src="https://github.com/user-attachments/assets/786515aa-b7b8-4c85-ba03-c574cdc3a369" />



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

1. **Environment setup:** Enable the credits feature by setting `NEXT_PUBLIC_STRIPE_CREDITS_PRICE_ID` in `.env`
2. **Navigate to:** Settings → Teams → [Any Team] → Billing
3. **Look at:** The "Credits" section with the progress bar
4. **Toggle dark mode:** Settings → Appearance → Dark