### PR TITLE
chore: added eas (expo pipeline)

### DIFF
--- a/companion/app.json
+++ b/companion/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "expo-wxt-app",
-    "slug": "expo-wxt-app",
+    "slug": "calcom-companion",
     "scheme": "expo-wxt-app",
     "version": "1.0.0",
     "orientation": "portrait",
@@ -15,18 +15,29 @@
     },
     "ios": {
       "supportsTablet": true,
-      "deploymentTarget": "18.0"
+      "deploymentTarget": "18.0",
+      "bundleIdentifier": "com.calcom.companion",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.calcom.companion"
     },
     "web": {
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
-    }
+    },
+    "extra": {
+      "eas": {
+        "projectId": "f5e97f6f-1e95-44ac-bfa4-f737ef90f198"
+      }
+    },
+    "owner": "calcoms-organization"
   }
 }

--- a/companion/eas.json
+++ b/companion/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 16.28.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -31,7 +31,7 @@
         "react-native": "0.81.5",
         "react-native-context-menu-view": "^1.20.0",
         "react-native-gesture-handler": "^2.29.1",
-        "react-native-reanimated": "~3.17.4",
+        "react-native-reanimated": "~3.10.1",
         "react-native-safe-area-context": "5.4.0",
         "react-native-svg": "^15.15.0",
         "react-native-web": "^0.21.2",
@@ -13016,36 +13016,22 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.10.1.tgz",
+      "integrity": "sha512-sfxg6vYphrDc/g4jf/7iJ7NRi+26z2+BszPmvmk0Vnrz6FL7HYljJqTf531F1x6tFmsf+FEAmuCtTUIXFLVo9w==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
         "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
         "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
         "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
         "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4",
-        "react-native-is-edge-to-edge": "1.1.7"
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
-      "license": "MIT",
-      "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }

--- a/companion/package.json
+++ b/companion/package.json
@@ -39,7 +39,7 @@
     "react-native": "0.81.5",
     "react-native-context-menu-view": "^1.20.0",
     "react-native-gesture-handler": "^2.29.1",
-    "react-native-reanimated": "~3.17.4",
+    "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "^15.15.0",
     "react-native-web": "^0.21.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added EAS build pipeline for the Companion app to support internal builds and production releases.

- **New Features**
  - Added companion/eas.json with build profiles: development (dev client, internal), preview (internal), production (autoIncrement), and remote appVersion source.
  - Updated app.json: new slug (calcom-companion), iOS bundleIdentifier, Android package, owner, extra.eas.projectId, and infoPlist encryption flag.

- **Dependencies**
  - Downgraded react-native-reanimated to ~3.10.1.

<sup>Written for commit a2e4f7d4fc78a248dc7c532edbf3dac8b4332595. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

