### PR TITLE
feat: add hidden event toggle for managed events (Fixes #25903)

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -597,10 +597,10 @@ export const InfiniteEventTypeList = ({
                                     e.preventDefault();
                                     e.stopPropagation();
 
-                                    const currentMetadata = type.metadata || {};
-                                    const currentManagedConfig = type.metadata?.managedEventConfig || {};
-                                    const currentUnlocked = currentManagedConfig?.unlockedFields || {};
-                                    const isHiddenLocked = !currentUnlocked?.hidden;
+                                    const currentMetadata = (type.metadata as any) || {};
+                                    const currentManagedConfig = currentMetadata.managedEventConfig || {};
+                                    const currentUnlocked = currentManagedConfig.unlockedFields || {};
+                                    const isHiddenLocked = !currentUnlocked.hidden;
 
                                     const newUnlocked = { ...currentUnlocked };
                                     if (isHiddenLocked) {

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -312,7 +312,13 @@ export const InfiniteEventTypeList = ({
               pages: oldData.pages.map((page) => ({
                 ...page,
                 eventTypes: page.eventTypes.map((eventType) =>
-                  eventType.id === data.id ? { ...eventType, hidden: !eventType.hidden } : eventType
+                  eventType.id === data.id
+                    ? {
+                        ...eventType,
+                        hidden: data.hidden !== undefined ? data.hidden : !eventType.hidden,
+                        metadata: data.metadata ? (data.metadata as typeof eventType.metadata) : eventType.metadata,
+                      }
+                    : eventType
                 ),
               })),
             };
@@ -608,6 +614,7 @@ export const InfiniteEventTypeList = ({
 
                                     setHiddenMutation.mutate({
                                       id: type.id,
+                                      hidden: type.hidden,
                                       // @ts-ignore
                                       metadata: {
                                         ...currentMetadata,

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -570,7 +570,57 @@ export const InfiniteEventTypeList = ({
                           />
                         )}
                         <div className="flex items-center justify-between space-x-2 rtl:space-x-reverse">
-                          {!isManagedEventType && (
+                          <div className="flex items-center">
+                            {isManagedEventType && (
+                              <Tooltip
+                                content={
+                                  !type.metadata?.managedEventConfig?.unlockedFields?.hidden
+                                    ? t("locked")
+                                    : t("unlocked")
+                                }>
+                                <Button
+                                  className="mr-2"
+                                  variant="icon"
+                                  StartIcon={
+                                    !type.metadata?.managedEventConfig?.unlockedFields?.hidden
+                                      ? "lock"
+                                      : "unlock"
+                                  }
+                                  color="secondary"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    const currentMetadata = (type.metadata as object) || {};
+                                    // @ts-ignore
+                                    const currentManagedConfig = currentMetadata.managedEventConfig || {};
+                                    // @ts-ignore
+                                    const currentUnlocked = currentManagedConfig.unlockedFields || {};
+                                    const isHiddenLocked = !currentUnlocked.hidden;
+
+                                    const newUnlocked = { ...currentUnlocked };
+                                    if (isHiddenLocked) {
+                                      // @ts-ignore
+                                      newUnlocked.hidden = true;
+                                    } else {
+                                      // @ts-ignore
+                                      delete newUnlocked.hidden;
+                                    }
+
+                                    setHiddenMutation.mutate({
+                                      id: type.id,
+                                      // @ts-ignore
+                                      metadata: {
+                                        ...currentMetadata,
+                                        managedEventConfig: {
+                                          ...currentManagedConfig,
+                                          unlockedFields: newUnlocked,
+                                        },
+                                      },
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
+                            )}
                             <>
                               {type.hidden && <Badge variant="gray">{t("hidden")}</Badge>}
                               <Tooltip
@@ -589,7 +639,7 @@ export const InfiniteEventTypeList = ({
                                 </div>
                               </Tooltip>
                             </>
-                          )}
+                          </div>
 
                           <ButtonGroup combined>
                             {!isManagedEventType && (

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -596,26 +596,22 @@ export const InfiniteEventTypeList = ({
                                   onClick={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
-                                    const currentMetadata = (type.metadata as object) || {};
-                                    // @ts-ignore
-                                    const currentManagedConfig = currentMetadata.managedEventConfig || {};
-                                    // @ts-ignore
-                                    const currentUnlocked = currentManagedConfig.unlockedFields || {};
-                                    const isHiddenLocked = !currentUnlocked.hidden;
+
+                                    const currentMetadata = type.metadata || {};
+                                    const currentManagedConfig = type.metadata?.managedEventConfig || {};
+                                    const currentUnlocked = currentManagedConfig?.unlockedFields || {};
+                                    const isHiddenLocked = !currentUnlocked?.hidden;
 
                                     const newUnlocked = { ...currentUnlocked };
                                     if (isHiddenLocked) {
-                                      // @ts-ignore
                                       newUnlocked.hidden = true;
                                     } else {
-                                      // @ts-ignore
                                       delete newUnlocked.hidden;
                                     }
 
                                     setHiddenMutation.mutate({
                                       id: type.id,
                                       hidden: type.hidden,
-                                      // @ts-ignore
                                       metadata: {
                                         ...currentMetadata,
                                         managedEventConfig: {

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -597,7 +597,15 @@ export const InfiniteEventTypeList = ({
                                     e.preventDefault();
                                     e.stopPropagation();
 
-                                    const currentMetadata = (type.metadata as any) || {};
+                                    interface EventTypeMetadata {
+                                      managedEventConfig?: {
+                                        unlockedFields?: {
+                                          hidden?: boolean;
+                                        };
+                                      };
+                                    }
+
+                                    const currentMetadata = (type.metadata || {}) as EventTypeMetadata;
                                     const currentManagedConfig = currentMetadata.managedEventConfig || {};
                                     const currentUnlocked = currentManagedConfig.unlockedFields || {};
                                     const isHiddenLocked = !currentUnlocked.hidden;

--- a/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
+++ b/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts
@@ -226,7 +226,7 @@ export default async function handleChildrenEventTypes({
         onlyShowFirstAvailableSlot: managedEventTypeValues.onlyShowFirstAvailableSlot ?? false,
         userId,
         parentId,
-        hidden: children?.find((ch) => ch.owner.id === userId)?.hidden ?? false,
+        hidden: children?.find((ch) => ch.owner.id === userId)?.hidden ?? eventType.hidden,
         /**
          * RR Segment isn't applicable for managed event types.
          */
@@ -333,7 +333,9 @@ export default async function handleChildrenEventTypes({
           data: {
             ...updatePayloadFiltered,
             rrHostSubsetEnabled: false,
-            hidden: children?.find((ch) => ch.owner.id === userId)?.hidden ?? false,
+            ...(children?.find((ch) => ch.owner.id === userId)
+              ? { hidden: children.find((ch) => ch.owner.id === userId)?.hidden }
+              : {}),
             ...("schedule" in unlockedFieldProps ? {} : { scheduleId: eventType.scheduleId || null }),
             restrictionScheduleId: null,
             useBookerTimezone: false,


### PR DESCRIPTION
## What does this PR do?

This PR implements the "Hidden Event" toggle for Parent Managed Events, a feature that was previously missing. It allows administrators to control the visibility of managed events directly from the parent level.

Key changes include:
- **Frontend**: Enabled the "Hidden" toggle switch for Managed Events in the event types listing.
- **Frontend**: Added a **Lock/Unlock** mechanism for the hidden toggle, allowing admins to enforce this setting on child events or let members override it.
- **Backend**: Updated [handleChildrenEventTypes](cci:1://file:///c:/Users/pawan/OneDrive/Desktop/cal/packages/features/ee/managed-event-types/lib/handleChildrenEventTypes.ts:127:0-421:1) to correctly propagate the `hidden` status to child events:
    - New child events inherit the parent's `hidden` status.
    - Existing child events are updated if the field is locked on the parent.
    - If unlocked, child events retain their individual settings.

- Fixes #25903



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A (I have updated the developer docs in /docs unless N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **Setup**: Ensure you have a Managed Event created with at least one assigned member (child event).
2. **Lock & Hide**:
   - Go to the Event Types listing (`/event-types`).
   - On the Parent Managed Event, ensure the **Lock icon** is closed (Locked).
   - Toggle the **Hidden switch** to ON.
   - **Verify**: The parent event is hidden. Check the child event (login as member or check DB/admin view) -> it should also be hidden.
3. **Unlock & Override**:
   - Click the **Lock icon** to Unlock (Open).
   - Toggle the **Hidden switch** on the parent.
   - **Verify**: The child event's status does NOT change immediately (it is now independent).
   - As the child user, verify you can now toggle the Hidden status yourself.
4. **Relock**:
   - Lock the field on the parent again and save/toggle.
   - **Verify**: The child event syncs back to the parent's state.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings