### PR TITLE
fix: form step in teams invite

### DIFF
--- a/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
@@ -125,6 +125,10 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
     router.replace(gettingStartedPath);
   };
 
+  const handleSubmitClick = () => {
+    form.handleSubmit(handleContinue)();
+  };
+
   // Watch form values to pass to browser view for real-time updates
   const watchedInvites = form.watch("invites");
 
@@ -152,11 +156,12 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
                     {t("onboarding_skip_for_now")}
                   </Button>
                   <Button
-                    type="submit"
+                    type="button"
                     color="primary"
                     className="rounded-[10px]"
                     disabled={!hasValidInvites || isSubmitting}
-                    loading={isSubmitting}>
+                    loading={isSubmitting}
+                    onClick={handleSubmitClick}>
                     {t("continue")}
                   </Button>
                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the Continue button in the team invite step so it reliably submits the form and runs validation. It now calls form.handleSubmit(handleContinue) on click instead of using type="submit".

<sup>Written for commit df7abe3e6adc11a73c0dd01eb31c8c5282f14308. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

