### PR TITLE
fix: handle string + object formats for AI call phone extraction

### DIFF
--- a/packages/features/ee/workflows/lib/reminders/aiPhoneCallManager.ts
+++ b/packages/features/ee/workflows/lib/reminders/aiPhoneCallManager.ts
@@ -20,19 +20,26 @@ type timeUnitLowerCase = "day" | "hour" | "minute";
 function extractPhoneNumber(responses: BookingInfo["responses"]): string | undefined {
   if (!responses) return undefined;
 
-  // Priority 1: CAL_AI_AGENT_PHONE_NUMBER_FIELD first
   const aiAgentPhoneResponse = responses[CAL_AI_AGENT_PHONE_NUMBER_FIELD];
+  
+  // Handle plain string format (how booking form actually stores it)
+  if (typeof aiAgentPhoneResponse === "string") {
+    return aiAgentPhoneResponse;
+  }
+  
+  // Handle object with value property (legacy/alternative format)
   if (aiAgentPhoneResponse && typeof aiAgentPhoneResponse === "object" && "value" in aiAgentPhoneResponse) {
     return aiAgentPhoneResponse.value as string;
   }
 
-  // Priority 2: attendeePhoneNumber as fallback
+  // Same for attendeePhoneNumber fallback...
   const attendeePhoneResponse = responses.attendeePhoneNumber;
-  if (
-    attendeePhoneResponse &&
-    typeof attendeePhoneResponse === "object" &&
-    "value" in attendeePhoneResponse
-  ) {
+  
+  if (typeof attendeePhoneResponse === "string") {
+    return attendeePhoneResponse;
+  }
+  
+  if (attendeePhoneResponse && typeof attendeePhoneResponse === "object" && "value" in attendeePhoneResponse) {
     return attendeePhoneResponse.value as string;
   }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a silent failure in the AI phone-call workflow by making the phone-number extractor accept both formats the booking form can produce (plain string and `{ value: string }`). Previously the extractor expected an object and returned `undefined` for plain-string responses, preventing `WorkflowReminder` and `Task` creation. This change restores correct behavior for CAL_AI_PHONE_CALL workflows.
The solution is based on proposed fix from the linked issue.

- Fixes #25742 
- Fixes [CAL-6892](https://linear.app/calcom/issue/CAL-6892/bug-ai-phone-call-workflow-fails-extractphonenumber-expects-object-but)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Create an event type with a CAL_AI_PHONE_CALL workflow (e.g., 30-minute reminder)
- Book the event and fill in the aiAgentCallPhoneNumber field
- Wait for the reminder trigger time
- AI phone call is made

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code does follow the style guidelines of this project
- I have checked if my changes generate no new warnings
