### PR TITLE
issue #25589 solved

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/booking-fields.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/booking-fields.ts
@@ -1,5 +1,6 @@
 import type {
   InputBookingField_2024_06_14,
+  PhoneDefaultFieldInput_2024_06_14,
   PhoneDefaultFieldOutput_2024_06_14,
   MultiSelectFieldInput_2024_06_14,
   CheckboxGroupFieldInput_2024_06_14,
@@ -28,7 +29,7 @@ import {
   systemBeforeFieldNameSplit,
 } from "../internal-to-api";
 
-type InputBookingField = InputBookingField_2024_06_14 | PhoneDefaultFieldOutput_2024_06_14;
+type InputBookingField = InputBookingField_2024_06_14 | PhoneDefaultFieldInput_2024_06_14 | PhoneDefaultFieldOutput_2024_06_14;
 
 export function transformBookingFieldsApiToInternal(bookingFields: InputBookingField[]) {
   const customBookingFields = bookingFields.map((field) => {
@@ -79,14 +80,23 @@ function getBaseProperties(field: InputBookingField): CustomField | SystemField 
   }
 
   if (fieldIsDefaultAttendeePhone(field)) {
-    return {
+    const phoneField: any = {
       ...systemBeforeFieldPhone,
       required: field.required,
       hidden: field.hidden,
-      label: field.label,
-      placeholder: field.placeholder,
       disableOnPrefill: !!field.disableOnPrefill,
     };
+
+    // Only override label if explicitly provided, otherwise use defaultLabel from systemBeforeFieldPhone
+    if (field.label !== undefined) {
+      phoneField.label = field.label;
+    }
+
+    if (field.placeholder !== undefined) {
+      phoneField.placeholder = field.placeholder;
+    }
+
+    return phoneField;
   }
 
   if (fieldIsCustomSystemName(field)) {
@@ -286,7 +296,9 @@ function fieldIsCustomSystemRescheduleReason(
   return "slug" in field && field.slug === "rescheduleReason";
 }
 
-function fieldIsDefaultAttendeePhone(field: InputBookingField): field is PhoneDefaultFieldOutput_2024_06_14 {
+function fieldIsDefaultAttendeePhone(
+  field: InputBookingField
+): field is PhoneDefaultFieldInput_2024_06_14 | PhoneDefaultFieldOutput_2024_06_14 {
   const isPhone = "type" in field && field.type === "phone";
   const isAttendeePhoneNumber = "slug" in field && field.slug === "attendeePhoneNumber";
   return isPhone && isAttendeePhoneNumber;

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -23,7 +23,14 @@ const inputBookingFieldTypes = [
   "url",
 ] as const;
 
-const inputBookingFieldSlugs = ["title", "location", "notes", "guests", "rescheduleReason"] as const;
+const inputBookingFieldSlugs = [
+  "title",
+  "location",
+  "notes",
+  "guests",
+  "rescheduleReason",
+  "attendeePhoneNumber",
+] as const;
 
 export class NameDefaultFieldInput_2024_06_14 {
   @IsIn(inputBookingFieldTypes)
@@ -146,6 +153,53 @@ export class EmailDefaultFieldInput_2024_06_14 {
       "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.\
       For example, if URL contains query parameter `&email=bob@gmail.com`,\
       the email field will be prefilled with this value and disabled. In case of Booker atom need to pass 'email' to defaultFormValues prop with the desired value e.g. `defaultFormValues={{email: 'bob@gmail.com'}}`. See guide https://cal.com/docs/platform/guides/booking-field",
+  })
+  disableOnPrefill?: boolean;
+}
+
+export class PhoneDefaultFieldInput_2024_06_14 {
+  @IsIn(inputBookingFieldSlugs)
+  @DocsProperty({
+    example: "attendeePhoneNumber",
+    description: "only allowed value for slug is `attendeePhoneNumber`",
+  })
+  slug!: "attendeePhoneNumber";
+
+  @IsIn(inputBookingFieldTypes)
+  @DocsProperty({
+    example: "phone",
+    description: "only allowed value for type is `phone`",
+  })
+  type!: "phone";
+
+  @IsString()
+  @IsOptional()
+  @DocsProperty()
+  label?: string;
+
+  @IsBoolean()
+  @DocsProperty()
+  required!: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @DocsPropertyOptional({
+    description:
+      "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
+  })
+  hidden?: boolean;
+
+  @IsString()
+  @IsOptional()
+  @DocsProperty()
+  placeholder?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @DocsPropertyOptional({
+    type: Boolean,
+    description:
+      "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.\      For example, if URL contains query parameter `&attendeePhoneNumber=+37122222222`,\      the phone field will be prefilled with this value and disabled. In case of Booker atom need to pass 'attendeePhoneNumber' to defaultFormValues prop with the desired value e.g. `defaultFormValues={{attendeePhoneNumber: '+37122222222'}}`. See guide https://cal.com/docs/platform/guides/booking-field",
   })
   disableOnPrefill?: boolean;
 }
@@ -887,6 +941,7 @@ type InputDefaultField_2024_06_14 =
   | NameDefaultFieldInput_2024_06_14
   | SplitNameDefaultFieldInput_2024_06_14
   | EmailDefaultFieldInput_2024_06_14
+  | PhoneDefaultFieldInput_2024_06_14
   | TitleDefaultFieldInput_2024_06_14
   | LocationDefaultFieldInput_2024_06_14
   | NotesDefaultFieldInput_2024_06_14
@@ -914,6 +969,7 @@ class InputBookingFieldValidator_2024_06_14 implements ValidatorConstraintInterf
     name: NameDefaultFieldInput_2024_06_14,
     splitName: SplitNameDefaultFieldInput_2024_06_14,
     email: EmailDefaultFieldInput_2024_06_14,
+    attendeePhoneNumber: PhoneDefaultFieldInput_2024_06_14,
     title: TitleDefaultFieldInput_2024_06_14,
     location: LocationDefaultFieldInput_2024_06_14,
     notes: NotesDefaultFieldInput_2024_06_14,
@@ -950,15 +1006,16 @@ class InputBookingFieldValidator_2024_06_14 implements ValidatorConstraintInterf
         slug !== "notes" &&
         slug !== "guests" &&
         slug !== "rescheduleReason" &&
-        slug !== "location";
+        slug !== "location" &&
+        slug !== "attendeePhoneNumber";
 
       if (fieldNeedsType && !type) {
         throw new BadRequestException(
-          `All booking fields except ones with slug equal to title, notes, guests, rescheduleReason and location must have a 'type' property.`
+          `All booking fields except ones with slug equal to title, notes, guests, rescheduleReason, location and attendeePhoneNumber must have a 'type' property.`
         );
       }
 
-      const fieldNeedsSlug = type !== "name" && type !== "splitName" && type !== "email";
+      const fieldNeedsSlug = type !== "name" && type !== "splitName" && type !== "email" && slug !== "attendeePhoneNumber";
       if (fieldNeedsSlug && !slug) {
         throw new BadRequestException(
           `Each booking field except ones with type equal to name, splitName, email must have a 'slug' property.`


### PR DESCRIPTION
# Phone Booking Field Label Fix

## Issue #25589 
When creating event types via the v2 API, phone booking fields required a `label` property, causing this error:
```
400 Bad Request - Validation failed for phone booking field: label must be a string
```

This prevented using the default translatable label (like the UI does), breaking multilingual support.

## Solution
Created `PhoneDefaultFieldInput_2024_06_14` class with optional `label` field. When `label` is omitted, the system uses the default translatable `"phone_number"` label.

## Changes Made

### 1. `packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts`
- Added `attendeePhoneNumber` to `inputBookingFieldSlugs` constant
- Created `PhoneDefaultFieldInput_2024_06_14` class with optional `label` field
- Added class to `InputDefaultField_2024_06_14` union type
- Updated validator to handle `attendeePhoneNumber` as special slug (doesn't require `type` property)

### 2. `apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/booking-fields.ts`
- Imported `PhoneDefaultFieldInput_2024_06_14` type
- Updated `fieldIsDefaultAttendeePhone` type guard to accept both input and output types
- Modified transformation to conditionally set `label` only when provided, preserving default translatable label otherwise

## Usage

**Without label (uses translatable default):**
```json
{
  "bookingFields": [
    {
      "slug": "attendeePhoneNumber",
      "required": true
    }
  ]
}
```

**With custom label:**
```json
{
  "bookingFields": [
    {
      "slug": "attendeePhoneNumber",
      "required": true,
      "label": "Your Contact Number"
    }
  ]
}
```

## Benefits
Preserves multilingual support  
Backward compatible  
Matches UI behavior  
Fixes N8N automation issues

---
**Fixed by:** Raunak | **Date:** December 6, 2025
