### PR TITLE
fix: add ui fix for availability page

### DIFF
--- a/packages/platform/atoms/availability/AvailabilitySettings.tsx
+++ b/packages/platform/atoms/availability/AvailabilitySettings.tsx
@@ -679,7 +679,7 @@ export const AvailabilitySettings = forwardRef<AvailabilitySettingsFormRef, Avai
                 </div>
               </div>
               {enableOverrides && (
-                <div className="border-subtle rounded-md border">
+                <div className="border-subtle rounded-md border mb-6">
                   <BookerStoreProvider>
                     <DateOverride
                       isDryRun={isDryRun}


### PR DESCRIPTION
## What does this PR do?

This pr solves the margin issue in the Availability page within Date Overrides and Timezone component 

- Fixes #26234
- Fixes [CAL-6981](https://linear.app/calcom/issue/CAL-6981/availability-page-ui-bug)

## Visual Demo (For contributors especially)

From this :
<img width="910" height="272" alt="AvailError" src="https://github.com/user-attachments/assets/701c3812-e35d-4bbb-a5a7-6a115337a47e" />


To this:
<img width="998" height="305" alt="AvailSol" src="https://github.com/user-attachments/assets/f142eaab-acf0-4744-84a4-5807b3897729" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Start your local cal repo with yarn dx
- Go to /availability/ page
- Check the distance between Date overrides and Timezone


