### PR TITLE
feat: prevent password from being same as username

### DIFF
--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -50,6 +50,18 @@ async function handler(req: NextRequest) {
     },
   });
 
+  const userForPasswordCheck = await prisma.user.findUnique({
+    where: { email: maybeRequest.email },
+    select: { username: true },
+  });
+
+  if (
+    userForPasswordCheck?.username &&
+    rawPassword.toLowerCase() === userForPasswordCheck.username.toLowerCase()
+  ) {
+    return NextResponse.json({ error: "Password cannot be the same as username" }, { status: 400 });
+  }
+
   const hashedPassword = await hashPassword(rawPassword);
   // this can fail if a password request has been made for an email that has since changed or-
   // never existed within Cal. In this case we do not want to disclose the email's existence.
@@ -71,7 +83,7 @@ async function handler(req: NextRequest) {
         identityProviderId: null,
       },
     });
-  } catch (e) {
+  } catch {
     return NextResponse.json({}, { status: 404 });
   }
 

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -105,6 +105,14 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
     username = usernameAndEmailValidation.username;
   }
 
+  // Check if password is the same as username (case-insensitive)
+  if (username && password.toLowerCase() === username.toLowerCase()) {
+    throw new HttpError({
+      statusCode: 400,
+      message: "password_same_as_username",
+    });
+  }
+
   // Create the customer in Stripe
 
   const customer = await billingService.createCustomer({

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -879,37 +879,27 @@ export const emailSchemaRefinement = (value: string) => {
   return emailSchema.safeParse(value).success;
 };
 
-export const signupSchema = z
-  .object({
-    // Username is marked optional here because it's requirement depends on if it's the Organization invite or a team invite which isn't easily done in zod
-    // It's better handled beyond zod in `validateAndGetCorrectedUsernameAndEmail`
-    username: z.string().optional(),
-    email: z.string().regex(emailRegex, { message: "Invalid email" }),
-    password: z.string().superRefine((data, ctx) => {
-      const isStrict = false;
-      const result = isPasswordValid(data, true, isStrict);
-      Object.keys(result).map((key: string) => {
-        if (!result[key as keyof typeof result]) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: [key],
-            message: key,
-          });
-        }
-      });
-    }),
-    language: z.string().optional(),
-    token: z.string().optional(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.username && data.password.toLowerCase() === data.username.toLowerCase()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["password"],
-        message: "password_same_as_username",
-      });
-    }
-  });
+export const signupSchema = z.object({
+  // Username is marked optional here because it's requirement depends on if it's the Organization invite or a team invite which isn't easily done in zod
+  // It's better handled beyond zod in `validateAndGetCorrectedUsernameAndEmail`
+  username: z.string().optional(),
+  email: z.string().regex(emailRegex, { message: "Invalid email" }),
+  password: z.string().superRefine((data, ctx) => {
+    const isStrict = false;
+    const result = isPasswordValid(data, true, isStrict);
+    Object.keys(result).map((key: string) => {
+      if (!result[key as keyof typeof result]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: key,
+        });
+      }
+    });
+  }),
+  language: z.string().optional(),
+  token: z.string().optional(),
+});
 
 export const ZVerifyCodeInputSchema = z.object({
   email: emailSchema,

--- a/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
+++ b/packages/trpc/server/routers/viewer/auth/changePassword.handler.ts
@@ -21,6 +21,10 @@ export const changePasswordHandler = async ({ input, ctx }: ChangePasswordOption
 
   const { user } = ctx;
 
+  if (user.username && newPassword.toLowerCase() === user.username.toLowerCase()) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "password_same_as_username" });
+  }
+
   if (user.identityProvider !== IdentityProvider.CAL) {
     const userWithPassword = await prisma.user.findUnique({
       where: {

--- a/packages/trpc/server/routers/viewer/organizations/setPassword.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/setPassword.handler.ts
@@ -19,6 +19,10 @@ type UpdateOptions = {
 export const setPasswordHandler = async ({ ctx, input }: UpdateOptions) => {
   const { newPassword } = input;
 
+  if (ctx.user.username && newPassword.toLowerCase() === ctx.user.username.toLowerCase()) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "password_same_as_username" });
+  }
+
   const user = await prisma.user.findUnique({
     where: {
       id: ctx.user.id,


### PR DESCRIPTION
## What does this PR do?

Adds validation to prevent users from setting their password to be the same as their username (case-insensitive comparison). This is a common security practice to prevent easily guessable passwords.

The validation is applied to all password-related flows:
- **Signup**: Added check in `calcomHandler.ts` (after username is finalized)
- **Change Password**: Added check in `changePassword.handler.ts`
- **Reset Password**: Added check in `reset-password/route.ts`
- **Organization Set Password**: Added check in `setPassword.handler.ts`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Signup flow**: Try to sign up with a password that matches the username (e.g., username: `testuser`, password: `TestUser`) - should be rejected
2. **Change password**: Log in and try to change password to match your username - should be rejected
3. **Reset password**: Request a password reset and try to set the new password to match your username - should be rejected
4. **Organization set password**: For org users with auto-generated passwords, try setting password to match username - should be rejected

All comparisons are case-insensitive, so `TestUser` and `testuser` should be treated as matching.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Important Review Notes

- The error message key `password_same_as_username` is used consistently across tRPC handlers - please verify this translation key exists or is handled by the frontend
- **Note**: The reset-password route returns `{ error: "Password cannot be the same as username" }` directly instead of using the translation key - reviewer should confirm if this is acceptable or should be aligned
- The reset-password route requires an additional DB query to fetch the username since it's not available in the request context
- No unit tests were added for this validation

## Updates since last revision

- Moved signup validation from `signupSchema` (zod-utils.ts) to `calcomHandler.ts` handler. The original approach using `.superRefine()` on the schema changed its type from `ZodObject` to `ZodEffects`, which broke `.pick()` and `.extend()` methods used elsewhere in the codebase.

---

**Requested by**: @emrysal (alex@cal.com)
**Link to Devin run**: https://app.devin.ai/sessions/bf47dada7cb045a4822bf07780689a8e