### PR TITLE
fix(ci): verify org membership when author_association fails

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,9 +69,29 @@ jobs:
               return;
             }
 
-            console.log(`Author ${pr.user.login} is external (${pr.author_association}), checking for core team approval...`);
+            console.log(`Author ${pr.user.login} has association ${pr.author_association}, verifying org membership via API...`);
 
-            // Check 2: Has a core team member approved the current commit?
+            // Check 2: Verify org membership directly via API (author_association can be unreliable)
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: owner,
+                username: pr.user.login,
+              });
+              // 204 response means user is an org member
+              console.log(`Author ${pr.user.login} verified as org member via API`);
+              core.setOutput('is-trusted', true);
+              return;
+            } catch (e) {
+              if (e.status === 404) {
+                console.log(`Author ${pr.user.login} is not an org member`);
+              } else {
+                console.log(`Could not verify org membership for ${pr.user.login}: ${e.message}`);
+              }
+            }
+
+            console.log(`Author ${pr.user.login} is external, checking for core team approval...`);
+
+            // Check 3: Has a core team member approved the current commit?
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
               repo,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,22 @@ jobs:
             const prNumber = pr.number;
             const headSha = pr.head.sha;
 
+            async function isCoreTeamMember(username) {
+              try {
+                await github.rest.teams.getMembershipForUserInOrg({
+                  org: owner,
+                  team_slug: 'core',
+                  username,
+                });
+                return true;
+              } catch (e) {
+                if (e.status !== 404) {
+                  console.log(`Could not verify core team membership for ${username}: ${e.message}`);
+                }
+                return false;
+              }
+            }
+
             console.log(`PR #${prNumber} by ${pr.user.login}`);
             console.log(`Author association: ${pr.author_association}`);
             console.log(`Head SHA: ${headSha}`);
@@ -69,28 +85,14 @@ jobs:
               return;
             }
 
-            console.log(`Author ${pr.user.login} has association ${pr.author_association}, verifying core team membership via API...`);
-
-            // Check 2: Verify core team membership directly via API (author_association can be unreliable)
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org: owner,
-                team_slug: 'core',
-                username: pr.user.login,
-              });
-              // 200 response means user is a core team member
-              console.log(`Author ${pr.user.login} verified as core team member via API`);
+            // Check 2: Verify core team membership via API (author_association can be unreliable)
+            if (await isCoreTeamMember(pr.user.login)) {
+              console.log(`Author ${pr.user.login} verified as core team member`);
               core.setOutput('is-trusted', true);
               return;
-            } catch (e) {
-              if (e.status === 404) {
-                console.log(`Author ${pr.user.login} is not a core team member`);
-              } else {
-                console.log(`Could not verify core team membership for ${pr.user.login}: ${e.message}`);
-              }
             }
 
-            console.log(`Author ${pr.user.login} is external, checking for core team approval...`);
+            console.log(`Author ${pr.user.login} is not a core team member, checking for approval...`);
 
             // Check 3: Has a core team member approved the current commit?
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -126,30 +128,18 @@ jobs:
               }
             }
 
-            // Check if any approver is a core team member (has write access or higher)
+            // Check if any approver is a core team member
             for (const [reviewer, reviewData] of reviewerStates) {
               if (reviewData.state !== 'APPROVED') {
                 continue;
               }
 
-              try {
-                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner,
-                  repo,
-                  username: reviewer,
-                });
-
-                const isCoreTeam = ['admin', 'maintain', 'write'].includes(permission.permission);
-                console.log(`Reviewer ${reviewer}: permission=${permission.permission}, isCoreTeam=${isCoreTeam}`);
-
-                if (isCoreTeam) {
-                  console.log(`PR approved by core team member ${reviewer} for commit ${headSha}`);
-                  core.setOutput('is-trusted', true);
-                  return;
-                }
-              } catch (e) {
-                console.log(`Could not check permission for ${reviewer}: ${e.message}`);
+              if (await isCoreTeamMember(reviewer)) {
+                console.log(`PR approved by core team member ${reviewer} for commit ${headSha}`);
+                core.setOutput('is-trusted', true);
+                return;
               }
+              console.log(`Reviewer ${reviewer} is not a core team member`);
             }
 
             console.log('PR requires approval from a core team member before CI can run');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,23 +69,24 @@ jobs:
               return;
             }
 
-            console.log(`Author ${pr.user.login} has association ${pr.author_association}, verifying org membership via API...`);
+            console.log(`Author ${pr.user.login} has association ${pr.author_association}, verifying core team membership via API...`);
 
-            // Check 2: Verify org membership directly via API (author_association can be unreliable)
+            // Check 2: Verify core team membership directly via API (author_association can be unreliable)
             try {
-              await github.rest.orgs.checkMembershipForUser({
+              await github.rest.teams.getMembershipForUserInOrg({
                 org: owner,
+                team_slug: 'core',
                 username: pr.user.login,
               });
-              // 204 response means user is an org member
-              console.log(`Author ${pr.user.login} verified as org member via API`);
+              // 200 response means user is a core team member
+              console.log(`Author ${pr.user.login} verified as core team member via API`);
               core.setOutput('is-trusted', true);
               return;
             } catch (e) {
               if (e.status === 404) {
-                console.log(`Author ${pr.user.login} is not an org member`);
+                console.log(`Author ${pr.user.login} is not a core team member`);
               } else {
-                console.log(`Could not verify org membership for ${pr.user.login}: ${e.message}`);
+                console.log(`Could not verify core team membership for ${pr.user.login}: ${e.message}`);
               }
             }
 


### PR DESCRIPTION
 ## What does this PR do?

Adds a fallback to verify org membership via GitHub API when `author_association` is unreliable.
GitHub's `author_association` field sometimes returns `CONTRIBUTOR` instead of `MEMBER` for actual org members, causing the trust-check to incorrectly flag them as external contributors.

### Changes

- Adds direct org membership API check (`orgs.checkMembershipForUser`) as fallback when `author_association` is not in trusted list
- Returns 204 → user verified as org member and trusted
- Returns 404/error → continues to existing core team approval flow

## How should this be tested?

1. Create a PR from an org member whose `author_association` returns `CONTRIBUTOR` - CI should run (API fallback succeeds)
2. Create a PR from actual external contributor - CI should NOT run until approved

## Mandatory Tasks

- [x] I have self-reviewed the code
- [ ] **N/A** - No documentation changes required
- [ ] **N/A** - I confirm automated tests are in place that prove my fix is effective or that my feature works