### PR TITLE
fix: add missing Korean translations

### DIFF
--- a/apps/web/public/static/locales/ko/common.json
+++ b/apps/web/public/static/locales/ko/common.json
@@ -2892,6 +2892,7 @@
   "ooo_slots_returning": "<0>{{displayName}}</0>은 외출 중에도 회의를 진행할 수 있습니다.",
   "ooo_slots_book_with": "{{displayName}} 예약",
   "ooo_select_reason": "사유 선택",
+  "show_note_publicly_description": "공개 예약 페이지에 메모 표시",
   "create_an_out_of_office": "부재중 설정",
   "edit_an_out_of_office": "부재중 항목 수정",
   "submit_feedback": "피드백 제출",


### PR DESCRIPTION
## What does this PR do?

- Add a missing Korean translation for this key

<img width="539" height="532" alt="Screenshot 2025-12-20 at 3 09 01 PM" src="https://github.com/user-attachments/assets/2357b09e-f828-45fd-b3cb-9987c2125913" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.