### PR TITLE
fix: remove PR/commit-specific keys from docs-build cache

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: |
             **/docs/**
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}
+          key: ${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}
       - name: Run build
         if: steps.cache-docs-build.outputs.cache-hit != 'true'
         working-directory: docs

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -20,12 +20,10 @@ jobs:
           cache-name: docs-build
           key-1: ${{ hashFiles('yarn.lock') }}
           key-2: ${{ hashFiles('docs/**.*', '!**/node_modules') }}
-          key-3: ${{ github.event.pull_request.number || github.ref }}
-          key-4: ${{ github.sha }}
         with:
           path: |
             **/docs/**
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}
             # Log cache hit
       - name: Log Cache Hit
         if: steps.cache-docs-build.outputs.cache-hit == 'true'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,10 +24,6 @@ jobs:
           path: |
             **/docs/**
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}
-            # Log cache hit
-      - name: Log Cache Hit
-        if: steps.cache-docs-build.outputs.cache-hit == 'true'
-        run: echo "Cache hit for Docs build. Skipping build."
       - name: Run build
         if: steps.cache-docs-build.outputs.cache-hit != 'true'
         working-directory: docs


### PR DESCRIPTION
## What does this PR do?

Removes `key-3` (PR number/git ref) and `key-4` (commit SHA) from the docs-build workflow cache key. This allows the cache to persist across all jobs and PRs until the actual files change (`yarn.lock` or `docs/**` files).

Previously, the cache was unique per PR/commit, preventing cache reuse across different CI runs.

Also removes the redundant "Log Cache Hit" step since cache hits are already visible in the GitHub Actions logs.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow change.

## How should this be tested?

1. Verify the docs-build workflow runs successfully
2. On subsequent runs with unchanged `yarn.lock` and `docs/**` files, the cache should hit
3. The "Run build" step should be skipped when cache hits

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

### Link to Devin run
https://app.devin.ai/sessions/2f651ad6578a43f2befd4ab983c625a6

### Requested by
keith@cal.com (@keithwillcode)