### PR TITLE
fix: When checking email domains to block replace `includes` with `endsWith`

### DIFF
--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -1345,7 +1345,7 @@ describe("getBookingResponsesPartialSchema - Prefill validation", () => {
 
 describe("excluded email/domain validation", () => {
   test("should fail if the email is present in excluded emails", async () => {
-    const excludedEmails = "spammer@cal.com, hotmail.com, yahoo, @gmail.com";
+    const excludedEmails = "spammer@cal.com, hotmail.com, yahoo.com, gmail.com";
 
     const schema = getBookingResponsesSchema({
       bookingFields: [
@@ -1382,7 +1382,7 @@ describe("excluded email/domain validation", () => {
   });
 
   test("should pass if the email is not present in excluded emails", async () => {
-    const excludedEmails = "spammer@cal.com, hotmail.com, yahoo, @gmail.com";
+    const excludedEmails = "spammer@cal.com, hotmail.com, yahoo.com, gmail.com";
 
     const schema = getBookingResponsesSchema({
       bookingFields: [
@@ -1417,11 +1417,130 @@ describe("excluded email/domain validation", () => {
       email: "harry@workmail.com",
     });
   });
+
+  test("should not block email domains that contain excluded domain as substring", async () => {
+    // This tests the fix for the bug where `includes` was used instead of `endsWith`
+    // e.g., blocking "test.co" should not block "test.com"
+    const excludedEmails = "test.co";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // test.com should NOT be blocked when test.co is excluded
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "user@test.com",
+    });
+
+    expect(parsedResponses.success).toBe(true);
+
+    if (!parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.data).toEqual({
+      name: "test",
+      email: "user@test.com",
+    });
+  });
+
+  test("should block exact domain match when using endsWith", async () => {
+    const excludedEmails = "test.co";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // test.co should be blocked
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "user@test.co",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_EXCLUDED_ERROR_MSG}`,
+      })
+    );
+  });
+
+  test("should not block emails where excluded domain appears in local part", async () => {
+    // Ensures that the @ anchor prevents matching domains in the local part of email
+    const excludedEmails = "blocked.com";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          excludeEmails: excludedEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // Email with blocked.com in local part should not be blocked
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "blocked.com@allowed.com",
+    });
+
+    expect(parsedResponses.success).toBe(true);
+
+    if (!parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.data).toEqual({
+      name: "test",
+      email: "blocked.com@allowed.com",
+    });
+  });
 });
 
 describe("require email/domain validation", () => {
   test("should fail if the required email/domain is not present", async () => {
-    const requiredEmails = "gmail.com, user@hotmail.com, @yahoo.com";
+    const requiredEmails = "gmail.com, user@hotmail.com, yahoo.com";
     const schema = getBookingResponsesSchema({
       bookingFields: [
         {
@@ -1459,7 +1578,7 @@ describe("require email/domain validation", () => {
   });
 
   test("should pass if the required email/domain is present", async () => {
-    const requiredEmails = "gmail.com, user@hotmail.com, @yahoo.com";
+    const requiredEmails = "gmail.com, user@hotmail.com, yahoo.com";
 
     const schema = getBookingResponsesSchema({
       bookingFields: [
@@ -1493,5 +1612,126 @@ describe("require email/domain validation", () => {
       name: "test",
       email: "test@gmail.com",
     });
+  });
+
+  test("should not match email domains that contain required domain as substring", async () => {
+    // This tests the fix for the bug where `includes` was used instead of `endsWith`
+    // e.g., requiring "test.co" should not match "test.com"
+    const requiredEmails = "test.co";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          requireEmails: requiredEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // test.com should NOT match when test.co is required
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "user@test.com",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_REQUIRED_ERROR_MSG}`,
+      })
+    );
+  });
+
+  test("should match exact domain when using endsWith", async () => {
+    const requiredEmails = "test.co";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          requireEmails: requiredEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // test.co should match
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "user@test.co",
+    });
+
+    expect(parsedResponses.success).toBe(true);
+
+    if (!parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.data).toEqual({
+      name: "test",
+      email: "user@test.co",
+    });
+  });
+
+  test("should not match emails where required domain appears in local part", async () => {
+    // Ensures that the @ anchor prevents matching domains in the local part of email
+    const requiredEmails = "required.com";
+
+    const schema = getBookingResponsesSchema({
+      bookingFields: [
+        {
+          name: "name",
+          type: "name",
+          required: true,
+        },
+        {
+          name: "email",
+          type: "email",
+          required: true,
+          requireEmails: requiredEmails,
+        },
+      ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+      view: "ALL_VIEWS",
+    });
+
+    // Email with required.com in local part should not match
+    const parsedResponses = await schema.safeParseAsync({
+      name: "test",
+      email: "required.com@other.com",
+    });
+
+    expect(parsedResponses.success).toBe(false);
+
+    if (parsedResponses.success) {
+      throw new Error("Should not reach here");
+    }
+
+    expect(parsedResponses.error.issues[0]).toEqual(
+      expect.objectContaining({
+        code: "custom",
+        message: `{email}${CUSTOM_EMAIL_REQUIRED_ERROR_MSG}`,
+      })
+    );
   });
 });

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -1,10 +1,10 @@
-import logger from "@calomc/lib/logger";
 import { isValidPhoneNumber } from "libphonenumber-js/max";
 import z from "zod";
 
 import type { ALL_VIEWS } from "@calcom/features/form-builder/schema";
 import { fieldTypesSchemaMap } from "@calcom/features/form-builder/schema";
 import { dbReadResponseSchema } from "@calcom/lib/dbReadResponseSchema";
+import logger from "@calcom/lib/logger";
 import type { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
 import { bookingResponses, emailSchemaRefinement } from "@calcom/prisma/zod-utils";
 

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -208,7 +208,7 @@ function preprocess<T extends z.ZodType>({
             const excludedEmails =
               bookingField.excludeEmails?.split(",").map((domain) => domain.trim()) || [];
 
-            const match = excludedEmails.find((email) => bookerEmail.includes(email));
+            const match = excludedEmails.find((email) => bookerEmail.endsWith("@" + email));
             if (match) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
@@ -220,7 +220,7 @@ function preprocess<T extends z.ZodType>({
                 ?.split(",")
                 .map((domain) => domain.trim())
                 .filter(Boolean) || [];
-            const requiredEmailsMatch = requiredEmails.find((email) => bookerEmail.includes(email));
+            const requiredEmailsMatch = requiredEmails.find((email) => bookerEmail.endsWith("@" + email));
             if (requiredEmails.length > 0 && !requiredEmailsMatch) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When checking email domains we use `includes`. This causes non-blocked domains to be blocked if they contain a substring of the blocked domain ex. `test.com` will be blocked if a blocked domain is `test.co`.

Instead we should use `endsWith` and prepend the `@` symbol as an anchor to ensure that the listed domain is a full match.

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Enter a blocked email domain under an event type like `test.co`
- Try to book with a email domain that contains the blocked domain as a substring like `test.com`
    - The booking should go through

**Automated tests added:**
- `should not block email domains that contain excluded domain as substring` - verifies `test.com` is not blocked when `test.co` is excluded
- `should block exact domain match when using endsWith` - verifies `test.co` is still blocked
- `should not block emails where excluded domain appears in local part` - verifies `blocked.com@allowed.com` is not blocked
- Equivalent tests for `requireEmails` validation

Run tests with: `TZ=UTC yarn test packages/features/bookings/lib/getBookingResponsesSchema.test.ts`

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/1b86710148b84c59b9695c38d52ec30e
**Requested by:** joe@cal.com (@joeauyeung)