### PR TITLE
fix: Handle error when no default calendar exists for a o365 account

### DIFF
--- a/apps/web/components/apps/CalendarListContainer.tsx
+++ b/apps/web/components/apps/CalendarListContainer.tsx
@@ -106,7 +106,7 @@ export function CalendarListContainer({
   const { error, setQuery: setError } = useRouterQuery("error");
 
   useEffect(() => {
-    if (error === "account_already_linked") {
+    if (error === "account_already_linked" || error === "no_default_calendar") {
       showToast(t(error), "error", { id: error });
       setError(undefined);
     }

--- a/apps/web/modules/apps/[slug]/slug-view.tsx
+++ b/apps/web/modules/apps/[slug]/slug-view.tsx
@@ -15,7 +15,7 @@ import App from "@components/apps/App";
 function SingleAppPage(props: AppDataProps) {
   const { error, setQuery: setError } = useRouterQuery("error");
   const { t } = useLocale();
-  if (error === "account_already_linked") {
+  if (error === "account_already_linked" || error === "no_default_calendar") {
     showToast(t(error), "error", { id: error });
     setError(undefined);
   }
@@ -66,7 +66,7 @@ function SingleAppPage(props: AppDataProps) {
       //   privacy="https://zoom.us/privacy"
       body={
         <>
-          {/* eslint-disable-next-line react/no-danger */}
+          { }
           <div dangerouslySetInnerHTML={{ __html: markdownToSafeHTML(source.content) }} />
         </>
       }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2893,6 +2893,7 @@
   "field_identifiers_as_variables": "Use field identifiers as variables for your custom event redirect",
   "field_identifiers_as_variables_with_example": "Use field identifiers as variables for your custom event redirect (e.g. {{variable}})",
   "account_already_linked": "Account is already linked",
+  "no_default_calendar": "No default calendar found for this account, unable to link",
   "send_email": "Send email",
   "cal_ai_phone_call_action": "Call attendee using Cal.ai Voice Agent",
   "call_to_confirm_booking": "Call to confirm booking",

--- a/packages/app-store/office365calendar/api/callback.ts
+++ b/packages/app-store/office365calendar/api/callback.ts
@@ -104,15 +104,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     logger.info("Office365 Calendar: handleErrorsJson completed", {
       userId: req.session?.user?.id,
-      calendarCount: calBody.value.length ?? 0,
+      calendarCount: calBody.value?.length ?? 0,
     });
 
     if (typeof responseBody === "string") {
       calBody = JSON.parse(responseBody) as { value: OfficeCalendar[] };
     }
 
-    const findDefaultCalendar = calBody.value.find((calendar) => calendar.isDefaultCalendar);
-
+    const findDefaultCalendar = (calBody.value ?? []).find((calendar) => calendar.isDefaultCalendar);
     if (findDefaultCalendar) {
       defaultCalendar = findDefaultCalendar;
     }
@@ -124,7 +123,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  if (defaultCalendar?.id && req.session?.user?.id) {
+  if (!defaultCalendar?.id) {
+    const errorMessage = "no_default_calendar";
+    res.redirect(
+      `/apps/installed/calendar?error=${errorMessage}`
+    );
+    return;
+  }
+
+  if (req.session?.user?.id) {
     const credential = await prisma.credential.create({
       data: {
         type: "office365_calendar",

--- a/packages/app-store/office365calendar/api/callback.ts
+++ b/packages/app-store/office365calendar/api/callback.ts
@@ -126,7 +126,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!defaultCalendar?.id) {
     const errorMessage = "no_default_calendar";
     res.redirect(
-      `/apps/installed/calendar?error=${errorMessage}`
+      `${getSafeRedirectUrl(state?.onErrorReturnTo) ?? getInstalledAppPath({ variant: "calendar", slug: "office365-calendar" })}?error=${errorMessage}`
     );
     return;
   }


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Office 365 calendar connect flow when an account has no default calendar. The link now fails gracefully and shows a clear error to the user.

- **Bug Fixes**
  - Detect missing default calendar in the OAuth callback and redirect with error=no_default_calendar, avoiding credential creation.
  - Show a localized error toast for no_default_calendar in CalendarList and Single App views (new i18n string added).
  - Safely parse calendar data by guarding access to calBody.value and its length.

<sup>Written for commit 65509e6977277d77c81e4b91c9cb89dcb895f16e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





