### PR TITLE
fix: vertical tab spacing

### DIFF
--- a/packages/ui/components/navigation/tabs/VerticalTabs.tsx
+++ b/packages/ui/components/navigation/tabs/VerticalTabs.tsx
@@ -29,7 +29,7 @@ const NavTabs = function ({
   return (
     <nav
       className={classNames(
-        `no-scrollbar flex flex-col stack-y-0.5 overflow-scroll ${className}`,
+        `no-scrollbar flex flex-col stack-y-1 overflow-scroll ${className}`,
         sticky && "sticky top-0 -mt-7"
       )}
       style={{


### PR DESCRIPTION
## What does this PR do?

## Visual Demo (For contributors especially)

BEFORE: 

[Screencast from 2025-12-04 17-55-05.webm](https://github.com/user-attachments/assets/94b33b98-f6a1-444b-9c26-9cfb2d71499d)

AFTER: 

[Screencast from 2025-12-04 17-50-32.webm](https://github.com/user-attachments/assets/9ff252f0-ea5c-42ba-abf7-ad523684c194)


## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase vertical spacing between items in VerticalTabs to prevent cramped tabs and improve readability. Replaces stack-y-0.5 with stack-y-1 without changing scroll or sticky behavior.

<sup>Written for commit f849dde4c75409b1efab6af75b224ae076bf506b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

