### PR TITLE
fix: watch invites to ensure reactivity of invites

### DIFF
--- a/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
@@ -125,13 +125,12 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
     router.replace(gettingStartedPath);
   };
 
-  const hasValidInvites = fields.some((_, index) => {
-    const email = form.watch(`invites.${index}.email`);
-    return email && email.trim().length > 0;
-  });
-
   // Watch form values to pass to browser view for real-time updates
   const watchedInvites = form.watch("invites");
+
+  const hasValidInvites = watchedInvites.some((invite) => {
+    return invite.email && invite.email.trim().length > 0;
+  });
 
   return (
     <OnboardingLayout userEmail={userEmail} currentStep={3} totalSteps={3}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes invite form reactivity by watching the invites array, so hasValidInvites updates in real time and the UI (e.g., Continue button) reflects changes immediately.

- **Bug Fixes**
  - Compute hasValidInvites from form.watch("invites") instead of per-index watches to avoid stale values.

<sup>Written for commit 13ced9ae6f664a6e872ddbed528183f97965d8d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

