### PR TITLE
fix: config is statically analyzed, failing on build

### DIFF
--- a/apps/api/v1/middleware.ts
+++ b/apps/api/v1/middleware.ts
@@ -1,25 +1,19 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export const BLOCKED_ROUTE_SEGMENTS = ["_get", "_post", "_patch", "_delete", "_auth-middleware"] as const;
-
-const pathContainsBlockedSegment = (pathname: string) =>
-  pathname
-    .split("/")
-    .filter(Boolean)
-    .some((segment) => BLOCKED_ROUTE_SEGMENTS.includes(segment as (typeof BLOCKED_ROUTE_SEGMENTS)[number]));
-
-export function middleware(request: NextRequest) {
-  if (pathContainsBlockedSegment(request.nextUrl.pathname)) {
-    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
-  }
-
-  return NextResponse.next();
+export function middleware(_request: NextRequest) {
+  // Matcher guarantees the last segment is one of the blocked segments, so we can
+  // immediately return a 403 without further path checks.
+  return NextResponse.json({ message: "Forbidden" }, { status: 403 });
 }
 
 export const config = {
-  matcher: BLOCKED_ROUTE_SEGMENTS.flatMap((segment) => [
-    `/:path*/${segment}/:rest*`,
-    `/:path*/${segment}`,
-  ]),
+  // The blocked segment is always the last part of the path, so we only need this matcher.
+  matcher: [
+    "/:path*/_get",
+    "/:path*/_post",
+    "/:path*/_patch",
+    "/:path*/_delete",
+    "/:path*/_auth-middleware",
+  ],
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix build failures by replacing the dynamic middleware matcher with explicit patterns. Blocked routes now match statically and return 403 without path parsing.

- **Bug Fixes**
  - Replaced dynamic matcher (BLOCKED_ROUTE_SEGMENTS.flatMap) with explicit entries for _get, _post, _patch, _delete, and _auth-middleware.
  - Simplified middleware to immediately return 403 for matched routes; removed pathContainsBlockedSegment.

<sup>Written for commit 42c5550d0ff514797798cdb2f7cb4b1c99cdbf5a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

