### PR TITLE
chore: Remove next build eslint and ts checks disabled for CI

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -108,7 +108,6 @@ const informAboutDuplicateTranslations = () => {
   }
 };
 
-
 const plugins = [];
 if (process.env.ANALYZE === "true") {
   // only load dependency if env `ANALYZE` was set
@@ -211,14 +210,6 @@ const nextConfig = (phase) => {
       webpackBuildWorker: true,
     },
     productionBrowserSourceMaps: true,
-    /* We already do type check on GH actions */
-    typescript: {
-      ignoreBuildErrors: !!process.env.CI,
-    },
-    /* We already do linting on GH actions */
-    eslint: {
-      ignoreDuringBuilds: !!process.env.CI,
-    },
     transpilePackages: [
       "@calcom/app-store",
       "@calcom/dayjs",


### PR DESCRIPTION
## What does this PR do?







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled TypeScript and ESLint checks during Next.js builds by removing CI-specific ignore flags. Builds now fail on type or lint errors, aligning build behavior with local checks.

- **Refactors**
  - Removed typescript.ignoreBuildErrors and eslint.ignoreDuringBuilds from apps/web/next.config.js.

<sup>Written for commit cf19384b5669456f23cad166899f3b1baab53f58. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





