### PR TITLE
fix: timezone select menu padding

### DIFF
--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -75,7 +75,6 @@ export function TimezoneSelectComponent({
   classNames: timezoneClassNames,
   timezoneSelectCustomClassname,
   components,
-  variant = "default",
   isPending,
   value,
   size = "md",
@@ -198,7 +197,7 @@ export function TimezoneSelectComponent({
           ),
         menu: (state) =>
           classNames(
-            "rounded-md bg-default text-sm leading-4 text-default mt-1 border border-subtle",
+            "rounded-md bg-default text-sm leading-4 text-default mt-1 border border-subtle p-1",
             state.selectProps.menuIsOpen && "shadow-dropdown", // Add box-shadow when menu is open
             timezoneClassNames?.menu && timezoneClassNames.menu(state)
           ),


### PR DESCRIPTION
## What does this PR do?

Earlier, the Timezone select menu has no padding. leading to inconsistent UI.


- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

**BEFORE:**

<img width="1015" height="921" alt="image" src="https://github.com/user-attachments/assets/f30a04a8-dbc5-4b04-8983-a993aaf52362" />


**AFTER**

<img width="1015" height="921" alt="image" src="https://github.com/user-attachments/assets/3b1ace38-c479-4211-bc96-5e2cf2c8d9b3" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add padding to the Timezone select menu to fix cramped spacing and align it with other inputs. Improves readability of menu items.

<sup>Written for commit 014477dee77bbd9d64e139c9f2f9f83d4b6a57b0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

