### PR TITLE
refactor: trpc test file is importing @calcom/web

### DIFF
--- a/packages/trpc/eslint.config.mjs
+++ b/packages/trpc/eslint.config.mjs
@@ -1,8 +1,14 @@
 import { config } from "@calcom/eslint-config/base";
+import { forbid } from "@calcom/eslint-config/base";
 
 export default [
   ...config,
   {
     ignores: ["./types/**"],
   },
+  forbid({
+    from: "../apps/web/**",
+    target: ".",
+    message: "trpc package should not import from apps/web to avoid circular dependencies.",
+  }),
 ];


### PR DESCRIPTION
## What does this PR do?

Prevents the trpc package from importing apps/web to avoid circular dependencies.

**Changes:**
1. Added an ESLint `forbid` rule in `packages/trpc/eslint.config.mjs` to block imports from `../apps/web/**`
2. Refactored `setDestinationCalendar.handler.test.ts` to remove `@calcom/web` imports and use local mocks instead

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
