### PR TITLE
chore: Delete yarn-install cache entries on PR close

### DIFF
--- a/.github/workflows/delete-blacksmith-cache.yml
+++ b/.github/workflows/delete-blacksmith-cache.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: useblacksmith/cache-delete@v1
         with:
-          cache_key: ${{ inputs.cache_key }}
+          key: ${{ inputs.cache_key }}
 
   delete-yarn-install-cache-on-pr-close:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
@@ -26,19 +26,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Delete yarn-install caches for this PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          echo "Deleting yarn-install caches for PR #${PR_NUMBER}..."
-
-          # List all caches and filter by those ending with the PR number
-          gh cache list --json key --jq '.[].key' | while read -r cache_key; do
-            if [[ "$cache_key" =~ -${PR_NUMBER}$ ]]; then
-              echo "Deleting cache: $cache_key"
-              gh cache delete "$cache_key" || true
-            fi
-          done
-
-          echo "Cache cleanup complete for PR #${PR_NUMBER}"
+      - name: Delete yarn-download-cache
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: yarn-download-cache-${{ hashFiles('yarn.lock') }}-${{ github.event.pull_request.number }}
+      - name: Delete yarn-nm-cache
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: Linux-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}-${{ github.event.pull_request.number }}
+      - name: Delete yarn-install-state-cache
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: Linux-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/delete-blacksmith-cache.yml
+++ b/.github/workflows/delete-blacksmith-cache.yml
@@ -1,4 +1,4 @@
-name: Manually Delete Blacksmith Cache
+name: Delete Blacksmith Cache
 on:
   workflow_dispatch:
     inputs:
@@ -6,8 +6,12 @@ on:
         description: "Blacksmith Cache Key to Delete"
         required: true
         type: string
+  pull_request:
+    types: [closed]
+
 jobs:
   manually-delete-blacksmith-cache:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -15,3 +19,26 @@ jobs:
       - uses: useblacksmith/cache-delete@v1
         with:
           cache_key: ${{ inputs.cache_key }}
+
+  delete-yarn-install-cache-on-pr-close:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Delete yarn-install caches for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "Deleting yarn-install caches for PR #${PR_NUMBER}..."
+
+          # List all caches and filter by those ending with the PR number
+          gh cache list --json key --jq '.[].key' | while read -r cache_key; do
+            if [[ "$cache_key" =~ -${PR_NUMBER}$ ]]; then
+              echo "Deleting cache: $cache_key"
+              gh cache delete "$cache_key" || true
+            fi
+          done
+
+          echo "Cache cleanup complete for PR #${PR_NUMBER}"


### PR DESCRIPTION
## What does this PR do?

Adds automatic cleanup of yarn-install cache entries when a PR is merged or closed. This complements PR #26262 which scopes yarn caches to each PR by appending the PR number to cache keys.

Since PR-scoped caches consume more storage on Blacksmith, this workflow automatically deletes the caches associated with a PR when it's closed, preventing cache accumulation.

## How it works

- Triggers on `pull_request: closed` events (covers both merged and closed PRs)
- Uses `useblacksmith/cache-delete@v1` to delete the three yarn-install cache entries:
  - `yarn-download-cache-{hashFiles('yarn.lock')}-{PR_NUMBER}`
  - `Linux-yarn-nm-cache-{hashFiles('yarn.lock', '.yarnrc.yml')}-{PR_NUMBER}`
  - `Linux-yarn-install-state-cache-{hashFiles('yarn.lock', '.yarnrc.yml')}-{PR_NUMBER}`
- Uses `hashFiles()` to compute the exact cache keys matching the format from #26262

The existing manual cache deletion functionality via `workflow_dispatch` is preserved. Also fixed a bug where the action input was `cache_key` but should be `key`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow that will be validated when PRs are closed.

## How should this be tested?

This workflow can be tested by:
1. Merging PR #26262 first (which creates PR-scoped cache keys)
2. Opening a test PR and letting CI run (creates caches ending with the PR number)
3. Closing/merging the test PR
4. Verifying the `delete-yarn-install-cache-on-pr-close` job runs and deletes the caches

## Human Review Checklist

- [ ] Verify cache key format exactly matches what #26262 creates (yarn-download-cache, Linux-yarn-nm-cache, Linux-yarn-install-state-cache)
- [ ] Note: This only deletes caches for the final yarn.lock state - if yarn.lock changed during the PR, older caches will remain
- [ ] Ensure this PR is merged after #26262 to be effective

---

> **Link to Devin run**: https://app.devin.ai/sessions/5f9c61ed5aef4b9e8def5b85daad81c1
> **Requested by**: keith@cal.com (@keithwillcode)