### PR TITLE
fix: prevent OOO dialog from closing on outside click

### DIFF
--- a/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -188,6 +188,7 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
       }}>
       <DialogContent
         enableOverflow
+        preventCloseOnOutsideClick
         onOpenAutoFocus={(event) => {
           event.preventDefault();
         }}>


### PR DESCRIPTION
## What does this PR do?

Prevents the Out of Office (OOO) creation/edit dialog from closing when clicking outside of it. The dialog will now only close when the user explicitly clicks the "Cancel" button.

This improves UX by preventing accidental dismissal of the dialog when users may have partially filled out the form.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - uses existing `preventCloseOnOutsideClick` prop from Dialog component.

## How should this be tested?

1. Navigate to Settings > My Account > Out of Office
2. Click "Add an entry" to open the OOO dialog
3. Click outside the dialog (on the overlay)
4. **Expected**: Dialog should remain open
5. Click the "Cancel" button
6. **Expected**: Dialog should close

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run**: https://app.devin.ai/sessions/a64b02c5db004509bb26d40c99fed967
> **Requested by**: Volnei Munhoz (volnei@cal.com) (@volnei)