### PR TITLE
fix: Companion CI with Bun

### DIFF
--- a/.github/workflows/companion-build.yml
+++ b/.github/workflows/companion-build.yml
@@ -14,24 +14,29 @@ jobs:
     name: Build Companion App & Extension
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
         with:
-          node-version: 20
-          cache: npm
+          bun-version: 1.3.0
+          cache: true
           cache-dependency-path: companion/bun.lock
+
       - name: Install dependencies
         working-directory: companion
-        run: npm ci
+        run: bun install --frozen-lockfile
+
       - name: Build Expo web app
         working-directory: companion
         env:
           EXPO_NO_TELEMETRY: 1
           CI: true
-        run: npx expo export --platform web
+        run: bunx expo export --platform web
+
       - name: Build browser extension
         working-directory: companion
-        run: npm run ext:build
+        run: bun run ext:build


### PR DESCRIPTION
## What does this PR do?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Companion CI to Bun to simplify tooling and speed up builds. The web app and browser extension now build with Bun commands and Bun caching.

- **Refactors**
  - Use oven-sh/setup-bun@v1 (bun 1.3.0) instead of actions/setup-node.
  - Replace npm commands with bun install and bunx expo export.
  - Build the extension with bun run ext:build and cache via bun.lock.

<sup>Written for commit ea33f423f2cb41e02831dd1036c4f8d04ec2f1a4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

