### PR TITLE
fix: add destructive color and rounded-t-none to user dropdown button

### DIFF
--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -203,7 +203,9 @@ export function UserDropdown({ small }: UserDropdownProps) {
               <DropdownMenuItem>
                 <DropdownItem
                   type="button"
+                  color="destructive"
                   StartIcon="log-out"
+                  className="rounded-t-none"
                   aria-hidden="true"
                   onClick={() => {
                     signOut({ callbackUrl: "/auth/logout" });


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26274
- Fixes [CAL-6989](https://linear.app/calcom/issue/CAL-6989/fix-make-sign-out-button-destructive)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:

<img width="270" height="433" alt="Screenshot 2025-12-29 at 8 40 41 PM" src="https://github.com/user-attachments/assets/f1bfe9d7-2579-4c86-82a5-0dd4d95b174f" />


after:

<img width="311" height="305" alt="Screenshot 2025-12-29 at 8 41 17 PM" src="https://github.com/user-attachments/assets/aa8a23cf-0199-4b7c-a1e5-cbdfaf87c273" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Sign Out button in the user dropdown clearly destructive and fix its corner styling. Adds destructive color and rounded-t-none to match the dropdown design and meet Linear CAL-6989.

<sup>Written for commit f09aed65561a4b7bdc4ea4f5f6bdcd89ebe7408c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





