### PR TITLE
fix(caldav): robust SCHEDULE-AGENT injection and attendee deduplication

### DIFF
--- a/packages/app-store/apps.browser.generated.tsx
+++ b/packages/app-store/apps.browser.generated.tsx
@@ -3,150 +3,68 @@
     Don't modify this file manually.
 **/
 import dynamic from "next/dynamic";
-
 export const InstallAppButtonMap = {
-  exchange2013calendar: dynamic(
-    () => import("./exchange2013calendar/components/InstallAppButton")
-  ),
-  exchange2016calendar: dynamic(
-    () => import("./exchange2016calendar/components/InstallAppButton")
-  ),
-  office365video: dynamic(
-    () => import("./office365video/components/InstallAppButton")
-  ),
+  exchange2013calendar: dynamic(() => import("./exchange2013calendar/components/InstallAppButton")),
+  exchange2016calendar: dynamic(() => import("./exchange2016calendar/components/InstallAppButton")),
+  office365video: dynamic(() => import("./office365video/components/InstallAppButton")),
   vital: dynamic(() => import("./vital/components/InstallAppButton")),
 };
-
 export const AppSettingsComponentsMap = {
   "general-app-settings": dynamic(
-    () =>
-      import("./templates/general-app-settings/components/AppSettingsInterface")
+    () => import("./templates/general-app-settings/components/AppSettingsInterface")
   ),
   weather_in_your_calendar: dynamic(
     () => import("./weather_in_your_calendar/components/AppSettingsInterface")
   ),
   zapier: dynamic(() => import("./zapier/components/AppSettingsInterface")),
 };
-
 export const EventTypeAddonMap = {
   alby: dynamic(() => import("./alby/components/EventTypeAppCardInterface")),
-  basecamp3: dynamic(
-    () => import("./basecamp3/components/EventTypeAppCardInterface")
-  ),
-  btcpayserver: dynamic(
-    () => import("./btcpayserver/components/EventTypeAppCardInterface")
-  ),
-  closecom: dynamic(
-    () => import("./closecom/components/EventTypeAppCardInterface")
-  ),
-  databuddy: dynamic(
-    () => import("./databuddy/components/EventTypeAppCardInterface")
-  ),
-  fathom: dynamic(
-    () => import("./fathom/components/EventTypeAppCardInterface")
-  ),
+  basecamp3: dynamic(() => import("./basecamp3/components/EventTypeAppCardInterface")),
+  btcpayserver: dynamic(() => import("./btcpayserver/components/EventTypeAppCardInterface")),
+  closecom: dynamic(() => import("./closecom/components/EventTypeAppCardInterface")),
+  databuddy: dynamic(() => import("./databuddy/components/EventTypeAppCardInterface")),
+  fathom: dynamic(() => import("./fathom/components/EventTypeAppCardInterface")),
   ga4: dynamic(() => import("./ga4/components/EventTypeAppCardInterface")),
   giphy: dynamic(() => import("./giphy/components/EventTypeAppCardInterface")),
   gtm: dynamic(() => import("./gtm/components/EventTypeAppCardInterface")),
-  hitpay: dynamic(
-    () => import("./hitpay/components/EventTypeAppCardInterface")
-  ),
-  hubspot: dynamic(
-    () => import("./hubspot/components/EventTypeAppCardInterface")
-  ),
-  insihts: dynamic(
-    () => import("./insihts/components/EventTypeAppCardInterface")
-  ),
-  matomo: dynamic(
-    () => import("./matomo/components/EventTypeAppCardInterface")
-  ),
-  metapixel: dynamic(
-    () => import("./metapixel/components/EventTypeAppCardInterface")
-  ),
-  "mock-payment-app": dynamic(
-    () => import("./mock-payment-app/components/EventTypeAppCardInterface")
-  ),
-  paypal: dynamic(
-    () => import("./paypal/components/EventTypeAppCardInterface")
-  ),
-  "pipedrive-crm": dynamic(
-    () => import("./pipedrive-crm/components/EventTypeAppCardInterface")
-  ),
-  plausible: dynamic(
-    () => import("./plausible/components/EventTypeAppCardInterface")
-  ),
-  posthog: dynamic(
-    () => import("./posthog/components/EventTypeAppCardInterface")
-  ),
-  qr_code: dynamic(
-    () => import("./qr_code/components/EventTypeAppCardInterface")
-  ),
-  salesforce: dynamic(
-    () => import("./salesforce/components/EventTypeAppCardInterface")
-  ),
-  stripepayment: dynamic(
-    () => import("./stripepayment/components/EventTypeAppCardInterface")
-  ),
+  hitpay: dynamic(() => import("./hitpay/components/EventTypeAppCardInterface")),
+  hubspot: dynamic(() => import("./hubspot/components/EventTypeAppCardInterface")),
+  insihts: dynamic(() => import("./insihts/components/EventTypeAppCardInterface")),
+  matomo: dynamic(() => import("./matomo/components/EventTypeAppCardInterface")),
+  metapixel: dynamic(() => import("./metapixel/components/EventTypeAppCardInterface")),
+  "mock-payment-app": dynamic(() => import("./mock-payment-app/components/EventTypeAppCardInterface")),
+  paypal: dynamic(() => import("./paypal/components/EventTypeAppCardInterface")),
+  "pipedrive-crm": dynamic(() => import("./pipedrive-crm/components/EventTypeAppCardInterface")),
+  plausible: dynamic(() => import("./plausible/components/EventTypeAppCardInterface")),
+  posthog: dynamic(() => import("./posthog/components/EventTypeAppCardInterface")),
+  qr_code: dynamic(() => import("./qr_code/components/EventTypeAppCardInterface")),
+  salesforce: dynamic(() => import("./salesforce/components/EventTypeAppCardInterface")),
+  stripepayment: dynamic(() => import("./stripepayment/components/EventTypeAppCardInterface")),
   "booking-pages-tag": dynamic(
-    () =>
-      import(
-        "./templates/booking-pages-tag/components/EventTypeAppCardInterface"
-      )
+    () => import("./templates/booking-pages-tag/components/EventTypeAppCardInterface")
   ),
   "event-type-app-card": dynamic(
-    () =>
-      import(
-        "./templates/event-type-app-card/components/EventTypeAppCardInterface"
-      )
+    () => import("./templates/event-type-app-card/components/EventTypeAppCardInterface")
   ),
-  twipla: dynamic(
-    () => import("./twipla/components/EventTypeAppCardInterface")
-  ),
+  twipla: dynamic(() => import("./twipla/components/EventTypeAppCardInterface")),
   umami: dynamic(() => import("./umami/components/EventTypeAppCardInterface")),
-  "zoho-bigin": dynamic(
-    () => import("./zoho-bigin/components/EventTypeAppCardInterface")
-  ),
-  zohocrm: dynamic(
-    () => import("./zohocrm/components/EventTypeAppCardInterface")
-  ),
+  "zoho-bigin": dynamic(() => import("./zoho-bigin/components/EventTypeAppCardInterface")),
+  zohocrm: dynamic(() => import("./zohocrm/components/EventTypeAppCardInterface")),
 };
 export const EventTypeSettingsMap = {
-  alby: dynamic(
-    () => import("./alby/components/EventTypeAppSettingsInterface")
-  ),
-  basecamp3: dynamic(
-    () => import("./basecamp3/components/EventTypeAppSettingsInterface")
-  ),
-  btcpayserver: dynamic(
-    () => import("./btcpayserver/components/EventTypeAppSettingsInterface")
-  ),
-  databuddy: dynamic(
-    () => import("./databuddy/components/EventTypeAppSettingsInterface")
-  ),
-  fathom: dynamic(
-    () => import("./fathom/components/EventTypeAppSettingsInterface")
-  ),
+  alby: dynamic(() => import("./alby/components/EventTypeAppSettingsInterface")),
+  basecamp3: dynamic(() => import("./basecamp3/components/EventTypeAppSettingsInterface")),
+  btcpayserver: dynamic(() => import("./btcpayserver/components/EventTypeAppSettingsInterface")),
+  databuddy: dynamic(() => import("./databuddy/components/EventTypeAppSettingsInterface")),
+  fathom: dynamic(() => import("./fathom/components/EventTypeAppSettingsInterface")),
   ga4: dynamic(() => import("./ga4/components/EventTypeAppSettingsInterface")),
-  giphy: dynamic(
-    () => import("./giphy/components/EventTypeAppSettingsInterface")
-  ),
+  giphy: dynamic(() => import("./giphy/components/EventTypeAppSettingsInterface")),
   gtm: dynamic(() => import("./gtm/components/EventTypeAppSettingsInterface")),
-  hitpay: dynamic(
-    () => import("./hitpay/components/EventTypeAppSettingsInterface")
-  ),
-  metapixel: dynamic(
-    () => import("./metapixel/components/EventTypeAppSettingsInterface")
-  ),
-  paypal: dynamic(
-    () => import("./paypal/components/EventTypeAppSettingsInterface")
-  ),
-  plausible: dynamic(
-    () => import("./plausible/components/EventTypeAppSettingsInterface")
-  ),
-  qr_code: dynamic(
-    () => import("./qr_code/components/EventTypeAppSettingsInterface")
-  ),
-  stripepayment: dynamic(
-    () => import("./stripepayment/components/EventTypeAppSettingsInterface")
-  ),
+  hitpay: dynamic(() => import("./hitpay/components/EventTypeAppSettingsInterface")),
+  metapixel: dynamic(() => import("./metapixel/components/EventTypeAppSettingsInterface")),
+  paypal: dynamic(() => import("./paypal/components/EventTypeAppSettingsInterface")),
+  plausible: dynamic(() => import("./plausible/components/EventTypeAppSettingsInterface")),
+  qr_code: dynamic(() => import("./qr_code/components/EventTypeAppSettingsInterface")),
+  stripepayment: dynamic(() => import("./stripepayment/components/EventTypeAppSettingsInterface")),
 };

--- a/packages/lib/CalendarService.test.ts
+++ b/packages/lib/CalendarService.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import BaseCalendarService from "./CalendarService";
 import { createEvent as createIcsEvent } from "ics";
-import { createCalendarObject } from "tsdav";
+import { createCalendarObject, updateCalendarObject } from "tsdav";
+import type { CalendarServiceEvent, IntegrationCalendar } from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
 
 // Mock dependencies
 vi.mock("ics", async () => ({
@@ -11,6 +13,7 @@ vi.mock("ics", async () => ({
 vi.mock("tsdav", async () => ({
   createAccount: vi.fn(),
   createCalendarObject: vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("ok") }),
+  updateCalendarObject: vi.fn().mockResolvedValue({ status: 200 }),
   fetchCalendars: vi.fn().mockResolvedValue([
     { url: "http://cal.com/cal1", displayName: "Calendar 1" }
   ]),
@@ -22,9 +25,14 @@ vi.mock("./crypto", () => ({
   symmetricDecrypt: () => JSON.stringify({ username: "user", password: "pass", url: "http://cal.com" }),
 }));
 
-vi.mock("uuid", () => ({
-  v4: () => "mock-uid",
-}));
+vi.mock("uuid", () => {
+  const v5 = vi.fn(() => "6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+  (v5 as unknown as Record<string, string>).URL = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+  return {
+    v4: () => "mock-uid",
+    v5,
+  };
+});
 
 // Mock logger to avoid clutter
 vi.mock("./logger", () => ({
@@ -41,10 +49,20 @@ vi.mock("./logger", () => ({
 class TestCalendarService extends BaseCalendarService {
   constructor() {
     super(
-      { key: "encrypted-key", user: { email: "user@example.com" } } as any,
+      { key: "encrypted-key", user: { email: "user@example.com" } } as unknown as CredentialPayload,
       "test-integration",
       "http://cal.com"
     );
+  }
+
+  // Override to ensure we have a calendar to "create" events in
+  async listCalendars(): Promise<IntegrationCalendar[]> {
+    return [{ externalId: "cal-1", name: "Test Calendar", primary: true, integration: "test", email: "user@example.com" }];
+  }
+
+  // Helper to mock protected methods
+  public async testUpdateEvent(uid: string, event: any) {
+    return this.updateEvent(uid, event);
   }
 }
 
@@ -58,7 +76,7 @@ describe("BaseCalendarService", () => {
     
     // Mock ics output
     const mockIcsOutput = "BEGIN:VCALENDAR\r\nMETHOD:PUBLISH\r\nORGANIZER;CN=Test:mailto:test@example.com\r\nATTENDEE;CN=Guest:mailto:guest@example.com\r\nEND:VCALENDAR";
-    (createIcsEvent as any).mockReturnValue({ error: null, value: mockIcsOutput });
+    vi.mocked(createIcsEvent).mockReturnValue({ error: null as unknown as Error, value: mockIcsOutput });
 
     const event = {
       title: "Test Event",
@@ -66,12 +84,12 @@ describe("BaseCalendarService", () => {
       endTime: "2023-01-01T11:00:00Z",
       organizer: { name: "Test", email: "test@example.com" },
       attendees: [{ name: "Guest", email: "guest@example.com" }],
-    } as any;
+    } as unknown as CalendarServiceEvent;
 
     await service.createEvent(event, 1);
 
     expect(createCalendarObject).toHaveBeenCalled();
-    const calledArg = (createCalendarObject as any).mock.calls[0][0];
+    const calledArg = vi.mocked(createCalendarObject).mock.calls[0][0];
     const iCalString = calledArg.iCalString;
 
     expect(iCalString).not.toContain("METHOD:PUBLISH");
@@ -85,7 +103,7 @@ describe("BaseCalendarService", () => {
     
     // Mock ics output without parameters
     const mockIcsOutput = "BEGIN:VCALENDAR\r\nMETHOD:PUBLISH\r\nORGANIZER:mailto:test@example.com\r\nEND:VCALENDAR";
-    (createIcsEvent as any).mockReturnValue({ error: null, value: mockIcsOutput });
+    vi.mocked(createIcsEvent).mockReturnValue({ error: null as unknown as Error, value: mockIcsOutput });
 
     const event = {
       title: "Test Event",
@@ -93,12 +111,12 @@ describe("BaseCalendarService", () => {
       endTime: "2023-01-01T11:00:00Z",
       organizer: { name: "Test", email: "test@example.com" },
       attendees: [],
-    } as any;
+    } as unknown as CalendarServiceEvent;
 
     await service.createEvent(event, 1);
 
     expect(createCalendarObject).toHaveBeenCalled();
-    const calledArg = (createCalendarObject as any).mock.calls[0][0];
+    const calledArg = vi.mocked(createCalendarObject).mock.calls[0][0];
     const iCalString = calledArg.iCalString;
 
     expect(iCalString).toContain("ORGANIZER;SCHEDULE-AGENT=CLIENT:mailto:test@example.com");
@@ -106,7 +124,7 @@ describe("BaseCalendarService", () => {
 
   it("should deduplicate attendees by email", async () => {
     const service = new TestCalendarService();
-    (createIcsEvent as any).mockReturnValue({ error: null, value: "mock-ics" });
+    vi.mocked(createIcsEvent).mockReturnValue({ error: null as unknown as Error, value: "mock-ics" });
 
     const event = {
       title: "Test Event",
@@ -117,19 +135,51 @@ describe("BaseCalendarService", () => {
       team: {
         members: [{ name: "Duplicate", email: "duplicate@example.com" }, { name: "Unique", email: "unique@example.com" }]
       }
-    } as any;
+    } as unknown as CalendarServiceEvent;
 
     await service.createEvent(event, 1);
 
-    const icsCallArgs = (createIcsEvent as any).mock.calls[0][0];
+    const icsCallArgs = vi.mocked(createIcsEvent).mock.calls[0][0];
     const attendees = icsCallArgs.attendees;
 
     // Should have 2 unique attendees (duplicate@example.com and unique@example.com)
     expect(attendees).toHaveLength(2);
-    const emails = attendees.map((a: any) => a.email);
-    expect(emails).toContain("duplicate@example.com");
-    expect(emails).toContain("unique@example.com");
-    // Verify count of duplicate@example.com is exactly 1
-    expect(emails.filter(e => e === "duplicate@example.com")).toHaveLength(1);
+    if (attendees) {
+      const emails = attendees.map((a) => a.email);
+      expect(emails).toContain("duplicate@example.com");
+      expect(emails).toContain("unique@example.com");
+      // Verify count of duplicate@example.com is exactly 1
+      expect(emails.filter(e => e === "duplicate@example.com")).toHaveLength(1);
+    }
+  });
+
+  it("should update event with SCHEDULE-AGENT=CLIENT", async () => {
+    const service = new TestCalendarService();
+    const mockIcsOutput = "BEGIN:VCALENDAR\r\nMETHOD:PUBLISH\r\nORGANIZER;CN=Test:mailto:test@example.com\r\nEND:VCALENDAR";
+    vi.mocked(createIcsEvent).mockReturnValue({ error: null as unknown as Error, value: mockIcsOutput });
+
+    const event = {
+      title: "Updated Event",
+      startTime: "2023-01-01T10:00:00Z",
+      endTime: "2023-01-01T11:00:00Z",
+      organizer: {
+        name: "Test", 
+        email: "test@example.com",
+        language: { translate: vi.fn((key) => key) }
+      },
+      attendees: [],
+    } as unknown as any;
+
+    // Mock getEventsByUID to return a calendar event
+    (service as unknown as Record<string, any>).getEventsByUID = vi.fn().mockResolvedValue([{ uid: "mock-uid", url: "http://cal.com/event", etag: "etag" }]);
+
+    await service.testUpdateEvent("mock-uid", event);
+
+    expect(updateCalendarObject).toHaveBeenCalled();
+    const calledArg = vi.mocked(updateCalendarObject).mock.calls[0][0];
+    const data = calledArg.calendarObject.data;
+
+    expect(data).not.toContain("METHOD:PUBLISH");
+    expect(data).toContain("ORGANIZER;SCHEDULE-AGENT=CLIENT;CN=Test");
   });
 });

--- a/packages/lib/CalendarService.test.ts
+++ b/packages/lib/CalendarService.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import BaseCalendarService from "./CalendarService";
+import { createEvent as createIcsEvent } from "ics";
+import { createCalendarObject } from "tsdav";
+
+// Mock dependencies
+vi.mock("ics", async () => ({
+  createEvent: vi.fn(),
+}));
+
+vi.mock("tsdav", async () => ({
+  createAccount: vi.fn(),
+  createCalendarObject: vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("ok") }),
+  fetchCalendars: vi.fn().mockResolvedValue([
+    { url: "http://cal.com/cal1", displayName: "Calendar 1" }
+  ]),
+  fetchCalendarObjects: vi.fn(),
+  getBasicAuthHeaders: vi.fn(),
+}));
+
+vi.mock("./crypto", () => ({
+  symmetricDecrypt: () => JSON.stringify({ username: "user", password: "pass", url: "http://cal.com" }),
+}));
+
+vi.mock("uuid", () => ({
+  v4: () => "mock-uid",
+}));
+
+// Mock logger to avoid clutter
+vi.mock("./logger", () => ({
+  default: {
+    getSubLogger: () => ({
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+    error: vi.fn(),
+  },
+}));
+
+// Concrete implementation for testing
+class TestCalendarService extends BaseCalendarService {
+  constructor() {
+    super(
+      { key: "encrypted-key", user: { email: "user@example.com" } } as any,
+      "test-integration",
+      "http://cal.com"
+    );
+  }
+}
+
+describe("BaseCalendarService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should inject SCHEDULE-AGENT=CLIENT and remove METHOD:PUBLISH", async () => {
+    const service = new TestCalendarService();
+    
+    // Mock ics output
+    const mockIcsOutput = "BEGIN:VCALENDAR\r\nMETHOD:PUBLISH\r\nORGANIZER;CN=Test:mailto:test@example.com\r\nATTENDEE;CN=Guest:mailto:guest@example.com\r\nEND:VCALENDAR";
+    (createIcsEvent as any).mockReturnValue({ error: null, value: mockIcsOutput });
+
+    const event = {
+      title: "Test Event",
+      startTime: "2023-01-01T10:00:00Z",
+      endTime: "2023-01-01T11:00:00Z",
+      organizer: { name: "Test", email: "test@example.com" },
+      attendees: [{ name: "Guest", email: "guest@example.com" }],
+    } as any;
+
+    await service.createEvent(event, 1);
+
+    expect(createCalendarObject).toHaveBeenCalled();
+    const calledArg = (createCalendarObject as any).mock.calls[0][0];
+    const iCalString = calledArg.iCalString;
+
+    expect(iCalString).not.toContain("METHOD:PUBLISH");
+    // Regex logic check
+    expect(iCalString).toContain("ORGANIZER;SCHEDULE-AGENT=CLIENT;CN=Test");
+    expect(iCalString).toContain("ATTENDEE;SCHEDULE-AGENT=CLIENT;CN=Guest");
+  });
+
+  it("should handle properties without parameters correctly", async () => {
+    const service = new TestCalendarService();
+    
+    // Mock ics output without parameters
+    const mockIcsOutput = "BEGIN:VCALENDAR\r\nMETHOD:PUBLISH\r\nORGANIZER:mailto:test@example.com\r\nEND:VCALENDAR";
+    (createIcsEvent as any).mockReturnValue({ error: null, value: mockIcsOutput });
+
+    const event = {
+      title: "Test Event",
+      startTime: "2023-01-01T10:00:00Z",
+      endTime: "2023-01-01T11:00:00Z",
+      organizer: { name: "Test", email: "test@example.com" },
+      attendees: [],
+    } as any;
+
+    await service.createEvent(event, 1);
+
+    expect(createCalendarObject).toHaveBeenCalled();
+    const calledArg = (createCalendarObject as any).mock.calls[0][0];
+    const iCalString = calledArg.iCalString;
+
+    expect(iCalString).toContain("ORGANIZER;SCHEDULE-AGENT=CLIENT:mailto:test@example.com");
+  });
+});

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -188,8 +188,8 @@ export default abstract class BaseCalendarService implements Calendar {
               filename: `${uid}.ics`,
               // according to https://datatracker.ietf.org/doc/html/rfc4791#section-4.1, Calendar object resources contained in calendar collections MUST NOT specify the iCalendar METHOD property.
               iCalString: iCalString
-                .replace(/METHOD:[^\r\n]+\r\n/g, "")
-                ?.replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
+                .replace(/METHOD:[^\r\n]+[\r\n]+/g, "")
+                ?.replace(/(ORGANIZER|ATTENDEE)([:;])/g, "$1;SCHEDULE-AGENT=CLIENT$2"),
               headers: this.headers,
             })
           )
@@ -258,8 +258,8 @@ export default abstract class BaseCalendarService implements Calendar {
               url: calendarEvent.url,
               // ensures compliance with standard iCal string (known as iCal2.0 by some) required by various providers
               data: iCalString
-                ?.replace(/METHOD:[^\r\n]+\r\n/g, "")
-                ?.replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
+                ?.replace(/METHOD:[^\r\n]+[\r\n]+/g, "")
+                ?.replace(/(ORGANIZER|ATTENDEE)([:;])/g, "$1;SCHEDULE-AGENT=CLIENT$2"),
               etag: calendarEvent?.etag,
             },
             headers: this.headers,

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -187,7 +187,9 @@ export default abstract class BaseCalendarService implements Calendar {
               },
               filename: `${uid}.ics`,
               // according to https://datatracker.ietf.org/doc/html/rfc4791#section-4.1, Calendar object resources contained in calendar collections MUST NOT specify the iCalendar METHOD property.
-              iCalString: iCalString.replace(/METHOD:[^\r\n]+\r\n/g, ""),
+              iCalString: iCalString
+                .replace(/METHOD:[^\r\n]+\r\n/g, "")
+                .replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
               headers: this.headers,
             })
           )
@@ -255,7 +257,9 @@ export default abstract class BaseCalendarService implements Calendar {
             calendarObject: {
               url: calendarEvent.url,
               // ensures compliance with standard iCal string (known as iCal2.0 by some) required by various providers
-              data: iCalString?.replace(/METHOD:[^\r\n]+\r\n/g, ""),
+              data: iCalString
+                ?.replace(/METHOD:[^\r\n]+\r\n/g, "")
+                .replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
               etag: calendarEvent?.etag,
             },
             headers: this.headers,

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -136,7 +136,12 @@ export default abstract class BaseCalendarService implements Calendar {
       attendees.push(...mapAttendees(teamAttendeesWithoutCurrentUser));
     }
 
-    return attendees;
+    // Deduplicate attendees by email
+    const uniqueAttendees = Array.from(
+      new Map(attendees.map((attendee) => [attendee.email, attendee])).values()
+    );
+
+    return uniqueAttendees;
   }
 
   async createEvent(event: CalendarServiceEvent, credentialId: number): Promise<NewCalendarEventType> {

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -189,7 +189,7 @@ export default abstract class BaseCalendarService implements Calendar {
               // according to https://datatracker.ietf.org/doc/html/rfc4791#section-4.1, Calendar object resources contained in calendar collections MUST NOT specify the iCalendar METHOD property.
               iCalString: iCalString
                 .replace(/METHOD:[^\r\n]+\r\n/g, "")
-                .replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
+                ?.replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
               headers: this.headers,
             })
           )
@@ -259,7 +259,7 @@ export default abstract class BaseCalendarService implements Calendar {
               // ensures compliance with standard iCal string (known as iCal2.0 by some) required by various providers
               data: iCalString
                 ?.replace(/METHOD:[^\r\n]+\r\n/g, "")
-                .replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
+                ?.replace(/(ORGANIZER|ATTENDEE);/g, "$1;SCHEDULE-AGENT=CLIENT;"),
               etag: calendarEvent?.etag,
             },
             headers: this.headers,

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -193,7 +193,7 @@ export default abstract class BaseCalendarService implements Calendar {
               filename: `${uid}.ics`,
               // according to https://datatracker.ietf.org/doc/html/rfc4791#section-4.1, Calendar object resources contained in calendar collections MUST NOT specify the iCalendar METHOD property.
               iCalString: iCalString
-                .replace(/METHOD:[^\r\n]+[\r\n]+/g, "")
+                ?.replace(/METHOD:[^\r\n]+[\r\n]+/g, "")
                 ?.replace(/(ORGANIZER|ATTENDEE)([:;])/g, "$1;SCHEDULE-AGENT=CLIENT$2"),
               headers: this.headers,
             })
@@ -386,7 +386,7 @@ export default abstract class BaseCalendarService implements Calendar {
     const userTimeZone = userId ? await this.getUserTimezoneFromDB(userId) : "Europe/London";
     const events: { start: string; end: string }[] = [];
     objects.forEach((object) => {
-      if (!object || object.data == null || JSON.stringify(object.data) == "{}") return;
+      if (!object || object.data == null || JSON.stringify(object.data) === "{}") return;
       let vcalendar: ICAL.Component;
       try {
         const jcalData = ICAL.parse(sanitizeCalendarObject(object));
@@ -404,7 +404,7 @@ export default abstract class BaseCalendarService implements Calendar {
         const dtstartProperty = vevent.getFirstProperty("dtstart");
         const tzidFromDtstart = dtstartProperty ? (dtstartProperty as any).jCal[1].tzid : undefined;
         const dtstart: { [key: string]: string } | undefined = vevent?.getFirstPropertyValue("dtstart");
-        const timezone = dtstart ? dtstart["timezone"] : undefined;
+        const timezone = dtstart ? dtstart.timezone : undefined;
         // We check if the dtstart timezone is in UTC which is actually represented by Z instead, but not recognized as that in ICAL.js as UTC
         const isUTC = timezone === "Z";
 


### PR DESCRIPTION
# fix(caldav): robust SCHEDULE-AGENT injection and attendee deduplication
 
# Description
Closes #9485
/claim #9485
 
## Problem
When creating events via CalDAV providers like Fastmail, the server often automatically sends invitation emails to attendees. Since Cal.com also sends its own emails, this results in users receiving duplicate invitations. 
Additionally, attendees appearing in both guest and team lists could receive multiple invites from Cal.com itself.
 
## Solution
1. **Robust SCHEDULE-AGENT Injection**: Injects `SCHEDULE-AGENT=CLIENT` into `ORGANIZER` and `ATTENDEE` properties using a robust regex that handles both CRLF/LF line endings and varying property parameter formats.
2. **Attendee Deduplication**: Implemented logic to deduplicate attendees by email address before generating the iCalendar string.
 
## Changes
- Modified `packages/lib/CalendarService.ts`
- Added comprehensive unit tests in `packages/lib/CalendarService.test.ts`
 
## Testing
- Verified robust regex against CRLF and LF line endings.
- Verified parameter injection with and without existing parameters (`;` vs `:`).
- Verified attendee deduplication logic.
- Added Vitest unit tests to prevent regressions.
