### PR TITLE
ci: shard API v2 E2E tests into 4 parallel jobs

### DIFF
--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -9,16 +9,19 @@ permissions:
 env:
   API_KEY_PREFIX: ${{ secrets.CI_API_KEY_PREFIX }}
   API_PORT: ${{ vars.CI_API_V2_PORT }}
+  API_URL: "http://localhost"
   CALCOM_LICENSE_KEY: ${{ secrets.CI_CALCOM_LICENSE_KEY }}
   DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
   DATABASE_READ_URL: ${{ secrets.CI_DATABASE_URL }}
   DATABASE_WRITE_URL: ${{ secrets.CI_DATABASE_URL }}
   JWT_SECRET: ${{ secrets.CI_JWT_SECRET }}
   NEXTAUTH_SECRET: ${{ secrets.CI_NEXTAUTH_SECRET }}
+  NODE_ENV: ${{ vars.CI_NODE_ENV }}
   NODE_OPTIONS: --max-old-space-size=4096
   REDIS_URL: "redis://localhost:6379"
   STRIPE_API_KEY: ${{ secrets.CI_STRIPE_PRIVATE_KEY }}
   STRIPE_WEBHOOK_SECRET: ${{ secrets.CI_STRIPE_WEBHOOK_SECRET }}
+  WEB_APP_URL: "https://app.cal.com"
 
 jobs:
   check-api-v2-breaking-changes:

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -7,7 +7,18 @@ permissions:
   contents: read
 
 env:
-  NODE_OPTIONS: --max-old-space-size=29000
+  API_KEY_PREFIX: ${{ secrets.CI_API_KEY_PREFIX }}
+  API_PORT: ${{ vars.CI_API_V2_PORT }}
+  CALCOM_LICENSE_KEY: ${{ secrets.CI_CALCOM_LICENSE_KEY }}
+  DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
+  DATABASE_READ_URL: ${{ secrets.CI_DATABASE_URL }}
+  DATABASE_WRITE_URL: ${{ secrets.CI_DATABASE_URL }}
+  JWT_SECRET: ${{ secrets.CI_JWT_SECRET }}
+  NEXTAUTH_SECRET: ${{ secrets.CI_NEXTAUTH_SECRET }}
+  NODE_OPTIONS: --max-old-space-size=4096
+  REDIS_URL: "redis://localhost:6379"
+  STRIPE_API_KEY: ${{ secrets.CI_STRIPE_PRIVATE_KEY }}
+  STRIPE_WEBHOOK_SECRET: ${{ secrets.CI_STRIPE_WEBHOOK_SECRET }}
 
 jobs:
   check-api-v2-breaking-changes:

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -1,0 +1,36 @@
+name: Check API v2 breaking changes
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-api-v2-breaking-changes:
+    name: Check API v2 breaking changes
+    timeout-minutes: 10
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/dangerous-git-checkout
+      - uses: ./.github/actions/yarn-install
+
+      - name: Generate Swagger
+        working-directory: apps/api/v2
+        run: yarn generate-swagger
+
+      - name: Check API v2 breaking changes
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" -w /work \
+            tufin/oasdiff:latest \
+            breaking \
+            https://raw.githubusercontent.com/calcom/cal.com/refs/heads/main/docs/api-reference/v2/openapi.json \
+            docs/api-reference/v2/openapi.json \
+            --fail-on ERR \
+            --err-ignore .github/oasdiff-err-ignore.txt

--- a/.github/workflows/check-api-v2-breaking-changes.yml
+++ b/.github/workflows/check-api-v2-breaking-changes.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_OPTIONS: --max-old-space-size=29000
+
 jobs:
   check-api-v2-breaking-changes:
     name: Check API v2 breaking changes

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -75,10 +75,28 @@ jobs:
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
 
+      - name: Cache platform-libraries build
+        uses: buildjet/cache@v4
+        id: cache-platform-libraries
+        env:
+          cache-name: platform-libraries-build
+          key-1: ${{ hashFiles('yarn.lock') }}
+          key-2: ${{ hashFiles('packages/platform/libraries/**.[jt]s', 'packages/platform/libraries/**.[jt]sx', '!**/node_modules') }}
+          key-3: ${{ github.event.pull_request.number || github.ref }}
+          key-4: ${{ github.sha }}
+        with:
+          path: |
+            packages/platform/libraries/dist/**
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}
+
+      - name: Build platform-libraries
+        if: steps.cache-platform-libraries.outputs.cache-hit != 'true'
+        run: yarn workspace @calcom/platform-libraries build
+
       - name: Run Tests
         working-directory: apps/api/v2
         run: |
-          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }}
           EXIT_CODE=$?
           echo "yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} command exit code: $EXIT_CODE"
           exit $EXIT_CODE

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -28,38 +28,9 @@ env:
   JWT_SECRET: ${{ secrets.CI_JWT_SECRET }}
   NODE_ENV: ${{ vars.CI_NODE_ENV }}
 jobs:
-  check-api-v2-breaking-changes:
-    timeout-minutes: 10
-    name: Check API v2 breaking changes
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/dangerous-git-checkout
-      - uses: ./.github/actions/yarn-install
-
-      - name: Generate Swagger
-        working-directory: apps/api/v2
-        run: yarn generate-swagger
-
-      - name: Check API v2 breaking changes
-        run: |
-          docker run --rm \
-            -v "$PWD:/work" -w /work \
-            tufin/oasdiff:latest \
-            breaking \
-            https://raw.githubusercontent.com/calcom/cal.com/refs/heads/main/docs/api-reference/v2/openapi.json \
-            docs/api-reference/v2/openapi.json \
-            --fail-on ERR \
-            --err-ignore .github/oasdiff-err-ignore.txt
-
   e2e:
     timeout-minutes: 20
-    name: E2E API v2 (${{ matrix.shard }}/4)
-    needs: check-api-v2-breaking-changes
+    name: E2E API v2 (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: buildjet-16vcpu-ubuntu-2204
     services:
       postgres:
@@ -107,9 +78,9 @@ jobs:
       - name: Run Tests
         working-directory: apps/api/v2
         run: |
-          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/4
+          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }}
           EXIT_CODE=$?
-          echo "yarn test:e2e --shard=${{ matrix.shard }}/4 command exit code: $EXIT_CODE"
+          echo "yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} command exit code: $EXIT_CODE"
           exit $EXIT_CODE
 
       - name: Upload Test Results

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -58,7 +58,7 @@ jobs:
 
   e2e:
     timeout-minutes: 20
-    name: E2E API v2 (${{ matrix.shard }}/${{ strategy.job-total }})
+    name: E2E API v2 (${{ matrix.shard }}/4)
     needs: check-api-v2-breaking-changes
     runs-on: buildjet-16vcpu-ubuntu-2204
     services:
@@ -107,9 +107,9 @@ jobs:
       - name: Run Tests
         working-directory: apps/api/v2
         run: |
-          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/4
           EXIT_CODE=$?
-          echo "yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} command exit code: $EXIT_CODE"
+          echo "yarn test:e2e --shard=${{ matrix.shard }}/4 command exit code: $EXIT_CODE"
           exit $EXIT_CODE
 
       - name: Upload Test Results

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -75,24 +75,6 @@ jobs:
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
 
-      - name: Cache platform-libraries build
-        uses: buildjet/cache@v4
-        id: cache-platform-libraries
-        env:
-          cache-name: platform-libraries-build
-          key-1: ${{ hashFiles('yarn.lock') }}
-          key-2: ${{ hashFiles('packages/platform/libraries/**.[jt]s', 'packages/platform/libraries/**.[jt]sx', '!**/node_modules') }}
-          key-3: ${{ github.event.pull_request.number || github.ref }}
-          key-4: ${{ github.sha }}
-        with:
-          path: |
-            packages/platform/libraries/dist/**
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}
-
-      - name: Build platform-libraries
-        if: steps.cache-platform-libraries.outputs.cache-hit != 'true'
-        run: yarn workspace @calcom/platform-libraries build
-
       - name: Run Tests
         working-directory: apps/api/v2
         run: |

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -28,9 +28,38 @@ env:
   JWT_SECRET: ${{ secrets.CI_JWT_SECRET }}
   NODE_ENV: ${{ vars.CI_NODE_ENV }}
 jobs:
+  check-breaking-changes:
+    timeout-minutes: 10
+    name: Check breaking changes
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/dangerous-git-checkout
+      - uses: ./.github/actions/yarn-install
+
+      - name: Generate Swagger
+        working-directory: apps/api/v2
+        run: yarn generate-swagger
+
+      - name: Check breaking changes
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" -w /work \
+            tufin/oasdiff:latest \
+            breaking \
+            https://raw.githubusercontent.com/calcom/cal.com/refs/heads/main/docs/api-reference/v2/openapi.json \
+            docs/api-reference/v2/openapi.json \
+            --fail-on ERR \
+            --err-ignore .github/oasdiff-err-ignore.txt
+
   e2e:
     timeout-minutes: 20
-    name: E2E API v2
+    name: E2E API v2 (${{ matrix.shard }}/${{ strategy.job-total }})
+    needs: check-breaking-changes
     runs-on: buildjet-16vcpu-ubuntu-2204
     services:
       postgres:
@@ -63,6 +92,8 @@ jobs:
           --health-retries 5
     strategy:
       fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: docker/login-action@v3
         with:
@@ -73,32 +104,17 @@ jobs:
       - uses: ./.github/actions/yarn-install
       - uses: ./.github/actions/cache-db
 
-      - name: Generate Swagger
-        working-directory: apps/api/v2
-        run: yarn generate-swagger
-
-      - name: Check breaking changes
-        run: |
-          docker run --rm \
-            -v "$PWD:/work" -w /work \
-            tufin/oasdiff:latest \
-            breaking \
-            https://raw.githubusercontent.com/calcom/cal.com/refs/heads/main/docs/api-reference/v2/openapi.json \
-            docs/api-reference/v2/openapi.json \
-            --fail-on ERR \
-            --err-ignore .github/oasdiff-err-ignore.txt
-
       - name: Run Tests
         working-directory: apps/api/v2
         run: |
-          yarn workspace @calcom/platform-libraries build && yarn test:e2e
+          yarn workspace @calcom/platform-libraries build && yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }}
           EXIT_CODE=$?
-          echo "yarn workspace @calcom/platform-libraries build && yarn test:e2e command exit code: $EXIT_CODE"
+          echo "yarn test:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} command exit code: $EXIT_CODE"
           exit $EXIT_CODE
 
       - name: Upload Test Results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-api-v2
+          name: test-results-api-v2-shard-${{ matrix.shard }}
           path: test-results

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -28,9 +28,9 @@ env:
   JWT_SECRET: ${{ secrets.CI_JWT_SECRET }}
   NODE_ENV: ${{ vars.CI_NODE_ENV }}
 jobs:
-  check-breaking-changes:
+  check-api-v2-breaking-changes:
     timeout-minutes: 10
-    name: Check breaking changes
+    name: Check API v2 breaking changes
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: docker/login-action@v3
@@ -45,7 +45,7 @@ jobs:
         working-directory: apps/api/v2
         run: yarn generate-swagger
 
-      - name: Check breaking changes
+      - name: Check API v2 breaking changes
         run: |
           docker run --rm \
             -v "$PWD:/work" -w /work \
@@ -59,7 +59,7 @@ jobs:
   e2e:
     timeout-minutes: 20
     name: E2E API v2 (${{ matrix.shard }}/${{ strategy.job-total }})
-    needs: check-breaking-changes
+    needs: check-api-v2-breaking-changes
     runs-on: buildjet-16vcpu-ubuntu-2204
     services:
       postgres:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -201,6 +201,13 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 
+  check-api-v2-breaking-changes:
+    name: Check API v2 breaking changes
+    needs: [prepare, deps]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    uses: ./.github/workflows/check-api-v2-breaking-changes.yml
+    secrets: inherit
+
   e2e-api-v2:
     name: Tests
     needs: [prepare, setup-db]
@@ -242,6 +249,7 @@ jobs:
         lint,
         type-check,
         unit-test,
+        check-api-v2-breaking-changes,
         integration-test,
         build,
         build-api-v1,
@@ -268,6 +276,7 @@ jobs:
               needs.lint.result != 'success' ||
               needs.type-check.result != 'success' ||
               needs.unit-test.result != 'success' ||
+              needs.check-api-v2-breaking-changes.result != 'success' ||
               needs.build.result != 'success' ||
               needs.build-api-v1.result != 'success' ||
               needs.build-api-v2.result != 'success' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,11 @@
-name: PR Updatee
+name: PR Update
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR Update
+name: PR Updatee
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,11 @@
 name: PR Update
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,8 @@
 name: PR Update
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - gh-actions-test-branch
   workflow_dispatch:
 
 permissions:

--- a/apps/api/v2/jest-e2e.ts
+++ b/apps/api/v2/jest-e2e.ts
@@ -9,7 +9,7 @@ const getMaxWorkers = () => {
   if (process.env.CI && isSharding) {
     // In CI with sharding: reduce workers to improve test isolation
     // Sharding already provides parallelism across shards (4 parallel jobs)
-    return 2;
+    return 4;
   }
   // Local development or non-sharded: use more workers (similar to Playwright)
   return 8;

--- a/apps/api/v2/jest-e2e.ts
+++ b/apps/api/v2/jest-e2e.ts
@@ -1,5 +1,22 @@
 import type { Config } from "jest";
 
+// Detect if sharding is being used by checking for --shard flag
+const isSharding = process.argv.some((arg) => arg.includes("--shard"));
+
+// For Jest e2e, we reduce parallelism when sharding in CI to improve test isolation
+// since tests share database state and can interfere with each other
+const getMaxWorkers = () => {
+  if (process.env.CI && isSharding) {
+    // In CI with sharding: reduce workers to improve test isolation
+    // Sharding already provides parallelism across shards (4 parallel jobs)
+    return 2;
+  }
+  // Local development or non-sharded: use more workers (similar to Playwright)
+  return 8;
+};
+
+const maxWorkers = getMaxWorkers();
+
 const config: Config = {
   preset: "ts-jest",
   moduleFileExtensions: ["js", "json", "ts"],
@@ -17,7 +34,7 @@ const config: Config = {
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup-e2e.ts"],
   reporters: ["default", "jest-summarizing-reporter"],
   workerIdleMemoryLimit: "512MB",
-  maxWorkers: 8,
+  maxWorkers,
   testPathIgnorePatterns: ["/dist/", "/node_modules/"],
   transformIgnorePatterns: ["/dist/", "/node_modules/"],
 };


### PR DESCRIPTION
## What does this PR do?

Shards the API v2 E2E tests into 4 parallel jobs to reduce CI runtime. The current single-job approach takes 10+ minutes; sharding should reduce wall-clock time significantly.

**Changes:**
- Split the workflow into two jobs:
  - `check-breaking-changes`: Runs swagger generation and oasdiff check once (on smaller buildjet-4vcpu runner)
  - `e2e`: Runs sharded tests (4 shards) using Jest's built-in `--shard` option
- Each shard runs independently with its own postgres and redis services
- Artifact names are now unique per shard: `test-results-api-v2-shard-{1,2,3,4}`

**Analysis:**
- 82 E2E test files with 1,102 total test cases
- Top 3 files contain ~17% of all tests (user-bookings: 75, event-types: 67, slots: 47)
- Jest 29.7.0 supports native `--shard` which distributes tests across shards

