### PR TITLE
feat: allow to disable workflow notifications for non paid users

### DIFF
--- a/packages/features/ee/workflows/lib/allowDisablingStandardEmails.ts
+++ b/packages/features/ee/workflows/lib/allowDisablingStandardEmails.ts
@@ -7,21 +7,11 @@ type WorkflowWithStepsAndTrigger = {
   }[];
 };
 
-export function allowDisablingHostConfirmationEmails(workflows: WorkflowWithStepsAndTrigger[]) {
-  return !!workflows.find(
-    (workflow) =>
-      workflow.trigger === WorkflowTriggerEvents.NEW_EVENT &&
-      !!workflow.steps.find((step) => step.action === WorkflowActions.EMAIL_HOST)
-  );
+export function allowDisablingHostConfirmationEmails(_workflows: WorkflowWithStepsAndTrigger[]) {
+  return true;
 }
 
-export function allowDisablingAttendeeConfirmationEmails(workflows: WorkflowWithStepsAndTrigger[]) {
-  return !!workflows.find(
-    (workflow) =>
-      workflow.trigger === WorkflowTriggerEvents.NEW_EVENT &&
-      !!workflow.steps.find(
-        (step) =>
-          step.action === WorkflowActions.EMAIL_ATTENDEE || step.action === WorkflowActions.SMS_ATTENDEE
-      )
-  );
+
+export function allowDisablingAttendeeConfirmationEmails(_workflows: WorkflowWithStepsAndTrigger[]) {
+  return true;
 }


### PR DESCRIPTION
## What does this PR do?

Allows all users (including free/individual plans) to disable default confirmation emails without requiring a custom workflow. Previously, these toggles were only visible to users who had created a `NEW_EVENT` workflow with specific email actions, effectively limiting this basic feature to paid users.

This change enables users to disable Cal.com's default booking confirmation emails so they can use their own external email marketing tools without sending duplicate notifications to attendees.

- Fixes #25537
- Fixes [CAL-6857](https://linear.app/calcom/issue/CAL-6857/abillity-to-disable-workflow-notifications-for-non-paid-users)

## Visual Demo (For contributors especially)

#### Video Demo:

**Before** :
https://www.loom.com/share/93e194d409b24f948fe0f72a157f4c6a

**Paid plan**
https://www.loom.com/share/0516fda77b74414fb6999c7e2ec5223e

**After:**
https://www.loom.com/share/c89f6d22c16345ce9f95c92e0f5a4e23

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - This is a feature enablement, no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

### Prerequisites:
- Local development environment with Cal.com running
- Have at least one event type created
- Workflow should look like this - : 
<img width="924" height="778" alt="image" src="https://github.com/user-attachments/assets/36fcaeb6-8dca-4033-b5ad-829f5dc2bfb1" />
