### PR TITLE
Fix add action dialog dropdown overflow

### DIFF
--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -169,18 +169,11 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                       isSearchable={false}
                       className="text-sm"
                       menuPlacement="bottom"
+                      maxMenuHeight={150}
+                      menuPortalTarget={null}
                       defaultValue={actionOptions[0]}
                       onChange={handleSelectAction}
-                      options={actionOptions.map((option) => ({
-                        label: option.label,
-                        value: option.value,
-                        needsTeamsUpgrade: option.needsTeamsUpgrade,
-                      }))}
-                      isOptionDisabled={(option: {
-                        label: string;
-                        value: WorkflowActions;
-                        needsTeamsUpgrade?: boolean;
-                      }) => !!option.needsTeamsUpgrade}
+                      options={actionOptions}
                     />
                   );
                 }}

--- a/packages/features/ee/workflows/components/AddActionDialog.tsx
+++ b/packages/features/ee/workflows/components/AddActionDialog.tsx
@@ -173,7 +173,16 @@ export const AddActionDialog = (props: IAddActionDialog) => {
                       menuPortalTarget={null}
                       defaultValue={actionOptions[0]}
                       onChange={handleSelectAction}
-                      options={actionOptions}
+                      options={actionOptions.map((option) => ({
+                        label: option.label,
+                        value: option.value,
+                        needsTeamsUpgrade: option.needsTeamsUpgrade,
+                      }))}
+                      isOptionDisabled={(option: {
+                        label: string;
+                        value: WorkflowActions;
+                        needsTeamsUpgrade?: boolean;
+                      }) => !!option.needsTeamsUpgrade}
                     />
                   );
                 }}


### PR DESCRIPTION
This PR fixes the dropdown overflow behavior inside the Add Action dialog
by constraining scrolling to the dropdown instead of the entire dialog.

Additionally still if the dropdown is longer than dialog box, it adds scrollbar to the dialog box also.
Images are attached for the reference

- Fixes #26086 
- Fixes CAL-6962

## Visual Demo (For contributors especially)
<img width="1919" height="914" alt="Screenshot from 2025-12-21 14-07-33" src="https://github.com/user-attachments/assets/144cea81-5604-4497-a5ef-28bb76457210" />
<img width="1919" height="914" alt="Screenshot from 2025-12-21 14-07-47" src="https://github.com/user-attachments/assets/70d53c48-0da7-427c-97ad-bd29cf486a80" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my changes generate no new warnings
