### PR TITLE
fix: workflow reminder send to all RR hosts.

### DIFF
--- a/packages/features/CalendarEventBuilder.test.ts
+++ b/packages/features/CalendarEventBuilder.test.ts
@@ -980,6 +980,9 @@ describe("CalendarEventBuilder", () => {
     });
 
     it("should create a calendar event from booking with team", async () => {
+      // Note: The CalendarEventBuilder filters team members to only include hosts
+      // whose emails appear in booking.attendees. This simulates a COLLECTIVE event
+      // where all hosts are assigned to the booking.
       const mockBooking = {
         uid: "booking-789",
         metadata: null,
@@ -998,6 +1001,14 @@ describe("CalendarEventBuilder", () => {
             name: "Client",
             email: "client@example.com",
             timeZone: "America/Chicago",
+            locale: "en",
+            phoneNumber: null,
+          },
+          {
+            // Team member host - included in attendees for COLLECTIVE events
+            name: "Team Member",
+            email: "member@example.com",
+            timeZone: "America/Los_Angeles",
             locale: "en",
             phoneNumber: null,
           },
@@ -1647,6 +1658,14 @@ describe("CalendarEventBuilder", () => {
             locale: "en",
             phoneNumber: null,
           },
+          {
+            // Team member host - included in attendees for COLLECTIVE events
+            name: "Team Member",
+            email: "member@example.com",
+            timeZone: "America/Los_Angeles",
+            locale: "en",
+            phoneNumber: null,
+          },
         ],
         user: {
           id: 100,
@@ -1836,12 +1855,14 @@ describe("CalendarEventBuilder", () => {
       expect(builtFromBooking.organizer.username).toBe("teamlead");
       expect(builtFromBooking.organizer.timeZone).toBe("America/New_York");
 
-      expect(builtFromBooking.attendees).toHaveLength(2);
+      expect(builtFromBooking.attendees).toHaveLength(3);
       expect(builtFromBooking.attendees[0].name).toBe("Complete User");
       expect(builtFromBooking.attendees[0].email).toBe("complete@example.com");
       expect(builtFromBooking.attendees[0].timeZone).toBe("America/New_York");
       expect(builtFromBooking.attendees[1].name).toBe("Guest User");
       expect(builtFromBooking.attendees[1].email).toBe("guest@example.com");
+      expect(builtFromBooking.attendees[2].name).toBe("Team Member");
+      expect(builtFromBooking.attendees[2].email).toBe("member@example.com");
 
       expect(builtFromBooking.team).toBeDefined();
       expect(builtFromBooking.team?.id).toBe(50);

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -242,7 +242,7 @@ export class CalendarEventBuilder {
 
       const hostCalendars = [
         user.destinationCalendar,
-        ...hostsWithoutOrganizer.hosts.map((h) => h.user.destinationCalendar).filter(Boolean),
+        ...hostsWithoutOrganizer.map((h) => h.user.destinationCalendar).filter(Boolean),
         user.destinationCalendar,
       ].filter(Boolean) as NonNullable<DestinationCalendar>[];
 

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -241,7 +241,8 @@ export class CalendarEventBuilder {
       );
 
       const hostCalendars = [
-        ...eventType.hosts.map((h) => h.user.destinationCalendar).filter(Boolean),
+        user.destinationCalendar,
+        ...hostsWithoutOrganizer.hosts.map((h) => h.user.destinationCalendar).filter(Boolean),
         user.destinationCalendar,
       ].filter(Boolean) as NonNullable<DestinationCalendar>[];
 

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -235,7 +235,9 @@ export class CalendarEventBuilder {
       );
 
       const hostsWithoutOrganizer = await Promise.all(
-        hostsToInclude.map((h) => _buildPersonFromUser(h.user))
+        hostsToInclude
+          .filter((host) => host.user.email !== user.email)
+          .map((host) => _buildPersonFromUser(host.user))
       );
 
       const hostCalendars = [

--- a/packages/features/CalendarEventBuilder.ts
+++ b/packages/features/CalendarEventBuilder.ts
@@ -234,15 +234,17 @@ export class CalendarEventBuilder {
         bookingAttendees.some((attendee) => attendee.email === host.user.email)
       );
 
+      const hostsWithoutOrganizerData = hostsToInclude.filter(
+        (host) => host.user.email !== user.email
+      );
+
       const hostsWithoutOrganizer = await Promise.all(
-        hostsToInclude
-          .filter((host) => host.user.email !== user.email)
-          .map((host) => _buildPersonFromUser(host.user))
+        hostsWithoutOrganizerData.map((host) => _buildPersonFromUser(host.user))
       );
 
       const hostCalendars = [
         user.destinationCalendar,
-        ...hostsWithoutOrganizer.map((h) => h.user.destinationCalendar).filter(Boolean),
+        ...hostsWithoutOrganizerData.map((h) => h.user.destinationCalendar).filter(Boolean),
         user.destinationCalendar,
       ].filter(Boolean) as NonNullable<DestinationCalendar>[];
 

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, vi, beforeEach, test } from "vitest";
 
 import type { BookingSeatRepository } from "@calcom/features/bookings/repositories/BookingSeatRepository";
 import type { WorkflowReminderRepository } from "@calcom/features/ee/workflows/repositories/WorkflowReminderRepository";
-import { WorkflowActions, WorkflowTemplates, WorkflowTriggerEvents } from "@calcom/prisma/enums";
+import {
+  SchedulingType,
+  TimeUnit,
+  WorkflowActions,
+  WorkflowTemplates,
+  WorkflowTriggerEvents,
+} from "@calcom/prisma/enums";
 import type { CalendarEvent } from "@calcom/types/Calendar";
+
+import { EmailWorkflowService } from "./EmailWorkflowService";
 
 vi.mock("@calcom/emails/workflow-email-service", () => ({
   sendCustomWorkflowEmail: vi.fn(),
@@ -21,8 +29,6 @@ vi.mock("@calcom/prisma", () => ({
   default: {},
   prisma: {},
 }));
-
-import { EmailWorkflowService } from "./EmailWorkflowService";
 
 const mockWorkflowReminderRepository: Pick<WorkflowReminderRepository, "findByIdIncludeStepAndWorkflow"> = {
   findByIdIncludeStepAndWorkflow: vi.fn(),
@@ -154,6 +160,219 @@ describe("EmailWorkflowService", () => {
       }
 
       expect(mockBookingSeatRepository.getByUidIncludeAttendee).toHaveBeenCalledWith("seat-123");
+    });
+  });
+
+  describe("generateParametersToBuildEmailWorkflowContent - EMAIL_HOST", () => {
+    const mockCommonScheduleFunctionParams = {
+      triggerEvent: WorkflowTriggerEvents.BEFORE_EVENT,
+      timeSpan: {
+        time: 24,
+        timeUnit: TimeUnit.HOUR,
+      },
+      workflowStepId: 1,
+      template: WorkflowTemplates.REMINDER,
+      userId: 1,
+      teamId: null,
+      seatReferenceUid: undefined,
+      verifiedAt: new Date(),
+      creditCheckFn: vi.fn().mockResolvedValue(true),
+    };
+
+    const baseMockEvt: Partial<CalendarEvent> = {
+      uid: "booking-123",
+      bookerUrl: "https://cal.com",
+      title: "Test Meeting",
+      startTime: "2024-12-01T10:00:00Z",
+      endTime: "2024-12-01T11:00:00Z",
+      organizer: {
+        name: "Organizer Name",
+        email: "organizer@example.com",
+        timeZone: "UTC",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        language: { locale: "en", translate: (() => "") as any },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        timeFormat: "h:mma" as any,
+      },
+      attendees: [
+        {
+          name: "Attendee Name",
+          email: "attendee@example.com",
+          timeZone: "UTC",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          language: { locale: "en", translate: (() => "") as any },
+        },
+      ],
+    };
+
+    const mockWorkflowStep = {
+      id: 1,
+      action: WorkflowActions.EMAIL_HOST,
+      verifiedAt: new Date(),
+      sendTo: null,
+      template: WorkflowTemplates.REMINDER,
+      reminderBody: null,
+      emailSubject: null,
+      sender: null,
+      includeCalendarEvent: false,
+      numberVerificationPending: false,
+      numberRequired: false,
+    };
+
+    test("should send to organizer only for ROUND_ROBIN scheduling type", async () => {
+      const mockEvt: Partial<CalendarEvent> = {
+        ...baseMockEvt,
+        schedulingType: SchedulingType.ROUND_ROBIN,
+        team: {
+          id: 1,
+          name: "Test Team",
+          members: [
+            {
+              id: 1,
+              name: "Team Member 1",
+              email: "team1@example.com",
+              timeZone: "UTC",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              language: { locale: "en", translate: (() => "") as any },
+            },
+            {
+              id: 2,
+              name: "Team Member 2",
+              email: "team2@example.com",
+              timeZone: "UTC",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              language: { locale: "en", translate: (() => "") as any },
+            },
+          ],
+        },
+      };
+
+      const result = await emailWorkflowService.generateParametersToBuildEmailWorkflowContent({
+        evt: mockEvt as CalendarEvent,
+        workflowStep: mockWorkflowStep,
+        workflow: { userId: 1 },
+        commonScheduleFunctionParams: mockCommonScheduleFunctionParams,
+        hideBranding: false,
+      });
+
+      expect(result.sendTo).toEqual(["organizer@example.com"]);
+      expect(result.sendTo.length).toBe(1);
+    });
+
+    test("should send to organizer and team members for COLLECTIVE scheduling type", async () => {
+      const mockEvt: Partial<CalendarEvent> = {
+        ...baseMockEvt,
+        schedulingType: SchedulingType.COLLECTIVE,
+        team: {
+          id: 1,
+          name: "Test Team",
+          members: [
+            {
+              id: 1,
+              name: "Team Member 1",
+              email: "team1@example.com",
+              timeZone: "UTC",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              language: { locale: "en", translate: (() => "") as any },
+            },
+            {
+              id: 2,
+              name: "Team Member 2",
+              email: "team2@example.com",
+              timeZone: "UTC",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              language: { locale: "en", translate: (() => "") as any },
+            },
+          ],
+        },
+      };
+
+      const result = await emailWorkflowService.generateParametersToBuildEmailWorkflowContent({
+        evt: mockEvt as CalendarEvent,
+        workflowStep: mockWorkflowStep,
+        workflow: { userId: 1 },
+        commonScheduleFunctionParams: mockCommonScheduleFunctionParams,
+        hideBranding: false,
+      });
+
+      expect(result.sendTo).toContain("organizer@example.com");
+      expect(result.sendTo).toContain("team1@example.com");
+      expect(result.sendTo).toContain("team2@example.com");
+      expect(result.sendTo.length).toBe(3);
+    });
+
+    test("should send to organizer only when team is undefined for COLLECTIVE", async () => {
+      const mockEvt: Partial<CalendarEvent> = {
+        ...baseMockEvt,
+        schedulingType: SchedulingType.COLLECTIVE,
+        team: undefined,
+      } as Partial<CalendarEvent>;
+
+      const result = await emailWorkflowService.generateParametersToBuildEmailWorkflowContent({
+        evt: mockEvt as CalendarEvent,
+        workflowStep: mockWorkflowStep,
+        workflow: { userId: 1 },
+        commonScheduleFunctionParams: mockCommonScheduleFunctionParams,
+        hideBranding: false,
+      });
+
+      expect(result.sendTo).toEqual(["organizer@example.com"]);
+      expect(result.sendTo.length).toBe(1);
+    });
+
+    test("should send to organizer only when team members array is empty for COLLECTIVE", async () => {
+      const mockEvt: Partial<CalendarEvent> = {
+        ...baseMockEvt,
+        schedulingType: SchedulingType.COLLECTIVE,
+        team: {
+          id: 1,
+          name: "Test Team",
+          members: [],
+        },
+      };
+
+      const result = await emailWorkflowService.generateParametersToBuildEmailWorkflowContent({
+        evt: mockEvt as CalendarEvent,
+        workflowStep: mockWorkflowStep,
+        workflow: { userId: 1 },
+        commonScheduleFunctionParams: mockCommonScheduleFunctionParams,
+        hideBranding: false,
+      });
+
+      expect(result.sendTo).toEqual(["organizer@example.com"]);
+      expect(result.sendTo.length).toBe(1);
+    });
+
+    test("should send to organizer only for other scheduling types (e.g., null)", async () => {
+      const mockEvt: Partial<CalendarEvent> = {
+        ...baseMockEvt,
+        schedulingType: null,
+        team: {
+          id: 1,
+          name: "Test Team",
+          members: [
+            {
+              id: 1,
+              name: "Team Member 1",
+              email: "team1@example.com",
+              timeZone: "UTC",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              language: { locale: "en", translate: (() => "") as any },
+            },
+          ],
+        },
+      } as Partial<CalendarEvent>;
+
+      const result = await emailWorkflowService.generateParametersToBuildEmailWorkflowContent({
+        evt: mockEvt as CalendarEvent,
+        workflowStep: mockWorkflowStep,
+        workflow: { userId: 1 },
+        commonScheduleFunctionParams: mockCommonScheduleFunctionParams,
+        hideBranding: false,
+      });
+
+      expect(result.sendTo).toEqual(["organizer@example.com"]);
+      expect(result.sendTo.length).toBe(1);
     });
   });
 });

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts
@@ -219,7 +219,9 @@ describe("EmailWorkflowService", () => {
       numberRequired: false,
     };
 
-    test("should send to organizer only for ROUND_ROBIN scheduling type", async () => {
+    test("should send to organizer and team members for ROUND_ROBIN scheduling type", async () => {
+      // Note: For ROUND_ROBIN, the CalendarEventBuilder filters team members to only include
+      // those assigned to the booking. EmailWorkflowService sends to all team members in evt.team.members.
       const mockEvt: Partial<CalendarEvent> = {
         ...baseMockEvt,
         schedulingType: SchedulingType.ROUND_ROBIN,
@@ -255,8 +257,12 @@ describe("EmailWorkflowService", () => {
         hideBranding: false,
       });
 
-      expect(result.sendTo).toEqual(["organizer@example.com"]);
-      expect(result.sendTo.length).toBe(1);
+      // EmailWorkflowService sends to organizer + all team members in evt.team.members
+      // The filtering of team members happens in CalendarEventBuilder, not here
+      expect(result.sendTo).toContain("organizer@example.com");
+      expect(result.sendTo).toContain("team1@example.com");
+      expect(result.sendTo).toContain("team2@example.com");
+      expect(result.sendTo.length).toBe(3);
     });
 
     test("should send to organizer and team members for COLLECTIVE scheduling type", async () => {

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -409,11 +409,14 @@ export class EmailWorkflowService {
     const organizerT = await getTranslation(evt.organizer.language.locale || "en", "common");
 
     const calendarEvent = evt as CalendarEvent;
-    
+
     if (calendarEvent.schedulingType !== SchedulingType.COLLECTIVE) {
       calendarEvent.team = undefined;
     }
-    const teamMemberEmails = new Set(calendarEvent.team?.members.map((member) => member.email.toLowerCase()) || []);
+
+    const teamMemberEmails = new Set(
+      calendarEvent.team?.members.map((member) => member.email.toLowerCase()) || []
+    );
     const uniqueAttendees = evt.attendees.filter(
       (attendee) => !teamMemberEmails.has(attendee.email.toLowerCase())
     );

--- a/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
+++ b/packages/features/ee/workflows/lib/service/EmailWorkflowService.ts
@@ -411,7 +411,6 @@ export class EmailWorkflowService {
 
     const organizerT = await getTranslation(evt.organizer.language.locale || "en", "common");
 
-    // Process all attendees, not just the first one
     const processedAttendees = await Promise.all(
       evt.attendees.map(async (attendee) => {
         const attendeeT = await getTranslation(attendee.language.locale || "en", "common");


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow reminder emails so both round-robin and collective send to the organizer and assigned hosts. Attendee names and locales are processed per person.

- **Bug Fixes**
  - Send to organizer + assigned team members for round-robin and collective.
  - Include only hosts assigned to the booking when building team calendars.
  - Process every attendee with name preprocessing and per-locale translations.

- **Refactors**
  - Import SchedulingType as a value (enum).

<sup>Written for commit 80f829e1ba2470cc1849cd5dbfc54cd842346b7c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











## What does this PR do?

Fixes workflow reminder emails to correctly handle round-robin and collective scheduling types by filtering team members in `CalendarEventBuilder` to only include hosts assigned to the booking.

## Updates since last revision

- Fixed failing test in `EmailWorkflowService.test.ts` for ROUND_ROBIN scheduling type
- Updated test to correctly reflect that `EmailWorkflowService` sends to all team members in `evt.team.members`, while the filtering of team members happens upstream in `CalendarEventBuilder`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/ee/workflows/lib/service/EmailWorkflowService.test.ts`
2. All 9 tests should pass, including the EMAIL_HOST tests for ROUND_ROBIN and COLLECTIVE scheduling types

## Human Review Checklist

- [ ] Verify the test correctly reflects the architecture: `CalendarEventBuilder` filters team members, `EmailWorkflowService` sends to all members in `evt.team.members`
- [ ] Confirm the ROUND_ROBIN test expecting 3 recipients (organizer + 2 team members) is correct given the filtering happens in CalendarEventBuilder

---
Link to Devin run: https://app.devin.ai/sessions/3144a82137964e3e8b8f40a7d4d54b0f
Requested by: joe@cal.com (joe@cal.com) (@joeauyeung)