### PR TITLE
test: flaky e2e tests

### DIFF
--- a/apps/web/modules/ee/teams/components/CreateANewTeamForm.tsx
+++ b/apps/web/modules/ee/teams/components/CreateANewTeamForm.tsx
@@ -44,8 +44,8 @@ export const CreateANewTeamForm = (props: CreateANewTeamFormProps) => {
   const createTeamMutation = trpc.viewer.teams.create.useMutation({
     onSuccess: async (data) => {
       await utils.viewer.eventTypes.getUserEventGroups.invalidate();
-      revalidateEventTypesList();
-      revalidateTeamsList();
+      await revalidateEventTypesList();
+      await revalidateTeamsList();
       onSuccess(data);
     },
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Await data revalidation after team creation to ensure lists update before continuing, reducing flaky e2e tests in the team creation flow. This prevents stale data from being used right after a team is created.

- **Bug Fixes**
  - Await revalidateEventTypesList() and revalidateTeamsList() in createTeamMutation onSuccess.
  - Avoid race conditions by ensuring lists refresh before calling onSuccess.

<sup>Written for commit 8e88a266d2c24ddc83df78002d4fd588ee6f8ade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

