### PR TITLE
fix: Add /router to isBookingPages to prevent 500 error on customPageMessage redirect

### DIFF
--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -1,3 +1,12 @@
+/**
+ * PAGES ROUTER ONLY - Used exclusively by Next.js Pages Router
+ * 
+ * Currently only serves the /router endpoint (routing forms redirect page).
+ * DO NOT add new features here - this file will be deprecated once we remove apps/web/pages.
+ * 
+ * For App Router, use PageWrapperAppDir.tsx instead.
+ */
+
 "use client";
 
 import { DefaultSeo } from "next-seo";

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -1,3 +1,12 @@
+/**
+ * PAGES ROUTER ONLY - Used exclusively by Next.js Pages Router (_app.tsx)
+ * 
+ * Currently only serves the /router endpoint (routing forms redirect page).
+ * DO NOT add new features here - this file will be deprecated once we remove apps/web/pages.
+ * 
+ * For App Router, use app-providers-app-dir.tsx instead.
+ */
+
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { dir } from "i18next";
 import type { Session } from "next-auth";
@@ -12,7 +21,6 @@ import type { ParsedUrlQuery } from "querystring";
 import type { PropsWithChildren, ReactNode } from "react";
 import { useEffect } from "react";
 
-import DynamicPostHogProvider from "@calcom/features/ee/event-tracking/lib/posthog/providerDynamic";
 import { OrgBrandingProvider } from "@calcom/features/ee/organizations/context/provider";
 import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/providerDynamic";
 import DynamicIntercomProvider from "@calcom/features/ee/support/lib/intercom/providerDynamic";
@@ -53,12 +61,6 @@ export type AppProps = Omit<
   err?: Error;
 };
 
-const PostHogPageView = dynamic(
-  () => import("@calcom/features/ee/event-tracking/lib/posthog/web/PostHogPageView"),
-  {
-    ssr: false,
-  }
-);
 
 type AppPropsWithChildren = AppProps & {
   children: ReactNode;
@@ -134,8 +136,8 @@ const enum ThemeSupport {
 
 type CalcomThemeProps = PropsWithChildren<
   Pick<AppProps, "router"> &
-    Pick<AppProps["pageProps"], "themeBasis"> &
-    Pick<AppProps["Component"], "isBookingPage" | "isThemeSupported">
+  Pick<AppProps["pageProps"], "themeBasis"> &
+  Pick<AppProps["Component"], "isBookingPage" | "isThemeSupported">
 >;
 const CalcomThemeProvider = (props: CalcomThemeProps) => {
   // Use namespace of embed to ensure same namespaced embed are displayed with same theme. This allows different embeds on the same website to be themed differently
@@ -209,8 +211,8 @@ function getThemeProviderProps({
     ? ThemeSupport.Booking
     : // if isThemeSupported is explicitly false, we don't use theme there
     props.isThemeSupported === false
-    ? ThemeSupport.None
-    : ThemeSupport.App;
+      ? ThemeSupport.None
+      : ThemeSupport.App;
 
   const isBookingPageThemeSupportRequired = themeSupport === ThemeSupport.Booking;
   const themeBasis = props.themeBasis;
@@ -234,13 +236,13 @@ function getThemeProviderProps({
 
   const storageKey = isEmbedMode
     ? // Same Namespace, Same Organizer but different themes would still work seamless and not cause theme flicker
-      // Even though it's recommended to use different namespaces when you want to theme differently on the same page but if the embeds are on different pages, the problem can still arise
-      `embed-theme-${embedNamespace}${appearanceIdSuffix}${embedExplicitlySetThemeSuffix}`
+    // Even though it's recommended to use different namespaces when you want to theme differently on the same page but if the embeds are on different pages, the problem can still arise
+    `embed-theme-${embedNamespace}${appearanceIdSuffix}${embedExplicitlySetThemeSuffix}`
     : themeSupport === ThemeSupport.App
-    ? "app-theme"
-    : isBookingPageThemeSupportRequired
-    ? `booking-theme${appearanceIdSuffix}`
-    : undefined;
+      ? "app-theme"
+      : isBookingPageThemeSupportRequired
+        ? `booking-theme${appearanceIdSuffix}`
+        : undefined;
 
   return {
     storageKey,
@@ -307,12 +309,7 @@ const AppProviders = (props: AppPropsWithChildren) => {
 
   return (
     <>
-      <DynamicHelpscoutProvider>
-        <DynamicPostHogProvider>
-          <PostHogPageView />
-          {RemainingProviders}
-        </DynamicPostHogProvider>
-      </DynamicHelpscoutProvider>
+      <DynamicHelpscoutProvider>{RemainingProviders}</DynamicHelpscoutProvider>
     </>
   );
 };

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -1,7 +1,9 @@
 import { usePathname } from "next/navigation";
 
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
-
+// TODO: This approach of checking booking page isn't correct.
+// app.cal.com/rick is a booking page but useIsBookingPage won't return true. This is because all unregistered router in Next.js could technically be a booking page throw catch all routes.
+// The only way to confirm it is by actually checking if we actually rendered a booking route.
 export default function useIsBookingPage(): boolean {
   const pathname = usePathname();
   const isBookingPage = [

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -13,6 +13,7 @@ export default function useIsBookingPage(): boolean {
     "/d", // Private Link of booking page
     "/apps/routing-forms/routing-link", // Routing Form page
     "/forms/", // Rewrites to /apps/routing-forms/routing-link
+    "/router", // Headless router page - Loads as a page when redirect type is customPageMessage
   ].some((route) => pathname?.startsWith(route));
   const isBookingsListPage = ["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"].some(
     (route) => pathname?.endsWith(route)


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 error that occurs on the `/router` path when `redirectType` for a chosen route is `customPageMessage`.

**Root cause:** The PostHogProvider was added to the Pages Router's AppProviders, but the required GeoProvider dependency was not added. This caused a crash when loading the `/router` endpoint.

**Solution:**
1. Mark `/router` as a booking page in `useIsBookingPage.ts`
2. Remove PostHogProvider from Pages Router AppProviders - the Pages Router only serves the `/router` endpoint (routing forms redirect page), which is a booking page and doesn't need PostHog tracking
3. Add documentation headers to `PageWrapper.tsx` and `app-providers.tsx` clarifying these are Pages Router only files that will be deprecated

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal code documentation only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a routing form with a route that has `redirectType` set to `customPageMessage`
2. Submit the form and trigger that route
3. Verify the `/router` page loads without a 500 error
4. Verify the booking theme is applied correctly on the `/router` page

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat /router as a booking page and simplify the legacy Pages Router providers. This applies the correct booking theme on /router and removes unused PostHog wiring to avoid router-page crashes.

- **Bug Fixes**
  - Add /router to useIsBookingPage so the booking UI and theming load on the headless router.

- **Refactors**
  - Remove PostHog provider/page-view from Pages Router AppProviders; add "Pages Router only" headers to PageWrapper and app-providers.

<sup>Written for commit d572b071374bf01abb666113f72e629db4c8509e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->