### PR TITLE
fix: booking page metadata

### DIFF
--- a/apps/web/app/(booking-page-wrapper)/booking/[uid]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking/[uid]/embed/page.tsx
@@ -13,6 +13,13 @@ import {
   type PageProps as ClientPageProps,
 } from "~/bookings/views/bookings-single-view.getServerSideProps";
 
+export const metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
 const getEmbedData = withEmbedSsrAppDir<ClientPageProps>(getServerSideProps);
 
 const ServerPage = async ({ params, searchParams }: ServerPageProps) => {

--- a/apps/web/app/(booking-page-wrapper)/booking/[uid]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking/[uid]/page.tsx
@@ -16,13 +16,15 @@ import {
   type PageProps as ClientPageProps,
 } from "~/bookings/views/bookings-single-view.getServerSideProps";
 
+const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
+
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const { bookingInfo, eventType, recurringBookings, orgSlug } = await getData(
     buildLegacyCtx(await headers(), await cookies(), await params, await searchParams)
   );
   const needsConfirmation = bookingInfo.status === BookingStatus.PENDING && eventType.requiresConfirmation;
 
-  return await _generateMetadata(
+  const metadata = await _generateMetadata(
     (t) =>
       t(`booking_${needsConfirmation ? "submitted" : "confirmed"}${recurringBookings ? "_recurring" : ""}`),
     (t) =>
@@ -31,9 +33,15 @@ export const generateMetadata = async ({ params, searchParams }: _PageProps) => 
     getOrgFullOrigin(orgSlug),
     `/booking/${(await params).uid}`
   );
-};
 
-const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
+  return {
+    ...metadata,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+};
 
 const ServerPage = async ({ params, searchParams }: _PageProps) => {
   const context = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);


### PR DESCRIPTION
## What does this PR do?

Updates metadata configuration for booking confirmation pages.

**Changes:**
- Update metadata in `/booking/[uid]/page.tsx`
- Add metadata export to `/booking/[uid]/embed/page.tsx`

Follows the same pattern used in `not-found.tsx`.

## Changes

| File | Description |
|------|-------------|
| `apps/web/app/(booking-page-wrapper)/booking/[uid]/page.tsx` | Update generateMetadata return |
| `apps/web/app/(booking-page-wrapper)/booking/[uid]/embed/page.tsx` | Add metadata export |

## How should this be tested?

1. Create a test booking
2. Navigate to `/booking/[uid]`
3. Inspect page source
4. Verify metadata is correctly set

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] **N/A** Documentation change
- [ ] **N/A** - Metadata change, verified manually