### PR TITLE
chore: pass guests and pass updated noShow property

### DIFF
--- a/packages/features/tasker/tasks/triggerNoShow/getBooking.ts
+++ b/packages/features/tasker/tasks/triggerNoShow/getBooking.ts
@@ -19,6 +19,7 @@ export const getBooking = async (bookingId: number) => {
       eventTypeId: true,
       references: true,
       fromReschedule: true,
+      noShowHost: true,
       eventType: {
         select: {
           id: true,

--- a/packages/features/tasker/tasks/triggerNoShow/triggerGuestNoShow.test.ts
+++ b/packages/features/tasker/tasks/triggerNoShow/triggerGuestNoShow.test.ts
@@ -90,6 +90,14 @@ describe("Trigger Guest No Show:", () => {
               startTime: bookingStartTime,
               endTime: `${plus1DateString}T05:15:00.000Z`,
               user: { id: organizer.id },
+              attendees: [
+                {
+                  email: "guest@example.com",
+                  name: "Guest User",
+                  timeZone: "UTC",
+                  locale: "en",
+                },
+              ],
               metadata: {
                 videoCallUrl: "https://existing-daily-video-call-url.example.com",
               },
@@ -149,7 +157,20 @@ describe("Trigger Guest No Show:", () => {
         triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
         payload: {
           title: "Test Booking Title",
-          attendees: [],
+          attendees: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
+          guests: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
           bookingId: 222,
           bookingUid: uidOfBooking,
           participants: [],
@@ -228,6 +249,14 @@ describe("Trigger Guest No Show:", () => {
               startTime: bookingStartTime,
               endTime: `${plus1DateString}T05:15:00.000Z`,
               user: { id: organizer.id },
+              attendees: [
+                {
+                  email: "guest@example.com",
+                  name: "Guest User",
+                  timeZone: "UTC",
+                  locale: "en",
+                },
+              ],
               metadata: {
                 videoCallUrl: "https://existing-daily-video-call-url.example.com",
               },
@@ -315,7 +344,20 @@ describe("Trigger Guest No Show:", () => {
         triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
         payload: {
           title: "Test Booking Title",
-          attendees: [],
+          attendees: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
+          guests: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
           bookingId: 222,
           bookingUid: uidOfBooking,
           participants: MOCKED_PARTICIPANTS,
@@ -433,6 +475,14 @@ describe("Trigger Guest No Show:", () => {
               endTime: `${plus1DateString}T05:30:00.000Z`,
               user: { id: organizer.id },
               fromReschedule: uidOfBooking,
+              attendees: [
+                {
+                  email: "guest@example.com",
+                  name: "Guest User",
+                  timeZone: "UTC",
+                  locale: "en",
+                },
+              ],
               metadata: {
                 videoCallUrl: "https://existing-daily-video-call-url.example.com",
               },
@@ -519,7 +569,20 @@ describe("Trigger Guest No Show:", () => {
         triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
         payload: {
           title: "Test Booking Title",
-          attendees: [],
+          attendees: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
+          guests: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
           bookingId: 224,
           bookingUid: newUidOfBooking,
           participants: MOCKED_PARTICIPANTS,
@@ -691,6 +754,192 @@ describe("Trigger Guest No Show:", () => {
           payload: expect.any(Object),
         })
       ).toThrow();
+    },
+    timeout
+  );
+
+  test(
+    `Should send updated attendees with noShow=true in webhook payload`,
+    async () => {
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+
+      const uidOfBooking = "n5Wv3eHgconAED2j4gcVhP";
+      const iCalUID = `${uidOfBooking}@Cal.com`;
+      const subscriberUrl = "http://my-webhook.example.com";
+      const bookingStartTime = `${plus1DateString}T05:00:00.000Z`;
+
+      await createBookingScenario(
+        getScenarioData({
+          webhooks: [
+            {
+              id: "22",
+              userId: organizer.id,
+              eventTriggers: [WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW],
+              subscriberUrl,
+              active: true,
+              eventTypeId: 1,
+              appId: null,
+              time: 5,
+              timeUnit: TimeUnit.MINUTE,
+            },
+          ],
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 15,
+              length: 15,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          bookings: [
+            {
+              id: 222,
+              uid: uidOfBooking,
+              eventTypeId: 1,
+              status: BookingStatus.ACCEPTED,
+              startTime: bookingStartTime,
+              endTime: `${plus1DateString}T05:15:00.000Z`,
+              user: { id: organizer.id },
+              attendees: [
+                {
+                  email: "guest@example.com",
+                  name: "Guest User",
+                  timeZone: "UTC",
+                  locale: "en",
+                },
+              ],
+              metadata: {
+                videoCallUrl: "https://existing-daily-video-call-url.example.com",
+              },
+              references: [
+                {
+                  type: appStoreMetadata.dailyvideo.type,
+                  uid: "MOCK_ID",
+                  meetingId: "MOCK_ID",
+                  meetingPassword: "MOCK_PASS",
+                  meetingUrl: "http://mock-dailyvideo.example.com",
+                  credentialId: null,
+                },
+                {
+                  type: appStoreMetadata.googlecalendar.type,
+                  uid: "MOCK_ID",
+                  meetingId: "MOCK_ID",
+                  meetingPassword: "MOCK_PASSWORD",
+                  meetingUrl: "https://UNUSED_URL",
+                  externalCalendarId: "MOCK_EXTERNAL_CALENDAR_ID",
+                  credentialId: undefined,
+                },
+              ],
+              iCalUID,
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+        })
+      );
+
+      const MOCKED_PARTICIPANTS = [
+        {
+          user_id: "101",
+          email: "organizer@example.com",
+          participant_id: "MOCK_PARTICIPANT_ID",
+          user_name: "Organizer",
+          join_time: 0,
+          duration: 15,
+          isLoggedIn: true,
+        },
+      ];
+
+      const MOCKED_MEETING_SESSIONS = {
+        total_count: 1,
+        data: [
+          {
+            id: "MOCK_ID",
+            room: "MOCK_ROOM",
+            start_time: 1234567890,
+            duration: 15,
+            max_participants: 1,
+            participants: MOCKED_PARTICIPANTS,
+          },
+        ],
+      };
+
+      vi.mocked(getMeetingSessionsFromRoomName).mockResolvedValue(MOCKED_MEETING_SESSIONS);
+
+      const TEST_WEBHOOK = {
+        id: "22",
+        eventTriggers: [WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW],
+        subscriberUrl,
+        active: true,
+        eventTypeId: 1,
+        appId: null,
+        time: 5,
+        timeUnit: TimeUnit.MINUTE,
+        payloadTemplate: null,
+        secret: null,
+      };
+
+      const payload = JSON.stringify({
+        triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
+        bookingId: 222,
+        webhook: TEST_WEBHOOK,
+      } satisfies TSendNoShowWebhookPayloadSchema);
+
+      await triggerGuestNoShow(payload);
+
+      const maxStartTime = calculateMaxStartTime(bookingStartTime as unknown as Date, 5, TimeUnit.MINUTE);
+      const maxStartTimeHumanReadable = dayjs.unix(maxStartTime).format("YYYY-MM-DD HH:mm:ss Z");
+
+      await expectWebhookToHaveBeenCalledWith(subscriberUrl, {
+        triggerEvent: WebhookTriggerEvents.AFTER_GUESTS_CAL_VIDEO_NO_SHOW,
+        payload: {
+          title: "Test Booking Title",
+          attendees: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
+          guests: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+              noShow: true,
+            }),
+          ],
+          bookingId: 222,
+          bookingUid: uidOfBooking,
+          participants: MOCKED_PARTICIPANTS,
+          startTime: `${plus1DateString}T05:00:00.000Z`,
+          endTime: `${plus1DateString}T05:15:00.000Z`,
+          eventType: {
+            id: 1,
+            teamId: null,
+            parentId: null,
+            calVideoSettings: null,
+          },
+          webhook: {
+            ...TEST_WEBHOOK,
+            secret: undefined,
+            active: undefined,
+            eventTypeId: undefined,
+          },
+          message: `Guest didn't join the call or didn't join before ${maxStartTimeHumanReadable}`,
+        },
+      });
     },
     timeout
   );

--- a/packages/features/tasker/tasks/triggerNoShow/triggerHostNoShow.test.ts
+++ b/packages/features/tasker/tasks/triggerNoShow/triggerHostNoShow.test.ts
@@ -9,7 +9,7 @@ import {
 import { expectWebhookToHaveBeenCalledWith } from "@calcom/web/test/utils/bookingScenario/expects";
 import { setupAndTeardown } from "@calcom/web/test/utils/bookingScenario/setupAndTeardown";
 
-import { describe, vi, test } from "vitest";
+import { describe, vi, test, expect } from "vitest";
 
 import { appStoreMetadata } from "@calcom/app-store/apps.metadata.generated";
 import dayjs from "@calcom/dayjs";
@@ -154,6 +154,7 @@ describe("Trigger Host No Show:", () => {
           bookingUid: uidOfBooking,
           participants: [],
           hostEmail: "organizer@example.com",
+          noShowHost: true,
           startTime: `${plus1DateString}T05:00:00.000Z`,
           endTime: `${plus1DateString}T05:15:00.000Z`,
           eventType: {
@@ -319,6 +320,7 @@ describe("Trigger Host No Show:", () => {
           bookingUid: uidOfBooking,
           participants: MOCKED_PARTICIPANTS,
           hostEmail: "organizer@example.com",
+          noShowHost: true,
           startTime: `${plus1DateString}T05:00:00.000Z`,
           endTime: `${plus1DateString}T05:15:00.000Z`,
           eventType: {
@@ -523,9 +525,163 @@ describe("Trigger Host No Show:", () => {
           bookingUid: newUidOfBooking,
           participants: MOCKED_PARTICIPANTS,
           hostEmail: "organizer@example.com",
+          noShowHost: true,
           startTime: `${plus1DateString}T05:15:00.000Z`,
           endTime: `${plus1DateString}T05:30:00.000Z`,
           rescheduledBy: organizer.email,
+          eventType: {
+            id: 1,
+            teamId: null,
+            parentId: null,
+            calVideoSettings: null,
+          },
+          webhook: {
+            ...TEST_WEBHOOK,
+            secret: undefined,
+            active: undefined,
+            eventTypeId: undefined,
+          },
+          message: `Host with email ${organizer.email} didn't join the call or didn't join before ${maxStartTimeHumanReadable}`,
+        },
+      });
+    },
+    timeout
+  );
+
+  test(
+    `Should send updated attendees with noShow=true when host in attendees table doesn't join`,
+    async () => {
+      const organizer = getOrganizer({
+        name: "Organizer",
+        email: "organizer@example.com",
+        id: 101,
+        schedules: [TestData.schedules.IstWorkHours],
+        credentials: [getGoogleCalendarCredential()],
+        selectedCalendars: [TestData.selectedCalendars.google],
+      });
+      const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+
+      const uidOfBooking = "n5Wv3eHgconAED2j4gcVhP";
+      const iCalUID = `${uidOfBooking}@Cal.com`;
+      const subscriberUrl = "http://my-webhook.example.com";
+      const bookingStartTime = `${plus1DateString}T05:00:00.000Z`;
+
+      await createBookingScenario(
+        getScenarioData({
+          webhooks: [
+            {
+              id: "22",
+              userId: organizer.id,
+              eventTriggers: [WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW],
+              subscriberUrl,
+              active: true,
+              eventTypeId: 1,
+              appId: null,
+              time: 5,
+              timeUnit: TimeUnit.MINUTE,
+            },
+          ],
+          eventTypes: [
+            {
+              id: 1,
+              slotInterval: 15,
+              length: 15,
+              users: [
+                {
+                  id: 101,
+                },
+              ],
+            },
+          ],
+          bookings: [
+            {
+              id: 222,
+              uid: uidOfBooking,
+              eventTypeId: 1,
+              status: BookingStatus.ACCEPTED,
+              startTime: bookingStartTime,
+              endTime: `${plus1DateString}T05:15:00.000Z`,
+              user: { id: organizer.id },
+              attendees: [
+                {
+                  email: "guest@example.com",
+                  name: "Guest User",
+                  timeZone: "UTC",
+                  locale: "en",
+                },
+              ],
+              metadata: {
+                videoCallUrl: "https://existing-daily-video-call-url.example.com",
+              },
+              references: [
+                {
+                  type: appStoreMetadata.dailyvideo.type,
+                  uid: "MOCK_ID",
+                  meetingId: "MOCK_ID",
+                  meetingPassword: "MOCK_PASS",
+                  meetingUrl: "http://mock-dailyvideo.example.com",
+                  credentialId: null,
+                },
+                {
+                  type: appStoreMetadata.googlecalendar.type,
+                  uid: "MOCK_ID",
+                  meetingId: "MOCK_ID",
+                  meetingPassword: "MOCK_PASSWORD",
+                  meetingUrl: "https://UNUSED_URL",
+                  externalCalendarId: "MOCK_EXTERNAL_CALENDAR_ID",
+                  credentialId: undefined,
+                },
+              ],
+              iCalUID,
+            },
+          ],
+          organizer,
+          apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+        })
+      );
+
+      vi.mocked(getMeetingSessionsFromRoomName).mockResolvedValue(EMPTY_MEETING_SESSIONS);
+
+      const TEST_WEBHOOK = {
+        id: "22",
+        eventTriggers: [WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW],
+        subscriberUrl,
+        active: true,
+        eventTypeId: 1,
+        appId: null,
+        time: 5,
+        timeUnit: TimeUnit.MINUTE,
+        payloadTemplate: null,
+        secret: null,
+      };
+
+      const payload = JSON.stringify({
+        triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+        bookingId: 222,
+        webhook: TEST_WEBHOOK,
+      } satisfies TSendNoShowWebhookPayloadSchema);
+
+      await triggerHostNoShow(payload);
+      const maxStartTime = calculateMaxStartTime(bookingStartTime as unknown as Date, 5, TimeUnit.MINUTE);
+      const maxStartTimeHumanReadable = dayjs.unix(maxStartTime).format("YYYY-MM-DD HH:mm:ss Z");
+
+      await expectWebhookToHaveBeenCalledWith(subscriberUrl, {
+        triggerEvent: WebhookTriggerEvents.AFTER_HOSTS_CAL_VIDEO_NO_SHOW,
+        payload: {
+          title: "Test Booking Title",
+          attendees: [
+            expect.objectContaining({
+              email: "guest@example.com",
+              name: "Guest User",
+            }),
+          ],
+          bookingId: 222,
+          bookingUid: uidOfBooking,
+          participants: [],
+          hostEmail: "organizer@example.com",
+          noShowHost: true,
+          startTime: `${plus1DateString}T05:00:00.000Z`,
+          endTime: `${plus1DateString}T05:15:00.000Z`,
           eventType: {
             id: 1,
             teamId: null,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

![Screenshot 2025-12-17 at 2 35 48 PM](https://github.com/user-attachments/assets/e7939ebc-45e3-43ab-92e3-3204a0b3863f)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1) Create a webhook "AFTER_GUESTS_DIDNT_JOIN_CAL_VIDEO" in event type settings
2) Book a meeting on that event type
3) Change scheduleDate in Task Model and run tasker (GET api/tasks/cron) that would send the webhook and update in DB

Make sure `noShow` property is updated to true 






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guests and updated attendee noShow status to no-show webhook payloads, and includes the noShowHost flag for host no-shows. This makes downstream consumers receive accurate participant data.

- **New Features**
  - Guest no-show: after marking attendees, include updated attendees and a guests array (attendees excluding hosts) in AFTER_GUESTS_CAL_VIDEO_NO_SHOW payloads.
  - Host no-show: set booking.noShowHost and include it in AFTER_HOSTS_CAL_VIDEO_NO_SHOW payloads; also return updated attendees.
  - Webhook payloads now conditionally include noShowHost (host no-show) and guests (guest no-show).
  - getBooking selects noShowHost.
  - Tests expanded to cover updated payloads and attendee updates.

<sup>Written for commit 24aa5b36b27d57da07493b48d172105706fa7acd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



