### PR TITLE
fix: reduce flakiness in analytics apps e2e tests

### DIFF
--- a/apps/web/playwright/apps/analytics/analyticsApps.e2e.ts
+++ b/apps/web/playwright/apps/analytics/analyticsApps.e2e.ts
@@ -15,10 +15,8 @@ test.describe("check analytics Apps", () => {
       }) => {
         const user = await users.create();
         await user.apiLogin();
-        await page.goto("apps/categories/analytics");
+        await page.goto("/apps/categories/analytics");
         await appsPage.installAnalyticsAppSkipConfigure(app);
-        // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(1000); // waits for 1 second
         await page.goto("/event-types");
         await appsPage.goToEventType("30 min");
         await appsPage.goToAppsTab();


### PR DESCRIPTION
## What does this PR do?

Fixes flaky analytics apps e2e tests (`gtm` and `metapixel`) that were failing intermittently on CI with "element(s) not found" errors.

Root causes identified and fixed:
- **Missing leading `/` in URLs**: `page.goto("apps/categories/analytics")` resolved incorrectly when the current URL was `/event-types`, causing navigation to wrong routes
- **Missing await on click**: `(await page.waitForSelector(...)).click()` didn't await the click, causing race conditions
- **Hardcoded waits**: `waitForTimeout(1000)` was unreliable on CI; replaced with proper element visibility waits
- **Fragile verification**: Combined selector `[data-testid='${app}-app-switch'][data-state="checked"]` failed if element wasn't immediately in checked state

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only changes
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the analytics apps e2e tests multiple times to verify reduced flakiness:
   ```bash
   PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/apps/analytics/analyticsApps.e2e.ts
   ```
2. The tests should pass consistently without intermittent failures
3. CI should show these tests passing on the PR

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify URL path changes are correct (relative → absolute with leading `/`)
- [ ] Confirm `Promise.all` pattern is correctly applied for navigation-triggering clicks
- [ ] Check that visibility waits are sufficient before interacting with elements
- [ ] Note: `installConferencingAppNewFlow` was also updated - verify this doesn't break other conferencing app tests

---

**Link to Devin run**: https://app.devin.ai/sessions/5c114465ab4c40c292507bf7c51d190a
**Requested by**: keith@cal.com (@keithwillcode)