### PR TITLE
refactor: migrate EventType.tsx and EventAvailabilityTab.tsx to packages/platform

### DIFF
--- a/packages/platform/atoms/event-types/components/EventType.tsx
+++ b/packages/platform/atoms/event-types/components/EventType.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-/* eslint-disable @typescript-eslint/no-empty-function */
+ 
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import type { UseFormReturn } from "react-hook-form";
 
@@ -17,7 +17,7 @@ import type { RouterOutputs } from "@calcom/trpc/react";
 import { Form } from "@calcom/ui/components/form";
 import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
 
-import { EventTypeSingleLayout } from "./EventTypeLayout";
+import { EventTypeSingleLayout } from "@calcom/features/eventtypes/components/EventTypeLayout";
 
 export type Host = {
   isFixed: boolean;
@@ -30,7 +30,7 @@ export type Host = {
 
 export type CustomInputParsed = typeof customInputSchema._output;
 
-const tabs = [
+const _tabs = [
   "setup",
   "availability",
   "team",
@@ -62,7 +62,7 @@ export type EventTypeComponentProps = EventTypeSetupProps & {
   eventTypeApps?: EventTypeApps;
   isUpdating: boolean;
   isPlatform?: boolean;
-  tabName: (typeof tabs)[number];
+  tabName: (typeof _tabs)[number];
   tabsNavigation: VerticalTabItemProps[];
   allowDelete?: boolean;
   saveButtonRef?: React.RefObject<HTMLButtonElement>;

--- a/packages/platform/atoms/event-types/components/tabs/availability/EventAvailabilityTab.tsx
+++ b/packages/platform/atoms/event-types/components/tabs/availability/EventAvailabilityTab.tsx
@@ -10,7 +10,7 @@ import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import dayjs from "@calcom/dayjs";
 import { SelectSkeletonLoader } from "@calcom/features/availability/components/SkeletonLoader";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
-import type { TeamMembers } from "@calcom/features/eventtypes/components/EventType";
+import type { TeamMembers } from "../../EventType";
 import type {
   AvailabilityOption,
   FormValues,
@@ -469,7 +469,6 @@ const EventTypeSchedule = ({
         shouldDirty: true,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scheduleId, schedulesQueryData]);
 
   if (isSchedulesPending || !schedulesQueryData) {

--- a/packages/platform/atoms/event-types/hooks/useHandleRouteChange.ts
+++ b/packages/platform/atoms/event-types/hooks/useHandleRouteChange.ts
@@ -1,10 +1,9 @@
-// eslint-disable-next-line @calcom/eslint/deprecated-imports-next-router
 import { useEffect } from "react";
 
 import type {
   EventTypeAssignedUsers,
   EventTypeHosts,
-} from "@calcom/features/eventtypes/components/EventType";
+} from "../components/EventType";
 import { checkForEmptyAssignment } from "@calcom/features/eventtypes/lib/checkForEmptyAssignment";
 
 export const useHandleRouteChange = ({
@@ -57,6 +56,5 @@ export const useHandleRouteChange = ({
     return () => {
       onEnd?.(handleRouteChange);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [watchTrigger, hosts, assignedUsers, assignAllTeamMembers, onError, onStart, onEnd]);
 };

--- a/packages/platform/atoms/event-types/wrappers/EventAvailabilityTabPlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventAvailabilityTabPlatformWrapper.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
 
-import type { EventAvailabilityTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab";
-import { EventAvailabilityTab } from "@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab";
-import type { ScheduleQueryData } from "@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab";
+import type { EventAvailabilityTabCustomClassNames } from "../components/tabs/availability/EventAvailabilityTab";
+import { EventAvailabilityTab } from "../components/tabs/availability/EventAvailabilityTab";
+import type { ScheduleQueryData } from "../components/tabs/availability/EventAvailabilityTab";
 import type { EventTypeSetup, FormValues } from "@calcom/features/eventtypes/lib/types";
 import type { User } from "@calcom/prisma/client";
 

--- a/packages/platform/atoms/event-types/wrappers/EventAvailabilityTabWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventAvailabilityTabWebWrapper.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
 
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
-import type { TeamMembers } from "@calcom/features/eventtypes/components/EventType";
-import { EventAvailabilityTab } from "@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab";
+import type { TeamMembers } from "../components/EventType";
+import { EventAvailabilityTab } from "../components/tabs/availability/EventAvailabilityTab";
 import type { EventTypeSetup, FormValues } from "@calcom/features/eventtypes/lib/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";

--- a/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypePlatformWrapper.tsx
@@ -5,11 +5,11 @@ import { useRef, useState, useEffect, forwardRef, useImperativeHandle, useCallba
 
 import { BookerStoreProvider } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import type { ChildrenEventType } from "@calcom/features/eventtypes/components/ChildrenEventTypeSelect";
-import { EventType as EventTypeComponent } from "@calcom/features/eventtypes/components/EventType";
+import { EventType as EventTypeComponent } from "../components/EventType";
 import ManagedEventTypeDialog from "@calcom/features/eventtypes/components/dialogs/ManagedEventDialog";
 import type { EventAdvancedTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/advanced/EventAdvancedTab";
 import type { EventTeamAssignmentTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/assignment/EventTeamAssignmentTab";
-import type { EventAvailabilityTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab";
+import type { EventAvailabilityTabCustomClassNames } from "../components/tabs/availability/EventAvailabilityTab";
 import type { EventLimitsTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/limits/EventLimitsTab";
 import type { EventRecurringTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/recurring/RecurringEventController";
 import type { EventSetupTabCustomClassNames } from "@calcom/features/eventtypes/components/tabs/setup/EventSetupTab";
@@ -324,9 +324,11 @@ const EventType = forwardRef<
   const onDelete = () => {
     if (allowDelete && !isDryRun) {
       isTeamEventTypeDeleted.current = true;
-      team?.id
-        ? deleteTeamEventTypeMutation.mutate({ eventTypeId: id, teamId: team.id })
-        : deleteMutation.mutate(id);
+      if (team?.id) {
+        deleteTeamEventTypeMutation.mutate({ eventTypeId: id, teamId: team.id });
+      } else {
+        deleteMutation.mutate(id);
+      }
     }
 
     if (isDryRun) {

--- a/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -7,7 +7,7 @@ import { z } from "zod";
 
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import type { ChildrenEventType } from "@calcom/features/eventtypes/components/ChildrenEventTypeSelect";
-import { EventType as EventTypeComponent } from "@calcom/features/eventtypes/components/EventType";
+import { EventType as EventTypeComponent } from "../components/EventType";
 import type { EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types";
 import { EventPermissionProvider } from "@calcom/features/pbac/client/context/EventPermissionContext";
 import { useWorkflowPermission } from "@calcom/features/pbac/client/hooks/useEventPermission";


### PR DESCRIPTION
## What does this PR do?

Migrates `EventType.tsx` and `EventAvailabilityTab.tsx` from `packages/features/eventtypes/components/` to `packages/platform/atoms/event-types/components/` since these files are only consumed within the platform package.

The `/features` directory is meant for shared server code, but these components were exclusively used by platform wrappers, so they belong in `/packages/platform`.

## Changes

- Move `EventType.tsx` to `packages/platform/atoms/event-types/components/`
- Move `EventAvailabilityTab.tsx` to `packages/platform/atoms/event-types/components/tabs/availability/`
- Update all import paths in consuming files:
  - `EventTypeWebWrapper.tsx`
  - `EventTypePlatformWrapper.tsx`
  - `EventAvailabilityTabWebWrapper.tsx`
  - `EventAvailabilityTabPlatformWrapper.tsx`
  - `useHandleRouteChange.ts`
- Fix lint warnings in migrated files (removed eslint-disable comments for rules not defined in platform package)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactor only
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a refactoring PR that moves files without changing functionality. Testing should verify:

1. Run type check: `yarn type-check:ci --force` - should pass without new errors related to these files
2. Run lint: `yarn lint` - should pass
3. Verify the platform atoms package builds correctly
4. Verify event type editing functionality still works in both web and platform contexts

## Human Review Checklist

- [ ] Verify no other files in the codebase import from the old `@calcom/features/eventtypes/components/EventType` or `@calcom/features/eventtypes/components/tabs/availability/EventAvailabilityTab` paths
- [ ] Verify the `EventTypeSingleLayout` import change (from relative to `@calcom/features/eventtypes/components/EventTypeLayout`) is correct since that component stays in features
- [ ] Verify the ternary-to-if-else conversion in `EventTypePlatformWrapper.tsx` `onDelete` function is functionally equivalent

---

> **Link to Devin run**: https://app.devin.ai/sessions/8f48c8b2d5c14769abce24bf337a6ebf
> **Requested by**: benny@cal.com (@hbjORbj)