### PR TITLE
fix: simplify credentials provider authorization flow

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -169,21 +169,15 @@ const providers: Provider[] = [
         identifier: hashEmail(user.email),
       });
 
-      if (!user.password?.hash && user.identityProvider !== IdentityProvider.CAL && !credentials.totpCode) {
-        throw new Error(ErrorCode.IncorrectEmailPassword);
-      }
-      if (!user.password?.hash && user.identityProvider == IdentityProvider.CAL) {
+      // Users without a password must use their identity provider (Google/SAML) to login
+      if (!user.password?.hash) {
         throw new Error(ErrorCode.IncorrectEmailPassword);
       }
 
-      if (user.password?.hash && !credentials.totpCode) {
-        if (!user.password?.hash) {
-          throw new Error(ErrorCode.IncorrectEmailPassword);
-        }
-        const isCorrectPassword = await verifyPassword(credentials.password, user.password.hash);
-        if (!isCorrectPassword) {
-          throw new Error(ErrorCode.IncorrectEmailPassword);
-        }
+      // Always verify password for users who have one
+      const isCorrectPassword = await verifyPassword(credentials.password, user.password.hash);
+      if (!isCorrectPassword) {
+        throw new Error(ErrorCode.IncorrectEmailPassword);
       }
 
       if (user.twoFactorEnabled && credentials.backupCode) {


### PR DESCRIPTION
## What does this PR do?

Simplifies the authorization logic in the credentials provider by:
- Consolidating password validation checks into a cleaner flow
- Ensuring users without a password are directed to use their identity provider (Google/SAML)
- Always verifying password for users who have one set

This removes redundant conditional branches and makes the authorization flow more straightforward and easier to audit.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **CAL identity users with password**: Should be able to log in with email/password as normal
2. **CAL identity users with 2FA enabled**: Should be prompted for TOTP code after password verification
3. **Google/SAML users**: Should continue using OAuth flow; credentials endpoint should reject them
4. **Backup code flow**: Should still work for users with 2FA enabled

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run**: https://app.devin.ai/sessions/f865ce4087d345c9a15948b353c833ef
> **Requested by**: alex@cal.com (@emrysal)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the credentials provider auth flow to make password checks consistent and the login rules clear. Users without a password must use their identity provider; users with a password always have it verified. Addresses Linear issue 1764752159.

- **Refactors**
  - Removed provider-specific branches and pre-checks from credentials auth.
  - Centralized password verification for accounts with stored hashes.

<sup>Written for commit 416a38133198f5e06ef074af646d2c10abcfaa46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

