### PR TITLE
fix: styling override at availability settings

### DIFF
--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -645,7 +645,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
               handleSubmit(props);
             }}
             className={cn(customClassNames?.formClassName, "flex flex-col sm:mx-0 xl:flex-row xl:space-x-6")}>
-            <div className="flex-1 flex-row xl:mr-0">
+            <div className="flex-1">
               <div
                 className={cn(
                   "border-subtle mb-6 rounded-md border",


### PR DESCRIPTION
## What does this PR do?

Fix extra right spacing in Availability Settings layout on xl screens
TL;DR
- removed an override `xl:mr-0` that was canceling `xl:space-x-6`.
- removed unused styling 

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

**BEFORE:**

<img width="1850" height="921" alt="Screenshot from 2025-12-02 12-57-23" src="https://github.com/user-attachments/assets/67ddcec1-c1b7-471f-9626-8806521117cc" />


**AFTER:**

<img width="1850" height="921" alt="Screenshot from 2025-12-02 12-58-36" src="https://github.com/user-attachments/assets/0cc8b119-ce43-4a78-970e-aaf869df0391" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
