### PR TITLE
docs: add Repository + DTO pattern guidance for Prisma type isolation

### DIFF
--- a/agents/coding-standards.md
+++ b/agents/coding-standards.md
@@ -27,6 +27,12 @@ import { User } from "@prisma/client";
 
 - Use React children and context instead of passing props through multiple components
 
+### ORM and Types
+
+- Never import `@calcom/prisma/client` in features, services, UI, or handlers.
+- Use repository DTOs or domain types instead.
+- See "Repository + DTO Pattern and Method Conventions" in the knowledge base for details and examples.
+
 ### Security Rules
 
 ```typescript

--- a/agents/knowledge-base.md
+++ b/agents/knowledge-base.md
@@ -308,9 +308,22 @@ import { Button } from "@calcom/ui/components/button";
 
 ## Repository + DTO Pattern and Method Conventions
 
-We use a Repository + DTO pattern to isolate Prisma and the database from business logic. Repositories are the only layer that talks to Prisma and database models. All services, tRPC handlers, API controllers, workflows, and UI should depend on DTOs or domain types, not Prisma types. This makes it possible to evolve the Prisma schema or even swap the ORM without rewriting business logic.
+We use a Repository + DTO pattern to isolate Prisma and the database from business logic. Repositories are the only layer that talks to Prisma and database models. All services, tRPC handlers, API controllers, workflows, and UI should depend on DTOs or domain types, not Prisma types.
 
 DTOs (Data Transfer Objects) are simple TypeScript types or interfaces that represent our domain data in an ORM-agnostic way and are returned from repositories.
+
+### Why this pattern?
+
+Understanding the "why" makes adoption easier. This pattern provides three key benefits:
+
+**1. Type-leak prevention**
+When Prisma types spread throughout the codebase, any schema change (renaming a field, changing a type, adding a required field) causes type errors across dozens of files. With DTOs, schema changes only affect repository mapping functions—the rest of the codebase remains untouched.
+
+**2. Safe refactors**
+Business logic that depends on DTOs can be refactored, tested, and reasoned about independently of the database. You can change how data is stored without touching service logic, and vice versa. This separation makes large refactors tractable and reduces the risk of breaking unrelated features.
+
+**3. ORM swap possibility**
+While we currently use Prisma, isolating it to repositories means we could migrate to a different ORM (Drizzle, Kysely, raw SQL) without rewriting business logic. The repository interface stays the same; only the implementation changes. This future-proofs the codebase against ORM-level breaking changes or performance needs.
 
 ### What not to do: tight Prisma coupling in business logic
 


### PR DESCRIPTION
## What does this PR do?

Adds documentation guidance for the Repository + DTO pattern to establish clear architectural direction for isolating Prisma types from business logic.

This addresses the discussion in Slack about moving away from tight Prisma coupling (where business logic imports types directly from `@calcom/prisma/client`) toward a cleaner Repository + DTO pattern.

**Changes:**
- Renamed "Repository Method Conventions" section to "Repository + DTO Pattern and Method Conventions" in `agents/knowledge-base.md`
- Added architectural goal explanation and DTO definition
- Added "What not to do" anti-pattern examples showing tight Prisma coupling
- Added "DTOs in repositories" section with concrete code examples
- Added "Prisma boundaries" section defining where Prisma is/isn't allowed
- Added cross-reference in `agents/coding-standards.md` under "ORM and Types"

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - this PR is itself documentation.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only.

## How should this be tested?

This is a documentation-only PR. Review the content for:
- Clarity of the architectural direction
- Accuracy of the "Prisma boundaries" list
- Quality of the code examples

## Human Review Checklist

- [ ] Verify the architectural direction (Repository + DTO pattern) aligns with team's vision
- [ ] Check if the "Prisma boundaries" list accurately reflects where Prisma should/shouldn't be used
- [ ] Confirm the examples are clear and follow existing documentation style

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Requested by:** @eunjae-lee (eunjae@cal.com)
**Link to Devin run:** https://app.devin.ai/sessions/030fa39f44ea4e2f8dec4fab9653da3c