### PR TITLE
fix: preserve metadata fields during partial event type updates

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
@@ -228,10 +228,16 @@ export class InputEventTypesService_2024_06_14 {
 
     const metadata: EventTypeMetadata = {
       ...metadataTransformed,
-      bookerLayouts: this.transformInputBookerLayouts(bookerLayouts),
-      requiresConfirmationThreshold:
-        confirmationPolicyTransformed?.requiresConfirmationThreshold ?? undefined,
-      multipleDuration: lengthInMinutesOptions,
+      ...(bookerLayouts !== undefined
+        ? { bookerLayouts: this.transformInputBookerLayouts(bookerLayouts) }
+        : {}),
+      ...(confirmationPolicy !== undefined
+        ? {
+            requiresConfirmationThreshold:
+              confirmationPolicyTransformed?.requiresConfirmationThreshold ?? undefined,
+          }
+        : {}),
+      ...(lengthInMinutesOptions !== undefined ? { multipleDuration: lengthInMinutesOptions } : {}),
     };
 
     const eventType = {

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
@@ -1294,10 +1294,10 @@ describe("Organizations Event Types Endpoints", () => {
       expect(updatedEventType.bookingRequiresAuthentication).toEqual(false);
     });
 
-    it("should preserve lengthInMinutesOptions when doing partial update", async () => {
+    it("should preserve metadata fields when doing partial update", async () => {
       const createBody: CreateTeamEventTypeInput_2024_06_14 = {
-        title: "Coding consultation with multiple durations",
-        slug: `organizations-event-types-durations-${randomString()}`,
+        title: "Coding consultation with metadata",
+        slug: `organizations-event-types-metadata-${randomString()}`,
         description: "Our team will review your codebase.",
         lengthInMinutes: 30,
         lengthInMinutesOptions: [15, 30, 60],
@@ -1313,6 +1313,22 @@ describe("Organizations Event Types Endpoints", () => {
             userId: teammate1.id,
           },
         ],
+        bookerLayouts: {
+          enabledLayouts: [
+            BookerLayoutsInputEnum_2024_06_14.column,
+            BookerLayoutsInputEnum_2024_06_14.month,
+            BookerLayoutsInputEnum_2024_06_14.week,
+          ],
+          defaultLayout: BookerLayoutsInputEnum_2024_06_14.month,
+        },
+        confirmationPolicy: {
+          type: ConfirmationPolicyEnum.TIME,
+          noticeThreshold: {
+            count: 60,
+            unit: NoticeThresholdUnitEnum.MINUTES,
+          },
+          blockUnconfirmedBookingsInBooker: true,
+        },
       };
 
       const createResponse = await request(app.getHttpServer())
@@ -1321,10 +1337,16 @@ describe("Organizations Event Types Endpoints", () => {
         .expect(201);
 
       const createdEventType: TeamEventTypeOutput_2024_06_14 = createResponse.body.data;
+
+      // Verify all metadata fields are set correctly on creation
       expect(createdEventType.lengthInMinutesOptions).toBeDefined();
       expect(createdEventType.lengthInMinutesOptions).toEqual([15, 30, 60]);
+      expect(createdEventType.bookerLayouts).toBeDefined();
+      expect(createdEventType.bookerLayouts).toEqual(createBody.bookerLayouts);
+      expect(createdEventType.confirmationPolicy).toBeDefined();
+      expect(createdEventType.confirmationPolicy).toEqual(createBody.confirmationPolicy);
 
-      // Now do a partial update that only changes a different field (not lengthInMinutesOptions)
+      // Now do a partial update that only changes a different field (not metadata fields)
       const updateBody: UpdateTeamEventTypeInput_2024_06_14 = {
         bookingRequiresAuthentication: false,
       };
@@ -1336,9 +1358,13 @@ describe("Organizations Event Types Endpoints", () => {
 
       const updatedEventType: TeamEventTypeOutput_2024_06_14 = updateResponse.body.data;
 
-      // Verify that lengthInMinutesOptions is preserved and not reset to undefined
+      // Verify that all metadata fields are preserved and not reset to undefined
       expect(updatedEventType.lengthInMinutesOptions).toBeDefined();
       expect(updatedEventType.lengthInMinutesOptions).toEqual([15, 30, 60]);
+      expect(updatedEventType.bookerLayouts).toBeDefined();
+      expect(updatedEventType.bookerLayouts).toEqual(createBody.bookerLayouts);
+      expect(updatedEventType.confirmationPolicy).toBeDefined();
+      expect(updatedEventType.confirmationPolicy).toEqual(createBody.confirmationPolicy);
       expect(updatedEventType.bookingRequiresAuthentication).toEqual(false);
     });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the API v2 PATCH endpoint `PATCH /v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}` where partial updates were incorrectly resetting metadata fields to `undefined`.

This is a follow-up to #25450 which fixed the same issue for `seatsPerTimeSlot`. During investigation, we found three additional metadata fields with the same problem:
- `multipleDuration` (exposed as `lengthInMinutesOptions` in the API)
- `bookerLayouts`
- `requiresConfirmationThreshold`

**Root cause:** In `transformInputUpdateEventType`, these metadata fields were being set unconditionally even when their corresponding inputs were `undefined`. When spreading `{ field: undefined }` over the existing metadata, it overwrites the preserved value from the database.

**Fix:** Added conditional spreads to only update these fields when explicitly provided:
```typescript
// Before
const metadata: EventTypeMetadata = {
  ...metadataTransformed,
  bookerLayouts: this.transformInputBookerLayouts(bookerLayouts),
  requiresConfirmationThreshold: confirmationPolicyTransformed?.requiresConfirmationThreshold ?? undefined,
  multipleDuration: lengthInMinutesOptions,
};

// After
const metadata: EventTypeMetadata = {
  ...metadataTransformed,
  ...(bookerLayouts !== undefined ? { bookerLayouts: this.transformInputBookerLayouts(bookerLayouts) } : {}),
  ...(confirmationPolicy !== undefined ? { requiresConfirmationThreshold: ... } : {}),
  ...(lengthInMinutesOptions !== undefined ? { multipleDuration: lengthInMinutesOptions } : {}),
};
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with metadata fields set:
   - `lengthInMinutesOptions` (e.g., `[15, 30, 60]`)
   - `bookerLayouts` (e.g., `{enabledLayouts: ["column", "month", "week"], defaultLayout: "month"}`)
   - `confirmationPolicy` (e.g., `{type: "TIME", noticeThreshold: {count: 60, unit: "MINUTES"}}`)
2. Perform a PATCH request with only a different field (e.g., `{"bookingRequiresAuthentication": false}`)
3. Verify that all metadata fields are preserved and not reset to undefined

The added e2e test (`should preserve metadata fields when doing partial update`) covers all three metadata fields.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

1. **Verify conditional spread logic**: Ensure the `!== undefined` checks correctly distinguish between "field not provided" vs "field explicitly set to null/empty"
2. **Intentional clearing**: Verify users can still explicitly clear these fields by providing appropriate values (e.g., `null` or disabled objects)

---

Link to Devin run: https://app.devin.ai/sessions/399662bef79a44c98c5285577bc273b7
Requested by: morgan@cal.com (@ThyMinimalDev)