### PR TITLE
fix: removed weird scrollbar from apps/intalled/ navigation

### DIFF
--- a/packages/app-store/_components/AppCategoryNavigation.tsx
+++ b/packages/app-store/_components/AppCategoryNavigation.tsx
@@ -35,7 +35,7 @@ const AppCategoryNavigation = ({
       <div className="hidden xl:block">
         <VerticalTabs tabs={appCategories} sticky linkShallow itemClassname={classNames?.verticalTabsItem} />
       </div>
-      <div className="block overflow-x-scroll xl:hidden">
+      <div className="block xl:hidden">
         <HorizontalTabs tabs={appCategories} linkShallow />
       </div>
       <main className={classNames?.container ?? containerClassname} ref={animationRef}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,7 +2557,6 @@ __metadata:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
     react-is: ^18.2.0
-    stripe: ^9.0.0 || ^15.0.0
     zod: ^3.0.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,6 +2557,7 @@ __metadata:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
     react-is: ^18.2.0
+    stripe: ^9.0.0 || ^15.0.0
     zod: ^3.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## What does this PR do?

This pr remove the weird scrollbar appearing in smaller screen size for apps/installed/   

- Fixes #26335
- Fixes [CAL-7002](https://linear.app/calcom/issue/CAL-7002/weird-scrollbar-appearing-in-smaller-screen-size-for-appsinstalled)

#### Explanation :

There is already overflow-x-scroll class inside HorizontalTabs.tsx with no-scrollbar class. So removing overflow-x-scroll class inside HorizontalTabs wrapper div is redundant. Removing it solves the issue 

#### Image Demo :

Before : 

<img width="910" height="246" alt="Image" src="https://github.com/user-attachments/assets/3d50f781-c519-4f36-bc49-5663a3dc387a" />

After :

<img width="908" height="566" alt="Image" src="https://github.com/user-attachments/assets/2d13d261-b724-40ac-9ab6-e2345d321637" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. go to apps/installed
2. Look at the bottom of Navigation 
3. no scrollbar appears 