### PR TITLE
feat: add booking selection state when using slideover

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -288,9 +288,10 @@ function BookingListItem(booking: BookingItemProps) {
       data-booking-list-item="true"
       data-booking-uid={booking.uid}
       className={classNames(
-        "group w-full transition-all duration-100 ease-out",
+        "group relative w-full transition-all duration-100 ease-out",
         "hover:bg-cal-muted",
-        isSelected && "bg-cal-muted border-l-4 border-l-brand-default rounded-r-md"
+        isSelected && "bg-cal-muted rounded-r-md",
+        isSelected && "before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:bg-brand-default"
       )}>
       <div className="flex flex-col sm:flex-row">
         <div className="sm:min-w-48 hidden align-top ltr:pl-3 rtl:pr-6 sm:table-cell">

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 
 import { getPaymentAppData } from "@calcom/app-store/_utils/payments/getPaymentAppData";
@@ -41,6 +41,7 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 
 import { buildBookingLink } from "../../modules/bookings/lib/buildBookingLink";
+import { useBookingDetailsSheetStore } from "../../modules/bookings/store/bookingDetailsSheetStore";
 import type { BookingAttendee } from "../../modules/bookings/types";
 import { AcceptBookingButton } from "./AcceptBookingButton";
 import { RejectBookingButton } from "./RejectBookingButton";
@@ -136,6 +137,7 @@ const ConditionalLink = ({
 
 function BookingListItem(booking: BookingItemProps) {
   const parsedBooking = buildParsedBooking(booking);
+  const itemRef = useRef<HTMLDivElement>(null);
 
   const { userTimeZone, userTimeFormat, userEmail } = booking.loggedInUser;
   const { onClick } = booking;
@@ -143,6 +145,21 @@ function BookingListItem(booking: BookingItemProps) {
     t,
     i18n: { language },
   } = useLocale();
+
+  // Get selected booking UID from store
+  // The provider should always be available when BookingListItem is rendered (bookingsV3Enabled is true)
+  const selectedBookingUid = useBookingDetailsSheetStore((state) => state.selectedBookingUid);
+  const isSelected = !!selectedBookingUid && selectedBookingUid === booking.uid;
+
+  // Scroll into view when this booking becomes selected
+  useEffect(() => {
+    if (isSelected && itemRef.current) {
+      itemRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+  }, [isSelected]);
 
   const attendeeList = booking.attendees.map((attendee) => ({
     ...attendee,
@@ -265,10 +282,16 @@ function BookingListItem(booking: BookingItemProps) {
 
   return (
     <div
+      ref={itemRef}
       data-testid="booking-item"
       data-today={String(booking.isToday)}
       data-booking-list-item="true"
-      className="hover:bg-cal-muted group w-full">
+      data-booking-uid={booking.uid}
+      className={classNames(
+        "group w-full transition-all duration-100 ease-out",
+        "hover:bg-cal-muted",
+        isSelected && "bg-cal-muted border-l-4 border-l-brand-default rounded-r-md"
+      )}>
       <div className="flex flex-col sm:flex-row">
         <div className="sm:min-w-48 hidden align-top ltr:pl-3 rtl:pr-6 sm:table-cell">
           <div className="flex h-full items-center">

--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -291,10 +291,11 @@ function BookingListItem(booking: BookingItemProps) {
         "group relative w-full transition-all duration-100 ease-out",
         "hover:bg-cal-muted",
         isSelected && "bg-cal-muted rounded-r-md",
-        isSelected && "before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:bg-brand-default"
+        isSelected &&
+          "before:bg-brand-default before:absolute before:left-0 before:top-0 before:h-full before:w-1"
       )}>
       <div className="flex flex-col sm:flex-row">
-        <div className="sm:min-w-48 hidden align-top ltr:pl-3 rtl:pr-6 sm:table-cell">
+        <div className="hidden align-top sm:table-cell sm:min-w-48 ltr:pl-3 rtl:pr-6">
           <div className="flex h-full items-center">
             {eventTypeColor && <div className="h-[70%] w-0.5" style={{ backgroundColor: eventTypeColor }} />}
             <ConditionalLink onClick={onClick} bookingLink={bookingLink} className="ml-3">
@@ -368,23 +369,23 @@ function BookingListItem(booking: BookingItemProps) {
               </div>
 
               {isPending && (
-                <Badge className="ltr:mr-2 rtl:ml-2 sm:hidden" variant="orange">
+                <Badge className="sm:hidden ltr:mr-2 rtl:ml-2" variant="orange">
                   {t("unconfirmed")}
                 </Badge>
               )}
               {booking.eventType?.team && (
-                <Badge className="ltr:mr-2 rtl:ml-2 sm:hidden" variant="gray">
+                <Badge className="sm:hidden ltr:mr-2 rtl:ml-2" variant="gray">
                   {booking.eventType.team.name}
                 </Badge>
               )}
               {showPendingPayment && (
-                <Badge className="ltr:mr-2 rtl:ml-2 sm:hidden" variant="orange">
+                <Badge className="sm:hidden ltr:mr-2 rtl:ml-2" variant="orange">
                   {t("pending_payment")}
                 </Badge>
               )}
               {isRescheduled && (
                 <Tooltip content={`${t("rescheduled_by")} ${booking.rescheduler}`}>
-                  <Badge variant="orange" className="ltr:mr-2 rtl:ml-2 sm:hidden">
+                  <Badge variant="orange" className="sm:hidden ltr:mr-2 rtl:ml-2">
                     {t("rescheduled")}
                   </Badge>
                 </Tooltip>
@@ -405,7 +406,7 @@ function BookingListItem(booking: BookingItemProps) {
               <div
                 title={title}
                 className={classNames(
-                  "max-w-10/12 sm:max-w-56 text-emphasis break-words text-sm font-medium leading-6 md:max-w-full",
+                  "max-w-10/12 text-emphasis break-words text-sm font-medium leading-6 sm:max-w-56 md:max-w-full",
                   isCancelled ? "line-through" : ""
                 )}>
                 {title}
@@ -419,7 +420,7 @@ function BookingListItem(booking: BookingItemProps) {
               </div>
               {booking.description && (
                 <div
-                  className="max-w-10/12 sm:max-w-32 md:max-w-52 xl:max-w-80 text-default truncate text-sm"
+                  className="max-w-10/12 text-default truncate text-sm sm:max-w-32 md:max-w-52 xl:max-w-80"
                   title={booking.description}>
                   &quot;{booking.description}&quot;
                 </div>
@@ -441,7 +442,7 @@ function BookingListItem(booking: BookingItemProps) {
             </div>
           </ConditionalLink>
         </div>
-        <div className="flex flex-col flex-wrap items-end justify-end gap-2 py-4 pl-4 text-right text-sm font-medium ltr:pr-4 rtl:pl-4 sm:flex-shrink-0 sm:flex-row sm:flex-nowrap sm:items-start sm:pl-0">
+        <div className="flex flex-col flex-wrap items-end justify-end gap-2 py-4 pl-4 text-right text-sm font-medium sm:flex-shrink-0 sm:flex-row sm:flex-nowrap sm:items-start sm:pl-0 ltr:pr-4 rtl:pl-4">
           {shouldShowPendingActions(actionContext) && (
             <div className="flex space-x-2 rtl:space-x-reverse">
               <RejectBookingButton

--- a/apps/web/modules/bookings/components/BookingCalendarView.tsx
+++ b/apps/web/modules/bookings/components/BookingCalendarView.tsx
@@ -24,6 +24,7 @@ export function BookingCalendarView({
   onWeekStartChange,
 }: BookingCalendarViewProps) {
   const setSelectedBookingUid = useBookingDetailsSheetStore((state) => state.setSelectedBookingUid);
+  const selectedBookingUid = useBookingDetailsSheetStore((state) => state.selectedBookingUid);
   const { timezone } = useTimePreferences();
   const { resolvedTheme, forcedTheme } = useGetTheme();
   const { bannersHeight } = useBanners();
@@ -91,6 +92,7 @@ export function BookingCalendarView({
           showBackgroundPattern={false}
           showBorder={false}
           borderColor="subtle"
+          selectedBookingUid={selectedBookingUid}
           onEventClick={(event) => {
             const bookingUid = event.options?.bookingUid;
             if (bookingUid) {

--- a/packages/features/calendars/weeklyview/components/Calendar.tsx
+++ b/packages/features/calendars/weeklyview/components/Calendar.tsx
@@ -67,7 +67,7 @@ function CalendarInner(props: CalendarComponentProps) {
           className="bg-default dark:bg-cal-muted relative isolate flex h-full flex-auto flex-col">
           <div
             style={{ width: "165%" }}
-            className="flex h-full max-w-full flex-none flex-col sm:max-w-none md:max-w-full">
+            className="flex max-w-full flex-none flex-col sm:max-w-none md:max-w-full">
             <DateValues
               containerNavRef={containerNav}
               days={days}
@@ -80,9 +80,9 @@ function CalendarInner(props: CalendarComponentProps) {
                 className={classNames(
                   "bg-default dark:bg-cal-muted ring-muted sticky left-0 z-10 w-16 flex-none ring-1",
                   showBorder &&
-                  (borderColor === "subtle"
-                    ? "border-subtle border-l border-r"
-                    : "border-default border-l border-r")
+                    (borderColor === "subtle"
+                      ? "border-subtle border-l border-r"
+                      : "border-default border-l border-r")
                 )}
               />
               <div
@@ -91,10 +91,10 @@ function CalendarInner(props: CalendarComponentProps) {
                   showBackgroundPattern === false
                     ? undefined
                     : {
-                      backgroundColor: "var(--disabled-gradient-background)",
-                      background:
-                        "repeating-linear-gradient(-45deg, var(--disabled-gradient-background), var(--disabled-gradient-background) 2.5px, var(--disabled-gradient-foreground) 2.5px, var(--disabled-gradient-foreground) 5px)",
-                    }
+                        backgroundColor: "var(--disabled-gradient-background)",
+                        background:
+                          "repeating-linear-gradient(-45deg, var(--disabled-gradient-background), var(--disabled-gradient-background) 2.5px, var(--disabled-gradient-foreground) 2.5px, var(--disabled-gradient-foreground) 5px)",
+                      }
                 }>
                 <HorizontalLines
                   hours={hours}

--- a/packages/features/calendars/weeklyview/components/event/Event.tsx
+++ b/packages/features/calendars/weeklyview/components/event/Event.tsx
@@ -32,7 +32,7 @@ const eventClasses = cva(
         false: "hover:cursor-pointer",
       },
       selected: {
-        true: "bg-inverted text-inverted border border-transparent",
+        true: "",
         false: "",
       },
       borderOnly: {
@@ -120,7 +120,7 @@ export function Event({
             borderOnly: options?.borderOnly ?? false,
           }),
           options?.className,
-          isHovered && "ring-brand-default shadow-lg ring-2 ring-offset-0"
+          (isHovered || selected) && "ring-brand-default shadow-lg ring-2 ring-offset-0"
         )}
         style={{
           transition: "all 100ms ease-out",

--- a/packages/features/calendars/weeklyview/components/event/EventList.tsx
+++ b/packages/features/calendars/weeklyview/components/event/EventList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 
 import dayjs from "@calcom/dayjs";
@@ -64,11 +64,25 @@ export function EventList({ day }: Props) {
   // Find the event ID that matches the selected booking UID (only for events on this day)
   const selectedEventId = useMemo(() => {
     if (!selectedBookingUid) return undefined;
-    const matchingEvent = dayEvents.find(
-      (event) => event.options?.bookingUid === selectedBookingUid
-    );
+    const matchingEvent = dayEvents.find((event) => event.options?.bookingUid === selectedBookingUid);
     return matchingEvent?.id;
   }, [dayEvents, selectedBookingUid]);
+
+  // Scroll to the selected event when it changes
+  useEffect(() => {
+    if (selectedEventId === undefined) return;
+
+    // Use requestAnimationFrame to ensure the DOM has updated
+    requestAnimationFrame(() => {
+      const eventElement = document.querySelector(`[data-calendar-event-id="${selectedEventId}"]`);
+      if (eventElement) {
+        eventElement.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    });
+  }, [selectedEventId]);
 
   return (
     <>
@@ -84,7 +98,7 @@ export function EventList({ day }: Props) {
         const isHovered = hoveredEventId === event.id;
         const isSelected = selectedEventId === event.id;
         const isInHoveredGroup = hoveredGroupIndex !== null && layout.groupIndex === hoveredGroupIndex;
-        const zIndex = isHovered || isSelected ? 100 : layout.baseZIndex;
+        const zIndex = isHovered || isSelected ? 79 : layout.baseZIndex;
 
         return (
           <div
@@ -94,6 +108,7 @@ export function EventList({ day }: Props) {
               event.options?.borderOnly && "pointer-events-none"
             )}
             data-testid={event.options?.["data-test-id"]}
+            data-calendar-event-id={event.id}
             onMouseEnter={() => setHoveredEventId(event.id)}
             onMouseLeave={() => setHoveredEventId(null)}
             style={{

--- a/packages/features/calendars/weeklyview/state/store.ts
+++ b/packages/features/calendars/weeklyview/state/store.ts
@@ -50,6 +50,7 @@ export function createCalendarStore(initial?: Partial<CalendarComponentProps>): 
         ...state,
         blockingDates,
         events,
+        selectedBookingUid: state.selectedBookingUid,
       });
     },
     setSelectedEvent: (event) => set({ selectedEvent: event }),

--- a/packages/features/calendars/weeklyview/types/state.ts
+++ b/packages/features/calendars/weeklyview/types/state.ts
@@ -152,6 +152,10 @@ export type CalendarState = {
    * @default false
    */
   showTimezone?: boolean;
+  /**
+   * Selected booking UID to highlight the corresponding event
+   */
+  selectedBookingUid?: string | null;
 };
 
 export type CalendarComponentProps = CalendarPublicActions & CalendarState & { isPending?: boolean };


### PR DESCRIPTION
## What does this PR do?

https://github.com/user-attachments/assets/6c5ce734-7dc6-4c7b-8176-d33b855a557c


https://github.com/user-attachments/assets/f626d34d-6ae6-43c0-9bbc-6a620494957e













<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a booking selection state that ties the slideover to both the list and weekly calendar. The selected booking is highlighted and auto-scrolled into view to keep context.

- **New Features**
  - Highlights the selected booking in the list and weekly calendar with focus styles (ring, shadow, slight scale).
  - Auto-scrolls the selected booking into view in both the list and weekly calendar.
  - Preserves selection state in the calendar store across event updates.

<sup>Written for commit cb4781005314099d778743439ab252200216bf33. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











