### PR TITLE
style: add mb-2 to workflows page flex container

### DIFF
--- a/packages/features/ee/workflows/pages/index.tsx
+++ b/packages/features/ee/workflows/pages/index.tsx
@@ -73,7 +73,7 @@ function WorkflowsPage({ filteredList }: PageProps) {
           }>
           <>
             {filteredWorkflows?.totalCount ? (
-              <div className="flex">
+              <div className="flex mb-2">
                 <TeamsFilter />
                 <div className="mb-4 ml-auto">
                   <CreateButtonWithTeamsList


### PR DESCRIPTION
## What does this PR do?

- Fixes #25786
- Fixes [CAL-6902](https://linear.app/calcom/issue/CAL-6902/fix-add-spacing-to-workflows-filter-row)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:

<img width="1287" height="742" alt="Screenshot 2025-12-11 at 2 36 00 PM" src="https://github.com/user-attachments/assets/c1a288e0-511a-49fd-8553-6340cfc3e3e9" />

<img width="1285" height="570" alt="Screenshot 2025-12-11 at 2 51 21 PM" src="https://github.com/user-attachments/assets/a20c2aee-155a-4e06-9680-f7c6311a1a27" />

after:

<img width="1290" height="670" alt="Screenshot 2025-12-11 at 2 53 14 PM" src="https://github.com/user-attachments/assets/dcfd7eee-8922-4122-8c94-63f5adb4b369" />

<img width="1293" height="674" alt="Screenshot 2025-12-11 at 2 56 00 PM" src="https://github.com/user-attachments/assets/0659d7b3-4d34-44e2-9dd0-c40a19ca9aef" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mb-2 to the workflows page flex container to create proper spacing under the filter row, improving layout and readability. Aligns with Linear CAL-6902 requirements to add spacing to the workflows filter row.

<sup>Written for commit 515a9c79458bb676e85880e13578ad493a650268. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

