### PR TITLE
feat: add password confirmation for critical admin actions

### DIFF
--- a/packages/features/components/PasswordConfirmationDialogContent.tsx
+++ b/packages/features/components/PasswordConfirmationDialogContent.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { PropsWithChildren, ReactElement } from "react";
+import { useRef, useState } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import { DialogClose, DialogContent } from "@calcom/ui/components/dialog";
+import { PasswordField } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
+
+type ConfirmBtnType =
+  | { confirmBtn?: never; confirmBtnText?: string }
+  | { confirmBtnText?: never; confirmBtn?: ReactElement };
+
+export type PasswordConfirmationDialogContentProps = {
+  cancelBtnText?: string;
+  isPending?: boolean;
+  loadingText?: string;
+  onConfirm?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  title: string;
+  variety?: "danger" | "warning" | "success";
+} & ConfirmBtnType;
+
+export function PasswordConfirmationDialogContent(
+  props: PropsWithChildren<PasswordConfirmationDialogContentProps>
+) {
+  return (
+    <DialogContent type="creation">
+      <PasswordConfirmationContent {...props} />
+    </DialogContent>
+  );
+}
+
+export const PasswordConfirmationContent = (
+  props: PropsWithChildren<PasswordConfirmationDialogContentProps>
+) => {
+  const { t } = useLocale();
+  const {
+    title,
+    variety,
+    confirmBtn = null,
+    confirmBtnText = t("confirm"),
+    cancelBtnText = t("cancel"),
+    loadingText = t("loading"),
+    isPending = false,
+    onConfirm,
+    children,
+  } = props;
+
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const passwordRef = useRef<HTMLInputElement>(null!);
+
+  const verifyPasswordMutation = trpc.viewer.auth.verifyPassword.useMutation({
+    onSuccess() {
+      setPasswordError(null);
+    },
+    onError() {
+      setPasswordError(t("incorrect_password"));
+    },
+  });
+
+  const handleConfirm = async (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    e.preventDefault();
+    const password = passwordRef.current?.value;
+
+    if (!password) {
+      setPasswordError(t("error_required_field"));
+      return;
+    }
+
+    try {
+      await verifyPasswordMutation.mutateAsync({ passwordInput: password });
+      onConfirm?.(e);
+    } catch {
+      // Error is handled in onError callback
+    }
+  };
+
+  const isLoading = isPending || verifyPasswordMutation.isPending;
+
+  return (
+    <>
+      <div className="flex">
+        {variety && (
+          <div className="mt-0.5 ltr:mr-3">
+            {variety === "danger" && (
+              <div className="bg-error mx-auto rounded-full p-2 text-center">
+                <Icon name="circle-alert" className="h-5 w-5 text-red-600 dark:text-red-100" />
+              </div>
+            )}
+            {variety === "warning" && (
+              <div className="bg-attention mx-auto rounded-full p-2 text-center">
+                <Icon name="circle-alert" className="h-5 w-5 text-orange-600" />
+              </div>
+            )}
+            {variety === "success" && (
+              <div className="bg-cal-success mx-auto rounded-full p-2 text-center">
+                <Icon name="check" className="h-5 w-5 text-green-600" />
+              </div>
+            )}
+          </div>
+        )}
+        <div className="w-full">
+          <h2 className="font-cal text-emphasis mt-2 text-xl">{title}</h2>
+          <div className="text-subtle text-sm">{children}</div>
+        </div>
+      </div>
+      <div className="mt-5">
+        <PasswordField
+          data-testid="password-confirmation"
+          name="password"
+          id="password-confirmation"
+          autoComplete="current-password"
+          required
+          label={t("password")}
+          ref={passwordRef}
+          onChange={() => setPasswordError(null)}
+        />
+        {passwordError && <p className="text-error mt-1 text-sm">{passwordError}</p>}
+      </div>
+      <div className="my-5 flex flex-row-reverse gap-x-2 sm:my-8">
+        {confirmBtn ? (
+          confirmBtn
+        ) : (
+          <DialogClose
+            color="primary"
+            loading={isLoading}
+            onClick={handleConfirm}
+            data-testid="dialog-confirmation">
+            {isLoading ? loadingText : confirmBtnText}
+          </DialogClose>
+        )}
+        <DialogClose disabled={isLoading}>{cancelBtnText}</DialogClose>
+      </div>
+    </>
+  );
+};

--- a/packages/features/components/PasswordConfirmationDialogContent.tsx
+++ b/packages/features/components/PasswordConfirmationDialogContent.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
+import { Button } from "@calcom/ui/components/button";
 import { DialogClose, DialogContent } from "@calcom/ui/components/dialog";
 import { PasswordField } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
@@ -123,13 +124,13 @@ export const PasswordConfirmationContent = (
         {confirmBtn ? (
           confirmBtn
         ) : (
-          <DialogClose
+          <Button
             color="primary"
             loading={isLoading}
             onClick={handleConfirm}
             data-testid="dialog-confirmation">
             {isLoading ? loadingText : confirmBtnText}
-          </DialogClose>
+          </Button>
         )}
         <DialogClose disabled={isLoading}>{cancelBtnText}</DialogClose>
       </div>

--- a/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
+++ b/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
@@ -1,11 +1,13 @@
+import { useSession } from "next-auth/react";
 import { useState } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { PasswordConfirmationDialogContent } from "@calcom/features/components/PasswordConfirmationDialogContent";
 import { DataTableSelectionBar } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
-import { DialogTrigger } from "@calcom/ui/components/dialog";
+import { DialogTrigger, ConfirmationDialogContent } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 
 import type { UserTableUser } from "../types";
@@ -17,9 +19,13 @@ interface Props {
 
 export function DeleteBulkUsers({ users, onRemove }: Props) {
   const { t } = useLocale();
+  const { data: session } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const selectedRows = users; // Get selected rows from table
   const utils = trpc.useUtils();
+
+  const isCALIdentityProvider = session?.user.identityProvider === IdentityProvider.CAL;
+
   const deleteMutation = trpc.viewer.organizations.bulkDeleteUsers.useMutation({
     onSuccess: () => {
       showToast("Deleted Users", "success");
@@ -31,6 +37,21 @@ export function DeleteBulkUsers({ users, onRemove }: Props) {
       showToast(error.message, "error");
     },
   });
+
+  const handleConfirm = () => {
+    deleteMutation.mutate({
+      userIds: selectedRows.map((user) => user.id),
+    });
+  };
+
+  const confirmationContent = (
+    <p className="mt-5">
+      {t("remove_users_from_org_confirm", {
+        userCount: selectedRows.length,
+      })}
+    </p>
+  );
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
@@ -38,22 +59,25 @@ export function DeleteBulkUsers({ users, onRemove }: Props) {
           {t("Delete")}
         </DataTableSelectionBar.Button>
       </DialogTrigger>
-      <PasswordConfirmationDialogContent
-        variety="danger"
-        title={t("remove_users_from_org")}
-        confirmBtnText={t("remove")}
-        isPending={deleteMutation.isPending}
-        onConfirm={() => {
-          deleteMutation.mutate({
-            userIds: selectedRows.map((user) => user.id),
-          });
-        }}>
-        <p className="mt-5">
-          {t("remove_users_from_org_confirm", {
-            userCount: selectedRows.length,
-          })}
-        </p>
-      </PasswordConfirmationDialogContent>
+      {isCALIdentityProvider ? (
+        <PasswordConfirmationDialogContent
+          variety="danger"
+          title={t("remove_users_from_org")}
+          confirmBtnText={t("remove")}
+          isPending={deleteMutation.isPending}
+          onConfirm={handleConfirm}>
+          {confirmationContent}
+        </PasswordConfirmationDialogContent>
+      ) : (
+        <ConfirmationDialogContent
+          variety="danger"
+          title={t("remove_users_from_org")}
+          confirmBtnText={t("remove")}
+          isPending={deleteMutation.isPending}
+          onConfirm={handleConfirm}>
+          {confirmationContent}
+        </ConfirmationDialogContent>
+      )}
     </Dialog>
   );
 }

--- a/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
+++ b/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
+
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { PasswordConfirmationDialogContent } from "@calcom/features/components/PasswordConfirmationDialogContent";
 import { DataTableSelectionBar } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { DialogTrigger, ConfirmationDialogContent } from "@calcom/ui/components/dialog";
+import { DialogTrigger } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 
 import type { UserTableUser } from "../types";
@@ -14,41 +17,43 @@ interface Props {
 
 export function DeleteBulkUsers({ users, onRemove }: Props) {
   const { t } = useLocale();
+  const [isOpen, setIsOpen] = useState(false);
   const selectedRows = users; // Get selected rows from table
   const utils = trpc.useUtils();
   const deleteMutation = trpc.viewer.organizations.bulkDeleteUsers.useMutation({
     onSuccess: () => {
       showToast("Deleted Users", "success");
       utils.viewer.organizations.listMembers.invalidate();
+      setIsOpen(false);
+      onRemove();
     },
     onError: (error) => {
       showToast(error.message, "error");
     },
   });
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <DataTableSelectionBar.Button icon="ban" color="destructive">
           {t("Delete")}
         </DataTableSelectionBar.Button>
       </DialogTrigger>
-      <ConfirmationDialogContent
+      <PasswordConfirmationDialogContent
         variety="danger"
         title={t("remove_users_from_org")}
         confirmBtnText={t("remove")}
         isPending={deleteMutation.isPending}
         onConfirm={() => {
-          deleteMutation.mutateAsync({
+          deleteMutation.mutate({
             userIds: selectedRows.map((user) => user.id),
           });
-          onRemove();
         }}>
         <p className="mt-5">
           {t("remove_users_from_org_confirm", {
             userCount: selectedRows.length,
           })}
         </p>
-      </ConfirmationDialogContent>
+      </PasswordConfirmationDialogContent>
     </Dialog>
   );
 }

--- a/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
+++ b/packages/features/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
@@ -1,4 +1,3 @@
-import { useSession } from "next-auth/react";
 import { useState } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
@@ -19,12 +18,12 @@ interface Props {
 
 export function DeleteBulkUsers({ users, onRemove }: Props) {
   const { t } = useLocale();
-  const { data: session } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const selectedRows = users; // Get selected rows from table
   const utils = trpc.useUtils();
 
-  const isCALIdentityProvider = session?.user.identityProvider === IdentityProvider.CAL;
+  const { data: currentUser } = trpc.viewer.me.get.useQuery();
+  const isCALIdentityProvider = currentUser?.identityProvider === IdentityProvider.CAL;
 
   const deleteMutation = trpc.viewer.organizations.bulkDeleteUsers.useMutation({
     onSuccess: () => {

--- a/packages/features/users/components/UserTable/DeleteMemberModal.tsx
+++ b/packages/features/users/components/UserTable/DeleteMemberModal.tsx
@@ -22,7 +22,8 @@ export function DeleteMemberModal({
   const { data: session } = useSession();
   const utils = trpc.useUtils();
 
-  const isCALIdentityProvider = session?.user.identityProvider === IdentityProvider.CAL;
+  const { data: currentUser } = trpc.viewer.me.get.useQuery();
+  const isCALIdentityProvider = currentUser?.identityProvider === IdentityProvider.CAL;
 
   const removeMemberMutation = trpc.viewer.teams.removeMember.useMutation({
     onSuccess() {

--- a/packages/features/users/components/UserTable/DeleteMemberModal.tsx
+++ b/packages/features/users/components/UserTable/DeleteMemberModal.tsx
@@ -4,7 +4,9 @@ import type { Dispatch } from "react";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import { PasswordConfirmationDialogContent } from "@calcom/features/components/PasswordConfirmationDialogContent";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { IdentityProvider } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc";
+import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 
 import type { UserTableAction, UserTableState } from "./types";
@@ -19,6 +21,9 @@ export function DeleteMemberModal({
   const { t } = useLocale();
   const { data: session } = useSession();
   const utils = trpc.useUtils();
+
+  const isCALIdentityProvider = session?.user.identityProvider === IdentityProvider.CAL;
+
   const removeMemberMutation = trpc.viewer.teams.removeMember.useMutation({
     onSuccess() {
       utils.viewer.organizations.listMembers.invalidate();
@@ -34,6 +39,18 @@ export function DeleteMemberModal({
       showToast(err.message, "error");
     },
   });
+
+  const handleConfirm = () => {
+    // Shouldn't ever happen just for type safety
+    if (!session?.user.org?.id || !state?.deleteMember?.user?.id) return;
+
+    removeMemberMutation.mutate({
+      teamIds: [session?.user.org.id],
+      memberIds: [state?.deleteMember?.user.id],
+      isOrg: true,
+    });
+  };
+
   return (
     <Dialog
       open={state.deleteMember.showModal}
@@ -43,23 +60,25 @@ export function DeleteMemberModal({
           type: "CLOSE_MODAL",
         })
       }>
-      <PasswordConfirmationDialogContent
-        variety="danger"
-        title={t("remove_member")}
-        confirmBtnText={t("confirm_remove_member")}
-        isPending={removeMemberMutation.isPending}
-        onConfirm={() => {
-          // Shouldn't ever happen just for type safety
-          if (!session?.user.org?.id || !state?.deleteMember?.user?.id) return;
-
-          removeMemberMutation.mutate({
-            teamIds: [session?.user.org.id],
-            memberIds: [state?.deleteMember?.user.id],
-            isOrg: true,
-          });
-        }}>
-        {t("remove_member_confirmation_message")}
-      </PasswordConfirmationDialogContent>
+      {isCALIdentityProvider ? (
+        <PasswordConfirmationDialogContent
+          variety="danger"
+          title={t("remove_member")}
+          confirmBtnText={t("confirm_remove_member")}
+          isPending={removeMemberMutation.isPending}
+          onConfirm={handleConfirm}>
+          {t("remove_member_confirmation_message")}
+        </PasswordConfirmationDialogContent>
+      ) : (
+        <ConfirmationDialogContent
+          variety="danger"
+          title={t("remove_member")}
+          confirmBtnText={t("confirm_remove_member")}
+          isPending={removeMemberMutation.isPending}
+          onConfirm={handleConfirm}>
+          {t("remove_member_confirmation_message")}
+        </ConfirmationDialogContent>
+      )}
     </Dialog>
   );
 }

--- a/packages/features/users/components/UserTable/DeleteMemberModal.tsx
+++ b/packages/features/users/components/UserTable/DeleteMemberModal.tsx
@@ -2,9 +2,9 @@ import { useSession } from "next-auth/react";
 import type { Dispatch } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { PasswordConfirmationDialogContent } from "@calcom/features/components/PasswordConfirmationDialogContent";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc";
-import { ConfirmationDialogContent } from "@calcom/ui/components/dialog";
 import { showToast } from "@calcom/ui/components/toast";
 
 import type { UserTableAction, UserTableState } from "./types";
@@ -43,10 +43,11 @@ export function DeleteMemberModal({
           type: "CLOSE_MODAL",
         })
       }>
-      <ConfirmationDialogContent
+      <PasswordConfirmationDialogContent
         variety="danger"
         title={t("remove_member")}
         confirmBtnText={t("confirm_remove_member")}
+        isPending={removeMemberMutation.isPending}
         onConfirm={() => {
           // Shouldn't ever happen just for type safety
           if (!session?.user.org?.id || !state?.deleteMember?.user?.id) return;
@@ -58,7 +59,7 @@ export function DeleteMemberModal({
           });
         }}>
         {t("remove_member_confirmation_message")}
-      </ConfirmationDialogContent>
+      </PasswordConfirmationDialogContent>
     </Dialog>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Adds password confirmation requirement for critical admin actions when managing organization members. Previously, deleting users from an organization only required clicking a confirmation button. Now admins with Cal.com accounts must enter their password before proceeding with destructive actions.

**Changes:**
- Created a new reusable `PasswordConfirmationDialogContent` component that verifies the user's password via the existing `viewer.auth.verifyPassword` tRPC endpoint before allowing the action to proceed
- Updated `DeleteMemberModal` to require password confirmation when removing a single member
- Updated `DeleteBulkUsers` to require password confirmation when bulk deleting users
- Added identity provider gating: users with Cal.com identity (password-based accounts) see the password confirmation dialog, while OAuth/SSO users see the standard confirmation dialog

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**For Cal.com identity users (password-based accounts):**
1. Log in as an organization admin with a Cal.com account (not OAuth)
2. Navigate to the organization members list
3. Try to remove a single member - verify password dialog appears
4. Enter incorrect password - verify error message appears
5. Enter correct password - verify member is removed
6. Select multiple members and try bulk delete - verify password dialog appears
7. Confirm password verification works for bulk deletion as well

**For OAuth/SSO users:**
1. Log in as an organization admin via OAuth (Google, etc.)
2. Navigate to the organization members list
3. Try to remove a member - verify standard confirmation dialog appears (no password field)
4. Confirm the action proceeds normally

## Human Review Checklist

- [ ] Verify the identity provider check (`currentUser?.identityProvider === IdentityProvider.CAL`) correctly identifies password-based users
- [ ] Verify the password verification mutation correctly validates passwords
- [ ] Consider whether backend handlers should also require password verification (currently UI-only)
- [ ] Test dialog behavior - confirm button should only close dialog on successful password verification

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run**: https://app.devin.ai/sessions/b44cf2116e8c457eb3588d0ad2ca0e22
> **Requested by**: @emrysal (alex@cal.com)