### PR TITLE
fix: react version external packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "dayjs@^1": "patch:dayjs@npm%3A1.11.4#./.yarn/patches/dayjs-npm-1.11.4-97921cd375.patch",
     "dayjs@^1.8.29": "patch:dayjs@npm%3A1.11.4#./.yarn/patches/dayjs-npm-1.11.4-97921cd375.patch",
     "import-in-the-middle": "1.13.1",
-    "react@19.2.0": "19.2.1"
+    "react@19.2.0": "19.2.2",
+    "react@19.2.1": "19.2.2"
   },
   "engines": {
     "npm": ">=7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42144,10 +42144,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:19.2.1":
-  version: 19.2.1
-  resolution: "react@npm:19.2.1"
-  checksum: 9b32ace5c532ed78bc5a907bfec77d966c8f117049d9bf06b627c4cebe5ef2c899f18ed283f8ed5b85346176b5ccc5328ab6fae0b389f2936a87575ce0e47670
+"react@npm:19.2.2":
+  version: 19.2.2
+  resolution: "react@npm:19.2.2"
+  checksum: c0e99ec3f533c625db0dfccc4bf3683192c1a6ca3f829a27b667d5dea6164175ee3c84d6d3413fab0a867f026204b6a83ea13cf59cc357e9ae2f3da2864d4611
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned React versions across external packages by pinning everything to 19.2.2 to prevent mismatches and duplicate installs.

- **Dependencies**
  - Added Yarn resolutions to map react@19.2.0 and react@19.2.1 to 19.2.2.
  - Updated yarn.lock to reflect React 19.2.2.

<sup>Written for commit 163288f3a48c2ee8909c52bcc1a7f23d1b9d2010. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

