### PR TITLE
fix: replace title with aria-label to avoid multiple tooltips

### DIFF
--- a/packages/ui/components/badge/InfoBadge.tsx
+++ b/packages/ui/components/badge/InfoBadge.tsx
@@ -5,7 +5,7 @@ export function InfoBadge({ content }: { content: string }) {
   return (
     <>
       <Tooltip side="top" content={content}>
-        <span title={content}>
+        <span aria-label={content}>
           <Icon name="info" className="text-subtle relative left-1 right-1 top-px mt-px h-4 w-4" />
         </span>
       </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Replaces the title attribute with aria-label to keep the info badge accessible while avoiding multiple tooltips on hover.

The second tooltip was coming from the browser because of the title attribute.

- Fixes #26371
- Fixes CAL-7008

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
