### PR TITLE
fix: exclude .next/node_modules from yarn cache to prevent corruption

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -43,7 +43,9 @@ runs:
       id: yarn-nm-cache
       uses: actions/cache@v4
       with:
-        path: "**/node_modules/"
+        path: |
+          **/node_modules/
+          !**/.next/node_modules/
         key: ${{ runner.os }}-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     # Invalidated on yarn.lock changes


### PR DESCRIPTION
## What does this PR do?

Fixes cache corruption issues that occurred after migrating from Buildjet to Blacksmith runners. The `**/node_modules/` glob pattern was unintentionally capturing `apps/web/.next/node_modules/` directories (Next.js build output), which contain symlinks and generated files that can be in flux during builds. This led to corrupted cache archives with tar extraction errors like:

```
/usr/bin/tar: apps/web/.next/node_modules/@boxyhq/saml-jackson-...: Cannot mkdir: File exists
/usr/bin/tar: apps/web/.next/node_modules/.../node_modules: Cannot mkdir: No such file or directory
```

This PR excludes `.next/node_modules/` from the cache path to prevent these directories from being captured.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflows will validate the fix.

## How should this be tested?

This change can only be validated by running CI workflows:

1. **Purge existing corrupted caches** - Delete cache keys matching `Linux-yarn-nm-cache-*` to remove the corrupted archives
2. Run a workflow that uses the yarn-install action
3. Verify the cache is saved and restored without tar extraction errors
4. Confirm `.next/node_modules/` directories are not included in the cache

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [x] Verify the exclusion pattern `!**/.next/node_modules/` is valid syntax for `actions/cache@v4`
- [x] Consider if other generated directories (e.g., `.turbo/`) should also be excluded
- [x] Note: Existing corrupted cache entries need to be purged for this fix to take effect

---

Link to Devin run: https://app.devin.ai/sessions/ab6c600047e241968580e8b6c089f370
Requested by: keith@cal.com (@keithwillcode)