### PR TITLE
chore: disable lint staged from merge main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,10 @@
-yarn lint-staged
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
 
+if [ -f .git/MERGE_HEAD ]; then
+  echo "Merge detected. Skipping lint-staged and generators."
+  exit 0
+fi
+
+yarn lint-staged
 yarn app-store:build && git add packages/app-store/*.generated.*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 if [ -f .git/MERGE_HEAD ]; then
   echo "Merge detected. Skipping lint-staged and generators."
   exit 0


### PR DESCRIPTION
## What does this PR do?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Husky pre-commit hook to detect merges and skip lint-staged and generator steps to avoid unnecessary changes and failures during merge operations. Normal commits still run lint-staged and generate app-store files.

<sup>Written for commit 3ffd87db442c1a500f3d501ecab4bb3d1903b8e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

