### PR TITLE
disable noExcessiveLinesPerFunction-off-for-tests for tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -70,16 +70,6 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts", "**/*.test.tsx"],
-      "linter": {
-        "rules": {
-          "complexity": {
-            "useArrowFunction": "off"
-          }
-        }
-      }
-    },
-    {
       "includes": ["**/*.tsx"],
       "javascript": {
         "jsxRuntime": "transparent"
@@ -144,6 +134,17 @@
           "security": {
             "noBlankTarget": "warn",
             "noDangerouslySetInnerHtml": "warn"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useArrowFunction": "off",
+            "noExcessiveLinesPerFunction": "off"
           }
         }
       }


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the noExcessiveLinesPerFunction linter rule for *.test.ts and *.test.tsx in Biome, and keep useArrowFunction off. This reduces lint noise in tests that use longer setups or fixtures.

<sup>Written for commit d97b6d41ee0cd0382752cae9759911e11dcebc3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

