### PR TITLE
fix: improve test isolation for managed event type e2e tests

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
@@ -63,9 +63,11 @@ describe("Organizations Event Types Endpoints", () => {
     let collectiveEventType: TeamEventTypeOutput_2024_06_14;
     let managedEventType: TeamEventTypeOutput_2024_06_14;
 
-    const managedEventTypeSlug = `organizations-event-types-managed-${randomString()}`;
+    let managedEventTypeSlug: string;
 
     beforeAll(async () => {
+      // Generate unique slug inside beforeAll to ensure uniqueness across test runs
+      managedEventTypeSlug = `organizations-event-types-managed-${randomString()}`;
       const moduleRef = await withApiAuth(
         userEmail,
         Test.createTestingModule({
@@ -1383,6 +1385,9 @@ describe("Organizations Event Types Endpoints", () => {
       await userRepositoryFixture.deleteByEmail(teammate1.email);
       await userRepositoryFixture.deleteByEmail(teammate2.email);
       await userRepositoryFixture.deleteByEmail(falseTestUser.email);
+      // Explicitly delete all team event types before deleting the team to ensure proper cleanup
+      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(team.id);
+      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(falseTestTeam.id);
       await teamsRepositoryFixture.delete(team.id);
       await teamsRepositoryFixture.delete(falseTestTeam.id);
       await organizationsRepositoryFixture.delete(org.id);

--- a/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
@@ -58,6 +58,14 @@ export class EventTypesRepositoryFixture {
     return this.prismaWriteClient.eventType.delete({ where: { id: eventTypeId } });
   }
 
+  async deleteAllTeamEventTypes(teamId: number) {
+    return this.prismaWriteClient.eventType.deleteMany({
+      where: {
+        teamId,
+      },
+    });
+  }
+
   async findById(eventTypeId: EventType["id"]) {
     return this.prismaReadClient.eventType.findUnique({ where: { id: eventTypeId } });
   }


### PR DESCRIPTION
## What does this PR do?

Fixes flaky e2e tests in `organizations-member-team-admin-event-types.e2e-spec.ts` where tests were intermittently failing with:
- 400 Bad Request when creating managed team event-type
- "expected 2, got 7" when getting team event-types

The fix improves test isolation by:
1. Moving `managedEventTypeSlug` generation inside `beforeAll` to ensure a fresh unique slug for each test run
2. Adding explicit cleanup of team event types in `afterAll` before deleting teams

### Changes
- Changed `managedEventTypeSlug` from a module-level constant to a variable initialized in `beforeAll`
- Added `deleteAllTeamEventTypes(teamId)` method to `EventTypesRepositoryFixture`
- Added explicit event type cleanup in `afterAll` to ensure no leftover data between test runs

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the e2e tests multiple times to verify they no longer flake:
```bash
yarn test:e2e --testPathPattern="organizations-member-team-admin-event-types"
```

The tests should pass consistently without intermittent 400 errors or count mismatches.

## Human Review Checklist

- [ ] Verify the root cause analysis is correct - the fix addresses test isolation but the exact cause of flakiness wasn't definitively reproduced
- [ ] Consider if there are other potential causes for the 400 Bad Request error
- [ ] Verify cleanup order (event types before teams) is appropriate

---

Link to Devin run: https://app.devin.ai/sessions/f3f852ee0bce45329a92660aadd1e4dd
Requested by: anik@cal.com (@anikdhabal)