### PR TITLE
fix: use idiomatic dorny/paths-filter exclusion pattern

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,15 @@ jobs:
         with:
           filters: |
             has-files-requiring-all-checks:
-              - "!(companion/**|**.md|**.mdx|.github/CODEOWNERS|docs/**|help/**|apps/web/public/static/locales/**/common.json|i18n.lock)"
+              - '**'
+              - '!companion/**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!.github/CODEOWNERS'
+              - '!docs/**'
+              - '!help/**'
+              - '!apps/web/public/static/locales/**/common.json'
+              - '!i18n.lock'
             has_companion:
               - "companion/**"
       - name: Get Latest Commit SHA


### PR DESCRIPTION
## What does this PR do?

Fixes the `has-files-requiring-all-checks` filter in the PR workflow that was incorrectly returning `true` even when only `companion/` folder files were changed.

The extglob negation pattern `!(companion/**|**.md|...)` doesn't work reliably with `dorny/paths-filter`. This caused all CI checks to run unnecessarily for companion-only changes.

This PR replaces it with the documented idiomatic approach:
- Match all files with `'**'`
- Exclude specific paths with `'!'` prefix on separate lines

Also fixes `**.md` to `**/*.md` for safer glob matching across different glob engines.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - CI config change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a CI workflow fix that can be verified by testing a PR with companion-only changes.

## How should this be tested?

1. Create a test PR that only modifies files in the `companion/` folder
2. Verify that `has-files-requiring-all-checks` output is `false` in the "Detect changes" job
3. Verify that the main CI checks (lint, type-check, unit-test, etc.) are skipped
4. Verify that `build-companion` job still runs

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Link to Devin run**: https://app.devin.ai/sessions/4c6cb120f73846a0afe2b97ac4924b1c
> **Requested by**: Volnei Munhoz (@volnei)