### PR TITLE
ci: simplify DB cache key and skip yarn-install on cache hit

### DIFF
--- a/.github/actions/cache-db-key/action.yml
+++ b/.github/actions/cache-db-key/action.yml
@@ -1,0 +1,23 @@
+name: Generate cache-db key
+description: "Generate the cache key for database caching"
+inputs:
+  path:
+    required: false
+    default: "backups/backup.sql"
+    description: "Path to the backup file"
+outputs:
+  key:
+    description: "The generated cache key"
+    value: ${{ steps.generate-key.outputs.key }}
+runs:
+  using: "composite"
+  steps:
+    - name: Generate cache key
+      id: generate-key
+      shell: bash
+      env:
+        CACHE_NAME: cache-db
+        PATH_KEY: ${{ inputs.path }}
+        PRISMA_HASH: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
+      run: |
+        echo "key=${{ runner.os }}-${CACHE_NAME}-${PATH_KEY}-${PRISMA_HASH}" >> $GITHUB_OUTPUT

--- a/.github/actions/cache-db-key/action.yml
+++ b/.github/actions/cache-db-key/action.yml
@@ -20,4 +20,4 @@ runs:
         PATH_KEY: ${{ inputs.path }}
         PRISMA_HASH: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
       run: |
-        echo "key=${{ runner.os }}-${CACHE_NAME}-${PATH_KEY}-${PRISMA_HASH}" >> $GITHUB_OUTPUT
+        echo "key=${CACHE_NAME}-${PATH_KEY}-${PRISMA_HASH}" >> $GITHUB_OUTPUT

--- a/.github/actions/cache-db/action.yml
+++ b/.github/actions/cache-db/action.yml
@@ -10,12 +10,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Generate cache key
+      id: cache-key
+      uses: ./.github/actions/cache-db-key
+      with:
+        path: ${{ inputs.path }}
     - name: Cache database
       id: cache-db
       uses: actions/cache@v4
       env:
-        cache-name: cache-db
-        key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
         DATABASE_URL: ${{ inputs.DATABASE_URL }}
         DATABASE_DIRECT_URL: ${{ inputs.DATABASE_URL }}
         E2E_TEST_CALCOM_QA_EMAIL: ${{ inputs.E2E_TEST_CALCOM_QA_EMAIL }}
@@ -23,7 +26,7 @@ runs:
         E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS: ${{ inputs.E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS }}
       with:
         path: ${{ inputs.path }}
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.path }}-${{ env.key-1 }}
+        key: ${{ steps.cache-key.outputs.key }}
     - run: yarn db-seed
       if: steps.cache-db.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/actions/cache-db/action.yml
+++ b/.github/actions/cache-db/action.yml
@@ -7,10 +7,6 @@ inputs:
   path:
     required: false
     default: "backups/backup.sql"
-  COMMIT_SHA:
-    required: false
-    default: ""
-    description: "Commit SHA to include in cache key (passed from workflow)"
 runs:
   using: "composite"
   steps:
@@ -20,8 +16,6 @@ runs:
       env:
         cache-name: cache-db
         key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
-        key-2: ${{ github.event.pull_request.number || github.ref }}
-        key-3: ${{ inputs.COMMIT_SHA || github.event.pull_request.head.sha || github.sha }}
         DATABASE_URL: ${{ inputs.DATABASE_URL }}
         DATABASE_DIRECT_URL: ${{ inputs.DATABASE_URL }}
         E2E_TEST_CALCOM_QA_EMAIL: ${{ inputs.E2E_TEST_CALCOM_QA_EMAIL }}
@@ -29,7 +23,7 @@ runs:
         E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS: ${{ inputs.E2E_TEST_CALCOM_QA_GCAL_CREDENTIALS }}
       with:
         path: ${{ inputs.path }}
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.path }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.path }}-${{ env.key-1 }}
     - run: yarn db-seed
       if: steps.cache-db.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -293,12 +293,28 @@ jobs:
     uses: ./.github/workflows/api-v2-unit-tests.yml
     secrets: inherit
 
-  setup-db:
-    name: Setup Database
+  setup-db-seed:
+    name: Setup Database (Seed)
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
     uses: ./.github/workflows/setup-db.yml
     secrets: inherit
+
+  setup-db:
+    name: Setup Database
+    needs: [prepare, setup-db-seed]
+    if: ${{ always() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Check setup-db-seed result
+        run: |
+          if [[ "${{ needs.prepare.outputs.db-cache-hit }}" == "true" ]]; then
+            echo "DB cache hit - skipping seed"
+            exit 0
+          elif [[ "${{ needs.setup-db-seed.result }}" != "success" ]]; then
+            echo "setup-db-seed failed"
+            exit 1
+          fi
 
   build-api-v1:
     name: Production builds
@@ -451,8 +467,7 @@ jobs:
               needs.build-api-v2.result != 'success' ||
               needs.build-atoms.result != 'success' ||
               needs.build-docs.result != 'success' ||
-              (needs.setup-db.result != 'success' && needs.setup-db.result != 'skipped') ||
-              (needs.setup-db.result == 'skipped' && needs.prepare.outputs.db-cache-hit != 'true') ||
+              needs.setup-db.result != 'success' ||
               needs.integration-test.result != 'success' ||
               needs.e2e.result != 'success' ||
               needs.e2e-api-v2.result != 'success' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,6 +161,7 @@ jobs:
       has_companion: ${{ steps.filter.outputs.has_companion }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
+      db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -185,6 +186,18 @@ jobs:
         id: get_sha
         run: |
           echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Check DB cache (lookup-only)
+        id: cache-db-check
+        uses: actions/cache/restore@v4
+        env:
+          cache-name: cache-db
+          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
+          key-2: ${{ github.event.pull_request.number || github.ref }}
+          key-3: ${{ steps.get_sha.outputs.commit-sha }}
+        with:
+          path: backups/backup.sql
+          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
+          lookup-only: true
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
@@ -285,7 +298,7 @@ jobs:
   setup-db:
     name: Setup Database
     needs: [prepare]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
     uses: ./.github/workflows/setup-db.yml
     with:
       COMMIT_SHA: ${{ needs.prepare.outputs.commit-sha }}
@@ -442,7 +455,7 @@ jobs:
               needs.build-api-v2.result != 'success' ||
               needs.build-atoms.result != 'success' ||
               needs.build-docs.result != 'success' ||
-              needs.setup-db.result != 'success' ||
+              (needs.setup-db.result != 'success' && needs.setup-db.result != 'skipped') ||
               needs.integration-test.result != 'success' ||
               needs.e2e.result != 'success' ||
               needs.e2e-api-v2.result != 'success' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,9 +161,20 @@ jobs:
       has_companion: ${{ steps.filter.outputs.has_companion }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
+      db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
+      - name: Check DB cache (lookup-only)
+        id: cache-db-check
+        uses: actions/cache/restore@v4
+        env:
+          cache-name: cache-db
+          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
+        with:
+          path: backups/backup.sql
+          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}
+          lookup-only: true
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -287,6 +298,8 @@ jobs:
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/setup-db.yml
+    with:
+      DB_CACHE_HIT: ${{ needs.prepare.outputs.db-cache-hit }}
     secrets: inherit
 
   build-api-v1:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -293,14 +293,28 @@ jobs:
     uses: ./.github/workflows/api-v2-unit-tests.yml
     secrets: inherit
 
+  setup-db-seed:
+    name: Setup Database (Seed)
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
+    uses: ./.github/workflows/setup-db.yml
+    secrets: inherit
+
   setup-db:
     name: Setup Database
-    needs: [prepare]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
-    uses: ./.github/workflows/setup-db.yml
-    with:
-      DB_CACHE_HIT: ${{ needs.prepare.outputs.db-cache-hit }}
-    secrets: inherit
+    needs: [prepare, setup-db-seed]
+    if: ${{ always() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Check setup-db-seed result
+        run: |
+          if [[ "${{ needs.prepare.outputs.db-cache-hit }}" == "true" ]]; then
+            echo "DB cache hit - skipping seed"
+            exit 0
+          elif [[ "${{ needs.setup-db-seed.result }}" != "success" ]]; then
+            echo "setup-db-seed failed"
+            exit 1
+          fi
 
   build-api-v1:
     name: Production builds

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -293,28 +293,12 @@ jobs:
     uses: ./.github/workflows/api-v2-unit-tests.yml
     secrets: inherit
 
-  setup-db-seed:
-    name: Setup Database (Seed)
+  setup-db:
+    name: Setup Database
     needs: [prepare]
     if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
     uses: ./.github/workflows/setup-db.yml
     secrets: inherit
-
-  setup-db:
-    name: Setup Database
-    needs: [prepare, setup-db-seed]
-    if: ${{ always() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - name: Check setup-db-seed result
-        run: |
-          if [[ "${{ needs.prepare.outputs.db-cache-hit }}" == "true" ]]; then
-            echo "DB cache hit - skipping seed"
-            exit 0
-          elif [[ "${{ needs.setup-db-seed.result }}" != "success" ]]; then
-            echo "setup-db-seed failed"
-            exit 1
-          fi
 
   build-api-v1:
     name: Production builds
@@ -467,7 +451,8 @@ jobs:
               needs.build-api-v2.result != 'success' ||
               needs.build-atoms.result != 'success' ||
               needs.build-docs.result != 'success' ||
-              needs.setup-db.result != 'success' ||
+              (needs.setup-db.result != 'success' && needs.setup-db.result != 'skipped') ||
+              (needs.setup-db.result == 'skipped' && needs.prepare.outputs.db-cache-hit != 'true') ||
               needs.integration-test.result != 'success' ||
               needs.e2e.result != 'success' ||
               needs.e2e-api-v2.result != 'success' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -165,15 +165,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
+      - name: Generate DB cache key
+        id: cache-db-key
+        uses: ./.github/actions/cache-db-key
       - name: Check DB cache (lookup-only)
         id: cache-db-check
         uses: actions/cache/restore@v4
-        env:
-          cache-name: cache-db
-          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
         with:
           path: backups/backup.sql
-          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}
+          key: ${{ steps.cache-db-key.outputs.key }}
           lookup-only: true
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,7 +161,6 @@ jobs:
       has_companion: ${{ steps.filter.outputs.has_companion }}
       commit-sha: ${{ steps.get_sha.outputs.commit-sha }}
       run-e2e: ${{ steps.check-if-pr-has-label.outputs.run-e2e == 'true' }}
-      db-cache-hit: ${{ steps.cache-db-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -186,18 +185,6 @@ jobs:
         id: get_sha
         run: |
           echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - name: Check DB cache (lookup-only)
-        id: cache-db-check
-        uses: actions/cache/restore@v4
-        env:
-          cache-name: cache-db
-          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
-          key-2: ${{ github.event.pull_request.number || github.ref }}
-          key-3: ${{ steps.get_sha.outputs.commit-sha }}
-        with:
-          path: backups/backup.sql
-          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
-          lookup-only: true
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
         uses: actions/github-script@v7
@@ -298,10 +285,8 @@ jobs:
   setup-db:
     name: Setup Database
     needs: [prepare]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
     uses: ./.github/workflows/setup-db.yml
-    with:
-      COMMIT_SHA: ${{ needs.prepare.outputs.commit-sha }}
     secrets: inherit
 
   build-api-v1:
@@ -455,7 +440,7 @@ jobs:
               needs.build-api-v2.result != 'success' ||
               needs.build-atoms.result != 'success' ||
               needs.build-docs.result != 'success' ||
-              (needs.setup-db.result != 'success' && needs.setup-db.result != 'skipped') ||
+              needs.setup-db.result != 'success' ||
               needs.integration-test.result != 'success' ||
               needs.e2e.result != 'success' ||
               needs.e2e-api-v2.result != 'success' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -293,28 +293,14 @@ jobs:
     uses: ./.github/workflows/api-v2-unit-tests.yml
     secrets: inherit
 
-  setup-db-seed:
-    name: Setup Database (Seed)
-    needs: [prepare]
-    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' && needs.prepare.outputs.db-cache-hit != 'true' }}
-    uses: ./.github/workflows/setup-db.yml
-    secrets: inherit
-
   setup-db:
     name: Setup Database
-    needs: [prepare, setup-db-seed]
-    if: ${{ always() && needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - name: Check setup-db-seed result
-        run: |
-          if [[ "${{ needs.prepare.outputs.db-cache-hit }}" == "true" ]]; then
-            echo "DB cache hit - skipping seed"
-            exit 0
-          elif [[ "${{ needs.setup-db-seed.result }}" != "success" ]]; then
-            echo "setup-db-seed failed"
-            exit 1
-          fi
+    needs: [prepare]
+    if: ${{ needs.prepare.outputs.run-e2e == 'true' && needs.prepare.outputs.has-files-requiring-all-checks == 'true' }}
+    uses: ./.github/workflows/setup-db.yml
+    with:
+      DB_CACHE_HIT: ${{ needs.prepare.outputs.db-cache-hit }}
+    secrets: inherit
 
   build-api-v1:
     name: Production builds

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -2,6 +2,12 @@ name: Setup Database
 
 on:
   workflow_call:
+    inputs:
+      DB_CACHE_HIT:
+        required: false
+        type: string
+        default: "false"
+        description: "Whether the DB cache was hit (skip yarn-install and cache-db if true)"
 
 permissions:
   contents: read
@@ -43,4 +49,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
+        if: inputs.DB_CACHE_HIT != 'true'
       - uses: ./.github/actions/cache-db
+        if: inputs.DB_CACHE_HIT != 'true'

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -2,12 +2,6 @@ name: Setup Database
 
 on:
   workflow_call:
-    inputs:
-      COMMIT_SHA:
-        required: false
-        type: string
-        default: ""
-        description: "Commit SHA to include in cache key"
 
 permissions:
   contents: read
@@ -54,14 +48,10 @@ jobs:
         env:
           cache-name: cache-db
           key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
-          key-2: ${{ github.event.pull_request.number || github.ref }}
-          key-3: ${{ inputs.COMMIT_SHA || github.event.pull_request.head.sha || github.sha }}
         with:
           path: backups/backup.sql
-          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}
           lookup-only: true
       - uses: ./.github/actions/yarn-install
         if: steps.cache-db-check.outputs.cache-hit != 'true'
       - uses: ./.github/actions/cache-db
-        with:
-          COMMIT_SHA: ${{ inputs.COMMIT_SHA || github.sha }}

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -2,6 +2,12 @@ name: Setup Database
 
 on:
   workflow_call:
+    inputs:
+      DB_CACHE_HIT:
+        required: false
+        type: string
+        default: ""
+        description: "Whether DB cache was hit in prepare job (passed from pr.yml)"
 
 permissions:
   contents: read
@@ -42,16 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
-      - name: Check DB cache (lookup-only)
-        id: cache-db-check
-        uses: actions/cache/restore@v4
-        env:
-          cache-name: cache-db
-          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
-        with:
-          path: backups/backup.sql
-          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}
-          lookup-only: true
       - uses: ./.github/actions/yarn-install
-        if: steps.cache-db-check.outputs.cache-hit != 'true'
+        if: inputs.DB_CACHE_HIT != 'true'
       - uses: ./.github/actions/cache-db
+        if: inputs.DB_CACHE_HIT != 'true'

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -2,12 +2,6 @@ name: Setup Database
 
 on:
   workflow_call:
-    inputs:
-      DB_CACHE_HIT:
-        required: false
-        type: string
-        default: ""
-        description: "Whether DB cache was hit in prepare job (passed from pr.yml)"
 
 permissions:
   contents: read
@@ -49,6 +43,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
-        if: inputs.DB_CACHE_HIT != 'true'
       - uses: ./.github/actions/cache-db
-        if: inputs.DB_CACHE_HIT != 'true'

--- a/.github/workflows/setup-db.yml
+++ b/.github/workflows/setup-db.yml
@@ -48,7 +48,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
+      - name: Check DB cache (lookup-only)
+        id: cache-db-check
+        uses: actions/cache/restore@v4
+        env:
+          cache-name: cache-db
+          key-1: ${{ hashFiles('packages/prisma/schema.prisma', 'packages/prisma/migrations/**/**.sql', 'packages/prisma/*.ts') }}
+          key-2: ${{ github.event.pull_request.number || github.ref }}
+          key-3: ${{ inputs.COMMIT_SHA || github.event.pull_request.head.sha || github.sha }}
+        with:
+          path: backups/backup.sql
+          key: ${{ runner.os }}-${{ env.cache-name }}-backups/backup.sql-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}
+          lookup-only: true
       - uses: ./.github/actions/yarn-install
+        if: steps.cache-db-check.outputs.cache-hit != 'true'
       - uses: ./.github/actions/cache-db
         with:
           COMMIT_SHA: ${{ inputs.COMMIT_SHA || github.sha }}


### PR DESCRIPTION
## What does this PR do?

Optimizes the DB caching in CI workflows by:
1. **Simplifying the cache key** - Removed commit SHA, PR number, and runner OS from the cache key, so it now only depends on the prisma schema/migrations hash. This allows the cache to be reused across all PRs and commits where the prisma files haven't changed.
2. **Early cache detection** - Moved the cache lookup to the `prepare` step in pr.yml using `lookup-only` mode, outputting `db-cache-hit`.
3. **Skipping expensive steps on cache hit** - Pass `DB_CACHE_HIT` input to `setup-db.yml`, which skips `yarn-install` and `cache-db` steps when cache exists (~17s savings).
4. **Centralized cache key generation** - Created a new `cache-db-key` action (similar to `cache-build-key`) that generates the DB cache key in one place. Both `cache-db` action and `pr.yml` prepare step use this action, ensuring the lookup key always matches the actual cache key.

**Cache key change:**
- Before: `{os}-cache-db-{path}-{prisma-hash}-{pr-number}-{commit-sha}`
- After: `cache-db-{path}-{prisma-hash}`

**Time savings:** ~17s when cache exists (yarn-install skip). Container initialization optimization deferred to follow-up.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow optimization, will be validated by workflow runs.

## How should this be tested?

**Note:** This PR modifies `pr.yml` which uses `pull_request_target`. Changes won't be tested by CI on this PR - they take effect after merge.

1. After merge, observe the `setup-db` job on a PR where the DB cache already exists - `yarn-install` and `cache-db` steps should be skipped
2. Observe the `setup-db` job on a PR with schema/migration changes - should run all steps normally
3. Verify downstream jobs (e2e, integration-test, build-api-v1) still run correctly

## Human Review Checklist

- [x] ~~Verify the cache key in `pr.yml` prepare step matches exactly with the key in `.github/actions/cache-db/action.yml`~~ - Now guaranteed by shared `cache-db-key` action
- [ ] Verify the conditional step logic in `setup-db.yml` (`if: inputs.DB_CACHE_HIT != 'true'`) will correctly skip steps
- [ ] Confirm that `yarn db-seed` only depends on the prisma files being hashed (schema.prisma, migrations, packages/prisma/*.ts) and not on other application code that could cause stale cache issues
- [ ] Review the `cache-db-key` action to ensure `hashFiles` works correctly in the composite action context
- [ ] **Important:** Full validation requires merge due to `pull_request_target` - monitor first few PRs after merge

---

Link to Devin run: https://app.devin.ai/sessions/f69f14a76b594880a91de42fbae69adc
Requested by: keith@cal.com (@keithwillcode)