### PR TITLE
fix: error spam for pbac is not enabled on this team

### DIFF
--- a/packages/trpc/server/routers/viewer/pbac/_router.tsx
+++ b/packages/trpc/server/routers/viewer/pbac/_router.tsx
@@ -193,7 +193,7 @@ export const permissionsRouter = router({
       }
 
       if (!teamHasPBACFeature) {
-        throw new Error("PBAC is not enabled for this team");
+        return [];
       }
 
       // Check if user has permission to view roles


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where when a user calls pbac get roles on a team without pbac we hard throw and throw an error.
Fixing by simpily returning an empty array to prevent spam in sentry
