### PR TITLE
chore: Use npm @calcom/atoms version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@boxyhq/saml-jackson": "1.52.2",
+    "@calcom/atoms": "^2.3.0",
     "@calcom/app-store": "workspace:*",
     "@calcom/app-store-cli": "workspace:*",
     "@calcom/dayjs": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@boxyhq/saml-jackson": "1.52.2",
-    "@calcom/atoms": "^2.3.0",
     "@calcom/app-store": "workspace:*",
     "@calcom/app-store-cli": "workspace:*",
+    "@calcom/atoms": "^2.3.0",
     "@calcom/dayjs": "workspace:*",
     "@calcom/embed-core": "workspace:*",
     "@calcom/embed-react": "workspace:*",

--- a/example-apps/credential-sync/package.json
+++ b/example-apps/credential-sync/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@calcom/atoms": "workspace:*",
+    "@calcom/atoms": "^2.3.0",
     "@calcom/eslint-config": "workspace:*",
     "@prisma/client": "6.7.0",
     "next": "14.2.35",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -12,7 +12,7 @@
     "deploy:trigger": "npx trigger.dev@latest deploy"
   },
   "dependencies": {
-    "@calcom/atoms": "workspace:*",
+    "@calcom/atoms": "^2.3.0",
     "@calcom/dayjs": "workspace:*",
     "@calcom/lib": "workspace:*",
     "@calcom/trpc": "workspace:*",

--- a/packages/platform/examples/base/package.json
+++ b/packages/platform/examples/base/package.json
@@ -12,7 +12,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@calcom/atoms": "workspace:*",
+    "@calcom/atoms": "^2.3.0",
     "@prisma/client": "6.7.0",
     "next": "14.2.35",
     "prisma": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,7 +3028,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcom/atoms@workspace:*, @calcom/atoms@workspace:packages/platform/atoms":
+"@calcom/atoms@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@calcom/atoms@npm:2.3.0"
+  dependencies:
+    "@radix-ui/react-dialog-atoms": "npm:@radix-ui/react-dialog@^1.0.4"
+    "@radix-ui/react-slot": ^1.0.2
+    "@radix-ui/react-switch": ^1.1.0
+    "@radix-ui/react-toast": ^1.1.5
+    "@radix-ui/react-tooltip-atoms": "npm:@radix-ui/react-tooltip@^1.0.0"
+    "@tanstack/react-query": ^5.17.15
+    class-variance-authority: ^0.4.0
+    clsx: ^2.0.0
+    dompurify: ^3.2.3
+    marked: ^15.0.3
+    react-use: ^17.4.2
+    tailwind-merge: ^1.13.2
+    tailwindcss: ^4
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    typescript: ^5.0.0
+  checksum: e9ca7a196545ace7fb594719d08a8aa17d4717333dcc684989d8ab70bd0e4758a01ed8afee977da639629156ac76ca1d44db902cfd91c5ab18402d9aae598327
+  languageName: node
+  linkType: hard
+
+"@calcom/atoms@workspace:packages/platform/atoms":
   version: 0.0.0-use.local
   resolution: "@calcom/atoms@workspace:packages/platform/atoms"
   dependencies:
@@ -3106,7 +3130,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/base@workspace:packages/platform/examples/base"
   dependencies:
-    "@calcom/atoms": "workspace:*"
+    "@calcom/atoms": ^2.3.0
     "@calcom/eslint-config": "workspace:*"
     "@playwright/test": ^1.45.3
     "@prisma/client": 6.7.0
@@ -3460,7 +3484,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/example-app-credential-sync@workspace:example-apps/credential-sync"
   dependencies:
-    "@calcom/atoms": "workspace:*"
+    "@calcom/atoms": ^2.3.0
     "@calcom/eslint-config": "workspace:*"
     "@prisma/client": 6.7.0
     "@types/node": ^20.3.1
@@ -3558,7 +3582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcom/features@workspace:packages/features"
   dependencies:
-    "@calcom/atoms": "workspace:*"
+    "@calcom/atoms": ^2.3.0
     "@calcom/dayjs": "workspace:*"
     "@calcom/lib": "workspace:*"
     "@calcom/trpc": "workspace:*"
@@ -4395,6 +4419,7 @@ __metadata:
     "@boxyhq/saml-jackson": 1.52.2
     "@calcom/app-store": "workspace:*"
     "@calcom/app-store-cli": "workspace:*"
+    "@calcom/atoms": ^2.3.0
     "@calcom/config": "workspace:*"
     "@calcom/dayjs": "workspace:*"
     "@calcom/embed-core": "workspace:*"


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched @calcom/atoms to the npm version (^2.3.0) in credential-sync, features, and the platform base example, and added it to web to standardize builds and keep versions consistent.

<sup>Written for commit 8c8956ff8057fbf23fcf6b79fcac0f528f5481b6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





