### PR TITLE
feat(bookings): conditionally show heading/subtitle based on view

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -1,6 +1,6 @@
 import { ShellMainAppDir } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDir";
 import type { PageProps } from "app/_types";
-import { _generateMetadata } from "app/_utils";
+import { _generateMetadata, getTranslate } from "app/_utils";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
@@ -34,6 +34,7 @@ const Page = async ({ params }: PageProps) => {
   if (!parsed.success) {
     redirect("/bookings/upcoming");
   }
+  const t = await getTranslate();
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
   let canReadOthersBookings = false;
@@ -59,7 +60,10 @@ const Page = async ({ params }: PageProps) => {
     : false;
 
   return (
-    <ShellMainAppDir>
+    <ShellMainAppDir
+      heading={t("bookings")}
+      subtitle={t("bookings_description")}
+      headerClassName="bookings-shell-heading">
       <BookingsList
         status={parsed.data.status}
         userId={session?.user?.id}

--- a/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
-import React, { useMemo, useEffect } from "react";
+import React, { useMemo, useEffect, useLayoutEffect } from "react";
 
 import dayjs from "@calcom/dayjs";
 import { DataTableFilters } from "@calcom/features/data-table";
@@ -172,6 +172,27 @@ export function BookingCalendarContainer(props: BookingCalendarContainerProps) {
   const { canReadOthersBookings } = props.permissions;
   const { userIds } = useBookingFilters();
   const { currentWeekStart, setCurrentWeekStart, userWeekStart } = useCurrentWeekStart();
+
+  // Hide the shell heading when calendar view is mounted
+  // This is needed because the heading/subtitle are rendered in the server component (page.tsx)
+  // but we only want to show them in list view
+  useLayoutEffect(() => {
+    const marker = document.querySelector(".bookings-shell-heading");
+    if (!marker) return;
+
+    // Find the outer header wrapper (the div with md:mb-6 md:mt-0)
+    const headerWrapper = marker.closest("header")?.parentElement;
+    if (!headerWrapper) return;
+
+    // Store the original display value and hide the header
+    const originalDisplay = headerWrapper.style.display;
+    headerWrapper.style.display = "none";
+
+    // Restore on unmount (when switching back to list view)
+    return () => {
+      headerWrapper.style.display = originalDisplay;
+    };
+  }, []);
 
   const allowedFilterIds = useCalendarAllowedFilters({
     canReadOthersBookings,

--- a/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/react-table";
-import React, { useMemo, useEffect, useLayoutEffect } from "react";
+import React, { useMemo, useEffect } from "react";
 
 import dayjs from "@calcom/dayjs";
 import { DataTableFilters } from "@calcom/features/data-table";
@@ -172,27 +172,6 @@ export function BookingCalendarContainer(props: BookingCalendarContainerProps) {
   const { canReadOthersBookings } = props.permissions;
   const { userIds } = useBookingFilters();
   const { currentWeekStart, setCurrentWeekStart, userWeekStart } = useCurrentWeekStart();
-
-  // Hide the shell heading when calendar view is mounted
-  // This is needed because the heading/subtitle are rendered in the server component (page.tsx)
-  // but we only want to show them in list view
-  useLayoutEffect(() => {
-    const marker = document.querySelector(".bookings-shell-heading");
-    if (!marker) return;
-
-    // Find the outer header wrapper (the div with md:mb-6 md:mt-0)
-    const headerWrapper = marker.closest("header")?.parentElement;
-    if (!headerWrapper) return;
-
-    // Store the original display value and hide the header
-    const originalDisplay = headerWrapper.style.display;
-    headerWrapper.style.display = "none";
-
-    // Restore on unmount (when switching back to list view)
-    return () => {
-      headerWrapper.style.display = originalDisplay;
-    };
-  }, []);
 
   const allowedFilterIds = useCalendarAllowedFilters({
     canReadOthersBookings,

--- a/apps/web/modules/bookings/hooks/useBookingsShellHeadingVisibility.ts
+++ b/apps/web/modules/bookings/hooks/useBookingsShellHeadingVisibility.ts
@@ -3,15 +3,7 @@
 import { useLayoutEffect } from "react";
 
 const MARKER_CLASS = "bookings-shell-heading";
-const HIDDEN_DATA_ATTR = "data-bookings-shell-heading-hidden";
 
-/**
- * Hook to control the visibility of the bookings page shell heading.
- * This is needed because the heading/subtitle are rendered in the server component (page.tsx)
- * but we only want to show them in list view, not calendar view.
- *
- * @param visible - Whether the heading should be visible
- */
 export function useBookingsShellHeadingVisibility({ visible }: { visible: boolean }) {
   useLayoutEffect(() => {
     const marker = document.querySelector(`.${MARKER_CLASS}`);
@@ -20,23 +12,14 @@ export function useBookingsShellHeadingVisibility({ visible }: { visible: boolea
     const headerWrapper = marker.closest("header")?.parentElement;
     if (!headerWrapper) return;
 
-    if (!visible) {
-      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) !== "true") {
-        headerWrapper.classList.add("hidden");
-        headerWrapper.setAttribute(HIDDEN_DATA_ATTR, "true");
-      }
+    if (visible) {
+      headerWrapper.classList.remove("hidden");
     } else {
-      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) === "true") {
-        headerWrapper.classList.remove("hidden");
-        headerWrapper.removeAttribute(HIDDEN_DATA_ATTR);
-      }
+      headerWrapper.classList.add("hidden");
     }
 
     return () => {
-      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) === "true") {
-        headerWrapper.classList.remove("hidden");
-        headerWrapper.removeAttribute(HIDDEN_DATA_ATTR);
-      }
+      headerWrapper.classList.remove("hidden");
     };
   }, [visible]);
 }

--- a/apps/web/modules/bookings/hooks/useBookingsShellHeadingVisibility.ts
+++ b/apps/web/modules/bookings/hooks/useBookingsShellHeadingVisibility.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+const MARKER_CLASS = "bookings-shell-heading";
+const HIDDEN_DATA_ATTR = "data-bookings-shell-heading-hidden";
+
+/**
+ * Hook to control the visibility of the bookings page shell heading.
+ * This is needed because the heading/subtitle are rendered in the server component (page.tsx)
+ * but we only want to show them in list view, not calendar view.
+ *
+ * @param visible - Whether the heading should be visible
+ */
+export function useBookingsShellHeadingVisibility({ visible }: { visible: boolean }) {
+  useLayoutEffect(() => {
+    const marker = document.querySelector(`.${MARKER_CLASS}`);
+    if (!marker) return;
+
+    const headerWrapper = marker.closest("header")?.parentElement;
+    if (!headerWrapper) return;
+
+    if (!visible) {
+      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) !== "true") {
+        headerWrapper.classList.add("hidden");
+        headerWrapper.setAttribute(HIDDEN_DATA_ATTR, "true");
+      }
+    } else {
+      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) === "true") {
+        headerWrapper.classList.remove("hidden");
+        headerWrapper.removeAttribute(HIDDEN_DATA_ATTR);
+      }
+    }
+
+    return () => {
+      if (headerWrapper.getAttribute(HIDDEN_DATA_ATTR) === "true") {
+        headerWrapper.classList.remove("hidden");
+        headerWrapper.removeAttribute(HIDDEN_DATA_ATTR);
+      }
+    };
+  }, [visible]);
+}

--- a/apps/web/modules/bookings/views/bookings-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-view.tsx
@@ -10,6 +10,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 
 import { BookingListContainer } from "../components/BookingListContainer";
+import { useBookingsShellHeadingVisibility } from "../hooks/useBookingsShellHeadingVisibility";
 import { useBookingsView } from "../hooks/useBookingsView";
 import type { validStatuses } from "../lib/validStatuses";
 
@@ -69,6 +70,8 @@ export default function Bookings(props: BookingsProps) {
 
 function BookingsContent({ status, permissions, bookingsV3Enabled }: BookingsProps) {
   const [view] = useBookingsView({ bookingsV3Enabled });
+
+  useBookingsShellHeadingVisibility({ visible: view === "list" });
 
   return (
     <div className={classNames(view === "calendar" && "-mb-8")}>


### PR DESCRIPTION
## What does this PR do?

Restores the `heading` and `subtitle` props to the bookings page shell, but conditionally hides them when the calendar view is active.

**Background:** The bookings page has two views - list and calendar. The heading/subtitle should only be visible in list view. Since `view` is client-side state (from URL query params via nuqs) and the shell is rendered in a server component, this PR uses a DOM-based approach to hide the heading when the calendar view mounts.

**Approach:**
1. Add `heading`, `subtitle`, and a marker `headerClassName` to `ShellMainAppDir` in the server component
2. In `bookings-view` (client component), use `useBookingsShellHeadingVisibility` (`useLayoutEffect`) to find and show/hide the header wrapper when view switches between list and calendar.

## Demo


https://github.com/user-attachments/assets/0edec67d-99f0-4b7c-8c22-78d33bfe9a7c



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to `/bookings/upcoming` - heading "Bookings" and subtitle should be visible
2. Switch to calendar view using the view toggle - heading should disappear
3. Switch back to list view - heading should reappear
4. Navigate directly to `/bookings/upcoming?view=calendar` - heading should be hidden (note: there may be a brief flash before the effect runs)

## Human Review Checklist

- [ ] Verify the DOM traversal (`marker.closest("header")?.parentElement`) correctly targets the header wrapper element in `ShellMainAppDir`
- [ ] Test view switching works correctly in both directions
- [ ] Consider if the DOM manipulation approach is acceptable vs. alternative solutions

---

> **Link to Devin run:** https://app.devin.ai/sessions/9c886cfde7c34736af9b38c7aa8f165b
> **Requested by:** @eunjae-lee (eunjae@cal.com)