### PR TITLE
fix: replace workflow upsert transaction with createMany to prevent timeouts

### DIFF
--- a/apps/web/test/lib/handleChildrenEventTypes.test.ts
+++ b/apps/web/test/lib/handleChildrenEventTypes.test.ts
@@ -658,19 +658,11 @@ describe("handleChildrenEventTypes", () => {
           },
         },
       });
-      // Verify workflowsOnEventTypes.upsert was called for existing users' workflows
-      expect(prismaMock.workflowsOnEventTypes.upsert).toHaveBeenCalledWith({
-        create: {
-          eventTypeId: 2,
-          workflowId: 11,
-        },
-        update: {},
-        where: {
-          workflowId_eventTypeId: {
-            eventTypeId: 2,
-            workflowId: 11,
-          },
-        },
+      // Verify workflowsOnEventTypes.createMany was called for existing users' workflows
+      // Note: createMany is called twice - once for new users (in transaction) and once for existing users
+      expect(prismaMock.workflowsOnEventTypes.createMany).toHaveBeenCalledWith({
+        data: [{ eventTypeId: 2, workflowId: 11 }],
+        skipDuplicates: true,
       });
     });
   });


### PR DESCRIPTION
Generating PR description...

Devin Session: https://app.devin.ai/sessions/acf3d7eff700467ab6ea3deaabfaadab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced N×M workflow upsert transactions with a single createMany call using skipDuplicates to prevent timeouts when updating managed event types with many children. Ensures lock/unlock changes propagate reliably across all child event types.

- **Bug Fixes**
  - Build workflow connections once and insert via createMany with skipDuplicates (replaces $transaction + upserts; consistent with new user handling).
  - Updated tests to assert createMany is called for existing workflows.

<sup>Written for commit 5bbe47e22838d903a8aab82dcd865d24248d3b8d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

