### PR TITLE
fix: Make "Show note on public booking page" consistent across all views of OOO

### DIFF
--- a/packages/features/calendars/weeklyview/components/event/Empty.tsx
+++ b/packages/features/calendars/weeklyview/components/event/Empty.tsx
@@ -78,7 +78,7 @@ export function AvailableCellsForDay({ timezone, availableSlots, day, startHour 
       const lastSlot = slotsForToday[lastSlotIndex];
       startEndTimeDuration = dayjs(lastSlot.end).diff(dayjs(firstSlot.start), "minutes");
 
-      if (firstSlot.toUser == null) {
+      if (firstSlot.toUser == null && !firstSlot.showNotePublicly) {
         return null;
       }
 
@@ -108,6 +108,8 @@ export function AvailableCellsForDay({ timezone, availableSlots, day, startHour 
           toUser={firstSlot?.toUser}
           reason={firstSlot?.reason}
           emoji={firstSlot?.emoji}
+          notes={firstSlot?.notes}
+          showNotePublicly={firstSlot?.showNotePublicly}
           borderDashed={false}
           date={dateFormatted}
           className="pb-0"

--- a/packages/features/calendars/weeklyview/types/state.ts
+++ b/packages/features/calendars/weeklyview/types/state.ts
@@ -58,6 +58,8 @@ type TimeRangeExtended = TimeRange & {
   toUser?: IToUser;
   reason?: string;
   emoji?: string;
+  notes?: string | null;
+  showNotePublicly?: boolean;
 };
 
 export type CalendarAvailableTimeslots = {

--- a/packages/features/schedules/lib/use-schedule/useNonEmptyScheduleDays.ts
+++ b/packages/features/schedules/lib/use-schedule/useNonEmptyScheduleDays.ts
@@ -8,7 +8,7 @@ export const getNonEmptyScheduleDays = (slots?: Slots) => {
   const nonEmptyDays: string[] = [];
 
   Object.keys(slots).forEach((date) => {
-    if (slots[date].some((slot) => !(slot?.away && !slot.toUser) && slots[date].length > 0)) {
+    if (slots[date].some((slot) => !(slot?.away && !slot.toUser && !slot.showNotePublicly) && slots[date].length > 0)) {
       nonEmptyDays.push(date);
     }
   });

--- a/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -162,6 +162,8 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
 
   const watchedTeamUserId = watch("toTeamUserId");
   const watchForUserId = watch("forUserId");
+  const watchedNotes = watch("notes");
+  const hasValidNotes = Boolean(watchedNotes?.trim());
 
   const createOrEditOutOfOfficeEntry = trpc.viewer.ooo.outOfOfficeCreateOrUpdate.useMutation({
     onSuccess: () => {
@@ -345,7 +347,11 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                 placeholder={t("additional_notes")}
                 {...register("notes")}
                 onChange={(e) => {
-                  setValue("notes", e?.target.value);
+                  const newNotes = e?.target.value;
+                  setValue("notes", newNotes);
+                  if (!newNotes?.trim()) {
+                    setValue("showNotePublicly", false);
+                  }
                 }}
               />
               <Controller
@@ -358,8 +364,14 @@ export const CreateOrEditOutOfOfficeEntryModal = ({
                       data-testid="show-note-publicly-checkbox"
                       checked={value ?? false}
                       onCheckedChange={onChange}
+                      disabled={!hasValidNotes}
                     />
-                    <label htmlFor="show-note-publicly" className="text-emphasis ml-2 cursor-pointer text-sm">
+                    <label
+                      htmlFor="show-note-publicly"
+                      className={classNames(
+                        "ml-2 text-sm",
+                        hasValidNotes ? "text-emphasis cursor-pointer" : "text-muted cursor-not-allowed"
+                      )}>
                       {t("show_note_publicly_description")}
                     </label>
                   </div>


### PR DESCRIPTION
### Before:

_Inconsistent Behaviour:_


https://github.com/user-attachments/assets/02bc99cb-cb42-48e9-944e-9dd7295def6a




_no validation:_



https://github.com/user-attachments/assets/591bf873-7adb-40f5-a763-f86ce8cd7b3a



### After:



https://github.com/user-attachments/assets/5be48863-ddda-4a6f-a65e-fa3421ed4122




## What does this PR do?

Fixes inconsistent behavior of the OOO "Show note on public booking page" feature across different booking views (month, column, weekly).

### Problem
- **Month view**: OOO with public notes was working correctly
- **Column view**: OOO was only visible when a redirect user was set, ignoring public notes
- **Weekly view**: OOO was not displayed at all without a redirect user

### Solution
Applied consistent logic across all views: `OOO is displayable = toUser exists OR showNotePublicly is true`

### Changes

**Weekly View** (`packages/features/calendars/weeklyview/components/event/Empty.tsx`)
- Updated condition to show OOO when `showNotePublicly` is true (even without redirect)
- Added `notes` and `showNotePublicly` props to `OutOfOfficeInSlots` component

**Column View** (`packages/features/schedules/lib/use-schedule/useNonEmptyScheduleDays.ts`)
- Updated filtering to include days with OOO + public note

**Types** (`packages/features/calendars/weeklyview/types/state.ts`)
- Added `notes` and `showNotePublicly` to `TimeRangeExtended` type

**Validation** (`packages/features/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx`)
- Disabled "Show note on public booking page" checkbox when notes are empty/blank
- Auto-uncheck when notes are cleared