### PR TITLE
fix: track fallback route in assignment reason for routed bookings

### DIFF
--- a/packages/features/ee/round-robin/assignmentReason/AssignmentReasonRecorder.ts
+++ b/packages/features/ee/round-robin/assignmentReason/AssignmentReasonRecorder.ts
@@ -1,4 +1,5 @@
 import { acrossQueryValueCompatiblity } from "@calcom/app-store/_utils/raqb/raqbUtils";
+import { isFallbackRoute } from "@calcom/app-store/routing-forms/lib/isFallbackRoute";
 import type { FormResponse, Fields } from "@calcom/app-store/routing-forms/types/types";
 import { zodRoutes } from "@calcom/app-store/routing-forms/zod";
 import { withReporting } from "@calcom/lib/sentryWrapper";
@@ -102,7 +103,7 @@ export default class AssignmentReasonRecorder {
 
       const attributeValue = attributeToFilter.value;
 
-      if (!userAttribute || !attributeValue || typeof attributeValue[0] === null) continue;
+      if (!userAttribute || !attributeValue || attributeValue[0] === null) continue;
 
       if (attributeValue && attributeValue[0]) {
         const attributeValueString = (() => {
@@ -117,9 +118,12 @@ export default class AssignmentReasonRecorder {
       }
     }
 
+    const isFallback = isFallbackRoute(takenRoute);
     const reasonEnum = isRerouting
       ? AssignmentReasonEnum.REROUTED
-      : AssignmentReasonEnum.ROUTING_FORM_ROUTING;
+      : isFallback
+        ? AssignmentReasonEnum.ROUTING_FORM_ROUTING_FALLBACK
+        : AssignmentReasonEnum.ROUTING_FORM_ROUTING;
     const reasonString = `${
       isRerouting && reroutedByEmail ? `Rerouted by ${reroutedByEmail}` : ""
     } ${attributeValues.join(", ")}`;


### PR DESCRIPTION
## What does this PR do?

When recording assignment reasons for routed bookings from a form, this PR now tracks whether a fallback route was hit by using the `ROUTING_FORM_ROUTING_FALLBACK` enum value instead of `ROUTING_FORM_ROUTING`.

The `AssignmentReasonEnum.ROUTING_FORM_ROUTING_FALLBACK` value already existed in the schema but was never being used. This change imports the existing `isFallbackRoute` utility and uses it to determine the correct enum value.

Also fixes a pre-existing bug where `typeof attributeValue[0] === null` was used instead of `attributeValue[0] === null` (typeof returns a string, so comparing to null would always be false).

<!-- Link to Devin run: https://app.devin.ai/sessions/f254a849ba3e4d5599767c23b1cced2e -->
<!-- Requested by: joe@cal.com (@joeauyeung) -->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a routing form with multiple routes and a fallback route
2. Submit a form response that doesn't match any specific route (triggers fallback)
3. Complete the booking
4. Check the assignment reason in the database - it should now show `ROUTING_FORM_ROUTING_FALLBACK` instead of `ROUTING_FORM_ROUTING`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings