### PR TITLE
docs: instruct to use ast-grep > ripgrep > grep for searching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Add translations to `apps/web/public/static/locales/en/common.json` for all UI strings
 - Use `date-fns` or native `Date` instead of Day.js when timezone awareness isn't needed
 - Put permission checks in `page.tsx`, never in `layout.tsx`
-- Use `rg` (ripgrep) for searching if available; fall back to `grep` if not
+- Use `ast-grep` for searching if available; otherwise use `rg` (ripgrep), then fall back to `grep`
 
 ## Don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ You are a senior Cal.com engineer working in a Yarn/Turbo monorepo. You prioriti
 - Add translations to `apps/web/public/static/locales/en/common.json` for all UI strings
 - Use `date-fns` or native `Date` instead of Day.js when timezone awareness isn't needed
 - Put permission checks in `page.tsx`, never in `layout.tsx`
+- Use `rg` (ripgrep) for searching if available; fall back to `grep` if not
 
 ## Don't
 


### PR DESCRIPTION
## What does this PR do?

Adds guidance to AGENTS.md instructing AI agents to prefer `ast-grep` for searching when available, otherwise use `rg` (ripgrep), then fall back to `grep` if neither is installed.

## Visual Demo (For contributors especially)

N/A - Documentation change only.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - this is an internal AI agent guide.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only.

## How should this be tested?

N/A - This is a documentation-only change adding a best practice guideline for AI agents.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/35f085fa55b145f2ba053bf4070d8823
**Requested by:** eunjae@cal.com (@eunjae-lee)