### PR TITLE
chore: Companion build notifications

### DIFF
--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -35,3 +35,23 @@ jobs:
       - name: Build browser extension
         working-directory: companion
         run: npm run ext:build
+      - name: Notify Slack on Success
+        if: success()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":large_green_circle: Companion build workflow *${{ github.workflow }}* succeeded in job *${{ github.job }}*.\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":red_circle: Companion build workflow *${{ github.workflow }}* failed in job *${{ github.job }}*.\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## What does this PR do?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Slack notifications to the Companion GitHub Actions build workflow to alert on success or failure, including a link to the run for quick visibility.

Helps the team track build status without checking Actions manually.

<sup>Written for commit 4404aa9f7a954f45ae3a67424869d06dc41cf976. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

