### PR TITLE
feat(companion): open cal.com/app on new tab and fix extension/mobile UX issues

### DIFF
--- a/apps/web/pagesAndRewritePaths.js
+++ b/apps/web/pagesAndRewritePaths.js
@@ -5,22 +5,22 @@ const { nextJsOrgRewriteConfig } = require("./getNextjsOrgRewriteConfig");
 
 // Top-level route names that are explicitly allowed for org rewrite (whitelist)
 
-const topLevelRouteNamesWhitelistedForRewrite = exports.topLevelRouteNamesWhitelistedForRewrite = [
+const topLevelRouteNamesWhitelistedForRewrite = (exports.topLevelRouteNamesWhitelistedForRewrite = [
   // We don't allow all dashboard route names to be used as slug because people are probably accustomed to access links like acme.cal.com/workflows, acme.cal.com/event-types etc.
   // So, we carefully allow, what is absolutely needed.
   // Allowed to be a team/user slug in organization because onboarding is a common team name
-  'onboarding',
-]
+  "onboarding",
+]);
 
 /**
  * Extracts top-level route names from all pages/app files and excludes them from org rewrite.
  * For example: /abc/def/ghi -> 'abc'
- * 
+ *
  * These top-level route names are excluded from rewrites in beforeFiles in next.config.js
  * to prevent conflicts with organization slug rewrites.
  */
 /* eslint-disable no-undef */
-let topLevelRoutesExcludedFromOrgRewrite = exports.topLevelRoutesExcludedFromOrgRewrite = glob
+let topLevelRoutesExcludedFromOrgRewrite = (exports.topLevelRoutesExcludedFromOrgRewrite = glob
   .sync(
     "{pages,app,app/(booking-page-wrapper),app/(use-page-wrapper),app/(use-page-wrapper)/(main-nav)}/**/[^_]*.{tsx,js,ts}",
     {
@@ -58,7 +58,7 @@ let topLevelRoutesExcludedFromOrgRewrite = exports.topLevelRoutesExcludedFromOrg
   )
   .filter((page) => {
     return !topLevelRouteNamesWhitelistedForRewrite.includes(page);
-  });
+  }));
 
 // .* matches / as well(Note: *(i.e wildcard) doesn't match / but .*(i.e. RegExp) does)
 // It would match /free/30min but not /bookings/upcoming because 'bookings' is an item in pages
@@ -76,7 +76,10 @@ exports.nextJsOrgRewriteConfig = nextJsOrgRewriteConfig;
 function getRegExpMatchingAllReservedRoutes(suffix) {
   // Following routes don't exist but they work by doing rewrite. Thus they need to be excluded from matching the orgRewrite patterns
   // Make sure to keep it upto date as more nonExistingRouteRewrites are added.
-  const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel"];
+  // "app" is reserved for the Cal.com Companion landing page served by Framer at cal.com/app.
+  // The browser extension redirects users to cal.com/app when clicked on restricted pages (like chrome://newtab).
+  // Without this reservation, /app would be treated as a username lookup and show "username available" error.
+  const otherNonExistingRoutePrefixes = ["forms", "router", "success", "cancel", "app"];
 
   // Most files/dirs in public dir must not be rewritten to org pages. Ideally it should be all the content of public dir, but that can be done later
   // It is important to exclude the embed pages separately here because with SINGLE_ORG_SLUG enabled, the entire domain is eligible for rewrite vs just the org subdomain otherwise

--- a/companion/app/(tabs)/(event-types)/index.tsx
+++ b/companion/app/(tabs)/(event-types)/index.tsx
@@ -471,7 +471,7 @@ export default function EventTypes() {
     <>
       <Stack.Screen
         options={{
-          headerShown: true,
+          headerShown: Platform.OS !== "web",
           title: "Event Types",
           headerLargeTitleEnabled: true,
           headerStyle: {

--- a/companion/app/(tabs)/_layout.tsx
+++ b/companion/app/(tabs)/_layout.tsx
@@ -53,7 +53,7 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="event-types"
+        name="(event-types)"
         options={{
           title: "Event Types",
           tabBarIcon: ({ color, focused }) => (

--- a/companion/wxt.config.ts
+++ b/companion/wxt.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
         process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI
       ),
       "import.meta.env.EXPO_PUBLIC_COMPANION_DEV_URL": JSON.stringify(
-        process.env.EXPO_PUBLIC_COMPANION_DEV_URL
+        process.env.EXPO_PUBLIC_COMPANION_DEV_URL || ""
       ),
       "import.meta.env.EXPO_PUBLIC_CACHE_STALE_TIME_MINUTES": JSON.stringify(
         process.env.EXPO_PUBLIC_CACHE_STALE_TIME_MINUTES


### PR DESCRIPTION
Video:


https://github.com/user-attachments/assets/a0d37b1f-8eb8-45cc-acc7-8b721f1522c5




Updated Video for new tab extension opening


https://github.com/user-attachments/assets/3ef7358b-3ba2-4775-b538-2b2c5b62c017




## Summary

This PR improves the browser extension experience when users click the extension icon on restricted pages (like `chrome://newtab`) and fixes several UX issues in both the extension and mobile apps.

## Changes

### Extension - New Tab Support
- Detect restricted URLs (chrome://, about:, edge://, etc.) where content scripts can't run
- Open `cal.com/app` (Framer landing page) when extension clicked on restricted pages
- Auto-open sidebar when page loads with `?openExtension=true` parameter

### Extension/Web - UI Fixes
- **Duplicate search bar**: Hide native Stack.Screen header on web platform to prevent duplicate search bars in Event Types
- **Tab order**: Fix route name mismatch (`event-types` → `(event-types)`) to ensure correct tab order: Event Types, Bookings, Availability, More
- **Sign out button**: Add `LogoutConfirmModal` for web platform since `Alert.alert` doesn't work on web

### Build Config
- Default `EXPO_PUBLIC_COMPANION_DEV_URL` to empty string so production builds use `companion.cal.com`