### PR TITLE
chore: Make tRPC build required to pass

### DIFF
--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . ",
-    "build": "yarn trpc:generate || true",
+    "build": "yarn trpc:generate",
     "trpc:generate": "yarn tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -321,6 +321,7 @@
       "dependsOn": ["@calcom/prisma#db-up"]
     },
     "@calcom/trpc#build": {
+      "dependsOn": ["@calcom/prisma#post-install"],
       "outputs": ["./types"]
     },
     "@calcom/web#build": {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require tRPC code generation to pass by removing "|| true" from the tRPC package build script and making the tRPC build depend on Prisma post-install. CI will now fail if "yarn trpc:generate" errors or runs before Prisma is set up.

<sup>Written for commit 7b19cbfe886ad090eb2a44e868934699b562cd49. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



