### PR TITLE
fix: make isReschedule required in checkIfBookerEmailIsBlocked

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/checkIfBookerEmailIsBlocked.ts
+++ b/packages/features/bookings/lib/handleNewBooking/checkIfBookerEmailIsBlocked.ts
@@ -8,12 +8,12 @@ export const checkIfBookerEmailIsBlocked = async ({
   bookerEmail,
   loggedInUserId,
   verificationCode,
-  isReschedule = false,
+  isReschedule,
 }: {
   bookerEmail: string;
   loggedInUserId?: number;
   verificationCode?: string;
-  isReschedule?: boolean;
+  isReschedule: boolean;
 }) => {
   const baseEmail = extractBaseEmail(bookerEmail);
 


### PR DESCRIPTION
## What does this PR do?

Makes `isReschedule` a required parameter in the `checkIfBookerEmailIsBlocked` function instead of an optional parameter with a default value.

This is a follow-up to #25427 based on code review feedback from @Udit-takkar 

## Why?

By making `isReschedule` required, we ensure that any future caller of this function must explicitly specify whether they're handling a reschedule scenario. This prevents accidental bugs where a developer forgets to pass the parameter and the function defaults to treating it as a new booking.