### PR TITLE
fix(companion): update react-native-reanimated to Expo 54 compatible version

### DIFF
--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -31,11 +31,11 @@
         "react-native": "0.81.5",
         "react-native-context-menu-view": "^1.20.0",
         "react-native-gesture-handler": "^2.29.1",
-        "react-native-reanimated": "~3.10.1",
+        "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "5.4.0",
         "react-native-svg": "^15.15.0",
         "react-native-web": "^0.21.2",
-        "react-native-worklets": "^0.6.1"
+        "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.31",
@@ -13016,24 +13016,31 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.10.1.tgz",
-      "integrity": "sha512-sfxg6vYphrDc/g4jf/7iJ7NRi+26z2+BszPmvmk0Vnrz6FL7HYljJqTf531F1x6tFmsf+FEAmuCtTUIXFLVo9w==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
+      "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4"
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -13110,9 +13117,9 @@
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.1.tgz",
-      "integrity": "sha512-URca8l7c7Uog7gv4mcg9KILdJlnbvwdS5yfXQYf5TDkD2W1VY1sduEKrD+sA3lUPXH/TG1vmXAvNxCNwPMYgGg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",

--- a/companion/package.json
+++ b/companion/package.json
@@ -39,11 +39,11 @@
     "react-native": "0.81.5",
     "react-native-context-menu-view": "^1.20.0",
     "react-native-gesture-handler": "^2.29.1",
-    "react-native-reanimated": "~3.10.1",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "^15.15.0",
     "react-native-web": "^0.21.2",
-    "react-native-worklets": "^0.6.1"
+    "react-native-worklets": "0.5.1"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## What does this PR do?

Fixes the Android build failure for the companion app by updating `react-native-reanimated` and `react-native-worklets` to versions compatible with Expo SDK 54 and React Native 0.81.5.

The build was failing with errors like:
- `cannot find symbol: ReactViewBackgroundDrawable`
- `cannot find symbol: TRACE_TAG_REACT_JAVA_BRIDGE`
- `cannot find symbol: getRuntimeExecutor()`
- `no suitable method found for updateLayout`

**Root cause:** `react-native-reanimated ~3.10.1` is incompatible with React Native 0.81.5 (used by Expo SDK 54).

**Fix:** Updated to Expo 54 bundled versions using `npx expo install`:
- `react-native-reanimated`: `~3.10.1` → `~4.1.1`
- `react-native-worklets`: `^0.6.1` → `0.5.1`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - dependency version update only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Trigger an EAS Android build for the companion app
2. Verify the gradle build completes without the `react-native-reanimated` compilation errors
3. Test the companion app on Android to ensure animations work correctly

## Human Review Checklist

- [ ] Verify the Android build passes with these version changes
- [ ] Check if any companion app code uses reanimated APIs that may have changed between v3 and v4
- [ ] Confirm the worklets downgrade (0.6.1 → 0.5.1) doesn't break any functionality

---

Link to Devin run: https://app.devin.ai/sessions/3a0cb7ff9e3b49059cc69d819a9bc472
Requested by: Volnei Munhoz (volnei@cal.com) (@volnei)