### PR TITLE
fix: prevent navigation for disabled booking actions

### DIFF
--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -598,7 +598,7 @@ export function BookingActionsDropdown({
                       type="button"
                       color={action.color}
                       StartIcon={action.icon}
-                      href={action.href}
+                      href={action.disabled ? undefined : action.href}
                       disabled={action.disabled}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -621,7 +621,7 @@ export function BookingActionsDropdown({
                   type="button"
                   color={action.color}
                   StartIcon={action.icon}
-                  href={action.href}
+                  href={action.disabled ? undefined : action.href}
                   disabled={action.disabled}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -642,7 +642,7 @@ export function BookingActionsDropdown({
                   type="button"
                   color={action.color}
                   StartIcon={action.icon}
-                  href={action.href}
+                  href={action.disabled ? undefined : action.href}
                   onClick={(e) => {
                     e.stopPropagation();
                     action.onClick?.(e);


### PR DESCRIPTION
## What does this PR do?






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents navigation from disabled booking actions in the BookingActionsDropdown. Disabled items no longer link out, so accidental clicks won’t redirect.

- **Bug Fixes**
  - Unset href for disabled actions across all dropdown button variants (href is undefined when action.disabled is true).

<sup>Written for commit 73da5d65bdea9805ba24490dd90bda347ea5c907. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







