### PR TITLE
fix: skip plan on invite to team

### DIFF
--- a/packages/features/auth/lib/onboardingUtils.ts
+++ b/packages/features/auth/lib/onboardingUtils.ts
@@ -64,5 +64,18 @@ export async function checkOnboardingRedirect(
   // Determine which onboarding path to use
   const onboardingV3Enabled = await featuresRepository.checkIfFeatureIsEnabledGlobally("onboarding-v3");
 
+  // Check if user has pending team invites - if so, skip plan selection and go straight to personal onboarding
+  const pendingInvites = await prisma.membership.findMany({
+    where: {
+      userId: userId,
+      accepted: false,
+    },
+  });
+
+  if (pendingInvites.length > 0 && onboardingV3Enabled) {
+    // User has pending invites, redirect directly to personal onboarding
+    return "/onboarding/personal/settings";
+  }
+
   return onboardingV3Enabled ? "/onboarding/getting-started" : "/getting-started";
 }

--- a/packages/features/auth/lib/onboardingUtils.ts
+++ b/packages/features/auth/lib/onboardingUtils.ts
@@ -64,16 +64,17 @@ export async function checkOnboardingRedirect(
   // Determine which onboarding path to use
   const onboardingV3Enabled = await featuresRepository.checkIfFeatureIsEnabledGlobally("onboarding-v3");
 
-  // Check if user has pending team invites - if so, skip plan selection and go straight to personal onboarding
-  const pendingInvites = await prisma.membership.findMany({
+  const pendingInvite = await prisma.membership.findFirst({
     where: {
       userId: userId,
       accepted: false,
     },
+    select: {
+      id: true,
+    },
   });
 
-  if (pendingInvites.length > 0 && onboardingV3Enabled) {
-    // User has pending invites, redirect directly to personal onboarding
+  if (pendingInvite && onboardingV3Enabled) {
     return "/onboarding/personal/settings";
   }
 


### PR DESCRIPTION
https://www.loom.com/share/1782c09c89d141bbb13e681626d47812

Ref: https://calendso.slack.com/archives/C08BXNPTRFS/p1765886595431119?thread_ts=1765826257.431639&cid=C08BXNPTRFS 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip plan selection for users with pending team invites and redirect them straight to personal onboarding settings. Adds a brief loading state while we check invites to avoid flicker.

- **Bug Fixes**
  - Client: Check pending invites and redirect to /onboarding/personal/settings, setting plan to “personal”.
  - Server: Update onboarding redirect to send invited users to personal onboarding when v3 is enabled.
  - UI: Show a loading card while invites are being checked or redirecting.

<sup>Written for commit 42c742a547d00492153900771ed91421e6d84886. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



