### PR TITLE
fix: prevent overwriting existing event type values with undefined

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -232,7 +232,10 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   const data: Prisma.EventTypeUpdateInput = {
     ...rest,
     // autoTranslate feature is allowed for org users only
-    autoTranslateDescriptionEnabled: !!(ctx.user.organizationId && autoTranslateDescriptionEnabled),
+    // Only set if explicitly provided to avoid overwriting existing value with false
+    ...(autoTranslateDescriptionEnabled !== undefined && {
+      autoTranslateDescriptionEnabled: Boolean(ctx.user.organizationId && autoTranslateDescriptionEnabled),
+    }),
     description: newDescription,
     title: newTitle,
     bookingFields,
@@ -242,7 +245,10 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       rest.rrSegmentQueryValue === null ? Prisma.DbNull : (rest.rrSegmentQueryValue as Prisma.InputJsonValue),
     metadata: rest.metadata === null ? Prisma.DbNull : (rest.metadata as Prisma.InputJsonObject),
     eventTypeColor: eventTypeColor === null ? Prisma.DbNull : (eventTypeColor as Prisma.InputJsonObject),
-    disableGuests: guestsField?.hidden ?? false,
+    // Only set disableGuests if bookingFields is explicitly provided to avoid overwriting existing value
+    ...(bookingFields !== undefined && {
+      disableGuests: guestsField?.hidden ?? false,
+    }),
     seatsPerTimeSlot,
     maxLeadThreshold: isLoadBalancingDisabled ? null : rest.maxLeadThreshold,
   };


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the event type update endpoint where certain fields were being overwritten with `false` even when they weren't explicitly provided in the update request.

**Problem:** When updating an event type, if a field like `autoTranslateDescriptionEnabled` wasn't included in the request, it was being set to `false` instead of preserving the existing value. This happened because:
- `autoTranslateDescriptionEnabled: !!(ctx.user.organizationId && autoTranslateDescriptionEnabled)` evaluates to `false` when `autoTranslateDescriptionEnabled` is `undefined`
- `disableGuests: guestsField?.hidden ?? false` defaults to `false` when `bookingFields` isn't provided

**Solution:** Only set these fields when they are explicitly provided (not `undefined`), using conditional spreading.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create an event type with `autoTranslateDescriptionEnabled` set to `true` (requires organization)
2. Update the event type without including `autoTranslateDescriptionEnabled` in the request
3. Verify that `autoTranslateDescriptionEnabled` remains `true` (previously it would be reset to `false`)

Similarly for `disableGuests`:
1. Create an event type with guests disabled
2. Update the event type without including `bookingFields` in the request
3. Verify that `disableGuests` remains `true` (previously it would be reset to `false`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

### Link to Devin run
https://app.devin.ai/sessions/3771dfb687a246d4a484ef4bea5438ac

### Requested by
joe@cal.com (joe@cal.com) (@joeauyeung)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops event type updates from overwriting unset fields. Existing values for autoTranslateDescriptionEnabled and disableGuests are preserved, aligning with Linear issue 1764871385.

- **Bug Fixes**
  - Only set autoTranslateDescriptionEnabled when explicitly provided, and only for org users.
  - Only set disableGuests when bookingFields is provided (derived from the guests field).

<sup>Written for commit fcaa7ef1a3b1bd7fbd320c8abd229b9e0df05988. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

