### PR TITLE
chore: Change atoms build command to build-npm

### DIFF
--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -37,5 +37,5 @@ jobs:
           export NODE_OPTIONS="--max_old_space_size=8192"
           rm -rf packages/platform/atoms/node_modules
           yarn install
-          yarn workspace @calcom/atoms run build
+          yarn workspace @calcom/atoms run build-npm
         shell: bash

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "web": "yarn workspace @calcom/web",
     "changesets-add": "yarn changeset add",
     "changesets-version": "yarn changeset version",
-    "changesets-release": "NODE_OPTIONS='--max_old_space_size=12288' turbo run build --filter=@calcom/atoms && yarn changeset publish",
+    "changesets-release": "NODE_OPTIONS='--max_old_space_size=12288' turbo run build-npm --filter=@calcom/atoms && yarn changeset publish",
     "lint-staged": "lint-staged"
   },
   "devDependencies": {

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "dev": "yarn vite build --watch & npx postcss ./globals.css -o ./globals.min.css",
-    "build": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx postcss ./globals.css -o ./globals.min.css",
-    "publish-npm": "yarn build && npm publish --access public",
+    "build-npm": "NODE_OPTIONS='--max_old_space_size=12288' rm -rf dist && yarn vite build && npx postcss ./globals.css -o ./globals.min.css",
+    "publish-npm": "yarn build-npm && npm publish --access public",
     "test": "jest",
     "dev-on": "node scripts/dev-on.js",
     "dev-off": "git checkout -- package.json vite.config.ts"

--- a/turbo.json
+++ b/turbo.json
@@ -373,7 +373,7 @@
       "cache": false,
       "dependsOn": []
     },
-    "@calcom/atoms#build": {
+    "@calcom/atoms#build-npm": {
       "outputs": ["dist/**", "globals.min.css"]
     },
     "@calcom/api-v2#build": {


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the atoms package build script to build-npm and updated the release workflow to call it. This isolates the npm build and prevents Turbo from running broader compilations during publish.

- **Refactors**
  - Updated atoms/package.json: replaced build with build-npm and set publish-npm to use it.
  - Updated root package.json: changesets-release now runs turbo build-npm for @calcom/atoms.
  - Updated turbo.json: renamed @calcom/atoms task from build to build-npm.

<sup>Written for commit bea1cff6796566fc0ceed9b27abed6fb870a8aba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





