### PR TITLE
chore(companion): small wxt related fixes

### DIFF
--- a/companion/components/LoginScreen.tsx
+++ b/companion/components/LoginScreen.tsx
@@ -32,7 +32,7 @@ export function LoginScreen() {
     <View className="flex-1 bg-white">
       {/* Logo centered in the middle */}
       <View className="flex-1 items-center justify-center">
-        <CalComLogo width={240} height={54} color="#111827" />
+        <CalComLogo width={180} height={40} color="#111827" />
       </View>
 
       {/* Bottom section with button */}

--- a/companion/extension/public/manifest.json
+++ b/companion/extension/public/manifest.json
@@ -7,6 +7,15 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'; frame-src 'self' https://companion.cal.com;"
   },
+  "data_collection_permissions": {
+    "libraries": [
+      {
+        "name": "cal.com",
+        "url": "https://cal.com/privacy",
+        "purpose": "Booking and scheduling"
+      }
+    ]
+  },
   "action": {
     "default_title": "Cal.com Companion"
   },

--- a/companion/package.json
+++ b/companion/package.json
@@ -9,6 +9,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "ext:build": "wxt build",
+    "build:firefox": "wxt build -b firefox",
+    "build:safari": "wxt build -b safari",
     "ext": "wxt",
     "ext:zip": "wxt zip",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",

--- a/companion/wxt.config.ts
+++ b/companion/wxt.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from "wxt";
 
 export default defineConfig({
+  hooks: {
+    "build:manifestGenerated": (_wxt, manifest) => {
+      manifest.browser_specific_settings ??= {};
+      manifest.browser_specific_settings.gecko ??= {};
+      manifest.browser_specific_settings.gecko.data_collection_permissions = {
+        required: ["none"],
+      };
+    },
+  },
   srcDir: "extension",
   entrypointsDir: "entrypoints",
   publicDir: "extension/public",
@@ -19,6 +28,9 @@ export default defineConfig({
     content_security_policy: {
       extension_pages:
         "script-src 'self'; object-src 'self'; frame-src 'self' https://companion.cal.com",
+    },
+    data_collection_permissions: {
+      collects_data: false,
     },
     action: {
       default_title: "Cal.com Companion",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the WXT config and manifest to enable Firefox/Safari builds and explicitly set data collection permissions. Resized the login screen logo for a better fit.

- **New Features**
  - Added build scripts for Firefox and Safari.
  - Declared data collection permissions in manifest and WXT config (collects_data: false; Gecko required: ["none"]).

<sup>Written for commit 1472d0f3e91ad6063388bbd40e87288493f09460. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

