### PR TITLE
fix: localize booking title with attendee language

### DIFF
--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1401,7 +1401,7 @@ async function handler(
     location: bookingLocation,
     eventDuration: dayjs(reqBody.end).diff(reqBody.start, "minutes"),
     bookingFields: { ...responses },
-    t: tOrganizer,
+    t: tAttendees,
   };
 
   const iCalUID = getICalUID({


### PR DESCRIPTION
 ## What does this PR do?

  The booking title was using the organizer's locale instead of the language provided in the API request. Changed `eventNameObject` to use `tAttendees` (derived from request language)
 instead of `tOrganizer`.

  - Fixes #25495

  ## Mandatory Tasks (DO NOT REMOVE)

  - [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
  - [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
  - [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

  ## How should this be tested?

  1. Make a booking via API with a `language` param set to something other than the organizer's locale (e.g. `"es"`)
  2. Check the booking title in the response
  3. Should now be localized using the requested language instead of the organizer's default