### PR TITLE
fix: e2e flake visible on CI

### DIFF
--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -330,7 +330,11 @@ test.describe("Out of office", () => {
     //As member1, OOO is created on Next month 4th - 5th, forwarding to 'owner'
     await member1User?.apiLogin();
     await goToOOOPage(page);
+    const legacyListMembersRespPromise = page.waitForResponse(
+      (response) => response.url().includes("legacyListMembers") && response.status() === 200
+    );
     await openOOODialog(page);
+    await legacyListMembersRespPromise;
     await selectDateAndCreateOOO(page, "4", "5", owner.id);
     await expect(page.locator(`data-testid=table-redirect-${owner.username ?? "n-a"}`).nth(0)).toBeVisible();
   });
@@ -757,5 +761,9 @@ async function goToOOOPage(page: Page, type: "individual" | "team" = "individual
 }
 
 async function openOOODialog(page: Page) {
+  const reasonListRespPromise = page.waitForResponse(
+    (response) => response.url().includes("outOfOfficeReasonList?batch=1") && response.status() === 200
+  );
   await page.getByTestId("add_entry_ooo").click();
+  await reasonListRespPromise;
 }

--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -455,10 +455,12 @@ test.describe("Out of office", () => {
     const entriesListRespPromise = page.waitForResponse(
       (response) => response.url().includes("outOfOfficeEntriesList") && response.status() === 200
     );
+    const legacyListMembersRespPromise = page.waitForResponse(
+      (response) => response.url().includes("legacyListMembers") && response.status() === 200
+    );
     await page.goto("/settings/my-account/out-of-office");
     await page.waitForLoadState("domcontentloaded");
     await entriesListRespPromise;
-
     const addOOOButton = page.getByTestId("add_entry_ooo");
     const dateButton = page.locator('[data-testid="date-range"]');
     const reasonListRespPromise = page.waitForResponse(
@@ -467,6 +469,7 @@ test.describe("Out of office", () => {
     await test.step("As owner,OOO is created on Next month 1st - 3rd, forwarding to 'member-1'", async () => {
       await addOOOButton.click();
       await reasonListRespPromise;
+      await legacyListMembersRespPromise;
       await dateButton.click();
       await selectDateAndCreateOOO(page, "1", "3", member1User?.id);
       await expect(

--- a/apps/web/playwright/out-of-office.e2e.ts
+++ b/apps/web/playwright/out-of-office.e2e.ts
@@ -330,11 +330,7 @@ test.describe("Out of office", () => {
     //As member1, OOO is created on Next month 4th - 5th, forwarding to 'owner'
     await member1User?.apiLogin();
     await goToOOOPage(page);
-    const legacyListMembersRespPromise = page.waitForResponse(
-      (response) => response.url().includes("legacyListMembers") && response.status() === 200
-    );
     await openOOODialog(page);
-    await legacyListMembersRespPromise;
     await selectDateAndCreateOOO(page, "4", "5", owner.id);
     await expect(page.locator(`data-testid=table-redirect-${owner.username ?? "n-a"}`).nth(0)).toBeVisible();
   });
@@ -764,6 +760,9 @@ async function openOOODialog(page: Page) {
   const reasonListRespPromise = page.waitForResponse(
     (response) => response.url().includes("outOfOfficeReasonList?batch=1") && response.status() === 200
   );
+  const hasTeamPlanRespPromise = page.waitForResponse(
+    (response) => response.url().includes("hasTeamPlan?batch=1") && response.status() === 200
+  );
   await page.getByTestId("add_entry_ooo").click();
-  await reasonListRespPromise;
+  await Promise.all([reasonListRespPromise, hasTeamPlanRespPromise]);
 }


### PR DESCRIPTION
1 failed
    [@***com/web] › apps/web/playwright/out-of-office.e2e.ts:440:7 › Out of office › User cannot create infinite or overlapping reverse redirect OOOs

