### PR TITLE
fix: handle existing users on invite token flow

### DIFF
--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -16,6 +16,7 @@ import { z } from "zod";
 
 import getStripe from "@calcom/app-store/stripepayment/lib/client";
 import { getPremiumPlanPriceValue } from "@calcom/app-store/stripepayment/lib/utils";
+import { fetchSignup, isUserAlreadyExistsError, hasCheckoutSession } from "@calcom/features/auth/signup/lib/fetchSignup";
 import { getOrgUsernameFromEmail } from "@calcom/features/auth/signup/utils/getOrgUsernameFromEmail";
 import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomains";
 import ServerTrans from "@calcom/lib/components/ServerTrans";
@@ -222,23 +223,6 @@ export default function Signup({
   const loadingSubmitState = isSubmitSuccessful || isSubmitting;
   const displayBackButton = token ? false : displayEmailForm;
 
-  const handleErrorsAndStripe = async (resp: Response) => {
-    if (!resp.ok) {
-      const err = await resp.json();
-      if (err.checkoutSessionId) {
-        const stripe = await getStripe();
-        if (stripe) {
-          const { error } = await stripe.redirectToCheckout({
-            sessionId: err.checkoutSessionId,
-          });
-          console.warn(error.message);
-        }
-      } else {
-        throw new Error(err.message);
-      }
-    }
-  };
-
   const isPlatformUser = redirectUrl?.includes("platform") && redirectUrl?.includes("new");
 
   const signUp: SubmitHandler<FormValues> = async (_data) => {
@@ -252,77 +236,90 @@ export default function Signup({
       username_taken: usernameTaken,
     });
 
-    await fetch("/api/auth/signup", {
-      body: JSON.stringify({
-        ...data,
-        language: i18n.language,
-        token,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        "cf-access-token": cfToken ?? "invalid-token",
-      },
-      method: "POST",
-    })
-      .then(handleErrorsAndStripe)
-      .then(async () => {
-        if (process.env.NEXT_PUBLIC_GTM_ID)
-          pushGTMEvent("create_account", { email: data.email, user: data.username, lang: data.language });
-
-        // telemetry.event(telemetryEventTypes.signup, collectPageParameters());
-
-        const gettingStartedPath = onboardingV3Enabled ? "onboarding/getting-started" : "getting-started";
-        const verifyOrGettingStarted = emailVerificationEnabled ? "auth/verify-email" : gettingStartedPath;
-        const gettingStartedWithPlatform = "settings/platform/new";
-
-        const constructCallBackIfUrlPresent = () => {
-          if (isOrgInviteByLink) {
-            return `${WEBAPP_URL}/${searchParams.get("callbackUrl")}`;
-          }
-
-          return addOrUpdateQueryParam(`${WEBAPP_URL}/${searchParams.get("callbackUrl")}`, "from", "signup");
-        };
-
-        const constructCallBackIfUrlNotPresent = () => {
-          if (isPlatformUser) {
-            return `${WEBAPP_URL}/${gettingStartedWithPlatform}?from=signup`;
-          }
-
-          return `${WEBAPP_URL}/${verifyOrGettingStarted}?from=signup`;
-        };
-
-        const constructCallBackUrl = () => {
-          const callbackUrlSearchParams = searchParams?.get("callbackUrl");
-
-          return callbackUrlSearchParams
-            ? constructCallBackIfUrlPresent()
-            : constructCallBackIfUrlNotPresent();
-        };
-
-        const callBackUrl = constructCallBackUrl();
-
-        await signIn<"credentials">("credentials", {
+    try {
+      const result = await fetchSignup(
+        {
           ...data,
-          callbackUrl: callBackUrl,
-        });
-      })
-      .catch((err) => {
-        setTurnstileKey((k) => k + 1);
-        formMethods.setValue("cfToken", undefined);
+          language: i18n.language,
+          token,
+        },
+        cfToken
+      );
 
-        if (err.message === INVALID_CLOUDFLARE_TOKEN_ERROR) {
+      if (!result.ok) {
+        if (isUserAlreadyExistsError(result)) {
+          showToast(t("account_already_exists_please_login"), "warning");
+          const callbackUrl = token ? `/teams?token=${token}` : "/event-types";
+          setTimeout(() => {
+            router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+          }, 3000);
           return;
         }
 
-        posthog.capture("signup_form_submit_error", {
-          has_token: !!token,
-          is_org_invite: isOrgInviteByLink,
-          org_slug: orgSlug,
-          is_premium_username: premiumUsername,
-          error_message: err.message,
-        });
-        formMethods.setError("apiError", { message: err.message });
+        if (hasCheckoutSession(result)) {
+          const stripe = await getStripe();
+          if (stripe) {
+            const { error } = await stripe.redirectToCheckout({
+              sessionId: result.error.checkoutSessionId,
+            });
+            console.warn(error.message);
+          }
+          return;
+        }
+
+        throw new Error(result.error.message);
+      }
+
+      if (process.env.NEXT_PUBLIC_GTM_ID) {
+        pushGTMEvent("create_account", { email: data.email, user: data.username, lang: data.language });
+      }
+
+      const gettingStartedPath = onboardingV3Enabled ? "onboarding/getting-started" : "getting-started";
+      const verifyOrGettingStarted = emailVerificationEnabled ? "auth/verify-email" : gettingStartedPath;
+      const gettingStartedWithPlatform = "settings/platform/new";
+
+      const constructCallBackIfUrlPresent = () => {
+        if (isOrgInviteByLink) {
+          return `${WEBAPP_URL}/${searchParams.get("callbackUrl")}`;
+        }
+        return addOrUpdateQueryParam(`${WEBAPP_URL}/${searchParams.get("callbackUrl")}`, "from", "signup");
+      };
+
+      const constructCallBackIfUrlNotPresent = () => {
+        if (isPlatformUser) {
+          return `${WEBAPP_URL}/${gettingStartedWithPlatform}?from=signup`;
+        }
+        return `${WEBAPP_URL}/${verifyOrGettingStarted}?from=signup`;
+      };
+
+      const constructCallBackUrl = () => {
+        const callbackUrlSearchParams = searchParams?.get("callbackUrl");
+        return callbackUrlSearchParams ? constructCallBackIfUrlPresent() : constructCallBackIfUrlNotPresent();
+      };
+
+      await signIn<"credentials">("credentials", {
+        ...data,
+        callbackUrl: constructCallBackUrl(),
       });
+    } catch (err) {
+      setTurnstileKey((k) => k + 1);
+      formMethods.setValue("cfToken", undefined);
+
+      const errorMessage = err instanceof Error ? err.message : "An unexpected error occurred";
+
+      if (errorMessage === INVALID_CLOUDFLARE_TOKEN_ERROR) {
+        return;
+      }
+
+      posthog.capture("signup_form_submit_error", {
+        has_token: !!token,
+        is_org_invite: isOrgInviteByLink,
+        org_slug: orgSlug,
+        is_premium_username: premiumUsername,
+        error_message: errorMessage,
+      });
+      formMethods.setError("apiError", { message: errorMessage });
+    }
   };
 
   return (

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -262,7 +262,7 @@ export default function Signup({
             const { error } = await stripe.redirectToCheckout({
               sessionId: result.error.checkoutSessionId,
             });
-            console.warn(error.message);
+            if (error) console.warn(error.message);
           }
           return;
         }
@@ -305,7 +305,7 @@ export default function Signup({
       setTurnstileKey((k) => k + 1);
       formMethods.setValue("cfToken", undefined);
 
-      const errorMessage = err instanceof Error ? err.message : "An unexpected error occurred";
+      const errorMessage = err instanceof Error ? err.message : t("unexpected_error_try_again");
 
       if (errorMessage === INVALID_CLOUDFLARE_TOKEN_ERROR) {
         return;

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -560,7 +560,7 @@ export default function Signup({
                         const username = formMethods.getValues("username");
                         if (!username) {
                           // should not be reached but needed to bypass type errors
-                          showToast("error", t("username_required"));
+                          showToast(t("username_required"), "error");
                           return;
                         }
 

--- a/apps/web/playwright/signup.e2e.ts
+++ b/apps/web/playwright/signup.e2e.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
+import { hashSync } from "bcryptjs";
 import { randomBytes } from "node:crypto";
 
 import { APP_NAME, IS_PREMIUM_USERNAME_ENABLED, IS_MAILHOG_ENABLED } from "@calcom/lib/constants";
@@ -115,6 +116,86 @@ test.describe("Email Signup Flow Test", async () => {
       expect(alertMessageInner).toContain(alertMessageInner);
     });
   });
+
+  test("Signup with org invite token for existing user redirects to login without overwriting password", async ({
+    page,
+    prisma,
+  }) => {
+    const originalPassword = "OriginalPass99!";
+    const attackerPassword = "AttackerPass99!";
+    const testEmail = `existing-user-${Date.now()}@example.com`;
+
+    // Create existing user without emailVerified to bypass server-side check
+    const hashedPassword = hashSync(originalPassword, 12);
+    const existingUser = await prisma.user.create({
+      data: {
+        email: testEmail,
+        username: `existing-user-${Date.now()}`,
+        password: { create: { hash: hashedPassword } },
+        emailVerified: null,
+      },
+    });
+
+    // Create org invite token for the existing user's email
+    const token = randomBytes(32).toString("hex");
+    const org = await prisma.team.create({
+      data: {
+        name: "Test Org",
+        slug: `test-org-${Date.now()}`,
+        isOrganization: true,
+      },
+    });
+
+    await prisma.verificationToken.create({
+      data: {
+        identifier: existingUser.email,
+        token,
+        expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        teamId: org.id,
+      },
+    });
+
+    // Clear any existing session before attempting signup
+    await page.context().clearCookies();
+
+    // Try to signup with the invite token using a different password
+    await page.goto(`/signup?token=${token}`);
+    await expect(page.getByTestId("signup-submit-button")).toBeVisible();
+
+    await page.locator('input[name="password"]').fill(attackerPassword);
+
+    // Intercept the signup API request to verify 409 response
+    const responsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/auth/signup") && response.request().method() === "POST"
+    );
+
+    const submitButton = page.getByTestId("signup-submit-button");
+    await submitButton.click();
+
+    // Verify API returns 409 (user already exists)
+    const response = await responsePromise;
+    expect(response.status()).toBe(409);
+
+    const responseBody = await response.json();
+    expect(responseBody.message).toBe("user_already_exists");
+
+    // Should redirect to login (toast shows and redirects after 3s)
+    await page.waitForURL(/\/auth\/login/, { timeout: 8000 });
+
+    // Verify original password still works by logging in
+    await page.locator('input[name="email"]').fill(existingUser.email);
+    await page.locator('input[name="password"]').fill(originalPassword);
+    await page.locator('button[type="submit"]').click();
+
+    // Should successfully login with original password
+    await page.waitForURL(/\/(getting-started|event-types|teams)/, { timeout: 8000 });
+
+    // Cleanup
+    await prisma.verificationToken.deleteMany({ where: { token } });
+    await prisma.user.delete({ where: { id: existingUser.id } });
+    await prisma.team.delete({ where: { id: org.id } });
+  });
+
   test("Premium Username Flow - creates stripe checkout", async ({ page, users, prisma }) => {
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(!IS_PREMIUM_USERNAME_ENABLED, "Only run on Cal.com");
@@ -182,7 +263,7 @@ test.describe("Email Signup Flow Test", async () => {
     // Verify that the username is the same as the one provided and isn't accidentally changed to email derived username - That happens only for organization member signup
     expect(dbUser?.username).toBe(userToCreate.username);
   });
-  test("Signup fields prefilled with query params", async ({ page, users }) => {
+  test("Signup fields prefilled with query params", async ({ page, users: _users }) => {
     const signupUrlWithParams = "/signup?username=rick-jones&email=rick-jones%40example.com";
     await page.goto(signupUrlWithParams);
     await preventFlakyTest(page);
@@ -354,7 +435,7 @@ test.describe("Email Signup Flow Test", async () => {
     });
   });
 
-  test("Checkbox for cookie consent does not need to be checked", async ({ page, users }) => {
+  test("Checkbox for cookie consent does not need to be checked", async ({ page, users: _users }) => {
     await page.goto("/signup");
     await preventFlakyTest(page);
 

--- a/apps/web/playwright/signup.e2e.ts
+++ b/apps/web/playwright/signup.e2e.ts
@@ -180,7 +180,7 @@ test.describe("Email Signup Flow Test", async () => {
     expect(responseBody.message).toBe("user_already_exists");
 
     // Should redirect to login (toast shows and redirects after 3s)
-    await page.waitForURL(/\/auth\/login/, { timeout: 8000 });
+    await expect(page).toHaveURL(/\/auth\/login/, { timeout: 8000 });
 
     // Verify original password still works by logging in
     await page.locator('input[name="email"]').fill(existingUser.email);
@@ -188,7 +188,7 @@ test.describe("Email Signup Flow Test", async () => {
     await page.locator('button[type="submit"]').click();
 
     // Should successfully login with original password
-    await page.waitForURL(/\/(getting-started|event-types|teams)/, { timeout: 8000 });
+    await expect(page).toHaveURL(/\/(getting-started|event-types|teams)/, { timeout: 8000 });
 
     // Cleanup
     await prisma.verificationToken.deleteMany({ where: { token } });

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -4183,6 +4183,6 @@
   "audit_logs_owner_not_in_organization": "The booking owner is not a member of your organization.",
   "audit_logs_permission_denied": "You do not have permission to view audit logs for this booking.",
   "audit_logs_permission_check_error": "An error occurred while checking permissions.",
-  "account_already_exists_please_login": "An account with this email already exists. Please log in with your existing password to accept the invitation.",
+  "account_already_exists_please_login": "An account with this email already exists. Please log in to accept the invitation.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -4183,5 +4183,6 @@
   "audit_logs_owner_not_in_organization": "The booking owner is not a member of your organization.",
   "audit_logs_permission_denied": "You do not have permission to view audit logs for this booking.",
   "audit_logs_permission_check_error": "An error occurred while checking permissions.",
+  "account_already_exists_please_login": "An account with this email already exists. Please log in with your existing password to accept the invitation.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/auth/signup/constants.ts
+++ b/packages/features/auth/signup/constants.ts
@@ -1,0 +1,5 @@
+export const SIGNUP_ERROR_CODES = {
+  USER_ALREADY_EXISTS: "user_already_exists",
+} as const;
+
+export type SignupErrorCode = (typeof SIGNUP_ERROR_CODES)[keyof typeof SIGNUP_ERROR_CODES];

--- a/packages/features/auth/signup/constants.ts
+++ b/packages/features/auth/signup/constants.ts
@@ -1,5 +1,6 @@
 export const SIGNUP_ERROR_CODES = {
   USER_ALREADY_EXISTS: "user_already_exists",
+  INVALID_SERVER_RESPONSE: "invalid_server_response",
 } as const;
 
 export type SignupErrorCode = (typeof SIGNUP_ERROR_CODES)[keyof typeof SIGNUP_ERROR_CODES];

--- a/packages/features/auth/signup/handlers/__tests__/calcomHandler.test.ts
+++ b/packages/features/auth/signup/handlers/__tests__/calcomHandler.test.ts
@@ -1,0 +1,105 @@
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+
+import type { MockResponse } from "./mocks/next.mocks";
+
+// Hoisted imports for proper mock initialization
+const {
+  prismaMock,
+  resetPrismaMock,
+  createPrismaMock,
+} = (await vi.hoisted(
+  async () => await import("./mocks/prisma.mocks")
+)) as Awaited<typeof import("./mocks/prisma.mocks")>;
+
+const {
+  createNextServerMock,
+  createNextHeadersMock,
+} = (await vi.hoisted(
+  async () => await import("./mocks/next.mocks")
+)) as Awaited<typeof import("./mocks/next.mocks")>;
+
+const {
+  createMockTeam,
+  createMockFoundToken,
+} = (await vi.hoisted(
+  async () => await import("./mocks/signup.factories")
+)) as Awaited<typeof import("./mocks/signup.factories")>;
+
+const mockFindTokenByToken: Mock = vi.fn();
+const mockValidateAndGetCorrectedUsernameForTeam: Mock = vi.fn();
+
+type UsernameStatus = {
+  statusCode: 200 | 402 | 418;
+  requestedUserName: string;
+  json: { available: boolean; premium: boolean };
+};
+
+type InnerHandler = (body: Record<string, string>, status: UsernameStatus) => Promise<MockResponse>;
+
+let capturedHandler: InnerHandler | null = null;
+
+vi.mock("next/server", createNextServerMock);
+vi.mock("next/headers", createNextHeadersMock);
+vi.mock("@calcom/prisma", createPrismaMock);
+vi.mock("@calcom/prisma/client", createPrismaMock);
+vi.mock("@calcom/lib/logger", () => ({
+  default: { getSubLogger: () => ({ warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() }) },
+}));
+vi.mock("@calcom/lib/auth/hashPassword", () => ({ hashPassword: vi.fn().mockResolvedValue("hashed") }));
+vi.mock("@calcom/lib/constants", () => ({ WEBAPP_URL: "http://localhost:3000" }));
+vi.mock("@calcom/lib/tracking", () => ({ getTrackingFromCookies: vi.fn().mockReturnValue({}) }));
+vi.mock("@calcom/app-store/stripepayment/lib/utils", () => ({ getPremiumMonthlyPlanPriceId: vi.fn() }));
+vi.mock("@calcom/features/auth/lib/getLocaleFromRequest", () => ({ getLocaleFromRequest: vi.fn().mockResolvedValue("en") }));
+vi.mock("@calcom/features/auth/lib/verifyEmail", () => ({ sendEmailVerification: vi.fn() }));
+vi.mock("@calcom/features/auth/signup/utils/createOrUpdateMemberships", () => ({ createOrUpdateMemberships: vi.fn() }));
+vi.mock("@calcom/features/auth/signup/utils/prefillAvatar", () => ({ prefillAvatar: vi.fn() }));
+vi.mock("@calcom/features/auth/signup/utils/validateUsername", () => ({
+  validateAndGetCorrectedUsernameAndEmail: vi.fn().mockResolvedValue({ isValid: true, username: "testuser" }),
+}));
+vi.mock("@calcom/features/ee/billing/di/containers/Billing", () => ({
+  getBillingProviderService: vi.fn().mockReturnValue({
+    createCustomer: vi.fn().mockResolvedValue({ stripeCustomerId: "cus_123" }),
+  }),
+}));
+vi.mock("@calcom/features/watchlist/lib/telemetry", () => ({ sentrySpan: {} }));
+vi.mock("@calcom/features/watchlist/operations/check-if-email-in-watchlist.controller", () => ({
+  checkIfEmailIsBlockedInWatchlistController: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("@calcom/web/lib/buildLegacyCtx", () => ({ buildLegacyRequest: vi.fn() }));
+vi.mock("../../utils/organization", () => ({ joinAnyChildTeamOnOrgInvite: vi.fn() }));
+vi.mock("../../utils/token", () => ({
+  findTokenByToken: (...args: unknown[]) => mockFindTokenByToken(...args),
+  throwIfTokenExpired: vi.fn(),
+  validateAndGetCorrectedUsernameForTeam: (...args: unknown[]) => mockValidateAndGetCorrectedUsernameForTeam(...args),
+}));
+
+// Capture inner handler from usernameHandler wrapper
+vi.mock("@calcom/lib/server/username", () => ({
+  usernameHandler: (handler: InnerHandler) => {
+    capturedHandler = handler;
+    return handler;
+  },
+}));
+
+// Import after mocks
+await import("../calcomHandler");
+import { runP2002TestSuite } from "./p2002.test-suite";
+
+function callHandler(body: Record<string, string | undefined>): Promise<MockResponse> {
+  if (!capturedHandler) throw new Error("Handler not captured");
+  return capturedHandler(body as Record<string, string>, {
+    statusCode: 200,
+    requestedUserName: body.username || "testuser",
+    json: { available: true, premium: false },
+  });
+}
+
+runP2002TestSuite("calcomHandler", callHandler, () => {
+  vi.clearAllMocks();
+  resetPrismaMock();
+  mockFindTokenByToken.mockResolvedValue(createMockFoundToken());
+  mockValidateAndGetCorrectedUsernameForTeam.mockResolvedValue("testuser");
+  prismaMock.team.findUnique.mockResolvedValue(createMockTeam() as never);
+  prismaMock.verificationToken.delete.mockResolvedValue({} as never);
+});

--- a/packages/features/auth/signup/handlers/__tests__/mocks/next.mocks.ts
+++ b/packages/features/auth/signup/handlers/__tests__/mocks/next.mocks.ts
@@ -1,0 +1,40 @@
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+
+// biome-ignore lint/style/useExportsLast: interface needed before function that uses it
+export interface MockResponse {
+  status: number;
+  body: unknown;
+  json: () => Promise<unknown>;
+}
+
+function createMockNextResponse(body: unknown, init?: { status?: number }): MockResponse {
+  if (init?.status === undefined) {
+    throw new Error("NextResponse.json() called without explicit status");
+  }
+  return {
+    status: init.status,
+    body,
+    json: () => Promise.resolve(body),
+  };
+}
+
+export function createNextServerMock(): {
+  NextResponse: { json: (body: unknown, init?: { status?: number }) => MockResponse };
+} {
+  return {
+    NextResponse: {
+      json: (body: unknown, init?: { status?: number }) => createMockNextResponse(body, init),
+    },
+  };
+}
+
+export function createNextHeadersMock(): {
+  cookies: Mock;
+  headers: Mock;
+} {
+  return {
+    cookies: vi.fn().mockResolvedValue({ getAll: () => [] }),
+    headers: vi.fn().mockResolvedValue(new Map()),
+  };
+}

--- a/packages/features/auth/signup/handlers/__tests__/mocks/prisma.mocks.ts
+++ b/packages/features/auth/signup/handlers/__tests__/mocks/prisma.mocks.ts
@@ -1,0 +1,57 @@
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+
+import type { PrismaClient } from "@calcom/prisma";
+
+// Prisma mock instance (singleton)
+export const prismaMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+export function resetPrismaMock(): void {
+  mockReset(prismaMock);
+}
+
+// Custom P2002 error class for testing unique constraint violations
+export class MockPrismaClientKnownRequestError extends Error {
+  code: string;
+  meta?: { target?: string[] };
+
+  constructor(message: string, { code, meta }: { code: string; meta?: { target?: string[] } }) {
+    super(message);
+    this.name = "PrismaClientKnownRequestError";
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+export function createPrismaMock(): {
+  default: DeepMockProxy<PrismaClient>;
+  prisma: DeepMockProxy<PrismaClient>;
+  Prisma: { PrismaClientKnownRequestError: typeof MockPrismaClientKnownRequestError };
+} {
+  return {
+    default: prismaMock,
+    prisma: prismaMock,
+    Prisma: { PrismaClientKnownRequestError: MockPrismaClientKnownRequestError },
+  };
+}
+
+// P2002 error factories
+export function createP2002Error(target: string[]): MockPrismaClientKnownRequestError {
+  return new MockPrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    meta: { target },
+  });
+}
+
+export function createP2002ErrorWithoutTarget(): MockPrismaClientKnownRequestError {
+  return new MockPrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    meta: {},
+  });
+}
+
+export function createGenericPrismaError(): MockPrismaClientKnownRequestError {
+  return new MockPrismaClientKnownRequestError("Record not found", {
+    code: "P2025",
+    meta: {},
+  });
+}

--- a/packages/features/auth/signup/handlers/__tests__/mocks/signup.factories.ts
+++ b/packages/features/auth/signup/handlers/__tests__/mocks/signup.factories.ts
@@ -1,0 +1,60 @@
+export interface MockTeam {
+  id: number;
+  isOrganization: boolean;
+  parent: { id: number; slug: string; organizationSettings: null } | null;
+  organizationSettings: null;
+}
+
+export interface MockFoundToken {
+  id: number;
+  teamId: number | null;
+  expires: Date;
+}
+
+export interface MockUser {
+  id: number;
+}
+
+export interface SignupBody {
+  email: string;
+  password: string;
+  username: string;
+  language: string;
+  token?: string;
+}
+
+export function createMockTeam(overrides: Partial<MockTeam> = {}): MockTeam {
+  return {
+    id: 1,
+    isOrganization: true,
+    parent: null,
+    organizationSettings: null,
+    ...overrides,
+  };
+}
+
+export function createMockFoundToken(overrides: Partial<MockFoundToken> = {}): MockFoundToken {
+  return {
+    id: 1,
+    teamId: 1,
+    expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+export function createMockUser(overrides: Partial<MockUser> = {}): MockUser {
+  return {
+    id: 1,
+    ...overrides,
+  };
+}
+
+export function createSignupBody(overrides: Partial<SignupBody> = {}): SignupBody {
+  return {
+    email: "test@example.com",
+    password: "ValidPassword123!",
+    username: "testuser",
+    language: "en",
+    ...overrides,
+  };
+}

--- a/packages/features/auth/signup/handlers/__tests__/p2002.test-suite.ts
+++ b/packages/features/auth/signup/handlers/__tests__/p2002.test-suite.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { SIGNUP_ERROR_CODES } from "../../constants";
+import type { MockResponse } from "./mocks/next.mocks";
+import {
+  prismaMock,
+  createP2002Error,
+  createP2002ErrorWithoutTarget,
+  createGenericPrismaError,
+} from "./mocks/prisma.mocks";
+import { createSignupBody, createMockUser } from "./mocks/signup.factories";
+
+import type { SignupBody } from "./mocks/signup.factories";
+
+type CallHandler = (body: SignupBody) => Promise<MockResponse>;
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: test suite contains multiple test cases
+export function runP2002TestSuite(
+  handlerName: string,
+  callHandler: CallHandler,
+  setupMocks: () => void
+): void {
+  describe(`${handlerName} – signup P2002 contract`, () => {
+    describe("P2002 Error Handling", () => {
+      beforeEach(setupMocks);
+
+      it("returns 409 when target includes 'email'", async () => {
+        prismaMock.user.create.mockRejectedValue(createP2002Error(["email"]));
+
+        const response = await callHandler(createSignupBody({ token: "valid-token" }));
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({
+          message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+        });
+      });
+
+      it("returns 409 when target includes 'email' among other fields", async () => {
+        prismaMock.user.create.mockRejectedValue(createP2002Error(["id", "email", "username"]));
+
+        const response = await callHandler(createSignupBody({ token: "valid-token" }));
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({
+          message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+        });
+      });
+
+      it("re-throws when target is 'username' only", async () => {
+        const error = createP2002Error(["username"]);
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
+      });
+
+      it("re-throws when target is empty", async () => {
+        const error = createP2002ErrorWithoutTarget();
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
+      });
+
+      it("re-throws when target is undefined", async () => {
+        const error = createP2002Error([]);
+        error.meta = undefined;
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
+      });
+
+      it("re-throws non-P2002 Prisma errors", async () => {
+        const error = createGenericPrismaError();
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
+      });
+
+      it("re-throws generic errors", async () => {
+        const error = new Error("Database connection failed");
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
+      });
+    });
+
+    describe("Successful Creation", () => {
+      beforeEach(setupMocks);
+
+      it("returns 201 when user is created", async () => {
+        prismaMock.user.create.mockResolvedValue(createMockUser());
+
+        const response = await callHandler(createSignupBody({ token: "valid-token" }));
+
+        expect(response.status).toBe(201);
+      });
+    });
+  });
+}

--- a/packages/features/auth/signup/handlers/__tests__/p2002.test-suite.ts
+++ b/packages/features/auth/signup/handlers/__tests__/p2002.test-suite.ts
@@ -21,13 +21,13 @@ export function runP2002TestSuite(
   setupMocks: () => void
 ): void {
   describe(`${handlerName} – signup P2002 contract`, () => {
-    describe("P2002 Error Handling", () => {
+    describe("P2002 Error Handling (non-token flow)", () => {
       beforeEach(setupMocks);
 
       it("returns 409 when target includes 'email'", async () => {
         prismaMock.user.create.mockRejectedValue(createP2002Error(["email"]));
 
-        const response = await callHandler(createSignupBody({ token: "valid-token" }));
+        const response = await callHandler(createSignupBody());
 
         expect(response.status).toBe(409);
         expect(await response.json()).toEqual({
@@ -38,6 +38,83 @@ export function runP2002TestSuite(
       it("returns 409 when target includes 'email' among other fields", async () => {
         prismaMock.user.create.mockRejectedValue(createP2002Error(["id", "email", "username"]));
 
+        const response = await callHandler(createSignupBody());
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({
+          message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+        });
+      });
+
+      it("returns 409 when target is 'username' only", async () => {
+        prismaMock.user.create.mockRejectedValue(createP2002Error(["username"]));
+
+        const response = await callHandler(createSignupBody());
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({
+          message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS,
+        });
+      });
+
+      it("re-throws when target is empty", async () => {
+        const error = createP2002ErrorWithoutTarget();
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody())).rejects.toThrow(error);
+      });
+
+      it("re-throws when target is undefined", async () => {
+        const error = createP2002Error([]);
+        error.meta = undefined;
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody())).rejects.toThrow(error);
+      });
+
+      it("re-throws non-P2002 Prisma errors", async () => {
+        const error = createGenericPrismaError();
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody())).rejects.toThrow(error);
+      });
+
+      it("re-throws generic errors", async () => {
+        const error = new Error("Database connection failed");
+        prismaMock.user.create.mockRejectedValue(error);
+
+        await expect(callHandler(createSignupBody())).rejects.toThrow(error);
+      });
+    });
+
+    describe("Successful Creation", () => {
+      beforeEach(setupMocks);
+
+      it("returns 201 when user is created (non-token flow)", async () => {
+        prismaMock.user.create.mockResolvedValue(createMockUser());
+
+        const response = await callHandler(createSignupBody());
+
+        expect(response.status).toBe(201);
+      });
+
+      it("returns 201 when user is created via invite (token flow)", async () => {
+        prismaMock.user.findUnique.mockResolvedValue(null as never);
+        prismaMock.user.findFirst.mockResolvedValue(null as never);
+        prismaMock.user.upsert.mockResolvedValue(createMockUser() as never);
+
+        const response = await callHandler(createSignupBody({ token: "valid-token" }));
+
+        expect(response.status).toBe(201);
+      });
+    });
+
+    describe("Invite flow - existing user validation", () => {
+      beforeEach(setupMocks);
+
+      it("returns 409 when user exists but was not invited to this team", async () => {
+        prismaMock.user.findUnique.mockResolvedValue({ id: 99, invitedTo: 999 } as never);
+
         const response = await callHandler(createSignupBody({ token: "valid-token" }));
 
         expect(response.status).toBe(409);
@@ -46,48 +123,10 @@ export function runP2002TestSuite(
         });
       });
 
-      it("re-throws when target is 'username' only", async () => {
-        const error = createP2002Error(["username"]);
-        prismaMock.user.create.mockRejectedValue(error);
-
-        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
-      });
-
-      it("re-throws when target is empty", async () => {
-        const error = createP2002ErrorWithoutTarget();
-        prismaMock.user.create.mockRejectedValue(error);
-
-        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
-      });
-
-      it("re-throws when target is undefined", async () => {
-        const error = createP2002Error([]);
-        error.meta = undefined;
-        prismaMock.user.create.mockRejectedValue(error);
-
-        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
-      });
-
-      it("re-throws non-P2002 Prisma errors", async () => {
-        const error = createGenericPrismaError();
-        prismaMock.user.create.mockRejectedValue(error);
-
-        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
-      });
-
-      it("re-throws generic errors", async () => {
-        const error = new Error("Database connection failed");
-        prismaMock.user.create.mockRejectedValue(error);
-
-        await expect(callHandler(createSignupBody({ token: "valid-token" }))).rejects.toThrow(error);
-      });
-    });
-
-    describe("Successful Creation", () => {
-      beforeEach(setupMocks);
-
-      it("returns 201 when user is created", async () => {
-        prismaMock.user.create.mockResolvedValue(createMockUser());
+      it("returns 201 when user exists and was invited to this team", async () => {
+        prismaMock.user.findUnique.mockResolvedValue({ id: 99, invitedTo: 1 } as never);
+        prismaMock.user.findFirst.mockResolvedValue(null as never);
+        prismaMock.user.upsert.mockResolvedValue(createMockUser() as never);
 
         const response = await callHandler(createSignupBody({ token: "valid-token" }));
 

--- a/packages/features/auth/signup/handlers/__tests__/selfHostedHandler.test.ts
+++ b/packages/features/auth/signup/handlers/__tests__/selfHostedHandler.test.ts
@@ -1,0 +1,65 @@
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+
+// Hoisted imports for proper mock initialization
+const {
+  prismaMock,
+  resetPrismaMock,
+  createPrismaMock,
+} = (await vi.hoisted(
+  async () => await import("./mocks/prisma.mocks")
+)) as Awaited<typeof import("./mocks/prisma.mocks")>;
+
+const { createNextServerMock } = (await vi.hoisted(
+  async () => await import("./mocks/next.mocks")
+)) as Awaited<typeof import("./mocks/next.mocks")>;
+
+const {
+  createMockTeam,
+  createMockFoundToken,
+} = (await vi.hoisted(
+  async () => await import("./mocks/signup.factories")
+)) as Awaited<typeof import("./mocks/signup.factories")>;
+
+const mockFindTokenByToken: Mock = vi.fn();
+const mockValidateAndGetCorrectedUsernameForTeam: Mock = vi.fn();
+
+vi.mock("next/server", createNextServerMock);
+vi.mock("@calcom/prisma", createPrismaMock);
+vi.mock("@calcom/prisma/client", createPrismaMock);
+vi.mock("@calcom/lib/logger", () => ({
+  default: { getSubLogger: () => ({ warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() }) },
+}));
+vi.mock("@calcom/lib/auth/hashPassword", () => ({ hashPassword: vi.fn().mockResolvedValue("hashed") }));
+vi.mock("@calcom/lib/slugify", () => ({ default: vi.fn((s: string) => s.toLowerCase()) }));
+vi.mock("@calcom/lib/constants", () => ({ IS_PREMIUM_USERNAME_ENABLED: false }));
+vi.mock("@calcom/lib/server/username", () => ({ isUsernameReservedDueToMigration: vi.fn().mockResolvedValue(false) }));
+vi.mock("@calcom/features/auth/lib/verifyEmail", () => ({ sendEmailVerification: vi.fn() }));
+vi.mock("@calcom/features/auth/signup/utils/createOrUpdateMemberships", () => ({ createOrUpdateMemberships: vi.fn() }));
+vi.mock("@calcom/features/auth/signup/utils/validateUsername", () => ({
+  validateAndGetCorrectedUsernameAndEmail: vi.fn().mockResolvedValue({ isValid: true, username: "testuser" }),
+}));
+vi.mock("../../utils/organization", () => ({ joinAnyChildTeamOnOrgInvite: vi.fn() }));
+vi.mock("../../utils/prefillAvatar", () => ({ prefillAvatar: vi.fn() }));
+vi.mock("../../utils/token", () => ({
+  findTokenByToken: (...args: unknown[]) => mockFindTokenByToken(...args),
+  throwIfTokenExpired: vi.fn(),
+  validateAndGetCorrectedUsernameForTeam: (...args: unknown[]) => mockValidateAndGetCorrectedUsernameForTeam(...args),
+}));
+
+// Import after mocks
+import handler from "../selfHostedHandler";
+import { runP2002TestSuite } from "./p2002.test-suite";
+
+function callHandler(body: Record<string, string | undefined>): ReturnType<typeof handler> {
+  return handler(body as Record<string, string>);
+}
+
+runP2002TestSuite("selfHostedHandler", callHandler, () => {
+  vi.clearAllMocks();
+  resetPrismaMock();
+  mockFindTokenByToken.mockResolvedValue(createMockFoundToken());
+  mockValidateAndGetCorrectedUsernameForTeam.mockResolvedValue("testuser");
+  prismaMock.team.findUnique.mockResolvedValue(createMockTeam() as never);
+  prismaMock.verificationToken.delete.mockResolvedValue({} as never);
+});

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -222,7 +222,10 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
         });
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
-          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+          const target = String(error.meta?.target ?? "");
+          if (target.includes("email") || target.includes("username")) {
+            return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+          }
         }
         throw error;
       }

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -85,6 +85,15 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
       teamId: foundToken?.teamId ?? null,
       isSignup: true,
     });
+
+    // Check if user already exists before creating Stripe customer (e.g., invite link used by existing user)
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (existingUser) {
+      return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+    }
   } else {
     const usernameAndEmailValidation = await validateAndGetCorrectedUsernameAndEmail({
       username,

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -86,12 +86,11 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
       isSignup: true,
     });
 
-    // Check if user already exists before creating Stripe customer (e.g., invite link used by existing user)
     const existingUser = await prisma.user.findUnique({
       where: { email },
-      select: { id: true },
+      select: { id: true, invitedTo: true },
     });
-    if (existingUser) {
+    if (existingUser && existingUser.invitedTo !== foundToken.teamId) {
       return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
     }
   } else {
@@ -179,31 +178,43 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
     if (team) {
       const organizationId = team.isOrganization ? team.id : team.parent?.id ?? null;
 
-      let user: { id: number };
-      try {
-        user = await prisma.user.create({
-          data: {
-            username,
-            email,
-            emailVerified: new Date(Date.now()),
-            identityProvider: IdentityProvider.CAL,
-            password: { create: { hash: hashedPassword } },
-            organizationId,
-          },
-          select: { id: true },
-        });
-      } catch (error) {
-        if (isPrismaError(error) && error.code === "P2002") {
-          const target = error.meta?.target as string[] | undefined;
-          if (target?.includes("email")) {
-            return NextResponse.json(
-              { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
-              { status: 409 }
-            );
-          }
-        }
-        throw error;
+      const existingUserByUsername = await prisma.user.findFirst({
+        where: {
+          username,
+          organizationId,
+          NOT: { email }, // Exclude the invited user themselves
+        },
+      });
+      if (existingUserByUsername) {
+        return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
       }
+
+      // Use upsert to handle users created by invite
+      // Security: Already verified if user exists + invited to this team
+      const user = await prisma.user.upsert({
+        where: { email },
+        update: {
+          username,
+          emailVerified: new Date(Date.now()),
+          identityProvider: IdentityProvider.CAL,
+          password: {
+            upsert: {
+              create: { hash: hashedPassword },
+              update: { hash: hashedPassword },
+            },
+          },
+          organizationId,
+        },
+        create: {
+          username,
+          email,
+          emailVerified: new Date(Date.now()),
+          identityProvider: IdentityProvider.CAL,
+          password: { create: { hash: hashedPassword } },
+          organizationId,
+        },
+        select: { id: true },
+      });
 
       await createOrUpdateMemberships({
         user,
@@ -242,9 +253,10 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
         },
       });
     } catch (error) {
+      // Fallback for race conditions where user was created between our check and create
       if (isPrismaError(error) && error.code === "P2002") {
-        const target = error.meta?.target as string[] | undefined;
-        if (target?.includes("email")) {
+        const target = String(error.meta?.target ?? "");
+        if (target.includes("email") || target.includes("username")) {
           return NextResponse.json(
             { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
             { status: 409 }

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -180,13 +180,17 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
             password: { create: { hash: hashedPassword } },
             organizationId,
           },
+          select: { id: true },
         });
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-          return NextResponse.json(
-            { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
-            { status: 409 }
-          );
+          const target = error.meta?.target as string[] | undefined;
+          if (target?.includes("email")) {
+            return NextResponse.json(
+              { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
+              { status: 409 }
+            );
+          }
         }
         throw error;
       }

--- a/packages/features/auth/signup/handlers/calcomHandler.ts
+++ b/packages/features/auth/signup/handlers/calcomHandler.ts
@@ -14,11 +14,11 @@ import { hashPassword } from "@calcom/lib/auth/hashPassword";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
+import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import type { CustomNextApiHandler } from "@calcom/lib/server/username";
 import { usernameHandler } from "@calcom/lib/server/username";
 import { getTrackingFromCookies } from "@calcom/lib/tracking";
 import prisma from "@calcom/prisma";
-import { Prisma } from "@calcom/prisma/client";
 import { CreationSource } from "@calcom/prisma/enums";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
@@ -193,7 +193,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
           select: { id: true },
         });
       } catch (error) {
-        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        if (isPrismaError(error) && error.code === "P2002") {
           const target = error.meta?.target as string[] | undefined;
           if (target?.includes("email")) {
             return NextResponse.json(
@@ -242,7 +242,7 @@ const handler: CustomNextApiHandler = async (body, usernameStatus) => {
         },
       });
     } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      if (isPrismaError(error) && error.code === "P2002") {
         const target = error.meta?.target as string[] | undefined;
         if (target?.includes("email")) {
           return NextResponse.json(

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -102,13 +102,17 @@ export default async function handler(body: Record<string, string>) {
             identityProvider: IdentityProvider.CAL,
             organizationId,
           },
+          select: { id: true },
         });
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-          return NextResponse.json(
-            { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
-            { status: 409 }
-          );
+          const target = error.meta?.target as string[] | undefined;
+          if (target?.includes("email")) {
+            return NextResponse.json(
+              { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
+              { status: 409 }
+            );
+          }
         }
         throw error;
       }

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -161,6 +161,7 @@ export default async function handler(body: Record<string, string>) {
           password: { create: { hash: hashedPassword } },
           identityProvider: IdentityProvider.CAL,
         },
+        select: { id: true },
       });
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -142,7 +142,10 @@ export default async function handler(body: Record<string, string>) {
         });
       } catch (error) {
         if (isPrismaError(error) && error.code === "P2002") {
-          return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+          const target = String(error.meta?.target ?? "");
+          if (target.includes("email") || target.includes("username")) {
+            return NextResponse.json({ message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS }, { status: 409 });
+          }
         }
         throw error;
       }

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -7,10 +7,10 @@ import { validateAndGetCorrectedUsernameAndEmail } from "@calcom/features/auth/s
 import { hashPassword } from "@calcom/lib/auth/hashPassword";
 import { IS_PREMIUM_USERNAME_ENABLED } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";
+import { isPrismaError } from "@calcom/lib/server/getServerErrorFromUnknown";
 import { isUsernameReservedDueToMigration } from "@calcom/lib/server/username";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import { Prisma } from "@calcom/prisma/client";
 import { IdentityProvider } from "@calcom/prisma/enums";
 import { signupSchema } from "@calcom/prisma/zod-utils";
 
@@ -106,7 +106,7 @@ export default async function handler(body: Record<string, string>) {
           select: { id: true },
         });
       } catch (error) {
-        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        if (isPrismaError(error) && error.code === "P2002") {
           const target = error.meta?.target as string[] | undefined;
           if (target?.includes("email")) {
             return NextResponse.json(
@@ -164,7 +164,7 @@ export default async function handler(body: Record<string, string>) {
         select: { id: true },
       });
     } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      if (isPrismaError(error) && error.code === "P2002") {
         const target = error.meta?.target as string[] | undefined;
         if (target?.includes("email")) {
           return NextResponse.json(

--- a/packages/features/auth/signup/lib/fetchSignup.test.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { SIGNUP_ERROR_CODES } from "../constants";
+import { fetchSignup, isUserAlreadyExistsError, hasCheckoutSession } from "./fetchSignup";
+
+const createSuccessResponse = (data = { message: "Created user" }) => ({
+  ok: true,
+  json: () => Promise.resolve(data),
+});
+
+const createErrorResponse = (status: number, error: { message: string; checkoutSessionId?: string }) => ({
+  ok: false,
+  status,
+  json: () => Promise.resolve(error),
+});
+
+describe("fetchSignup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns success when signup completes", async () => {
+    global.fetch = vi.fn().mockResolvedValue(createSuccessResponse());
+
+    const result = await fetchSignup({
+      email: "test@example.com",
+      password: "password123",
+      language: "en",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns error with status code when signup fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      createErrorResponse(409, { message: "Username is already taken" })
+    );
+
+    const result = await fetchSignup({
+      email: "test@example.com",
+      password: "password123",
+      language: "en",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+    }
+  });
+});
+
+describe("isUserAlreadyExistsError", () => {
+  it("returns true for 409 with user_already_exists message", () => {
+    const result = {
+      ok: false as const,
+      status: 409,
+      error: { message: SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS },
+    };
+
+    expect(isUserAlreadyExistsError(result)).toBe(true);
+  });
+
+  it("returns false for other error messages", () => {
+    const result = {
+      ok: false as const,
+      status: 409,
+      error: { message: "Username is already taken" },
+    };
+
+    expect(isUserAlreadyExistsError(result)).toBe(false);
+  });
+
+  it("returns false for success responses", () => {
+    const result = {
+      ok: true as const,
+      data: { message: "Created user" },
+    };
+
+    expect(isUserAlreadyExistsError(result)).toBe(false);
+  });
+});
+
+describe("hasCheckoutSession", () => {
+  it("returns true when checkoutSessionId exists", () => {
+    const result = {
+      ok: false as const,
+      status: 402,
+      error: { message: "Payment required", checkoutSessionId: "cs_123" },
+    };
+
+    expect(hasCheckoutSession(result)).toBe(true);
+  });
+
+  it("returns false when checkoutSessionId is absent", () => {
+    const result = {
+      ok: false as const,
+      status: 409,
+      error: { message: "Error" },
+    };
+
+    expect(hasCheckoutSession(result)).toBe(false);
+  });
+});

--- a/packages/features/auth/signup/lib/fetchSignup.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.ts
@@ -39,7 +39,7 @@ export async function fetchSignup(data: SignupData, cfToken?: string): Promise<S
     return {
       ok: false,
       status: response.status,
-      error: { message: "Invalid server response" },
+      error: { message: SIGNUP_ERROR_CODES.INVALID_SERVER_RESPONSE },
     };
   }
 

--- a/packages/features/auth/signup/lib/fetchSignup.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.ts
@@ -34,6 +34,15 @@ export async function fetchSignup(data: SignupData, cfToken?: string): Promise<S
     body: JSON.stringify(data),
   });
 
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return {
+      ok: false,
+      status: response.status,
+      error: { message: "Invalid server response" },
+    };
+  }
+
   const json = (await response.json()) as SignupResponse;
 
   if (!response.ok) {

--- a/packages/features/auth/signup/lib/fetchSignup.ts
+++ b/packages/features/auth/signup/lib/fetchSignup.ts
@@ -1,0 +1,59 @@
+import { SIGNUP_ERROR_CODES } from "../constants";
+
+type SignupData = {
+  username?: string;
+  email: string;
+  password: string;
+  language: string;
+  token?: string;
+};
+
+type SignupSuccessResponse = {
+  message: string;
+  stripeCustomerId?: string;
+};
+
+type SignupErrorResponse = {
+  message: string;
+  checkoutSessionId?: string;
+};
+
+type SignupResponse = SignupSuccessResponse | SignupErrorResponse;
+
+export type SignupResult =
+  | { ok: true; data: SignupSuccessResponse }
+  | { ok: false; status: number; error: SignupErrorResponse };
+
+export async function fetchSignup(data: SignupData, cfToken?: string): Promise<SignupResult> {
+  const response = await fetch("/api/auth/signup", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "cf-access-token": cfToken ?? "invalid-token",
+    },
+    body: JSON.stringify(data),
+  });
+
+  const json = (await response.json()) as SignupResponse;
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: json as SignupErrorResponse,
+    };
+  }
+
+  return {
+    ok: true,
+    data: json as SignupSuccessResponse,
+  };
+}
+
+export function isUserAlreadyExistsError(result: SignupResult): boolean {
+  return !result.ok && result.status === 409 && result.error.message === SIGNUP_ERROR_CODES.USER_ALREADY_EXISTS;
+}
+
+export function hasCheckoutSession(result: SignupResult): result is { ok: false; status: number; error: SignupErrorResponse & { checkoutSessionId: string } } {
+  return !result.ok && !!result.error.checkoutSessionId;
+}

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -18,8 +18,12 @@ function isZodError(cause: unknown): cause is ZodError {
   return cause instanceof ZodError || (hasName(cause) && cause.name === "ZodError");
 }
 
+// Fallback to name check when instanceof fails due to different Prisma client instances
 function isPrismaError(cause: unknown): cause is Prisma.PrismaClientKnownRequestError {
-  return cause instanceof Prisma.PrismaClientKnownRequestError;
+  return (
+    cause instanceof Prisma.PrismaClientKnownRequestError ||
+    (hasName(cause) && cause.name === "PrismaClientKnownRequestError")
+  );
 }
 
 function parseZodErrorIssues(issues: ZodIssue[]): string {
@@ -201,3 +205,5 @@ function getServerErrorFromPrismaError(
   }
   return getHttpError({ statusCode: 400, cause, traceId, tracedData });
 }
+
+export { isPrismaError };

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -18,11 +18,11 @@ function isZodError(cause: unknown): cause is ZodError {
   return cause instanceof ZodError || (hasName(cause) && cause.name === "ZodError");
 }
 
-// Fallback to name check when instanceof fails due to different Prisma client instances
+// Fallback to code check when instanceof fails due to different Prisma client instances
 function isPrismaError(cause: unknown): cause is Prisma.PrismaClientKnownRequestError {
   return (
     cause instanceof Prisma.PrismaClientKnownRequestError ||
-    (hasName(cause) && cause.name === "PrismaClientKnownRequestError")
+    (cause instanceof Error && "code" in cause && typeof cause.code === "string" && cause.code.startsWith("P"))
   );
 }
 


### PR DESCRIPTION
 ## What does this PR do?

Adds user existence validation to signup handlers when processing team/organization invite tokens. This ensures proper handling when an invited email already has an account, redirecting them to login instead of creating a duplicate flow.

### Changes

- Added user existence check before account creation in `calcomHandler` and `selfHostedHandler`
- Return 409 status when user already exists with invite token
- Refactored signup fetch logic to dedicated module with proper error handling
- Added translation for user-friendly redirect message
- Added E2E test coverage for invite token signup flow

### How to test

1. Create a user with email `test@example.com`
2. Generate an org/team invite token for `test@example.com`
3. Navigate to `/signup?token=<token>`
4. Fill password and submit
5. Should see toast message and redirect to login page
6. Run E2E test: `yarn playwright test apps/web/playwright/signup.e2e.ts --grep "org invite token"`

## Mandatory Tasks

- [x] I have self-reviewed the code
- [ ] **N/A** I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.