### PR TITLE
feat: use pbac on v2 api org/team event types

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-event-types.controller.ts
@@ -8,11 +8,13 @@ import {
 } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { PlatformPlanGuard } from "@/modules/auth/guards/billing/platform-plan.guard";
 import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-admin-api-enabled.guard";
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
 import { OutputTeamEventTypesResponsePipe } from "@/modules/organizations/event-types/pipes/team-event-types-response.transformer";
@@ -77,7 +79,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
+  @Pbac(["eventType.create"])
   @Post("/teams/:teamId/event-types")
   @ApiOperation({ summary: "Create an event type" })
   async createTeamEventType(
@@ -111,7 +122,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
+  @Pbac(["eventType.read"])
   @Get("/teams/:teamId/event-types/:eventTypeId")
   @ApiOperation({ summary: "Get an event type" })
   async getTeamEventType(
@@ -134,7 +154,8 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @Post("/teams/:teamId/event-types/:eventTypeId/create-phone-call")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, IsTeamInOrg, RolesGuard)
+  @UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, IsTeamInOrg)
+  @Pbac(["eventType.update"])
   @ApiOperation({ summary: "Create a phone call" })
   async createPhoneCall(
     @Param("eventTypeId") eventTypeId: number,
@@ -189,7 +210,8 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(ApiAuthGuard, IsOrgGuard, PbacGuard, RolesGuard, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @Pbac(["eventType.read"])
   @Get("/teams/event-types")
   @ApiOperation({ summary: "Get all team event types" })
   async getTeamsEventTypes(
@@ -211,7 +233,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
+  @Pbac(["eventType.update"])
   @Patch("/teams/:teamId/event-types/:eventTypeId")
   @ApiOperation({ summary: "Update a team event type" })
   async updateTeamEventType(
@@ -242,7 +273,16 @@ export class OrganizationsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, IsOrgGuard, RolesGuard, IsTeamInOrg, PlatformPlanGuard, IsAdminAPIEnabledGuard)
+  @UseGuards(
+    ApiAuthGuard,
+    IsOrgGuard,
+    PbacGuard,
+    RolesGuard,
+    IsTeamInOrg,
+    PlatformPlanGuard,
+    IsAdminAPIEnabledGuard
+  )
+  @Pbac(["eventType.delete"])
   @Delete("/teams/:teamId/event-types/:eventTypeId")
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Delete a team event type" })

--- a/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.ts
+++ b/apps/api/v2/src/modules/teams/event-types/controllers/teams-event-types.controller.ts
@@ -4,8 +4,10 @@ import { API_VERSIONS_VALUES } from "@/lib/api-versions";
 import { API_KEY_HEADER } from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
+import { Pbac } from "@/modules/auth/decorators/pbac/pbac.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
+import { PbacGuard } from "@/modules/auth/guards/pbac/pbac.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { OutputTeamEventTypesResponsePipe } from "@/modules/organizations/event-types/pipes/team-event-types-response.transformer";
 import { InputOrganizationsEventTypesService } from "@/modules/organizations/event-types/services/input.service";
@@ -39,7 +41,6 @@ import { handleCreatePhoneCall } from "@calcom/platform-libraries";
 import {
   CreateTeamEventTypeInput_2024_06_14,
   GetTeamEventTypesQuery_2024_06_14,
-  SkipTakePagination,
   TeamEventTypeOutput_2024_06_14,
   UpdateTeamEventTypeInput_2024_06_14,
 } from "@calcom/platform-types";
@@ -63,7 +64,8 @@ export class TeamsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @PlatformPlan("ESSENTIALS")
-  @UseGuards(ApiAuthGuard, RolesGuard)
+  @UseGuards(ApiAuthGuard, PbacGuard, RolesGuard)
+  @Pbac(["eventType.create"])
   @ApiHeader(API_KEY_HEADER)
   @Post("/")
   @ApiOperation({ summary: "Create an event type" })
@@ -87,7 +89,8 @@ export class TeamsEventTypesController {
   }
 
   @Roles("TEAM_ADMIN")
-  @UseGuards(ApiAuthGuard, RolesGuard)
+  @UseGuards(ApiAuthGuard, PbacGuard, RolesGuard)
+  @Pbac(["eventType.read"])
   @ApiHeader(API_KEY_HEADER)
   @Get("/:eventTypeId")
   @ApiOperation({ summary: "Get an event type" })
@@ -111,7 +114,8 @@ export class TeamsEventTypesController {
 
   @Roles("TEAM_ADMIN")
   @Post("/:eventTypeId/create-phone-call")
-  @UseGuards(ApiAuthGuard, RolesGuard)
+  @UseGuards(ApiAuthGuard, PbacGuard, RolesGuard)
+  @Pbac(["eventType.update"])
   @ApiHeader(API_KEY_HEADER)
   @ApiOperation({ summary: "Create a phone call" })
   async createPhoneCall(
@@ -165,7 +169,8 @@ export class TeamsEventTypesController {
   }
 
   @Roles("TEAM_ADMIN")
-  @UseGuards(ApiAuthGuard, RolesGuard)
+  @UseGuards(ApiAuthGuard, PbacGuard, RolesGuard)
+  @Pbac(["eventType.update"])
   @ApiHeader(API_KEY_HEADER)
   @Patch("/:eventTypeId")
   @ApiOperation({ summary: "Update a team event type" })
@@ -197,7 +202,8 @@ export class TeamsEventTypesController {
   }
 
   @Roles("TEAM_ADMIN")
-  @UseGuards(ApiAuthGuard, RolesGuard)
+  @UseGuards(ApiAuthGuard, PbacGuard, RolesGuard)
+  @Pbac(["eventType.delete"])
   @ApiHeader(API_KEY_HEADER)
   @Delete("/:eventTypeId")
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
Solves #25530 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PBAC permission checks to v2 organization and team event type endpoints. Enforces eventType.create, read, update, and delete permissions and aligns with #25530.

- **New Features**
  - Organizations API: added PbacGuard and @Pbac to create, get, list, update, delete, and create-phone-call endpoints.
  - Teams API: added PbacGuard and @Pbac to create, get, update, delete, and create-phone-call endpoints.

<sup>Written for commit 12f8d46cbe42a61676854c572ebb8e11c8a8d156. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

