### PR TITLE
fix: enforce team-only access on premium toggles in cal video (#25680)

### DIFF
--- a/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
+++ b/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useFormContext, Controller } from "react-hook-form";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
+import { useHasTeamPlan } from "@calcom/features/billing/hooks/useHasPaidPlan";
 import type { FormValues } from "@calcom/features/eventtypes/lib/types";
 import type { CalVideoSettings as CalVideoSettingsType } from "@calcom/features/eventtypes/lib/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
@@ -22,6 +23,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
   const isPlatform = useIsPlatform();
   const [isExpanded, setIsExpanded] = useState(false);
   const [parent] = useAutoAnimate<HTMLDivElement>();
+  const { hasTeamPlan } = useHasTeamPlan();
   return (
     <>
       <Tooltip content="expandable" side="right" className="lg:hidden">
@@ -51,6 +53,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                     title={t("disable_recording_for_guests")}
                     labelClassName="text-sm leading-6 whitespace-normal wrap-break-word"
                     checked={value}
+                    disabled={!hasTeamPlan}
                     onCheckedChange={onChange}
                     Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                   />
@@ -67,6 +70,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                     title={t("disable_recording_for_organizer")}
                     labelClassName="text-sm leading-6 whitespace-normal wrap-break-word"
                     checked={value}
+                    disabled={!hasTeamPlan}
                     onCheckedChange={onChange}
                     Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                   />
@@ -84,6 +88,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                       title={t("enable_automatic_recording")}
                       labelClassName="text-sm"
                       checked={value}
+                      disabled={!hasTeamPlan}
                       onCheckedChange={onChange}
                       Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                     />
@@ -101,6 +106,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                     title={t("enable_automatic_transcription")}
                     labelClassName="text-sm leading-6 whitespace-normal wrap-break-word"
                     checked={value}
+                    disabled={!hasTeamPlan}
                     onCheckedChange={onChange}
                     Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                   />
@@ -118,6 +124,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                       title={t("disable_transcription_for_guests")}
                       labelClassName="text-sm leading-6 whitespace-normal wrap-break-word"
                       checked={value}
+                      disabled={!hasTeamPlan}
                       onCheckedChange={onChange}
                       Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                     />
@@ -135,6 +142,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                       title={t("disable_transcription_for_organizer")}
                       labelClassName="text-sm leading-6 whitespace-normal wrap-break-word"
                       checked={value}
+                      disabled={!hasTeamPlan}
                       onCheckedChange={onChange}
                       Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                     />
@@ -153,6 +161,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                     description={t("require_email_for_guests_description")}
                     labelClassName="text-sm leading-6 whitespace-normal break-words"
                     checked={value}
+                    disabled={!hasTeamPlan}
                     onCheckedChange={onChange}
                     Badge={<UpgradeTeamsBadge checkForActiveStatus />}
                   />

--- a/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
+++ b/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
@@ -175,8 +175,6 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
               data-testid="calVideoSettings.redirectUrlOnExit"
               containerClassName="mt-4"
               className="leading-6"
-              disabled={!hasTeamPlan}
-              LockedIcon={!hasTeamPlan ? <UpgradeTeamsBadge checkForActiveStatus /> : undefined}
               {...formMethods.register("calVideoSettings.redirectUrlOnExit", {
                 setValueAs: (v) => (!v || v.trim() === "" ? null : v),
               })}

--- a/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
+++ b/packages/features/eventtypes/components/locations/CalVideoSettings.tsx
@@ -175,6 +175,8 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
               data-testid="calVideoSettings.redirectUrlOnExit"
               containerClassName="mt-4"
               className="leading-6"
+              disabled={!hasTeamPlan}
+              LockedIcon={!hasTeamPlan ? <UpgradeTeamsBadge checkForActiveStatus /> : undefined}
               {...formMethods.register("calVideoSettings.redirectUrlOnExit", {
                 setValueAs: (v) => (!v || v.trim() === "" ? null : v),
               })}


### PR DESCRIPTION
## What does this PR do?

This PR fixes a permissions bug in Cal Video Settings where premium Cal Video features (recording, transcription, and guest controls) were incorrectly toggleable by users without a team plan.

- Fixes #25680
- Fixes [CAL-6879](https://linear.app/calcom/issue/CAL-6879/cal-video-premium-settings-toggles-accessible-without-team-plan)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):
before : 
All toggles were interactive for non-team users

https://github.com/user-attachments/assets/b25439b1-47e7-4ca3-a9f7-7ace73787d3b

after: 

https://github.com/user-attachments/assets/df1ae9dd-826d-40b6-b96e-a599a8c7fb50

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs).N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Log in as a free-tier user or a user without a team plan
- Navigate to: Event Types → Cal Video Settings
- Validate:All 7 premium toggles are disabled
- UpgradeTeamsBadge or disabled UI appears
- Log in as a team plan member
- Validate: All toggles behave normally (enabled, interactive)\


### References
1. appearance-view.tsx
Location: apps/web/modules/settings/my-account/appearance-view.tsx
Used as the pattern for individual premium features (hasPaidPlan).

2. CreateOrEditOutOfOfficeModal.tsx
Location: packages/features/out-of-office/components/CreateOrEditOutOfOfficeModal.tsx
Correct pattern for team-only features using hasTeamPlan.

3. CalVideoSettings.tsx (Bug location)
Missing disabled props entirely on premium toggles.
This is where the fix was applied: added useHasTeamPlan and disabled={!hasTeamPlan} to all premium settings.
