### PR TITLE
fix: improve flaky E2E tests for payment apps and reschedule

### DIFF
--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -109,10 +109,18 @@ export async function selectFirstAvailableTimeSlotNextMonth(page: Page | Frame) 
   // Let current month dates fully render.
   await page.getByTestId("incrementMonth").click();
 
-  // Waiting for full month increment
-  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).click();
+  // Wait for calendar to be ready - ensure at least one enabled day is visible
+  const enabledDayLocator = page.locator('[data-testid="day"][data-disabled="false"]');
+  await enabledDayLocator.first().waitFor({ state: "visible", timeout: 10000 });
 
-  await page.locator('[data-testid="time"]').nth(0).click();
+  // Click the first enabled day
+  await enabledDayLocator.nth(0).click();
+
+  // Wait for time slots to load after selecting a day
+  const timeSlotLocator = page.locator('[data-testid="time"]');
+  await timeSlotLocator.first().waitFor({ state: "visible", timeout: 10000 });
+
+  await timeSlotLocator.nth(0).click();
 }
 
 export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
@@ -515,8 +523,14 @@ export async function submitAndWaitForJsonResponse(
 }
 
 export async function confirmReschedule(page: Page, url = "/api/book/event") {
+  const confirmButton = page.locator('[data-testid="confirm-reschedule-button"]');
+  // Wait for the button to be visible and stable before clicking
+  await confirmButton.waitFor({ state: "visible", timeout: 10000 });
+  // Small delay to ensure button is stable after any re-renders
+  await page.waitForTimeout(500);
+
   await submitAndWaitForResponse(page, url, {
-    action: () => page.locator('[data-testid="confirm-reschedule-button"]').click(),
+    action: () => confirmButton.click(),
   });
 }
 export async function confirmBooking(page: Page, url = "/api/book/event") {

--- a/apps/web/playwright/payment-apps.e2e.ts
+++ b/apps/web/playwright/payment-apps.e2e.ts
@@ -92,15 +92,15 @@ test.describe("Payment app", () => {
 
     await page.goto(`${user.username}/${paymentEvent?.slug}`);
 
-    // expect 200 sats to be displayed in page
-    expect(await page.locator("text=350").first()).toBeTruthy();
+    // expect $350.00 to be displayed in page (wait for it to be visible)
+    await expect(page.locator("text=$350.00").first()).toBeVisible();
 
     await selectFirstAvailableTimeSlotNextMonth(page);
-    expect(await page.locator("text=350").first()).toBeTruthy();
+    await expect(page.locator("text=$350.00").first()).toBeVisible();
 
-    // go to /event-types and check if the price is 200 sats
+    // go to /event-types and check if the price is $350.00
     await page.goto(`event-types/`);
-    expect(await page.locator("text=350").first()).toBeTruthy();
+    await expect(page.locator("text=$350.00").first()).toBeVisible();
   });
 
   test("Should be able to edit paypal price, currency", async ({ page, users }) => {
@@ -138,16 +138,16 @@ test.describe("Payment app", () => {
 
     await page.goto(`${user.username}/${paymentEvent?.slug}`);
 
-    // expect 150 to be displayed in page
-    expect(await page.locator("text=MX$150.00").first()).toBeTruthy();
+    // expect MX$150.00 to be displayed in page (wait for it to be visible)
+    await expect(page.locator("text=MX$150.00").first()).toBeVisible();
 
     await selectFirstAvailableTimeSlotNextMonth(page);
-    // expect 150 to be displayed in page
-    expect(await page.locator("text=MX$150.00").first()).toBeTruthy();
+    // expect MX$150.00 to be displayed in page
+    await expect(page.locator("text=MX$150.00").first()).toBeVisible();
 
-    // go to /event-types and check if the price is 150
+    // go to /event-types and check if the price is MX$150.00
     await page.goto(`event-types/`);
-    expect(await page.locator("text=MX$150.00").first()).toBeTruthy();
+    await expect(page.locator("text=MX$150.00").first()).toBeVisible();
   });
 
   test("Should display App is not setup already for alby", async ({ page, users }) => {
@@ -168,13 +168,13 @@ test.describe("Payment app", () => {
 
     await page.locator("#event-type-form").getByRole("switch").click();
 
-    // expect text "This app has not been setup yet" to be displayed
-    expect(await page.locator("text=This app has not been setup yet").first()).toBeTruthy();
+    // expect text "This app has not been setup yet" to be displayed (wait for it to be visible)
+    await expect(page.locator("text=This app has not been setup yet").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Setup" }).click();
 
-    // Expect "Connect with Alby" to be displayed
-    expect(await page.locator("text=Connect with Alby").first()).toBeTruthy();
+    // Expect "Connect with Alby" to be displayed (wait for it to be visible)
+    await expect(page.locator("text=Connect with Alby").first()).toBeVisible();
   });
 
   test("Should display App is not setup already for paypal", async ({ page, users }) => {
@@ -195,13 +195,13 @@ test.describe("Payment app", () => {
 
     await page.locator("#event-type-form").getByRole("switch").click();
 
-    // expect text "This app has not been setup yet" to be displayed
-    expect(await page.locator("text=This app has not been setup yet").first()).toBeTruthy();
+    // expect text "This app has not been setup yet" to be displayed (wait for it to be visible)
+    await expect(page.locator("text=This app has not been setup yet").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Setup" }).click();
 
-    // Expect "Getting started with Paypal APP" to be displayed
-    expect(await page.locator("text=Getting started with Paypal APP").first()).toBeTruthy();
+    // Expect "Getting started with Paypal APP" to be displayed (wait for it to be visible)
+    await expect(page.locator("text=Getting started with Paypal APP").first()).toBeVisible();
   });
 
   /**
@@ -229,8 +229,8 @@ test.describe("Payment app", () => {
     await goToAppsTab(page, paymentEvent?.id);
 
     await page.locator("#event-type-form").getByRole("switch").click();
-    // make sure Tracking ID is displayed
-    expect(await page.locator("text=Tracking ID").first()).toBeTruthy();
+    // make sure Tracking ID is displayed (wait for it to be visible)
+    await expect(page.locator("text=Tracking ID").first()).toBeVisible();
     await page.getByLabel("Tracking ID").click();
     await page.getByLabel("Tracking ID").fill("demo");
     await page.getByTestId("update-eventtype").click();


### PR DESCRIPTION
## What does this PR do?

Fixes 6 flaky E2E tests by adding proper element waits and using correct Playwright assertions:

- `payment-apps.e2e.ts:18` - Should be able to edit alby price, currency
- `payment-apps.e2e.ts:61` - Should be able to edit stripe price, currency
- `payment-apps.e2e.ts:106` - Should be able to edit paypal price, currency
- `payment-apps.e2e.ts:153` - Should display App is not setup already for alby
- `payment-apps.e2e.ts:282` - when more than one payment app is installed the price should be updated when changing settings
- `reschedule.e2e.ts:260` - Opt in event should be ACCEPTED when rescheduled by OWNER

**Root causes identified:**
1. `selectFirstAvailableTimeSlotNextMonth` was clicking on day elements before the calendar finished rendering
2. `confirmReschedule` button was being clicked before it was stable (element detached during re-renders)
3. Payment tests used `expect(await page.locator(...)).toBeTruthy()` which doesn't actually wait for elements - it just checks if the locator object exists (always true)

**Fixes applied:**
- Added explicit `waitFor({ state: "visible" })` calls before clicking calendar elements
- Added wait for time slots to load after selecting a day
- Added visibility wait and 500ms stability delay for reschedule confirm button
- Changed payment test assertions to use `toBeVisible()` which properly waits for elements

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the E2E tests multiple times to verify they no longer flake:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e payment-apps.e2e.ts
PLAYWRIGHT_HEADLESS=1 yarn e2e reschedule.e2e.ts
```

The tests should pass consistently without intermittent failures.

## Human Review Checklist

- [ ] Verify the text assertions in payment-apps.e2e.ts match what's actually displayed (e.g., `$350.00` vs `350`)
- [ ] Review the 500ms stability delay in `confirmReschedule` - is this appropriate or should it use a different waiting strategy?
- [ ] Confirm the 10000ms timeouts are consistent with other timeouts in the test utilities

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

### Link to Devin run
https://app.devin.ai/sessions/0f78f59a478b4219887c6539102878ce

### Requested by
keith@cal.com (@keithwillcode)