### PR TITLE
fix: disable button routing

### DIFF
--- a/packages/features/eventtypes/components/tabs/advanced/DisableReschedulingController.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/DisableReschedulingController.tsx
@@ -47,7 +47,7 @@ export default function DisableReschedulingController({
   const shouldShowRadioButtons =
     disableRescheduling ||
     (currentMinimumRescheduleNotice !== null && currentMinimumRescheduleNotice > 0) ||
-    eventType.disableRescheduling !== undefined;
+    eventType.disableRescheduling === true;
 
   useEffect(() => {
     if (currentMinimumRescheduleNotice && currentMinimumRescheduleNotice > 0) {


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/01a708b6-94d3-45fa-a052-bd35ba779729

## After

https://github.com/user-attachments/assets/08cfef57-3bbc-4426-a3b8-9fb224af220b

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Disable Rescheduling UI so radio buttons only show when disableRescheduling is true. This prevents the button from routing users when the feature is off.

- **Bug Fixes**
  - Show rescheduling controls only when eventType.disableRescheduling === true (not just defined).

<sup>Written for commit 3101f98e7a147850021368139e1d932666136231. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



