### PR TITLE
fix(web): resolve build errors on Windows (invalid headers & regex path separators)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -154,26 +154,26 @@ const orgDomainMatcherConfig: {
   root: nextJsOrgRewriteConfig.disableRootPathRewrite
     ? null
     : {
-        has: [
-          {
-            type: "host",
-            value: nextJsOrgRewriteConfig.orgHostPath,
-          },
-        ],
-        source: "/",
-      },
+      has: [
+        {
+          type: "host",
+          value: nextJsOrgRewriteConfig.orgHostPath,
+        },
+      ],
+      source: "/",
+    },
 
   rootEmbed: nextJsOrgRewriteConfig.disableRootEmbedPathRewrite
     ? null
     : {
-        has: [
-          {
-            type: "host",
-            value: nextJsOrgRewriteConfig.orgHostPath,
-          },
-        ],
-        source: "/embed",
-      },
+      has: [
+        {
+          type: "host",
+          value: nextJsOrgRewriteConfig.orgHostPath,
+        },
+      ],
+      source: "/embed",
+    },
 
   user: {
     has: [
@@ -306,31 +306,31 @@ const nextConfig = (phase: string): NextConfig => {
         },
         ...(isOrganizationsEnabled
           ? [
-              orgDomainMatcherConfig.root
-                ? {
-                    ...orgDomainMatcherConfig.root,
-                    destination: `/team/${orgSlug}?isOrgProfile=1`,
-                  }
-                : null,
-              orgDomainMatcherConfig.rootEmbed
-                ? {
-                    ...orgDomainMatcherConfig.rootEmbed,
-                    destination: `/team/${orgSlug}/embed?isOrgProfile=1`,
-                  }
-                : null,
-              {
-                ...orgDomainMatcherConfig.user,
-                destination: `/org/${orgSlug}/:user`,
-              },
-              {
-                ...orgDomainMatcherConfig.userType,
-                destination: `/org/${orgSlug}/:user/:type`,
-              },
-              {
-                ...orgDomainMatcherConfig.userTypeEmbed,
-                destination: `/org/${orgSlug}/:user/:type/embed`,
-              },
-            ]
+            orgDomainMatcherConfig.root
+              ? {
+                ...orgDomainMatcherConfig.root,
+                destination: `/team/${orgSlug}?isOrgProfile=1`,
+              }
+              : null,
+            orgDomainMatcherConfig.rootEmbed
+              ? {
+                ...orgDomainMatcherConfig.rootEmbed,
+                destination: `/team/${orgSlug}/embed?isOrgProfile=1`,
+              }
+              : null,
+            {
+              ...orgDomainMatcherConfig.user,
+              destination: `/org/${orgSlug}/:user`,
+            },
+            {
+              ...orgDomainMatcherConfig.userType,
+              destination: `/org/${orgSlug}/:user/:type`,
+            },
+            {
+              ...orgDomainMatcherConfig.userTypeEmbed,
+              destination: `/org/${orgSlug}/:user/:type/embed`,
+            },
+          ]
           : []),
       ].filter(isNotNull);
 
@@ -449,7 +449,7 @@ const nextConfig = (phase: string): NextConfig => {
           headers: [CORP_CROSS_ORIGIN_HEADER],
         },
         {
-          source: "/icons/sprite.svg(\\?v=[0-9a-zA-Z\\-\\.]+)?",
+          source: "/icons/sprite.svg",
           headers: [
             CORP_CROSS_ORIGIN_HEADER,
             ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
@@ -461,45 +461,45 @@ const nextConfig = (phase: string): NextConfig => {
         },
         ...(isOrganizationsEnabled
           ? [
-              orgDomainMatcherConfig.root
-                ? {
-                    ...orgDomainMatcherConfig.root,
-                    headers: [
-                      {
-                        key: "X-Cal-Org-path",
-                        value: `/team/${orgSlug}`,
-                      },
-                    ],
-                  }
-                : null,
-              {
-                ...orgDomainMatcherConfig.user,
+            orgDomainMatcherConfig.root
+              ? {
+                ...orgDomainMatcherConfig.root,
                 headers: [
                   {
                     key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user`,
+                    value: `/team/${orgSlug}`,
                   },
                 ],
-              },
-              {
-                ...orgDomainMatcherConfig.userType,
-                headers: [
-                  {
-                    key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user/:type`,
-                  },
-                ],
-              },
-              {
-                ...orgDomainMatcherConfig.userTypeEmbed,
-                headers: [
-                  {
-                    key: "X-Cal-Org-path",
-                    value: `/org/${orgSlug}/:user/:type/embed`,
-                  },
-                ],
-              },
-            ]
+              }
+              : null,
+            {
+              ...orgDomainMatcherConfig.user,
+              headers: [
+                {
+                  key: "X-Cal-Org-path",
+                  value: `/org/${orgSlug}/:user`,
+                },
+              ],
+            },
+            {
+              ...orgDomainMatcherConfig.userType,
+              headers: [
+                {
+                  key: "X-Cal-Org-path",
+                  value: `/org/${orgSlug}/:user/:type`,
+                },
+              ],
+            },
+            {
+              ...orgDomainMatcherConfig.userTypeEmbed,
+              headers: [
+                {
+                  key: "X-Cal-Org-path",
+                  value: `/org/${orgSlug}/:user/:type/embed`,
+                },
+              ],
+            },
+          ]
           : []),
       ].filter(isNotNull);
     },
@@ -625,22 +625,22 @@ const nextConfig = (phase: string): NextConfig => {
           permanent: true,
         },
         ...(process.env.NODE_ENV === "development" &&
-        isOrganizationsEnabled &&
-        process.env.NEXT_PUBLIC_WEBAPP_URL !== "http://localhost:3000"
+          isOrganizationsEnabled &&
+          process.env.NEXT_PUBLIC_WEBAPP_URL !== "http://localhost:3000"
           ? [
-              {
-                has: [
-                  {
-                    type: "header" as const,
-                    key: "host",
-                    value: "localhost:3000",
-                  },
-                ],
-                source: "/api/integrations/:args*",
-                destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/api/integrations/:args*`,
-                permanent: false,
-              },
-            ]
+            {
+              has: [
+                {
+                  type: "header" as const,
+                  key: "host",
+                  value: "localhost:3000",
+                },
+              ],
+              source: "/api/integrations/:args*",
+              destination: `${process.env.NEXT_PUBLIC_WEBAPP_URL}/api/integrations/:args*`,
+              permanent: false,
+            },
+          ]
           : []),
       ];
 

--- a/apps/web/pagesAndRewritePaths.ts
+++ b/apps/web/pagesAndRewritePaths.ts
@@ -24,7 +24,7 @@ export const topLevelRoutesExcludedFromOrgRewrite: string[] = globSync(
   }
 )
   .map((filename) =>
-    filename
+    filename.split("\\").join("/")
       // Remove the directory prefix (pages/, app/ and route group folders.)
       .replace(
         /^(app\/\(use-page-wrapper\)\/\(main-nav\)|app\/\(use-page-wrapper\)|app\/\(booking-page-wrapper\)|pages|app)\//,


### PR DESCRIPTION

## Description

This PR fixes two specific issues preventing the `@calcom/web` app from building successfully on Windows environments:

1.  **Invalid Path Separators in Rewrite Logic**:

    - In `apps/web/pagesAndRewritePaths.ts`, `globSync` returns paths with backslashes (`\`) on Windows.
    - These paths are used to construct a Regex for excluded routes. Backslashes in the regex string were causing "Invalid route source" errors or matching failures because they were interpreted as escape characters or literal backslashes rather than path separators.
    - **Fix**: Normalized all file paths to use forward slashes (`/`) regardless of the OS.

2.  **Invalid Source Pattern in `next.config.ts`**:
    - The `sprite.svg` route configuration included a query string matcher `(\\?v=[0-9a-zA-Z\\-\\.]+)?`.
    - Next.js `rewrites` and `headers` `source` fields **do not support query strings**. Including them causes "Invalid headers found" or route parsing errors.
    - **Fix**: Simplified the source to `/icons/sprite.svg`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)

## How Has This Been Tested?

- **Local Build (Windows)**: Ran `npm run build` in `apps/web`. Confirmed that the build process now passes the configuration parsing and route generation stages where it previously failed immediately.
- **Note**: The build is memory intensive. It is recommended to use `NODE_OPTIONS="--max-old-space-size=8192"` if encountering OOM errors.
