### PR TITLE
fix(workflows): change delete button color to destructive

### DIFF
--- a/packages/features/ee/workflows/components/WorkflowListPage.tsx
+++ b/packages/features/ee/workflows/components/WorkflowListPage.tsx
@@ -272,7 +272,7 @@ export default function WorkflowListPage({ workflows }: Props) {
                                 setDeleteDialogOpen(true);
                                 setwWorkflowToDeleteId(workflow.id);
                               }}
-                              color="secondary"
+                              color="destructive"
                               variant="icon"
                               disabled={
                                 workflow.permissions ? !workflow.permissions?.canDelete : workflow.readOnly

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1940,18 +1940,18 @@ model Avatar {
 }
 
 model OutOfOfficeEntry {
-  id              Int                @id @default(autoincrement())
-  uuid            String             @unique
-  start           DateTime
-  end             DateTime
-  notes           String?
-  showNotePublicly Boolean           @default(false)
-  userId          Int
-  user            User               @relation(fields: [userId], references: [id], onDelete: Cascade)
-  toUserId        Int?
-  toUser          User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
-  reasonId        Int?
-  reason          OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
+  id               Int                @id @default(autoincrement())
+  uuid             String             @unique
+  start            DateTime
+  end              DateTime
+  notes            String?
+  showNotePublicly Boolean            @default(false)
+  userId           Int
+  user             User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  toUserId         Int?
+  toUser           User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
+  reasonId         Int?
+  reason           OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1940,18 +1940,18 @@ model Avatar {
 }
 
 model OutOfOfficeEntry {
-  id               Int                @id @default(autoincrement())
-  uuid             String             @unique
-  start            DateTime
-  end              DateTime
-  notes            String?
-  showNotePublicly Boolean            @default(false)
-  userId           Int
-  user             User               @relation(fields: [userId], references: [id], onDelete: Cascade)
-  toUserId         Int?
-  toUser           User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
-  reasonId         Int?
-  reason           OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
+  id              Int                @id @default(autoincrement())
+  uuid            String             @unique
+  start           DateTime
+  end             DateTime
+  notes           String?
+  showNotePublicly Boolean           @default(false)
+  userId          Int
+  user            User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  toUserId        Int?
+  toUser          User?              @relation(name: "toUser", fields: [toUserId], references: [id], onDelete: Cascade)
+  reasonId        Int?
+  reason          OutOfOfficeReason? @relation(fields: [reasonId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Description
Fixed the Delete button in the Workflows List. It was previously using the `secondary` color (gray), which was inconsistent with the design system for dangerous actions.

I updated it to `destructive` (red), so it now properly signals a delete action and turns red on hover.

## Fixes
Fixes #25964

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
<img width="2482" height="1516" alt="image" src="https://github.com/user-attachments/assets/a73de0da-3320-4743-b37e-46b21bd14721" />