### PR TITLE
feat: enhance CreatedAuditActionService with Salesforce app data for Team Round Robin events

### DIFF
--- a/packages/features/booking-audit/lib/extractSalesforceAuditData.ts
+++ b/packages/features/booking-audit/lib/extractSalesforceAuditData.ts
@@ -1,0 +1,128 @@
+import type { SalesforceAuditData, AppsAuditData } from "./actions/CreatedAuditActionService";
+
+/**
+ * Salesforce additional info structure returned by the Salesforce CRM service
+ * when creating events
+ */
+interface SalesforceAdditionalInfo {
+    contacts?: Array<{
+        id: string;
+        email: string;
+        recordType?: string;
+    }>;
+    sfEvent?: {
+        id: string;
+        success: boolean;
+    };
+    calWarnings?: string[];
+    /** Fields written to the event record */
+    eventRecordFields?: Record<string, unknown>;
+    /** Fields written to the lead/contact record */
+    leadOrContactFields?: Record<string, unknown>;
+    /** Record created in Salesforce */
+    createdRecord?: {
+        type: "lead" | "contact";
+        id: string;
+    };
+}
+
+/**
+ * EventManager result structure for CRM events
+ */
+interface CrmEventResult {
+    type: string;
+    appName?: string;
+    success: boolean;
+    uid: string;
+    createdEvent?: {
+        id: string;
+        additionalInfo?: SalesforceAdditionalInfo;
+    };
+    id?: string;
+    credentialId?: number;
+}
+
+/**
+ * Extracts Salesforce audit data from EventManager results
+ * 
+ * This function processes the results from EventManager.create() or EventManager.reschedule()
+ * and extracts Salesforce-specific data for audit logging.
+ * 
+ * @param results - Array of event results from EventManager
+ * @returns AppsAuditData object with Salesforce data if available, undefined otherwise
+ */
+export function extractSalesforceAuditData(results: unknown[]): AppsAuditData | undefined {
+    if (!results || !Array.isArray(results) || results.length === 0) {
+        return undefined;
+    }
+
+    // Find Salesforce CRM result
+    const salesforceResult = results.find((result): result is CrmEventResult => {
+        if (!result || typeof result !== "object") return false;
+        const r = result as Record<string, unknown>;
+        return (
+            typeof r.type === "string" &&
+            (r.type.includes("salesforce") || r.type === "salesforce_other_calendar")
+        );
+    });
+
+    if (!salesforceResult) {
+        return undefined;
+    }
+
+    const additionalInfo = salesforceResult.createdEvent?.additionalInfo as SalesforceAdditionalInfo | undefined;
+
+    if (!additionalInfo) {
+        return undefined;
+    }
+
+    const salesforceData: SalesforceAuditData = {};
+
+    // Extract lead/contact created info
+    if (additionalInfo.createdRecord) {
+        salesforceData.leadOrContactCreated = {
+            type: additionalInfo.createdRecord.type,
+            id: additionalInfo.createdRecord.id,
+        };
+    } else if (additionalInfo.contacts && additionalInfo.contacts.length > 0) {
+        // Fallback: try to extract from contacts array
+        const firstContact = additionalInfo.contacts[0];
+        if (firstContact.id) {
+            salesforceData.leadOrContactCreated = {
+                type: (firstContact.recordType?.toLowerCase() === "lead" ? "lead" : "contact") as "lead" | "contact",
+                id: firstContact.id,
+            };
+        }
+    }
+
+    // Extract event record fields
+    if (additionalInfo.eventRecordFields && Object.keys(additionalInfo.eventRecordFields).length > 0) {
+        salesforceData.eventRecordFields = additionalInfo.eventRecordFields;
+    }
+
+    // Extract lead/contact fields
+    if (additionalInfo.leadOrContactFields && Object.keys(additionalInfo.leadOrContactFields).length > 0) {
+        salesforceData.leadOrContactFields = additionalInfo.leadOrContactFields;
+    }
+
+    // Only return if we have any Salesforce data
+    if (Object.keys(salesforceData).length === 0) {
+        return undefined;
+    }
+
+    return {
+        salesforce: salesforceData,
+    };
+}
+
+/**
+ * Type guard to check if a result is a Salesforce CRM result
+ */
+export function isSalesforceCrmResult(result: unknown): result is CrmEventResult {
+    if (!result || typeof result !== "object") return false;
+    const r = result as Record<string, unknown>;
+    return (
+        typeof r.type === "string" &&
+        (r.type.includes("salesforce") || r.type === "salesforce_other_calendar")
+    );
+}

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -38,6 +38,7 @@ import { BookingEventHandlerService } from "@calcom/features/bookings/lib/onBook
 import { BookingEmailAndSmsTasker } from "@calcom/features/bookings/lib/tasker/BookingEmailAndSmsTasker";
 import type { BookingRescheduledPayload } from "@calcom/features/bookings/lib/onBookingEvents/types.d";
 import type { ActionSource } from "@calcom/features/booking-audit/lib/common/actionSource";
+import { extractSalesforceAuditData } from "@calcom/features/booking-audit/lib/extractSalesforceAuditData";
 import { getSpamCheckService } from "@calcom/features/di/watchlist/containers/SpamCheckService.container";
 import { CreditService } from "@calcom/features/ee/billing/credit-service";
 import { getBookerBaseUrl } from "@calcom/features/ee/organizations/lib/getBookerUrlServer";
@@ -2371,6 +2372,9 @@ async function handler(
       operationId: null,
     });
   } else {
+    // Extract Salesforce audit data from CRM results for Team Round Robin events
+    const salesforceAuditData = extractSalesforceAuditData(results);
+
     await bookingEventHandler.onBookingCreated({
       payload: bookingCreatedPayload,
       actor: auditActor,
@@ -2378,6 +2382,7 @@ async function handler(
         startTime: bookingCreatedPayload.booking.startTime.getTime(),
         endTime: bookingCreatedPayload.booking.endTime.getTime(),
         status: bookingCreatedPayload.booking.status,
+        ...(salesforceAuditData ? { apps: salesforceAuditData } : {}),
       },
       source: actionSource,
       operationId: null,


### PR DESCRIPTION
## What does this PR do?

Enhances the booking audit system to capture Salesforce CRM data during booking creation, specifically for Team Round Robin events. This builds on PR #25125 (booking-audit-more-infra).

**Changes:**
- Adds Salesforce audit data schema to `CreatedAuditActionService` to track lead/contact creation and field writes
- Creates `extractSalesforceAuditData` helper to extract Salesforce data from EventManager results
- Modifies Salesforce CRM service to capture and return fields written to event records and lead/contact records
- Updates `RegularBookingService` to pass extracted Salesforce data to the audit system

**Data captured:**
- Lead/Contact record ID and type when created
- Fields written to the Salesforce Event record with their values
- Fields written to the Lead/Contact record with their values

Link to Devin run: https://app.devin.ai/sessions/2b352c202412416d95ac10c6202178d2
Requested by: hariom@cal.com (@hariombalhara)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal audit logging changes only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a Team Round Robin event type with Salesforce integration configured
2. Configure Salesforce app options to write to event records and/or lead/contact records on booking
3. Create a booking for the event type
4. Check the booking audit log to verify Salesforce data is captured:
   - `apps.salesforce.leadOrContactCreated` should contain the contact/lead ID and type
   - `apps.salesforce.eventRecordFields` should contain fields written to the SF Event
   - `apps.salesforce.leadOrContactFields` should contain fields written to the lead/contact

**Environment variables needed:**
- Salesforce app credentials configured

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Items for Human Review

- [ ] Verify `writeToRecordAndReturnFields` correctly mirrors `writeToRecord` behavior (CrmService.ts lines 1099-1168)
- [ ] Confirm no other callers of `salesforceCreateEvent` exist that might be affected by the return type change
- [ ] Consider whether `createdRecord` should be populated when new leads/contacts are created (currently only captures existing contacts)
- [ ] Unit tests for `extractSalesforceAuditData` helper function are not included