### PR TITLE
fix: try submit instead of form manual submition

### DIFF
--- a/apps/web/modules/onboarding/components/OnboardingLayout.tsx
+++ b/apps/web/modules/onboarding/components/OnboardingLayout.tsx
@@ -3,6 +3,7 @@
 import classNames from "classnames";
 import { signOut } from "next-auth/react";
 import { Children, type ReactNode } from "react";
+import { Toaster } from "sonner";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
@@ -71,6 +72,7 @@ export const OnboardingLayout = ({ userEmail, currentStep, totalSteps, children 
           {t("sign_out")}
         </Button>
       </div>
+      <Toaster position="bottom-right" />
     </div>
   );
 };

--- a/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
@@ -43,13 +43,13 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
   // Read teamId from query params and store it (from payment callback or redirect)
   useEffect(() => {
     const teamIdParam = searchParams?.get("teamId");
-    if (teamIdParam) {
-      const teamId = parseInt(teamIdParam, 10);
-      if (!isNaN(teamId)) {
-        setTeamId(teamId);
+    if (teamIdParam && !teamId) {
+      const parsedTeamId = parseInt(teamIdParam, 10);
+      if (!isNaN(parsedTeamId)) {
+        setTeamId(parsedTeamId);
       }
     }
-  }, [searchParams, setTeamId]);
+  }, [searchParams, setTeamId, teamId]);
 
   const formSchema = z.object({
     invites: z.array(
@@ -125,10 +125,6 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
     router.replace(gettingStartedPath);
   };
 
-  const handleSubmitClick = () => {
-    form.handleSubmit(handleContinue)();
-  };
-
   // Watch form values to pass to browser view for real-time updates
   const watchedInvites = form.watch("invites");
 
@@ -156,12 +152,11 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
                     {t("onboarding_skip_for_now")}
                   </Button>
                   <Button
-                    type="button"
+                    type="submit"
                     color="primary"
                     className="rounded-[10px]"
                     disabled={!hasValidInvites || isSubmitting}
-                    loading={isSubmitting}
-                    onClick={handleSubmitClick}>
+                    loading={isSubmitting}>
                     {t("continue")}
                   </Button>
                 </div>

--- a/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
+++ b/apps/web/modules/onboarding/teams/invite/email/team-invite-email-view.tsx
@@ -79,6 +79,7 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
     const teamIdParam = searchParams?.get("teamId");
     const parsedTeamId = !teamId ? parseInt(teamIdParam || "", 10) : teamId;
     if (!parsedTeamId) {
+      console.log("Team ID is missing. Please go back and create your team first.");
       showToast(
         t("team_id_missing") || "Team ID is missing. Please go back and create your team first.",
         "error"
@@ -113,6 +114,7 @@ export const TeamInviteEmailView = ({ userEmail }: TeamInviteEmailViewProps) => 
       }
     } else {
       // No invites, skip to personal settings
+      console.log("No invites, skipping to personal settings");
       const gettingStartedPath = "/onboarding/personal/settings?fromTeamOnboarding=true";
       router.replace(gettingStartedPath);
     }


### PR DESCRIPTION
Chrome can be a lot more strick for manual form submitions



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the team invite form to native submission and tighten teamId parsing to improve reliability in Chrome and avoid re-setting teamId.

- **Bug Fixes**
  - Change the Continue button to type="submit" and remove the manual onClick handler.
  - Only set teamId from search params when it’s not already set; add teamId to the effect’s dependencies.
  - Add a Toaster to the onboarding layout so toast messages appear during the flow.

<sup>Written for commit 0429596eb1eea99d252af31529336e7b1f71047f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



