### PR TITLE
chore: Keep yarn-install cache local to PR

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -36,7 +36,7 @@ runs:
       id: yarn-download-cache
       with:
         path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
-        key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
+        key: yarn-download-cache-${{ hashFiles('yarn.lock') }}-${{ github.event.pull_request.number || github.ref }}
 
     # Invalidated on yarn.lock changes
     - name: Restore node_modules
@@ -44,7 +44,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: "**/node_modules/"
-        key: ${{ runner.os }}-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+        key: ${{ runner.os }}-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}-${{ github.event.pull_request.number || github.ref }}
 
     # Invalidated on yarn.lock changes
     - name: Restore yarn install state
@@ -52,7 +52,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .yarn/ci-cache/
-        key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+        key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}-${{ github.event.pull_request.number || github.ref }}
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scopes Yarn caches to each PR by appending the PR number/ref to cache keys. This avoids cross-branch cache collisions and makes CI installs more predictable.

- **Refactors**
  - Append ${{ github.event.pull_request.number || github.ref }} to cache keys for yarn-download, node_modules, and install-state.
  - Keep invalidation tied to yarn.lock and .yarnrc.yml changes.

<sup>Written for commit 63151d9ff2e7879cffe75ec934fcfbb06f102c28. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

