### PR TITLE
revert: Slugified event type slug when an event is created/updated from API v2

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/services/input-event-types.service.ts
@@ -27,7 +27,6 @@ import {
 import { UserWithProfile } from "@/modules/users/users.repository";
 import { Injectable, BadRequestException } from "@nestjs/common";
 
-import { slugify } from "@calcom/platform-libraries";
 import { getApps, getUsersCredentialsIncludeServiceAccountKey } from "@calcom/platform-libraries/app-store";
 import {
   validateCustomEventName,
@@ -130,7 +129,6 @@ export class InputEventTypesService_2024_06_14 {
       useDestinationCalendarEmail,
       disableGuests,
       bookerActiveBookingsLimit,
-      slug,
       ...rest
     } = inputEventType;
     const confirmationPolicyTransformed = this.transformInputConfirmationPolicy(confirmationPolicy);
@@ -146,8 +144,6 @@ export class InputEventTypesService_2024_06_14 {
       ? this.transformInputBookerActiveBookingsLimit(bookerActiveBookingsLimit)
       : {};
 
-    const slugifiedSlug = slugify(slug);
-
     const metadata: EventTypeMetadata = {
       bookerLayouts: this.transformInputBookerLayouts(bookerLayouts),
       requiresConfirmationThreshold:
@@ -157,7 +153,6 @@ export class InputEventTypesService_2024_06_14 {
 
     const eventType = {
       ...rest,
-      slug: slugifiedSlug,
       length: lengthInMinutes,
       locations: locationsTransformed,
       bookingFields: this.transformInputBookingFields(effectiveBookingFields),
@@ -214,7 +209,6 @@ export class InputEventTypesService_2024_06_14 {
       useDestinationCalendarEmail,
       disableGuests,
       bookerActiveBookingsLimit,
-      slug,
       ...rest
     } = inputEventType;
     const eventTypeDb = await this.eventTypesRepository.getEventTypeWithMetaData(eventTypeId);
@@ -249,7 +243,6 @@ export class InputEventTypesService_2024_06_14 {
 
     const eventType = {
       ...rest,
-      ...(slug ? { slug: slugify(slug) } : {}),
       length: lengthInMinutes,
       locations: locations ? this.transformInputLocations(locations) : undefined,
       bookingFields: effectiveBookingFields

--- a/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/services/input.service.ts
@@ -8,7 +8,6 @@ import { UsersRepository } from "@/modules/users/users.repository";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 
 import { SchedulingType } from "@calcom/platform-libraries";
-import { slugify } from "@calcom/platform-libraries";
 import { EventTypeMetadata } from "@calcom/platform-libraries/event-types";
 import {
   CreateTeamEventTypeInput_2024_06_14,
@@ -43,13 +42,11 @@ export class InputOrganizationsEventTypesService {
     teamId: number,
     inputEventType: CreateTeamEventTypeInput_2024_06_14
   ) {
-    const slugifiedInputEventType = { ...inputEventType, slug: slugify(inputEventType.slug) };
-
     await this.validateInputLocations(teamId, inputEventType.locations);
     await this.validateHosts(teamId, inputEventType.hosts);
-    await this.validateTeamEventTypeSlug(teamId, slugifiedInputEventType.slug);
+    await this.validateTeamEventTypeSlug(teamId, inputEventType.slug);
 
-    const transformedBody = await this.transformInputCreateTeamEventType(teamId, slugifiedInputEventType);
+    const transformedBody = await this.transformInputCreateTeamEventType(teamId, inputEventType);
 
     await this.inputEventTypesService.validateEventTypeInputs({
       seatsPerTimeSlot: transformedBody.seatsPerTimeSlot,
@@ -78,21 +75,13 @@ export class InputOrganizationsEventTypesService {
     teamId: number,
     inputEventType: UpdateTeamEventTypeInput_2024_06_14
   ) {
-    const slugifiedInputEventType = inputEventType.slug
-      ? { ...inputEventType, slug: slugify(inputEventType.slug) }
-      : inputEventType;
-
     await this.validateInputLocations(teamId, inputEventType.locations);
     await this.validateHosts(teamId, inputEventType.hosts);
-    if (slugifiedInputEventType.slug) {
-      await this.validateTeamEventTypeSlug(teamId, slugifiedInputEventType.slug);
+    if (inputEventType.slug) {
+      await this.validateTeamEventTypeSlug(teamId, inputEventType.slug);
     }
 
-    const transformedBody = await this.transformInputUpdateTeamEventType(
-      eventTypeId,
-      teamId,
-      slugifiedInputEventType
-    );
+    const transformedBody = await this.transformInputUpdateTeamEventType(eventTypeId, teamId, inputEventType);
 
     await this.inputEventTypesService.validateEventTypeInputs({
       eventTypeId: eventTypeId,


### PR DESCRIPTION
Reverts calcom/cal.com#25791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts automatic slugification of event type slugs in API v2 (event-type create/update and team event types). Slugs are now accepted and validated as provided, preventing unexpected changes to existing slugs.

<sup>Written for commit f025301625902fbd3ffa819e62084ddbf72fac03. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

