### PR TITLE
fix: Change matcher params for CI changes matcher

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,7 @@ jobs:
               - '!i18n.lock'
             has_companion:
               - "companion/**"
+          predicate-quantifier: every
       - name: Get Latest Commit SHA
         id: get_sha
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: "every"
           filters: |
             has-files-requiring-all-checks:
               - '**'
@@ -46,7 +47,6 @@ jobs:
               - '!i18n.lock'
             has_companion:
               - "companion/**"
-          predicate-quantifier: "every"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
               - '!i18n.lock'
             has_companion:
               - "companion/**"
-          predicate-quantifier: every
+          predicate-quantifier: "every"
       - name: Get Latest Commit SHA
         id: get_sha
         run: |


### PR DESCRIPTION
## What does this PR do?











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the PR GitHub Actions workflow to require all predicates to pass (predicate-quantifier: every). This ensures jobs only run when all file matching conditions are met, preventing partial-match triggers.

<sup>Written for commit cea952885196d61abc3f87dd4779c21a078f8d79. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




## Reference docs
https://github.com/dorny/paths-filter

<img width="742" height="372" alt="image" src="https://github.com/user-attachments/assets/7c618a36-b63d-4d82-a5c3-d6f577dde112" />






