### PR TITLE
fix: use cal video link for daily payload

### DIFF
--- a/packages/features/webhooks/lib/sendPayload.test.ts
+++ b/packages/features/webhooks/lib/sendPayload.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Webhook } from "@calcom/prisma/client";
+
+import type { EventPayloadType } from "./sendPayload";
+import sendPayload from "./sendPayload";
+
+vi.mock("@calcom/lib/constants", () => ({
+  __esModule: true,
+  WEBAPP_URL: "https://app.cal.com",
+  APP_NAME: "Cal.com",
+  IS_PRODUCTION: false,
+}));
+
+describe("sendPayload", () => {
+  const webhook: Pick<Webhook, "subscriberUrl" | "appId" | "payloadTemplate"> = {
+    subscriberUrl: "https://example.com/webhook",
+    appId: null,
+    payloadTemplate: null,
+  };
+
+  it("sends cal.com video link for daily meetings", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const basePerson = {
+      name: "Tester",
+      email: "test@example.com",
+      timeZone: "UTC",
+      language: { translate: (key: string) => key, locale: "en" },
+    };
+
+    const payload: EventPayloadType = {
+      type: "daily-event",
+      title: "Daily Call",
+      startTime: "2024-01-01T00:00:00.000Z",
+      endTime: "2024-01-01T00:30:00.000Z",
+      organizer: basePerson,
+      attendees: [basePerson],
+      uid: "test-uid",
+      location: "integrations:daily",
+      videoCallData: {
+        type: "daily_video",
+        id: "meeting-id",
+        url: "https://meetco.daily.co/original",
+        password: "",
+      },
+    };
+
+    try {
+      await sendPayload(null, "BOOKING_CREATED", "2024-01-01T00:00:00.000Z", webhook, payload);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse((fetchMock.mock.calls[0]?.[1]?.body as string) ?? "{}");
+      expect(body.payload.videoCallData.url).toBe("https://app.cal.com/video/test-uid");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes webhook payload inconsistency where Daily video meetings show the provider's direct URL in `videoCallData.url` instead of the Cal.com public video link. Normalizes Daily webhook payloads so `videoCallData.url` uses the Cal.com link (matching `metadata.videoCallUrl`), while keeping other providers unchanged.

- Fixes #25604
- Fixes [CAL-6869](https://linear.app/calcom/issue/CAL-6869/show-cal-video-url-in-webhook-payload)

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):
Before

```{
  "triggerEvent": "BOOKING_CREATED",
  "payload": {
    "videoCallData": {
      "type": "daily_video",
      "url": "https://meetco.daily.co/cal-abc123"
    },
    "metadata": {
      "videoCallUrl": "https://app.cal.com/video/xyz789"
    }
  }
}
```
After
```
{
  "triggerEvent": "BOOKING_CREATED",
  "payload": {
    "videoCallData": {
      "type": "daily_video",
      "url": "https://app.cal.com/video/xyz789"
    },
    "metadata": {
      "videoCallUrl": "https://app.cal.com/video/xyz789"
    }
  }
}
```
<img width="1021" height="230" alt="image" src="https://github.com/user-attachments/assets/38db3e30-a3dc-45a8-87c8-9d18cc5a4e7b" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - webhook payload structure unchanged
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

**Automated test:**
```bash
yarn vitest packages/features/webhooks/lib/sendPayload.test.ts