### PR TITLE
chore: remove labeled trigger to prevent workflow reruns on non-E2E labels

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Update
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - gh-actions-test-branch
@@ -57,7 +57,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' && (github.event.action != 'labeled' || github.event.label.name == 'ready-for-e2e') }}
+      run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
     steps:
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where adding any label to a PR would trigger a full workflow re-run, causing issues when non-`ready-for-e2e` labels were added. The E2E check would incorrectly fail, and the only workaround was to remove and re-add the `ready-for-e2e` label.

**The problem:** The workflow triggered on `labeled` events, so adding any label (like `automation`) would re-run the entire workflow. The `run-e2e` output had extra gating logic that would evaluate to false for non-`ready-for-e2e` labels, causing E2E tests to be skipped even if the PR already had the `ready-for-e2e` label.

**The fix:** Remove `labeled` from the trigger types entirely. This is the simplest solution:
- Adding non-E2E labels no longer triggers any workflow run
- When `ready-for-e2e` is added, users click "Re-run all jobs" in GitHub Actions UI to trigger E2E tests
- Simplified the `run-e2e` output since the event-based gating is no longer needed

## Key Changes

- Removed `labeled` from `pull_request_target` trigger types
- Simplified `run-e2e` output from complex event-based condition to just checking if the label exists

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - CI workflow fix only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow change that can be verified by testing label behavior on a PR.

## How should this be tested?

**Scenario 1: Non-E2E label added**
1. Create a test PR
2. Add a label like `automation` or `area/api`
3. Verify that NO workflow run is triggered

**Scenario 2: E2E label workflow**
1. Create a test PR and push code
2. Wait for initial CI run (E2E skipped since no label)
3. Add `ready-for-e2e` label
4. Click "Re-run all jobs" in GitHub Actions UI
5. Verify E2E tests now run

## Human Review Checklist

- [ ] Confirm the UX change is acceptable: users must manually re-run jobs after adding `ready-for-e2e` label
- [ ] Verify no other workflows or automation depend on the `labeled` trigger behavior
- [ ] Check if Graphite's auto-labeling on approval will still work with the manual re-run requirement

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run**: https://app.devin.ai/sessions/6603d63b53e34e6c9c5fca16a4a27c8e
**Requested by**: @keithwillcode