### PR TITLE
docs(cal-provider): document isEmbed prop

### DIFF
--- a/docs/platform/atoms/cal-provider.mdx
+++ b/docs/platform/atoms/cal-provider.mdx
@@ -4,8 +4,6 @@ title: "Cal Provider"
 
 Cal Provider is used to setup scheduling within your app. It is used in the root of your app, be it _app.js or or _app.tsx in case of
 Next.js or App.js or App.ts in case of React. Here is an example:
-
-
 ```js
 import "@calcom/atoms/globals.min.css";
 import { CalProvider } from '@calcom/atoms';
@@ -40,3 +38,4 @@ Below is a list of props that can be passed to the Cal Provider.
 | autoUpdateTimezone         | No       | Whether to automatically update managed user timezone (default: true)                                          |
 | language                   | No       | Language code (default: "en") - available languages: "en", "de", "fr", "it", "nl", "pt-BR", "es"                                                                          |
 | organizationId             | No       | ID of your organization                                                                                |
+| isEmbed                    | No       | Whether this is an embedded booking (default: false). When true, the `x-cal-platform-embed` header is set for platform-specific behavior                                                                                |


### PR DESCRIPTION
## Summary
Adds missing `isEmbed` prop to the CalProvider documentation.

Fixes #24966

## Changes
- ✅ Added `isEmbed` prop to the props table in `docs/platform/atoms/cal-provider.mdx`
- ✅ Documented that it sets the `x-cal-platform-embed` header
- ✅ Specified default value as `false`

## Context
The `isEmbed` prop was added to CalProvider in #17611 and #18314, but the documentation wasn't updated. This PR completes the documentation to match the current implementation.

## Testing
- [x] Verified the prop exists in `packages/platform/atoms/cal-provider/CalProvider.tsx`
- [x] Confirmed the header is set via `http.setPlatformEmbedHeader()`
- [x] Documentation table is properly formatted