### PR TITLE
fix: integration test of booking audit service

### DIFF
--- a/packages/features/booking-audit/lib/service/booking-audit.integration-test.ts
+++ b/packages/features/booking-audit/lib/service/booking-audit.integration-test.ts
@@ -123,8 +123,11 @@ const enableFeatureForOrganization = async (organizationId: number, featureSlug:
       teamId: organizationId,
       featureId: featureSlug,
       assignedBy: "test-system",
+      enabled: true,
     },
-    update: {},
+    update: {
+      enabled: true,
+    },
   });
 };
 


### PR DESCRIPTION
## What does this PR do?

follow up of #25765

fixing an integration test. somehow it was not caught in #25765's CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the booking-audit integration test by enabling the feature flag during test setup. The upsert now sets enabled: true on both create and update to ensure the feature is active for the organization.

<sup>Written for commit 9cdcefcf36a77122251d8e43c1875153dd173353. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

