### PR TITLE
chore: Use 8 shards for E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase E2E shards in GitHub Actions from 4 to 8 to parallelize test runs and reduce CI time.

<sup>Written for commit a25da942c3e3855a49856a71de3006ece1669bd4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

