### PR TITLE
fix: Hide team members in social preview when team is private

### DIFF
--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
@@ -13,7 +13,7 @@ import Page from "~/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-mee
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const context = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
-  const { isBrandingHidden, eventData } = await getData(context);
+  const { isBrandingHidden, eventData, teamIsPrivate } = await getData(context);
 
   const profileName = eventData?.profile.name ?? "";
   const profileImage = eventData?.profile.image;
@@ -22,12 +22,15 @@ export const generateMetadata = async ({ params, searchParams }: _PageProps) => 
   const meeting = {
     title,
     profile: { name: profileName, image: profileImage },
-    users: [
-      ...(eventData?.users || []).map((user) => ({
-        name: `${user.name}`,
-        username: `${user.username}`,
-      })),
-    ],
+    // Hide team member names in preview if team is private
+    users: teamIsPrivate
+      ? []
+      : [
+          ...(eventData?.users || []).map((user) => ({
+            name: `${user.name}`,
+            username: `${user.username}`,
+          })),
+        ],
   };
   const decodedParams = decodeParams(await params);
   const metadata = await generateMeetingMetadata(

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/pageWithCachedData.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/pageWithCachedData.tsx
@@ -91,15 +91,20 @@ export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const profileName = enrichedEventType.profile.name ?? "";
   const profileImage = enrichedEventType.profile.image;
 
+  const teamIsPrivate = teamData.isPrivate;
+
   const meeting = {
     title,
     profile: { name: profileName, image: profileImage },
-    users: [
-      ...(enrichedEventType?.subsetOfUsers || []).map((user) => ({
-        name: `${user.name}`,
-        username: `${user.username}`,
-      })),
-    ],
+    // Hide team member names in preview if team is private
+    users: teamIsPrivate
+      ? []
+      : [
+          ...(enrichedEventType?.subsetOfUsers || []).map((user) => ({
+            name: `${user.name}`,
+            username: `${user.username}`,
+          })),
+        ],
   };
 
   const { hideBranding, isSEOIndexable } = _getTeamMetadataForBooking(teamData, enrichedEventType.id);

--- a/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
+++ b/apps/web/lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps.ts
@@ -28,6 +28,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     },
     select: {
       id: true,
+      isPrivate: true,
       hideBranding: true,
       parent: {
         select: {
@@ -86,6 +87,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
         team,
       }),
       themeBasis: null,
+      teamIsPrivate: team.isPrivate,
     },
   };
 };


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide team members from social previews when a team is private. This stops names and usernames from appearing in previews on team and org booking pages.

- **Bug Fixes**
  - Pass team privacy (isPrivate) to metadata generation.
  - For private teams, return an empty users array in meeting metadata (org and team pages, including cached paths).

<sup>Written for commit 233f806fed97d2e1e9ce2c121917c607afc5d27e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



