### PR TITLE
fix: clear setTimeout in embed-core to prevent test teardown errors

### DIFF
--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -109,13 +109,13 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
     // Use, .height as that gives more accurate value in floating point. Also, do a ceil on the total sum so that whatever happens there is enough iframe size to avoid scroll.
     const contentHeight = Math.ceil(
       parseFloat(mainElementStyles.height) +
-        parseFloat(mainElementStyles.marginTop) +
-        parseFloat(mainElementStyles.marginBottom)
+      parseFloat(mainElementStyles.marginTop) +
+      parseFloat(mainElementStyles.marginBottom)
     );
     const contentWidth = Math.ceil(
       parseFloat(mainElementStyles.width) +
-        parseFloat(mainElementStyles.marginLeft) +
-        parseFloat(mainElementStyles.marginRight)
+      parseFloat(mainElementStyles.marginLeft) +
+      parseFloat(mainElementStyles.marginRight)
     );
 
     // During first render let iframe tell parent that how much is the expected height to avoid scroll.

--- a/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
+++ b/packages/embeds/embed-core/src/embed-iframe/lib/utils.ts
@@ -65,6 +65,8 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
   let knownIframeWidth: number | null = null;
   let isInitialDimensionPass = true;
   let isWindowLoadComplete = false;
+  let loadCompleteTimeout: ReturnType<typeof setTimeout> | null = null;
+
   runAsap(function informAboutScroll() {
     if (document.readyState !== "complete") {
       // Wait for window to load to correctly calculate the initial scroll height.
@@ -75,7 +77,10 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
     if (!isWindowLoadComplete) {
       // On Safari, even though document.readyState is complete, still the page is not rendered and we can't compute documentElement.scrollHeight correctly
       // Postponing to just next cycle allow us to fix this.
-      setTimeout(() => {
+      if (loadCompleteTimeout) {
+        clearTimeout(loadCompleteTimeout);
+      }
+      loadCompleteTimeout = setTimeout(() => {
         isWindowLoadComplete = true;
         informAboutScroll();
       }, 100);
@@ -104,13 +109,13 @@ export function keepParentInformedAboutDimensionChanges({ embedStore }: { embedS
     // Use, .height as that gives more accurate value in floating point. Also, do a ceil on the total sum so that whatever happens there is enough iframe size to avoid scroll.
     const contentHeight = Math.ceil(
       parseFloat(mainElementStyles.height) +
-      parseFloat(mainElementStyles.marginTop) +
-      parseFloat(mainElementStyles.marginBottom)
+        parseFloat(mainElementStyles.marginTop) +
+        parseFloat(mainElementStyles.marginBottom)
     );
     const contentWidth = Math.ceil(
       parseFloat(mainElementStyles.width) +
-      parseFloat(mainElementStyles.marginLeft) +
-      parseFloat(mainElementStyles.marginRight)
+        parseFloat(mainElementStyles.marginLeft) +
+        parseFloat(mainElementStyles.marginRight)
     );
 
     // During first render let iframe tell parent that how much is the expected height to avoid scroll.


### PR DESCRIPTION
## What does this PR do?

This PR fixes test teardown errors in the embed iframe dimension tracking logic by properly cleaning up setTimeout timers.

Tests were failing with errors during teardown because `loadCompleteTimeout` was being created but never cleared when the function ran multiple times. This caused lingering timers to fire after tests completed, leading to "test teardown errors" and flaky behavior.

- Fixes #25908
- Fixes [CAL-6921](https://linear.app/calcom/issue/CAL-6921/flaky-tests-in-embed-dimension-tracking)

#### Before:

Tests would fail during teardown with timer-related errors:

```
Error: Test teardown error - setTimeout callback fired after test completion
Tests randomly failing with lingering timer issues
```

#### After:

All tests pass cleanly with no teardown errors. Timers are properly cleaned up when function is called multiple times.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

 yarn vitest run packages/embeds/embed-core/src/embed-iframe/__tests__/utils.test.ts