### PR TITLE
fix: email reject button not working in organizer request email

### DIFF
--- a/apps/web/app/api/verify-booking-token/route.ts
+++ b/apps/web/app/api/verify-booking-token/route.ts
@@ -35,13 +35,6 @@ async function getHandler(request: NextRequest) {
   try {
     const { action, token, bookingUid, userId } = querySchema.parse(queryParams);
 
-    if (action === DirectAction.REJECT) {
-      // Rejections should use POST method
-      return NextResponse.redirect(
-        `${url.origin}/booking/${bookingUid}?error=${encodeURIComponent("Rejection requires POST method")}`
-      );
-    }
-
     return await handleBookingAction(action, token, bookingUid, userId, request, undefined);
   } catch (error) {
     const bookingUid = queryParams.bookingUid || "";

--- a/packages/emails/src/templates/OrganizerRequestEmailV2.tsx
+++ b/packages/emails/src/templates/OrganizerRequestEmailV2.tsx
@@ -1,6 +1,6 @@
 import { WEBAPP_URL } from "@calcom/lib/constants";
 
-import { CallToAction, Separator, CallToActionTable, BookingConfirmationForm } from "../components";
+import { CallToAction, Separator, CallToActionTable } from "../components";
 import { OrganizerScheduledEmail } from "./OrganizerScheduledEmail";
 
 export const OrganizerRequestEmailV2 = (props: React.ComponentProps<typeof OrganizerScheduledEmail>) => {
@@ -20,22 +20,20 @@ export const OrganizerRequestEmailV2 = (props: React.ComponentProps<typeof Organ
       headerType="calendarCircle"
       subject="event_awaiting_approval_subject"
       callToAction={
-        <BookingConfirmationForm action={`${actionHref}&action=reject`}>
-          <CallToActionTable>
-            <CallToAction
-              label={props.calEvent.organizer.language.translate("confirm")}
-              href={`${actionHref}&action=accept`}
-              startIconName="confirmIcon"
-            />
-            <Separator />
-            <CallToAction
-              label={props.calEvent.organizer.language.translate("reject")}
-              // href={`${actionHref}&action=reject`}
-              startIconName="rejectIcon"
-              secondary
-            />
-          </CallToActionTable>
-        </BookingConfirmationForm>
+        <CallToActionTable>
+          <CallToAction
+            label={props.calEvent.organizer.language.translate("confirm")}
+            href={`${actionHref}&action=accept`}
+            startIconName="confirmIcon"
+          />
+          <Separator />
+          <CallToAction
+            label={props.calEvent.organizer.language.translate("reject")}
+            href={`${actionHref}&action=reject`}
+            startIconName="rejectIcon"
+            secondary
+          />
+        </CallToActionTable>
       }
       {...props}
     />

--- a/packages/features/bookings/lib/handleNewBooking/createBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking/createBooking.ts
@@ -236,7 +236,7 @@ function buildNewBookingData(params: CreateBookingParams) {
     description: evt.seatsPerTimeSlot ? null : evt.additionalNotes,
     customInputs: isPrismaObjOrUndefined(evt.customInputs),
     status: eventType.isConfirmedByDefault ? BookingStatus.ACCEPTED : BookingStatus.PENDING,
-    oneTimePassword: evt.oneTimePassword,
+    ...(evt.oneTimePassword !== undefined && { oneTimePassword: evt.oneTimePassword }),
     location: evt.location,
     eventType: eventTypeRel,
     smsReminderNumber: input.smsReminderNumber,


### PR DESCRIPTION
### What was wrong

The V2 organizer request email template (behind `organizer-request-email-v2` feature flag) has a broken Reject button:
- The Reject button's `href` was commented out, relying on HTML form submission
- Email clients don't support HTML forms, so clicking Reject did nothing or showed "Rejection requires POST method"
- Additionally, the `oneTimePassword` token wasn't being generated for new bookings, causing "Error confirming booking" for both buttons

### How we fixed it

1. `packages/emails/src/templates/OrganizerRequestEmailV2.tsx`
- Uncommented and added `href` to the Reject button
- Removed the `BookingConfirmationForm` wrapper (forms don't work in emails)

2. `apps/web/app/api/verify-booking-token/route.ts`
- Allow GET requests for rejection (email links are always GET)

3. `packages/features/bookings/lib/handleNewBooking/createBooking.ts`
- Fixed token generation - passing `undefined` to Prisma was overriding the database default UUID

### Why we removed the "Reason for rejection" form

The form with a text area for rejection reason never worked because email clients ignore HTML forms. Removed to avoid confusion.

### Videos:

Before:



https://github.com/user-attachments/assets/1064932a-79eb-40c2-9899-5a6ad4843999




After:



https://github.com/user-attachments/assets/1b8fb124-8f7c-4afa-8255-2d4fda376497

