### PR TITLE
feat: add enabled column to UserFeatures and TeamFeatures for tri-state semantics

### DIFF
--- a/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
@@ -112,7 +112,7 @@ describe("Organizations Roles Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledOrganization.id, "pbac", "enabled");
+    await featuresRepositoryFixture.setTeamFeatureState(pbacEnabledOrganization.id, "pbac", "enabled");
 
     // Create memberships
     await membershipRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/organizations-roles.controller.e2e-spec.ts
@@ -112,7 +112,7 @@ describe("Organizations Roles Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.enableFeatureForTeam(pbacEnabledOrganization.id, "pbac");
+    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledOrganization.id, "pbac", "enabled");
 
     // Create memberships
     await membershipRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
@@ -58,7 +58,7 @@ describe("Organizations Roles Permissions Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledOrganization.id, "pbac", "enabled");
+    await featuresRepositoryFixture.setTeamFeatureState(pbacEnabledOrganization.id, "pbac", "enabled");
 
     // Create user + membership in org
     pbacOrgUserWithRolePermission = await userRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/roles/permissions/organizations-roles-permissions.controller.e2e-spec.ts
@@ -58,7 +58,7 @@ describe("Organizations Roles Permissions Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.enableFeatureForTeam(pbacEnabledOrganization.id, "pbac");
+    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledOrganization.id, "pbac", "enabled");
 
     // Create user + membership in org
     pbacOrgUserWithRolePermission = await userRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
@@ -126,7 +126,7 @@ describe("Organizations Roles Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledTeam.id, "pbac", "enabled");
+    await featuresRepositoryFixture.setTeamFeatureState(pbacEnabledTeam.id, "pbac", "enabled");
 
     // Create memberships
     await membershipRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/organizations-teams-roles.controller.e2e-spec.ts
@@ -126,7 +126,7 @@ describe("Organizations Roles Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.enableFeatureForTeam(pbacEnabledTeam.id, "pbac");
+    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledTeam.id, "pbac", "enabled");
 
     // Create memberships
     await membershipRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
@@ -67,7 +67,7 @@ describe("Organizations Teams Roles Permissions Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledTeam.id, "pbac", "enabled");
+    await featuresRepositoryFixture.setTeamFeatureState(pbacEnabledTeam.id, "pbac", "enabled");
 
     // Create user + membership in org
     pbacOrgUserWithRolePermission = await userRepositoryFixture.create({

--- a/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/teams/roles/permissions/organizations-teams-roles-permissions.controller.e2e-spec.ts
@@ -67,7 +67,7 @@ describe("Organizations Teams Roles Permissions Endpoints", () => {
     });
 
     await featuresRepositoryFixture.create({ slug: "pbac", enabled: true });
-    await featuresRepositoryFixture.enableFeatureForTeam(pbacEnabledTeam.id, "pbac");
+    await featuresRepositoryFixture.updateFeatureForTeam(pbacEnabledTeam.id, "pbac", "enabled");
 
     // Create user + membership in org
     pbacOrgUserWithRolePermission = await userRepositoryFixture.create({

--- a/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
@@ -28,7 +28,7 @@ export class FeaturesRepositoryFixture {
     });
   }
 
-  async updateFeatureForTeam(teamId: number, featureId: string, state, assignedBy = "test") {
+  async setTeamFeatureState(teamId: number, featureId: string, state, assignedBy = "test") {
     if (state === "enabled" || state === "disabled") {
       await this.prismaWriteClient.teamFeatures.upsert({
         where: {

--- a/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
@@ -28,24 +28,33 @@ export class FeaturesRepositoryFixture {
     });
   }
 
-  async enableFeatureForTeam(teamId: number, featureId: string, assignedBy = "test") {
-    await this.prismaWriteClient.teamFeatures.upsert({
-      where: {
-        teamId_featureId: {
+  async updateFeatureForTeam(teamId: number, featureId: string, state, assignedBy = "test") {
+    if (state === "enabled" || state === "disabled") {
+      await this.prismaWriteClient.teamFeatures.upsert({
+        where: {
+          teamId_featureId: {
+            teamId,
+            featureId,
+          },
+        },
+        create: {
+          teamId,
+          featureId,
+          assignedBy,
+          enabled: state === "enabled",
+        },
+        update: {
+          enabled: state === "enabled",
+        },
+      });
+    } else if (state === "inherit") {
+      await this.prismaWriteClient.teamFeatures.deleteMany({
+        where: {
           teamId,
           featureId,
         },
-      },
-      create: {
-        teamId,
-        featureId,
-        assignedBy,
-        enabled: true,
-      },
-      update: {
-        enabled: true,
-      },
-    });
+      });
+    }
   }
 
   async disableFeatureForTeam(teamId: number, featureSlug: string) {

--- a/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
@@ -40,8 +40,11 @@ export class FeaturesRepositoryFixture {
         teamId,
         featureId,
         assignedBy,
+        enabled: true,
       },
-      update: {},
+      update: {
+        enabled: true,
+      },
     });
   }
 

--- a/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/features.repository.fixture.ts
@@ -28,7 +28,12 @@ export class FeaturesRepositoryFixture {
     });
   }
 
-  async setTeamFeatureState(teamId: number, featureId: string, state, assignedBy = "test") {
+  async setTeamFeatureState(
+    teamId: number,
+    featureId: string,
+    state: "enabled" | "disabled" | "inherit",
+    assignedBy = "test"
+  ) {
     if (state === "enabled" || state === "disabled") {
       await this.prismaWriteClient.teamFeatures.upsert({
         where: {

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/layout.tsx
@@ -20,7 +20,7 @@ import SettingsLayoutAppDirClient from "./SettingsLayoutAppDirClient";
 const getTeamFeatures = unstable_cache(
   async (teamId: number) => {
     const featuresRepository = new FeaturesRepository(prisma);
-    return await featuresRepository.getTeamFeatures(teamId);
+    return await featuresRepository.getEnabledTeamFeatures(teamId);
   },
   ["team-features"],
   {

--- a/apps/web/playwright/lib/test-helpers/pbac.ts
+++ b/apps/web/playwright/lib/test-helpers/pbac.ts
@@ -24,6 +24,7 @@ export const enablePBACForTeam = async (teamId: number) => {
       teamId: teamId,
       assignedBy: "e2e",
       assignedAt: new Date(),
+      enabled: true,
     },
   });
 };

--- a/packages/features/ee/teams/repositories/TeamRepository.ts
+++ b/packages/features/ee/teams/repositories/TeamRepository.ts
@@ -556,7 +556,7 @@ export class TeamRepository {
       FROM "Membership" m
       INNER JOIN "User" u ON m."userId" = u.id
       LEFT JOIN "Role" r ON m."customRoleId" = r.id
-      LEFT JOIN "TeamFeatures" f ON m."teamId" = f."teamId" AND f."featureId" = 'pbac'
+      LEFT JOIN "TeamFeatures" f ON m."teamId" = f."teamId" AND f."featureId" = 'pbac' AND f.enabled = true
       WHERE m."teamId" = ${teamId}
         AND m."accepted" = true
         AND (

--- a/packages/features/flags/config.ts
+++ b/packages/features/flags/config.ts
@@ -37,3 +37,5 @@ export type AppFlags = {
 };
 
 export type TeamFeatures = Record<keyof AppFlags, boolean>;
+
+export type FeatureState = "enabled" | "disabled" | "inherit";

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, beforeAll, afterAll, beforeEach, it } from "vitest";
-import prisma from "@calcom/prisma";
+
+import { prisma } from "@calcom/prisma";
+
 import type { AppFlags } from "./config";
 import { FeaturesRepository } from "./features.repository";
 
@@ -7,7 +9,7 @@ const featuresRepository = new FeaturesRepository(prisma);
 
 // Access private clearCache method through type assertion
 const clearCache = () => {
-  (featuresRepository as any).clearCache();
+  (featuresRepository as unknown as { clearCache: () => void }).clearCache();
 };
 
 describe("FeaturesRepository Integration Tests", () => {
@@ -155,6 +157,71 @@ describe("FeaturesRepository Integration Tests", () => {
       expect(result).toBe(true);
     });
 
+    it("should return false when user has feature with enabled=false (tri-state)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.userFeatures.create({
+        data: {
+          userId: testUser.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeature(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when user has enabled=false even if team has feature (tri-state blocks inheritance)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // Team has the feature enabled
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: true,
+          assignedBy: "test",
+        },
+      });
+
+      // User is a member of the team
+      await prisma.membership.create({
+        data: {
+          teamId: testTeam.id,
+          userId: testUser.id,
+          role: "MEMBER",
+          accepted: true,
+        },
+      });
+
+      // But user has explicitly disabled the feature
+      await prisma.userFeatures.create({
+        data: {
+          userId: testUser.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeature(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+
     it("should return true when user belongs to team with feature", async () => {
       await prisma.feature.create({
         data: {
@@ -183,6 +250,38 @@ describe("FeaturesRepository Integration Tests", () => {
 
       const result = await featuresRepository.checkIfUserHasFeature(testUser.id, testFeature);
       expect(result).toBe(true);
+    });
+
+    it("should return false when user belongs to team with feature disabled (tri-state)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // Team has the feature explicitly disabled
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      await prisma.membership.create({
+        data: {
+          teamId: testTeam.id,
+          userId: testUser.id,
+          role: "MEMBER",
+          accepted: true,
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeature(testUser.id, testFeature);
+      expect(result).toBe(false);
     });
 
     it("should return true when user belongs to team where parent team has feature", async () => {
@@ -282,6 +381,28 @@ describe("FeaturesRepository Integration Tests", () => {
       expect(result).toBe(true);
     });
 
+    it("should return false when team has feature with enabled=false (tri-state)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfTeamHasFeature(testTeam.id, testFeature);
+      expect(result).toBe(false);
+    });
+
     it("should return true when parent team has feature", async () => {
       const parentTeam = await prisma.team.create({
         data: {
@@ -321,6 +442,318 @@ describe("FeaturesRepository Integration Tests", () => {
       await prisma.team.delete({
         where: { id: parentTeam.id },
       });
+    });
+
+    it("should return false when parent has feature with enabled=false (tri-state)", async () => {
+      const parentTeam = await prisma.team.create({
+        data: {
+          name: `Parent Team ${Date.now()}`,
+          slug: `parent-team-${Date.now()}`,
+        },
+      });
+
+      await prisma.team.update({
+        where: { id: testTeam.id },
+        data: { parentId: parentTeam.id },
+      });
+
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // Parent has the feature explicitly disabled
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: parentTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfTeamHasFeature(testTeam.id, testFeature);
+      expect(result).toBe(false);
+
+      // Clean up parent team
+      await prisma.teamFeatures.deleteMany({
+        where: { teamId: parentTeam.id },
+      });
+      await prisma.team.delete({
+        where: { id: parentTeam.id },
+      });
+    });
+  });
+
+  describe("checkIfUserHasFeatureNonHierarchical", () => {
+    it("should return false when user does not have feature", async () => {
+      const result = await featuresRepository.checkIfUserHasFeatureNonHierarchical(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when user has feature directly assigned", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.userFeatures.create({
+        data: {
+          userId: testUser.id,
+          featureId: testFeature,
+          enabled: true,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeatureNonHierarchical(testUser.id, testFeature);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when user has feature with enabled=false (tri-state)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.userFeatures.create({
+        data: {
+          userId: testUser.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeatureNonHierarchical(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when user belongs to direct team with feature (non-hierarchical)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: true,
+          assignedBy: "test",
+        },
+      });
+
+      await prisma.membership.create({
+        data: {
+          teamId: testTeam.id,
+          userId: testUser.id,
+          role: "MEMBER",
+          accepted: true,
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeatureNonHierarchical(testUser.id, testFeature);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when user belongs to direct team with feature disabled (tri-state)", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      await prisma.membership.create({
+        data: {
+          teamId: testTeam.id,
+          userId: testUser.id,
+          role: "MEMBER",
+          accepted: true,
+        },
+      });
+
+      const result = await featuresRepository.checkIfUserHasFeatureNonHierarchical(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("enableFeatureForTeam", () => {
+    it("should create a new TeamFeatures row with enabled=true", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      await featuresRepository.enableFeatureForTeam(testTeam.id, testFeature, "test-assigner");
+
+      const teamFeature = await prisma.teamFeatures.findUnique({
+        where: {
+          teamId_featureId: {
+            teamId: testTeam.id,
+            featureId: testFeature,
+          },
+        },
+      });
+
+      expect(teamFeature).not.toBeNull();
+      expect(teamFeature?.enabled).toBe(true);
+      expect(teamFeature?.assignedBy).toBe("test-assigner");
+    });
+
+    it("should update existing TeamFeatures row to enabled=true", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // Create with enabled=false first
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "original-assigner",
+        },
+      });
+
+      // Now enable the feature
+      await featuresRepository.enableFeatureForTeam(testTeam.id, testFeature, "new-assigner");
+
+      const teamFeature = await prisma.teamFeatures.findUnique({
+        where: {
+          teamId_featureId: {
+            teamId: testTeam.id,
+            featureId: testFeature,
+          },
+        },
+      });
+
+      expect(teamFeature).not.toBeNull();
+      expect(teamFeature?.enabled).toBe(true);
+      expect(teamFeature?.assignedBy).toBe("new-assigner");
+    });
+  });
+
+  describe("getTeamsWithFeatureEnabled", () => {
+    it("should return empty array when no teams have the feature", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      clearCache();
+
+      const result = await featuresRepository.getTeamsWithFeatureEnabled(testFeature);
+      expect(result).toEqual([]);
+    });
+
+    it("should return teams with enabled=true only", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // Create a second team
+      const secondTeam = await prisma.team.create({
+        data: {
+          name: `Second Team ${Date.now()}`,
+          slug: `second-team-${Date.now()}`,
+        },
+      });
+
+      // testTeam has feature enabled
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: true,
+          assignedBy: "test",
+        },
+      });
+
+      // secondTeam has feature disabled
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: secondTeam.id,
+          featureId: testFeature,
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      clearCache();
+
+      const result = await featuresRepository.getTeamsWithFeatureEnabled(testFeature);
+      expect(result).toContain(testTeam.id);
+      expect(result).not.toContain(secondTeam.id);
+
+      // Clean up second team
+      await prisma.teamFeatures.deleteMany({
+        where: { teamId: secondTeam.id },
+      });
+      await prisma.team.delete({
+        where: { id: secondTeam.id },
+      });
+    });
+
+    it("should return empty array when feature is not globally enabled", async () => {
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: false, // Globally disabled
+          type: "OPERATIONAL",
+        },
+      });
+
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: testTeam.id,
+          featureId: testFeature,
+          enabled: true,
+          assignedBy: "test",
+        },
+      });
+
+      clearCache();
+
+      const result = await featuresRepository.getTeamsWithFeatureEnabled(testFeature);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -631,7 +631,7 @@ describe("FeaturesRepository Integration Tests", () => {
     });
   });
 
-  describe("updateFeatureForTeam", () => {
+  describe("setTeamFeatureState", () => {
     it("should create a new TeamFeatures row with enabled=true", async () => {
       await prisma.feature.create({
         data: {
@@ -641,7 +641,7 @@ describe("FeaturesRepository Integration Tests", () => {
         },
       });
 
-      await featuresRepository.updateFeatureForTeam(testTeam.id, testFeature, "test-assigner", "enabled");
+      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "test-assigner", "enabled");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {
@@ -677,7 +677,7 @@ describe("FeaturesRepository Integration Tests", () => {
       });
 
       // Now enable the feature
-      await featuresRepository.updateFeatureForTeam(testTeam.id, testFeature, "new-assigner", "enabled");
+      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "new-assigner", "enabled");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -175,6 +175,7 @@ describe("FeaturesRepository Integration Tests", () => {
           userId: testUser.id,
           featureId: testFeature,
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -261,6 +262,7 @@ describe("FeaturesRepository Integration Tests", () => {
           teamId: testTeam.id,
           featureId: testFeature,
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -343,6 +345,7 @@ describe("FeaturesRepository Integration Tests", () => {
           teamId: org.id,
           featureId: testFeature,
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -399,6 +402,7 @@ describe("FeaturesRepository Integration Tests", () => {
           teamId: testTeam.id,
           featureId: testFeature,
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -454,6 +458,7 @@ describe("FeaturesRepository Integration Tests", () => {
           teamId: parentTeam.id,
           featureId: testFeature,
           assignedBy: "test",
+          enabled: true,
         },
       });
 

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -631,7 +631,7 @@ describe("FeaturesRepository Integration Tests", () => {
     });
   });
 
-  describe("enableFeatureForTeam", () => {
+  describe("updateFeatureForTeam", () => {
     it("should create a new TeamFeatures row with enabled=true", async () => {
       await prisma.feature.create({
         data: {
@@ -641,7 +641,7 @@ describe("FeaturesRepository Integration Tests", () => {
         },
       });
 
-      await featuresRepository.enableFeatureForTeam(testTeam.id, testFeature, "test-assigner");
+      await featuresRepository.updateFeatureForTeam(testTeam.id, testFeature, "test-assigner", "enabled");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {
@@ -677,7 +677,7 @@ describe("FeaturesRepository Integration Tests", () => {
       });
 
       // Now enable the feature
-      await featuresRepository.enableFeatureForTeam(testTeam.id, testFeature, "new-assigner");
+      await featuresRepository.updateFeatureForTeam(testTeam.id, testFeature, "new-assigner", "enabled");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -641,7 +641,7 @@ describe("FeaturesRepository Integration Tests", () => {
         },
       });
 
-      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "test-assigner", "enabled");
+      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "enabled", "test-assigner");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {
@@ -677,7 +677,7 @@ describe("FeaturesRepository Integration Tests", () => {
       });
 
       // Now enable the feature
-      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "new-assigner", "enabled");
+      await featuresRepository.setTeamFeatureState(testTeam.id, testFeature, "enabled", "new-assigner");
 
       const teamFeature = await prisma.teamFeatures.findUnique({
         where: {

--- a/packages/features/flags/features.repository.integration-test.ts
+++ b/packages/features/flags/features.repository.integration-test.ts
@@ -136,6 +136,31 @@ describe("FeaturesRepository Integration Tests", () => {
       expect(result).toBe(false);
     });
 
+    it("should return false when no UserFeatures row and no TeamFeatures row exist (tri-state inheritance)", async () => {
+      // Create the feature globally
+      await prisma.feature.create({
+        data: {
+          slug: testFeature,
+          enabled: true,
+          type: "OPERATIONAL",
+        },
+      });
+
+      // User is a member of a team
+      await prisma.membership.create({
+        data: {
+          teamId: testTeam.id,
+          userId: testUser.id,
+          role: "MEMBER",
+          accepted: true,
+        },
+      });
+
+      // No UserFeatures row, no TeamFeatures row - should return false
+      const result = await featuresRepository.checkIfUserHasFeature(testUser.id, testFeature);
+      expect(result).toBe(false);
+    });
+
     it("should return true when user has feature directly assigned", async () => {
       await prisma.feature.create({
         data: {

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -10,7 +10,7 @@ export interface IFeaturesRepository {
   checkIfUserHasFeatureNonHierarchical(userId: number, slug: string): Promise<boolean>;
   checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags): Promise<boolean>;
   getTeamsWithFeatureEnabled(slug: keyof AppFlags): Promise<number[]>;
-  updateFeatureForTeam(
+  setTeamFeatureState(
     teamId: number,
     featureId: keyof AppFlags,
     state: FeatureState,

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -1,4 +1,4 @@
-import type { AppFlags } from "./config";
+import type { AppFlags, FeatureState } from "./config";
 
 /**
  * Interface for the core FeaturesRepository.
@@ -10,5 +10,10 @@ export interface IFeaturesRepository {
   checkIfUserHasFeatureNonHierarchical(userId: number, slug: string): Promise<boolean>;
   checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags): Promise<boolean>;
   getTeamsWithFeatureEnabled(slug: keyof AppFlags): Promise<number[]>;
-  enableFeatureForTeam(teamId: number, featureId: keyof AppFlags, assignedBy: string): Promise<void>;
+  updateFeatureForTeam(
+    teamId: number,
+    featureId: keyof AppFlags,
+    state: FeatureState,
+    assignedBy: string
+  ): Promise<void>;
 }

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -3,9 +3,6 @@ import type { AppFlags } from "./config";
 /**
  * Interface for the core FeaturesRepository.
  * This interface defines methods for checking feature flags and team feature access.
- *
- * Note: For feature opt-in specific operations (setting user/team features, auto opt-in),
- * see IFeatureOptInRepository in the feature-opt-in package.
  */
 export interface IFeaturesRepository {
   checkIfFeatureIsEnabledGlobally(slug: keyof AppFlags): Promise<boolean>;

--- a/packages/features/flags/features.repository.interface.ts
+++ b/packages/features/flags/features.repository.interface.ts
@@ -1,8 +1,17 @@
 import type { AppFlags } from "./config";
 
+/**
+ * Interface for the core FeaturesRepository.
+ * This interface defines methods for checking feature flags and team feature access.
+ *
+ * Note: For feature opt-in specific operations (setting user/team features, auto opt-in),
+ * see IFeatureOptInRepository in the feature-opt-in package.
+ */
 export interface IFeaturesRepository {
   checkIfFeatureIsEnabledGlobally(slug: keyof AppFlags): Promise<boolean>;
   checkIfUserHasFeature(userId: number, slug: string): Promise<boolean>;
+  checkIfUserHasFeatureNonHierarchical(userId: number, slug: string): Promise<boolean>;
   checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags): Promise<boolean>;
   getTeamsWithFeatureEnabled(slug: keyof AppFlags): Promise<number[]>;
+  enableFeatureForTeam(teamId: number, featureId: keyof AppFlags, assignedBy: string): Promise<void>;
 }

--- a/packages/features/flags/features.repository.mock.ts
+++ b/packages/features/flags/features.repository.mock.ts
@@ -1,13 +1,32 @@
+import type { AppFlags } from "./config";
 import type { IFeaturesRepository } from "./features.repository.interface";
 
 export class MockFeaturesRepository implements IFeaturesRepository {
   async checkIfUserHasFeature(userId: number, slug: string) {
     return slug === "mock-feature";
   }
-  async checkIfTeamHasFeature(team: number, slug: string) {
+
+  async checkIfUserHasFeatureNonHierarchical(userId: number, slug: string) {
     return slug === "mock-feature";
   }
-  async checkIfFeatureIsEnabledGlobally() {
+
+  async checkIfTeamHasFeature(teamId: number, slug: keyof AppFlags) {
+    return slug === "mock-feature";
+  }
+
+  async checkIfFeatureIsEnabledGlobally(_slug: keyof AppFlags) {
     return true;
+  }
+
+  async getTeamsWithFeatureEnabled(_slug: keyof AppFlags): Promise<number[]> {
+    return [];
+  }
+
+  async enableFeatureForTeam(
+    _teamId: number,
+    _featureId: keyof AppFlags,
+    _assignedBy: string
+  ): Promise<void> {
+    // Mock implementation - do nothing
   }
 }

--- a/packages/features/flags/features.repository.mock.ts
+++ b/packages/features/flags/features.repository.mock.ts
@@ -22,7 +22,7 @@ export class MockFeaturesRepository implements IFeaturesRepository {
     return [];
   }
 
-  async updateFeatureForTeam(
+  async setTeamFeatureState(
     _teamId: number,
     _featureId: keyof AppFlags,
     _state: FeatureState,

--- a/packages/features/flags/features.repository.mock.ts
+++ b/packages/features/flags/features.repository.mock.ts
@@ -1,4 +1,4 @@
-import type { AppFlags } from "./config";
+import type { AppFlags, FeatureState } from "./config";
 import type { IFeaturesRepository } from "./features.repository.interface";
 
 export class MockFeaturesRepository implements IFeaturesRepository {
@@ -22,9 +22,10 @@ export class MockFeaturesRepository implements IFeaturesRepository {
     return [];
   }
 
-  async enableFeatureForTeam(
+  async updateFeatureForTeam(
     _teamId: number,
     _featureId: keyof AppFlags,
+    _state: FeatureState,
     _assignedBy: string
   ): Promise<void> {
     // Mock implementation - do nothing

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -171,6 +171,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           userId,
           featureId: slug,
         },
+        select: { enabled: true },
       });
 
       // If user has an explicit setting, use it
@@ -332,6 +333,7 @@ export class FeaturesRepository implements IFeaturesRepository {
             featureId,
           },
         },
+        select: { enabled: true },
       });
       if (teamFeature) return teamFeature.enabled;
 

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -69,12 +69,12 @@ export class FeaturesRepository implements IFeaturesRepository {
     const result = await this.prismaClient.teamFeatures.findMany({
       where: {
         teamId,
+        enabled: true,
       },
-      include: {
+      select: {
         feature: {
           select: {
             slug: true,
-            enabled: true,
           },
         },
       },
@@ -133,6 +133,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           userId,
           featureId: slug,
         },
+        select: { enabled: true },
       });
 
       // If user has an explicit setting, use it

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -14,6 +14,9 @@ interface CacheOptions {
  * Repository class for managing feature flags and feature access control.
  * Implements the IFeaturesRepository interface to provide feature flag functionality
  * for users, teams, and global application features.
+ *
+ * Note: For feature opt-in specific operations (setting user/team features, auto opt-in),
+ * use FeatureOptInRepository instead.
  */
 export class FeaturesRepository implements IFeaturesRepository {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -110,8 +113,15 @@ export class FeaturesRepository implements IFeaturesRepository {
   }
 
   /**
-   * Checks if a specific user has access to a feature.
-   * Checks both direct user feature assignments and team-based feature access.
+   * Checks if a specific user has access to a feature based on user and team assignments.
+   * Uses tri-state semantics:
+   * - Row with enabled=true → feature is enabled
+   * - Row with enabled=false → feature is explicitly disabled (blocks inheritance)
+   * - No row → inherit from team/org level
+   *
+   * Note: This method does NOT check auto opt-in. For full feature access checks
+   * including auto opt-in, use FeatureAccessService.checkIfUserHasFeature().
+   *
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
    * @returns Promise<boolean> - True if the user has access to the feature, false otherwise
@@ -124,18 +134,22 @@ export class FeaturesRepository implements IFeaturesRepository {
        * FIXME refactor when upgrading prismock
        * https://github.com/morintd/prismock/issues/592
        */
-      const userHasFeature = await this.prismaClient.userFeatures.findFirst({
+      const userFeature = await this.prismaClient.userFeatures.findFirst({
         where: {
           userId,
           featureId: slug,
         },
       });
-      if (userHasFeature) return true;
-      // If the user doesn't have the feature, check if they belong to a team with the feature.
+
+      // If user has an explicit setting, use it
+      if (userFeature) {
+        return userFeature.enabled;
+      }
+
+      // If no user-level setting, check if they belong to a team with the feature.
       // This also covers organizations, which are teams.
       const userBelongsToTeamWithFeature = await this.checkIfUserBelongsToTeamWithFeature(userId, slug);
-      if (userBelongsToTeamWithFeature) return true;
-      return false;
+      return userBelongsToTeamWithFeature;
     } catch (err) {
       captureException(err);
       throw err;
@@ -145,6 +159,14 @@ export class FeaturesRepository implements IFeaturesRepository {
   /**
    * Checks if a specific user has access to a feature, ignoring hierarchical (parent) teams.
    * Only checks direct user assignments and direct team memberships — does not traverse parents.
+   * Uses tri-state semantics:
+   * - Row with enabled=true → feature is enabled
+   * - Row with enabled=false → feature is explicitly disabled
+   * - No row → inherit from direct team memberships
+   *
+   * Note: This method does NOT check auto opt-in. For full feature access checks
+   * including auto opt-in, use FeatureAccessService.
+   *
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
    * @returns Promise<boolean> - True if the user has direct or same-level team access to the feature
@@ -153,16 +175,17 @@ export class FeaturesRepository implements IFeaturesRepository {
   async checkIfUserHasFeatureNonHierarchical(userId: number, slug: string) {
     try {
       // Prismock limitation: findUnique may fail, use findFirst instead
-      const userHasFeature = await this.prismaClient.userFeatures.findFirst({
-        select: {
-          userId: true,
-        },
+      const userFeature = await this.prismaClient.userFeatures.findFirst({
         where: {
           userId,
           featureId: slug,
         },
       });
-      if (userHasFeature) return true;
+
+      // If user has an explicit setting, use it
+      if (userFeature) {
+        return userFeature.enabled;
+      }
 
       const userBelongsToTeamWithFeature = await this.checkIfUserBelongsToTeamWithFeatureNonHierarchical(
         userId,
@@ -178,9 +201,10 @@ export class FeaturesRepository implements IFeaturesRepository {
 
   /**
    * Private helper method to check if a user belongs to any team that has access to a feature.
+   * Uses tri-state semantics: only treats as enabled if TeamFeatures row exists AND enabled=true.
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
-   * @returns Promise<boolean> - True if the user belongs to a team with the feature, false otherwise
+   * @returns Promise<boolean> - True if the user belongs to a team with the feature enabled, false otherwise
    * @throws Error if the team feature check fails
    * @private
    */
@@ -192,7 +216,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           SELECT DISTINCT t.id, t."parentId",
             CASE WHEN EXISTS (
               SELECT 1 FROM "TeamFeatures" tf
-              WHERE tf."teamId" = t.id AND tf."featureId" = ${slug}
+              WHERE tf."teamId" = t.id AND tf."featureId" = ${slug} AND tf."enabled" = true
             ) THEN true ELSE false END as has_feature
           FROM "Team" t
           INNER JOIN "Membership" m ON m."teamId" = t.id
@@ -204,7 +228,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           SELECT DISTINCT p.id, p."parentId",
             CASE WHEN EXISTS (
               SELECT 1 FROM "TeamFeatures" tf
-              WHERE tf."teamId" = p.id AND tf."featureId" = ${slug}
+              WHERE tf."teamId" = p.id AND tf."featureId" = ${slug} AND tf."enabled" = true
             ) THEN true ELSE false END as has_feature
           FROM "Team" p
           INNER JOIN TeamHierarchy c ON p.id = c."parentId"
@@ -227,9 +251,10 @@ export class FeaturesRepository implements IFeaturesRepository {
   /**
    * Checks if a user belongs to any direct team that has access to a feature.
    * This version ignores parent/child team relationships — no recursion or hierarchy traversal.
+   * Uses tri-state semantics: only treats as enabled if TeamFeatures row exists AND enabled=true.
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
-   * @returns Promise<boolean> - True if the user belongs to a team with the feature (direct only)
+   * @returns Promise<boolean> - True if the user belongs to a team with the feature enabled (direct only)
    * @throws Error if the query fails
    * @private
    */
@@ -246,6 +271,7 @@ export class FeaturesRepository implements IFeaturesRepository {
             FROM "TeamFeatures" tf
             WHERE tf."teamId" = t.id
               AND tf."featureId" = ${slug}
+              AND tf."enabled" = true
           )
         LIMIT 1;
       `;
@@ -260,6 +286,7 @@ export class FeaturesRepository implements IFeaturesRepository {
 
   /**
    * Enables a feature for a specific team.
+   * Uses tri-state semantics: creates/updates a row with enabled=true.
    * @param teamId - The ID of the team to enable the feature for
    * @param featureId - The feature identifier to enable
    * @param assignedBy - The user or what assigned the feature
@@ -278,9 +305,13 @@ export class FeaturesRepository implements IFeaturesRepository {
         create: {
           teamId,
           featureId,
+          enabled: true,
           assignedBy,
         },
-        update: {},
+        update: {
+          enabled: true,
+          assignedBy,
+        },
       });
       // Clear cache when features are modified
       this.clearCache();
@@ -293,15 +324,20 @@ export class FeaturesRepository implements IFeaturesRepository {
   /**
    * Checks if a team or any of its ancestors has access to a specific feature.
    * Uses a recursive CTE raw SQL query for performance.
+   * Uses tri-state semantics: only treats as enabled if TeamFeatures row exists AND enabled=true.
+   *
+   * Note: This method does NOT check auto opt-in. For full feature access checks
+   * including auto opt-in, use FeatureAccessService.
+   *
    * @param teamId - The ID of the team to start the check from
    * @param featureId - The feature identifier to check
-   * @returns Promise<boolean> - True if the team or any ancestor has the feature, false otherwise
+   * @returns Promise<boolean> - True if the team or any ancestor has the feature enabled, false otherwise
    * @throws Error if the database query fails
    */
   async checkIfTeamHasFeature(teamId: number, featureId: keyof AppFlags): Promise<boolean> {
     try {
-      // Early return if team has feature directly assigned
-      const teamHasFeature = await this.prismaClient.teamFeatures.findUnique({
+      // Early return if team has feature directly assigned with enabled=true
+      const teamFeature = await this.prismaClient.teamFeatures.findUnique({
         where: {
           teamId_featureId: {
             teamId,
@@ -309,7 +345,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           },
         },
       });
-      if (teamHasFeature) return true;
+      if (teamFeature) return teamFeature.enabled;
 
       const query = Prisma.sql`
         WITH RECURSIVE TeamHierarchy AS (
@@ -317,7 +353,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           SELECT id, "parentId",
             CASE WHEN EXISTS (
               SELECT 1 FROM "TeamFeatures" tf
-              WHERE tf."teamId" = id AND tf."featureId" = ${featureId}
+              WHERE tf."teamId" = id AND tf."featureId" = ${featureId} AND tf."enabled" = true
             ) THEN true ELSE false END as has_feature
           FROM "Team"
           WHERE id = ${teamId}
@@ -328,7 +364,7 @@ export class FeaturesRepository implements IFeaturesRepository {
           SELECT p.id, p."parentId",
             CASE WHEN EXISTS (
               SELECT 1 FROM "TeamFeatures" tf
-              WHERE tf."teamId" = p.id AND tf."featureId" = ${featureId}
+              WHERE tf."teamId" = p.id AND tf."featureId" = ${featureId} AND tf."enabled" = true
             ) THEN true ELSE false END as has_feature
           FROM "Team" p
           INNER JOIN TeamHierarchy c ON p.id = c."parentId"
@@ -358,8 +394,12 @@ export class FeaturesRepository implements IFeaturesRepository {
       const isGloballyEnabled = await this.checkIfFeatureIsEnabledGlobally(slug);
       if (!isGloballyEnabled) return [];
 
+      // Only return teams where enabled=true (tri-state semantics)
       const rows = await this.prismaClient.teamFeatures.findMany({
-        where: { featureId: slug },
+        where: {
+          featureId: slug,
+          enabled: true,
+        },
         select: { teamId: true },
         orderBy: { teamId: "asc" },
       });

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -14,9 +14,6 @@ interface CacheOptions {
  * Repository class for managing feature flags and feature access control.
  * Implements the IFeaturesRepository interface to provide feature flag functionality
  * for users, teams, and global application features.
- *
- * Note: For feature opt-in specific operations (setting user/team features, auto opt-in),
- * use FeatureOptInRepository instead.
  */
 export class FeaturesRepository implements IFeaturesRepository {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,9 +116,6 @@ export class FeaturesRepository implements IFeaturesRepository {
    * - Row with enabled=false → feature is explicitly disabled (blocks inheritance)
    * - No row → inherit from team/org level
    *
-   * Note: This method does NOT check auto opt-in. For full feature access checks
-   * including auto opt-in, use FeatureAccessService.checkIfUserHasFeature().
-   *
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
    * @returns Promise<boolean> - True if the user has access to the feature, false otherwise
@@ -163,9 +157,6 @@ export class FeaturesRepository implements IFeaturesRepository {
    * - Row with enabled=true → feature is enabled
    * - Row with enabled=false → feature is explicitly disabled
    * - No row → inherit from direct team memberships
-   *
-   * Note: This method does NOT check auto opt-in. For full feature access checks
-   * including auto opt-in, use FeatureAccessService.
    *
    * @param userId - The ID of the user to check
    * @param slug - The feature identifier to check
@@ -325,9 +316,6 @@ export class FeaturesRepository implements IFeaturesRepository {
    * Checks if a team or any of its ancestors has access to a specific feature.
    * Uses a recursive CTE raw SQL query for performance.
    * Uses tri-state semantics: only treats as enabled if TeamFeatures row exists AND enabled=true.
-   *
-   * Note: This method does NOT check auto opt-in. For full feature access checks
-   * including auto opt-in, use FeatureAccessService.
    *
    * @param teamId - The ID of the team to start the check from
    * @param featureId - The feature identifier to check

--- a/packages/features/flags/features.repository.ts
+++ b/packages/features/flags/features.repository.ts
@@ -287,7 +287,7 @@ export class FeaturesRepository implements IFeaturesRepository {
    * @returns Promise<void>
    * @throws Error if the feature enabling fails
    */
-  async updateFeatureForTeam(
+  async setTeamFeatureState(
     teamId: number,
     featureId: keyof AppFlags,
     state: FeatureState,

--- a/packages/features/flags/operations/check-if-user-has-feature.controller.test.ts
+++ b/packages/features/flags/operations/check-if-user-has-feature.controller.test.ts
@@ -16,6 +16,7 @@ it("checks if user has access to feature", async () => {
       featureId: "mock-feature",
       assignedBy: "1",
       updatedAt: new Date(),
+      enabled: true,
     },
   });
   await expect(checkIfUserHasFeatureController(userId, "nonexistent-feature")).resolves.toBe(false);

--- a/packages/features/flags/operations/check-if-user-has-feature.use-case.test.ts
+++ b/packages/features/flags/operations/check-if-user-has-feature.use-case.test.ts
@@ -14,6 +14,7 @@ it("returns if user has access to feature", async () => {
       featureId: "mock-feature",
       assignedBy: "1",
       updatedAt: new Date(),
+      enabled: true,
     },
   });
   await expect(checkIfUserHasFeatureUseCase(userId, "nonexistent-feature")).resolves.toBe(false);

--- a/packages/features/pbac/infrastructure/repositories/PermissionRepository.ts
+++ b/packages/features/pbac/infrastructure/repositories/PermissionRepository.ts
@@ -301,7 +301,7 @@ export class PermissionRepository implements IPermissionRepository {
       SELECT DISTINCT m."teamId"
       FROM "Membership" m
       INNER JOIN "Team" t ON m."teamId" = t.id
-      LEFT JOIN "TeamFeatures" f ON f."teamId" = t.id AND f."featureId" = ${this.PBAC_FEATURE_FLAG}
+      LEFT JOIN "TeamFeatures" f ON f."teamId" = t.id AND f."featureId" = ${this.PBAC_FEATURE_FLAG} AND f.enabled = true
       WHERE m."userId" = ${userId}
         AND m."accepted" = true
         AND m."role"::text = ANY(${fallbackRoles})
@@ -311,7 +311,7 @@ export class PermissionRepository implements IPermissionRepository {
       FROM "Membership" m
       INNER JOIN "Team" org ON m."teamId" = org.id
       INNER JOIN "Team" child ON child."parentId" = org.id
-      LEFT JOIN "TeamFeatures" f ON f."teamId" = org.id AND f."featureId" = ${this.PBAC_FEATURE_FLAG}
+      LEFT JOIN "TeamFeatures" f ON f."teamId" = org.id AND f."featureId" = ${this.PBAC_FEATURE_FLAG} AND f.enabled = true
       WHERE m."userId" = ${userId}
         AND m."accepted" = true
         AND m."role"::text = ANY(${fallbackRoles})

--- a/packages/features/pbac/infrastructure/repositories/__tests__/PermissionRepository.integration-test.ts
+++ b/packages/features/pbac/infrastructure/repositories/__tests__/PermissionRepository.integration-test.ts
@@ -17,11 +17,13 @@ describe("PermissionRepository - Integration Tests", () => {
   });
 
   beforeEach(async () => {
+    const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
     // Create test user
     const testUser = await prisma.user.create({
       data: {
-        email: `test-${Date.now()}@example.com`,
-        username: `testuser-${Date.now()}`,
+        email: `test-${uniqueId}@example.com`,
+        username: `testuser-${uniqueId}`,
       },
     });
     testUserId = testUser.id;
@@ -29,8 +31,8 @@ describe("PermissionRepository - Integration Tests", () => {
     // Create test team
     const testTeam = await prisma.team.create({
       data: {
-        name: `Test Team ${Date.now()}`,
-        slug: `test-team-${Date.now()}`,
+        name: `Test Team ${uniqueId}`,
+        slug: `test-team-${uniqueId}`,
       },
     });
     testTeamId = testTeam.id;
@@ -471,11 +473,12 @@ describe("PermissionRepository - Integration Tests", () => {
     });
 
     it("should return child team IDs when user has PBAC permissions via org", async () => {
+      const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
       // Create organization
       const org = await prisma.team.create({
         data: {
-          name: `Test Org ${Date.now()}`,
-          slug: `test-org-${Date.now()}`,
+          name: `Test Org ${uniqueId}`,
+          slug: `test-org-${uniqueId}`,
           isOrganization: true,
         },
       });
@@ -493,7 +496,7 @@ describe("PermissionRepository - Integration Tests", () => {
       // Create org role
       const orgRole = await prisma.role.create({
         data: {
-          name: `Org Role ${Date.now()}`,
+          name: `Org Role ${uniqueId}`,
           teamId: org.id,
         },
       });
@@ -526,8 +529,8 @@ describe("PermissionRepository - Integration Tests", () => {
       // Create child team
       const childTeam = await prisma.team.create({
         data: {
-          name: `Child Team ${Date.now()}`,
-          slug: `child-team-${Date.now()}`,
+          name: `Child Team ${uniqueId}`,
+          slug: `child-team-${uniqueId}`,
           parentId: org.id,
         },
       });
@@ -549,11 +552,12 @@ describe("PermissionRepository - Integration Tests", () => {
     });
 
     it("should return child team IDs when user has fallback roles via org", async () => {
+      const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
       // Create organization
       const org = await prisma.team.create({
         data: {
-          name: `Test Org ${Date.now()}`,
-          slug: `test-org-${Date.now()}`,
+          name: `Test Org ${uniqueId}`,
+          slug: `test-org-${uniqueId}`,
           isOrganization: true,
         },
       });
@@ -574,8 +578,8 @@ describe("PermissionRepository - Integration Tests", () => {
       // Create child team
       const childTeam = await prisma.team.create({
         data: {
-          name: `Child Team ${Date.now()}`,
-          slug: `child-team-${Date.now()}`,
+          name: `Child Team ${uniqueId}`,
+          slug: `child-team-${uniqueId}`,
           parentId: org.id,
         },
       });
@@ -719,17 +723,18 @@ describe("PermissionRepository - Integration Tests", () => {
     });
 
     it("should return multiple teams when user has permissions on multiple teams", async () => {
+      const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
       // Create first team with its own role
       const team1 = await prisma.team.create({
         data: {
-          name: `Test Team 1 ${Date.now()}`,
-          slug: `test-team-1-${Date.now()}`,
+          name: `Test Team 1 ${uniqueId}`,
+          slug: `test-team-1-${uniqueId}`,
         },
       });
 
       const role1 = await prisma.role.create({
         data: {
-          name: `Test Role 1 ${Date.now()}`,
+          name: `Test Role 1 ${uniqueId}`,
           teamId: team1.id,
         },
       });
@@ -737,14 +742,14 @@ describe("PermissionRepository - Integration Tests", () => {
       // Create second team with its own role
       const team2 = await prisma.team.create({
         data: {
-          name: `Test Team 2 ${Date.now()}`,
-          slug: `test-team-2-${Date.now()}`,
+          name: `Test Team 2 ${uniqueId}`,
+          slug: `test-team-2-${uniqueId}`,
         },
       });
 
       const role2 = await prisma.role.create({
         data: {
-          name: `Test Role 2 ${Date.now()}`,
+          name: `Test Role 2 ${uniqueId}`,
           teamId: team2.id,
         },
       });
@@ -825,17 +830,18 @@ describe("PermissionRepository - Integration Tests", () => {
     });
 
     it("should combine PBAC and fallback teams in results", async () => {
+      const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
       // Create first team for PBAC
       const team1 = await prisma.team.create({
         data: {
-          name: `Test Team 1 ${Date.now()}`,
-          slug: `test-team-1-${Date.now()}`,
+          name: `Test Team 1 ${uniqueId}`,
+          slug: `test-team-1-${uniqueId}`,
         },
       });
 
       const role1 = await prisma.role.create({
         data: {
-          name: `Test Role 1 ${Date.now()}`,
+          name: `Test Role 1 ${uniqueId}`,
           teamId: team1.id,
         },
       });
@@ -843,8 +849,8 @@ describe("PermissionRepository - Integration Tests", () => {
       // Create second team for fallback
       const team2 = await prisma.team.create({
         data: {
-          name: `Test Team 2 ${Date.now()}`,
-          slug: `test-team-2-${Date.now()}`,
+          name: `Test Team 2 ${uniqueId}`,
+          slug: `test-team-2-${uniqueId}`,
         },
       });
 

--- a/packages/features/pbac/infrastructure/repositories/__tests__/PermissionRepository.integration-test.ts
+++ b/packages/features/pbac/infrastructure/repositories/__tests__/PermissionRepository.integration-test.ts
@@ -343,6 +343,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: testTeamId,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -388,6 +389,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: testTeamId,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -484,6 +486,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: org.id,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -597,6 +600,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: testTeamId,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -642,6 +646,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: testTeamId,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -681,6 +686,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: testTeamId,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 
@@ -746,8 +752,8 @@ describe("PermissionRepository - Integration Tests", () => {
       // Enable PBAC for both teams
       await prisma.teamFeatures.createMany({
         data: [
-          { teamId: team1.id, featureId: "pbac", assignedBy: "test" },
-          { teamId: team2.id, featureId: "pbac", assignedBy: "test" },
+          { teamId: team1.id, featureId: "pbac", assignedBy: "test", enabled: true },
+          { teamId: team2.id, featureId: "pbac", assignedBy: "test", enabled: true },
         ],
       });
 
@@ -848,6 +854,7 @@ describe("PermissionRepository - Integration Tests", () => {
           teamId: team1.id,
           featureId: "pbac",
           assignedBy: "test",
+          enabled: true,
         },
       });
 

--- a/packages/lib/server/repository/selectedCalendar.test.ts
+++ b/packages/lib/server/repository/selectedCalendar.test.ts
@@ -3,12 +3,62 @@ import prismock from "../../../../tests/libs/__mocks__/prisma";
 import { describe, expect, it, beforeEach } from "vitest";
 
 import prisma from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/enums";
 
 import { SelectedCalendarRepository } from "./selectedCalendar";
 
 describe("SelectedCalendarRepository", () => {
   beforeEach(() => {
     prismock.selectedCalendar.deleteMany();
+  });
+
+  describe("getNextBatchToWatch", () => {
+    it("excludes calendars when calendar-cache feature is disabled on a team", async () => {
+      const user = await prisma.user.create({
+        data: {
+          email: "calendar-cache-disabled@example.com",
+          username: "calendar-cache-disabled",
+        },
+      });
+
+      const team = await prisma.team.create({
+        data: {
+          name: "Calendar Cache Disabled Team",
+          slug: "calendar-cache-disabled-team",
+        },
+      });
+
+      await prisma.membership.create({
+        data: {
+          userId: user.id,
+          teamId: team.id,
+          role: MembershipRole.ADMIN,
+          accepted: true,
+        },
+      });
+
+      await prisma.teamFeatures.create({
+        data: {
+          teamId: team.id,
+          featureId: "calendar-cache",
+          enabled: false,
+          assignedBy: "test",
+        },
+      });
+
+      await prisma.selectedCalendar.create({
+        data: {
+          userId: user.id,
+          integration: "google_calendar",
+          externalId: "disabled@example.com",
+          credentialId: 1,
+        },
+      });
+
+      const nextBatch = await SelectedCalendarRepository.getNextBatchToWatch();
+
+      expect(nextBatch).toEqual([]);
+    });
   });
 
   describe("create", () => {

--- a/packages/lib/server/repository/selectedCalendar.ts
+++ b/packages/lib/server/repository/selectedCalendar.ts
@@ -158,6 +158,7 @@ export class SelectedCalendarRepository {
                 features: {
                   some: {
                     featureId: "calendar-cache",
+                    enabled: true,
                   },
                 },
               },
@@ -238,6 +239,7 @@ export class SelectedCalendarRepository {
                   features: {
                     none: {
                       featureId: "calendar-cache",
+                      enabled: true,
                     },
                   },
                 },

--- a/packages/prisma/migrations/20251210143104_add_enabled_to_user_and_team_features/migration.sql
+++ b/packages/prisma/migrations/20251210143104_add_enabled_to_user_and_team_features/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."TeamFeatures" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."UserFeatures" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/prisma/migrations/20251210143104_add_enabled_to_user_and_team_features/migration.sql
+++ b/packages/prisma/migrations/20251210143104_add_enabled_to_user_and_team_features/migration.sql
@@ -1,5 +1,9 @@
--- AlterTable
+-- AlterTable: Add enabled column with DEFAULT true so existing rows get enabled=true
 ALTER TABLE "public"."TeamFeatures" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true;
 
--- AlterTable
+-- AlterTable: Add enabled column with DEFAULT true so existing rows get enabled=true
 ALTER TABLE "public"."UserFeatures" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- Remove the DEFAULT constraint so new rows must explicitly set enabled
+ALTER TABLE "public"."TeamFeatures" ALTER COLUMN "enabled" DROP DEFAULT;
+ALTER TABLE "public"."UserFeatures" ALTER COLUMN "enabled" DROP DEFAULT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1698,7 +1698,7 @@ model UserFeatures {
   userId     Int
   feature    Feature  @relation(fields: [featureId], references: [slug], onDelete: Cascade)
   featureId  String
-  enabled    Boolean  @default(true)
+  enabled    Boolean
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
@@ -1712,7 +1712,7 @@ model TeamFeatures {
   teamId     Int
   feature    Feature  @relation(fields: [featureId], references: [slug], onDelete: Cascade)
   featureId  String
-  enabled    Boolean  @default(true)
+  enabled    Boolean
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1698,6 +1698,7 @@ model UserFeatures {
   userId     Int
   feature    Feature  @relation(fields: [featureId], references: [slug], onDelete: Cascade)
   featureId  String
+  enabled    Boolean  @default(true)
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
@@ -1711,6 +1712,7 @@ model TeamFeatures {
   teamId     Int
   feature    Feature  @relation(fields: [featureId], references: [slug], onDelete: Cascade)
   featureId  String
+  enabled    Boolean  @default(true)
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt

--- a/packages/prisma/sql/getSelectedCalendarsToWatch.sql
+++ b/packages/prisma/sql/getSelectedCalendarsToWatch.sql
@@ -10,6 +10,7 @@ FROM
 WHERE
   -- Only get calendars for teams where cache is enabled
   tf."featureId" = 'calendar-cache'
+  AND tf.enabled = true
   -- We currently only support google watchers
   AND sc."integration" = 'google_calendar'
   AND (

--- a/packages/trpc/server/routers/viewer/admin/assignFeatureToTeam.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/assignFeatureToTeam.handler.ts
@@ -26,6 +26,7 @@ export const assignFeatureToTeamHandler = async ({ ctx, input }: AssignFeatureOp
       teamId,
       featureId,
       assignedBy: `user:${user.id}`,
+      enabled: true,
     },
     update: {},
   });

--- a/packages/trpc/server/routers/viewer/admin/assignFeatureToTeam.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/assignFeatureToTeam.handler.ts
@@ -28,7 +28,9 @@ export const assignFeatureToTeamHandler = async ({ ctx, input }: AssignFeatureOp
       assignedBy: `user:${user.id}`,
       enabled: true,
     },
-    update: {},
+    update: {
+      enabled: true,
+    },
   });
 
   return { success: true };

--- a/packages/trpc/server/routers/viewer/admin/getTeamsForFeature.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/getTeamsForFeature.handler.ts
@@ -53,6 +53,7 @@ export const getTeamsForFeatureHandler = async ({ ctx, input }: GetTeamsOptions)
     prisma.teamFeatures.findMany({
       where: {
         featureId,
+        enabled: true,
       },
       select: {
         teamId: true,

--- a/packages/trpc/server/routers/viewer/pbac/_router.tsx
+++ b/packages/trpc/server/routers/viewer/pbac/_router.tsx
@@ -249,7 +249,7 @@ export const permissionsRouter = router({
     }
 
     // Enable PBAC feature for the organization
-    await featureRepo.enableFeatureForTeam(orgId, "pbac", "opt-in by user: " + ctx.user.id);
+    await featureRepo.updateFeatureForTeam(orgId, "pbac", "enabled", "opt-in by user: " + ctx.user.id);
 
     return { success: true, message: "PBAC enabled successfully" };
   }),

--- a/packages/trpc/server/routers/viewer/pbac/_router.tsx
+++ b/packages/trpc/server/routers/viewer/pbac/_router.tsx
@@ -249,7 +249,7 @@ export const permissionsRouter = router({
     }
 
     // Enable PBAC feature for the organization
-    await featureRepo.updateFeatureForTeam(orgId, "pbac", "enabled", "opt-in by user: " + ctx.user.id);
+    await featureRepo.setTeamFeatureState(orgId, "pbac", "enabled", "opt-in by user: " + ctx.user.id);
 
     return { success: true, message: "PBAC enabled successfully" };
   }),

--- a/scripts/prepare-local-for-delegation-credentials-testing.js
+++ b/scripts/prepare-local-for-delegation-credentials-testing.js
@@ -55,6 +55,7 @@ async function main() {
         teamId: org.id,
         featureId: "delegation-credential",
       },
+      enabled: true,
     },
   });
   if (!delegationFeature) {
@@ -79,6 +80,7 @@ async function main() {
         teamId: org.id,
         featureId: "calendar-cache",
       },
+      enabled: true,
     },
   });
   if (!calendarCacheFeature) {

--- a/scripts/prepare-local-for-delegation-credentials-testing.js
+++ b/scripts/prepare-local-for-delegation-credentials-testing.js
@@ -64,6 +64,7 @@ async function main() {
         featureId: "delegation-credential",
         assignedAt: new Date(),
         assignedBy: "prepare-local-script",
+        enabled: true,
       },
     });
     console.log("Created TeamFeatures: delegation-credential");
@@ -87,6 +88,7 @@ async function main() {
         featureId: "calendar-cache",
         assignedAt: new Date(),
         assignedBy: "prepare-local-script",
+        enabled: true,
       },
     });
     console.log("Created TeamFeatures: calendar-cache");

--- a/scripts/seed-pbac-organization.ts
+++ b/scripts/seed-pbac-organization.ts
@@ -57,6 +57,7 @@ export async function createPBACOrganization() {
       teamId: organization.id,
       assignedBy: "system (Seed script)",
       assignedAt: new Date(),
+      enabled: true,
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

This PR adds tri-state semantics to the feature flags system by introducing an `enabled` column to `UserFeatures` and `TeamFeatures` models.

**Previous behavior:** Row existence meant feature enabled, no row meant disabled.

**New behavior:**
- `enabled=true` (row exists): Feature is explicitly enabled
- `enabled=false` (row exists): Feature is explicitly disabled (blocks inheritance from team/org)
- No row: Inherit from team/org level

This enables more granular control over feature flags, allowing teams to block features for their users while still allowing other inheritance patterns.

This will help us implement feature opt-in banner system where admin controls features for their teams and members control their own feature preferences.

- fixes CAL-6928

## Updates since last revision

- Renamed `enableFeatureForTeam` to `setTeamFeatureState` for clearer semantics
- The new method accepts a `state` parameter: `"enabled"` | `"disabled"` | `"inherit"`
- Updated all call sites and test fixtures to use the new method name

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal feature flag infrastructure
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the database migration: `yarn workspace @calcom/prisma db-migrate`
2. Verify existing `UserFeatures` and `TeamFeatures` rows have `enabled=true` (backward compatible)
3. Test feature flag checks still work as expected for existing features

## Human Review Checklist

- [ ] Verify all SQL queries in `FeaturesRepository` consistently check `AND tf."enabled" = true`
- [ ] Verify `setTeamFeatureState` sets `enabled: true` when state is "enabled" and `enabled: false` when state is "disabled"
- [ ] Verify tri-state logic in `checkIfUserHasFeature`: returns `userFeature.enabled` when row exists, otherwise checks team
- [ ] Verify tri-state logic in `checkIfTeamHasFeature`: returns `teamFeature.enabled` when row exists directly
- [ ] Confirm migration is backward compatible (default `true` preserves existing behavior, then default is dropped)
- [ ] Verify all test fixtures and scripts include `enabled: true` when creating feature rows

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/5ae2e226dc814cf6acbde7d09945b16c
**Requested by:** @eunjae-lee (eunjae@cal.com)