### PR TITLE
fix(insights): align call history empty state with search bar

### DIFF
--- a/apps/web/modules/insights/insights-call-history-view.tsx
+++ b/apps/web/modules/insights/insights-call-history-view.tsx
@@ -312,14 +312,12 @@ function CallHistoryContent({ org: _org }: CallHistoryProps) {
           </>
         }
         EmptyView={
-          <div className="px-6 py-8">
             <EmptyScreen
               Icon="phone"
               headline={searchTerm ? t("no_result_found_for", { searchTerm }) : t("no_call_history")}
               description={t("no_call_history_description")}
               className="mb-16"
             />
-          </div>
         }
       />
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #25717
- Fixes [CAL-6888](https://linear.app/calcom/issue/CAL-6888/call-history-empty-state-container-misaligned-with-search-bar)
## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:
<img width="1289" height="860" alt="Screenshot 2025-12-09 at 7 30 25 AM" src="https://github.com/user-attachments/assets/ea5d8f51-cf9b-495a-a4ff-5d23da521fea" />


after:

<img width="1289" height="861" alt="Screenshot 2025-12-09 at 7 30 08 AM" src="https://github.com/user-attachments/assets/14fbdefa-4167-4bc9-9fb8-a474917b0c2a" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Call History empty state with the search bar in Insights by removing the padding wrapper around EmptyScreen. Fixes the misaligned container so width and spacing match the search bar, per Linear CAL-6888.

<sup>Written for commit a89e11b1e1532d87f073aa9abfaac8deb9daed89. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



