### PR TITLE
fix: allow organizations to sign up with existing usernames

### DIFF
--- a/packages/lib/server/username.ts
+++ b/packages/lib/server/username.ts
@@ -1,5 +1,7 @@
 import type { NextResponse } from "next/server";
 
+import { ErrorCode } from "@calcom/lib/errorCodes";
+import { ErrorWithCode } from "@calcom/lib/errors";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
 import { RedirectType } from "@calcom/prisma/enums";
@@ -131,7 +133,14 @@ const usernameCheck = async (usernameRaw: string, currentOrgDomain?: string | nu
         id: true,
       },
     });
-    organizationId = organization?.id ?? null;
+    if (!organization) {
+      throw new ErrorWithCode(
+        ErrorCode.NotFound,
+        `Organization with domain "${currentOrgDomain}" not found`,
+        { currentOrgDomain }
+      );
+    }
+    organizationId = organization.id;
   }
 
   const user = await prisma.user.findFirst({

--- a/packages/lib/server/username.ts
+++ b/packages/lib/server/username.ts
@@ -116,11 +116,29 @@ const usernameCheck = async (usernameRaw: string, currentOrgDomain?: string | nu
 
   const username = slugify(usernameRaw);
 
+  let organizationId: number | null = null;
+  if (currentOrgDomain) {
+    // Get organizationId from orgSlug
+    const organization = await prisma.team.findFirst({
+      where: {
+        isOrganization: true,
+        OR: [
+          { slug: currentOrgDomain },
+          { metadata: { path: ["requestedSlug"], equals: currentOrgDomain } },
+        ],
+      },
+      select: {
+        id: true,
+      },
+    });
+    organizationId = organization?.id ?? null;
+  }
+
   const user = await prisma.user.findFirst({
     where: {
       username,
-      // Simply remove it when we drop organizationId column
-      organizationId: null,
+      // Check in the specific organization context, or global namespace if no org
+      organizationId: organizationId ?? null,
     },
     select: {
       id: true,
@@ -140,12 +158,13 @@ const usernameCheck = async (usernameRaw: string, currentOrgDomain?: string | nu
     response.premium = true;
   }
 
-  // get list of similar usernames in the db
+  // get list of similar usernames in the db (scoped to organization if checking in org context)
   const users = await prisma.user.findMany({
     where: {
       username: {
         contains: username,
       },
+      ...(organizationId !== null ? { organizationId } : { organizationId: null }),
     },
     select: {
       username: true,


### PR DESCRIPTION
## Summary
Fixes username validation during organization signup to allow organizations to use usernames that exist in other organizations or the global namespace. Previously, org signups were incorrectly blocked by global username conflicts.

## Changes
- Updated `usernameCheck` function in `packages/lib/server/username.ts` to check organization context when `currentOrgDomain` is provided
- Organizations now check username availability only within their specific organization
- Username suggestions are also scoped to the organization context

## Problem
Organizations have their own unique usernames (enforced by `@@unique([username, organizationId])` in the schema), but the signup validation was checking the global namespace (`organizationId: null`), preventing org signups from using usernames that existed elsewhere.

## Solution
When `currentOrgDomain` is provided:
1. Resolve the `organizationId` from the org slug
2. Check username availability only within that specific organization
3. Scope similar username queries to the organization

This allows organizations to reuse usernames from other orgs or the global namespace, while still preventing duplicates within the same organization.

## Testing
- [x] Code follows existing patterns (similar to `checkRegularUsername`)
- [x] Backward compatible - global namespace checks unchanged
- [ ] Manual testing: Sign up an organization with a username that exists globally
- [ ] Manual testing: Sign up an organization with a username that exists in another org

## Related
Fixes #25800