### PR TITLE
fix: added message in schedule bulk update

### DIFF
--- a/apps/web/modules/availability/availability-view.tsx
+++ b/apps/web/modules/availability/availability-view.tsx
@@ -96,7 +96,7 @@ export function AvailabilityList({ availabilities }: AvailabilityListProps) {
         onSuccess: () => {
           utils.viewer.availability.list.invalidate();
           revalidateAvailabilityList();
-          showToast(t("success"), "success");
+          showToast(t("bulk_updated_schedule_successfully"), "success");
           callback();
         },
       }

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1294,6 +1294,7 @@
   "delete_schedule_description": "Deleting a schedule will remove it from all event types. This action cannot be undone.",
   "schedule_created_successfully": "{{scheduleName}} schedule created successfully",
   "availability_updated_successfully": "{{scheduleName}} schedule updated successfully",
+  "bulk_updated_schedule_successfully": "Bulk updated selected event types with default schedule",
   "schedule_deleted_successfully": "Schedule deleted successfully",
   "default_schedule_name": "Working Hours",
   "new_schedule_heading": "Create an availability schedule",


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26333  (GitHub issue number)
- Fixes CAL-7001 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before:

<img width="1627" height="955" alt="Screenshot from 2025-12-31 11-43-08" src="https://github.com/user-attachments/assets/969ccba4-918c-4175-9e0b-9aede87653dd" />

After:

<img width="1616" height="939" alt="Screenshot from 2025-12-30 21-30-33" src="https://github.com/user-attachments/assets/aa8f8548-f4a8-40cb-846a-146fe2ddb404" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. - N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

1. Go to availability
2. Set any availability option as default
3. Click on update in the bulk update modal
4. See the new message showing bulk update operation as successful


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a clear success toast after bulk updating selected event types to the default schedule in Availability. Replaces the generic message with a specific i18n string, addressing CAL-7001.

<sup>Written for commit 2e99f536410afa367892b553432ea24a5a56923a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

