### PR TITLE
fix: event type not installed apps list empty

### DIFF
--- a/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
+++ b/packages/platform/atoms/event-types/hooks/useTabsNavigations.tsx
@@ -67,8 +67,7 @@ export const useTabsNavigations = ({
 
   const activeWebhooksNumber = eventType.webhooks.filter((webhook) => webhook.active).length;
 
-  const installedAppsNumber = eventTypeApps?.items.length || 0;
-
+  const installedAppsNumber = eventTypeApps?.items.filter((app) => app.isInstalled).length || 0;
   const enabledWorkflowsNumber = allActiveWorkflows ? allActiveWorkflows.length : 0;
 
   const eventTypeId = formMethods.getValues("id");
@@ -104,12 +103,11 @@ export const useTabsNavigations = ({
           ? formMethods.getValues("schedule") === null
             ? t("members_default_schedule")
             : isChildrenManagedEventType
-            ? `${
-                formMethods.getValues("scheduleName")
-                  ? `${formMethods.getValues("scheduleName")} - ${t("managed")}`
-                  : t(`default_schedule_name`)
+              ? `${formMethods.getValues("scheduleName")
+                ? `${formMethods.getValues("scheduleName")} - ${t("managed")}`
+                : t(`default_schedule_name`)
               }`
-            : formMethods.getValues("scheduleName") ?? t(`default_schedule_name`)
+              : formMethods.getValues("scheduleName") ?? t(`default_schedule_name`)
           : formMethods.getValues("scheduleName") ?? t(`default_schedule_name`),
       "data-testid": "availability",
     });
@@ -119,9 +117,8 @@ export const useTabsNavigations = ({
         name: t("assignment"),
         href: `/event-types/${eventTypeId}?tabName=team`,
         icon: "users",
-        info: `${t(watchSchedulingType?.toLowerCase() ?? "")}${
-          isManagedEventType ? ` - ${t("number_member", { count: watchChildrenCount || 0 })}` : ""
-        }`,
+        info: `${t(watchSchedulingType?.toLowerCase() ?? "")}${isManagedEventType ? ` - ${t("number_member", { count: watchChildrenCount || 0 })}` : ""
+          }`,
         "data-testid": "assignment",
       });
     }

--- a/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -170,7 +170,6 @@ const EventTypeWeb = ({
   const { data: eventTypeApps, isPending: isPendingApps } = trpc.viewer.apps.integrations.useQuery({
     extendsFeature: "EventType",
     teamId: eventType.team?.id || eventType.parent?.teamId,
-    onlyInstalled: true,
   });
 
   // Check workflow permissions


### PR DESCRIPTION
## What does this PR do?

https://github.com/calcom/cal.com/pull/24491 introduced the bug

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

<img width="1512" height="982" alt="Screenshot 2025-12-22 at 6 08 22 PM" src="https://github.com/user-attachments/assets/cc211774-702b-407c-b94d-292d53c7b61c" />


<img width="1512" height="982" alt="Screenshot 2025-12-22 at 6 22 32 PM" src="https://github.com/user-attachments/assets/4746f1c8-4d3c-407d-a968-3ad5d615beff" />





## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Event Type “Apps” tab showing an empty list for not‑installed integrations. We now load all integrations and correctly display the installed count.

- **Bug Fixes**
  - Query all integrations (removed onlyInstalled) so not‑installed apps appear.
  - Installed apps badge counts only apps with isInstalled.
  - Minor label formatting cleanup in Availability and Assignment tabs.

<sup>Written for commit 03406b2aaf6c24318b3d91df49f6a30796cd0215. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



