### PR TITLE
feat: added rescheduled filter and fixed extra fetching of data for cancelled filter for insights

### DIFF
--- a/apps/web/modules/insights/components/BookingStatusBadge.tsx
+++ b/apps/web/modules/insights/components/BookingStatusBadge.tsx
@@ -4,12 +4,18 @@ import { type BadgeProps } from "@calcom/ui/components/badge";
 
 import { bookingStatusToText } from "@calcom/features/insights/lib/bookingStatusToText";
 
-export function BookingStatusBadge({ bookingStatus }: { bookingStatus: BookingStatus | null }) {
+export function BookingStatusBadge({
+  bookingStatus,
+}: {
+  bookingStatus: BookingStatus | "RESCHEDULED" | null;
+}) {
   let badgeVariant: BadgeProps["variant"] = "success";
 
   if (!bookingStatus) return null;
 
   switch (bookingStatus) {
+    case "RESCHEDULED":
+      return <Badge variant="orange">{bookingStatusToText(bookingStatus)}</Badge>;
     case BookingStatus.REJECTED:
     case BookingStatus.AWAITING_HOST:
     case BookingStatus.PENDING:

--- a/apps/web/modules/insights/hooks/useInsightsBookingFacetedUniqueValues.ts
+++ b/apps/web/modules/insights/hooks/useInsightsBookingFacetedUniqueValues.ts
@@ -3,17 +3,18 @@ import { useCallback } from "react";
 
 import { convertFacetedValuesToMap, type FacetedValue } from "@calcom/features/data-table";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, BookingStatusWithRescheduled } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 
 import { bookingStatusToText } from "@calcom/features/insights/lib/bookingStatusToText";
 
-const statusOrder: Record<BookingStatus, number> = {
+const statusOrder: Record<BookingStatusWithRescheduled, number> = {
   [BookingStatus.ACCEPTED]: 1,
   [BookingStatus.PENDING]: 2,
   [BookingStatus.AWAITING_HOST]: 3,
   [BookingStatus.CANCELLED]: 4,
   [BookingStatus.REJECTED]: 5,
+  RESCHEDULED: 6,
 };
 
 export const useInsightsBookingFacetedUniqueValues = ({
@@ -48,36 +49,36 @@ export const useInsightsBookingFacetedUniqueValues = ({
   );
 
   return useCallback(
-    (_: Table<any>, columnId: string) => (): Map<FacetedValue, number> => {
-      if (columnId === "status") {
-        return convertFacetedValuesToMap(
-          Object.keys(statusOrder).map((status) => ({
+    <TData>(_: Table<TData>, columnId: string) =>
+      (): Map<FacetedValue, number> => {
+        if (columnId === "status") {
+          const options = Object.keys(statusOrder).map((status) => ({
             value: status.toLowerCase(),
-            label: bookingStatusToText(status as BookingStatus),
-          }))
-        );
-      } else if (columnId === "userId") {
-        return convertFacetedValuesToMap(
-          users?.map((user) => ({
-            label: user.name ?? user.email,
-            value: user.id,
-          })) ?? []
-        );
-      } else if (columnId === "eventTypeId") {
-        return convertFacetedValuesToMap(
-          eventTypes?.map((eventType) => ({
-            value: eventType.id,
-            label: eventType.teamId ? `${eventType.title} (${eventType.team?.name})` : eventType.title,
-          })) ?? []
-        );
-      } else if (columnId === "paid") {
-        return convertFacetedValuesToMap([
-          { value: "true", label: t("paid") },
-          { value: "false", label: t("free") },
-        ]);
-      }
-      return new Map<FacetedValue, number>();
-    },
+            label: bookingStatusToText(status as BookingStatusWithRescheduled),
+          }));
+          return convertFacetedValuesToMap(options);
+        } else if (columnId === "userId") {
+          return convertFacetedValuesToMap(
+            users?.map((user) => ({
+              label: user.name ?? user.email,
+              value: user.id,
+            })) ?? []
+          );
+        } else if (columnId === "eventTypeId") {
+          return convertFacetedValuesToMap(
+            eventTypes?.map((eventType) => ({
+              value: eventType.id,
+              label: eventType.teamId ? `${eventType.title} (${eventType.team?.name})` : eventType.title,
+            })) ?? []
+          );
+        } else if (columnId === "paid") {
+          return convertFacetedValuesToMap([
+            { value: "true", label: t("paid") },
+            { value: "false", label: t("free") },
+          ]);
+        }
+        return new Map<FacetedValue, number>();
+      },
     [users, eventTypes, t]
   );
 };

--- a/apps/web/modules/insights/hooks/useInsightsRoutingFacetedUniqueValues.ts
+++ b/apps/web/modules/insights/hooks/useInsightsRoutingFacetedUniqueValues.ts
@@ -2,18 +2,19 @@ import type { Table } from "@tanstack/react-table";
 import { useCallback } from "react";
 
 import { convertFacetedValuesToMap, type FacetedValue } from "@calcom/features/data-table";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { BookingStatus, BookingStatusWithRescheduled } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 
 import { bookingStatusToText } from "@calcom/features/insights/lib/bookingStatusToText";
 import type { HeaderRow } from "@calcom/web/modules/insights/lib/types";
 
-const statusOrder: Record<BookingStatus, number> = {
+export const statusOrder: Record<BookingStatusWithRescheduled, number> = {
   [BookingStatus.ACCEPTED]: 1,
   [BookingStatus.PENDING]: 2,
   [BookingStatus.AWAITING_HOST]: 3,
   [BookingStatus.CANCELLED]: 4,
   [BookingStatus.REJECTED]: 5,
+  RESCHEDULED: 6,
 };
 
 export const useInsightsRoutingFacetedUniqueValues = ({
@@ -77,12 +78,11 @@ export const useInsightsRoutingFacetedUniqueValues = ({
               }))
           );
         } else if (columnId === "bookingStatusOrder") {
-          return convertFacetedValuesToMap(
-            Object.keys(statusOrder).map((status) => ({
-              value: statusOrder[status as BookingStatus],
-              label: bookingStatusToText(status as BookingStatus),
-            }))
-          );
+          const options = Object.keys(statusOrder).map((status) => ({
+            value: statusOrder[status as BookingStatusWithRescheduled],
+            label: bookingStatusToText(status as BookingStatusWithRescheduled),
+          }));
+          return convertFacetedValuesToMap(options);
         } else if (columnId === "formId") {
           return convertFacetedValuesToMap(
             forms?.map((form) => ({

--- a/apps/web/modules/insights/views/insights-routing-view.tsx
+++ b/apps/web/modules/insights/views/insights-routing-view.tsx
@@ -22,16 +22,13 @@ export default function InsightsRoutingFormResponsesPage({ timeZone }: { timeZon
   return (
     <DataTableProvider tableIdentifier={pathname} useSegments={useSegments} timeZone={timeZone}>
       <InsightsOrgTeamsProvider>
-        <div className="mb-4 stack-y-4">
+        <div className="stack-y-4 mb-4">
           <RoutingFormResponsesTable />
-
           <RoutingFunnel />
-
           <div className="flex flex-col gap-4 md:flex-row">
             <RoutedToPerPeriod />
             <FailedBookingsByField />
           </div>
-
           <small className="text-default block text-center">
             {t("looking_for_more_insights")}{" "}
             <a

--- a/apps/web/modules/insights/views/insights-view.tsx
+++ b/apps/web/modules/insights/views/insights-view.tsx
@@ -3,7 +3,13 @@
 import { usePathname } from "next/navigation";
 import { useState, useCallback } from "react";
 
-import { ColumnFilterType, type FilterableColumn } from "@calcom/features/data-table";
+import { usePathname } from "next/navigation";
+import { useState, useCallback } from "react";
+
+import {
+  ColumnFilterType,
+  type FilterableColumn,
+} from "@calcom/features/data-table";
 import { DataTableProvider } from "~/data-table/DataTableProvider";
 import { DataTableFilters, DateRangeFilter } from "~/data-table/components";
 import type { FilterType } from "@calcom/types/data-table";
@@ -30,7 +36,10 @@ import {
   TimezoneBadge,
 } from "@calcom/web/modules/insights/components/booking";
 import { InsightsOrgTeamsProvider } from "../components/context/InsightsOrgTeamsProvider";
-import { DateTargetSelector, type DateTarget } from "../components/filters/DateTargetSelector";
+import {
+  DateTargetSelector,
+  type DateTarget,
+} from "../components/filters/DateTargetSelector";
 import { Download } from "../components/filters/Download/Download";
 import { OrgTeamsFilter } from "../components/filters/OrgTeamsFilter";
 import { useInsightsBookings } from "@calcom/web/modules/insights/hooks/useInsightsBookings";
@@ -42,7 +51,11 @@ export default function InsightsPage({ timeZone }: { timeZone: string }) {
   const pathname = usePathname();
   if (!pathname) return null;
   return (
-    <DataTableProvider tableIdentifier={pathname} useSegments={useSegments} timeZone={timeZone}>
+    <DataTableProvider
+      tableIdentifier={pathname}
+      useSegments={useSegments}
+      timeZone={timeZone}
+    >
       <InsightsOrgTeamsProvider>
         <InsightsPageContent />
       </InsightsOrgTeamsProvider>
@@ -50,13 +63,19 @@ export default function InsightsPage({ timeZone }: { timeZone: string }) {
   );
 }
 
-const createdAtColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }> = {
+const createdAtColumn: Extract<
+  FilterableColumn,
+  { type: Extract<FilterType, "dr"> }
+> = {
   id: "createdAt",
   title: "createdAt",
   type: ColumnFilterType.DATE_RANGE,
 };
 
-const startTimeColumn: Extract<FilterableColumn, { type: Extract<FilterType, "dr"> }> = {
+const startTimeColumn: Extract<
+  FilterableColumn,
+  { type: Extract<FilterType, "dr"> }
+> = {
   id: "startTime",
   title: "startTime",
   type: ColumnFilterType.DATE_RANGE,
@@ -67,7 +86,9 @@ function InsightsPageContent() {
   const { table } = useInsightsBookings();
   const { isAll, teamId, userId } = useInsightsOrgTeams();
   const { removeFilter } = useDataTable();
-  const [dateTarget, _setDateTarget] = useState<"startTime" | "createdAt">("startTime");
+  const [dateTarget, _setDateTarget] = useState<"startTime" | "createdAt">(
+    "startTime"
+  );
 
   const setDateTarget = useCallback(
     (target: "startTime" | "createdAt") => {
@@ -81,18 +102,26 @@ function InsightsPageContent() {
     <>
       <div
         className="flex flex-wrap items-center gap-2"
-        data-testid={`insights-filters-${isAll}-${teamId}-${userId}`}>
+        data-testid={`insights-filters-${isAll}-${teamId}-${userId}`}
+      >
         <OrgTeamsFilter />
         <DataTableFilters.FilterBar table={table} />
-        <DataTableFilters.ClearFiltersButton exclude={["startTime", "createdAt"]} />
+        <DataTableFilters.ClearFiltersButton
+          exclude={["startTime", "createdAt"]}
+        />
         <div className="grow" />
         <Download />
         <ButtonGroup combined>
           <DateRangeFilter
-            column={dateTarget === "startTime" ? startTimeColumn : createdAtColumn}
+            column={
+              dateTarget === "startTime" ? startTimeColumn : createdAtColumn
+            }
             options={{ convertToTimeZone: true }}
           />
-          <DateTargetSelector value={dateTarget as DateTarget} onChange={setDateTarget} />
+          <DateTargetSelector
+            value={dateTarget as DateTarget}
+            onChange={setDateTarget}
+          />
         </ButtonGroup>
         <TimezoneBadge />
       </div>
@@ -149,7 +178,8 @@ function InsightsPageContent() {
           {t("looking_for_more_insights")}{" "}
           <a
             className="text-blue-500 hover:underline"
-            href="mailto:updates@cal.com?subject=Feature%20Request%3A%20More%20Analytics&body=Hey%20Cal.com%20Team%2C%20I%20love%20the%20analytics%20page%20but%20I%20am%20looking%20for%20...">
+            href="mailto:updates@cal.com?subject=Feature%20Request%3A%20More%20Analytics&body=Hey%20Cal.com%20Team%2C%20I%20love%20the%20analytics%20page%20but%20I%20am%20looking%20for%20..."
+          >
             {" "}
             {t("contact_support")}
           </a>

--- a/packages/app-store/redirect-apps.generated.ts
+++ b/packages/app-store/redirect-apps.generated.ts
@@ -27,6 +27,7 @@ export const REDIRECT_APPS = [
   "retell-ai",
   "synthflow",
   "telli",
+  "link-as-an-app",
   "vimcal",
   "wordpress",
   "zapier",

--- a/packages/features/insights/lib/bookingStatusToText.ts
+++ b/packages/features/insights/lib/bookingStatusToText.ts
@@ -1,7 +1,7 @@
 import type { BookingStatus } from "@calcom/prisma/enums";
 
 // Upper case the first letter of each word and replace underscores with spaces
-export function bookingStatusToText(status: BookingStatus) {
+export function bookingStatusToText(status: BookingStatus | "RESCHEDULED") {
   return status
     .toLowerCase()
     .replace(/_/g, " ")

--- a/packages/features/insights/services/InsightsBookingBaseService.ts
+++ b/packages/features/insights/services/InsightsBookingBaseService.ts
@@ -306,8 +306,42 @@ export class InsightsBookingBaseService {
     }
 
     if (id === "status" && isMultiSelectFilterValue(value)) {
-      const statusValues = value.data.map((status) => Prisma.sql`${status}::"BookingStatus"`);
-      return Prisma.sql`"status" IN (${Prisma.join(statusValues)})`;
+      const statusValuesRaw = value.data as unknown as string[];
+      const statusValues = statusValuesRaw
+        .filter((s) => s !== "rescheduled" && s !== "cancelled")
+        .map((status) => Prisma.sql`${status}::"BookingStatus"`);
+      const hasRescheduled = statusValuesRaw.includes("rescheduled");
+      const hasCancelled = statusValuesRaw.includes("cancelled");
+
+      const conditions: Prisma.Sql[] = [];
+
+      if (statusValues.length > 0) {
+        conditions.push(Prisma.sql`"status" IN (${Prisma.join(statusValues)})`);
+      }
+
+      // If both cancelled and rescheduled are selected, we simply want all cancelled bookings check
+      // because rescheduled bookings are effectively a subset of cancelled bookings in the DB
+      // with the rescheduled flag set.
+      if (hasCancelled && hasRescheduled) {
+        conditions.push(Prisma.sql`"status" = 'cancelled'`);
+      } else {
+        if (hasCancelled) {
+          // If only cancelled is selected, we want cancelled bookings that are NOT rescheduled
+          conditions.push(
+            Prisma.sql`"status" = 'cancelled' AND ("rescheduled" IS NULL OR "rescheduled" = false)`
+          );
+        }
+        if (hasRescheduled) {
+          // If only rescheduled is selected, we check for the rescheduled flag
+          conditions.push(Prisma.sql`"rescheduled" = true`);
+        }
+      }
+
+      if (conditions.length === 0) {
+        return null;
+      }
+
+      return Prisma.sql`(${Prisma.join(conditions, " OR ")})`;
     }
 
     if (id === "paid" && isSingleSelectFilterValue(value)) {

--- a/packages/features/insights/services/InsightsRoutingBaseService.ts
+++ b/packages/features/insights/services/InsightsRoutingBaseService.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import dayjs from "@calcom/dayjs";
 import { makeSqlCondition } from "@calcom/features/data-table/lib/server";
 import type { FilterValue, TextFilterValue, TypedColumnFilter } from "@calcom/features/data-table/lib/types";
-import type { FilterType } from "@calcom/types/data-table";
 import {
   isMultiSelectFilterValue,
   isTextFilterValue,
@@ -11,12 +10,13 @@ import {
   isSingleSelectFilterValue,
 } from "@calcom/features/data-table/lib/utils";
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
+import { statusOrder } from "@calcom/features/insights/hooks/useInsightsRoutingFacetedUniqueValues";
 import type { DateRange } from "@calcom/features/insights/server/insightsDateUtils";
 import { PermissionCheckService } from "@calcom/features/pbac/services/permission-check.service";
 import type { PrismaClient } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";
-import type { BookingStatus } from "@calcom/prisma/enums";
-import { MembershipRole } from "@calcom/prisma/enums";
+import { BookingStatusWithRescheduled, MembershipRole } from "@calcom/prisma/enums";
+import type { FilterType } from "@calcom/types/data-table";
 
 export const insightsRoutingServiceOptionsSchema = z.discriminatedUnion("scope", [
   z.object({
@@ -61,7 +61,7 @@ export type InsightsRoutingTableItem = {
   formUserId: number;
   bookingUid: string | null;
   bookingId: number | null;
-  bookingStatus: BookingStatus | null;
+  bookingStatus: BookingStatusWithRescheduled | null;
   bookingStatusOrder: number | null;
   bookingCreatedAt: Date | null;
   bookingUserId: number | null;
@@ -176,7 +176,7 @@ export class InsightsRoutingBaseService {
     const caseStatements = dateRanges
       .map(
         (dateRange) => Prisma.sql`
-      WHEN "createdAt" >= ${dateRange.startDate}::timestamp AND "createdAt" <= ${dateRange.endDate}::timestamp THEN ${dateRange.formattedDate}
+      WHEN rfrd."createdAt" >= ${dateRange.startDate}::timestamp AND rfrd."createdAt" <= ${dateRange.endDate}::timestamp THEN ${dateRange.formattedDate}
     `
       )
       .reduce((acc, curr) => Prisma.sql`${acc} ${curr}`);
@@ -191,6 +191,7 @@ export class InsightsRoutingBaseService {
           "bookingUid",
           "bookingStatus"
         FROM "RoutingFormResponseDenormalized" rfrd
+        LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
         WHERE ${baseConditions}
       )
       SELECT
@@ -270,6 +271,7 @@ export class InsightsRoutingBaseService {
     const totalCountQuery = Prisma.sql`
       SELECT COUNT(*) as count
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE ${baseConditions}
     `;
 
@@ -288,8 +290,8 @@ export class InsightsRoutingBaseService {
         rfrd."formUserId",
         rfrd."bookingUid",
         rfrd."bookingId",
-        UPPER(rfrd."bookingStatus"::text) as "bookingStatus",
-        rfrd."bookingStatusOrder",
+        CASE WHEN b."rescheduled" = true THEN 'RESCHEDULED' ELSE UPPER(rfrd."bookingStatus"::text) END as "bookingStatus",
+        CASE WHEN b."rescheduled" = true THEN 6 ELSE rfrd."bookingStatusOrder" END as "bookingStatusOrder",
         rfrd."bookingCreatedAt",
         rfrd."bookingUserId",
         rfrd."bookingUserName",
@@ -339,6 +341,7 @@ export class InsightsRoutingBaseService {
           WHERE f."responseId" = rfrd."id"
         ) as "fields"
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE ${baseConditions}
       ${orderByClause}
       LIMIT ${limit}
@@ -368,6 +371,7 @@ export class InsightsRoutingBaseService {
     const totalQuery = Prisma.sql`
       SELECT COUNT(*) as count
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE ${baseConditions}
     `;
 
@@ -377,6 +381,7 @@ export class InsightsRoutingBaseService {
     const totalWithoutBookingQuery = Prisma.sql`
       SELECT COUNT(*) as count
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE (${baseConditions}) AND ("bookingUid" IS NULL)
     `;
 
@@ -455,13 +460,14 @@ export class InsightsRoutingBaseService {
         "bookingUserEmail" as email,
         "bookingUserAvatarUrl" as "avatarUrl"
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE "bookingUid" IS NOT NULL
         AND "bookingUserId" IS NOT NULL
-        AND "createdAt" >= ${startDate}
-        AND "createdAt" <= ${endDate}
+        AND rfrd."createdAt" >= ${startDate}
+        AND rfrd."createdAt" <= ${endDate}
         AND ${baseConditions}
         AND ${searchCondition}
-      ORDER BY "bookingUserId", "createdAt" DESC
+      ORDER BY "bookingUserId", rfrd."createdAt" DESC
       ${limit ? Prisma.sql`LIMIT ${limit}` : Prisma.empty}
     `;
 
@@ -526,12 +532,13 @@ export class InsightsRoutingBaseService {
       booking_counts AS (
         SELECT
           "bookingUserId",
-          date_trunc(${dayjsPeriod}, "createdAt") as period_start,
+          date_trunc(${dayjsPeriod}, rfrd."createdAt") as period_start,
           COUNT(DISTINCT "bookingId")::integer as total
         FROM "RoutingFormResponseDenormalized" rfrd
+        LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
         WHERE "bookingUserId" IN (SELECT user_id FROM all_users)
-        AND "createdAt" >= (SELECT MIN(period_start) FROM paginated_periods)
-        AND "createdAt" < (
+        AND rfrd."createdAt" >= (SELECT MIN(period_start) FROM paginated_periods)
+        AND rfrd."createdAt" < (
           (SELECT MAX(period_start) FROM paginated_periods)
           + (CASE
               WHEN ${dayjsPeriod} = 'day' THEN interval '1 day'
@@ -568,9 +575,10 @@ export class InsightsRoutingBaseService {
         "bookingUserId" as "userId",
         COUNT(DISTINCT "bookingId")::integer as total_bookings
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       WHERE "bookingUid" IS NOT NULL
-        AND "createdAt" >= ${startDate}
-        AND "createdAt" <= ${endDate}
+        AND rfrd."createdAt" >= ${startDate}
+        AND rfrd."createdAt" <= ${endDate}
         AND ${baseConditions}
       GROUP BY "bookingUserId"
       ORDER BY total_bookings ASC
@@ -722,14 +730,46 @@ export class InsightsRoutingBaseService {
     // Extract booking status order filter
     const bookingStatusOrder = filtersMap["bookingStatusOrder"];
     if (bookingStatusOrder && isMultiSelectFilterValue(bookingStatusOrder.value)) {
-      // Convert string values to numbers for integer column
-      const integerFilterValue = {
-        ...bookingStatusOrder.value,
-        data: bookingStatusOrder.value.data.map((order) => Number(order)),
-      };
-      const statusCondition = makeSqlCondition(integerFilterValue);
-      if (statusCondition) {
-        conditions.push(Prisma.sql`rfrd."bookingStatusOrder" ${statusCondition}`);
+      const selectedStatuses = bookingStatusOrder.value.data.map((order) => Number(order));
+      const hasRescheduled = selectedStatuses.includes(statusOrder["RESCHEDULED"]);
+      const hasCancelled = selectedStatuses.includes(statusOrder["CANCELLED"]);
+      const otherStatuses = selectedStatuses.filter(
+        (s) => s !== statusOrder["RESCHEDULED"] && s !== statusOrder["CANCELLED"]
+      );
+
+      const statusConditions: Prisma.Sql[] = [];
+
+      if (hasCancelled && hasRescheduled) {
+        statusConditions.push(Prisma.sql`rfrd."bookingStatusOrder" = 4`);
+      } else {
+        if (hasCancelled) {
+          // Cancelled bookings that are NOT rescheduled
+          statusConditions.push(
+            Prisma.sql`(rfrd."bookingStatusOrder" = 4 AND (b."rescheduled" IS NULL OR b."rescheduled" = false))`
+          );
+        }
+
+        if (hasRescheduled) {
+          statusConditions.push(Prisma.sql`b."rescheduled" = true`);
+        }
+      }
+
+      if (otherStatuses.length > 0) {
+        const otherStatusesCondition = makeSqlCondition({
+          ...bookingStatusOrder.value,
+          data: otherStatuses,
+        });
+        if (otherStatusesCondition) {
+          statusConditions.push(Prisma.sql`rfrd."bookingStatusOrder" ${otherStatusesCondition}`);
+        }
+      }
+
+      if (statusConditions.length > 0) {
+        const joinedStatusCondition = statusConditions.reduce((acc, condition, index) => {
+          if (index === 0) return condition;
+          return Prisma.sql`(${acc} OR ${condition})`;
+        });
+        conditions.push(Prisma.sql`(${joinedStatusCondition})`);
       }
     }
 
@@ -1008,6 +1048,7 @@ export class InsightsRoutingBaseService {
           opt->>'id' as option_id,
           opt->>'label' as option_label
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       JOIN "App_RoutingForms_Form" f ON rfrd."formId" = f.id,
       LATERAL jsonb_array_elements(f.fields) as field
       LEFT JOIN LATERAL jsonb_array_elements(field->'options') as opt ON true
@@ -1021,6 +1062,7 @@ export class InsightsRoutingBaseService {
           COALESCE(arr.value, f."valueString", f."valueNumber"::text) as selected_option,
           COUNT(DISTINCT rfrd.id) as response_count
       FROM "RoutingFormResponseDenormalized" rfrd
+      LEFT JOIN "Booking" b ON b.id = rfrd."bookingId"
       JOIN "RoutingFormResponseField" f ON rfrd.id = f."responseId"
       LEFT JOIN LATERAL unnest(f."valueStringArray") as arr(value) ON f."valueStringArray" != '{}'
       WHERE ${baseConditions}


### PR DESCRIPTION
## What does this PR do?

- Fixes #24531
- Fixes CAL-6599

The Insights/Bookings and Routing false positively fetched the data when "Cancelled" booking status is selected. All the bookings has a column in DB called "Rescheduled" which is by default set to null, but when a meeting is rescheduled, it is set to true and the meeting status is set to "CANCELLED". So when the "Cancelled" status is selected, the rescheduled meetings are also being fetched which leads to incorrect stats. 

This PR resolves this false-positive fetching and introduces a separate "Rescheduled" filter to only fetch the rescheduled meetings.

There are 4 scenarios that can happen while fetching the data:

1. Cancelled or Rescheduled filters are not selected, in this case the data will be fetched normally
2. Cancelled is selected, in this case all Bookings which status is marked as CANCELLED and their "rescheduled" column is either null or false, they will be fetched.
3. Rescheduled is selected, in this case all Bookings whose "rescheduled" column is true will be fetched.
4. Rescheduled and Cancelled both are selected, in this case all the bookings with "CANCELLED" status will be fetched, this will also fetch the rescheduled bookings because rescheduled bookings are marked as CANCELLED and their "rescheduled" field is set to true.

This PR covers all of the above cases.

## Visual Demo (For contributors especially)

Insights/Routing:

https://github.com/user-attachments/assets/5e19fb0c-6193-4afd-bcfc-7e1d14a19016

Insights/Bookings:

https://github.com/user-attachments/assets/329ec1ae-3ee7-49b6-b951-ae1ae03f37f3



#### Image Demo (if applicable):

For routing:
<img width="379" height="434" alt="image" src="https://github.com/user-attachments/assets/b9a5c0bf-e3b4-4951-a10d-f01d1d694057" />

For Bookings:
<img width="369" height="410" alt="image" src="https://github.com/user-attachments/assets/9f9e0b6b-7e5b-43ba-9ca4-6518137108ac" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Will describe soon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/cal.com/pull/25745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
