### PR TITLE
perf: optimize postgres health check in all CI workflows

### DIFF
--- a/.github/workflows/api-v1-production-build.yml
+++ b/.github/workflows/api-v1-production-build.yml
@@ -56,10 +56,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/e2e-api-v2.yml
+++ b/.github/workflows/e2e-api-v2.yml
@@ -43,10 +43,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
       redis:

--- a/.github/workflows/e2e-app-store.yml
+++ b/.github/workflows/e2e-app-store.yml
@@ -57,10 +57,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
       mailhog:

--- a/.github/workflows/e2e-embed-react.yml
+++ b/.github/workflows/e2e-embed-react.yml
@@ -57,10 +57,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
     strategy:

--- a/.github/workflows/e2e-embed.yml
+++ b/.github/workflows/e2e-embed.yml
@@ -57,10 +57,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
       mailhog:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,10 +57,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: calendso
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "pg_isready -h 127.0.0.1 -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+          --health-start-period 2s
         ports:
           - 5432:5432
       mailhog:


### PR DESCRIPTION
## What does this PR do?

Optimizes the postgres service container health check configuration across all CI workflows to reduce the "Initialize Containers" step duration.

**Analysis of current behavior** (from [CI job logs](https://github.com/calcom/cal.com/actions/runs/20618340908/job/59215364816?pr=26331)):
- Container starts at 11:47:44
- Health check doesn't report "healthy" until 11:48:00
- Total wait time: ~16 seconds

The bottleneck is the `--health-interval 10s` setting. Docker can't mark a container as "healthy" until a health check actually runs and succeeds. Since postgres typically starts accepting connections within 1-2 seconds (especially with pre-cached images on Blacksmith runners), we're waiting unnecessarily.

**Changes applied to all 6 workflow files:**
- `e2e.yml`
- `e2e-app-store.yml`
- `e2e-embed.yml`
- `e2e-embed-react.yml`
- `e2e-api-v2.yml`
- `api-v1-production-build.yml`

**Configuration changes:**
- Reduce `--health-interval` from 10s to 2s for faster detection
- Increase `--health-retries` from 5 to 15 to maintain tolerance (~30s total)
- Add `--health-start-period 2s` for startup grace period
- Make health command more specific with `-h 127.0.0.1 -U postgres`

**Expected improvement:** ~16s → ~4-6s for postgres health check per workflow

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI config only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this optimizes CI itself; effectiveness will be visible in CI run times.

## How should this be tested?

1. Merge this PR and observe the "Initialize Containers" step timing in subsequent CI runs
2. Compare the postgres health check duration before (~16s) and after (~4-6s expected)
3. Monitor for any flakiness in the first few runs to ensure the health check parameters aren't too aggressive

## Human Review Checklist

- [ ] Verify health check parameters are reasonable (2s interval × 15 retries = 30s max wait time)
- [ ] Confirm `--health-start-period` is supported on Blacksmith runners (Docker API 1.48 confirmed in logs)
- [ ] Monitor first few CI runs after merge for any postgres connection issues

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

<!-- Link to Devin run: https://app.devin.ai/sessions/fa80ea6c652248a6afb2359e34bbb031 -->
<!-- Requested by: keith@cal.com (@keithwillcode) -->