### PR TITLE
fix: sync slug with event name until marked dirty

### DIFF
--- a/apps/web/modules/ee/teams/components/__tests__/CreateANewTeamForm.test.tsx
+++ b/apps/web/modules/ee/teams/components/__tests__/CreateANewTeamForm.test.tsx
@@ -1,0 +1,74 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { CreateANewTeamForm } from "../CreateANewTeamForm";
+
+function getTitleAndSlugInputs() {
+  const textboxes = screen.getAllByRole("textbox");
+  const titleInput = textboxes[0] as HTMLInputElement;
+  const slugInput = textboxes[1] as HTMLInputElement;
+  return { titleInput, slugInput };
+}
+
+vi.mock("@calcom/trpc/react", () => ({
+  trpc: {
+    useUtils: () => ({
+      viewer: {
+        eventTypes: {
+          getUserEventGroups: {
+            invalidate: () => {},
+          },
+        },
+      },
+    }),
+    viewer: {
+      teams: {
+        create: {
+          useMutation: () => ({ isPending: false, mutate: () => {} }),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@calcom/features/ee/organizations/context/provider", () => ({
+  useOrgBranding: () => ({ fullDomain: "https://example.org" }),
+}));
+
+describe("CreateANewTeamForm - Slug Auto-Sync Behavior", () => {
+  const defaultProps = {
+    inDialog: false,
+    onCancel: () => {},
+    submitLabel: "create",
+    onSuccess: vi.fn(),
+    slug: undefined,
+  } as const;
+
+  it("should auto-sync slug when name changes and behave like event form", async () => {
+    render(<CreateANewTeamForm {...defaultProps} />);
+
+    const { titleInput, slugInput } = getTitleAndSlugInputs();
+
+    // Initially empty
+    expect(titleInput.value).toBe("");
+    expect(slugInput.value).toBe("");
+
+    // Type team name
+    fireEvent.change(titleInput, { target: { value: "Acme Inc" } });
+    await waitFor(() => expect(slugInput.value).toBe("acme-inc"));
+
+    // Focus slug and blur without editing - auto-sync should continue
+    fireEvent.focus(slugInput);
+    fireEvent.blur(slugInput);
+    fireEvent.change(titleInput, { target: { value: "Acme Incorporated" } });
+    await waitFor(() => expect(slugInput.value).toBe("acme-incorporated"));
+
+    // Edit slug manually - stops auto-sync
+    fireEvent.change(slugInput, { target: { value: "custom-acme" } });
+    await waitFor(() => expect(slugInput.value).toBe("custom-acme"));
+
+    fireEvent.change(titleInput, { target: { value: "Acme Updated" } });
+    // slug should remain custom
+    await waitFor(() => expect(slugInput.value).toBe("custom-acme"));
+  });
+});

--- a/packages/features/eventtypes/components/CreateEventTypeForm.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeForm.tsx
@@ -71,7 +71,7 @@ export default function CreateEventTypeForm({
               }
               containerClassName="[&>div]:gap-0"
               className="pl-0"
-              {...register("slug")}
+              value={form.watch("slug") || ""}
               onChange={(e) => {
                 form.setValue("slug", slugify(e?.target.value), { shouldTouch: true });
               }}
@@ -98,7 +98,7 @@ export default function CreateEventTypeForm({
               }
               containerClassName="[&>div]:gap-0"
               className="pl-0"
-              {...register("slug")}
+              value={form.watch("slug") || ""}
               onChange={(e) => {
                 form.setValue("slug", slugify(e?.target.value), { shouldTouch: true });
               }}

--- a/packages/features/eventtypes/components/__tests__/CreateEventTypeForm.test.tsx
+++ b/packages/features/eventtypes/components/__tests__/CreateEventTypeForm.test.tsx
@@ -1,0 +1,77 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { vi } from "vitest";
+
+import type { CreateEventTypeFormValues } from "@calcom/features/eventtypes/hooks/useCreateEventType";
+
+import CreateEventTypeForm from "../CreateEventTypeForm";
+
+function getTitleAndSlugInputs() {
+  const textboxes = screen.getAllByRole("textbox");
+  const titleInput = textboxes[0] as HTMLInputElement;
+  const slugInput = textboxes[1] as HTMLInputElement;
+  return { titleInput, slugInput };
+}
+
+describe("CreateEventTypeForm - Slug Auto-Sync Behavior", () => {
+  const TestFormWrapper = ({
+    urlPrefix = "https://example.com/user",
+    onSubmit = vi.fn(),
+  }: {
+    urlPrefix?: string;
+    onSubmit?: (values: CreateEventTypeFormValues) => void;
+  }) => {
+    const form = useForm({
+      defaultValues: {
+        slug: "",
+        title: "",
+        length: 15,
+        description: "",
+      },
+    });
+
+    return (
+      <CreateEventTypeForm
+        form={form}
+        isManagedEventType={false}
+        handleSubmit={onSubmit}
+        urlPrefix={urlPrefix}
+        pageSlug="user"
+        isPending={false}
+        SubmitButton={(isPending) => (
+          <button type="submit" data-testid="submit-btn">
+            {isPending ? "Creating..." : "Create Event"}
+          </button>
+        )}
+      />
+    );
+  };
+
+  it("should auto-sync slug when title changes and behave like team form", async () => {
+    render(<TestFormWrapper />);
+
+    const { titleInput, slugInput } = getTitleAndSlugInputs();
+
+    // Initially empty
+    expect(titleInput.value).toBe("");
+    expect(slugInput.value).toBe("");
+
+    // Type in title
+    fireEvent.change(titleInput, { target: { value: "Quick Chat" } });
+    await waitFor(() => expect(slugInput.value).toBe("quick-chat"));
+
+    // Focus slug and blur without editing - auto-sync should continue
+    fireEvent.focus(slugInput);
+    fireEvent.blur(slugInput);
+    fireEvent.change(titleInput, { target: { value: "Quick Chat Meeting" } });
+    await waitFor(() => expect(slugInput.value).toBe("quick-chat-meeting"));
+
+    // Edit slug manually - stops auto-sync
+    fireEvent.change(slugInput, { target: { value: "custom-slug" } });
+    await waitFor(() => expect(slugInput.value).toBe("custom-slug"));
+
+    fireEvent.change(titleInput, { target: { value: "Quick Chat Meeting Updated" } });
+    // slug should remain custom
+    await waitFor(() => expect(slugInput.value).toBe("custom-slug"));
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Changes the way to track `slug` in `createEventTypeForm` to fix the bug mentioned in the issue and adds unit tests for both new event form and create team form so that we can avoid this regression in the future.

- Fixes #26265
- Fixes CAL-6986

Root cause - The register function was marking the slug dirty even on focus or blur events.

#### Video Demo

Before fix : 

https://github.com/user-attachments/assets/b4eb4353-cab5-4c06-8332-27fc4647031e


After fix : 

https://github.com/user-attachments/assets/6de6ff8b-ef45-4c0a-95cb-e29cb004341e

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.