### PR TITLE
feat: add enabled column user team features

### DIFF
--- a/packages/prisma/migrations/20251216210349_add_enabled_column_to_user_and_team_features/migration.sql
+++ b/packages/prisma/migrations/20251216210349_add_enabled_column_to_user_and_team_features/migration.sql
@@ -4,7 +4,7 @@ ALTER TABLE "UserFeatures" ADD COLUMN "enabled" BOOLEAN;
 -- AlterTable
 ALTER TABLE "TeamFeatures" ADD COLUMN "enabled" BOOLEAN;
 
--- Set existing records to enabled=true (they were previously treated as enabled by presence)
+-- Set existing records to enabled=true (previously treated as enabled by presence)
 UPDATE "UserFeatures" SET "enabled" = true WHERE "enabled" IS NULL;
 UPDATE "TeamFeatures" SET "enabled" = true WHERE "enabled" IS NULL;
 

--- a/packages/prisma/migrations/20251216210349_add_enabled_column_to_user_and_team_features/migration.sql
+++ b/packages/prisma/migrations/20251216210349_add_enabled_column_to_user_and_team_features/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "UserFeatures" ADD COLUMN "enabled" BOOLEAN;
+
+-- AlterTable
+ALTER TABLE "TeamFeatures" ADD COLUMN "enabled" BOOLEAN;
+
+-- Set existing records to enabled=true (they were previously treated as enabled by presence)
+UPDATE "UserFeatures" SET "enabled" = true WHERE "enabled" IS NULL;
+UPDATE "TeamFeatures" SET "enabled" = true WHERE "enabled" IS NULL;
+

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1704,6 +1704,8 @@ model UserFeatures {
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
+  // Tri-state: true = enabled, false = disabled, null = inherit
+  enabled    Boolean?
 
   @@id([userId, featureId])
   @@index([userId, featureId])
@@ -1717,6 +1719,8 @@ model TeamFeatures {
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
+  // Tri-state: true = enabled, false = disabled, null = inherit
+  enabled    Boolean?
 
   @@id([teamId, featureId])
   @@index([teamId, featureId])

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1704,7 +1704,7 @@ model UserFeatures {
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
-  // Tri-state: true = enabled, false = disabled, null = inherit
+  // true = enabled, false = disabled, null = inherit
   enabled    Boolean?
 
   @@id([userId, featureId])
@@ -1719,7 +1719,7 @@ model TeamFeatures {
   assignedAt DateTime @default(now())
   assignedBy String
   updatedAt  DateTime @updatedAt
-  // Tri-state: true = enabled, false = disabled, null = inherit
+  // true = enabled, false = disabled, null = inherit
   enabled    Boolean?
 
   @@id([teamId, featureId])


### PR DESCRIPTION
## Summary
Adds `enabled` column to `UserFeatures` and `TeamFeatures` tables to support tri-state semantics for feature opt-in configuration.

## Changes
- Added nullable `Boolean?` `enabled` column to `UserFeatures` model
- Added nullable `Boolean?` `enabled` column to `TeamFeatures` model
- Created migration to add columns and set existing records to `enabled=true`
- Supports tri-state semantics: `true` = enabled, `false` = disabled, `null` = inherit

## Context
This is part of the Feature Opt-In Banner implementation (#25927) to allow configurable feature flags on personal/team/org levels with inheritance semantics.

## Testing
- [x] Schema changes validated
- [x] Migration SQL reviewed
- [ ] Migration tested locally (pending `yarn prisma generate` and `yarn workspace @calcom/prisma db-migrate`)

## Related
Refs #25928