### PR TITLE
fix: change button color to destructive in WorkflowListPage

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowListPage.tsx
+++ b/packages/features/ee/workflows/components/WorkflowListPage.tsx
@@ -272,7 +272,7 @@ export default function WorkflowListPage({ workflows }: Props) {
                                 setDeleteDialogOpen(true);
                                 setwWorkflowToDeleteId(workflow.id);
                               }}
-                              color="secondary"
+                              color="destructive"
                               variant="icon"
                               disabled={
                                 workflow.permissions ? !workflow.permissions?.canDelete : workflow.readOnly


### PR DESCRIPTION
## What does this PR do?

- Fixes #25964
- Fixes [CAL-25964](https://linear.app/calcom/issue/CAL-6940/fixworkflows-delete-button-in-workflow-list-uses-secondary-color)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:

<img width="168" height="156" alt="Screenshot 2025-12-17 at 4 21 42 PM" src="https://github.com/user-attachments/assets/47d2878b-af46-4484-89bc-09511a8dca5e" />


after:

<img width="147" height="149" alt="Screenshot 2025-12-17 at 4 21 16 PM" src="https://github.com/user-attachments/assets/7a58e2a8-fe47-4fbd-ae09-ab8c700a62f1" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the delete button in WorkflowListPage to use the destructive color instead of secondary, making the delete action visually clear. Addresses Linear CAL-6940 by aligning the Workflow List delete action with the design system.

<sup>Written for commit 67dc884c9c8698a6a3879f513f1beb46937ce9b6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



