### PR TITLE
chore: use lookup-only cache check to skip deps job downloads

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -64,11 +64,25 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
         lookup-only: true
 
+    # Compute whether all caches hit (only in skip mode)
+    - name: Check if all caches hit
+      if: ${{ inputs.skip-install-if-cache-hit == 'true' }}
+      id: all-caches-check
+      shell: bash
+      run: |
+        if [[ "${{ steps.yarn-download-cache-check.outputs.cache-hit }}" == "true" && \
+              "${{ steps.yarn-nm-cache-check.outputs.cache-hit }}" == "true" && \
+              "${{ steps.yarn-install-state-cache-check.outputs.cache-hit }}" == "true" ]]; then
+          echo "all-hit=true" >> $GITHUB_OUTPUT
+        else
+          echo "all-hit=false" >> $GITHUB_OUTPUT
+        fi
+
     # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
     # Yarn cache is also reusable between arch and os.
-    # Only restore if not in skip mode, or if skip mode but cache check missed
+    # Only restore if not in skip mode, or if skip mode but any cache check missed
     - name: Restore yarn cache
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.all-caches-check.outputs.all-hit != 'true' }}
       uses: actions/cache@v4
       id: yarn-download-cache
       with:
@@ -77,7 +91,7 @@ runs:
 
     # Invalidated on yarn.lock changes
     - name: Restore node_modules
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.all-caches-check.outputs.all-hit != 'true' }}
       id: yarn-nm-cache
       uses: actions/cache@v4
       with:
@@ -88,7 +102,7 @@ runs:
 
     # Invalidated on yarn.lock changes
     - name: Restore yarn install state
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.all-caches-check.outputs.all-hit != 'true' }}
       id: yarn-install-state-cache
       uses: actions/cache@v4
       with:
@@ -96,7 +110,7 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.all-caches-check.outputs.all-hit != 'true' }}
       shell: bash
       run: |
         yarn install --inline-builds

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -33,9 +33,42 @@ runs:
       run: |
         echo "CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
+    # When skip-install-if-cache-hit is true, first check if all caches exist without downloading (lookup-only mode)
+    # This avoids downloading ~1.2GB of cache data when we just want to verify caches exist
+    - name: Check yarn cache (lookup-only)
+      if: ${{ inputs.skip-install-if-cache-hit == 'true' }}
+      uses: actions/cache/restore@v4
+      id: yarn-download-cache-check
+      with:
+        path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
+        key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
+        lookup-only: true
+
+    - name: Check node_modules cache (lookup-only)
+      if: ${{ inputs.skip-install-if-cache-hit == 'true' }}
+      uses: actions/cache/restore@v4
+      id: yarn-nm-cache-check
+      with:
+        path: |
+          **/node_modules/
+          !**/.next/node_modules/
+        key: ${{ runner.os }}-yarn-nm-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+        lookup-only: true
+
+    - name: Check yarn install state cache (lookup-only)
+      if: ${{ inputs.skip-install-if-cache-hit == 'true' }}
+      uses: actions/cache/restore@v4
+      id: yarn-install-state-cache-check
+      with:
+        path: .yarn/ci-cache/
+        key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+        lookup-only: true
+
     # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
     # Yarn cache is also reusable between arch and os.
+    # Only restore if not in skip mode, or if skip mode but cache check missed
     - name: Restore yarn cache
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
       uses: actions/cache@v4
       id: yarn-download-cache
       with:
@@ -44,6 +77,7 @@ runs:
 
     # Invalidated on yarn.lock changes
     - name: Restore node_modules
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
       id: yarn-nm-cache
       uses: actions/cache@v4
       with:
@@ -54,6 +88,7 @@ runs:
 
     # Invalidated on yarn.lock changes
     - name: Restore yarn install state
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
       id: yarn-install-state-cache
       uses: actions/cache@v4
       with:
@@ -61,7 +96,7 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache-check.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         yarn install --inline-builds

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: v20.x
   skip-install-if-cache-hit:
-    description: "Skip yarn install if node_modules cache is hit. Use this for jobs that only need to populate the cache."
+    description: "Skip yarn install if node_modules cache is hit. Use this for jobs that only need to check that cache exists."
     required: false
     default: "false"
 

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -61,7 +61,7 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' && steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         yarn install --inline-builds

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -15,6 +15,10 @@ inputs:
   node_version:
     required: false
     default: v20.x
+  skip-install-if-cache-hit:
+    description: "Skip yarn install if node_modules cache is hit. Use this for jobs that only need to populate the cache."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -57,6 +61,7 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         yarn install --inline-builds

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -61,7 +61,7 @@ runs:
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' && steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.yarn-nm-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         yarn install --inline-builds

--- a/.github/actions/yarn-playwright-install/action.yml
+++ b/.github/actions/yarn-playwright-install/action.yml
@@ -1,5 +1,10 @@
 name: Install playwright binaries
 description: "Install playwright, cache and restore if necessary"
+inputs:
+  skip-install-if-cache-hit:
+    description: "Skip playwright install if cache is hit. Use this for jobs that only need to populate the cache."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -17,6 +22,6 @@ runs:
           ${{ github.workspace }}/node_modules/playwright
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
     - name: Yarn playwright install
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.playwright-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: yarn playwright install --with-deps

--- a/.github/actions/yarn-playwright-install/action.yml
+++ b/.github/actions/yarn-playwright-install/action.yml
@@ -12,7 +12,23 @@ runs:
       shell: bash
       id: playwright-version
       run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
+
+    # When skip-install-if-cache-hit is true, first check if cache exists without downloading (lookup-only mode)
+    - name: Check playwright cache (lookup-only)
+      if: ${{ inputs.skip-install-if-cache-hit == 'true' }}
+      id: playwright-cache-check
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/Library/Caches/ms-playwright
+          ~/.cache/ms-playwright
+          ${{ github.workspace }}/node_modules/playwright
+        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        lookup-only: true
+
+    # Only restore cache if not in skip mode, or if skip mode but cache check missed
     - name: Cache playwright binaries
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.playwright-cache-check.outputs.cache-hit != 'true' }}
       id: playwright-cache
       uses: actions/cache@v4
       with:
@@ -21,7 +37,8 @@ runs:
           ~/.cache/ms-playwright
           ${{ github.workspace }}/node_modules/playwright
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
     - name: Yarn playwright install
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.playwright-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.playwright-cache-check.outputs.cache-hit != 'true' }}
       shell: bash
       run: yarn playwright install --with-deps

--- a/.github/actions/yarn-playwright-install/action.yml
+++ b/.github/actions/yarn-playwright-install/action.yml
@@ -38,7 +38,9 @@ runs:
           ${{ github.workspace }}/node_modules/playwright
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
+    # In default mode: run if playwright-cache missed
+    # In skip mode: run if playwright-cache-check missed (but cache restore step was also skipped)
     - name: Yarn playwright install
-      if: ${{ inputs.skip-install-if-cache-hit != 'true' || steps.playwright-cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ (inputs.skip-install-if-cache-hit != 'true' && steps.playwright-cache.outputs.cache-hit != 'true') || (inputs.skip-install-if-cache-hit == 'true' && steps.playwright-cache-check.outputs.cache-hit != 'true') }}
       shell: bash
       run: yarn playwright install --with-deps

--- a/.github/actions/yarn-playwright-install/action.yml
+++ b/.github/actions/yarn-playwright-install/action.yml
@@ -2,7 +2,7 @@ name: Install playwright binaries
 description: "Install playwright, cache and restore if necessary"
 inputs:
   skip-install-if-cache-hit:
-    description: "Skip playwright install if cache is hit. Use this for jobs that only need to populate the cache."
+    description: "Skip playwright install if cache is hit. Use this for jobs that only need to check that cache exists."
     required: false
     default: "false"
 runs:

--- a/.github/workflows/yarn-install.yml
+++ b/.github/workflows/yarn-install.yml
@@ -15,4 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
+        with:
+          skip-install-if-cache-hit: "true"
       - uses: ./.github/actions/yarn-playwright-install

--- a/.github/workflows/yarn-install.yml
+++ b/.github/workflows/yarn-install.yml
@@ -18,3 +18,5 @@ jobs:
         with:
           skip-install-if-cache-hit: "true"
       - uses: ./.github/actions/yarn-playwright-install
+        with:
+          skip-install-if-cache-hit: "true"


### PR DESCRIPTION
## What does this PR do?

Optimizes the "Install Dependencies / Yarn install & cache" step in pr.yml by using `lookup-only` cache checks to avoid downloading ~1.2GB of cache data when caches already exist.

The deps job is primarily for populating the cache when nothing is cached. Previously, even when skipping installs, the cache restore steps would still download all cached data. Now, when `skip-install-if-cache-hit: "true"` is set:

1. First, run `actions/cache/restore@v4` with `lookup-only: true` to check if caches exist **without downloading**
2. If all caches hit, skip the entire restore + install flow (no downloads at all)
3. If any cache misses, fall back to normal restore + install + save behavior

This adds a `skip-install-if-cache-hit` parameter to both the yarn-install and yarn-playwright-install actions (defaulting to "false" for backward compatibility) and enables it only for the deps job in yarn-install.yml.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow changes are tested by running CI itself.

## How should this be tested?

1. Create a PR with this change
2. On first run (cache miss), the deps job should:
   - Run lookup-only checks (which will miss)
   - Fall back to full cache restore + yarn install + playwright install
3. On subsequent runs (cache hit), the deps job should:
   - Run lookup-only checks (which will hit)
   - Skip ALL cache restore steps and installs (no 1.2GB download)
4. Verify other jobs (type-check, lint, unit-test, etc.) still work correctly as they don't pass the skip flag

## Human Review Checklist

- [x] Verify lookup-only steps only run when `skip-install-if-cache-hit == 'true'`
- [x] Verify restore/install steps are skipped when `skip-install-if-cache-hit == 'true' AND cache-hit == 'true'`
- [x] Verify the conditional uses `yarn-nm-cache-check` (the lookup-only step) not `yarn-nm-cache` (the restore step)
- [x] Confirm default value "false" maintains backward compatibility for other workflows
- [ ] Verify same pattern is applied consistently to playwright-install action

<!-- Link to Devin run: https://app.devin.ai/sessions/c0af76f23a6845789a52c221476cdad9 -->
<!-- Requested by: keith@cal.com (@keithwillcode) -->