### PR TITLE
perf: handleChildrenEventType eventtype user connect raw sql

### DIFF
--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -261,19 +261,6 @@ export default async function handleChildrenEventTypes({
         }
       }
 
-      await Promise.all(
-        createdEvents.map((event) =>
-          tx.eventType.update({
-            where: { id: event.id },
-            data: {
-              users: {
-                connect: [{ id: event.userId! }],
-              },
-            },
-          })
-        )
-      );
-
       // Link workflows if any exist
       if (currentWorkflowIds && currentWorkflowIds.length > 0) {
         const workflowConnections = createdEvents.flatMap((event) =>

--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -114,16 +114,14 @@ function connectUsersToEventTypesQueryWithParams(
     }
   }
 
-  // --- The Raw SQL Query ---
   const sqlQuery = `
         INSERT INTO "_user_eventtype" ("A", "B") 
         VALUES 
         ${valuePlaceholders.join(",\n")}
-        -- ON CONFLICT prevents inserting duplicate relationships and throwing an error
         ON CONFLICT DO NOTHING;
     `;
 
-  // Execute the raw SQL command, spreading the parameters array
+  // sqlQuery and its parameters for execution
   return { sqlQuery, parameters };
 }
 


### PR DESCRIPTION
## What does this PR do?

Bulk-connect users to event types in handleChildrenEventTypes using a parameterized raw SQL insert. This reduces many per-event updates to a single batched write and avoids duplicate links.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bulk-connect users to event types in handleChildrenEventTypes using a parameterized raw SQL insert. This reduces many per-event updates to a single batched write and avoids duplicate links.

- **Performance**
  - Added connectUsersToEventTypesQueryWithParams to build a parameterized INSERT into "_user_eventtype" with ON CONFLICT DO NOTHING.
  - Executes one SQL call for all new user–event type pairs when creating child event types.
  - Cuts DB calls and speeds up large managed event type operations.

<sup>Written for commit 02aa8e05c0baac6074d79f6107fccab48b7d85e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







