### PR TITLE
style: improve dropdown option spacing and hover separation

### DIFF
--- a/packages/features/components/timezone-select/TimezoneSelect.tsx
+++ b/packages/features/components/timezone-select/TimezoneSelect.tsx
@@ -205,7 +205,7 @@ export function TimezoneSelectComponent({
         groupHeading: () => "leading-none text-xs uppercase text-default pl-2.5 pt-4 pb-2",
         menuList: (state) =>
           classNames(
-            "scroll-bar scrollbar-track-w-20 rounded-md",
+            "scroll-bar scrollbar-track-w-20 rounded-md flex flex-col space-y-1",
             timezoneClassNames?.menuList && timezoneClassNames.menuList(state)
           ),
         indicatorsContainer: (state) =>

--- a/packages/ui/components/form/select/Select.tsx
+++ b/packages/ui/components/form/select/Select.tsx
@@ -60,7 +60,7 @@ export const Select = <
         input: () => cx("text-emphasis", innerClassNames?.input),
         option: (state) =>
           cx(
-            "bg-default flex cursor-pointer justify-between py-1.5 px-2 rounded-md text-default items-center",
+            "bg-default flex cursor-pointer justify-between py-2 px-3 rounded-md text-default items-center",
             state.isFocused && "bg-subtle",
             state.isDisabled && "bg-cal-muted",
             state.isSelected && "bg-emphasis text-default",
@@ -101,7 +101,7 @@ export const Select = <
         groupHeading: () => "leading-none text-xs text-muted p-2 font-medium ml-1",
         menuList: () =>
           cx(
-            "scroll-bar scrollbar-track-w-20 rounded-md flex flex-col stack-y-px",
+            "scroll-bar scrollbar-track-w-20 rounded-md flex flex-col space-y-1",
             innerClassNames?.menuList
           ),
         indicatorsContainer: (state) =>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## summary

- Adjust select option padding to give weekday options more breathing room vertically.
- Add vertical spacing between menu items so hover/selected states don’t visually merge.
- Reuse shared Select styles so the improvement applies consistently across all dropdowns using this component.


## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

before:

<img width="719" height="218" alt="Screenshot 2025-12-04 at 3 05 15 PM" src="https://github.com/user-attachments/assets/efff9487-4c7b-4710-aecb-bc972bd10574" />

<img width="823" height="143" alt="Screenshot 2025-12-04 at 3 20 25 PM" src="https://github.com/user-attachments/assets/569c4839-11de-4450-a3fa-4b618d253fb4" />

<img width="821" height="139" alt="Screenshot 2025-12-04 at 3 20 35 PM" src="https://github.com/user-attachments/assets/1302393e-332c-4849-ad54-fdff34844ab0" />

<img width="748" height="141" alt="Screenshot 2025-12-04 at 3 20 48 PM" src="https://github.com/user-attachments/assets/b59ed63c-5d4d-4a30-ac4a-ba8e8dcebcc0" />

after:

<img width="917" height="188" alt="Screenshot 2025-12-04 at 3 22 11 PM" src="https://github.com/user-attachments/assets/ff290e11-dff7-44c5-9017-b82f535f2669" />

<img width="835" height="152" alt="Screenshot 2025-12-04 at 3 22 06 PM" src="https://github.com/user-attachments/assets/52401b4e-d672-4f01-91bf-70587ac36640" />

<img width="849" height="124" alt="Screenshot 2025-12-04 at 3 22 01 PM" src="https://github.com/user-attachments/assets/a2ba4858-51d3-4d71-9359-90c71ba289de" />

<img width="826" height="145" alt="Screenshot 2025-12-04 at 3 21 53 PM" src="https://github.com/user-attachments/assets/60cfba41-7b06-49f0-8a41-48b40f36df40" />


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.