### PR TITLE
chore: Make atoms cache-key more reusable

### DIFF
--- a/.github/workflows/atoms-production-build.yml
+++ b/.github/workflows/atoms-production-build.yml
@@ -20,17 +20,11 @@ jobs:
         env:
           cache-name: atoms-build
           key-1: ${{ hashFiles('yarn.lock') }}
-          key-2: ${{ hashFiles('packages/platform/atoms/**.[jt]s', 'packages/platform/atoms/**.[jt]sx', '!**/node_modules') }}
-          key-3: ${{ github.event.pull_request.number || github.ref }}
-          # Ensures production-build.yml will always be fresh
-          key-4: ${{ github.sha }}
+          key-2: ${{ hashFiles('packages/platform/atoms/**.[jt]s', 'packages/platform/atoms/**.[jt]sx', 'packages/platform/atoms/package.json', '!**/node_modules') }}
         with:
           path: |
             **/dist/**
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}-${{ env.key-3 }}-${{ env.key-4 }}
-      - name: Log Cache Hit
-        if: steps.cache-atoms-build.outputs.cache-hit == 'true'
-        run: echo "Cache hit for Atoms build. Skipping build."
+          key: ${{ env.cache-name }}-${{ env.key-1 }}-${{ env.key-2 }}
       - name: Run build
         if: steps.cache-atoms-build.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the atoms production build cache key to improve reuse across branches and commits and speed up CI builds. The key now hashes yarn.lock, atoms source files, and the atoms package.json, and drops OS-, PR-, and commit-specific values.

<sup>Written for commit 0aac310ed806a3dcacf5ed3a8ae43a2f6caec404. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

