### PR TITLE
chore: enable booking redesign for e2e

### DIFF
--- a/apps/web/playwright/booking-seats.e2e.ts
+++ b/apps/web/playwright/booking-seats.e2e.ts
@@ -555,17 +555,23 @@ test.describe("Reschedule for booking with seats", () => {
     await page.waitForSelector('[data-testid="bookings"]');
 
     await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
-    await page.waitForTimeout(2000);
-    const href = await page.locator('[data-testid="reschedule"]').getAttribute("href");
+
+    // Wait for the reschedule link to be visible and have an href attribute
+    const rescheduleLink = page.locator('[data-testid="reschedule"]');
+    await expect(rescheduleLink).toBeVisible();
+    await expect(rescheduleLink).toHaveAttribute("href", /.+/);
+
+    const href = await rescheduleLink.getAttribute("href");
     const url = new URL(href!, page.url());
-    const seatReferenceUid = url.searchParams.get('seatReferenceUid');
-    if(!seatReferenceUid) {
+    const seatReferenceUid = url.searchParams.get("seatReferenceUid");
+    if (!seatReferenceUid) {
       await page.reload();
       await page.waitForSelector('[data-testid="bookings"]');
       await page.locator('[data-testid="booking-actions-dropdown"]').nth(0).click();
-      await page.waitForTimeout(2000);
+      await expect(rescheduleLink).toBeVisible();
+      await expect(rescheduleLink).toHaveAttribute("href", /.+/);
     }
-    await page.locator('[data-testid="reschedule"]').click();
+    await rescheduleLink.click();
     await expect(page.getByText("Seats available").first()).toBeVisible();
 
     await page.waitForURL((url) => {

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -305,12 +305,12 @@ export const createUsersFixture = (
              * @default DEFAULT_USER_FEATURE_FLAGS
              * @example
              * ```typescript
-             * // User without feature flags (default)
+             * // Default feature flags
              * const user = await users.create();
              *
-             * // User with specific feature flags
+             * // Specific feature flags
              * const user = await users.create({
-             *   userFeatureFlags: ["calendar-cache", "insights"]
+             *   userFeatureFlags: ["bookings-v3"]
              * });
              * ```
              */
@@ -348,23 +348,20 @@ export const createUsersFixture = (
          * @default DEFAULT_TEAM_FEATURE_FLAGS
          * @example
          * ```typescript
-         * // Use default flags (bookings-v3)
+         * // Default feature flags
          * const user = await users.create({}, { hasTeam: true });
          *
-         * // Disable all feature flags
-         * const user = await users.create({}, { hasTeam: true, teamFeatureFlags: [] });
-         *
-         * // Use custom flags
+         * // Specific feature flags
          * const user = await users.create({}, {
          *   hasTeam: true,
-         *   teamFeatureFlags: ["restriction-schedule", "pbac"]
+         *   teamFeatureFlags: ["pbac"]
          * });
          *
-         * // Organizations also get the flags
+         * // Organizations also get the flags by default
          * const user = await users.create({}, {
          *   hasTeam: true,
          *   isOrg: true
-         * }); // Org gets bookings-v3
+         * }); // Org gets DEFAULT_TEAM_FEATURE_FLAGS
          * ```
          */
         teamFeatureFlags?: Array<keyof AppFlags>;

--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -6,6 +6,7 @@ import { v4 } from "uuid";
 
 import updateChildrenEventTypes from "@calcom/features/ee/managed-event-types/lib/handleChildrenEventTypes";
 import stripe from "@calcom/features/ee/payments/server/stripe";
+import type { AppFlags } from "@calcom/features/flags/config";
 import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { DEFAULT_SCHEDULE, getAvailabilityFromSchedule } from "@calcom/lib/availability";
 import { WEBAPP_URL } from "@calcom/lib/constants";
@@ -26,6 +27,18 @@ export function hashPassword(password: string) {
   const hashedPassword = hash(password, 12);
   return hashedPassword;
 }
+
+/**
+ * Default feature flags enabled for all teams and organizations created in E2E tests.
+ * These flags represent the most common production features that should be tested by default.
+ */
+const DEFAULT_TEAM_FEATURE_FLAGS: Array<keyof AppFlags> = [];
+
+/**
+ * Default feature flags enabled for individual users created in E2E tests.
+ * Empty by default - users don't typically have feature flags unless explicitly needed.
+ */
+const DEFAULT_USER_FEATURE_FLAGS: Array<keyof AppFlags> = ["bookings-v3"];
 
 type UserFixture = ReturnType<typeof createUserFixture>;
 
@@ -155,6 +168,7 @@ const createTeamAndAddUser = async (
     schedulingType,
     assignAllTeamMembersForSubTeamEvents,
     teamSlug,
+    teamFeatureFlags,
   }: {
     user: { id: number; email: string; username: string | null; role?: MembershipRole };
     isUnpublished?: boolean;
@@ -168,6 +182,7 @@ const createTeamAndAddUser = async (
     schedulingType?: SchedulingType;
     assignAllTeamMembersForSubTeamEvents?: boolean;
     teamSlug?: string;
+    teamFeatureFlags?: Array<keyof AppFlags>;
   },
   workerInfo: WorkerInfo
 ) => {
@@ -196,13 +211,14 @@ const createTeamAndAddUser = async (
 
   data.slug = !isUnpublished ? slug : undefined;
   if (isOrg && hasSubteam) {
-    const team = await createTeamAndAddUser({ user }, workerInfo);
-    await createTeamEventType(user, team, {
+    const subteam = await createTeamAndAddUser({ user, teamFeatureFlags }, workerInfo);
+
+    await createTeamEventType(user, subteam, {
       schedulingType: schedulingType,
       assignAllTeamMembers: assignAllTeamMembersForSubTeamEvents,
     });
-    await createTeamWorkflow(user, team);
-    data.children = { connect: [{ id: team.id }] };
+    await createTeamWorkflow(user, subteam);
+    data.children = { connect: [{ id: subteam.id }] };
   }
   data.orgProfiles = isOrg
     ? {
@@ -234,6 +250,18 @@ const createTeamAndAddUser = async (
       accepted: true,
     },
   });
+
+  // Enable feature flags for the team if specified
+  if (teamFeatureFlags && teamFeatureFlags.length > 0) {
+    await prisma.teamFeatures.createMany({
+      data: teamFeatureFlags.map((featureFlag) => ({
+        teamId: team.id,
+        featureId: featureFlag,
+        assignedBy: "e2e-fixture",
+        assignedAt: new Date(),
+      })),
+    });
+  }
 
   return team;
 };
@@ -270,6 +298,23 @@ export const createUsersFixture = (
         | (CustomUserOpts & {
             organizationId?: number | null;
             overrideDefaultEventTypes?: boolean;
+            /**
+             * Feature flags to enable for this individual user.
+             * Defaults to DEFAULT_USER_FEATURE_FLAGS.
+             * Pass specific flags to enable user-level features.
+             * @default DEFAULT_USER_FEATURE_FLAGS
+             * @example
+             * ```typescript
+             * // User without feature flags (default)
+             * const user = await users.create();
+             *
+             * // User with specific feature flags
+             * const user = await users.create({
+             *   userFeatureFlags: ["calendar-cache", "insights"]
+             * });
+             * ```
+             */
+            userFeatureFlags?: Array<keyof AppFlags>;
           })
         | null,
       scenario: {
@@ -295,6 +340,34 @@ export const createUsersFixture = (
         orgRequestedSlug?: string;
         assignAllTeamMembers?: boolean;
         assignAllTeamMembersForSubTeamEvents?: boolean;
+        /**
+         * Feature flags to enable for the created team(s) and organization(s).
+         * Defaults to DEFAULT_TEAM_FEATURE_FLAGS when hasTeam is true.
+         * Pass an empty array to disable default flags, or pass specific flags to override.
+         * Applies to both regular teams and organizations (when isOrg: true).
+         * @default DEFAULT_TEAM_FEATURE_FLAGS
+         * @example
+         * ```typescript
+         * // Use default flags (bookings-v3)
+         * const user = await users.create({}, { hasTeam: true });
+         *
+         * // Disable all feature flags
+         * const user = await users.create({}, { hasTeam: true, teamFeatureFlags: [] });
+         *
+         * // Use custom flags
+         * const user = await users.create({}, {
+         *   hasTeam: true,
+         *   teamFeatureFlags: ["restriction-schedule", "pbac"]
+         * });
+         *
+         * // Organizations also get the flags
+         * const user = await users.create({}, {
+         *   hasTeam: true,
+         *   isOrg: true
+         * }); // Org gets bookings-v3
+         * ```
+         */
+        teamFeatureFlags?: Array<keyof AppFlags>;
       } = {}
     ) => {
       const _user = await prisma.user.create({
@@ -347,9 +420,27 @@ export const createUsersFixture = (
         where: { id: _user.id },
         include: userIncludes,
       });
+
+      // Enable feature flags for the user if specified
+      // Default to DEFAULT_USER_FEATURE_FLAGS if not specified
+      const userFeatureFlags = opts?.userFeatureFlags ?? DEFAULT_USER_FEATURE_FLAGS;
+      if (userFeatureFlags.length > 0) {
+        await prisma.userFeatures.createMany({
+          data: userFeatureFlags.map((featureFlag) => ({
+            userId: user.id,
+            featureId: featureFlag,
+            assignedBy: "e2e-fixture",
+            assignedAt: new Date(),
+          })),
+        });
+      }
+
       if (scenario.hasTeam) {
         const numberOfTeams = scenario.numberOfTeams || 1;
         for (let i = 0; i < numberOfTeams; i++) {
+          // Determine feature flags to use
+          const featureFlags = scenario.teamFeatureFlags ?? DEFAULT_TEAM_FEATURE_FLAGS;
+
           const team = await createTeamAndAddUser(
             {
               user: {
@@ -368,10 +459,12 @@ export const createUsersFixture = (
               schedulingType: scenario.schedulingType,
               assignAllTeamMembersForSubTeamEvents: scenario.assignAllTeamMembersForSubTeamEvents,
               teamSlug: scenario?.teamSlug,
+              teamFeatureFlags: featureFlags,
             },
             workerInfo
           );
           store.teams.push(team);
+
           const teamEvent = await createTeamEventType(user, team, scenario);
           if (scenario.teammates) {
             // Create Teammate users


### PR DESCRIPTION
## What does this PR do?

This PR enables bookings-v3 feature flag globally for e2e tests, and fixes some failing tests.

- Fixes CAL-6926



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the bookings-v3 redesign for E2E by default and stabilizes bookings tests for rescheduling and no‑show updates.

- **New Features**
  - User fixtures enable bookings-v3 by default; team/org fixtures support configurable feature flags.

- **Bug Fixes**
  - Reschedule test waits for a valid href before clicking.
  - No-show assertions use data-state instead of checkbox checked.
  - Removed unused setup and simplified assertions in bookings list/past tests.

<sup>Written for commit 6023e624a2b1bd55289c5c7774cce1317684ddbf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













