### PR TITLE
fix: handle invalid email formats in watchlist check to prevent 500 errors

### DIFF
--- a/packages/features/watchlist/operations/check-if-users-are-blocked.controller.ts
+++ b/packages/features/watchlist/operations/check-if-users-are-blocked.controller.ts
@@ -34,13 +34,14 @@ export async function checkIfUsersAreBlocked(params: CheckUsersBlockedParams): P
       let normalizedEmail: string;
       try {
         normalizedEmail = normalizeEmail(user.email);
-      } catch (error) {
+      } catch {
         // If email normalization fails (e.g., email contains characters like % that don't match our regex),
         // log the issue and skip watchlist check for this user. This prevents booking failures
         // when host users have emails with unusual but valid characters.
+        // Note: We intentionally don't log the error message as it contains the full email (PII).
         log.warn("Failed to normalize email for watchlist check, skipping user", {
           username: user.username,
-          error: error instanceof Error ? error.message : "Unknown error",
+          reason: "invalid_email_format",
         });
         continue;
       }


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 error on `/api/book/event` when a host user has an email containing characters that don't match our email validation regex (e.g., `%` character in `info%blackforest-service.de@gtempaccount.com`).

The error occurred in `loadAndValidateUsers` → `checkIfUsersAreBlocked` → `normalizeEmail`, where the email validation threw an unhandled exception that bubbled up as a 500 error during booking.

**Root cause:** The `emailRegex` in `@calcom/lib/emailSchema` doesn't allow `%` characters in the local part, even though `%` is technically valid per RFC 5321.

**Fix approach:** Rather than modifying the shared email regex (which could have broader implications across the codebase), this PR wraps the `normalizeEmail` call in a try/catch within `checkIfUsersAreBlocked`. When normalization fails, we log a warning and skip the watchlist check for that user, allowing the booking to proceed.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the unit tests: `TZ=UTC yarn test packages/features/watchlist/operations/check-if-users-are-blocked.controller.test.ts`
2. All 18 tests should pass, including 2 new tests:
   - `should not throw when email contains characters that fail normalization (e.g., %)`
   - `should return false when all users have invalid email formats`

**To reproduce the original issue:** A host user would need an email with `%` or other characters not in `[A-Z0-9_+-\.']` - this is rare but can happen with certain email providers or temporary account systems.

## Human Review Checklist

- [ ] **Security consideration**: This uses a "fail open" approach - users with invalid email formats are skipped from watchlist checks. Since this checks HOST users (not bookers), the risk is lower, but please verify this is acceptable.
- [ ] **Logging**: Verify the warning log includes username but not the full email (to avoid PII in logs).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/678aa444571045d98cf56f16d9c9354c
Requested by: benny@cal.com (@hbjORbj)