### PR TITLE
chore: log unauthenticated get booking recordings

### DIFF
--- a/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/controllers/bookings.controller.ts
@@ -214,9 +214,9 @@ export class BookingsController_2024_08_13 {
   @Get("/:bookingUid/recordings")
   // @Pbac(["booking.readRecordings"])
   @Permissions([BOOKING_READ])
-  @UseGuards(BookingUidGuard)
+  @UseGuards(BookingUidGuard, OptionalApiAuthGuard)
   // @UseGuards(ApiAuthGuard, BookingUidGuard, BookingPbacGuard)
-  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({
     summary: "Get all the recordings for the booking",
     description: `Fetches all the recordings for the booking \`:bookingUid\`. Requires authentication and proper authorization. Access is granted if you are the booking organizer, team admin or org admin/owner.
@@ -224,8 +224,11 @@ export class BookingsController_2024_08_13 {
     <Note>cal-api-version: \`2024-08-13\` is required in the request header.</Note>
     `,
   })
-  async getBookingRecordings(@Param("bookingUid") bookingUid: string): Promise<GetBookingRecordingsOutput> {
-    const recordings = await this.calVideoService.getRecordings(bookingUid);
+  async getBookingRecordings(
+    @Param("bookingUid") bookingUid: string,
+    @GetOptionalUser() user: AuthOptionalUser
+  ): Promise<GetBookingRecordingsOutput> {
+    const recordings = await this.calVideoService.getRecordings(bookingUid, !!user);
 
     return {
       status: SUCCESS_STATUS,
@@ -397,18 +400,18 @@ export class BookingsController_2024_08_13 {
     <Note>Please make sure to pass in the cal-api-version header value as mentioned in the Headers section. Not passing the correct value will default to an older version of this endpoint.</Note>
     `,
   })
-    async markNoShow(
-      @Param("bookingUid") bookingUid: string,
-      @Body() body: MarkAbsentBookingInput_2024_08_13,
-      @GetUser() user: ApiAuthGuardUser
-    ): Promise<MarkAbsentBookingOutput_2024_08_13> {
-      const booking = await this.bookingsService.markAbsent(bookingUid, user.id, body, user.uuid);
+  async markNoShow(
+    @Param("bookingUid") bookingUid: string,
+    @Body() body: MarkAbsentBookingInput_2024_08_13,
+    @GetUser() user: ApiAuthGuardUser
+  ): Promise<MarkAbsentBookingOutput_2024_08_13> {
+    const booking = await this.bookingsService.markAbsent(bookingUid, user.id, body, user.uuid);
 
-      return {
-        status: SUCCESS_STATUS,
-        data: booking,
-      };
-    }
+    return {
+      status: SUCCESS_STATUS,
+      data: booking,
+    };
+  }
 
   @Post("/:bookingUid/reassign")
   @HttpCode(HttpStatus.OK)

--- a/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/repositories/bookings.repository.ts
@@ -203,6 +203,15 @@ export class BookingsRepository_2024_08_13 {
       },
       select: {
         references: true,
+        // TODO: Remove below selects when get recording endpoint is authenticated properly
+        eventType: {
+          select: {
+            team: {
+              select: { id: true, parentId: true },
+            },
+            userId: true,
+          },
+        },
       },
     });
   }

--- a/apps/api/v2/src/ee/bookings/2024-08-13/services/cal-video.service.ts
+++ b/apps/api/v2/src/ee/bookings/2024-08-13/services/cal-video.service.ts
@@ -20,15 +20,22 @@ export class CalVideoService {
 
   private getVideoSessionsRoomName(references?: Array<{ type: string; meetingId?: string | null }>) {
     return (
-      references?.filter((reference) => reference.type === CAL_VIDEO_TYPE)?.pop()?.meetingId ??
-      undefined
+      references?.filter((reference) => reference.type === CAL_VIDEO_TYPE)?.pop()?.meetingId ?? undefined
     );
   }
 
-  async getRecordings(bookingUid: string) {
+  async getRecordings(bookingUid: string, isAuthenticatedUser: boolean) {
     const booking = await this.bookingsRepository.getByUidWithBookingReference(bookingUid);
     if (!booking) {
       throw new NotFoundException(`Booking with uid=${bookingUid} was not found in the database`);
+    }
+
+    if (!isAuthenticatedUser) {
+      this.logger.warn(`Unauthenticated access to get recordings for booking uid=${bookingUid}`, {
+        userId: booking.eventType?.userId,
+        teamId: booking.eventType?.team?.id ?? "N/A",
+        orgId: booking.eventType?.team?.parentId ?? "N/A",
+      });
     }
 
     const roomName = this.getVideoSessionsRoomName(booking.references);


### PR DESCRIPTION
## What does this PR do?

Log who is using the booking recording endpoint without authentication

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] n/a I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


- **Refactors**
  - Use OptionalApiAuthGuard and OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER on GET /:bookingUid/recordings.
  - Pass an isAuthenticated flag to CalVideoService.getRecordings and log unauthenticated access.
  - Select minimal eventType/team/user fields in the repository to support logging.

<sup>Written for commit fa5a05e19b7133c79ce06173c1ef2b23504b89b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

