### PR TITLE
fix: enable save button when workflows toggled

### DIFF
--- a/packages/features/eventtypes/lib/types.ts
+++ b/packages/features/eventtypes/lib/types.ts
@@ -178,6 +178,7 @@ export type FormValues = {
   restrictionScheduleName: string | null;
   calVideoSettings?: CalVideoSettings;
   maxActiveBookingPerBookerOfferReschedule: boolean;
+  workflows: number[];
 };
 
 export type LocationFormValues = Pick<FormValues, "id" | "locations" | "bookingFields" | "seatsPerTimeSlot">;

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -143,6 +143,7 @@ export const useEventTypeForm = ({
       maxActiveBookingsPerBooker: eventType.maxActiveBookingsPerBooker || null,
       maxActiveBookingPerBookerOfferReschedule: eventType.maxActiveBookingPerBookerOfferReschedule,
       showOptimizedSlots: eventType.showOptimizedSlots ?? false,
+      workflows: [],
     };
   }, [eventType, periodDates]);
 

--- a/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -239,6 +239,19 @@ const EventTypeWeb = ({
     },
   });
 
+  // Initialize workflows when data loads
+  const workflowsInitialized = useRef(false);
+  useEffect(() => {
+    if (allActiveWorkflows && !workflowsInitialized.current) {
+      form.setValue("workflows", allActiveWorkflows.map((w) => w.id), { shouldDirty: false });
+      workflowsInitialized.current = true;
+    }
+  }, [allActiveWorkflows, form]);
+  
+  useEffect(() => {
+    workflowsInitialized.current = false;
+  }, [id]);
+
   const orgBranding = useOrgBranding();
 
   const bookerUrl = orgBranding ? orgBranding?.fullDomain : WEBSITE_URL;

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -148,6 +148,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       },
       children: {
         select: {
+          id: true,
           userId: true,
         },
       },
@@ -636,7 +637,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   const isCalVideoLocationActive = locations
     ? locations.some((location) => location.type === DailyLocationType)
     : parsedEventTypeLocations.success &&
-    parsedEventTypeLocations.data?.some((location) => location.type === DailyLocationType);
+      parsedEventTypeLocations.data?.some((location) => location.type === DailyLocationType);
 
   if (eventType.calVideoSettings && !isCalVideoLocationActive) {
     await CalVideoSettingsRepository.deleteCalVideoSettings(id);
@@ -718,16 +719,16 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   // Sync workflows
   if (workflows !== undefined) {
     const eventTypeIds = [id, ...(eventType.children?.map((c) => c.id) || [])];
-    
+
     const current = await ctx.prisma.workflowsOnEventTypes.findMany({
       where: { eventTypeId: { in: eventTypeIds } },
       select: { workflowId: true },
     });
-    
-    const currentIds = [...new Set(current.map((w) => w.workflowId))];
+
+    const currentIds = Array.from(new Set(current.map((w) => w.workflowId)));
     const toRemove = currentIds.filter((id) => !workflows.includes(id));
     const toAdd = workflows.filter((id) => !currentIds.includes(id));
-    
+
     if (toRemove.length) {
       await ctx.prisma.workflowsOnEventTypes.deleteMany({
         where: { eventTypeId: { in: eventTypeIds }, workflowId: { in: toRemove } },
@@ -739,7 +740,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         },
       });
     }
-    
+
     for (const workflowId of toAdd) {
       for (const eventTypeId of eventTypeIds) {
         await ctx.prisma.workflowsOnEventTypes.upsert({

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -637,7 +637,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   const isCalVideoLocationActive = locations
     ? locations.some((location) => location.type === DailyLocationType)
     : parsedEventTypeLocations.success &&
-      parsedEventTypeLocations.data?.some((location) => location.type === DailyLocationType);
+    parsedEventTypeLocations.data?.some((location) => location.type === DailyLocationType);
 
   if (eventType.calVideoSettings && !isCalVideoLocationActive) {
     await CalVideoSettingsRepository.deleteCalVideoSettings(id);

--- a/packages/trpc/server/routers/viewer/eventTypes/types.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/types.ts
@@ -104,6 +104,7 @@ const BaseEventTypeUpdateInput = EventTypeSchema.extend({
   useEventLevelSelectedCalendars: z.boolean().optional(),
   seatsPerTimeSlot: z.number().min(1).max(MAX_SEATS_PER_TIME_SLOT).nullable().optional(),
   hostGroups: z.array(hostGroupSchema).optional(),
+  workflows: z.array(z.number()).optional(),
 })
   .partial()
   .extend(EventTypeSchema.pick({ id: true }).shape);


### PR DESCRIPTION
## What does this PR do?

Fixes the workflow toggle behavior in event type settings where the Save button remained disabled after enabling/disabling workflows, causing confusion as changes were auto-saving in the background without user awareness.

- Fixes #26052 
- Fixes [CAL-6956](https://linear.app/calcom/issue/CAL-6956/when-enabling-workflows-in-event-settings-the-save-button-remains)



## Visual Demo (For contributors especially)

- Before Fix: 

Workflow toggle called `activateEventTypeMutation.mutate()` → immediate save, Save button stays disabled

https://github.com/user-attachments/assets/c5feed89-02d6-4df8-9828-b1b2b734976d

- After Fix:

Workflow toggle updates form state via `setValue()` → Save button enables → user clicks Save → changes persist


https://github.com/user-attachments/assets/8eab5ae0-79b2-4e90-acf7-357e3222944a


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to Event Types → Select any event
2. Go to Workflows tab
3. Toggle any workflow on/off