### PR TITLE
feat: add externalReference field to Credential model

### DIFF
--- a/packages/prisma/migrations/20251204183447_add_external_reference_to_credential/migration.sql
+++ b/packages/prisma/migrations/20251204183447_add_external_reference_to_credential/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Credential" ADD COLUMN     "externalReference" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -298,6 +298,7 @@ model Credential {
   references             BookingReference[]
   delegationCredentialId String?
   delegationCredential   DelegationCredential? @relation(fields: [delegationCredentialId], references: [id], onDelete: Cascade)
+  externalReference      String?
 
   @@index([appId])
   @@index([subscriptionId])


### PR DESCRIPTION
Generating PR description...

Devin Session: https://app.devin.ai/sessions/37ecc0d286694e71b64435ff879a0fd5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional externalReference field to the Credential model so integrations can store their own external IDs or metadata. Includes a Prisma schema update and migration; no breaking changes.

- **Migration**
  - Run: prisma migrate deploy
  - Regenerate client: prisma generate
  - Optional: backfill externalReference for existing credentials if needed by your integration

<sup>Written for commit 83562e6c3557c3aa70d52879ccf54e7371257b12. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

