### PR TITLE
test: few more e2e flakes

### DIFF
--- a/apps/web/playwright/auth/auth-index.e2e.ts
+++ b/apps/web/playwright/auth/auth-index.e2e.ts
@@ -24,6 +24,7 @@ test.describe("Can signup from a team invite", async () => {
       email: `${proUser.username}-member@example.com`,
     };
     await page.goto("/settings/teams/new");
+    await page.waitForLoadState("networkidle");
 
     // Create a new team
     await page.locator('input[name="name"]').fill(teamName);

--- a/apps/web/playwright/availability.e2e.ts
+++ b/apps/web/playwright/availability.e2e.ts
@@ -113,7 +113,7 @@ test.describe("Availability", () => {
 
   test("Schedule listing", async ({ page }) => {
     await test.step("Can add a new schedule", async () => {
-      await page.getByTestId("new-schedule").click();
+      await page.getByTestId("new-schedule").first().click();
       await page.locator('[id="name"]').fill("More working hours");
       page.locator('[type="submit"]').click();
       await expect(page.getByTestId("availablity-title")).toHaveValue("More working hours");

--- a/apps/web/playwright/availability.e2e.ts
+++ b/apps/web/playwright/availability.e2e.ts
@@ -149,7 +149,7 @@ test.describe("Availability", () => {
     await page.getByTestId("availablity-title").click();
     // change availability name
     await page.getByTestId("availablity-title").fill("Working Hours test");
-    await expect(page.getByTestId("subtitle")).toBeVisible();
+    await expect(page.getByTestId("subtitle").first()).toBeVisible();
     await page.getByTestId(sunday).getByRole("switch").click();
     await page.getByTestId(monday).first().click();
     await page.getByTestId(wednesday).getByRole("switch").click();

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -455,13 +455,13 @@ test.describe("Booking on different layouts", () => {
 
   test("Book on week layout", async ({ page }) => {
     // Click first event type
-    await page.click('[data-testid="event-type-link"]');
+    await page.locator('[data-testid="event-type-link"]').first().click();
 
     await page.click('[data-testid="toggle-group-item-week_view"]');
 
     await page.click('[data-testid="incrementMonth"]');
 
-    await page.locator('[data-testid="calendar-empty-cell"]').nth(0).click();
+    await page.locator('[data-testid="calendar-empty-cell"]').nth(1).click();
 
     // Fill what is this meeting about? name email and notes
     await page.locator('[name="name"]').fill("Test name");
@@ -476,13 +476,13 @@ test.describe("Booking on different layouts", () => {
 
   test("Book on column layout", async ({ page }) => {
     // Click first event type
-    await page.click('[data-testid="event-type-link"]');
+    await page.locator('[data-testid="event-type-link"]').first().click();
 
     await page.click('[data-testid="toggle-group-item-column_view"]');
 
     await page.click('[data-testid="incrementMonth"]');
 
-    await page.locator('[data-testid="time"]').nth(0).click();
+    await page.locator('[data-testid="time"]').nth(1).click();
 
     // Fill what is this meeting about? name email and notes
     await page.locator('[name="name"]').fill("Test name");

--- a/apps/web/playwright/booking-pages.e2e.ts
+++ b/apps/web/playwright/booking-pages.e2e.ts
@@ -449,7 +449,15 @@ test.describe("prefill", () => {
 
 test.describe("Booking on different layouts", () => {
   test.beforeEach(async ({ page, users }) => {
-    const user = await users.create();
+    // Create user with specific availability (9 AM - 5 PM UTC, Monday-Friday)
+    // This ensures slots are available and reduces race conditions
+    const dateRanges: TimeRange = {
+      start: new Date(new Date().setUTCHours(9, 0, 0, 0)),
+      end: new Date(new Date().setUTCHours(17, 0, 0, 0)),
+    };
+    const schedule: Schedule = [[], [dateRanges], [dateRanges], [dateRanges], [dateRanges], [dateRanges], []];
+
+    const user = await users.create({ schedule });
     await page.goto(`/${user.username}`);
   });
 

--- a/apps/web/playwright/i18n-routing.e2e.ts
+++ b/apps/web/playwright/i18n-routing.e2e.ts
@@ -39,9 +39,7 @@ test.describe("Locale-specific pages must not 404", () => {
         await user.apiLogin();
         const response = await page.goto(`/${locale}/event-types`);
         expect(response?.status()).not.toBe(404);
-        await expect(
-          page.locator("text=Create events to share for people to book on your calendar.")
-        ).toBeVisible();
+        await expect(page.getByTestId("subtitle").first()).toBeVisible();
       });
 
       test(`/${locale}/availability page shouldn't 404`, async ({ page, users }) => {
@@ -49,7 +47,7 @@ test.describe("Locale-specific pages must not 404", () => {
         await user.apiLogin();
         const response = await page.goto(`/${locale}/availability`);
         expect(response?.status()).not.toBe(404);
-        await expect(page.locator("text=Configure times when you are available for bookings.")).toBeVisible();
+        await expect(page.getByTestId("subtitle").first()).toBeVisible();
       });
 
       test(`/${locale}/bookings/upcoming page shouldn't 404`, async ({ page, users }) => {
@@ -65,9 +63,7 @@ test.describe("Locale-specific pages must not 404", () => {
         await user.apiLogin();
         const response = await page.goto(`/${locale}/teams`);
         expect(response?.status()).not.toBe(404);
-        await expect(
-          page.locator("text=Create and manage teams to use collaborative features.")
-        ).toBeVisible();
+        await expect(page.getByTestId("subtitle").first()).toBeVisible();
       });
 
       test(`/${locale}/routing page shouldn't 404`, async ({ page, users }) => {
@@ -75,9 +71,7 @@ test.describe("Locale-specific pages must not 404", () => {
         await user.apiLogin();
         const response = await page.goto(`/${locale}/routing`);
         expect(response?.status()).not.toBe(404);
-        await expect(
-          page.locator("text=Create forms to direct attendees to the correct destinations")
-        ).toBeVisible();
+        await expect(page.getByTestId("subtitle").first()).toBeVisible();
       });
 
       test(`/${locale}/insights page shouldn't 404`, async ({ page, users }) => {
@@ -85,7 +79,7 @@ test.describe("Locale-specific pages must not 404", () => {
         await user.apiLogin();
         const response = await page.goto(`/${locale}/insights`);
         expect(response?.status()).not.toBe(404);
-        await expect(page.locator("text=View booking insights across your events")).toBeVisible();
+        await expect(page.getByTestId("subtitle").first()).toBeVisible();
       });
     });
   }

--- a/apps/web/playwright/organization/organization-privacy.e2e.ts
+++ b/apps/web/playwright/organization/organization-privacy.e2e.ts
@@ -49,15 +49,15 @@ test.describe("Organization - Privacy", () => {
     await page.goto(`/settings/organizations/${org.slug}/members`);
     await page.waitForLoadState("domcontentloaded");
 
-    const tableLocator = await page.getByTestId("user-list-data-table");
+    const tableLocator = page.getByTestId("user-list-data-table").first();
 
     await expect(tableLocator).toBeVisible();
 
     await memberInOrg.apiLogin();
     await page.goto(`/settings/organizations/${org.slug}/members`);
     await page.waitForLoadState("domcontentloaded");
-    const userDataTable = await page.getByTestId("user-list-data-table");
-    const membersPrivacyWarning = await page.getByTestId("members-privacy-warning");
+    const userDataTable = page.getByTestId("user-list-data-table").first();
+    const membersPrivacyWarning = page.getByTestId("members-privacy-warning").first();
     await expect(userDataTable).toBeHidden();
     await expect(membersPrivacyWarning).toBeVisible();
   });

--- a/apps/web/playwright/organization/team-management.e2e.ts
+++ b/apps/web/playwright/organization/team-management.e2e.ts
@@ -28,7 +28,7 @@ test.describe("Teams", () => {
     await test.step("Can create team", async () => {
       // Click text=Create Team
       await page.locator("text=Create a new Team").click();
-      await page.waitForURL((url) => url.pathname === "/settings/teams/new");
+      await page.waitForLoadState("networkidle");
       // Fill input[name="name"]
       await page.locator('input[name="name"]').fill(`${user.username}'s Team`);
       // Click text=Continue

--- a/apps/web/playwright/teams.e2e.ts
+++ b/apps/web/playwright/teams.e2e.ts
@@ -141,6 +141,7 @@ test.describe("Teams - NonOrg", () => {
 
       // Go directly to the create team page
       await page.goto("/settings/teams/new");
+      await page.waitForLoadState("networkidle");
       // Fill input[name="name"]
       await page.locator('input[name="name"]').fill(uniqueName);
       await page.click("[type=submit]");
@@ -161,7 +162,7 @@ test.describe("Teams - NonOrg", () => {
     await test.step("Can create team with same name", async () => {
       // Click text=Create Team
       await page.locator("text=Create Team").click();
-      await page.waitForURL("/settings/teams/new");
+      await page.waitForLoadState("networkidle");
       // Fill input[name="name"]
       await page.locator('input[name="name"]').fill(uniqueName);
       // Click text=Continue


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes Playwright e2e tests to reduce flakiness. Uses scoped testId locators, deterministic schedules, and networkidle waits across availability, i18n routing, booking pages, teams/auth flows, and organization privacy.

- **Bug Fixes**
  - Replace text-based assertions with page.getByTestId("subtitle").first() on locale pages and in the availability edit flow.
  - Make booking flows deterministic: create users with fixed weekday availability, click the first event type, and use nth(1) for time/date picks.
  - Stabilize team creation and invite flows: waitForLoadState("networkidle") after navigating to /settings/teams/new; scope organization members table and privacy warning with .first().

<sup>Written for commit 678016c9f1bb751a37ee57093aacb142e849bdfa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











