### PR TITLE
fix: slots ooo bug

### DIFF
--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -122,7 +122,6 @@ function buildSlotsWithDateRanges({
   const slotBoundaries = new Map<number, true>();
 
   orderedDateRanges.forEach((range) => {
-
     let slotStartTime = range.start.utc().isAfter(startTimeWithMinNotice)
       ? range.start
       : startTimeWithMinNotice;
@@ -181,7 +180,7 @@ function buildSlotsWithDateRanges({
       }
 
       slotBoundaries.set(slotStartTime.valueOf(), true);
-      const slotDateYYYYMMDD = slotStartTime.format("YYYY-MM-DD");
+      const slotDateYYYYMMDD = slotStartTime.utc().format("YYYY-MM-DD");
       const dateOutOfOfficeExists = datesOutOfOffice?.[slotDateYYYYMMDD];
       let slotData: {
         time: Dayjs;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes: OOO with booker in different timezone can cause “No available users found”

How to reproduce?
1) Create availability 12:00 AM to 11:59PM Europe/Berlin Timezone (everyday)
2) Create OOO entry on let's say 22nd december
3) Now go to booking page and try to book the first slot on 23rd december in Asia/Kolkata timezone

Eariler we were displaying slots from 12:00 AM to 4:30AM as well for Asia/Kolkata timezone which was still 22nd december in  Europe/Berlin timezone

https://calendso.slack.com/archives/C08B8SYUY02/p1765794582326579

Before:-
![Screenshot 2025-12-15 at 4 58 20 PM](https://github.com/user-attachments/assets/7937faef-3f76-4711-8e95-e802ef3cf58e)


After:-

<img width="2688" height="1252" alt="image" src="https://github.com/user-attachments/assets/10049068-4248-4d8c-a42d-2ae280434f31" />




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-timezone OOO handling in slot generation. Slots now use the UTC date when checking OOO, so times that overlap a host’s OOO day are marked as away instead of showing false availability.

- **Bug Fixes**
  - Normalize slot date to UTC before looking up datesOutOfOffice (YYYY-MM-DD).
  - Added tests for Berlin OOO viewed from Kolkata, UTC boundary crossings, and non-OOO cases.

<sup>Written for commit 9460a22324b316a48219141913ca31e3493b7ef8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







