### PR TITLE
fix:  not found nc command docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,9 @@ RUN scripts/replace-placeholder.sh http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER ${N
 FROM node:20 AS runner
 
 WORKDIR /calcom
+
+RUN apt-get update && apt-get install -y --no-install-recommends netcat-openbsd wget && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder-two /calcom ./
 ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
 ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \


### PR DESCRIPTION
## What does this PR do?

Fixes: #25821 

## How should this be tested?

# Start database
docker compose up -d database

# Build and run service
docker compose build calcom
docker compose up calcom

Watch docker logs and ensure there is no error or "nc command is missing" 


ref: https://protsenko.dev/infrastructure-security/no-install-recommends/
ref: https://askubuntu.com/questions/1050800/how-do-i-remove-the-apt-package-index 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install netcat-openbsd and wget in the runner Docker image to fix “nc command is missing” errors during container startup. Cleans up apt lists to keep the image small.

<sup>Written for commit cc637e7cb13b85b423c27c0866a7e90d35e28097. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

