### PR TITLE
fix: Api v1 block paths

### DIFF
--- a/apps/api/v1/middleware.ts
+++ b/apps/api/v1/middleware.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const BLOCKED_ROUTE_SEGMENTS = ["_get", "_post", "_patch", "_delete", "_auth-middleware"] as const;
+
+const pathContainsBlockedSegment = (pathname: string) =>
+  pathname
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => BLOCKED_ROUTE_SEGMENTS.includes(segment as (typeof BLOCKED_ROUTE_SEGMENTS)[number]));
+
+export function middleware(request: NextRequest) {
+  if (pathContainsBlockedSegment(request.nextUrl.pathname)) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: BLOCKED_ROUTE_SEGMENTS.flatMap((segment) => [
+    `/:path*/${segment}/:rest*`,
+    `/:path*/${segment}`,
+  ]),
+};


### PR DESCRIPTION
## What does this PR do?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add middleware to API v1 that blocks any path containing reserved segments (_get, _post, _patch, _delete, _auth-middleware).
Returns a 403 JSON response and matches these segments anywhere in the path.

<sup>Written for commit d7e7659a781c52820f89db00aeb3bde1822cd7d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

