### PR TITLE
fix:  Restrict the text inside input component

### DIFF
--- a/packages/ui/components/form/inputs/TextField.tsx
+++ b/packages/ui/components/form/inputs/TextField.tsx
@@ -16,6 +16,7 @@ export const inputStyles = cva(
     // Base styles
     "rounded-[10px] border",
     "leading-none font-normal",
+    "overflow-hidden",
 
     // Colors
     "bg-default",


### PR DESCRIPTION
## What does this PR do?

Added overflow-hidden class on the input to restrict the text inside it.

- Fixes #26209
- Fixes CAL-6976

## Visual Demo (For contributors especially)

Before the fix :

<img width="136" height="848" alt="before" src="https://github.com/user-attachments/assets/981da3f2-e5f8-4476-9f90-a111aa6117e2" />

After the fix : 

<img width="139" height="849" alt="after" src="https://github.com/user-attachments/assets/32362abb-6cda-4b20-9516-b821c0bd4ee0" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
