### PR TITLE
fix: checkout session completed

### DIFF
--- a/packages/features/ee/billing/api/webhook/_checkout.session.completed.ts
+++ b/packages/features/ee/billing/api/webhook/_checkout.session.completed.ts
@@ -45,9 +45,8 @@ const handler = async (data: SWHMap["checkout.session.completed"]["data"]) => {
     return await handleCalAIPhoneNumberSubscription(session);
   }
 
-  if (session.metadata?.teamName || session.metadata?.teamSlug) {
-    log.info("Skipping team checkout session - handled via redirect flow", { sessionId: session.id });
-    return { success: true, message: "Team checkout handled via redirect" };
+  if (session.metadata?.type === CHECKOUT_SESSION_TYPES.TEAM_CREATION) {
+    return await handleTeamCreationCheckoutSessionComplete(session);
   }
 
   // Handle credit purchases (existing logic)
@@ -108,6 +107,17 @@ async function saveToCreditBalance({
       creditBalanceId,
     });
   }
+}
+
+async function handleTeamCreationCheckoutSessionComplete(
+  session: SWHMap["checkout.session.completed"]["data"]["object"]
+) {
+  log.info("Team creation checkout session completed - handled via redirect flow", {
+    sessionId: session.id,
+    teamName: session.metadata?.teamName,
+    teamSlug: session.metadata?.teamSlug,
+  });
+  return { success: true, message: "Team checkout handled via redirect" };
 }
 
 async function handleCalAIPhoneNumberSubscription(

--- a/packages/features/ee/billing/api/webhook/_checkout.session.completed.ts
+++ b/packages/features/ee/billing/api/webhook/_checkout.session.completed.ts
@@ -45,6 +45,11 @@ const handler = async (data: SWHMap["checkout.session.completed"]["data"]) => {
     return await handleCalAIPhoneNumberSubscription(session);
   }
 
+  if (session.metadata?.teamName || session.metadata?.teamSlug) {
+    log.info("Skipping team checkout session - handled via redirect flow", { sessionId: session.id });
+    return { success: true, message: "Team checkout handled via redirect" };
+  }
+
   // Handle credit purchases (existing logic)
   if (!session.amount_total) {
     throw new HttpCode(400, "Missing required payment details");

--- a/packages/features/ee/billing/constants.ts
+++ b/packages/features/ee/billing/constants.ts
@@ -4,6 +4,7 @@
  */
 export const CHECKOUT_SESSION_TYPES = {
   PHONE_NUMBER_SUBSCRIPTION: "phone_number_subscription",
+  TEAM_CREATION: "team_creation",
 } as const;
 
 export type CheckoutSessionType = (typeof CHECKOUT_SESSION_TYPES)[keyof typeof CHECKOUT_SESSION_TYPES];

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { getStripeCustomerIdFromUserId } from "@calcom/app-store/stripepayment/lib/customer";
 import { getDubCustomer } from "@calcom/features/auth/lib/dub";
 import stripe from "@calcom/features/ee/payments/server/stripe";
+import { CHECKOUT_SESSION_TYPES } from "@calcom/features/ee/billing/constants";
 import {
   IS_PRODUCTION,
   ORGANIZATION_SELF_SERVE_PRICE,
@@ -98,6 +99,7 @@ export const generateTeamCheckoutSession = async ({
       trial_period_days: 14, // Add a 14-day trial
     },
     metadata: {
+      type: CHECKOUT_SESSION_TYPES.TEAM_CREATION,
       teamName,
       teamSlug,
       userId,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Error Flow 

1) When a user creates a team, generateTeamCheckoutSession() in [payments.ts](vscode-webview://1qvjfff8lb4hpv6a9n286kairfmgon08nmbcho1o0pmpfpdcihri/packages/features/ee/teams/lib/payments.ts#L48-L111) creates a Stripe checkout session with:
metadata: { teamName, teamSlug, userId, ... }
success_url: /api/teams/create?session_id={CHECKOUT_SESSION_ID}

2) After payment, Stripe:
Redirects the user to /api/teams/create?session_id=... (this handles team creation)
Sends a checkout.session.completed webhook to /api/stripe/webhook

3) The webhook handler in [_checkout.session.completed.ts](vscode-webview://1qvjfff8lb4hpv6a9n286kairfmgon08nmbcho1o0pmpfpdcihri/packages/features/ee/billing/api/webhook/_checkout.session.completed.ts) was designed for credit purchases, which expect:
priceId === process.env.NEXT_PUBLIC_STRIPE_CREDITS_PRICE_ID
A valid quantity of credits

4) Team checkouts don't have credits - they have team subscription data. So when the handler reached line 69:
if (!priceId || priceId !== process.env.NEXT_PUBLIC_STRIPE_CREDITS_PRICE_ID || !nrOfCredits) {
  throw new HttpCode(400, "Invalid price ID");
}
It threw a 400 error because the team's priceId doesn't match the credits price ID.



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] N/A I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip team creation checkout sessions in the checkout.session.completed webhook when metadata.type is team_creation. These are handled by the redirect flow, preventing duplicate processing and unintended credit handling.

<sup>Written for commit a67f51895fbabb37fd18f45b1ac704d31eef8d92. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



