### PR TITLE
fix: add 'use client' directive to embed-react build for Next.js App Router compatibility

### DIFF
--- a/packages/embeds/embed-react/vite.config.js
+++ b/packages/embeds/embed-react/vite.config.js
@@ -3,7 +3,7 @@ import path from "path";
 import { defineConfig } from "vite";
 
 import viteBaseConfig from "../vite.config";
-
+const useClientBanner = '"use client";';
 // https://vitejs.dev/config/
 export default defineConfig({
   ...viteBaseConfig,
@@ -18,13 +18,35 @@ export default defineConfig({
       // make sure to externalize deps that shouldn't be bundled
       // into your library
       external: ["react", "react/jsx-runtime", "react-dom", "react-dom/client"],
+      onwarn(warning, defaultHandler) {
+        // If "use client" directive has been added to the top of the file, then we can ignore the warnings related to it
+        if (useClientBanner) {
+          if (
+            // vite-plugin-react also ignores this warning - https://github.com/vitejs/vite-plugin-react/blob/3748fc7493cf0a07a2ae275fbd1ae035f01010cc/packages/plugin-react/src/index.ts#L307-L323
+            warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+            warning.message.includes('use client')
+          ) {
+            return
+          }
+          // It comes due to use client directive being ignored in the middle of the file
+          // Even though this could happen in other cases, but there would always be another corresponding error logged which could still highlight any issue during build
+          if (warning.message?.includes("Can't resolve original location of error")) {
+            return
+          }
+        }
+        defaultHandler(warning)
+      },
       output: {
         exports: "named",
+        // Add "use client" directive to the top of the bundle for Next.js App Router compatibility
+        // During bundling "use client" directive comes in b/w  the file which is ignored/removed by Rollup because it makes sense at the top only
+        banner: useClientBanner,
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
+          "react/jsx-runtime": "jsxRuntime",
         },
       },
     },


### PR DESCRIPTION
## What does this PR do?

Fixes the embed-react package build to properly support Next.js App Router by adding a `"use client"` directive banner to the Rollup output.

During bundling, the `"use client"` directive that exists in source files ends up in the middle of the bundled output, which Rollup ignores/removes since the directive only makes sense at the top of a file. This PR:

1. Adds a `"use client"` banner to the top of the bundled output for proper client component support
2. Suppresses the `MODULE_LEVEL_DIRECTIVE` warning that Rollup emits when it encounters `"use client"` mid-file (following the same approach as [vite-plugin-react](https://github.com/vitejs/vite-plugin-react/blob/3748fc7493cf0a07a2ae275fbd1ae035f01010cc/packages/plugin-react/src/index.ts#L307-L323))
3. Suppresses the "Can't resolve original location of error" warning that occurs due to the directive being ignored
4. Adds the missing UMD global for `react/jsx-runtime`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - build config change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Build the embed-react package: `yarn workspace @calcom/embed-react build`
2. Verify the output bundle starts with `"use client";`
3. Verify no MODULE_LEVEL_DIRECTIVE warnings appear during build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "use client" banner to the embed-react build and suppresses noisy Rollup warnings. Improves Next.js App Router compatibility and keeps build output clean.

- **Bug Fixes**
  - Add "use client" banner to Rollup output for client component support.
  - Ignore MODULE_LEVEL_DIRECTIVE and "Can't resolve original location of error" warnings when the banner is present.
  - Provide UMD global for react/jsx-runtime.

<sup>Written for commit 42e000e86c6ca45910733811522a336dd82cb87d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

