### PR TITLE
chore: atoms release changelog and package.json

### DIFF
--- a/packages/platform/atoms/CHANGELOG.md
+++ b/packages/platform/atoms/CHANGELOG.md
@@ -1,4 +1,24 @@
-## 1.1.2
+## 2.0.0
+
+⚠️ This version contains a breaking change ⚠️. Specifically, the tailwind upgrade under major changes. Atoms now use tailwind at version 4, which means that you have to upgrade your project to use tailwind at version 4.
+
+### Major Changes
+
+- [#25577](https://github.com/calcom/cal.com/pull/25577) [`a1e1bf8`](https://github.com/calcom/cal.com/commit/a1e1bf8b76da5489f91895c3a776c38dea346cee) Thanks [@supalarry](https://github.com/supalarry)! - feat: use tailwind v4 (breaking change).
+
+### Minor Changes
+
+- [#24857](https://github.com/calcom/cal.com/pull/24857) [`c6daa61`](https://github.com/calcom/cal.com/commit/c6daa61e5efe24665f3d3dd0bea33c79dda6f797) Thanks [@ibex088](https://github.com/ibex088)! - Fix Booker atom verify email dialog infinite re-render when entering verification code
+
+- [#24896](https://github.com/calcom/cal.com/pull/24896) [`957d197`](https://github.com/calcom/cal.com/commit/957d19740ed31834e8346d3fa309605a6d657c11) Thanks [@Ryukemeister](https://github.com/Ryukemeister)! - This PR introduces two variants for the calendar view atom, a generic calendar view and an event type specific view containing bookings data and busy times from connected calendars.
+
+- [#25093](https://github.com/calcom/cal.com/pull/25093) [`3e7a848`](https://github.com/calcom/cal.com/commit/3e7a848769d49295ee6e4251cf4afd2390793ae2) Thanks [@ibex088](https://github.com/ibex088)! - Refactor SettingsHeader to accept onBackButtonClick callback instead of using useRouter directly.
+
+- [#25204](https://github.com/calcom/cal.com/pull/25204) [`037cb8e`](https://github.com/calcom/cal.com/commit/037cb8ee2a83c1d725d5d913d47911a5997bee01) Thanks [@ThyMinimalDev](https://github.com/ThyMinimalDev)! - Add defaultPhoneCountry prop to BookerPlatformWrapper with ISO 3166-1 alpha-2 type safety
+
+### Patch Changes
+
+- [#25418](https://github.com/calcom/cal.com/pull/25418) [`8fcbf2c`](https://github.com/calcom/cal.com/commit/8fcbf2c167ce747e302c0c03095ddcdbebc728a3) Thanks [@Ryukemeister](https://github.com/Ryukemeister)! - This PR fixes the issue of connect atoms not working inside iframes. It also updates the atoms exports to include the `useAvailableSlots` hook.
 
 ## 1.12.1
 

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Customizable UI components to integrate scheduling into your product.",
   "authors": "Cal.com, Inc.",
-  "version": "1.12.1",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/calcom/cal.com"


### PR DESCRIPTION
I released atoms 2.0.0 manually because changeset was stuck, so adding readme and package.json of the release here.