### PR TITLE
feat(api): allow OAuth client credentials for org stripe and conferencing endpoints

### DIFF
--- a/apps/api/v2/src/modules/organizations/stripe/organizations-stripe.controller.ts
+++ b/apps/api/v2/src/modules/organizations/stripe/organizations-stripe.controller.ts
@@ -1,4 +1,29 @@
+import { SUCCESS_STATUS, X_CAL_CLIENT_ID } from "@calcom/platform-constants";
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Query,
+  Redirect,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiHeader, ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
+import { plainToClass } from "class-transformer";
+import type { Request } from "express";
+import { stringify } from "querystring";
 import { API_VERSIONS_VALUES } from "@/lib/api-versions";
+import {
+  OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER,
+  OPTIONAL_X_CAL_CLIENT_ID_HEADER,
+  OPTIONAL_X_CAL_SECRET_KEY_HEADER,
+} from "@/lib/docs/headers";
 import { PlatformPlan } from "@/modules/auth/decorators/billing/platform-plan.decorator";
 import { GetUser } from "@/modules/auth/decorators/get-user/get-user.decorator";
 import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
@@ -8,56 +33,34 @@ import { IsAdminAPIEnabledGuard } from "@/modules/auth/guards/organizations/is-a
 import { IsOrgGuard } from "@/modules/auth/guards/organizations/is-org.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { IsTeamInOrg } from "@/modules/auth/guards/teams/is-team-in-org.guard";
-import { OrganizationsStripeService } from "@/modules/organizations/stripe/services/organizations-stripe.service";
+import type { MembershipsRepository } from "@/modules/memberships/memberships.repository";
+import type { OAuthClientRepository } from "@/modules/oauth-clients/oauth-client.repository";
+import type { OrganizationsStripeService } from "@/modules/organizations/stripe/services/organizations-stripe.service";
 import {
   StripConnectOutputDto,
-  StripConnectOutputResponseDto,
-  StripCredentialsCheckOutputResponseDto,
-  StripCredentialsSaveOutputResponseDto,
+  type StripConnectOutputResponseDto,
+  type StripCredentialsCheckOutputResponseDto,
+  type StripCredentialsSaveOutputResponseDto,
 } from "@/modules/stripe/outputs/stripe.output";
-import { StripeService } from "@/modules/stripe/stripe.service";
+import type { OAuthCallbackState } from "@/modules/stripe/stripe.service";
 import { getOnErrorReturnToValueFromQueryState } from "@/modules/stripe/utils/getReturnToValueFromQueryState";
-import { TokensRepository } from "@/modules/tokens/tokens.repository";
-import { UserWithProfile } from "@/modules/users/users.repository";
-import {
-  Controller,
-  Get,
-  Query,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-  Param,
-  Headers,
-  Req,
-  ParseIntPipe,
-  Redirect,
-  BadRequestException,
-} from "@nestjs/common";
-import { ApiOperation, ApiTags as DocsTags } from "@nestjs/swagger";
-import { plainToClass } from "class-transformer";
-import { Request } from "express";
-import { stringify } from "querystring";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-
-export type OAuthCallbackState = {
-  accessToken: string;
-  teamId?: string;
-  orgId?: string;
-  fromApp?: boolean;
-  returnTo?: string;
-  onErrorReturnTo?: string;
-};
+import type { TokensRepository } from "@/modules/tokens/tokens.repository";
+import type { UserWithProfile } from "@/modules/users/users.repository";
 
 @Controller({
   path: "/v2/organizations/:orgId/teams/:teamId/stripe",
   version: API_VERSIONS_VALUES,
 })
 @DocsTags("Orgs / Teams / Stripe")
+@ApiHeader(OPTIONAL_X_CAL_CLIENT_ID_HEADER)
+@ApiHeader(OPTIONAL_X_CAL_SECRET_KEY_HEADER)
+@ApiHeader(OPTIONAL_API_KEY_OR_ACCESS_TOKEN_HEADER)
 export class OrganizationsStripeController {
   constructor(
     private readonly organizationsStripeService: OrganizationsStripeService,
-    private readonly tokensRepository: TokensRepository
+    private readonly tokensRepository: TokensRepository,
+    private readonly oAuthClientRepository: OAuthClientRepository,
+    private readonly membershipsRepository: MembershipsRepository
   ) {}
 
   @Roles("TEAM_ADMIN")
@@ -68,7 +71,7 @@ export class OrganizationsStripeController {
   @ApiOperation({ summary: "Get Stripe connect URL for a team" })
   async getTeamStripeConnectUrl(
     @Req() req: Request,
-    @Headers("Authorization") authorization: string,
+    @Headers("Authorization") authorization: string | undefined,
     @GetUser() user: UserWithProfile,
     @Param("teamId") teamId: string,
     @Param("orgId") orgId: string,
@@ -76,13 +79,18 @@ export class OrganizationsStripeController {
     @Query("onErrorReturnTo") onErrorReturnTo?: string
   ): Promise<StripConnectOutputResponseDto> {
     const origin = req.headers.origin;
-    const accessToken = authorization.replace("Bearer ", "");
+    const oAuthClientId = req.get(X_CAL_CLIENT_ID);
+
+    // Determine if using OAuth client credentials or Bearer token
+    const accessToken = authorization ? authorization.replace("Bearer ", "") : undefined;
 
     const state: OAuthCallbackState = {
-      onErrorReturnTo: !!onErrorReturnTo ? onErrorReturnTo : origin,
+      onErrorReturnTo: onErrorReturnTo ?? origin,
       fromApp: false,
-      returnTo: !!returnTo ? returnTo : origin,
+      returnTo: returnTo ?? origin,
+      // Store either access token or OAuth client ID for callback authentication
       accessToken,
+      oAuthClientId: !accessToken ? oAuthClientId : undefined,
       teamId,
       orgId,
     };
@@ -130,8 +138,6 @@ export class OrganizationsStripeController {
 
     const decodedCallbackState: OAuthCallbackState = JSON.parse(state);
     try {
-      const userId = await this.tokensRepository.getAccessTokenOwnerId(decodedCallbackState.accessToken);
-
       // user cancels flow
       if (error === "access_denied") {
         return { url: getOnErrorReturnToValueFromQueryState(state) };
@@ -141,15 +147,37 @@ export class OrganizationsStripeController {
         throw new BadRequestException(stringify({ error, error_description }));
       }
 
+      // Determine user ID based on authentication method stored in state
+      let userId: number | undefined;
+
+      if (decodedCallbackState.accessToken) {
+        // Standard flow: get user from access token
+        userId = await this.tokensRepository.getAccessTokenOwnerId(decodedCallbackState.accessToken);
+      } else if (decodedCallbackState.oAuthClientId) {
+        // OAuth client credentials flow: get platform owner/admin from OAuth client
+        const oAuthClient = await this.oAuthClientRepository.getOAuthClient(decodedCallbackState.oAuthClientId);
+        if (!oAuthClient) {
+          throw new UnauthorizedException("Invalid OAuth client ID in callback state");
+        }
+
+        userId =
+          (await this.membershipsRepository.findPlatformOwnerUserId(oAuthClient.organizationId)) ||
+          (await this.membershipsRepository.findPlatformAdminUserId(oAuthClient.organizationId));
+      }
+
+      if (!userId) {
+        throw new UnauthorizedException("Unable to determine user for Stripe account setup");
+      }
+
       return await this.organizationsStripeService.saveStripeAccount(
         decodedCallbackState,
         code,
         teamId,
         userId
       );
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(error.message);
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error(err.message);
       }
       return {
         url: decodedCallbackState.onErrorReturnTo ?? "",

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -24,7 +24,8 @@ import { stripeKeysResponseSchema } from "./utils/stripeDataSchemas";
 import stringify = require("qs-stringify");
 
 export type OAuthCallbackState = {
-  accessToken: string;
+  accessToken?: string;
+  oAuthClientId?: string;
   teamId?: string;
   orgId?: string;
   fromApp?: boolean;


### PR DESCRIPTION
## Summary
- Enables platform owners/admins to use `X-Cal-Client-Id` and `X-Cal-Secret-Key` headers to access organization-level Stripe and conferencing endpoints
- Removes the need to create a managed user with admin/owner role and use their access token

## Changes
- Update `OAuthCallbackState` type to support optional `accessToken` and `oAuthClientId`
- Modify connect/auth-url endpoints to detect and store OAuth credentials in state when no Bearer token
- Update callback/save endpoints to authenticate via OAuth client ID when no access token is present
- Add proper proxy header handling for OAuth credentials in callback flows

## Files Changed
- `apps/api/v2/src/modules/stripe/stripe.service.ts` - OAuthCallbackState type
- `apps/api/v2/src/modules/organizations/stripe/organizations-stripe.controller.ts` - Full OAuth support for team Stripe
- `apps/api/v2/src/modules/stripe/controllers/stripe.controller.ts` - Proxy header handling
- `apps/api/v2/src/modules/conferencing/controllers/conferencing.controller.ts` - OAuthCallbackState type & proxy headers
- `apps/api/v2/src/modules/conferencing/services/conferencing.service.ts` - OAuth client authentication
- `apps/api/v2/src/modules/organizations/conferencing/organizations-conferencing.controller.ts` - Full OAuth support for team conferencing

## How it works
When OAuth client credentials are used instead of a Bearer token:
1. The `connect`/`auth-url` endpoint stores `oAuthClientId` in the OAuth state (instead of `accessToken`)
2. On callback, the `save` endpoint checks for `oAuthClientId` in the decoded state
3. If found, it looks up the OAuth client and finds the platform owner/admin user to associate the credentials with

Closes #20937