### PR TITLE
fix: update NewApiKeyButton with size and variant props

### DIFF
--- a/apps/web/modules/settings/developer/api-keys-view.tsx
+++ b/apps/web/modules/settings/developer/api-keys-view.tsx
@@ -28,6 +28,8 @@ export const NewApiKeyButton = () => {
     <Button
       color="secondary"
       StartIcon="plus"
+      size="sm"
+      variant="fab"
       onClick={() => {
         apiKeyModalRef.current?.(true);
         apiKeyToEditRef.current?.(undefined);


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26271
- Fixes [CAL-6988
](https://linear.app/calcom/issue/CAL-6988/fix-add-mobile-plus-icon-to-api-keys-create-button-to-match-webhooks)
## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Image Demo (if applicable):

webhook mobile view just for reference:

<img width="485" height="472" alt="Screenshot 2025-12-29 at 8 28 49 PM" src="https://github.com/user-attachments/assets/1d236a18-2bce-4966-95f3-d4881d894a05" />


before:

<img width="486" height="468" alt="Screenshot 2025-12-29 at 8 26 31 PM" src="https://github.com/user-attachments/assets/3eb6db9a-1fc2-4267-abb3-bff587f8fe87" />


after:

<img width="488" height="570" alt="Screenshot 2025-12-29 at 8 27 14 PM" src="https://github.com/user-attachments/assets/0e7001e0-ccef-4f0a-9b63-bb64c9d69580" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the API Keys Create button a small FAB with a plus icon on mobile, matching the Webhooks UI. Implements this by setting size=sm and variant=fab on NewApiKeyButton (CAL-6988).

<sup>Written for commit 60350a8474a5ec0abe04828fad72028df4075544. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







