### PR TITLE
chore: Give Unit Tests job more vCPUs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: Unit
     timeout-minutes: 20
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the Unit test job runner from 2 to 4 vCPUs to speed up CI and reduce timeouts. Updates the workflow to use blacksmith-4vcpu-ubuntu-2404.

<sup>Written for commit d27c933d75839f6e3aff5b9fd449bc2b17a57200. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

This had been backed down to 2 but turns out it's a bit too low and causing this job to take 4-5m, which is too slow.

