### PR TITLE
fix: remove nested turbo run for copy-app-store-static to fix remote caching

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "sentry:release": "NODE_OPTIONS='--max-old-space-size=6144' node scripts/create-sentry-release.js",
     "copy-static": "turbo run copy-app-store-static",
     "copy-app-store-static": "node scripts/copy-app-store-static.js",
-    "build": "turbo run copy-app-store-static && next build && yarn sentry:release",
+    "build": "next build && yarn sentry:release",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/turbo.json
+++ b/turbo.json
@@ -327,7 +327,7 @@
       "outputs": ["./types"]
     },
     "@calcom/web#build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "copy-app-store-static"],
       "outputs": [".next/**"],
       "env": [
         "NEXT_PUBLIC_AVAILABILITY_SCHEDULE_INTERVAL",


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where remote caching was being disabled during `@calcom/web:build` even though `TURBO_TEAM` and `TURBO_TOKEN` were correctly configured.

**Root cause:** The build script was spawning a nested turbo process (`turbo run copy-app-store-static && next build`). While the outer turbo process has remote caching enabled, the nested child process doesn't inherit `TURBO_TOKEN`/`TURBO_TEAM` environment variables by default, causing it to print "Remote caching disabled".

**Fix:** Instead of calling turbo inside the build script, wire `copy-app-store-static` as a proper turbo dependency in `turbo.json`. This way the outer turbo handles it in the same task graph and remote caching works correctly.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - configuration change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI build will validate this works.

## How should this be tested?

1. Trigger a CI build and observe the turbo output
2. Verify that `@calcom/web:build` no longer shows "Remote caching disabled" for the `copy-app-store-static` step
3. Confirm that `copy-app-store-static` still runs before `next build` (turbo handles dependency ordering)

## Human Review Checklist

- [ ] Verify the turbo `dependsOn` syntax is correct for running `copy-app-store-static` before the build
- [ ] Confirm builds complete successfully with this change

---

Link to Devin run: https://app.devin.ai/sessions/c7fe4c2224b44695a80605af17454d37
Requested by: keith@cal.com (@keithwillcode)