### PR TITLE
chore: atoms rrHostSubsetIds changelog for release

### DIFF
--- a/.changeset/rude-candies-scream.md
+++ b/.changeset/rude-candies-scream.md
@@ -1,0 +1,5 @@
+---
+"@calcom/atoms": minor
+---
+
+feat: Booker accepts rrHostSubsetIds to specify round robin hosts


### PR DESCRIPTION
Adds changelog entry so changesets opens a PR that allows us to release atoms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares @calcom/atoms for a minor release by adding a changeset entry. The release adds Booker support for rrHostSubsetIds to specify round robin hosts.

<sup>Written for commit edaf4deb422af37818e5956db95938a5ee990db8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

