### PR TITLE
fix: prevent overwriting webhook time/timeUnit with null when not provided

### DIFF
--- a/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
@@ -62,8 +62,9 @@ export const editHandler = async ({ input, ctx }: EditOptions) => {
     },
     data: {
       ...data,
-      time: data.time ?? null,
-      timeUnit: data.timeUnit ?? null,
+      // Only set time and timeUnit when explicitly provided to avoid overwriting existing values
+      ...(data.time !== undefined && { time: data.time }),
+      ...(data.timeUnit !== undefined && { timeUnit: data.timeUnit }),
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where editing a webhook would unintentionally overwrite the `time` and `timeUnit` fields with `null` even when they weren't explicitly provided in the update request.

**Before:** When editing a webhook without providing `time`/`timeUnit`, the code would set them to `null` via `data.time ?? null`, overwriting any existing scheduling values.

**After:** These fields are only included in the update when explicitly provided (including explicit `null` to clear them).

This follows the same pattern used in the event type update handler fix.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a webhook with scheduling enabled (set `time` and `timeUnit` values)
2. Edit the webhook without changing the scheduling fields (e.g., just update the URL)
3. Verify the `time` and `timeUnit` values are preserved after the edit
4. Also verify that explicitly setting `time`/`timeUnit` to `null` still clears them correctly

## Human Review Checklist

- [ ] Verify the semantic change is correct: fields should only be updated when explicitly provided
- [ ] Verify that explicitly passing `null` still works to clear the scheduling values
- [ ] Consider if unit tests should be added for this behavior

---

> [!NOTE]
> Link to Devin run: https://app.devin.ai/sessions/7b69a90281f742919cecac7026e23198
> Requested by: alex@cal.com (@emrysal)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented webhook edits from overwriting time and timeUnit with null when those fields aren’t provided. This preserves existing scheduling values and addresses Linear issue 1764873729.

<sup>Written for commit 44bceeb4258d50b91708a29c14c97d10ffc7d29d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

