### PR TITLE
fix: types for onboarding

### DIFF
--- a/apps/web/modules/onboarding/components/OnboardingCard.tsx
+++ b/apps/web/modules/onboarding/components/OnboardingCard.tsx
@@ -9,8 +9,8 @@ import { SkeletonText } from "@calcom/ui/components/skeleton";
 type OnboardingCardProps = {
   title: string;
   subtitle: string;
-  children: ReactNode;
-  footer: ReactNode | null;
+  children?: ReactNode;
+  footer?: ReactNode;
   isLoading?: boolean;
   floatingFooter?: boolean;
 };
@@ -19,8 +19,8 @@ export const OnboardingCard = ({
   title,
   subtitle,
   children,
-  footer = null,
-  isLoading = false,
+  footer,
+  isLoading,
   floatingFooter = false,
 }: OnboardingCardProps) => {
   const pathname = usePathname();


### PR DESCRIPTION
## What does this PR do?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OnboardingCard props safer by marking children and footer as optional. This removes type errors when rendering cards without these sections.

- **Bug Fixes**
  - children and footer are now optional ReactNode.
  - Removed default values for footer and isLoading to match optional props.
  - Prevents required-prop errors in onboarding views.

<sup>Written for commit d444341056dca29f8702331e3be8964f6d359790. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

