### PR TITLE
perf: add z.ZodType annotations to high-impact schemas

### DIFF
--- a/packages/app-store/routing-forms/zod.ts
+++ b/packages/app-store/routing-forms/zod.ts
@@ -4,6 +4,26 @@ import { raqbQueryValueSchema } from "@calcom/lib/raqb/zod";
 
 import { routingFormAppDataSchemas } from "./appDataSchemas";
 
+export type FieldOption = {
+  label: string;
+  id: string | null;
+};
+
+export type TNonRouterField = {
+  id: string;
+  label: string;
+  identifier?: string;
+  placeholder?: string;
+  type: string;
+  /** @deprecated in favour of `options` */
+  selectText?: string;
+  required?: boolean;
+  deleted?: boolean;
+  options?: FieldOption[];
+};
+
+// Note: zodNonRouterField is NOT annotated with z.ZodType because it uses .extend() below
+// which requires the full ZodObject type to be preserved
 export const zodNonRouterField = z.object({
   id: z.string(),
   label: z.string(),
@@ -29,13 +49,21 @@ export const zodNonRouterField = z.object({
     .optional(),
 });
 
+export type TRouterField = TNonRouterField & {
+  routerId: string;
+};
+
+// Note: zodRouterField is NOT annotated with z.ZodType because it uses .extend() below
 export const zodRouterField = zodNonRouterField.extend({
   routerId: z.string(),
 });
 
+export type TField = TNonRouterField | TRouterField;
+export type TFields = TField[] | undefined;
+
 // This ordering is important - If routerId is present then it should be in the parsed object. Moving zodNonRouterField to first position doesn't do that
-export const zodField = z.union([zodRouterField, zodNonRouterField]);
-export const zodFields = z.array(zodField).optional();
+export const zodField: z.ZodType<TField> = z.union([zodRouterField, zodNonRouterField]);
+export const zodFields: z.ZodType<TFields> = z.array(zodField).optional();
 
 export const zodNonRouterFieldView = zodNonRouterField;
 export const zodRouterFieldView = zodRouterField.extend({

--- a/packages/features/eventtypes/lib/schemas.ts
+++ b/packages/features/eventtypes/lib/schemas.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
 import { SchedulingType } from "@calcom/prisma/enums";
+import type { EventTypeLocation, EventTypeMetadata } from "@calcom/prisma/zod-utils";
 import { eventTypeLocations, EventTypeMetaDataSchema, eventTypeSlug } from "@calcom/prisma/zod-utils";
 
+// Note: calVideoSettingsSchema is not annotated with z.ZodType because it's a local
+// variable and the .optional().nullable() chain creates complex type inference
 const calVideoSettingsSchema = z
   .object({
     disableRecordingForGuests: z.boolean().nullish(),
@@ -17,7 +20,18 @@ const calVideoSettingsSchema = z
   .optional()
   .nullable();
 
-export const EventTypeDuplicateInput = z
+type CalVideoSettings = z.infer<typeof calVideoSettingsSchema>;
+
+export type TEventTypeDuplicateInput = {
+  id: number;
+  slug: string;
+  title: string;
+  description: string;
+  length: number;
+  teamId?: number | null;
+};
+
+export const EventTypeDuplicateInput: z.ZodType<TEventTypeDuplicateInput> = z
   .object({
     id: z.number(),
     slug: z.string(),
@@ -28,7 +42,26 @@ export const EventTypeDuplicateInput = z
   })
   .strict();
 
-export const createEventTypeInput = z
+export type TCreateEventTypeInput = {
+  title: string;
+  slug: string;
+  description?: string | null;
+  length: number;
+  hidden?: boolean;
+  teamId?: number | null;
+  schedulingType?: SchedulingType | null;
+  locations?: EventTypeLocation[];
+  metadata?: EventTypeMetadata;
+  disableGuests?: boolean;
+  slotInterval?: number | null;
+  minimumBookingNotice?: number;
+  beforeEventBuffer?: number;
+  afterEventBuffer?: number;
+  scheduleId?: number;
+  calVideoSettings?: CalVideoSettings;
+};
+
+export const createEventTypeInput: z.ZodType<TCreateEventTypeInput> = z
   .object({
     title: z.string().trim().min(1),
     slug: eventTypeSlug,

--- a/packages/features/eventtypes/lib/schemas.ts
+++ b/packages/features/eventtypes/lib/schemas.ts
@@ -1,12 +1,23 @@
 import { z } from "zod";
 
 import { SchedulingType } from "@calcom/prisma/enums";
-import type { EventTypeLocation, EventTypeMetadata } from "@calcom/prisma/zod-utils";
 import { eventTypeLocations, EventTypeMetaDataSchema, eventTypeSlug } from "@calcom/prisma/zod-utils";
 
-// Note: calVideoSettingsSchema is not annotated with z.ZodType because it's a local
-// variable and the .optional().nullable() chain creates complex type inference
-const calVideoSettingsSchema = z
+type CalVideoSettings =
+  | {
+      disableRecordingForGuests?: boolean | null;
+      disableRecordingForOrganizer?: boolean | null;
+      enableAutomaticTranscription?: boolean | null;
+      enableAutomaticRecordingForOrganizer?: boolean | null;
+      disableTranscriptionForGuests?: boolean | null;
+      disableTranscriptionForOrganizer?: boolean | null;
+      redirectUrlOnExit?: string | null;
+      requireEmailForGuests?: boolean | null;
+    }
+  | null
+  | undefined;
+
+const calVideoSettingsSchema: z.ZodType<CalVideoSettings> = z
   .object({
     disableRecordingForGuests: z.boolean().nullish(),
     disableRecordingForOrganizer: z.boolean().nullish(),
@@ -20,7 +31,18 @@ const calVideoSettingsSchema = z
   .optional()
   .nullable();
 
-type CalVideoSettings = z.infer<typeof calVideoSettingsSchema>;
+type EventTypeLocation = {
+  type: string;
+  address?: string;
+  link?: string;
+  displayLocationPublicly?: boolean;
+  hostPhoneNumber?: string;
+  credentialId?: number;
+  teamName?: string;
+  customLabel?: string;
+};
+
+type EventTypeMetadata = z.infer<typeof EventTypeMetaDataSchema>;
 
 export type TEventTypeDuplicateInput = {
   id: number;

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -327,7 +327,18 @@ export const bookingResponses = z
 
 export type BookingResponses = z.infer<typeof bookingResponses>;
 
-export const eventTypeLocations = z.array(
+export type EventTypeLocation = {
+  type: string;
+  address?: string;
+  link?: string;
+  displayLocationPublicly?: boolean;
+  hostPhoneNumber?: string;
+  credentialId?: number;
+  teamName?: string;
+  customLabel?: string;
+};
+
+export const eventTypeLocations: z.ZodType<EventTypeLocation[]> = z.array(
   z.object({
     // TODO: Couldn't find a way to make it a union of types from App Store locations
     // Creating a dynamic union by iterating over the object doesn't seem to make TS happy


### PR DESCRIPTION
## What does this PR do?

Adds explicit `z.ZodType<T>` annotations to high-impact Zod schemas to reduce TypeScript type inference overhead and `.d.ts` file bloat in the tRPC package.

This is part of an effort to improve tRPC build times (currently 34.8s with 59% spent on type checking). By adding explicit type annotations, TypeScript doesn't need to infer complex nested generic types from Zod schemas, which reduces both check time and declaration file sizes.

**Changes:**
- `packages/prisma/zod-utils.ts`: Add `EventTypeLocation` type and annotate `eventTypeLocations` schema
- `packages/features/eventtypes/lib/schemas.ts`: Add `CalVideoSettings`, `EventTypeLocation`, `TEventTypeDuplicateInput`, and `TCreateEventTypeInput` types with annotations
- `packages/app-store/routing-forms/zod.ts`: Add `FieldOption`, `TNonRouterField`, `TRouterField`, `TField`, `TFields` types with annotations for `zodField` and `zodFields`

**Note:** Schemas that use `.extend()` (like `zodNonRouterField`, `zodRouterField`) are intentionally NOT annotated because `z.ZodType<T>` removes the `.extend()` method from the type.

### Updates since last revision

- Replaced `z.infer<typeof calVideoSettingsSchema>` with explicit `CalVideoSettings` type (using `z.infer` defeats the purpose of reducing type inference)
- Defined `EventTypeLocation` locally in `schemas.ts` to reduce type imports from prisma
- Added `z.ZodType<CalVideoSettings>` annotation to `calVideoSettingsSchema`

**Open question:** The file still imports Zod schemas (`eventTypeLocations`, `EventTypeMetaDataSchema`, `eventTypeSlug`) from `@calcom/prisma/zod-utils` for validation. Should these be moved to `@calcom/lib` in a separate PR?

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - type-only changes, verified via `yarn type-check:ci`.

## How should this be tested?

1. Run `yarn type-check:ci --force` - should pass without new errors in the modified files
2. Run `yarn lint:report` - should pass
3. Optionally, build the tRPC package and compare `.d.ts` file sizes before/after

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify type annotations accurately match the Zod schema output types (especially for schemas with `.partial()`, `.transform()`, `.refine()`)
- [ ] Confirm schemas using `.extend()` are correctly NOT annotated
- [ ] Check that `EventTypeMetadata = z.infer<typeof EventTypeMetaDataSchema>` doesn't reintroduce type-graph bloat (still references prisma import)
- [ ] Decide if remaining `@calcom/prisma/zod-utils` imports are acceptable or should be moved to `@calcom/lib`

---
Link to Devin run: https://app.devin.ai/sessions/ab130470471946a48d70d35f843e1f5c
Requested by: @keithwillcode (keith@cal.com)