### PR TITLE
refactor: Remove buildjet cache from cache-build action

### DIFF
--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -1,5 +1,5 @@
-name: Build production binaries
-description: "Build the web app using Turbo Remote Caching"
+name: Cache production build binaries
+description: "Cache or restore if necessary"
 inputs:
   node_version:
     required: false

--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -1,5 +1,5 @@
-name: Cache production build binaries
-description: "Cache or restore if necessary"
+name: Build production binaries
+description: "Build the web app using Turbo Remote Caching"
 inputs:
   node_version:
     required: false
@@ -7,29 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Cache production build
-      uses: buildjet/cache@v4
-      id: cache-build
-      env:
-        # WARN: Don't touch this cache key. Currently github.sha refers to the latest commit in main
-        # and not the branch that's attempting to merge to main, which causes CI errors when merged
-        # to main.
-        # TODO: Fix this problem if intending to modify this cache key.
-        cache-name: prod-build
-        key-1: ${{ inputs.node_version }}-${{ hashFiles('yarn.lock') }}
-        key-2: ${{ hashFiles('apps/**/**.[jt]s', 'apps/**/**.[jt]sx', 'packages/**/**.[jt]s', 'packages/**/**.[jt]sx', '!**/node_modules') }}
-        key-3: ${{ github.event.pull_request.number || github.ref }}
-        key-4: ${{ github.sha }}
-        key-5: ${{ github.event.pull_request.head.sha }}
-      with:
-        path: |
-          ${{ github.workspace }}/apps/web/.next
-          ${{ github.workspace }}/apps/web/public/embed
-          **/.turbo/**
-          **/dist/**
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}-${{ env.key-5 }}
     - run: |
         export NODE_OPTIONS="--max_old_space_size=8192"
         yarn build
-      if: steps.cache-build.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
## What does this PR do?

Removes the buildjet cache from the `cache-build` GitHub Action and simplifies it to just run `yarn build`, relying on Turbo Remote Caching instead.

**Root cause of the issue:** The buildjet cache was causing consistent cache misses because the `hashFiles()` function in `key-2` was producing different hashes between the build job and E2E shards. This happened because `yarn prisma generate` (run during `yarn-install`) generates `.ts` files in `packages/prisma/zod/` and `packages/kysely/` that are included in the hash pattern, and these generated files can differ slightly between runs.

**Why this fix works:** Since Turbo Remote Caching is already configured and handles the `.next` and `dist` outputs (as defined in `turbo.json`), the buildjet cache is redundant and was causing more problems than it solved.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - CI infrastructure change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - This will be validated by observing CI behavior.

## How should this be tested?

1. Merge this PR and observe a subsequent PR's CI run
2. Verify that E2E shards no longer show "Cache not found" for the prod-build cache
3. Verify that Turbo Remote Caching is being used (look for "Remote cache hit" in build logs)
4. Monitor build times to ensure they're acceptable

## Human Review Checklist

- [x] Verify Turbo Remote Caching is properly configured in CI (TURBO_TOKEN and TURBO_TEAM secrets are set)
- [x] Note: `@calcom/embed-core#build` has `cache: false` in turbo.json, so embed files will rebuild each time (this was an accepted tradeoff)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Updates since last revision

- Preserved the original action name and description per reviewer feedback

---

Link to Devin run: https://app.devin.ai/sessions/31be59cfbeb2411394ffac161d191049
Requested by: keith@cal.com (@keithwillcode)