### PR TITLE
chore: release amd as latest

### DIFF
--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Whether to push the built image"
     required: false
     default: "false"
+  use-as-latest:
+    description: "Publish as latest"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -61,7 +65,7 @@ runs:
           docker.io/calcom/cal.com
           ghcr.io/calcom/cal.com
         flavor: |
-          latest=${{ !github.event.release.prerelease && inputs.platform == 'amd64' }}
+          latest=${{ !github.event.release.prerelease && inputs.use-as-latest == 'true' }}
           suffix=${{ inputs.platform-suffix }}
 
     - name: Copy env

--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to build and test Docker images for Cal.com"
 
 inputs:
   platform:
-    description: "Target platform (linux/amd64 or linux/arm64)"
+    description: "Target platform (linux/amd64 or arm64)"
     required: true
   platform-suffix:
     description: "Suffix to add to image tags (e.g., -arm)"
@@ -61,7 +61,7 @@ runs:
           docker.io/calcom/cal.com
           ghcr.io/calcom/cal.com
         flavor: |
-          latest=${{ !github.event.release.prerelease && inputs.platform == 'linux/amd64' }}
+          latest=${{ !github.event.release.prerelease && inputs.platform == 'amd64' }}
           suffix=${{ inputs.platform-suffix }}
 
     - name: Copy env

--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to build and test Docker images for Cal.com"
 
 inputs:
   platform:
-    description: "Target platform (linux/amd64 or arm64)"
+    description: "Target platform (linux/amd64 or linux/arm64)"
     required: true
   platform-suffix:
     description: "Suffix to add to image tags (e.g., -arm)"
@@ -61,7 +61,7 @@ runs:
           docker.io/calcom/cal.com
           ghcr.io/calcom/cal.com
         flavor: |
-          latest=${{ !github.event.release.prerelease }}
+          latest=${{ !github.event.release.prerelease && inputs.platform == 'linux/amd64' }}
           suffix=${{ inputs.platform-suffix }}
 
     - name: Copy env

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Build and test Docker image
         uses: ./.github/actions/docker-build-and-test
         with:
-          platform: "linux/arm64"
+          platform: "arm64"
           platform-suffix: "-arm"
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -10,6 +10,7 @@ on:
   push:
     tags:
       - "v*"
+  # in case manual trigger is needed
   workflow_dispatch:
     inputs:
       RELEASE_TAG:

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -40,7 +40,7 @@ jobs:
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
           push-image: "true"
-          use-as-latest: true
+          use-as-latest: "true"
 
       - name: Notify Slack on Success
         if: success()

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -40,6 +40,7 @@ jobs:
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
           push-image: "true"
+          use-as-latest: true
 
       - name: Notify Slack on Success
         if: success()

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -10,7 +10,6 @@ on:
   push:
     tags:
       - "v*"
-  # in case manual trigger is needed
   workflow_dispatch:
     inputs:
       RELEASE_TAG:
@@ -76,7 +75,7 @@ jobs:
       - name: Build and test Docker image
         uses: ./.github/actions/docker-build-and-test
         with:
-          platform: "arm64"
+          platform: "linux/arm64"
           platform-suffix: "-arm"
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN yarn install
 # Build and make embed servable from web/public/embed folder
 RUN yarn workspace @calcom/trpc run build
 RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build
-RUN CI=true yarn --cwd apps/web workspace @calcom/web run build
+RUN yarn --cwd apps/web workspace @calcom/web run build
 RUN rm -rf node_modules/.cache .yarn/cache apps/web/.next/cache
 
 FROM node:20 AS builder-two

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN yarn install
 # Build and make embed servable from web/public/embed folder
 RUN yarn workspace @calcom/trpc run build
 RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build
-RUN yarn --cwd apps/web workspace @calcom/web run build
+RUN CI=true yarn --cwd apps/web workspace @calcom/web run build
 RUN rm -rf node_modules/.cache .yarn/cache apps/web/.next/cache
 
 FROM node:20 AS builder-two


### PR DESCRIPTION
## What does this PR do?














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags the amd64 Docker image as latest on non-prerelease releases when configured, and updates the Docker build action to use amd64 platform naming.

<sup>Written for commit beb8e1a3ad126195a76ecf2b01adb17d6d92d557. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













