### PR TITLE
fix: improve Vercel domain 'forbidden' error message and add schema fields

### DIFF
--- a/packages/lib/domainManager/deploymentServices/vercel.ts
+++ b/packages/lib/domainManager/deploymentServices/vercel.ts
@@ -12,8 +12,8 @@ const vercelDomainApiResponseSchema = z.object({
     .object({
       code: z.string().nullish(),
       domain: z.any().nullish(),
-      message: z.string().optional(),
-      invalidToken: z.boolean().optional(),
+      message: z.string().nullish(),
+      invalidToken: z.boolean().nullish(),
     })
     .optional(),
 });
@@ -79,9 +79,9 @@ export const deleteDomain = async (domain: string) => {
 function handleDomainCreationError(error: {
   code?: string | null;
   domain?: string | null;
-  message?: string;
-  invalidToken?: boolean;
-}) {
+  message?: string | null;
+  invalidToken?: boolean | null;
+}){
   // Vercel returns "forbidden" for various permission issues, not just domain ownership
   if (error.code === "forbidden") {
     const errorMessage =
@@ -128,9 +128,9 @@ function handleDomainCreationError(error: {
 function handleDomainDeletionError(error: {
   code?: string | null;
   domain?: string | null;
-  message?: string;
-  invalidToken?: boolean;
-}) {
+  message?: string | null;
+  invalidToken?: boolean | null;
+}){
   if (error.code === "not_found") {
     // Domain is already deleted
     return true;

--- a/packages/lib/domainManager/deploymentServices/vercel.ts
+++ b/packages/lib/domainManager/deploymentServices/vercel.ts
@@ -94,7 +94,7 @@ function handleDomainCreationError(error: {
     );
     throw new HttpError({
       message: errorMessage,
-      statusCode: 403,
+      statusCode: 400,
     });
   }
 
@@ -148,7 +148,7 @@ function handleDomainDeletionError(error: {
     );
     throw new HttpError({
       message: errorMessage,
-      statusCode: 403,
+      statusCode: 400,
     });
   }
 

--- a/packages/lib/domainManager/deploymentServices/vercel.ts
+++ b/packages/lib/domainManager/deploymentServices/vercel.ts
@@ -75,9 +75,10 @@ export const deleteDomain = async (domain: string) => {
 };
 
 function handleDomainCreationError(error: { code?: string | null; domain?: string | null }) {
-  // Domain is already owned by another team but you can request delegation to access it
+  // Vercel returns "forbidden" for various permission issues, not just domain ownership
   if (error.code === "forbidden") {
-    const errorMessage = "Domain is already owned by another team";
+    const errorMessage =
+      "Vercel denied permission to manage this domain. Please verify your Vercel project, team, and domain permissions.";
     log.error(
       safeStringify({
         errorMessage,
@@ -86,7 +87,7 @@ function handleDomainCreationError(error: { code?: string | null; domain?: strin
     );
     throw new HttpError({
       message: errorMessage,
-      statusCode: 400,
+      statusCode: 403,
     });
   }
 
@@ -123,9 +124,10 @@ function handleDomainDeletionError(error: { code?: string | null; domain?: strin
     return true;
   }
 
-  // Domain is already owned by another team but you can request delegation to access it
+  // Vercel returns "forbidden" for various permission issues, not just domain ownership
   if (error.code === "forbidden") {
-    const errorMessage = "Domain is owned by another team";
+    const errorMessage =
+      "Vercel denied permission to manage this domain. Please verify your Vercel project, team, and domain permissions.";
     log.error(
       safeStringify({
         errorMessage,
@@ -134,7 +136,7 @@ function handleDomainDeletionError(error: { code?: string | null; domain?: strin
     );
     throw new HttpError({
       message: errorMessage,
-      statusCode: 400,
+      statusCode: 403,
     });
   }
 

--- a/packages/lib/domainManager/deploymentServices/vercel.ts
+++ b/packages/lib/domainManager/deploymentServices/vercel.ts
@@ -12,6 +12,8 @@ const vercelDomainApiResponseSchema = z.object({
     .object({
       code: z.string().nullish(),
       domain: z.any().nullish(),
+      message: z.string().optional(),
+      invalidToken: z.boolean().optional(),
     })
     .optional(),
 });
@@ -74,7 +76,12 @@ export const deleteDomain = async (domain: string) => {
   return handleDomainDeletionError(data.error);
 };
 
-function handleDomainCreationError(error: { code?: string | null; domain?: string | null }) {
+function handleDomainCreationError(error: {
+  code?: string | null;
+  domain?: string | null;
+  message?: string;
+  invalidToken?: boolean;
+}) {
   // Vercel returns "forbidden" for various permission issues, not just domain ownership
   if (error.code === "forbidden") {
     const errorMessage =
@@ -118,7 +125,12 @@ function handleDomainCreationError(error: { code?: string | null; domain?: strin
   });
 }
 
-function handleDomainDeletionError(error: { code?: string | null; domain?: string | null }) {
+function handleDomainDeletionError(error: {
+  code?: string | null;
+  domain?: string | null;
+  message?: string;
+  invalidToken?: boolean;
+}) {
   if (error.code === "not_found") {
     // Domain is already deleted
     return true;


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect translation of Vercel's "forbidden" error code. The previous error message "Domain is already owned by another team" was misleading because Vercel returns "forbidden" for various permission issues, not just domain ownership conflicts.

**Changes:**
- Updated error message to: "Vercel denied permission to manage this domain. Please verify your Vercel project, team, and domain permissions."
- Added `message` and `invalidToken` fields to the Vercel error response schema for better logging (helps debug token invalidation issues)

**Note:** Status code kept at 400 (not changed to 403) to avoid potential downstream side effects.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - error message change only, existing error handling tests still apply.

## How should this be tested?

1. Trigger a Vercel "forbidden" error by using an invalid/expired token or incorrect team/project permissions
2. Verify the new error message appears: "Vercel denied permission to manage this domain..."
3. Check logs to confirm `message` and `invalidToken` fields are captured when present in Vercel's response

## Human Review Checklist

- [ ] Verify the new error message is appropriate for all "forbidden" scenarios from Vercel
- [ ] Confirm `.nullish()` is correct for handling Vercel API responses (handles both `null` and `undefined`)
- [ ] Verify keeping status code at 400 is acceptable (vs changing to 403)

---

**Requester:** @hariombalhara (hariom@cal.com)
**Link to Devin run:** https://app.devin.ai/sessions/b839486a723f4fb98d5dd3f6a5f7bf6a