### PR TITLE
chore: Use relative imports for @calcom/prisma inside of @calcom/prisma

### DIFF
--- a/packages/prisma/__mocks__/prisma.ts
+++ b/packages/prisma/__mocks__/prisma.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import type { PrismaClient } from "@calcom/prisma";
+import type { PrismaClient } from "./client";
 
 beforeEach(() => {
   mockReset(prisma);

--- a/packages/prisma/__mocks__/prisma.ts
+++ b/packages/prisma/__mocks__/prisma.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import type { PrismaClient } from "./client";
+import type { PrismaClient } from "../client";
 
 beforeEach(() => {
   mockReset(prisma);

--- a/packages/prisma/extensions/booking-idempotency-key.ts
+++ b/packages/prisma/extensions/booking-idempotency-key.ts
@@ -1,7 +1,7 @@
 import { v5 as uuidv5 } from "uuid";
 
-import { Prisma } from "@calcom/prisma/client";
-import { BookingStatus } from "@calcom/prisma/enums";
+import { Prisma } from "../client";
+import { BookingStatus } from "../enums";
 
 function generateIdempotencyKey({
   startTime,

--- a/packages/prisma/extensions/exclude-locked-users.ts
+++ b/packages/prisma/extensions/exclude-locked-users.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@calcom/prisma/client";
+import { Prisma } from "../client";
 
 export function excludeLockedUsersExtension() {
   return Prisma.defineExtension({
@@ -24,7 +24,7 @@ export function excludeLockedUsersExtension() {
   });
 }
 
-function safeJSONStringify(x: any) {
+function safeJSONStringify(x: unknown) {
   try {
     return JSON.stringify(x);
   } catch {

--- a/packages/prisma/extensions/exclude-pending-payment-teams.ts
+++ b/packages/prisma/extensions/exclude-pending-payment-teams.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@calcom/prisma/client";
+import { Prisma } from "../client";
 
 export function excludePendingPaymentsExtension() {
   return Prisma.defineExtension({

--- a/packages/prisma/is-prisma-available-check.ts
+++ b/packages/prisma/is-prisma-available-check.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@calcom/prisma/client";
+import { Prisma } from "./client";
 
 export async function isPrismaAvailableCheck(): Promise<boolean> {
   try {

--- a/packages/prisma/selects/app.ts
+++ b/packages/prisma/selects/app.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const safeAppSelect = {
   slug: true,

--- a/packages/prisma/selects/booking.ts
+++ b/packages/prisma/selects/booking.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const bookingMinimalSelect = {
   id: true,

--- a/packages/prisma/selects/credential.ts
+++ b/packages/prisma/selects/credential.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const credentialForCalendarServiceSelect = {
   id: true,

--- a/packages/prisma/selects/event-types.ts
+++ b/packages/prisma/selects/event-types.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const baseEventTypeSelect = {
   id: true,

--- a/packages/prisma/selects/payment.ts
+++ b/packages/prisma/selects/payment.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const paymentDataSelect = {
   data: true,

--- a/packages/prisma/selects/user.ts
+++ b/packages/prisma/selects/user.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "../client";
 
 export const availabilityUserSelect = {
   id: true,

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -11,9 +11,8 @@ import type {
   ZodTypeAny,
 } from "zod";
 
-import { EventTypeCustomInputType } from "@calcom/prisma/enums";
-
 import type { Prisma } from "./client";
+import { EventTypeCustomInputType } from "./enums";
 
 /** @see https://github.com/colinhacks/zod/issues/3155#issuecomment-2060045794 */
 export const emailRegex =
@@ -1056,7 +1055,8 @@ export const excludeOrRequireEmailSchema = z.string().superRefine((val, ctx) => 
   // Accept forms: domain-only, `@domain`, or `local@domain`
   // - Domain labels: alnum, hyphens allowed internally, no leading/trailing hyphen
   // - Require at least one dot and end with an alpha TLD of length ≥2
-  const EMAIL_OR_DOMAIN_PATTERN = /^(?:[a-z0-9._+'-]+@|@)?(?:[a-z]{2,}|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,})$/i;
+  const EMAIL_OR_DOMAIN_PATTERN =
+    /^(?:[a-z0-9._+'-]+@|@)?(?:[a-z]{2,}|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,})$/i;
 
   const isValid = allDomains.every((entry) => EMAIL_OR_DOMAIN_PATTERN.test(entry));
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch @calcom/prisma to use relative imports for client and enums. This removes self-references, stabilizes builds, and improves type resolution.

- **Refactors**
  - Replaced imports from "@calcom/prisma/*" with local "./client" and "./enums" across extensions, selects, mocks, and availability check.
  - Updated safeJSONStringify parameter type from any to unknown.
  - Minor formatting cleanup in zod-utils.

<sup>Written for commit 85c0a7b75fb1291be5b848a73d1ccb5543283f49. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



