### PR TITLE
perf: pass app data to OmniInstallAppButton to avoid redundant API calls

### DIFF
--- a/packages/app-store/_components/AppCard.tsx
+++ b/packages/app-store/_components/AppCard.tsx
@@ -116,6 +116,7 @@ export default function AppCard({
               <OmniInstallAppButton
                 className="ml-auto flex items-center"
                 appId={app.slug}
+                app={app}
                 returnTo={returnTo}
                 teamId={teamId}
                 onAppInstallSuccess={onAppInstallSuccess}

--- a/packages/app-store/_components/OmniInstallAppButton.tsx
+++ b/packages/app-store/_components/OmniInstallAppButton.tsx
@@ -27,7 +27,6 @@ export default function OmniInstallAppButton({
   onAppInstallSuccess,
 }: {
   appId: string;
-  /** Pre-fetched app data. When provided, skips the useApp query to avoid redundant API calls. */
   app?: AppData;
   className: string;
   onAppInstallSuccess: () => void;
@@ -35,7 +34,6 @@ export default function OmniInstallAppButton({
   teamId?: number;
 }) {
   const { t } = useLocale();
-  // Only fetch app data if not provided via props
   const { data: fetchedApp } = useApp(appId, { enabled: !appProp });
   const app = appProp ?? fetchedApp;
 

--- a/packages/app-store/_components/OmniInstallAppButton.tsx
+++ b/packages/app-store/_components/OmniInstallAppButton.tsx
@@ -5,27 +5,39 @@ import { Button } from "@calcom/ui/components/button";
 import { showToast } from "@calcom/ui/components/toast";
 
 import { InstallAppButton } from "../InstallAppButton";
+import type { AppCardApp } from "../types";
 import useAddAppMutation from "../_utils/useAddAppMutation";
+
+type AppData = Pick<AppCardApp, "type" | "variant" | "slug" | "teamsPlanRequired">;
 
 /**
  * Use this component to allow installing an app from anywhere on the app.
- * Use of this component requires you to remove custom InstallAppButtonComponent so that it can manage the redirection itself
+ * Use of this component requires you to remove custom InstallAppButtonComponent so that it can manage the redirection itself.
+ *
+ * When `app` prop is provided, it will use that data directly instead of fetching via useApp.
+ * This is useful when the app data is already available (e.g., from the integrations query)
+ * to avoid redundant API calls that can cause URL length issues when batched.
  */
 export default function OmniInstallAppButton({
   appId,
+  app: appProp,
   className,
   returnTo,
   teamId,
   onAppInstallSuccess,
 }: {
   appId: string;
+  /** Pre-fetched app data. When provided, skips the useApp query to avoid redundant API calls. */
+  app?: AppData;
   className: string;
   onAppInstallSuccess: () => void;
   returnTo?: string;
   teamId?: number;
 }) {
   const { t } = useLocale();
-  const { data: app } = useApp(appId);
+  // Only fetch app data if not provided via props
+  const { data: fetchedApp } = useApp(appId, { enabled: !appProp });
+  const app = appProp ?? fetchedApp;
 
   const mutation = useAddAppMutation(null, {
     returnTo,

--- a/packages/features/apps/hooks/useApp.ts
+++ b/packages/features/apps/hooks/useApp.ts
@@ -2,13 +2,13 @@ import { useSession } from "next-auth/react";
 
 import { trpc } from "@calcom/trpc/react";
 
-export default function useApp(appId: string) {
+export default function useApp(appId: string, options?: { enabled?: boolean }) {
   const { status } = useSession();
 
   return trpc.viewer.apps.appById.useQuery(
     { appId },
     {
-      enabled: status === "authenticated",
+      enabled: status === "authenticated" && (options?.enabled ?? true),
     }
   );
 }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pass pre-fetched app data to OmniInstallAppButton and only fetch when needed to avoid redundant API calls. This reduces URL length issues from batched requests on the Apps tab.

- **Refactors**
  - Added optional app prop to OmniInstallAppButton and use it when provided.
  - Updated useApp(appId, { enabled }) to control the query; skip when app is passed.
  - AppCard now passes app to OmniInstallAppButton.

<sup>Written for commit e8a77bbfdc1e6a42f7c2ce357af6ee991694da62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



