### PR TITLE
Fix: add Dialogue box to remove profile

### DIFF
--- a/apps/web/modules/settings/my-account/profile-view.tsx
+++ b/apps/web/modules/settings/my-account/profile-view.tsx
@@ -519,6 +519,7 @@ const ProfileForm = ({
 }) => {
   const { t } = useLocale();
   const [firstRender, setFirstRender] = useState(true);
+  const [removeProfileOpen, setRemoveProfileOpen] = useState(false);
 
   const profileFormSchema = z.object({
     username: z.string(),
@@ -641,13 +642,37 @@ const ProfileForm = ({
                       />
 
                       {showRemoveAvatarButton && (
-                        <Button
-                          color="destructive"
-                          onClick={() => {
-                            onChange(null);
-                          }}>
-                          {t("remove")}
-                        </Button>
+                        <Dialog open={removeProfileOpen} onOpenChange={setRemoveProfileOpen}>
+                            <DialogTrigger asChild>
+                              <Button
+                                color="destructive"
+                                onClick={() => {
+                                  setRemoveProfileOpen((prev)=>!prev);
+                                }}>
+                                {t("remove")}
+                             </Button>
+                            </DialogTrigger>
+                          <DialogContent
+                            title={"Remove Profile Picture"}
+                            description={"Are you sure you want to remove your current profile picture ?"}
+                            type="creation"
+                            Icon="triangle-alert">
+                            <>
+                              <DialogFooter showDivider>
+                                <DialogClose />
+                                <Button
+                                  color="destructive"
+                                  onClick={(e) => {
+                                    onChange(null)
+                                    setRemoveProfileOpen(false);
+                                  }}
+                                  >
+                                  Remove 
+                                </Button>
+                              </DialogFooter>
+                            </>
+                          </DialogContent>
+                        </Dialog>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## What does this PR do?

This pr fix the without warning profile picture removing by adding a Dialog box to warn before removing the profile picture. 

- Fixes #26323
- Fixes [CAL-6999](https://linear.app/calcom/issue/CAL-6999/profile-remove-button-do-not-show-warning)

#### Video Demo 

Before :

https://github.com/user-attachments/assets/78325501-f7b9-4807-b966-73b987c55fdf

After:

https://github.com/user-attachments/assets/0428a49c-39a7-4680-909a-1959eac96640

### Asking help from reviewers/maintainers !!
I directly add the text for warning dialogue. Cause for using t() function, I have to add translation for each language in apps/web/public/static/locales. What should I do ?  

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to settings/my-account/profile
2. Upload Avatar if not uploaded yet
3. Click Remove
4. You'll see a warning dialogue with remove or cancel button

