### PR TITLE
chore: Add webhook version documentation link to webapp

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3838,7 +3838,7 @@
   "webhook_attendee_timezone": "Timezone of the first attendee",
   "webhook_attendee_locale": "Locale of the first attendee",
   "webhook_version": "Webhook Version",
-  "webhook_version_docs": "View payload documentation",
+  "webhook_version_docs": "View payload documentation for version {{version}}",
   "webhook_team_name": "Name of the team booked",
   "webhook_team_members": "Members of the team booked",
   "webhook_video_call_url": "Video call URL for the meeting",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -3838,6 +3838,7 @@
   "webhook_attendee_timezone": "Timezone of the first attendee",
   "webhook_attendee_locale": "Locale of the first attendee",
   "webhook_version": "Webhook Version",
+  "webhook_version_docs": "View payload documentation",
   "webhook_team_name": "Name of the team booked",
   "webhook_team_members": "Members of the team booked",
   "webhook_video_call_url": "Video call URL for the meeting",

--- a/packages/features/webhooks/components/WebhookListItem.tsx
+++ b/packages/features/webhooks/components/WebhookListItem.tsx
@@ -96,11 +96,11 @@ export default function WebhookListItem(props: {
               </Badge>
             </div>
           </Tooltip>
-          <Tooltip content={t("webhook_version_docs")}>
+          <Tooltip content={t("webhook_version_docs", { version: getWebhookVersionLabel(webhook.version) })}>
             <Link
               href={getWebhookVersionDocsUrl(webhook.version)}
               target="_blank"
-              className="text-subtle hover:text-emphasis ml-1">
+              className="text-subtle hover:text-emphasis ml-1 flex items-center">
               <Icon name="external-link" className="h-4 w-4" />
             </Link>
           </Tooltip>

--- a/packages/features/webhooks/components/WebhookListItem.tsx
+++ b/packages/features/webhooks/components/WebhookListItem.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import Link from "next/link";
+
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
 import type { Webhook } from "../lib/dto/types";
-import { getWebhookVersionLabel } from "../lib/constants";
+import { getWebhookVersionLabel, getWebhookVersionDocsUrl } from "../lib/constants";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";
 import { Badge } from "@calcom/ui/components/badge";
@@ -17,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
 import { Switch } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
@@ -92,6 +95,14 @@ export default function WebhookListItem(props: {
                 {getWebhookVersionLabel(webhook.version)}
               </Badge>
             </div>
+          </Tooltip>
+          <Tooltip content={t("webhook_version_docs")}>
+            <Link
+              href={getWebhookVersionDocsUrl(webhook.version)}
+              target="_blank"
+              className="text-subtle hover:text-emphasis ml-1">
+              <Icon name="external-link" className="h-4 w-4" />
+            </Link>
           </Tooltip>
         </div>
         <Tooltip content={t("triggers_when")}>

--- a/packages/features/webhooks/lib/constants.ts
+++ b/packages/features/webhooks/lib/constants.ts
@@ -28,6 +28,21 @@ export const WEBHOOK_VERSION_OPTIONS = Object.values(WebhookVersion).map((versio
 export const getWebhookVersionLabel = (version: WebhookVersion): string =>
   WEBHOOK_VERSION_LABELS[version] ?? version;
 
+/**
+ * Documentation URLs for each webhook version.
+ * Links to the specific version's payload documentation.
+ */
+export const WEBHOOK_VERSION_DOCS: Record<WebhookVersion, string> = {
+  [WebhookVersion.V_2021_10_20]: "https://cal.com/docs/developing/guides/automation/webhooks#2021-10-20",
+  // Add new versions here: [WebhookVersion.V_YYYY_MM_DD]: "https://cal.com/docs/webhooks/v-yyyy-mm-dd",
+};
+
+/**
+ * Get documentation URL for a specific webhook version
+ */
+export const getWebhookVersionDocsUrl = (version: WebhookVersion): string =>
+  WEBHOOK_VERSION_DOCS[version] ?? "https://cal.com/docs/developing/guides/automation/webhooks";
+
 export const WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP = {
   core: [
     WebhookTriggerEvents.BOOKING_CANCELLED,

--- a/packages/features/webhooks/pages/webhook-edit-view.tsx
+++ b/packages/features/webhooks/pages/webhook-edit-view.tsx
@@ -94,11 +94,14 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
                   />
                 </div>
               </Tooltip>
-              <Tooltip content={t("webhook_version_docs")}>
+              <Tooltip
+                content={t("webhook_version_docs", {
+                  version: getWebhookVersionLabel(formMethods.watch("version")),
+                })}>
                 <Link
                   href={getWebhookVersionDocsUrl(formMethods.watch("version"))}
                   target="_blank"
-                  className="text-subtle hover:text-emphasis">
+                  className="text-subtle hover:text-emphasis flex items-center">
                   <Icon name="external-link" className="h-4 w-4" />
                 </Link>
               </Tooltip>

--- a/packages/features/webhooks/pages/webhook-edit-view.tsx
+++ b/packages/features/webhooks/pages/webhook-edit-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import SettingsHeaderWithBackButton from "@calcom/features/settings/appDir/SettingsHeaderWithBackButton";
@@ -8,9 +9,10 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { WebhookTriggerEvents } from "@calcom/prisma/enums";
 
 import type { WebhookVersion } from "../lib/interface/IWebhookRepository";
-import { WEBHOOK_VERSION_OPTIONS, getWebhookVersionLabel } from "../lib/constants";
+import { WEBHOOK_VERSION_OPTIONS, getWebhookVersionLabel, getWebhookVersionDocsUrl } from "../lib/constants";
 import { trpc } from "@calcom/trpc/react";
 import { Select } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonContainer } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
@@ -74,23 +76,33 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
           description={t("add_webhook_description", { appName: APP_NAME })}
           borderInShellHeader={true}
           CTA={
-            <Tooltip content={t("webhook_version")}>
-              <div>
-                <Select
-                  className="min-w-36"
-                  options={WEBHOOK_VERSION_OPTIONS}
-                  value={{
-                    value: formMethods.watch("version"),
-                    label: getWebhookVersionLabel(formMethods.watch("version")),
-                  }}
-                  onChange={(option) => {
-                    if (option) {
-                      formMethods.setValue("version", option.value, { shouldDirty: true });
-                    }
-                  }}
-                />
-              </div>
-            </Tooltip>
+            <div className="flex items-center gap-2">
+              <Tooltip content={t("webhook_version")}>
+                <div>
+                  <Select
+                    className="min-w-36"
+                    options={WEBHOOK_VERSION_OPTIONS}
+                    value={{
+                      value: formMethods.watch("version"),
+                      label: getWebhookVersionLabel(formMethods.watch("version")),
+                    }}
+                    onChange={(option) => {
+                      if (option) {
+                        formMethods.setValue("version", option.value, { shouldDirty: true });
+                      }
+                    }}
+                  />
+                </div>
+              </Tooltip>
+              <Tooltip content={t("webhook_version_docs")}>
+                <Link
+                  href={getWebhookVersionDocsUrl(formMethods.watch("version"))}
+                  target="_blank"
+                  className="text-subtle hover:text-emphasis">
+                  <Icon name="external-link" className="h-4 w-4" />
+                </Link>
+              </Tooltip>
+            </div>
           }>
           {children}
         </SettingsHeaderWithBackButton>

--- a/packages/features/webhooks/pages/webhook-new-view.tsx
+++ b/packages/features/webhooks/pages/webhook-new-view.tsx
@@ -110,11 +110,14 @@ export const NewWebhookView = ({ webhooks, installedApps }: Props) => {
                   />
                 </div>
               </Tooltip>
-              <Tooltip content={t("webhook_version_docs")}>
+              <Tooltip
+                content={t("webhook_version_docs", {
+                  version: getWebhookVersionLabel(formMethods.watch("version")),
+                })}>
                 <Link
                   href={getWebhookVersionDocsUrl(formMethods.watch("version"))}
                   target="_blank"
-                  className="text-subtle hover:text-emphasis">
+                  className="text-subtle hover:text-emphasis flex items-center">
                   <Icon name="external-link" className="h-4 w-4" />
                 </Link>
               </Tooltip>

--- a/packages/features/webhooks/pages/webhook-new-view.tsx
+++ b/packages/features/webhooks/pages/webhook-new-view.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import SettingsHeaderWithBackButton from "@calcom/features/settings/appDir/SettingsHeaderWithBackButton";
 import { APP_NAME } from "@calcom/lib/constants";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { WEBHOOK_VERSION_OPTIONS, getWebhookVersionLabel } from "../lib/constants";
+import { WEBHOOK_VERSION_OPTIONS, getWebhookVersionLabel, getWebhookVersionDocsUrl } from "../lib/constants";
 import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Select } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { revalidateWebhooksList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/actions";
@@ -90,23 +92,33 @@ export const NewWebhookView = ({ webhooks, installedApps }: Props) => {
           description={t("add_webhook_description", { appName: APP_NAME })}
           borderInShellHeader={true}
           CTA={
-            <Tooltip content={t("webhook_version")}>
-              <div>
-                <Select
-                  className="min-w-36"
-                  options={WEBHOOK_VERSION_OPTIONS}
-                  value={{
-                    value: formMethods.watch("version"),
-                    label: getWebhookVersionLabel(formMethods.watch("version")),
-                  }}
-                  onChange={(option) => {
-                    if (option) {
-                      formMethods.setValue("version", option.value, { shouldDirty: true });
-                    }
-                  }}
-                />
-              </div>
-            </Tooltip>
+            <div className="flex items-center gap-2">
+              <Tooltip content={t("webhook_version")}>
+                <div>
+                  <Select
+                    className="min-w-36"
+                    options={WEBHOOK_VERSION_OPTIONS}
+                    value={{
+                      value: formMethods.watch("version"),
+                      label: getWebhookVersionLabel(formMethods.watch("version")),
+                    }}
+                    onChange={(option) => {
+                      if (option) {
+                        formMethods.setValue("version", option.value, { shouldDirty: true });
+                      }
+                    }}
+                  />
+                </div>
+              </Tooltip>
+              <Tooltip content={t("webhook_version_docs")}>
+                <Link
+                  href={getWebhookVersionDocsUrl(formMethods.watch("version"))}
+                  target="_blank"
+                  className="text-subtle hover:text-emphasis">
+                  <Icon name="external-link" className="h-4 w-4" />
+                </Link>
+              </Tooltip>
+            </div>
           }>
           {children}
         </SettingsHeaderWithBackButton>


### PR DESCRIPTION
## What does this PR do?

Adds documentation hyperlinks for webhook versions across the webhook management UI. Users can now quickly access the payload documentation for the specific webhook version they're using or viewing.

**Changes:**
- Added `WEBHOOK_VERSION_DOCS` mapping and `getWebhookVersionDocsUrl()` helper in `packages/features/webhooks/lib/constants.ts`
- Added external link icon next to the version selector on the **New Webhook** page
- Added external link icon next to the version selector on the **Edit Webhook** page
- Added external link icon next to the version badge in the **Webhook List** view
- Added `webhook_version_docs` translation key with version interpolation

This improves developer experience by providing easy access to webhook payload documentation directly from the UI.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

| Location | Before | After |
|----------|--------|-------|
| Webhook List | Version badge only | Version badge + external link icon |
| New/Edit Webhook | Version dropdown only | Version dropdown + external link icon |

The external link icon (↗) appears next to the version badge/selector and opens the version-specific documentation in a new tab. Hovering shows tooltip: "View payload documentation for version 2021-10-20"

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - This links to existing docs, no doc changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to **Settings → Developer → Webhooks**
2. **Webhook List View:**
   - Verify each webhook shows an external link icon (↗) next to the version badge
   - Hover over the icon - should show tooltip "View payload documentation for version 2021-10-20"
   - Click the icon - should open docs page in new tab
3. **New Webhook Page:**
   - Click "New" to create a webhook
   - Verify external link icon appears next to the version dropdown in the header
   - Hover and click to verify tooltip and link work
4. **Edit Webhook Page:**
   - Click "Edit" on an existing webhook
   - Verify external link icon appears next to the version dropdown
   - Verify tooltip shows correct version and link opens docs

**Expected behavior:**
- Icon should be vertically centered with adjacent elements
- Tooltip should display: "View payload documentation for version {version}"
- Link should open: `https://cal.com/docs/developing/guides/automation/webhooks#2021-10-20`

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings