### PR TITLE
fix: Allow single-label domains and missing dots

### DIFF
--- a/packages/prisma/zod-utils.test.ts
+++ b/packages/prisma/zod-utils.test.ts
@@ -55,13 +55,14 @@ describe("excludeOrRequireEmailSchema", () => {
     it("accepts long multi-level domains", () => {
       expect(parse("example.co.uk.test.com").success).toBe(true);
     });
+
+    it("accepts single-label domains and missing dots", () => {
+      expect(parse("example").success).toBe(true);
+      expect(parse("@example").success).toBe(true);
+    });
   });
 
   describe("invalid inputs", () => {
-    it("rejects single-label domains and missing dots", () => {
-      expect(parse("example").success).toBe(false);
-      expect(parse("@example").success).toBe(false);
-    });
 
     it("rejects invalid TLD lengths", () => {
       expect(parse("example.c").success).toBe(false);

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -970,7 +970,7 @@ export const excludeOrRequireEmailSchema = z.string().superRefine((val, ctx) => 
   // Accept forms: domain-only, `@domain`, or `local@domain`
   // - Domain labels: alnum, hyphens allowed internally, no leading/trailing hyphen
   // - Require at least one dot and end with an alpha TLD of length ≥2
-  const EMAIL_OR_DOMAIN_PATTERN = /^(?:[a-z0-9._+'-]+@|@)?(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i;
+  const EMAIL_OR_DOMAIN_PATTERN = /^(?:[a-z0-9._+'-]+@|@)?(?:[a-z]{2,}|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,})$/i;
 
   const isValid = allDomains.every((entry) => EMAIL_OR_DOMAIN_PATTERN.test(entry));
 


### PR DESCRIPTION
## What does this PR do?

Fix regression on read

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression in excludeOrRequireEmailSchema by allowing single-label domains and inputs without dots (e.g., "example" and "@example"). Updates the validation and tests to match the intended acceptance.

- **Bug Fixes**
  - Relaxed the regex to permit single-label domains alongside multi-level domains.
  - Updated tests to accept "example" and "@example".

<sup>Written for commit 7671a3f78a5c1186f2efffb15d135d53de722556. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

