### PR TITLE
fix: adds org slug to url in invite browser view 

### DIFF
--- a/apps/web/modules/onboarding/components/onboarding-teams-browser-view.tsx
+++ b/apps/web/modules/onboarding/components/onboarding-teams-browser-view.tsx
@@ -3,7 +3,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { usePathname } from "next/navigation";
 
-import { WEBAPP_URL } from "@calcom/lib/constants";
+import { subdomainSuffix } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Avatar } from "@calcom/ui/components/avatar";
 import { Icon } from "@calcom/ui/components/icon";
@@ -13,6 +13,7 @@ type OnboardingTeamsBrowserViewProps = {
   organizationLogo?: string | null;
   organizationName?: string;
   organizationBanner?: string | null;
+  slug?: string;
 };
 
 export const OnboardingTeamsBrowserView = ({
@@ -20,10 +21,11 @@ export const OnboardingTeamsBrowserView = ({
   organizationLogo,
   organizationName,
   organizationBanner,
+  slug,
 }: OnboardingTeamsBrowserViewProps) => {
   const pathname = usePathname();
   const { t } = useLocale();
-  const webappUrl = WEBAPP_URL.replace(/^https?:\/\//, "");
+  const displayUrl = slug ? `${slug}.${subdomainSuffix()}` : subdomainSuffix();
 
   // Show placeholder if no teams or all teams are empty
   const hasValidTeams = teams.some((team) => team.name && team.name.trim().length > 0);
@@ -54,9 +56,9 @@ export const OnboardingTeamsBrowserView = ({
           <Icon name="arrow-right" className="text-subtle h-4 w-4" />
           <Icon name="rotate-cw" className="text-subtle h-4 w-4" />
         </div>
-        <div className="bg-cal-muted flex w-full items-center gap-2 rounded-[32px] px-3 py-2">
+        <div className="bg-cal-muted flex w-full min-w-0 items-center gap-2 rounded-[32px] px-3 py-2">
           <Icon name="lock" className="text-subtle h-4 w-4" />
-          <p className="text-default text-sm font-medium leading-tight">{webappUrl}/teams</p>
+          <p className="text-default truncate text-sm font-medium leading-tight">{displayUrl}/teams</p>
         </div>
         <Icon name="ellipsis-vertical" className="text-subtle h-4 w-4" />
       </div>

--- a/apps/web/modules/onboarding/organization/teams/organization-teams-view.tsx
+++ b/apps/web/modules/onboarding/organization/teams/organization-teams-view.tsx
@@ -150,6 +150,7 @@ export const OrganizationTeamsView = ({ userEmail }: OrganizationTeamsViewProps)
         organizationLogo={organizationBrand.logo}
         organizationName={organizationDetails.name}
         organizationBanner={organizationBrand.banner}
+        slug={organizationDetails.link}
       />
     </OnboardingLayout>
   );


### PR DESCRIPTION
<img width="2822" height="1860" alt="CleanShot 2025-12-12 at 09 52 09@2x" src="https://github.com/user-attachments/assets/fdddf77e-b14f-4a75-be3d-a6a3cc83bef4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the organization slug in the teams URL in the invite browser view so users see the correct org domain. The URL chip now truncates to prevent overflow.

- **Bug Fixes**
  - Build display URL with slug and subdomain suffix instead of WEBAPP_URL.
  - Pass slug from organization details into OnboardingTeamsBrowserView.
  - Add min-w-0 and truncate to keep long URLs from breaking the layout.

<sup>Written for commit 51159e01f76aa618a892a3678e16c4e0a5be1afc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

