### PR TITLE
test: onboarding v3 e2e tests

### DIFF
--- a/apps/web/playwright/onboarding-v3-organizations.e2e.ts
+++ b/apps/web/playwright/onboarding-v3-organizations.e2e.ts
@@ -1,0 +1,364 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./lib/fixtures";
+
+test.describe.configure({ mode: "parallel" });
+
+test.afterEach(({ users }) => users.deleteAll());
+
+test.describe("Onboarding V3 - Organization Flow", () => {
+  test("Complete organization onboarding flow with all steps", async ({ page, users }) => {
+    // Create user with company email (not a personal email provider)
+    // This is required for the organization option to be visible
+    const user = await users.create({
+      completedOnboarding: false,
+      name: null,
+      email: "admin@acmecorp.com", // Company email
+    });
+    await user.apiLogin();
+    await page.goto("/onboarding/getting-started");
+    await page.waitForURL("/onboarding/getting-started");
+
+    await test.step("Step 1 - Select Organization Plan", async () => {
+      // Wait for page to load
+      await expect(page.locator("text=getting started")).toBeVisible();
+
+      // Verify organization option is visible for company email
+      const organizationOption = page.locator('button[value="organization"]');
+      await expect(organizationOption).toBeVisible();
+
+      // Select organization plan
+      await organizationOption.click();
+
+      // Continue to next step
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/details");
+    });
+
+    await test.step("Step 2 - Organization Details", async () => {
+      await expect(page.locator("text=organization details")).toBeVisible();
+
+      // Test validation - try to continue without filling required fields
+      await page.locator('button:has-text("Continue")').click();
+      // Should still be on the same page (validation prevents navigation)
+      await expect(page).toHaveURL(/.*\/onboarding\/organization\/details/);
+
+      // Fill organization name
+      const orgName = "Acme Corporation";
+      await page.locator('input[placeholder*="organization"]').first().fill(orgName);
+
+      // Organization slug should auto-populate from name
+      await page.waitForTimeout(500); // Wait for slug auto-generation
+      const slugInput = page.locator('input[type="text"]').nth(1);
+      const slugValue = await slugInput.inputValue();
+      expect(slugValue).toBe("acme-corporation");
+
+      // Manually edit slug to test manual editing
+      await slugInput.clear();
+      await slugInput.fill("acme-corp");
+
+      // Test slug validation with invalid characters
+      await slugInput.clear();
+      await slugInput.fill("invalid slug!");
+      await expect(page.locator("text=/.*invalid.*/i").or(page.locator('[role="alert"]'))).toBeVisible();
+
+      // Use valid slug
+      await slugInput.clear();
+      await slugInput.fill("acme-corp");
+
+      // Fill optional bio
+      await page.locator('textarea[placeholder*="bio"]').fill("Leading provider of innovative solutions");
+
+      // Continue to brand step
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+    });
+
+    await test.step("Step 3 - Organization Brand", async () => {
+      await expect(page.locator("text=customize your brand")).toBeVisible();
+
+      // Test back navigation
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/organization/details");
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+
+      // Brand customization is optional, test skip button
+      await page.locator('button:has-text("Skip")').first().click();
+      await page.waitForURL("/onboarding/organization/teams");
+    });
+
+    await test.step("Step 4 - Organization Teams", async () => {
+      await expect(page.locator("text=create teams")).toBeVisible();
+
+      // Go back to test brand customization with actual values
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+
+      // Test brand color picker (optional)
+      // Color picker might be complex, so we'll just verify it's present
+      await expect(page.locator('text=/.*color.*/i')).toBeVisible();
+
+      // Continue to teams
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/teams");
+
+      // Add teams
+      const teamFields = page.locator('input[placeholder*="team"]');
+      await teamFields.first().fill("Engineering");
+
+      // Add another team
+      await page.locator('button:has-text("Add")').click();
+      await teamFields.nth(1).fill("Sales");
+
+      // Add a third team
+      await page.locator('button:has-text("Add")').click();
+      await teamFields.nth(2).fill("Marketing");
+
+      // Test remove team button
+      const removeButtons = page.locator('button[type="button"]').filter({ has: page.locator('[name="x"]') });
+      await removeButtons.nth(2).click(); // Remove Marketing team
+
+      // Continue to invite step
+      await page.locator('button[type="submit"]:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/invite/email");
+    });
+
+    await test.step("Step 5 - Organization Invite", async () => {
+      await expect(page.locator("text=invite your team")).toBeVisible();
+
+      // Test skip functionality
+      const skipButton = page.locator('button:has-text("Skip")').first();
+      if (await skipButton.isVisible()) {
+        // Just verify it's there, we'll test completing with invites
+      }
+
+      // Add email invites
+      const emailInputs = page.locator('input[type="email"]');
+      await emailInputs.first().fill("john@acmecorp.com");
+
+      // Select team for invite (if teams exist)
+      const teamSelects = page.locator('select, [role="combobox"]').filter({ hasText: /team/i });
+      if ((await teamSelects.count()) > 0) {
+        await teamSelects.first().click();
+        await page.locator('text=Engineering').first().click();
+      }
+
+      // Add another invite
+      const addInviteButton = page.locator('button:has-text("Add")').first();
+      if (await addInviteButton.isVisible()) {
+        await addInviteButton.click();
+        await emailInputs.nth(1).fill("jane@acmecorp.com");
+
+        // Select team for second invite
+        if ((await teamSelects.count()) > 1) {
+          await teamSelects.nth(1).click();
+          await page.locator('text=Sales').first().click();
+        }
+      }
+
+      // Test email validation with invalid email
+      await emailInputs.first().clear();
+      await emailInputs.first().fill("invalid-email");
+      await emailInputs.first().blur();
+      await expect(
+        page.locator("text=/.*invalid.*email.*/i").or(page.locator('[role="alert"]'))
+      ).toBeVisible();
+
+      // Fix invalid email
+      await emailInputs.first().clear();
+      await emailInputs.first().fill("john@acmecorp.com");
+
+      // Complete onboarding
+      await page.locator('button[type="submit"]:has-text("Continue")').click();
+
+      // Should redirect after successful completion
+      // The exact URL depends on the implementation, but should leave onboarding
+      await page.waitForTimeout(2000);
+      await expect(page).not.toHaveURL(/.*\/onboarding\/.*/);
+
+      // Verify user completed onboarding
+      const userComplete = await user.self();
+      expect(userComplete.completedOnboarding).toBe(true);
+    });
+  });
+
+  test("Organization onboarding - Skip optional steps", async ({ page, users }) => {
+    const user = await users.create({
+      completedOnboarding: false,
+      name: null,
+      email: "user@company.com",
+    });
+    await user.apiLogin();
+    await page.goto("/onboarding/getting-started");
+    await page.waitForURL("/onboarding/getting-started");
+
+    await test.step("Select organization and fill minimal details", async () => {
+      // Select organization
+      await page.locator('button[value="organization"]').click();
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/details");
+
+      // Fill only required fields
+      await page.locator('input[placeholder*="organization"]').first().fill("Test Corp");
+      await page.waitForTimeout(500);
+
+      // Continue through steps skipping optional ones
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+    });
+
+    await test.step("Skip brand customization", async () => {
+      await page.locator('button:has-text("Skip")').first().click();
+      await page.waitForURL("/onboarding/organization/teams");
+    });
+
+    await test.step("Skip team creation", async () => {
+      await page.locator('button:has-text("Skip")').first().click();
+      await page.waitForURL("/onboarding/organization/invite/email");
+    });
+
+    await test.step("Skip invites and complete", async () => {
+      await page.locator('button:has-text("Skip")').first().click();
+      await page.waitForTimeout(2000);
+
+      // Verify completion
+      await expect(page).not.toHaveURL(/.*\/onboarding\/.*/);
+      const userComplete = await user.self();
+      expect(userComplete.completedOnboarding).toBe(true);
+    });
+  });
+
+  test("Organization onboarding - Validation errors", async ({ page, users }) => {
+    const user = await users.create({
+      completedOnboarding: false,
+      name: null,
+      email: "test@validcompany.com",
+    });
+    await user.apiLogin();
+    await page.goto("/onboarding/organization/details");
+
+    await test.step("Test organization name validation", async () => {
+      // Try to continue with empty organization name
+      const continueButton = page.locator('button:has-text("Continue")');
+      await continueButton.click();
+
+      // Should remain on the same page
+      await expect(page).toHaveURL(/.*\/onboarding\/organization\/details/);
+      expect(await continueButton.isDisabled()).toBe(true);
+    });
+
+    await test.step("Test organization slug validation", async () => {
+      // Fill name
+      await page.locator('input[placeholder*="organization"]').first().fill("Test Company");
+      await page.waitForTimeout(500);
+
+      const slugInput = page.locator('input[type="text"]').nth(1);
+
+      // Test various invalid slug formats
+      const invalidSlugs = ["test company", "test@company", "test.company", "test/company"];
+
+      for (const invalidSlug of invalidSlugs) {
+        await slugInput.clear();
+        await slugInput.fill(invalidSlug);
+        await slugInput.blur();
+
+        // Check for validation error
+        const hasError =
+          (await page.locator("text=/.*invalid.*/i").count()) > 0 ||
+          (await page.locator('[role="alert"]').count()) > 0;
+
+        if (hasError) {
+          expect(hasError).toBe(true);
+        }
+      }
+
+      // Use valid slug
+      await slugInput.clear();
+      await slugInput.fill("test-company");
+      await page.waitForTimeout(500);
+    });
+  });
+
+  test("Organization onboarding - Personal email cannot see organization option", async ({
+    page,
+    users,
+  }) => {
+    // Create user with personal email (e.g., gmail.com)
+    const user = await users.create({
+      completedOnboarding: false,
+      name: null,
+      email: "user@gmail.com", // Personal email
+    });
+    await user.apiLogin();
+    await page.goto("/onboarding/getting-started");
+    await page.waitForURL("/onboarding/getting-started");
+
+    await test.step("Verify organization option is not visible", async () => {
+      await expect(page.locator("text=getting started")).toBeVisible();
+
+      // Organization option should NOT be visible for personal email
+      const organizationOption = page.locator('button[value="organization"]');
+      await expect(organizationOption).not.toBeVisible();
+
+      // Personal and Team options should still be visible
+      await expect(page.locator('button[value="personal"]')).toBeVisible();
+      await expect(page.locator('button[value="team"]')).toBeVisible();
+    });
+  });
+
+  test("Organization onboarding - Navigation between steps", async ({ page, users }) => {
+    const user = await users.create({
+      completedOnboarding: false,
+      name: null,
+      email: "user@enterprise.com",
+    });
+    await user.apiLogin();
+
+    await test.step("Test forward and backward navigation", async () => {
+      await page.goto("/onboarding/getting-started");
+      await page.waitForURL("/onboarding/getting-started");
+
+      // Select organization
+      await page.locator('button[value="organization"]').click();
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/details");
+
+      // Fill details
+      await page.locator('input[placeholder*="organization"]').first().fill("Nav Test Corp");
+      await page.waitForTimeout(500);
+
+      // Go to brand
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+
+      // Navigate back
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/organization/details");
+
+      // Verify data persistence - name should still be filled
+      const nameInput = page.locator('input[placeholder*="organization"]').first();
+      expect(await nameInput.inputValue()).toBe("Nav Test Corp");
+
+      // Go forward again
+      await page.locator('button:has-text("Continue")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+
+      // Skip to teams
+      await page.locator('button:has-text("Skip")').first().click();
+      await page.waitForURL("/onboarding/organization/teams");
+
+      // Back to brand
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/organization/brand");
+
+      // Back to details
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/organization/details");
+
+      // Back to getting started
+      await page.locator('button:has-text("Back")').click();
+      await page.waitForURL("/onboarding/getting-started");
+    });
+  });
+});

--- a/apps/web/playwright/onboarding-v3-organizations.e2e.ts
+++ b/apps/web/playwright/onboarding-v3-organizations.e2e.ts
@@ -8,156 +8,118 @@ test.afterEach(({ users }) => users.deleteAll());
 
 test.describe("Onboarding V3 - Organization Flow", () => {
   test("Complete organization onboarding flow with all steps", async ({ page, users }) => {
-    // Create user with company email (not a personal email provider)
-    // This is required for the organization option to be visible
     const user = await users.create({
       completedOnboarding: false,
       name: null,
-      email: "admin@acmecorp.com", // Company email
+      email: "admin@acmecorp.com",
     });
     await user.apiLogin();
     await page.goto("/onboarding/getting-started");
     await page.waitForURL("/onboarding/getting-started");
 
-    await test.step("Step 1 - Select Organization Plan", async () => {
-      // Wait for page to load
+    await test.step("step 1 - Select Organization Plan", async () => {
       await expect(page.locator("text=getting started")).toBeVisible();
 
-      // Verify organization option is visible for company email
       const organizationOption = page.locator('button[value="organization"]');
       await expect(organizationOption).toBeVisible();
-
-      // Select organization plan
       await organizationOption.click();
 
-      // Continue to next step
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/details");
     });
 
-    await test.step("Step 2 - Organization Details", async () => {
+    await test.step("step 2 - Organization Details", async () => {
       await expect(page.locator("text=organization details")).toBeVisible();
 
-      // Test validation - try to continue without filling required fields
       await page.locator('button:has-text("Continue")').click();
-      // Should still be on the same page (validation prevents navigation)
       await expect(page).toHaveURL(/.*\/onboarding\/organization\/details/);
 
-      // Fill organization name
       const orgName = "Acme Corporation";
       await page.locator('input[placeholder*="organization"]').first().fill(orgName);
 
-      // Organization slug should auto-populate from name
-      await page.waitForTimeout(500); // Wait for slug auto-generation
+      await page.waitForTimeout(500);
       const slugInput = page.locator('input[type="text"]').nth(1);
       const slugValue = await slugInput.inputValue();
       expect(slugValue).toBe("acme-corporation");
 
-      // Manually edit slug to test manual editing
       await slugInput.clear();
       await slugInput.fill("acme-corp");
 
-      // Test slug validation with invalid characters
       await slugInput.clear();
       await slugInput.fill("invalid slug!");
       await expect(page.locator("text=/.*invalid.*/i").or(page.locator('[role="alert"]'))).toBeVisible();
 
-      // Use valid slug
       await slugInput.clear();
       await slugInput.fill("acme-corp");
 
-      // Fill optional bio
       await page.locator('textarea[placeholder*="bio"]').fill("Leading provider of innovative solutions");
 
-      // Continue to brand step
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/brand");
     });
 
-    await test.step("Step 3 - Organization Brand", async () => {
+    await test.step("step 3 - Organization Brand", async () => {
       await expect(page.locator("text=customize your brand")).toBeVisible();
 
-      // Test back navigation
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/organization/details");
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/brand");
 
-      // Brand customization is optional, test skip button
       await page.locator('button:has-text("Skip")').first().click();
       await page.waitForURL("/onboarding/organization/teams");
     });
 
-    await test.step("Step 4 - Organization Teams", async () => {
+    await test.step("step 4 - Organization Teams", async () => {
       await expect(page.locator("text=create teams")).toBeVisible();
 
-      // Go back to test brand customization with actual values
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/organization/brand");
 
-      // Test brand color picker (optional)
-      // Color picker might be complex, so we'll just verify it's present
-      await expect(page.locator('text=/.*color.*/i')).toBeVisible();
+      await expect(page.locator("text=/.*color.*/i")).toBeVisible();
 
-      // Continue to teams
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/teams");
 
-      // Add teams
       const teamFields = page.locator('input[placeholder*="team"]');
       await teamFields.first().fill("Engineering");
 
-      // Add another team
       await page.locator('button:has-text("Add")').click();
       await teamFields.nth(1).fill("Sales");
 
-      // Add a third team
       await page.locator('button:has-text("Add")').click();
       await teamFields.nth(2).fill("Marketing");
 
-      // Test remove team button
       const removeButtons = page.locator('button[type="button"]').filter({ has: page.locator('[name="x"]') });
-      await removeButtons.nth(2).click(); // Remove Marketing team
+      await removeButtons.nth(2).click();
 
-      // Continue to invite step
       await page.locator('button[type="submit"]:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/invite/email");
     });
 
-    await test.step("Step 5 - Organization Invite", async () => {
+    await test.step("step 5 - Organization Invite", async () => {
       await expect(page.locator("text=invite your team")).toBeVisible();
 
-      // Test skip functionality
-      const skipButton = page.locator('button:has-text("Skip")').first();
-      if (await skipButton.isVisible()) {
-        // Just verify it's there, we'll test completing with invites
-      }
-
-      // Add email invites
       const emailInputs = page.locator('input[type="email"]');
       await emailInputs.first().fill("john@acmecorp.com");
 
-      // Select team for invite (if teams exist)
       const teamSelects = page.locator('select, [role="combobox"]').filter({ hasText: /team/i });
       if ((await teamSelects.count()) > 0) {
         await teamSelects.first().click();
-        await page.locator('text=Engineering').first().click();
+        await page.locator("text=Engineering").first().click();
       }
 
-      // Add another invite
       const addInviteButton = page.locator('button:has-text("Add")').first();
       if (await addInviteButton.isVisible()) {
         await addInviteButton.click();
         await emailInputs.nth(1).fill("jane@acmecorp.com");
 
-        // Select team for second invite
         if ((await teamSelects.count()) > 1) {
           await teamSelects.nth(1).click();
-          await page.locator('text=Sales').first().click();
+          await page.locator("text=Sales").first().click();
         }
       }
 
-      // Test email validation with invalid email
       await emailInputs.first().clear();
       await emailInputs.first().fill("invalid-email");
       await emailInputs.first().blur();
@@ -165,19 +127,14 @@ test.describe("Onboarding V3 - Organization Flow", () => {
         page.locator("text=/.*invalid.*email.*/i").or(page.locator('[role="alert"]'))
       ).toBeVisible();
 
-      // Fix invalid email
       await emailInputs.first().clear();
       await emailInputs.first().fill("john@acmecorp.com");
 
-      // Complete onboarding
       await page.locator('button[type="submit"]:has-text("Continue")').click();
 
-      // Should redirect after successful completion
-      // The exact URL depends on the implementation, but should leave onboarding
       await page.waitForTimeout(2000);
       await expect(page).not.toHaveURL(/.*\/onboarding\/.*/);
 
-      // Verify user completed onboarding
       const userComplete = await user.self();
       expect(userComplete.completedOnboarding).toBe(true);
     });
@@ -194,35 +151,27 @@ test.describe("Onboarding V3 - Organization Flow", () => {
     await page.waitForURL("/onboarding/getting-started");
 
     await test.step("Select organization and fill minimal details", async () => {
-      // Select organization
       await page.locator('button[value="organization"]').click();
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/details");
 
-      // Fill only required fields
       await page.locator('input[placeholder*="organization"]').first().fill("Test Corp");
       await page.waitForTimeout(500);
 
-      // Continue through steps skipping optional ones
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/brand");
     });
 
-    await test.step("Skip brand customization", async () => {
+    await test.step("Skip brand, teams, and invites", async () => {
       await page.locator('button:has-text("Skip")').first().click();
       await page.waitForURL("/onboarding/organization/teams");
-    });
 
-    await test.step("Skip team creation", async () => {
       await page.locator('button:has-text("Skip")').first().click();
       await page.waitForURL("/onboarding/organization/invite/email");
-    });
 
-    await test.step("Skip invites and complete", async () => {
       await page.locator('button:has-text("Skip")').first().click();
       await page.waitForTimeout(2000);
 
-      // Verify completion
       await expect(page).not.toHaveURL(/.*\/onboarding\/.*/);
       const userComplete = await user.self();
       expect(userComplete.completedOnboarding).toBe(true);
@@ -238,24 +187,18 @@ test.describe("Onboarding V3 - Organization Flow", () => {
     await user.apiLogin();
     await page.goto("/onboarding/organization/details");
 
-    await test.step("Test organization name validation", async () => {
-      // Try to continue with empty organization name
+    await test.step("Organization name and slug validation", async () => {
       const continueButton = page.locator('button:has-text("Continue")');
       await continueButton.click();
 
-      // Should remain on the same page
       await expect(page).toHaveURL(/.*\/onboarding\/organization\/details/);
       expect(await continueButton.isDisabled()).toBe(true);
-    });
 
-    await test.step("Test organization slug validation", async () => {
-      // Fill name
       await page.locator('input[placeholder*="organization"]').first().fill("Test Company");
       await page.waitForTimeout(500);
 
       const slugInput = page.locator('input[type="text"]').nth(1);
 
-      // Test various invalid slug formats
       const invalidSlugs = ["test company", "test@company", "test.company", "test/company"];
 
       for (const invalidSlug of invalidSlugs) {
@@ -263,7 +206,6 @@ test.describe("Onboarding V3 - Organization Flow", () => {
         await slugInput.fill(invalidSlug);
         await slugInput.blur();
 
-        // Check for validation error
         const hasError =
           (await page.locator("text=/.*invalid.*/i").count()) > 0 ||
           (await page.locator('[role="alert"]').count()) > 0;
@@ -273,17 +215,13 @@ test.describe("Onboarding V3 - Organization Flow", () => {
         }
       }
 
-      // Use valid slug
       await slugInput.clear();
       await slugInput.fill("test-company");
       await page.waitForTimeout(500);
     });
   });
 
-  test("Organization onboarding - Personal email cannot see organization option", async ({
-    page,
-    users,
-  }) => {
+  test("Organization onboarding - Personal email cannot see organization option", async ({ page, users }) => {
     // Create user with personal email (e.g., gmail.com)
     const user = await users.create({
       completedOnboarding: false,
@@ -315,48 +253,38 @@ test.describe("Onboarding V3 - Organization Flow", () => {
     });
     await user.apiLogin();
 
-    await test.step("Test forward and backward navigation", async () => {
+    await test.step("Forward and backward navigation", async () => {
       await page.goto("/onboarding/getting-started");
       await page.waitForURL("/onboarding/getting-started");
 
-      // Select organization
       await page.locator('button[value="organization"]').click();
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/details");
 
-      // Fill details
       await page.locator('input[placeholder*="organization"]').first().fill("Nav Test Corp");
       await page.waitForTimeout(500);
 
-      // Go to brand
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/brand");
 
-      // Navigate back
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/organization/details");
 
-      // Verify data persistence - name should still be filled
       const nameInput = page.locator('input[placeholder*="organization"]').first();
       expect(await nameInput.inputValue()).toBe("Nav Test Corp");
 
-      // Go forward again
       await page.locator('button:has-text("Continue")').click();
       await page.waitForURL("/onboarding/organization/brand");
 
-      // Skip to teams
       await page.locator('button:has-text("Skip")').first().click();
       await page.waitForURL("/onboarding/organization/teams");
 
-      // Back to brand
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/organization/brand");
 
-      // Back to details
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/organization/details");
 
-      // Back to getting started
       await page.locator('button:has-text("Back")').click();
       await page.waitForURL("/onboarding/getting-started");
     });

--- a/apps/web/playwright/onboarding-v3-personal.e2e.ts
+++ b/apps/web/playwright/onboarding-v3-personal.e2e.ts
@@ -1,0 +1,235 @@
+import { expect } from "@playwright/test";
+
+import { IdentityProvider } from "@calcom/prisma/enums";
+
+import { test } from "./lib/fixtures";
+
+test.describe.configure({ mode: "parallel" });
+
+test.afterEach(({ users }) => users.deleteAll());
+
+test.describe("Onboarding V3 - Personal Flow", () => {
+  const testPersonalOnboarding = (identityProvider: IdentityProvider) => {
+    test(`Personal Onboarding Flow - ${identityProvider} user`, async ({ page, users }) => {
+      const user = await users.create({
+        completedOnboarding: false,
+        name: null,
+        identityProvider,
+      });
+      await user.apiLogin();
+      
+      await test.step("Navigate to getting-started and select personal plan", async () => {
+        await page.goto("/onboarding/getting-started");
+        await page.waitForURL("/onboarding/getting-started");
+        
+        // Wait for page to load and select personal plan
+        await expect(page.locator('text="Personal"')).toBeVisible();
+        
+        // Click on personal plan radio option
+        await page.locator('input[value="personal"]').click();
+        
+        // Click continue button
+        await page.locator('button:has-text("Continue")').click();
+        
+        // Should navigate to personal settings
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+      });
+
+      await test.step("Step 1 - Personal Settings - Validation", async () => {
+        // Test required field validation
+        await page.locator('button[type="submit"]').click();
+        
+        // Should show validation error for name field
+        await expect(page.locator('form').locator('text=/name.*required/i')).toBeVisible();
+      });
+
+      await test.step("Step 1 - Personal Settings - Happy Path", async () => {
+        // Fill in name
+        await page.locator('input[name="name"]').fill("John Doe");
+        
+        // Username field should be visible (disabled for personal onboarding)
+        await expect(page.locator('input[name="username"]')).toBeVisible();
+        
+        // Fill in bio
+        await page.locator('textarea[name="bio"]').fill("Software engineer and scheduling enthusiast");
+        
+        // Test avatar upload functionality (optional - we can skip actual upload)
+        await expect(page.locator('text="Profile picture"')).toBeVisible();
+        
+        // Click continue button
+        await page.locator('button[type="submit"]').click();
+        
+        // Should navigate to calendar page
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
+        
+        // Verify user data was saved
+        const userComplete = await user.self();
+        expect(userComplete.name).toBe("John Doe");
+      });
+
+      await test.step("Step 2 - Calendar Integration - Test Skip", async () => {
+        // Wait for calendar integrations to load
+        await expect(page.locator('text="Connect your calendar"')).toBeVisible();
+        
+        // Verify back button exists
+        await expect(page.locator('button:has-text("Back")')).toBeVisible();
+        
+        // Verify skip button exists and is enabled
+        const skipButton = page.locator('button:has-text("Skip")').first();
+        await expect(skipButton).toBeVisible();
+        await expect(skipButton).toBeEnabled();
+        
+        // Click skip button
+        await skipButton.click();
+        
+        // Should complete onboarding and redirect to event-types
+        await page.waitForURL(/.*\/event-types/);
+        
+        // Verify user has completedOnboarding = true
+        const userComplete = await user.self();
+        expect(userComplete.completedOnboarding).toBe(true);
+      });
+    });
+
+    test(`Personal Onboarding Flow - ${identityProvider} user - Test Back Navigation`, async ({ page, users }) => {
+      const user = await users.create({
+        completedOnboarding: false,
+        name: null,
+        identityProvider,
+      });
+      await user.apiLogin();
+      
+      await test.step("Navigate to settings step", async () => {
+        await page.goto("/onboarding/getting-started");
+        await page.waitForURL("/onboarding/getting-started");
+        
+        await page.locator('input[value="personal"]').click();
+        await page.locator('button:has-text("Continue")').click();
+        
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+      });
+
+      await test.step("Test back navigation from settings to getting-started", async () => {
+        // Click back button
+        await page.locator('button:has-text("Back")').click();
+        
+        // Should navigate back to getting-started
+        await expect(page).toHaveURL(/.*\/onboarding\/getting-started/);
+        
+        // Personal plan should still be selected
+        await expect(page.locator('input[value="personal"]')).toBeChecked();
+      });
+
+      await test.step("Navigate forward and test back from calendar step", async () => {
+        // Continue to settings
+        await page.locator('button:has-text("Continue")').click();
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+        
+        // Fill in required fields
+        await page.locator('input[name="name"]').fill("Jane Smith");
+        await page.locator('button[type="submit"]').click();
+        
+        // Should be on calendar page
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
+        
+        // Click back button
+        await page.locator('button:has-text("Back")').click();
+        
+        // Should navigate back to settings
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+        
+        // Previously entered data should be preserved
+        await expect(page.locator('input[name="name"]')).toHaveValue("Jane Smith");
+      });
+    });
+
+    test(`Personal Onboarding Flow - ${identityProvider} user - Test Calendar Continue`, async ({ page, users }) => {
+      const user = await users.create({
+        completedOnboarding: false,
+        name: null,
+        identityProvider,
+      });
+      await user.apiLogin();
+      
+      await test.step("Navigate through to calendar step", async () => {
+        await page.goto("/onboarding/getting-started");
+        await page.waitForURL("/onboarding/getting-started");
+        
+        await page.locator('input[value="personal"]').click();
+        await page.locator('button:has-text("Continue")').click();
+        
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+        
+        await page.locator('input[name="name"]').fill("Test User");
+        await page.locator('button[type="submit"]').click();
+        
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
+      });
+
+      await test.step("Test continue button without calendar integration", async () => {
+        await expect(page.locator('text="Connect your calendar"')).toBeVisible();
+        
+        // Click continue button (not skip)
+        const continueButton = page.locator('button:has-text("Continue")').last();
+        await expect(continueButton).toBeVisible();
+        await expect(continueButton).toBeEnabled();
+        
+        await continueButton.click();
+        
+        // Should complete onboarding and redirect to event-types
+        await page.waitForURL(/.*\/event-types/);
+        
+        // Verify user has completedOnboarding = true
+        const userComplete = await user.self();
+        expect(userComplete.completedOnboarding).toBe(true);
+      });
+    });
+
+    test(`Personal Onboarding Flow - ${identityProvider} user - Direct URL Access`, async ({ page, users }) => {
+      const user = await users.create({
+        completedOnboarding: false,
+        name: null,
+        identityProvider,
+      });
+      await user.apiLogin();
+      
+      await test.step("Direct access to settings page", async () => {
+        // Navigate directly to settings page
+        await page.goto("/onboarding/personal/settings");
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
+        
+        // Form should be visible and functional
+        await expect(page.locator('input[name="name"]')).toBeVisible();
+        
+        // Fill form and continue
+        await page.locator('input[name="name"]').fill("Direct Access User");
+        await page.locator('button[type="submit"]').click();
+        
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
+      });
+
+      await test.step("Direct access to calendar page", async () => {
+        // Navigate directly to calendar page
+        await page.goto("/onboarding/personal/calendar");
+        await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
+        
+        // Calendar integrations should load
+        await expect(page.locator('text="Connect your calendar"')).toBeVisible();
+        
+        // Should be able to complete onboarding
+        const skipButton = page.locator('button:has-text("Skip")').first();
+        await skipButton.click();
+        
+        await page.waitForURL(/.*\/event-types/);
+        
+        const userComplete = await user.self();
+        expect(userComplete.completedOnboarding).toBe(true);
+      });
+    });
+  };
+
+  // Test with different identity providers
+  testPersonalOnboarding(IdentityProvider.CAL);
+  testPersonalOnboarding(IdentityProvider.GOOGLE);
+  testPersonalOnboarding(IdentityProvider.SAML);
+});

--- a/apps/web/playwright/onboarding-v3-personal.e2e.ts
+++ b/apps/web/playwright/onboarding-v3-personal.e2e.ts
@@ -17,218 +17,172 @@ test.describe("Onboarding V3 - Personal Flow", () => {
         identityProvider,
       });
       await user.apiLogin();
-      
+
       await test.step("Navigate to getting-started and select personal plan", async () => {
         await page.goto("/onboarding/getting-started");
         await page.waitForURL("/onboarding/getting-started");
-        
-        // Wait for page to load and select personal plan
+
         await expect(page.locator('text="Personal"')).toBeVisible();
-        
-        // Click on personal plan radio option
         await page.locator('input[value="personal"]').click();
-        
-        // Click continue button
         await page.locator('button:has-text("Continue")').click();
-        
-        // Should navigate to personal settings
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
       });
 
-      await test.step("Step 1 - Personal Settings - Validation", async () => {
-        // Test required field validation
+      await test.step("step 1 - Personal Settings - Validation", async () => {
         await page.locator('button[type="submit"]').click();
-        
-        // Should show validation error for name field
-        await expect(page.locator('form').locator('text=/name.*required/i')).toBeVisible();
+        await expect(page.locator("form").locator("text=/name.*required/i")).toBeVisible();
       });
 
-      await test.step("Step 1 - Personal Settings - Happy Path", async () => {
-        // Fill in name
+      await test.step("step 1 - Personal Settings - Happy Path", async () => {
         await page.locator('input[name="name"]').fill("John Doe");
-        
-        // Username field should be visible (disabled for personal onboarding)
         await expect(page.locator('input[name="username"]')).toBeVisible();
-        
-        // Fill in bio
         await page.locator('textarea[name="bio"]').fill("Software engineer and scheduling enthusiast");
-        
-        // Test avatar upload functionality (optional - we can skip actual upload)
         await expect(page.locator('text="Profile picture"')).toBeVisible();
-        
-        // Click continue button
         await page.locator('button[type="submit"]').click();
-        
-        // Should navigate to calendar page
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
-        
-        // Verify user data was saved
+
         const userComplete = await user.self();
         expect(userComplete.name).toBe("John Doe");
       });
 
-      await test.step("Step 2 - Calendar Integration - Test Skip", async () => {
-        // Wait for calendar integrations to load
+      await test.step("step 2 - Calendar Integration - Test Skip", async () => {
         await expect(page.locator('text="Connect your calendar"')).toBeVisible();
-        
-        // Verify back button exists
         await expect(page.locator('button:has-text("Back")')).toBeVisible();
-        
-        // Verify skip button exists and is enabled
+
         const skipButton = page.locator('button:has-text("Skip")').first();
         await expect(skipButton).toBeVisible();
         await expect(skipButton).toBeEnabled();
-        
-        // Click skip button
         await skipButton.click();
-        
-        // Should complete onboarding and redirect to event-types
+
         await page.waitForURL(/.*\/event-types/);
-        
-        // Verify user has completedOnboarding = true
+
         const userComplete = await user.self();
         expect(userComplete.completedOnboarding).toBe(true);
       });
     });
 
-    test(`Personal Onboarding Flow - ${identityProvider} user - Test Back Navigation`, async ({ page, users }) => {
+    test(`Personal Onboarding Flow - ${identityProvider} user - Back Navigation`, async ({ page, users }) => {
       const user = await users.create({
         completedOnboarding: false,
         name: null,
         identityProvider,
       });
       await user.apiLogin();
-      
+
       await test.step("Navigate to settings step", async () => {
         await page.goto("/onboarding/getting-started");
         await page.waitForURL("/onboarding/getting-started");
-        
+
         await page.locator('input[value="personal"]').click();
         await page.locator('button:has-text("Continue")').click();
-        
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
       });
 
-      await test.step("Test back navigation from settings to getting-started", async () => {
-        // Click back button
+      await test.step("Back navigation from settings to getting-started", async () => {
         await page.locator('button:has-text("Back")').click();
-        
-        // Should navigate back to getting-started
         await expect(page).toHaveURL(/.*\/onboarding\/getting-started/);
-        
-        // Personal plan should still be selected
         await expect(page.locator('input[value="personal"]')).toBeChecked();
       });
 
       await test.step("Navigate forward and test back from calendar step", async () => {
-        // Continue to settings
         await page.locator('button:has-text("Continue")').click();
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
-        
-        // Fill in required fields
+
         await page.locator('input[name="name"]').fill("Jane Smith");
         await page.locator('button[type="submit"]').click();
-        
-        // Should be on calendar page
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
-        
-        // Click back button
+
         await page.locator('button:has-text("Back")').click();
-        
-        // Should navigate back to settings
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
-        
-        // Previously entered data should be preserved
         await expect(page.locator('input[name="name"]')).toHaveValue("Jane Smith");
       });
     });
 
-    test(`Personal Onboarding Flow - ${identityProvider} user - Test Calendar Continue`, async ({ page, users }) => {
+    test(`Personal Onboarding Flow - ${identityProvider} user - Calendar Continue`, async ({
+      page,
+      users,
+    }) => {
       const user = await users.create({
         completedOnboarding: false,
         name: null,
         identityProvider,
       });
       await user.apiLogin();
-      
+
       await test.step("Navigate through to calendar step", async () => {
         await page.goto("/onboarding/getting-started");
         await page.waitForURL("/onboarding/getting-started");
-        
+
         await page.locator('input[value="personal"]').click();
         await page.locator('button:has-text("Continue")').click();
-        
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
-        
+
         await page.locator('input[name="name"]').fill("Test User");
         await page.locator('button[type="submit"]').click();
-        
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
       });
 
-      await test.step("Test continue button without calendar integration", async () => {
+      await test.step("Continue without calendar integration", async () => {
         await expect(page.locator('text="Connect your calendar"')).toBeVisible();
-        
-        // Click continue button (not skip)
+
         const continueButton = page.locator('button:has-text("Continue")').last();
         await expect(continueButton).toBeVisible();
         await expect(continueButton).toBeEnabled();
-        
         await continueButton.click();
-        
-        // Should complete onboarding and redirect to event-types
+
         await page.waitForURL(/.*\/event-types/);
-        
-        // Verify user has completedOnboarding = true
+
         const userComplete = await user.self();
         expect(userComplete.completedOnboarding).toBe(true);
       });
     });
 
-    test(`Personal Onboarding Flow - ${identityProvider} user - Direct URL Access`, async ({ page, users }) => {
+    test(`Personal Onboarding Flow - ${identityProvider} user - Direct URL Access`, async ({
+      page,
+      users,
+    }) => {
       const user = await users.create({
         completedOnboarding: false,
         name: null,
         identityProvider,
       });
       await user.apiLogin();
-      
+
       await test.step("Direct access to settings page", async () => {
-        // Navigate directly to settings page
         await page.goto("/onboarding/personal/settings");
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/settings/);
-        
-        // Form should be visible and functional
+
         await expect(page.locator('input[name="name"]')).toBeVisible();
-        
-        // Fill form and continue
+
         await page.locator('input[name="name"]').fill("Direct Access User");
         await page.locator('button[type="submit"]').click();
-        
+
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
       });
 
       await test.step("Direct access to calendar page", async () => {
-        // Navigate directly to calendar page
         await page.goto("/onboarding/personal/calendar");
         await expect(page).toHaveURL(/.*\/onboarding\/personal\/calendar/);
-        
-        // Calendar integrations should load
+
         await expect(page.locator('text="Connect your calendar"')).toBeVisible();
-        
-        // Should be able to complete onboarding
+
         const skipButton = page.locator('button:has-text("Skip")').first();
         await skipButton.click();
-        
+
         await page.waitForURL(/.*\/event-types/);
-        
+
         const userComplete = await user.self();
         expect(userComplete.completedOnboarding).toBe(true);
       });
     });
   };
 
-  // Test with different identity providers
   testPersonalOnboarding(IdentityProvider.CAL);
   testPersonalOnboarding(IdentityProvider.GOOGLE);
   testPersonalOnboarding(IdentityProvider.SAML);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Playwright E2E tests for Onboarding V3 covering organization and personal flows, including happy paths, validation, navigation, and completion state. Also verifies skip paths, direct URL access, and identity provider variants.

- **Test Coverage**
  - Organization: select plan; details with name/slug validation; brand; teams (add/remove); invites with email validation; back/forward nav; skip optional steps; personal email users can’t see organization option.
  - Personal: settings validation and save; calendar step (skip or continue) leading to event types; back nav preserves inputs; direct URL access to steps; ensures completedOnboarding is set.
  - Identity providers: runs personal flow for CAL, Google, and SAML.

<sup>Written for commit 9fc1ca95b36401fbd1a6df735a7f05853b36c713. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

