### PR TITLE
fix(signup): prevent calendar popup from being clipped

### DIFF
--- a/apps/web/styles/raqb.css
+++ b/apps/web/styles/raqb.css
@@ -143,3 +143,12 @@
     width: 100%;
   }
 }
+/* Fix react-date-picker calendar being clipped */
+.react-date-picker__calendar {
+  z-index: 9999 !important;
+}
+
+.signup-form-container {
+  overflow: visible !important;
+  position: relative;
+}


### PR DESCRIPTION
### What
Fixes an issue where the date picker calendar was clipped on the signup page.

### How
- Ensured calendar popup renders above parent containers using z-index
- Prevented overflow clipping on signup form container

### Issue
Fixes #26144
