### PR TITLE
style: adjust dark hover background for user page to subtle

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -115,7 +115,7 @@ export function UserPage(props: PageProps) {
                     eventType: type,
                   });
                 }}
-                className="bg-default border-subtle dark:bg-cal-muted dark:hover:bg-emphasis hover:bg-cal-muted group relative border-b transition first:rounded-t-md last:rounded-b-md last:border-b-0"
+                className="bg-default border-subtle dark:bg-cal-muted dark:hover:bg-subtle hover:bg-cal-muted group relative border-b transition first:rounded-t-md last:rounded-b-md last:border-b-0"
                 data-testid="event-type-link">
                 <Icon
                   name="arrow-right"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #25661
- Fixes [CAL-6876](https://linear.app/calcom/issue/CAL-6876/hover-state-on-event-type-links-uses-incorrect-background-color-token)
## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:
<img width="885" height="154" alt="Screenshot 2025-12-06 at 3 12 33 PM" src="https://github.com/user-attachments/assets/e6beb04a-5889-41bf-883f-7b7a5323f4fc" />

after:
<img width="808" height="126" alt="Screenshot 2025-12-06 at 3 24 49 PM" src="https://github.com/user-attachments/assets/c1811846-2ae4-4bb5-8d27-56c22e5af00c" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the dark-mode hover background on event type links in the user page to use the subtle token for a softer, consistent look. Addresses CAL-6876 and fixes #25661 by replacing dark:hover:bg-emphasis with dark:hover:bg-subtle.

<sup>Written for commit 1a47429f5098a3e941a60e57202a323fd939adf1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

