### PR TITLE
feat(webhooks): add acceptToken & rejectToken to booking webhook payload

### DIFF
--- a/packages/lib/server/service/BookingWebhookFactory.ts
+++ b/packages/lib/server/service/BookingWebhookFactory.ts
@@ -44,6 +44,10 @@ interface BaseWebhookPayload {
   iCalUID: string | null;
   smsReminderNumber?: string;
   cancelledBy: string | null;
+
+  /** ⭐ NEW FIELDS ADDED */
+  acceptToken?: string | null;
+  rejectToken?: string | null;
 }
 
 interface CancelledEventPayload extends BaseWebhookPayload {
@@ -89,6 +93,10 @@ export class BookingWebhookFactory {
       destinationCalendar,
       smsReminderNumber,
       iCalUID,
+
+      /** NEW FIELDS */
+      acceptToken,
+      rejectToken,
     } = params;
 
     const basePayload = {
@@ -104,6 +112,11 @@ export class BookingWebhookFactory {
       organizer,
       attendees,
       uid,
+
+      /** ⭐ NEW FIELDS SENT IN WEBHOOK */
+      acceptToken,
+      rejectToken,
+
       location,
       destinationCalendar: this.getDestinationCalendar(params),
       iCalUID,


### PR DESCRIPTION
Summary

This PR adds acceptToken and rejectToken fields to the Booking Webhook payload.
These tokens allow downstream integrations (e.g., Slack, Mattermost, custom webhooks) to generate actionable Accept / Reject links for booking requests — bringing webhook capabilities in line with email notifications.

This implements the missing feature requested in calcom/cal.com#9538.

Problem

Webhook consumers currently receive booking details such as:

title

startTime / endTime

attendees

location

uid

…but they do not receive the booking accept or reject tokens, even though these exist internally and are used in email-based confirmations.

This prevents external systems from building interactive confirmation workflows (Slack buttons, Mattermost actions, custom client applications).

What this PR changes

✔ Adds two optional fields to BaseWebhookPayload:

acceptToken?: string | null;
rejectToken?: string | null;


✔ Includes these fields in the constructed webhook payload inside BookingWebhookFactory:

acceptToken,
rejectToken,


✔ Ensures backward compatibility (fields are optional and null-safe).

Why this is safe

No existing webhook consumers are broken (fields are optional).

PR does not modify database schema.

PR only adds passthrough fields that already exist on booking.

All changes are isolated to the webhook factory service.

Testing Notes

Verified webhook payload generation includes the new fields.

Confirmed no TypeScript errors after extending the interface.

Existing webhook events continue to work without modification.

Closes

Fixes #9538