### PR TITLE
chore: CODEOWNERS Change Platform -> Consumer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@
 /packages/features/bookings/lib/getLuckyUser.ts @calcom/Foundation
 /packages/features/schedules/lib/slots.ts @calcom/Foundation
 /packages/platform/atoms/**/*WebWrapper.tsx @calcom/Consumer
-/packages/platform/**/* @calcom/Platform @calcom/Foundation
+/packages/platform/**/* @calcom/Consumer @calcom/Foundation
 /packages/prisma/**/* @calcom/Foundation
 /packages/trpc/server/routers/viewer/bookings/confirm.handler.ts @calcom/Foundation
 /packages/trpc/server/routers/viewer/bookings/get.handler.ts @calcom/Foundation


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated CODEOWNERS to assign /packages/platform/**/* to the Consumer team instead of Platform, with Foundation remaining co-owner. This ensures the right team is auto-requested for reviews on platform code.

<sup>Written for commit 3741a6612389ee8e253f3747c7af66ed9912587c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





