### PR TITLE
chore: upgrade husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn lint-staged
 
 yarn app-store:build && git add packages/app-store/*.generated.*

--- a/companion/.husky/pre-commit
+++ b/companion/.husky/pre-commit
@@ -1,6 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 cd companion
 npx lint-staged
-

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "checkly": "latest",
     "dotenv-checker": "^1.1.5",
     "eslint": "9.36.0",
-    "husky": "^9.1.7",
+    "husky": "9.1.7",
     "i18n-unused": "^0.13.0",
     "jest-diff": "^29.5.0",
     "jest-summarizing-reporter": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "checkly": "latest",
     "dotenv-checker": "^1.1.5",
     "eslint": "9.36.0",
-    "husky": "^8.0.0",
+    "husky": "^9.1.7",
     "i18n-unused": "^0.13.0",
     "jest-diff": "^29.5.0",
     "jest-summarizing-reporter": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22961,7 +22961,7 @@ __metadata:
     date-fns-tz: ^3.2.0
     dotenv-checker: ^1.1.5
     eslint: 9.36.0
-    husky: ^8.0.0
+    husky: ^9.1.7
     i18n-unused: ^0.13.0
     jest-diff: ^29.5.0
     jest-summarizing-reporter: ^1.1.4
@@ -31324,12 +31324,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^8.0.0":
-  version: 8.0.3
-  resolution: "husky@npm:8.0.3"
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
   bin:
-    husky: lib/bin.js
-  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
+    husky: bin.js
+  checksum: c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Husky to v9.1.7 and update pre-commit hooks to the new format to remove warnings and keep hooks working.

- **Dependencies**
  - Bumped Husky to 9.1.7 and updated yarn.lock.

- **Refactors**
  - Removed shebang and husky.sh bootstrap lines from .husky/pre-commit and companion/.husky/pre-commit while keeping existing lint-staged and build steps.

<sup>Written for commit 22ce46f9c848edea77aa0fb52839ed4e92a51eb5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





