### PR TITLE
fix: hide OOO slots across timezones

### DIFF
--- a/packages/features/schedules/lib/slots.test.ts
+++ b/packages/features/schedules/lib/slots.test.ts
@@ -877,9 +877,8 @@ describe("Tests the date-range slot logic with showOptimizedSlots", () => {
       datesOutOfOfficeTimeZone: "UTC",
     });
 
-    // Filter slots by day using UTC to be timezone-independent
-    const day1Slots = slots.filter((slot) => slot.time.utc().format("YYYY-MM-DD") === "2025-11-17");
-    const day2Slots = slots.filter((slot) => slot.time.utc().format("YYYY-MM-DD") === "2025-11-18");
+    const day1Slots = slots.filter((slot) => slot.time.format("YYYY-MM-DD") === "2025-11-17");
+    const day2Slots = slots.filter((slot) => slot.time.format("YYYY-MM-DD") === "2025-11-18");
 
     // Day 1 slots should NOT be marked as away
     day1Slots.forEach((slot) => {

--- a/packages/features/schedules/lib/slots.test.ts
+++ b/packages/features/schedules/lib/slots.test.ts
@@ -874,11 +874,12 @@ describe("Tests the date-range slot logic with showOptimizedSlots", () => {
         },
       ],
       datesOutOfOffice,
+      datesOutOfOfficeTimeZone: "UTC",
     });
 
-    // Filter slots by day
-    const day1Slots = slots.filter((slot) => slot.time.format("YYYY-MM-DD") === "2025-11-17");
-    const day2Slots = slots.filter((slot) => slot.time.format("YYYY-MM-DD") === "2025-11-18");
+    // Filter slots by day using UTC to be timezone-independent
+    const day1Slots = slots.filter((slot) => slot.time.utc().format("YYYY-MM-DD") === "2025-11-17");
+    const day2Slots = slots.filter((slot) => slot.time.utc().format("YYYY-MM-DD") === "2025-11-18");
 
     // Day 1 slots should NOT be marked as away
     day1Slots.forEach((slot) => {
@@ -925,6 +926,7 @@ describe("Tests the date-range slot logic with showOptimizedSlots", () => {
       eventLength: 30,
       dateRanges,
       datesOutOfOffice,
+      datesOutOfOfficeTimeZone: "Europe/Berlin",
     });
 
     expect(slots.length).toBeGreaterThan(0);
@@ -1008,6 +1010,48 @@ describe("Tests the date-range slot logic with showOptimizedSlots", () => {
     slots.forEach((slot) => {
       expect(slot.away).toBeUndefined();
     });
+
+    vi.useRealTimers();
+  });
+
+  it("should mark slots as away when host OOO day maps to next UTC day (LA host, Kolkata booker)", async () => {
+    vi.setSystemTime(dayjs.utc("2026-01-10T00:00:00Z").toDate());
+
+    const datesOutOfOffice = {
+      "2026-01-16": {
+        fromUser: { id: 1, displayName: "Host User" },
+        toUser: null,
+        reason: "OOO",
+        emoji: "🏖️",
+      },
+    };
+
+    const dateRanges = [
+      {
+        start: dayjs.tz("2026-01-16T16:00:00", "America/Los_Angeles"),
+        end: dayjs.tz("2026-01-16T17:00:00", "America/Los_Angeles"),
+      },
+    ];
+
+    const inviteeDate = dayjs.tz("2026-01-17T00:00:00", "Asia/Kolkata");
+
+    const slots = getSlots({
+      inviteeDate,
+      frequency: 30,
+      minimumBookingNotice: 0,
+      eventLength: 30,
+      dateRanges,
+      datesOutOfOffice,
+      datesOutOfOfficeTimeZone: "America/Los_Angeles",
+    });
+
+    const targetSlot = slots.find(
+      (slot) => slot.time.tz("Asia/Kolkata").format("YYYY-MM-DD HH:mm") === "2026-01-17 05:30"
+    );
+
+    expect(targetSlot).toBeDefined();
+    expect(targetSlot?.away).toBe(true);
+    expect(targetSlot?.reason).toBe("OOO");
 
     vi.useRealTimers();
   });

--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -184,7 +184,7 @@ function buildSlotsWithDateRanges({
 
       slotBoundaries.set(slotStartTime.valueOf(), true);
 
-      const dateOutOfOfficeExists = false;
+      let dateOutOfOfficeExists = false;
       if (datesOutOfOffice) {
         const slotDateYYYYMMDD = datesOutOfOfficeTimeZone
           ? slotStartTime.tz(datesOutOfOfficeTimeZone).format("YYYY-MM-DD")

--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -184,7 +184,7 @@ function buildSlotsWithDateRanges({
 
       slotBoundaries.set(slotStartTime.valueOf(), true);
 
-      let dateOutOfOfficeExists = false;
+      let dateOutOfOfficeExists = undefined;
       if (datesOutOfOffice) {
         const slotDateYYYYMMDD = datesOutOfOfficeTimeZone
           ? slotStartTime.tz(datesOutOfOfficeTimeZone).format("YYYY-MM-DD")

--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -183,10 +183,15 @@ function buildSlotsWithDateRanges({
       }
 
       slotBoundaries.set(slotStartTime.valueOf(), true);
-      const slotDateYYYYMMDD = datesOutOfOfficeTimeZone
-        ? slotStartTime.tz(datesOutOfOfficeTimeZone).format("YYYY-MM-DD")
-        : slotStartTime.utc().format("YYYY-MM-DD");
-      const dateOutOfOfficeExists = datesOutOfOffice?.[slotDateYYYYMMDD];
+
+      const dateOutOfOfficeExists = false;
+      if (datesOutOfOffice) {
+        const slotDateYYYYMMDD = datesOutOfOfficeTimeZone
+          ? slotStartTime.tz(datesOutOfOfficeTimeZone).format("YYYY-MM-DD")
+          : slotStartTime.utc().format("YYYY-MM-DD");
+        dateOutOfOfficeExists = datesOutOfOffice?.[slotDateYYYYMMDD];
+      }
+
       let slotData: {
         time: Dayjs;
         userIds?: number[];

--- a/packages/features/schedules/lib/slots.ts
+++ b/packages/features/schedules/lib/slots.ts
@@ -18,6 +18,7 @@ export type GetSlots = {
   offsetStart?: number;
   datesOutOfOffice?: IOutOfOfficeData;
   showOptimizedSlots?: boolean | null;
+  datesOutOfOfficeTimeZone?: string;
 };
 export type TimeFrame = { userIds?: number[]; startTime: number; endTime: number };
 
@@ -76,6 +77,7 @@ function buildSlotsWithDateRanges({
   offsetStart,
   datesOutOfOffice,
   showOptimizedSlots,
+  datesOutOfOfficeTimeZone,
 }: {
   dateRanges: DateRange[];
   frequency: number;
@@ -85,6 +87,7 @@ function buildSlotsWithDateRanges({
   offsetStart?: number;
   datesOutOfOffice?: IOutOfOfficeData;
   showOptimizedSlots?: boolean | null;
+  datesOutOfOfficeTimeZone?: string;
 }) {
   // keep the old safeguards in; may be needed.
   frequency = minimumOfOne(frequency);
@@ -180,7 +183,9 @@ function buildSlotsWithDateRanges({
       }
 
       slotBoundaries.set(slotStartTime.valueOf(), true);
-      const slotDateYYYYMMDD = slotStartTime.utc().format("YYYY-MM-DD");
+      const slotDateYYYYMMDD = datesOutOfOfficeTimeZone
+        ? slotStartTime.tz(datesOutOfOfficeTimeZone).format("YYYY-MM-DD")
+        : slotStartTime.utc().format("YYYY-MM-DD");
       const dateOutOfOfficeExists = datesOutOfOffice?.[slotDateYYYYMMDD];
       let slotData: {
         time: Dayjs;
@@ -228,6 +233,7 @@ const getSlots = ({
   offsetStart = 0,
   datesOutOfOffice,
   showOptimizedSlots,
+  datesOutOfOfficeTimeZone,
 }: GetSlots): {
   time: Dayjs;
   userIds?: number[];
@@ -246,6 +252,7 @@ const getSlots = ({
     offsetStart,
     datesOutOfOffice,
     showOptimizedSlots,
+    datesOutOfOfficeTimeZone,
   });
 };
 

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1203,6 +1203,7 @@ export class AvailableSlotsService {
       frequency: eventType.slotInterval || input.duration || eventType.length,
       datesOutOfOffice: !isTeamEvent ? allUsersAvailability[0]?.datesOutOfOffice : undefined,
       showOptimizedSlots: eventType.showOptimizedSlots,
+      datesOutOfOfficeTimeZone: !isTeamEvent ? allUsersAvailability[0]?.timeZone : undefined,
     });
 
     let availableTimeSlots: typeof timeSlots = [];


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes:- For eg: a user is marked OOO from January 14–16 in the America/Vancouver timezone (GMT-8). As a booker in the Asia/Kolkata timezone (GMT+05:30), January 17 appears available. However, when attempting to book, it results in a “No available users found” error.


![Screenshot 2025-12-17 at 4 36 36 PM](https://github.com/user-attachments/assets/2234b69c-82c1-41bf-9cb9-5e60cbedef7f)

![Screenshot 2025-12-17 at 4 36 51 PM](https://github.com/user-attachments/assets/10df1e98-78a2-47f3-ba26-31d0148ada12)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


