### PR TITLE
fix: Biome - format only for generated

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,12 +7,6 @@
     }
   },
   "formatter": {
-    "includes": [
-      "**/*",
-      "!packages/ui/components/icon/dynamicIconImports.tsx",
-      "!apps/api/v1/tests",
-      "!apps/api/v1/templates"
-    ],
     "lineWidth": 110,
     "indentStyle": "space",
     "indentWidth": 2,
@@ -70,6 +64,21 @@
   },
   "overrides": [
     {
+      "includes": ["packages/app-store/*.generated.ts"],
+      "javascript": {
+        "formatter": {
+          "enabled": true,
+          "arrowParentheses": "always",
+          "bracketSpacing": true,
+          "bracketSameLine": true,
+          "quoteStyle": "double",
+          "jsxQuoteStyle": "double",
+          "semicolons": "always",
+          "trailingCommas": "es5"
+        }
+      }
+    },
+    {
       "includes": ["**/*.test.ts", "**/*.test.tsx"],
       "linter": {
         "rules": {
@@ -86,7 +95,11 @@
       }
     },
     {
-      "includes": ["apps/web/app/**/page.tsx", "apps/web/app/**/layout.tsx", "apps/web/app/pages/**/*.tsx"],
+      "includes": [
+        "apps/web/app/**/page.tsx",
+        "apps/web/app/**/layout.tsx",
+        "apps/web/app/pages/**/*.tsx"
+      ],
       "linter": {
         "rules": {
           "style": {

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -7,6 +7,6 @@ export default {
     skipWarnings
       ? `biome lint ${files.join(" ")}`
       : `biome lint --error-on-warnings ${files.join(" ")}`,
-  "*.json": (files) => `biome format ${files.join(" ")}`,
+  // "*.json": (files) => `biome format ${files.join(" ")}`,
   "packages/prisma/schema.prisma": ["prisma format"],
 };


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits Biome formatting to generated TypeScript files and disables JSON auto-formatting in lint-staged to reduce noisy diffs. Adds a formatter override for packages/app-store/*.generated.ts with explicit style options and removes the global formatter includes.

<sup>Written for commit f41436dbcd890e8a786e21d1eeb14ab0b3bba9e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

