### PR TITLE
fix: use valid upId format in email confirmation link handler

### DIFF
--- a/apps/api/v1/pages/api/invites/_post.ts
+++ b/apps/api/v1/pages/api/invites/_post.ts
@@ -28,12 +28,12 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
           organizationId: null,
           organization: null,
           username: "",
-          upId: "",
+          upId: `usr-${req.userId}`,
         } satisfies UserProfile,
       },
       hasValidLicense: true,
       expires: "",
-      upId: "",
+      upId: `usr-${req.userId}`,
     };
   }
 

--- a/apps/api/v1/pages/api/teams/[teamId]/publish.ts
+++ b/apps/api/v1/pages/api/teams/[teamId]/publish.ts
@@ -29,12 +29,12 @@ const patchHandler = async (req: NextApiRequest, res: NextApiResponse) => {
           organizationId: null,
           organization: null,
           username: "",
-          upId: "",
+          upId: `usr-${req.userId}`,
         } satisfies UserProfile,
       },
       hasValidLicense: true /* To comply with TS signature */,
       expires: "" /* Not used in this context */,
-      upId: "",
+      upId: `usr-${req.userId}`,
     };
   }
   /** @see https://trpc.io/docs/server-side-calls */

--- a/apps/web/app/api/link/route.ts
+++ b/apps/web/app/api/link/route.ts
@@ -49,10 +49,10 @@ const createSessionGetter = (userId: number) => async () => {
         organizationId: null,
         organization: null,
         username: "",
-        upId: "",
+        upId: `usr-${userId}`,
       } satisfies UserProfile,
     },
-    upId: "",
+    upId: `usr-${userId}`,
     hasValidLicense: true,
     expires: "" /* Not used in this context */,
   };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the broken email confirmation flow for bookings that require confirmation.

When an organizer clicked "Confirm" or "Reject" from the email, they were redirected to the attendee-facing screen with an error: `?error=Invalid%20upId%20format%3A%20`

**Root Cause:** The `/api/link` route handler was creating a fake session with an empty `upId` string (`""`). When the TRPC middleware processed this session, it called `ProfileRepository.getLookupTarget("")` which threw an error because an empty string doesn't match any valid upId format (`usr-`, `prof-`, or numeric).

- Fixes #25553
- Fixes [CAL-6861](https://linear.app/calcom/issue/CAL-6861/bug-accept-booking-via-email-broken-requires-confirmation)

## Visual Demo (For contributors especially)

Before:
https://www.loom.com/share/6fa0e7f6b1d34477b008b644aa5704c3

After :
https://www.loom.com/share/94ae17f66c744982aa63b178c6c533f2

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with "Requires confirmation" set to "Always"
2. Create a test booking for that event type
3. Check the organizer's email for the "Awaiting Approval" email with Confirm/Reject buttons
4. Click "Confirm" in the email
5. **Expected:** The booking should be confirmed and you should be redirected to the booking page without errors



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken email confirmation flow for bookings that require approval. The /api/link handler and API v1 routes now set a valid upId (usr-<userId>) so Confirm/Reject links work without errors. Addresses CAL-6861 and #25553.

- **Bug Fixes**
  - Use usr-<userId> upId instead of an empty string when creating fake sessions in /api/link and API v1 routes (invites POST, teams publish), preventing invalid upId errors and redirecting correctly after confirmation.

<sup>Written for commit 36f506ea717e8a9b454aaedde0f32113068d650e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



