### PR TITLE
fix: resolve React hydration errors in confirmation dialogs

### DIFF
--- a/apps/web/components/apps/MultiDisconnectIntegration.tsx
+++ b/apps/web/components/apps/MultiDisconnectIntegration.tsx
@@ -108,9 +108,9 @@ export function MultiDisconnectIntegration({ credentials, onSuccess }: Props) {
               });
             }
           }}>
-          <p className="mt-5">
+          <div className="mt-5">
             {t("are_you_sure_you_want_to_remove_this_app_from")} {credentialToDelete?.name || t("unnamed")}?
-          </p>
+          </div>
         </ConfirmationDialogContent>
       </Dialog>
     </>

--- a/apps/web/components/apps/routing-forms/FormActions.tsx
+++ b/apps/web/components/apps/routing-forms/FormActions.tsx
@@ -115,7 +115,7 @@ function NewFormDialog({
               duplicateFrom: formToDuplicate,
             });
           }}>
-          <div className="mt-3 stack-y-5">
+          <div className="stack-y-5 mt-3">
             <TextField label={t("title")} required placeholder={t("a_routing_form")} {...register("name")} />
             <div className="mb-5">
               <TextAreaField
@@ -256,10 +256,12 @@ function Dialogs({
               id: deleteDialogFormId,
             });
           }}>
-          <ul className="list-disc pl-3">
-            <li> {t("delete_form_confirmation")}</li>
-            <li> {t("delete_form_confirmation_2")}</li>
-          </ul>
+          <div>
+            <ul className="list-disc pl-3">
+              <li> {t("delete_form_confirmation")}</li>
+              <li> {t("delete_form_confirmation_2")}</li>
+            </ul>
+          </div>
         </ConfirmationDialogContent>
       </Dialog>
       <NewFormDialog

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -817,16 +817,16 @@ export const InfiniteEventTypeList = ({
             e.preventDefault();
             deleteEventTypeHandler(deleteDialogTypeId);
           }}>
-          <p className="mt-5">
+          <div className="mt-5">
             {deleteDialogTypeSchedulingType === SchedulingType.MANAGED ? (
               <ul className="ml-4 list-disc">
                 <li>{t("delete_managed_event_type_description_1")}</li>
                 <li>{t("delete_managed_event_type_description_2")}</li>
               </ul>
             ) : (
-              t("delete_event_type_description")
+              <p>{t("delete_event_type_description")}</p>
             )}
-          </p>
+          </div>
         </ConfirmationDialogContent>
       </Dialog>
     </div>
@@ -884,8 +884,7 @@ const EmptyEventTypeList = ({
         buttonRaw={
           <Button
             href={`?dialog=new&eventPage=${group.profile.slug}&teamId=${group.teamId}`}
-            variant="button"
-          >
+            variant="button">
             {t("create")}
           </Button>
         }

--- a/packages/features/eventtypes/components/dialogs/DeleteDialog.tsx
+++ b/packages/features/eventtypes/components/dialogs/DeleteDialog.tsx
@@ -30,16 +30,16 @@ export function DeleteDialog({
           e.preventDefault();
           onDelete(eventTypeId);
         }}>
-        <p className="mt-5">
+        <div className="mt-5">
           {isManagedEvent ? (
             <ul className="ml-4 list-disc">
               <li>{t("delete_managed_event_type_description_1")}</li>
               <li>{t("delete_managed_event_type_description_2")}</li>
             </ul>
           ) : (
-            t("delete_event_type_description")
+            <p>{t("delete_event_type_description")}</p>
           )}
-        </p>
+        </div>
       </ConfirmationDialogContent>
     </Dialog>
   );

--- a/packages/features/eventtypes/components/dialogs/ManagedEventDialog.tsx
+++ b/packages/features/eventtypes/components/dialogs/ManagedEventDialog.tsx
@@ -29,7 +29,7 @@ export default function ManagedEventDialog(props: ManagedEventDialogProps) {
         })}
         cancelBtnText={t("go_back")}
         onConfirm={onConfirm}>
-        <p className="mt-5">
+        <div className="mt-5">
           <ServerTrans
             t={t}
             i18nKey={
@@ -47,8 +47,8 @@ export default function ManagedEventDialog(props: ManagedEventDialogProps) {
               slug,
             }}
           />
-        </p>{" "}
-        <p className="mt-5">{t("managed_event_dialog_clarification")}</p>
+        </div>
+        <div className="mt-5">{t("managed_event_dialog_clarification")}</div>
       </ConfirmationDialogContent>
     </Dialog>
   );

--- a/packages/ui/components/dialog/ConfirmationDialogContent.tsx
+++ b/packages/ui/components/dialog/ConfirmationDialogContent.tsx
@@ -68,8 +68,8 @@ export const ConfirmationContent = (props: PropsWithChildren<ConfirmationDialogC
           <DialogPrimitive.Title className="font-cal text-emphasis mt-2 text-xl">
             {title}
           </DialogPrimitive.Title>
-          <DialogPrimitive.Description className="text-subtle text-sm">
-            {children}
+          <DialogPrimitive.Description asChild>
+            <div className="text-subtle text-sm">{children}</div>
           </DialogPrimitive.Description>
         </div>
       </div>

--- a/packages/ui/components/disconnect-calendar-integration/DisconnectIntegration.tsx
+++ b/packages/ui/components/disconnect-calendar-integration/DisconnectIntegration.tsx
@@ -45,7 +45,7 @@ export const DisconnectIntegrationComponent = ({
           title={t("remove_app")}
           confirmBtnText={t("yes_remove_app")}
           onConfirm={onDeletionConfirmation}>
-          <p className="mt-5">{t("are_you_sure_you_want_to_remove_this_app")}</p>
+          <div className="mt-5">{t("are_you_sure_you_want_to_remove_this_app")}</div>
         </ConfirmationDialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #25253
- Fixes [CAL-6781](https://linear.app/calcom/issue/CAL-6781/react-hydration-errors-in-dialog-components-in-html-p-cannot-be-a)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed React hydration errors in confirmation dialogs by correcting HTML structure and making dialog descriptions render consistently on both server and client. Addresses CAL-6781.

- **Bug Fixes**
  - Replaced paragraph tags with div wrappers in dialog content to avoid nested/invalid markup.
  - Set DialogPrimitive.Description to asChild and wrapped children in a div for valid HTML.
  - Applied changes across confirmation dialogs so lists and text render without hydration warnings.

<sup>Written for commit 4824f1a0d9767261b22f6924df4f68560d483ff2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

