### PR TITLE
chore: improve release-docker workflow permissions

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,5 +1,9 @@
 name: "Release Docker"
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   POSTGRES_USER: "unicorn_user"
   POSTGRES_PASSWORD: "magical_password"


### PR DESCRIPTION
## What does this PR do?

Reduces the GitHub Actions permissions for the `release-docker` workflow from overly broad defaults to the minimum required permissions.

**Before:** The workflow had write access to too many things.

**After:** Only `contents: read` (for checkout) and `packages: write` (for pushing to ghcr.io) are granted.

This follows the principle of least privilege for better security posture.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - workflow permissions can only be verified when the workflow runs.

## How should this be tested?

This change will be verified when the release-docker workflow runs (on tag push or manual dispatch). The workflow should:
1. Successfully check out the repository
2. Successfully push Docker images to ghcr.io
3. Docker Hub pushes use separate credentials (not affected by GITHUB_TOKEN permissions)
4. Slack notifications use webhook URLs (not affected by GITHUB_TOKEN permissions)

## Human Review Checklist

- [ ] Verify no other GitHub API operations in the workflow require additional permissions
- [ ] Confirm the `useblacksmith/build-push-action@v2` doesn't implicitly require additional permissions (e.g., for provenance/attestations or GHA cache)

---

- **Link to Devin run**: https://app.devin.ai/sessions/61be865adc904df6a6a0bb04eb2b4fc7
- **Requested by**: keith@cal.com (@keithwillcode)