### PR TITLE
fix: use stable test dates in duplicate API calls E2E tests

### DIFF
--- a/apps/web/playwright/booking-duplicate-api-calls.e2e.ts
+++ b/apps/web/playwright/booking-duplicate-api-calls.e2e.ts
@@ -36,6 +36,18 @@ async function testDuplicateAPICalls(
   };
 }
 
+/**
+ * Creates a stable test date that avoids month boundary issues.
+ * Uses a fixed date in the middle of a month to ensure consistent behavior
+ * regardless of when the test is run.
+ * @param dayOfMonth - The day of the month to use (5 for beginning, 20 for end)
+ */
+function getStableTestDate(dayOfMonth: number): Date {
+  // Use a fixed future date to avoid any issues with past dates or month boundaries
+  // July 2030 is chosen as it's far in the future and has no special calendar quirks
+  return new Date(2030, 6, dayOfMonth, 12, 0, 0);
+}
+
 test.describe("Duplicate API Calls Prevention", () => {
   test.afterEach(({ users }) => users.deleteAll());
 
@@ -45,8 +57,7 @@ test.describe("Duplicate API Calls Prevention", () => {
   }) => {
     const user = await users.create();
     const eventType = user.eventTypes.find((e) => e.slug === "30-min");
-    const beginningOfMonth = new Date();
-    beginningOfMonth.setDate(5);
+    const beginningOfMonth = getStableTestDate(5);
 
     const { totalCalls, trpcCalls, apiV2Calls } = await testDuplicateAPICalls(
       page,
@@ -66,8 +77,7 @@ test.describe("Duplicate API Calls Prevention", () => {
   }) => {
     const user = await users.create();
     const eventType = user.eventTypes.find((e) => e.slug === "30-min");
-    const endOfMonth = new Date();
-    endOfMonth.setDate(20);
+    const endOfMonth = getStableTestDate(20);
 
     const { totalCalls, trpcCalls, apiV2Calls } = await testDuplicateAPICalls(
       page,
@@ -92,8 +102,7 @@ test.describe("Duplicate API Calls Prevention", () => {
         teammates: [{ name: "teammate-1" }],
       }
     );
-    const beginningOfMonth = new Date();
-    beginningOfMonth.setDate(5);
+    const beginningOfMonth = getStableTestDate(5);
 
     const { team } = await teamOwner.getFirstTeamMembership();
     const teamEvent = await createTeamEventType(
@@ -132,8 +141,7 @@ test.describe("Duplicate API Calls Prevention", () => {
       { id: team.id },
       { teamEventSlug: "team-event-test", teamEventTitle: "Team Event Test" }
     );
-    const endOfMonth = new Date();
-    endOfMonth.setDate(20);
+    const endOfMonth = getStableTestDate(20);
 
     const { totalCalls, trpcCalls, apiV2Calls } = await testDuplicateAPICalls(
       page,
@@ -169,8 +177,7 @@ test.describe("Duplicate API Calls Prevention", () => {
       { id: team.id },
       { teamEventSlug: "org-team-event", teamEventTitle: "Org Team Event" }
     );
-    const beginningOfMonth = new Date();
-    beginningOfMonth.setDate(5);
+    const beginningOfMonth = getStableTestDate(5);
 
     const { totalCalls, trpcCalls, apiV2Calls } = await testDuplicateAPICalls(
       page,
@@ -206,8 +213,7 @@ test.describe("Duplicate API Calls Prevention", () => {
       { id: team.id },
       { teamEventSlug: "org-team-event", teamEventTitle: "Org Team Event" }
     );
-    const endOfMonth = new Date();
-    endOfMonth.setDate(20);
+    const endOfMonth = getStableTestDate(20);
 
     const { totalCalls, trpcCalls, apiV2Calls } = await testDuplicateAPICalls(
       page,


### PR DESCRIPTION
## What does this PR do?

Fixes flaky E2E tests in `booking-duplicate-api-calls.e2e.ts` that were failing on December 31 due to month boundary issues.

The tests were using `new Date()` and then setting the day to 5 or 20, which caused issues when the prefetch logic in `isMonthViewPrefetchEnabled` evaluated the current date against month boundaries. On certain dates (like end of month/year), this could trigger additional API calls, causing the tests to fail with "Expected <= 1, Received 2".

This PR introduces a `getStableTestDate()` helper function that returns a fixed future date (July 2030) to ensure consistent test behavior regardless of when the tests are run.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the E2E tests: `PLAYWRIGHT_HEADLESS=1 yarn e2e booking-duplicate-api-calls.e2e.ts`
2. All 6 tests should pass regardless of the current date

## Human Review Checklist

- [ ] Verify that using a fixed future date (July 2030) doesn't change the fundamental behavior being tested
- [ ] Confirm the hypothesis that month boundary prefetch logic was causing the extra API calls
- [ ] Consider if there's a more robust approach (e.g., more comprehensive date mocking)

**Note**: Local testing was blocked by environment issues (Internal Server Error), so this fix is based on code analysis of the prefetch logic in `isMonthViewPrefetchEnabled.ts`. CI will verify the fix.

---

Link to Devin run: https://app.devin.ai/sessions/b1ce96e74aa14104aa9eb14f5e3449f6
Requested by: keith@cal.com (@keithwillcode)