### PR TITLE
fix: replace scroll-bar with no-scrollbar in AvailableTimeSlots component

### DIFF
--- a/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
+++ b/packages/features/bookings/Booker/components/AvailableTimeSlots.tsx
@@ -218,7 +218,7 @@ export const AvailableTimeSlots = ({
       <div
         ref={containerRef}
         className={classNames(
-          limitHeight && "scroll-bar grow overflow-auto md:h-[400px]",
+          limitHeight && "no-scrollbar grow overflow-auto md:h-[400px]",
           !limitHeight && "flex h-full w-full flex-row gap-4",
           `${customClassNames?.availableTimeSlotsContainer}`
         )}>
@@ -227,7 +227,7 @@ export const AvailableTimeSlots = ({
         {!isLoading &&
           slotsPerDay.length > 0 &&
           slotsPerDay.map((slots) => (
-            <div key={slots.date} className="scroll-bar overflow-x-hidden! h-full w-full overflow-y-auto">
+            <div key={slots.date} className="no-scrollbar overflow-x-hidden! h-full w-full overflow-y-auto">
               <AvailableTimes
                 className={customClassNames?.availableTimeSlotsContainer}
                 customClassNames={customClassNames?.availableTimes}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26338
- Fixes [CAL-7004](https://linear.app/calcom/issue/CAL-7004/visible-scrollbar-on-booking-page-time-slot-selector-creates-visual)

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

before:

https://github.com/user-attachments/assets/51ea1654-b4e0-459c-8259-85ce2ff881f4


after:

https://github.com/user-attachments/assets/f20b48ec-4682-46a5-bf9c-a6bb3738c8fb




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the visible scrollbar in the booking page time slot selector by switching to the no-scrollbar utility in AvailableTimeSlots. Scrolling still works; the UI is cleaner. Addresses CAL-7004 and #26338.

<sup>Written for commit a879f4080a735a954bc06472b2d24d0851b0de35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

