### PR TITLE
fix: add global RTL cleanup and mock focus-scope to prevent vitest unhandled errors

### DIFF
--- a/apps/web/components/apps/routing-forms/TestFormDialog.test.tsx
+++ b/apps/web/components/apps/routing-forms/TestFormDialog.test.tsx
@@ -1,10 +1,16 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { vi, afterEach, afterAll } from "vitest";
 
 import { findMatchingRoute } from "@calcom/app-store/routing-forms/lib/processRoute";
 
 import { TestFormRenderer } from "./TestForm";
+
+// Mock @radix-ui/react-focus-scope to prevent timer leaks during test teardown
+// The focus-scope module schedules setTimeout callbacks that can fire after jsdom is destroyed
+vi.mock("@radix-ui/react-focus-scope", () => ({
+  FocusScope: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
 vi.mock("framer-motion", async () => {
   return {
@@ -194,6 +200,11 @@ describe("TestFormDialog", () => {
   beforeEach(() => {
     resetFindTeamMembersMatchingAttributeLogicResponse();
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    // Clean up the focus-scope mock to prevent cross-test pollution in the same Vitest worker
+    vi.unmock("@radix-ui/react-focus-scope");
   });
 
   it("renders the dialog when open", () => {

--- a/setupVitest.ts
+++ b/setupVitest.ts
@@ -1,11 +1,17 @@
+import type { CalendarService } from "@calcom/types/Calendar";
 import matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
 import ResizeObserver from "resize-observer-polyfill";
-import { vi, expect } from "vitest";
+import { afterEach, expect, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 
-import type { CalendarService } from "@calcom/types/Calendar";
-
 global.ResizeObserver = ResizeObserver;
+
+// Global cleanup after each test to prevent React Testing Library component leaks
+// This is especially important after Vitest 4.0 upgrade which is stricter about unhandled errors
+afterEach(() => {
+  cleanup();
+});
 const fetchMocker = createFetchMock(vi);
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version


### PR DESCRIPTION
## What does this PR do?

Fixes flaky unit test failures that became more frequent after the Vitest 4.0 upgrade. The upgrade made the test runner stricter about unhandled errors/rejections, surfacing latent test cleanup issues.

**Root cause:** The `@radix-ui/react-focus-scope` module schedules `setTimeout` callbacks that can fire after jsdom is destroyed during test teardown, causing `TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'`.

**Changes:**
- Add global `afterEach(cleanup)` to `setupVitest.ts` to ensure React Testing Library components are properly cleaned up after each test
- Mock `@radix-ui/react-focus-scope` in `TestFormDialog.test.tsx` to prevent timer leaks
- Add `afterAll` cleanup to unmock focus-scope and prevent cross-test pollution

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test infrastructure change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the specific test file: `TZ=UTC yarn test apps/web/components/apps/routing-forms/TestFormDialog.test.tsx`
2. Run the full test suite to verify no regressions: `TZ=UTC yarn test`
3. CI should pass without "Unhandled Errors" that were previously causing failures

## Human Review Checklist

- [ ] Verify the `FocusScope` mock (simple passthrough) doesn't break any test assertions that rely on focus management behavior
- [ ] Confirm global `afterEach(cleanup)` doesn't cause any test regressions in other test files
- [ ] Consider if other test files using Radix UI dialogs might need similar focus-scope mocking

---

### Link to Devin run
https://app.devin.ai/sessions/6a9ba54641e64a809e87b541d67f631e

### Requested by
Volnei Munhoz (volnei@cal.com) (@volnei)