### PR TITLE
refactor: remove isTrpcCall prop from getEventTypeById

### DIFF
--- a/apps/api/v2/src/app.ts
+++ b/apps/api/v2/src/app.ts
@@ -5,7 +5,7 @@ import { PrismaExceptionFilter } from "@/filters/prisma-exception.filter";
 import { ZodExceptionFilter } from "@/filters/zod-exception.filter";
 import type { ValidationError } from "@nestjs/common";
 import { BadRequestException, ValidationPipe, VersioningType } from "@nestjs/common";
-import { BaseExceptionFilter, HttpAdapterHost } from "@nestjs/core";
+import { HttpAdapterHost } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
 import * as cookieParser from "cookie-parser";
 import { Request } from "express";
@@ -22,6 +22,7 @@ import {
 } from "@calcom/platform-constants";
 
 import { CalendarServiceExceptionFilter } from "./filters/calendar-service-exception.filter";
+import { ErrorWithCodeExceptionFilter } from "./filters/error-with-code-exception.filter";
 import { TRPCExceptionFilter } from "./filters/trpc-exception.filter";
 
 export const bootstrap = (app: NestExpressApplication): NestExpressApplication => {
@@ -72,16 +73,19 @@ export const bootstrap = (app: NestExpressApplication): NestExpressApplication =
   );
 
   // Exception filters, new filters go at the bottom, keep the order
-  const { httpAdapter } = app.get(HttpAdapterHost);
+  const { httpAdapter: _httpAdapter } = app.get(HttpAdapterHost);
   app.useGlobalFilters(new PrismaExceptionFilter());
   app.useGlobalFilters(new ZodExceptionFilter());
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalFilters(new TRPCExceptionFilter());
+  app.useGlobalFilters(new ErrorWithCodeExceptionFilter());
   app.useGlobalFilters(new CalendarServiceExceptionFilter());
 
   app.use(cookieParser());
 
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
   if (process?.env?.API_GLOBAL_PREFIX) {
+    // eslint-disable-next-line turbo/no-undeclared-env-vars
     app.setGlobalPrefix(process?.env?.API_GLOBAL_PREFIX);
   }
 

--- a/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_04_15/event-types.repository.ts
@@ -56,7 +56,6 @@ export class EventTypesRepository_2024_04_15 {
       userId: user.id,
       prisma: this.dbRead.prisma as unknown as PrismaClient,
       isUserOrganizationAdmin,
-      isTrpcCall: true,
     });
   }
 

--- a/apps/api/v2/src/filters/error-with-code-exception.filter.ts
+++ b/apps/api/v2/src/filters/error-with-code-exception.filter.ts
@@ -1,0 +1,40 @@
+import { extractUserContext } from "@/lib/extract-user-context";
+import { filterReqHeaders } from "@/lib/filterReqHeaders";
+import { ArgumentsHost, Catch, ExceptionFilter, Logger } from "@nestjs/common";
+import { Request } from "express";
+
+import { ErrorWithCode } from "@calcom/lib/errors";
+import { getHttpStatusCode } from "@calcom/lib/server/getServerErrorFromUnknown";
+import { ERROR_STATUS } from "@calcom/platform-constants";
+import { Response } from "@calcom/platform-types";
+
+@Catch(ErrorWithCode)
+export class ErrorWithCodeExceptionFilter implements ExceptionFilter<ErrorWithCode> {
+  private readonly logger = new Logger("ErrorWithCodeExceptionFilter");
+
+  catch(exception: ErrorWithCode, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const statusCode = getHttpStatusCode(exception);
+    const requestId = request.headers["X-Request-Id"] ?? "unknown-request-id";
+    response.setHeader("X-Request-Id", requestId.toString());
+    const userContext = extractUserContext(request);
+    this.logger.error(`ErrorWithCode Exception Filter: ${exception?.message}`, {
+      exception,
+      body: request.body,
+      headers: filterReqHeaders(request.headers),
+      url: request.url,
+      method: request.method,
+      requestId,
+      ...userContext,
+    });
+
+    response.status(statusCode).json({
+      status: ERROR_STATUS,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      error: { code: exception.code, message: exception.message, data: exception.data },
+    });
+  }
+}

--- a/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
+++ b/apps/api/v2/src/modules/atoms/services/event-types-atom.service.ts
@@ -83,7 +83,6 @@ export class EventTypesAtomService {
       userId: user.id,
       prisma: this.dbRead.prisma as unknown as PrismaClient,
       isUserOrganizationAdmin,
-      isTrpcCall: true,
     });
 
     if (!eventType) {

--- a/packages/trpc/server/routers/viewer/eventTypes/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/get.handler.ts
@@ -18,7 +18,6 @@ export const getHandler = ({ ctx, input }: GetOptions) => {
     eventTypeId: input.id,
     userId: ctx.user.id,
     prisma: ctx.prisma,
-    isTrpcCall: true,
     isUserOrganizationAdmin: !!ctx.user?.organization?.isOrgAdmin,
   });
 };


### PR DESCRIPTION
## What does this PR do?

Refactors `getEventTypeById` to remove the `isTrpcCall` prop by utilizing the existing `errorConversionMiddleware` in tRPC. This makes the function transport-agnostic by throwing `ErrorWithCode` instead of `TRPCError` directly.

**Changes:**
- Replace `TRPCError` throws with `ErrorWithCode` in `getEventTypeById`
- Add `ErrorWithCodeExceptionFilter` in API v2 to handle `ErrorWithCode` exceptions
- Remove `isTrpcCall` prop from interface and all callers

**How it works:**
- In tRPC context: `errorConversionMiddleware` catches `ErrorWithCode` and converts it to `TRPCError`
- In API v2 context: `ErrorWithCodeExceptionFilter` catches `ErrorWithCode` and returns proper HTTP responses

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactoring only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **tRPC context**: Call the `viewer.eventTypes.get` procedure with a non-existent event type ID and verify a proper NOT_FOUND error is returned
2. **API v2 context**: Call the event type endpoints with invalid IDs and verify proper 404 responses are returned

The error handling behavior should remain the same - this is a refactoring to improve code organization.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify `errorConversionMiddleware` is applied to procedures using `getEventTypeById` (it's applied to `authedProcedure`)
- [ ] Verify error codes (`EventTypeNotFound`, `NotFound`) map to HTTP 404 in `getHttpStatusCode`
- [ ] Verify `ErrorWithCodeExceptionFilter` response format is consistent with other API v2 filters

---

Link to Devin run: https://app.devin.ai/sessions/607b3950cbab44d4847009c6379c0874
Requested by: benny@cal.com (@hbjORbj)