### PR TITLE
fix: gap between giphy gif setup buttons

### DIFF
--- a/packages/app-store/giphy/components/SelectGifInput.tsx
+++ b/packages/app-store/giphy/components/SelectGifInput.tsx
@@ -22,7 +22,7 @@ export default function SelectGifInput(props: ISelectGifInput) {
           <img alt="Selected Gif Image" src={selectedGif} />
         </div>
       )}
-      <div className="flex">
+      <div className="flex gap-2">
         {selectedGif ? (
           <Button
             color="minimal"


### PR DESCRIPTION
## What does this PR do?

- add gap between gif setup buttons 

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)


**Before:**


https://github.com/user-attachments/assets/b23fad54-b08e-49bf-9d90-2b1f3829363b

**After:**

https://github.com/user-attachments/assets/18838692-a250-4f03-bee6-6193ecb01045



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
