### PR TITLE
fix: compose CalendarCacheWrapper with CalendarBatchWrapper for proper batching

### DIFF
--- a/packages/app-store/_utils/__tests__/getCalendar.test.ts
+++ b/packages/app-store/_utils/__tests__/getCalendar.test.ts
@@ -205,7 +205,7 @@ describe("getCalendar", () => {
       expect(result.__isBatchWrapper).toBeUndefined();
     });
 
-    test("should prioritize cache wrapper over batch wrapper when both are supported", async () => {
+    test("should compose cache wrapper over batch wrapper when both are supported", async () => {
       const mockCredential = createMockCredential({
         type: "google_calendar",
         delegatedTo: {
@@ -221,9 +221,10 @@ describe("getCalendar", () => {
       const result = (await getCalendar(mockCredential, true)) as TestCalendarResult;
 
       expect(result).toBeDefined();
-      // Cache should take precedence
+      // Cache wrapper should wrap batch wrapper, so both markers should be present
+      // The composition is: CalendarCacheWrapper(CalendarBatchWrapper(originalCalendar))
       expect(result.__isCacheWrapper).toBe(true);
-      expect(result.__isBatchWrapper).toBeUndefined();
+      expect(result.__isBatchWrapper).toBe(true);
     });
 
     test("should determine shouldServeCache from feature flags when not provided", async () => {


### PR DESCRIPTION
## What does this PR do?

Previously, `CalendarCacheWrapper` and `CalendarBatchWrapper` were mutually exclusive - when cache was enabled, the batch wrapper was bypassed entirely. This caused uncached calendars to skip the batching logic, resulting in multiple freebusy API calls per `delegationCredential` instead of one consolidated call.

This PR changes the wrapper composition so that:
- If cache is enabled AND batch is supported: `CalendarCacheWrapper(CalendarBatchWrapper(originalCalendar))`
- If cache is enabled but batch is not supported: `CalendarCacheWrapper(originalCalendar)`
- If cache is not enabled but batch is supported: `CalendarBatchWrapper(originalCalendar)`
- Otherwise: `originalCalendar`

This ensures that when `CalendarCacheWrapper` passes uncached calendars to its underlying calendar, they are still properly batched by `delegationCredentialId` via `CalendarBatchWrapper`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal implementation change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Enable both calendar cache and batch features for a Google Calendar credential with delegation
2. Have some calendars with sync enabled (cached) and some without (uncached)
3. Request availability for multiple calendars sharing the same `delegationCredentialId`
4. Verify in logs that uncached calendars are batched together per `delegationCredentialId` instead of making separate freebusy calls

**Expected behavior:** When both cache and batch are supported, the logs should show:
- "Calendar Batch is supported, wrapping with CalendarBatchWrapper"
- "Calendar Cache is enabled, wrapping with CalendarCacheWrapper" with `hasBatchWrapper: true`

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

---

### Human Review Checklist

- [ ] Verify the wrapper composition order is correct (batch wrapper applied first, then cache wrapper on top)
- [ ] Confirm that `CalendarCacheWrapper.getAvailability()` correctly forwards uncached calendars to its underlying calendar (now `CalendarBatchWrapper`)
- [ ] Verify this change achieves the goal of "one freebusy call per delegationCredential" for uncached calendars

---

Link to Devin run: https://app.devin.ai/sessions/bfd6c7ec011a4f70b20a29961fe1af7b
Requested by: Volnei Munhoz (volnei@cal.com) (@volnei)