### PR TITLE
chore: Use 8 shards for main E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This brings the total E2E suite time down 1 minute across all shards. See https://github.com/calcom/cal.com/actions/runs/20619038067/job/59217628017

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase main E2E test shards from 4 to 8 to improve parallelism and reduce CI duration. 

<sup>Written for commit 372035ec091e65531f476426d40116d3b39ea23f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

