### PR TITLE
fix(ci): use getCollaboratorPermissionLevel for trust check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
                   username,
                 });
                 const hasAccess = ['admin', 'maintain', 'write'].includes(permission.permission);
-                console.log(`User ${username}: permission=${permission.permission}, hasWriteAccess=${hasAccess}`);
+                console.log(`User ${username}: hasWriteAccess=${hasAccess}`);
                 return hasAccess;
               } catch (e) {
                 console.log(`Could not check permission for ${username}: ${e.message}`);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,19 +33,10 @@ jobs:
     outputs:
       is-trusted: ${{ steps.check-trust.outputs.is-trusted }}
     steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94
-        with:
-          app-id: ${{ secrets.CI_CAL_APP_ID }}
-          private-key: ${{ secrets.CI_CAL_APP_PRIVATE_KEY }}
-          owner: calcom
-
       - name: Check if PR is trusted
         id: check-trust
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
             const pr = context.payload.pull_request;
@@ -66,18 +57,19 @@ jobs:
             const prNumber = pr.number;
             const headSha = pr.head.sha;
 
-            async function isCoreTeamMember(username) {
+            // Check if user has write access or higher (admin, maintain, write)
+            async function hasWriteAccess(username) {
               try {
-                await github.rest.teams.getMembershipForUserInOrg({
-                  org: owner,
-                  team_slug: 'core',
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
                   username,
                 });
-                return true;
+                const hasAccess = ['admin', 'maintain', 'write'].includes(permission.permission);
+                console.log(`User ${username}: permission=${permission.permission}, hasWriteAccess=${hasAccess}`);
+                return hasAccess;
               } catch (e) {
-                if (e.status !== 404) {
-                  console.log(`Could not verify core team membership for ${username}: ${e.message}`);
-                }
+                console.log(`Could not check permission for ${username}: ${e.message}`);
                 return false;
               }
             }
@@ -94,16 +86,16 @@ jobs:
               return;
             }
 
-            // Check 2: Verify core team membership via API (author_association can be unreliable)
-            if (await isCoreTeamMember(pr.user.login)) {
-              console.log(`Author ${pr.user.login} verified as core team member`);
+            // Check 2: Verify write access via API (author_association can be unreliable)
+            if (await hasWriteAccess(pr.user.login)) {
+              console.log(`Author ${pr.user.login} verified as having write access`);
               core.setOutput('is-trusted', true);
               return;
             }
 
-            console.log(`Author ${pr.user.login} is not a core team member, checking for approval...`);
+            console.log(`Author ${pr.user.login} does not have write access, checking for approval...`);
 
-            // Check 3: Has a core team member approved the current commit?
+            // Check 3: Has someone with write access approved the current commit?
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
               repo,
@@ -137,21 +129,21 @@ jobs:
               }
             }
 
-            // Check if any approver is a core team member
+            // Check if any approver has write access
             for (const [reviewer, reviewData] of reviewerStates) {
               if (reviewData.state !== 'APPROVED') {
                 continue;
               }
 
-              if (await isCoreTeamMember(reviewer)) {
-                console.log(`PR approved by core team member ${reviewer} for commit ${headSha}`);
+              if (await hasWriteAccess(reviewer)) {
+                console.log(`PR approved by ${reviewer} (has write access) for commit ${headSha}`);
                 core.setOutput('is-trusted', true);
                 return;
               }
-              console.log(`Reviewer ${reviewer} is not a core team member`);
+              console.log(`Reviewer ${reviewer} does not have write access`);
             }
 
-            console.log('PR requires approval from a core team member before CI can run');
+            console.log('PR requires approval from someone with write access before CI can run');
             core.setOutput('is-trusted', false);
 
   prepare:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,10 +33,19 @@ jobs:
     outputs:
       is-trusted: ${{ steps.check-trust.outputs.is-trusted }}
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94
+        with:
+          app-id: ${{ secrets.CI_CAL_APP_ID }}
+          private-key: ${{ secrets.CI_CAL_APP_PRIVATE_KEY }}
+          owner: calcom
+
       - name: Check if PR is trusted
         id: check-trust
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
             const pr = context.payload.pull_request;


### PR DESCRIPTION
## What does this PR do?

Fixes the "Check if PR is trusted" step returning 404 when checking if a user is a core team member, even when they ARE a member of the team.

The root cause: The default `GITHUB_TOKEN` doesn't have org-level permissions to query team membership via the `teams.getMembershipForUserInOrg` API. GitHub returns 404 (instead of 403) to avoid leaking team existence/membership info when the caller lacks permission.

**Solution:** Replace the team membership check with `repos.getCollaboratorPermissionLevel`, which:
- Works with the default `GITHUB_TOKEN` (no elevated permissions needed)
- Checks if users have `write`/`maintain`/`admin` access to the repo
- Is semantically correct: if someone can push to the repo, they're trusted to run CI with secrets

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - CI workflow change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Since this uses `pull_request_target`, the workflow changes can only be validated after merge (the workflow runs from the base branch, not the PR branch).

After merge:
1. Have a user with write access (e.g., volnei) open or update a PR
2. Check the "Trust Check" job logs - it should show `User X: permission=write, hasWriteAccess=true` and `Author X verified as having write access`

## Human Review Checklist

- [ ] Verify that checking for write access is acceptable as a proxy for "trusted contributor" (vs. checking specific team membership)
- [ ] Consider edge cases: users with write access who aren't in "core" team will now be trusted; users in "core" team without write access will not be trusted

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/ffd9edb7655c4c81a52de67821aa8114
Requested by: keith@cal.com (@keithwillcode)