### PR TITLE
fix: reset store on getting started

### DIFF
--- a/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
+++ b/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
@@ -32,7 +32,7 @@ export const OnboardingView = ({ userEmail }: OnboardingViewProps) => {
   // Reset onboarding data when visiting this page, but preserve the selected plan
   useEffect(() => {
     resetOnboardingPreservingPlan();
-  }, [resetOnboardingPreservingPlan]);
+  }, []);
 
   // Plan order mapping for determining direction
   const planOrder: Record<PlanType, number> = {

--- a/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
+++ b/apps/web/modules/onboarding/getting-started/onboarding-view.tsx
@@ -25,9 +25,14 @@ type OnboardingViewProps = {
 export const OnboardingView = ({ userEmail }: OnboardingViewProps) => {
   const router = useRouter();
   const { t } = useLocale();
-  const { selectedPlan, setSelectedPlan } = useOnboardingStore();
+  const { selectedPlan, setSelectedPlan, resetOnboardingPreservingPlan } = useOnboardingStore();
   const previousPlanRef = useRef<PlanType | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  // Reset onboarding data when visiting this page, but preserve the selected plan
+  useEffect(() => {
+    resetOnboardingPreservingPlan();
+  }, [resetOnboardingPreservingPlan]);
 
   // Plan order mapping for determining direction
   const planOrder: Record<PlanType, number> = {

--- a/apps/web/modules/onboarding/store/onboarding-store.ts
+++ b/apps/web/modules/onboarding/store/onboarding-store.ts
@@ -87,6 +87,7 @@ export interface OnboardingState {
 
   // Reset
   resetOnboarding: () => void;
+  resetOnboardingPreservingPlan: () => void;
 }
 
 const initialState = {
@@ -167,6 +168,11 @@ export const useOnboardingStore = create<OnboardingState>()(
         })),
 
       resetOnboarding: () => set(initialState),
+      resetOnboardingPreservingPlan: () =>
+        set((state) => ({
+          ...initialState,
+          selectedPlan: state.selectedPlan,
+        })),
     }),
     {
       name: "cal-onboarding-storage", // Storage key


### PR DESCRIPTION
## What does this PR do?
Resuming state was never really used. Onboarding is like 2 steps long so it makes very little sense to have the complexity for restoring. 

Plus if you impersonate or change accounts the state is not tracked nicely at all. 
