### PR TITLE
feat(companion): use expo-constants for env vars and update Expo 54 best practices

### DIFF
--- a/companion/.env.example
+++ b/companion/.env.example
@@ -1,5 +1,9 @@
 # Cal.com OAuth Configuration
-EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID=your_oauth_client_id_here
+# These environment variables are loaded via expo-constants for cross-platform support
+# For native builds (iOS/Android), configure these in eas.json or EAS Secrets
+# For web builds, set these in your environment or .env file
 
+EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID=your_oauth_client_id_here
 EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI=your_oauth_redirect_uri_here
+EXPO_PUBLIC_CALCOM_BASE_URL=https://app.cal.com
 

--- a/companion/app.json
+++ b/companion/app.json
@@ -1,13 +1,16 @@
 {
   "expo": {
-    "name": "expo-wxt-app",
+    "name": "Cal.com Companion",
     "slug": "calcom-companion",
-    "scheme": "expo-wxt-app",
+    "scheme": "calcom-companion",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "experiments": {
+      "typedRoutes": true
+    },
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
@@ -15,11 +18,17 @@
     },
     "ios": {
       "supportsTablet": true,
-      "deploymentTarget": "18.0",
+      "deploymentTarget": "15.1",
       "bundleIdentifier": "com.calcom.companion",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
-      }
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSCalendarsUsageDescription": "Cal.com Companion needs access to your calendar to manage your bookings.",
+        "UIBackgroundModes": ["fetch", "remote-notification"]
+      },
+      "config": {
+        "usesNonExemptEncryption": false
+      },
+      "associatedDomains": ["applinks:app.cal.com", "applinks:cal.com"]
     },
     "android": {
       "adaptiveIcon": {
@@ -27,17 +36,52 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "com.calcom.companion"
+      "package": "com.calcom.companion",
+      "permissions": ["android.permission.INTERNET", "android.permission.ACCESS_NETWORK_STATE"],
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "app.cal.com",
+              "pathPrefix": "/booking"
+            },
+            {
+              "scheme": "https",
+              "host": "cal.com",
+              "pathPrefix": "/booking"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png",
-      "bundler": "metro"
+      "bundler": "metro",
+      "output": "single",
+      "name": "Cal.com Companion"
     },
+    "plugins": ["expo-router", "expo-secure-store"],
     "extra": {
+      "CALCOM_OAUTH_CLIENT_ID": "",
+      "CALCOM_OAUTH_REDIRECT_URI": "",
+      "CALCOM_BASE_URL": "https://app.cal.com",
       "eas": {
         "projectId": "f5e97f6f-1e95-44ac-bfa4-f737ef90f198"
+      },
+      "router": {
+        "origin": false
       }
     },
-    "owner": "calcoms-organization"
+    "owner": "calcoms-organization",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/f5e97f6f-1e95-44ac-bfa4-f737ef90f198"
+    }
   }
 }

--- a/companion/eas.json
+++ b/companion/eas.json
@@ -4,18 +4,57 @@
     "appVersionSource": "remote"
   },
   "build": {
+    "base": {
+      "node": "20.18.0",
+      "env": {
+        "EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID": "",
+        "EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI": "",
+        "EXPO_PUBLIC_CALCOM_BASE_URL": "https://app.cal.com"
+      }
+    },
     "development": {
+      "extends": "base",
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "extends": "base",
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      },
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "extends": "base",
+      "autoIncrement": true,
+      "ios": {
+        "resourceClass": "m-medium"
+      },
+      "android": {
+        "buildType": "app-bundle"
+      }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "appleId": "",
+        "ascAppId": "",
+        "appleTeamId": ""
+      },
+      "android": {
+        "serviceAccountKeyPath": "",
+        "track": "internal"
+      }
+    }
   }
 }

--- a/companion/eas.json
+++ b/companion/eas.json
@@ -7,8 +7,6 @@
     "base": {
       "node": "20.18.0",
       "env": {
-        "EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID": "",
-        "EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI": "",
         "EXPO_PUBLIC_CALCOM_BASE_URL": "https://app.cal.com"
       }
     },
@@ -45,16 +43,6 @@
     }
   },
   "submit": {
-    "production": {
-      "ios": {
-        "appleId": "",
-        "ascAppId": "",
-        "appleTeamId": ""
-      },
-      "android": {
-        "serviceAccountKeyPath": "",
-        "track": "internal"
-      }
-    }
+    "production": {}
   }
 }

--- a/companion/services/oauthService.ts
+++ b/companion/services/oauthService.ts
@@ -5,6 +5,8 @@ import * as Crypto from "expo-crypto";
 import * as WebBrowser from "expo-web-browser";
 import { Platform } from "react-native";
 
+import env from "../utils/env";
+
 // Complete warm up for WebBrowser on mobile
 WebBrowser.maybeCompleteAuthSession();
 
@@ -497,18 +499,16 @@ export class CalComOAuthService {
 }
 
 export function createCalComOAuthService(overrides: Partial<OAuthConfig> = {}): CalComOAuthService {
-  let defaultRedirectUri: string;
-
   const defaultConfig: OAuthConfig = {
-    clientId: process.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID || "",
-    redirectUri: process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI,
-    calcomBaseUrl: "https://app.cal.com",
+    clientId: env.CALCOM_OAUTH_CLIENT_ID,
+    redirectUri: env.CALCOM_OAUTH_REDIRECT_URI,
+    calcomBaseUrl: env.CALCOM_BASE_URL,
     ...overrides,
   };
 
   if (!defaultConfig.clientId) {
     throw new Error(
-      "OAuth client ID is required. Set EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID environment variable."
+      "OAuth client ID is required. Set EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID environment variable or configure it in app.json extra field."
     );
   }
 

--- a/companion/utils/env.ts
+++ b/companion/utils/env.ts
@@ -1,0 +1,89 @@
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+/**
+ * Environment configuration using expo-constants
+ *
+ * This module provides a centralized way to access environment variables
+ * across all platforms (iOS, Android, Web) using Expo's Constants API.
+ *
+ * For native builds (iOS/Android), environment variables are loaded from:
+ * - app.json/app.config.js `extra` field
+ * - EAS build environment variables
+ *
+ * For web builds, environment variables are loaded from:
+ * - process.env (for Expo web bundler)
+ * - import.meta.env (for Vite/WXT extension builds)
+ */
+
+interface EnvConfig {
+  CALCOM_OAUTH_CLIENT_ID: string;
+  CALCOM_OAUTH_REDIRECT_URI: string;
+  CALCOM_BASE_URL: string;
+}
+
+/**
+ * Get environment variable value with fallback support
+ * Checks multiple sources in order of priority:
+ * 1. expo-constants extra config (for native builds)
+ * 2. process.env (for Expo web bundler)
+ * 3. import.meta.env (for Vite/WXT builds)
+ */
+function getEnvVar(key: string, defaultValue: string = ""): string {
+  // For native platforms, use expo-constants
+  const expoConfig = Constants.expoConfig;
+  const extra = expoConfig?.extra;
+
+  if (extra && extra[key]) {
+    return extra[key] as string;
+  }
+
+  // For web platform, check process.env with EXPO_PUBLIC_ prefix
+  if (Platform.OS === "web") {
+    const envKey = `EXPO_PUBLIC_${key}`;
+
+    // Check process.env (Expo web bundler)
+    if (typeof process !== "undefined" && process.env && process.env[envKey]) {
+      return process.env[envKey] as string;
+    }
+
+    // Check import.meta.env (Vite/WXT builds)
+    if (typeof import.meta !== "undefined" && import.meta.env && import.meta.env[envKey]) {
+      return import.meta.env[envKey] as string;
+    }
+  }
+
+  return defaultValue;
+}
+
+/**
+ * Environment configuration object
+ * Access environment variables through this object for cross-platform compatibility
+ */
+export const env: EnvConfig = {
+  CALCOM_OAUTH_CLIENT_ID: getEnvVar("CALCOM_OAUTH_CLIENT_ID"),
+  CALCOM_OAUTH_REDIRECT_URI: getEnvVar("CALCOM_OAUTH_REDIRECT_URI"),
+  CALCOM_BASE_URL: getEnvVar("CALCOM_BASE_URL", "https://app.cal.com"),
+};
+
+/**
+ * Validate that required environment variables are set
+ * Call this during app initialization to catch configuration errors early
+ */
+export function validateEnv(): { isValid: boolean; missingVars: string[] } {
+  const requiredVars = ["CALCOM_OAUTH_CLIENT_ID"];
+  const missingVars: string[] = [];
+
+  for (const varName of requiredVars) {
+    if (!env[varName as keyof EnvConfig]) {
+      missingVars.push(varName);
+    }
+  }
+
+  return {
+    isValid: missingVars.length === 0,
+    missingVars,
+  };
+}
+
+export default env;

--- a/companion/utils/env.ts
+++ b/companion/utils/env.ts
@@ -13,7 +13,9 @@ import { Platform } from "react-native";
  *
  * For web builds, environment variables are loaded from:
  * - process.env (for Expo web bundler)
- * - import.meta.env (for Vite/WXT extension builds)
+ *
+ * Note: The browser extension (WXT/Vite) uses import.meta.env directly
+ * in wxt.config.ts and doesn't use this module.
  */
 
 interface EnvConfig {
@@ -27,7 +29,6 @@ interface EnvConfig {
  * Checks multiple sources in order of priority:
  * 1. expo-constants extra config (for native builds)
  * 2. process.env (for Expo web bundler)
- * 3. import.meta.env (for Vite/WXT builds)
  */
 function getEnvVar(key: string, defaultValue: string = ""): string {
   // For native platforms, use expo-constants
@@ -43,13 +44,8 @@ function getEnvVar(key: string, defaultValue: string = ""): string {
     const envKey = `EXPO_PUBLIC_${key}`;
 
     // Check process.env (Expo web bundler)
-    if (typeof process !== "undefined" && process.env && process.env[envKey]) {
+    if (typeof process !== "undefined" && process.env?.[envKey]) {
       return process.env[envKey] as string;
-    }
-
-    // Check import.meta.env (Vite/WXT builds)
-    if (typeof import.meta !== "undefined" && import.meta.env && import.meta.env[envKey]) {
-      return import.meta.env[envKey] as string;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where `expo-constants` was installed in the companion app but not being used for environment variable loading. It also updates the app configuration with Expo 54 best practices for smooth deployment across web, Android, and iOS.

**Key changes:**
- Created `utils/env.ts` to properly load environment variables using expo-constants with fallbacks for web builds
- Updated `oauthService.ts` to use the new centralized env config instead of direct `process.env` access
- Updated `app.json` with Expo 54 best practices (typed routes, deep linking, proper permissions)
- Updated `eas.json` with comprehensive build profiles for development, preview, and production
- Fixed EAS validation errors by removing empty string placeholders (env vars should come from EAS Secrets)

## Updates since last revision

- **Fixed eas.json validation errors**: Removed empty string values for `EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID` and `EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI` from eas.json. EAS validates the config statically and doesn't allow empty strings. These values should be configured via EAS Secrets instead.
- **Simplified submit configuration**: Removed placeholder empty strings from `submit.production` section to avoid validation errors.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - companion app internal changes
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Environment variable loading**: Verify env vars load correctly on each platform:
   - Web: Set `EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID` in .env and run `npm run web`
   - iOS/Android: Configure env vars in EAS Secrets and run a build

2. **OAuth flow**: Test the OAuth login flow works correctly with the new env config

3. **Build verification**: Run EAS builds for each profile (development, preview, production) to verify configurations are correct

**Environment variables required (via EAS Secrets):**
- `EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID`
- `EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI`

## Important items for reviewer

- [ ] The iOS `deploymentTarget` was changed from `18.0` to `15.1` - please verify this is the intended minimum iOS version
- [ ] Deep linking configuration (associatedDomains, intentFilters) requires corresponding server-side setup
- [ ] The `app.json` extra field has empty string placeholders for OAuth config - these are fallback defaults and won't cause EAS validation errors (unlike eas.json)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run**: https://app.devin.ai/sessions/482231f2c31843d38d3655122c2bce3a
> **Requested by**: Volnei Munhoz (@volnei)