### PR TITLE
chore: Change API v2 depends on for CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,42 +183,42 @@ jobs:
 
   integration-test:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build, build-api-v1]
     if: ${{ needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
 
   e2e:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build, build-api-v1]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
   e2e-api-v2:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build-api-v2]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-api-v2.yml
     secrets: inherit
 
   e2e-app-store:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-app-store.yml
     secrets: inherit
 
   e2e-embed:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed.yml
     secrets: inherit
 
   e2e-embed-react:
     name: Tests
-    needs: [prepare, build, build-api-v1, build-api-v2]
+    needs: [prepare, build]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/e2e-embed-react.yml
     secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update CI workflow dependencies to decouple non–API v2 tests from the API v2 build. This reduces unnecessary blocking and speeds up PR checks.

- **Refactors**
  - integration-test and e2e now depend on prepare, build, and build-api-v1 (removed build-api-v2).
  - e2e-api-v2 now depends only on prepare and build-api-v2 (removed build and build-api-v1).
  - e2e-app-store, e2e-embed, and e2e-embed-react now depend on prepare and build (removed API build dependencies).

<sup>Written for commit 2eaadf1481dfb79c5aea5afb35f54d5ff005f180. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

