### PR TITLE
fix: org banner on mobile

### DIFF
--- a/packages/features/bookings/Booker/Booker.tsx
+++ b/packages/features/bookings/Booker/Booker.tsx
@@ -411,7 +411,7 @@ const BookerComponent = ({
                 {!hideEventTypeDetails && orgBannerUrl && (
                   <img
                     loading="eager"
-                    className="-mb-9 h-16 object-cover object-top ltr:rounded-tl-md rtl:rounded-tr-md sm:h-auto"
+                    className="-mb-9 h-auto w-full object-contain object-top ltr:rounded-tl-md rtl:rounded-tr-md sm:h-16 sm:object-cover"
                     alt="org banner"
                     src={orgBannerUrl}
                   />


### PR DESCRIPTION
## What does this PR do?

Before:- 
<img width="328" height="420" alt="Screenshot 2025-12-08 at 6 07 13 PM" src="https://github.com/user-attachments/assets/60460a38-682f-464d-816e-629a00ae9f06" />
After:-
<img width="328" height="420" alt="Screenshot 2025-12-08 at 6 06 57 PM" src="https://github.com/user-attachments/assets/51f7e68c-4607-4313-94d2-4e1c780d8a61" />
