### PR TITLE
feat: skip onboarding steps 2-5 for platform users

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserSettings.tsx
+++ b/apps/web/components/getting-started/steps-views/UserSettings.tsx
@@ -20,6 +20,7 @@ interface IUserSettingsProps {
   nextStep: () => void;
   hideUsername?: boolean;
   user: RouterOutputs["viewer"]["me"]["get"];
+  isPlatformUser?: boolean;
 }
 
 const UserSettings = (props: IUserSettingsProps) => {
@@ -118,7 +119,7 @@ const UserSettings = (props: IUserSettingsProps) => {
         className="mt-8 flex w-full flex-row justify-center"
         loading={mutation.isPending}
         disabled={mutation.isPending}>
-        {t("connect_your_calendar")}
+        {props.isPlatformUser ? t("continue") : t("connect_your_calendar")}
       </Button>
     </form>
   );


### PR DESCRIPTION
## What does this PR do?

Platform users signing up from `/login?callbackUrl=...settings/platform/new` now only see the first onboarding step (user-settings) before being redirected to the platform dashboard.

This improves the onboarding experience for platform customers who create "non-user" admin accounts and don't need:
- Step 2: Connect your calendar
- Step 3: Connect your video apps
- Step 4: Set up your availability
- Step 5: Nearly there (profile setup)

### Implementation details:

**Original onboarding (`/getting-started`):**
- Detects platform users by checking if `onBoardingRedirect` in localStorage contains "platform" and "new"
- Returns only the first step for platform users via `getStepsAndHeadersForUser`
- After completing step 1, marks onboarding as complete and redirects to the stored platform URL (or `/settings/platform` as fallback)
- Changes the button text from "Connect your calendar" to "Continue" for platform users

**Onboarding v3 (`/onboarding/personal/settings` when feature flag enabled):**
- Platform users skip the calendar step and complete onboarding directly from the settings step
- Skips default event type creation for platform users (they don't need 15min/30min/secret events)
- Redirects platform users to `/settings/platform` instead of `/event-types`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Original onboarding flow:**
1. Go to `https://app.cal.com/login?callbackUrl=https://app.cal.com/settings/platform/new`
2. Create a new account
3. Verify that after the first onboarding step (user settings), you are redirected directly to `/settings/platform/new` instead of seeing steps 2-5
4. Verify the button on step 1 says "Continue" instead of "Connect your calendar"

**Onboarding v3 flow (if feature flag enabled):**
1. Enable the `onboarding-v3` feature flag
2. Go to `https://app.cal.com/login?callbackUrl=https://app.cal.com/settings/platform/new`
3. Create a new account
4. Verify that after the personal settings step, you are redirected directly to `/settings/platform` instead of seeing the calendar connection step
5. Verify no default event types (15min, 30min, secret) are created

For comparison, test a regular signup flow (without the platform callback URL) and verify all steps still appear.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the "continue" translation key exists in the i18n files
- [ ] Verify the localStorage detection matches how `onBoardingRedirect` is set in `signup-view.tsx` (line 211)
- [ ] Test the complete flow with a platform signup URL (both original and v3 onboarding)
- [ ] Consider edge case: what if a platform user navigates directly to `/getting-started/connected-calendar` or `/onboarding/personal/calendar`?
- [ ] Verify `isPlatformUser` state doesn't cause UI flicker (it's set in useEffect)

---

Link to Devin run: https://app.devin.ai/sessions/1f6ab7172c774e1a959e52c06d6e3465
Requested by: peer@cal.com (@PeerRich)