### PR TITLE
fix: create host records when team membership transitions to accepted via PATCH

### DIFF
--- a/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.e2e-spec.ts
@@ -307,6 +307,57 @@ describe("Teams Memberships Endpoints", () => {
         });
     });
 
+    it("should assign team wide events when membership transitions from accepted=false to accepted=true via PATCH", async () => {
+      const pendingUserEmail = `pending-user-${randomString()}@api.com`;
+      const pendingUser = await userRepositoryFixture.create({
+        email: pendingUserEmail,
+        username: pendingUserEmail,
+        bio,
+        metadata,
+      });
+
+      const createPendingMembershipBody: CreateTeamMembershipInput = {
+        userId: pendingUser.id,
+        accepted: false,
+        role: "MEMBER",
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post(`/v2/teams/${team.id}/memberships`)
+        .send(createPendingMembershipBody)
+        .expect(201);
+
+      const pendingMembership: TeamMembershipOutput = createResponse.body.data;
+      expect(pendingMembership.accepted).toEqual(false);
+
+      const teamEventTypesBeforePatch = await eventTypesRepositoryFixture.getAllTeamEventTypes(team.id);
+      const collectiveEventBeforePatch = teamEventTypesBeforePatch?.find(
+        (eventType) => eventType.slug === teamEventType.slug
+      );
+      const userHostBeforePatch = collectiveEventBeforePatch?.hosts.find((host) => host.userId === pendingUser.id);
+      expect(userHostBeforePatch).toBeFalsy();
+
+      const updateToAcceptedBody: UpdateTeamMembershipInput = {
+        accepted: true,
+      };
+
+      const patchResponse = await request(app.getHttpServer())
+        .patch(`/v2/teams/${team.id}/memberships/${pendingMembership.id}`)
+        .send(updateToAcceptedBody)
+        .expect(200);
+
+      const acceptedMembership: TeamMembershipOutput = patchResponse.body.data;
+      expect(acceptedMembership.accepted).toEqual(true);
+
+      await userHasCorrectEventTypes(pendingUser.id);
+
+      await request(app.getHttpServer())
+        .delete(`/v2/teams/${team.id}/memberships/${pendingMembership.id}`)
+        .expect(200);
+
+      await userRepositoryFixture.deleteByEmail(pendingUserEmail);
+    });
+
     it("should delete the membership of the org's team we created via api", async () => {
       return request(app.getHttpServer())
         .delete(`/v2/teams/${team.id}/memberships/${membershipCreatedViaApi.id}`)

--- a/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.ts
+++ b/apps/api/v2/src/modules/teams/memberships/controllers/teams-memberships.controller.ts
@@ -118,8 +118,6 @@ export class TeamsMembershipsController {
     @Param("membershipId", ParseIntPipe) membershipId: number,
     @Body() body: UpdateTeamMembershipInput
   ): Promise<UpdateTeamMembershipOutput> {
-    const membership = await this.teamsMembershipsService.updateTeamMembership(teamId, membershipId, body);
-
     const currentMembership = await this.teamsMembershipsService.getTeamMembership(teamId, membershipId);
 
     const updatedMembership = await this.teamsMembershipsService.updateTeamMembership(
@@ -127,6 +125,7 @@ export class TeamsMembershipsController {
       membershipId,
       body
     );
+
     if (!currentMembership.accepted && updatedMembership.accepted) {
       try {
         await updateNewTeamMemberEventTypes(updatedMembership.userId, teamId);
@@ -134,9 +133,10 @@ export class TeamsMembershipsController {
         this.logger.error("Could not update new team member eventTypes", err);
       }
     }
+
     return {
       status: SUCCESS_STATUS,
-      data: plainToClass(TeamMembershipOutput, membership, { strategy: "excludeAll" }),
+      data: plainToClass(TeamMembershipOutput, updatedMembership, { strategy: "excludeAll" }),
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the `/v2/teams/:teamId/memberships/:membershipId` PATCH endpoint where host records for `assignAllTeamMembers` event types were not being created when a membership transitioned from `accepted=false` to `accepted=true`.

**Root cause:** The code was updating the membership BEFORE reading the current state, so the transition check (`!currentMembership.accepted && updatedMembership.accepted`) never fired because `currentMembership` was already updated.

**The fix:** Reorder operations to get current membership state BEFORE updating, matching the pattern already used in the org-scoped controller (`organizations-teams-memberships.controller.ts`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

The new e2e test covers this scenario:
1. Create a team membership with `accepted: false`
2. Verify no host records exist for `assignAllTeamMembers` event types
3. PATCH the membership to `accepted: true`
4. Verify host records are now created

To run the test:
```bash
TZ=UTC yarn test --filter=@calcom/api-v2 -- --testPathPattern="teams-memberships.controller.e2e-spec"
```

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the operation ordering now correctly gets current state BEFORE updating (line 121 in new code)
- [ ] Verify the response now returns `updatedMembership` instead of the stale first-update result
- [ ] Verify the fix matches the pattern in `organizations-teams-memberships.controller.ts` (lines 147-162)

---
Link to Devin run: https://app.devin.ai/sessions/820cbf7c34d648ab89bfb9827e9d3d72
Requested by: hariom@cal.com (@hariombalhara)