### PR TITLE
fix: multiple settings buttons in different locations

### DIFF
--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -47,11 +47,12 @@ export function UserDropdown({ small }: UserDropdownProps) {
     //@ts-ignore
     const Beacon = window.Beacon;
     // window.Beacon is defined when user actually opens up HelpScout and username is available here. On every re-render update session info, so that it is always latest.
-    Beacon &&
+    if(Beacon) {
       Beacon("session-data", {
         username: user?.username || "Unknown",
         screenResolution: `${screen.width}x${screen.height}`,
       });
+    }
   });
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -143,16 +144,6 @@ export function UserDropdown({ small }: UserDropdownProps) {
                       }
                       href="/settings/my-account/profile">
                       {t("my_profile")}
-                    </DropdownItem>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <DropdownItem
-                      type="button"
-                      CustomStartIcon={
-                        <Icon name="settings" className="text-default h-4 w-4" aria-hidden="true" />
-                      }
-                      href="/settings/my-account/general">
-                      {t("my_settings")}
                     </DropdownItem>
                   </DropdownMenuItem>
                   <DropdownMenuItem>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the multiple display options for settings page. There was a settings gear icon and in the dropdown again there was a navigation link named "My Settings"

- Fixes #25788
- Fixes [CAL-6903](https://linear.app/calcom/issue/CAL-6903/settings-button-should-direct-towards-the-settings-panel-not-on) 

#### Image Demo (if applicable):
Before Change - 
<img width="246" height="310" alt="image" src="https://github.com/user-attachments/assets/951119ed-fe44-4468-97a0-2ec5083759e2" />


After Change - 
<img width="431" height="446" alt="image" src="https://github.com/user-attachments/assets/c48f37fe-d47b-473d-8f6a-b343de7427af" />



## Mandatory Tasks (DO NOT REMOVE)

- [1] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [1 ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. N/A
- [1] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
In the mobile, click the profile icon on the top right corner. You will not see the duplication navigation link named "My Settings"/



