### PR TITLE
fix: companion CI

### DIFF
--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: companion/package-lock.json
+          cache-dependency-path: companion/bun.lock
       - name: Install dependencies
         working-directory: companion
         run: npm ci


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the companion CI by pointing the Node cache to companion/bun.lock instead of package-lock.json. Caching now matches the lockfile and speeds up installs.

<sup>Written for commit bf4485134111a999cecf768d4e8645f2ede960a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

