### PR TITLE
chore: Fix peer dependencies in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,7 +2006,11 @@ __metadata:
     lodash: "npm:4.17.21"
     qs-stringify: "npm:1.2.1"
     react-i18next: "npm:12.3.1"
-    stripe: "npm:9.16.0"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    stripe: ^9.0.0 || ^15.0.0
+    zod: ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -2152,7 +2156,10 @@ __metadata:
     "@calcom/prisma": "workspace:*"
     "@calcom/types": "workspace:*"
     "@calcom/ui": "workspace:*"
-    react-hook-form: "npm:7.43.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2319,6 +2326,10 @@ __metadata:
     libphonenumber-js: "npm:^1.11.18"
     twilio: "npm:3.84.1"
     zod: "npm:3.25.76"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2357,9 +2368,10 @@ __metadata:
     "@calcom/lib": "workspace:*"
     "@calcom/tsconfig": "workspace:*"
     "@calcom/types": "workspace:*"
-    react: "npm:18.2.0"
-    react-dom: "npm:18.2.0"
     rrule: "npm:2.7.1"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -2477,7 +2489,10 @@ __metadata:
     "@calcom/types": "workspace:*"
     "@calcom/ui": "workspace:*"
     ews-javascript-api: "npm:0.11.0"
-    react-hook-form: "npm:7.43.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2490,7 +2505,10 @@ __metadata:
     "@calcom/types": "workspace:*"
     "@calcom/ui": "workspace:*"
     ews-javascript-api: "npm:0.11.0"
-    react-hook-form: "npm:7.43.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2573,8 +2591,9 @@ __metadata:
     web-push: "npm:3.6.7"
     zustand: "npm:4.5.2"
   peerDependencies:
-    react: 18.2.0
-    react-dom: 18.2.0
+    next: ">=14.0.0"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
     react-is: ^18.2.0
     stripe: ^9.0.0 || ^15.0.0
     zod: ^3.0.0
@@ -2720,7 +2739,10 @@ __metadata:
     "@calcom/prisma": "workspace:*"
     "@calcom/types": "workspace:*"
     "@calcom/ui": "workspace:*"
-    react-hook-form: "npm:7.43.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2994,6 +3016,11 @@ __metadata:
     vite: "npm:5.4.21"
     vite-plugin-dts: "npm:3.7.3"
     vite-plugin-environment: "npm:1.1.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    stripe: ^9.0.0 || ^15.0.0
+    zod: ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -3279,6 +3306,7 @@ __metadata:
     uuid: "npm:8.3.2"
     zod: "npm:3.25.76"
   peerDependencies:
+    "@tanstack/react-query": ^5.0.0
     next: ">=14.0.0"
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
@@ -3338,7 +3366,6 @@ __metadata:
     "@radix-ui/react-slider": "npm:1.2.2"
     "@storybook/blocks": "npm:7.6.3"
     "@storybook/react": "npm:7.6.3"
-    "@tanstack/react-query": "npm:5.17.19"
     "@tanstack/react-table": "npm:8.20.6"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:18.0.26"
@@ -3357,7 +3384,6 @@ __metadata:
     lexical: "npm:0.9.0"
     lucide-static: "npm:0.424.0"
     node-html-parser: "npm:6.1.13"
-    react: "npm:18.2.0"
     react-colorful: "npm:5.6.1"
     react-day-picker: "npm:8.10.1"
     react-easy-crop: "npm:5.0.0"
@@ -3370,7 +3396,9 @@ __metadata:
     uuid: "npm:11.1.0"
     zod: "npm:3.25.76"
   peerDependencies:
-    react-dom: 18.2.0
+    "@tanstack/react-query": ^5.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -4002,6 +4030,9 @@ __metadata:
     ts-node: "npm:10.9.2"
     tsc-absolute: "npm:1.0.0"
     typescript: "npm:5.9.0-beta"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns peer dependency declarations in yarn.lock across workspace packages to reduce install warnings and avoid duplicate installs. Adds React 19 compatibility with consistent peer ranges.

- **Dependencies**
  - Set react and react-dom peer ranges to ^18.0.0 || ^19.0.0.
  - Marked next (>=14) and @tanstack/react-query (^5) as peer deps where used.
  - Standardized react-hook-form (^7), stripe (^9 || ^15), and zod (^3) as peer deps.
  - Removed duplicated direct deps in favor of peerDependencies.

<sup>Written for commit e444b7874173670df656adcf3edb7a56e43790d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

These weren't done in https://github.com/calcom/cal.com/pull/26244