### PR TITLE
feat: re-trigger pr.yml when ready-for-e2e label is added

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   trigger:
     name: Trigger CI
-    if: github.event.label.name == 'run-ci'
+    if: github.event.label.name == 'run-ci' || github.event.label.name == 'ready-for-e2e'
     runs-on: ubuntu-latest
     steps:
       - name: Verify and trigger CI


### PR DESCRIPTION
## What does this PR do?

Extends the `run-ci.yml` workflow to also re-trigger the last run of `pr.yml` when the `ready-for-e2e` label is added to a PR, following the same pattern that pedroccastro implemented for the `run-ci` label.

This allows maintainers to re-run the full CI pipeline (including E2E tests) by simply adding the `ready-for-e2e` label, without needing to push a new commit or manually re-run workflows.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a CI workflow change that will be tested by using the label.

## How should this be tested?

1. Create or find a PR that has already run CI
2. Add the `ready-for-e2e` label to the PR
3. Verify that the `run-ci.yml` workflow triggers and re-runs the `pr.yml` workflow

## Human Review Checklist

- [ ] Verify the `ready-for-e2e` label exists in the repository
- [ ] Confirm this matches the intended behavior for triggering E2E tests

---

### Link to Devin run
https://app.devin.ai/sessions/bbd59ccd0c2642dabf6a64750ad1e9f6

### Requested by
keith@cal.com (@keithwillcode)