### PR TITLE
fix: all the e2e flakes visible

### DIFF
--- a/apps/web/playwright/booking-phone-autofill.e2e.ts
+++ b/apps/web/playwright/booking-phone-autofill.e2e.ts
@@ -38,7 +38,10 @@ test.describe("Phone Location Auto-fill Feature", () => {
     // Skip booking confirmation to keep this test fast and focused on autofill behavior
   });
 
-  test("should NOT sync changes from custom phone fields back to location or other fields", async ({ page, users }) => {
+  test("should NOT sync changes from custom phone fields back to location or other fields", async ({
+    page,
+    users,
+  }) => {
     await createUserWithPhoneFields({ users, page });
 
     await gotoBookingPage(page);
@@ -168,13 +171,17 @@ async function fillPhoneLocationInput(page: Page, phoneNumber: string) {
 
   // Ensure the field is empty first
   await locationInput.clear();
-  // Wait for mask/prefix to settle (empty string or just country prefix)
-  await expect.poll(async () => locationInput.inputValue()).toMatch(/^(?:|\+\d{1,3})$/);
+  // Wait for mask/prefix to settle (empty string, just "+", or country prefix)
+  await expect.poll(async () => locationInput.inputValue()).toMatch(/^(?:|\+|\+\d{1,3})$/);
 
-  // If the mask auto-inserts a country prefix, avoid duplicating it
+  // If the mask auto-inserts a country prefix (or just "+"), avoid duplicating it
   const prefill = await locationInput.inputValue();
   let toType = phoneNumber;
-  if (/^\+\d{1,3}$/.test(prefill) && phoneNumber.startsWith(prefill)) {
+  if (prefill === "+" && phoneNumber.startsWith("+")) {
+    // If field has just "+", type the rest without the "+"
+    toType = phoneNumber.slice(1);
+  } else if (/^\+\d{1,3}$/.test(prefill) && phoneNumber.startsWith(prefill)) {
+    // If field has a country prefix like "+1", type the rest
     toType = phoneNumber.slice(prefill.length);
   }
 

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -480,6 +480,9 @@ export async function gotoBookingPage(page: Page) {
   const previewLink = await page.locator("[data-testid=preview-button]").getAttribute("href");
 
   await page.goto(previewLink ?? "");
+  await page.waitForURL((url) => {
+    return url.searchParams.get("overlayCalendar") === "true";
+  });
 }
 
 export async function saveEventType(page: Page) {

--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -672,6 +672,9 @@ async function openBookingFormInPreviewTab(context: PlaywrightTestArgs["context"
   await page.locator('[data-testid="preview-button"]').click();
   const previewTabPage = await previewTabPromise;
   await previewTabPage.waitForLoadState();
+  await page.waitForURL((url) => {
+    return url.searchParams.get("overlayCalendar") === "true";
+  });
   await selectFirstAvailableTimeSlotNextMonth(previewTabPage);
   return previewTabPage;
 }

--- a/apps/web/playwright/manage-booking-questions.e2e.ts
+++ b/apps/web/playwright/manage-booking-questions.e2e.ts
@@ -672,7 +672,7 @@ async function openBookingFormInPreviewTab(context: PlaywrightTestArgs["context"
   await page.locator('[data-testid="preview-button"]').click();
   const previewTabPage = await previewTabPromise;
   await previewTabPage.waitForLoadState();
-  await page.waitForURL((url) => {
+  await previewTabPage.waitForURL((url) => {
     return url.searchParams.get("overlayCalendar") === "true";
   });
   await selectFirstAvailableTimeSlotNextMonth(previewTabPage);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ const IS_EMBED_REACT_TEST = process.argv.some((a) => a.startsWith("--project=@ca
 const webServer: PlaywrightTestConfig["webServer"] = [
   {
     command:
-      "NEXT_PUBLIC_IS_E2E=1 NODE_OPTIONS='--dns-result-order=ipv4first' yarn workspace @calcom/web start -p 3000",
+      "yarn workspace @calcom/web copy-app-store-static && NEXT_PUBLIC_IS_E2E=1 NODE_OPTIONS='--dns-result-order=ipv4first' yarn workspace @calcom/web start -p 3000",
     port: 3000,
     timeout: 60_000,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes flaky e2e tests around booking preview and phone location autofill for more reliable runs. We now wait for the overlay calendar to load and type phone numbers correctly when masks prefill "+" or country prefixes.

- **Bug Fixes**
  - Booking preview: wait for overlayCalendar=true in gotoBookingPage and the preview flow, and copy app store static before starting the web server to avoid missing assets.
  - Phone autofill: wait for the mask to settle (empty, "+", or "+<country>") and avoid duplicating prefixes by typing only the remainder.

<sup>Written for commit bf9d6931ac7abb81816869f53b507e0af9f9030c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





