### PR TITLE
chore: fix all style/useNodejsImportProtocol

### DIFF
--- a/.yarn/patches/next-i18next-npm-13.3.0-bf25b0943c.patch
+++ b/.yarn/patches/next-i18next-npm-13.3.0-bf25b0943c.patch
@@ -2,8 +2,8 @@ diff --git a/dist/commonjs/serverSideTranslations.js b/dist/commonjs/serverSideT
 index bcad3d02fbdfab8dacb1d85efd79e98623a0c257..fff668f598154a13c4030d1b4a90d5d9c18214ad 100644
 --- a/dist/commonjs/serverSideTranslations.js
 +++ b/dist/commonjs/serverSideTranslations.js
-@@ -36,7 +36,6 @@ var _fs = _interopRequireDefault(require("fs"));
- var _path = _interopRequireDefault(require("path"));
+@@ -36,7 +36,6 @@ var _fs = _interopRequireDefault(require("node:fs"));
+ var _path = _interopRequireDefault(require("node:path"));
  var _createConfig = require("./config/createConfig");
  var _node = _interopRequireDefault(require("./createClient/node"));
 -var _appWithTranslation = require("./appWithTranslation");

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -1,4 +1,4 @@
-const http = require("http");
+const http = require("node:http");
 const connect = require("connect");
 const { createProxyMiddleware } = require("http-proxy-middleware");
 

--- a/apps/api/v1/next-i18next.config.js
+++ b/apps/api/v1/next-i18next.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 const i18nConfig = require("@calcom/config/next-i18next.config");
 
 /** @type {import("next-i18next").UserConfig} */

--- a/apps/api/v1/test/jest-setup.js
+++ b/apps/api/v1/test/jest-setup.js
@@ -1,6 +1,6 @@
 // This is a workaround for https://github.com/jsdom/jsdom/issues/2524#issuecomment-902027138
 
 // See https://github.com/microsoft/accessibility-insights-web/blob/40416a4ae6b91baf43102f58e069eff787de4de2/src/tests/unit/jest-setup.ts
-const { TextEncoder, TextDecoder } = require("util");
+const { TextEncoder, TextDecoder } = require("node:util");
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;

--- a/apps/api/v2/next-i18next.config.js
+++ b/apps/api/v2/next-i18next.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const path = require("path");
+const path = require("node:path");
 const i18nConfig = require("@calcom/config/next-i18next.config");
 
 /** @type {import("next-i18next").UserConfig} */

--- a/apps/api/v2/scripts/docker-start.ts
+++ b/apps/api/v2/scripts/docker-start.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync } from "node:child_process";
 
 function checkCommandExists(command: string): boolean {
   try {

--- a/apps/api/v2/src/lib/api-key/index.ts
+++ b/apps/api/v2/src/lib/api-key/index.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 export const sha256Hash = (token: string): string => createHash("sha256").update(token).digest("hex");
 

--- a/apps/api/v2/src/lib/filterReqHeaders.ts
+++ b/apps/api/v2/src/lib/filterReqHeaders.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders } from "http";
+import { IncomingHttpHeaders } from "node:http";
 
 export function filterReqHeaders(headers: IncomingHttpHeaders): Partial<IncomingHttpHeaders> {
   return {

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots-worker.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import * as path from "path";
-import { Worker } from "worker_threads";
+import * as path from "node:path";
+import { Worker } from "node:worker_threads";
 
 // Import WorkerOptions type
 import type { GetScheduleOptions } from "@calcom/trpc/server/routers/viewer/slots/types";

--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/workers/slots.worker.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/workers/slots.worker.ts
@@ -1,8 +1,8 @@
 import { AvailableSlotsService } from "@/lib/services/available-slots.service";
 import { Logger } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
-import { IncomingMessage } from "http";
-import { parentPort, isMainThread } from "worker_threads";
+import { IncomingMessage } from "node:http";
+import { parentPort, isMainThread } from "node:worker_threads";
 
 import { SlotsWorkerModule } from "./slots.worker.module";
 

--- a/apps/api/v2/src/swagger/copy-swagger-module.ts
+++ b/apps/api/v2/src/swagger/copy-swagger-module.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs-extra";
-import * as path from "path";
+import * as path from "node:path";
 
 // First, copyNestSwagger is required to enable "@nestjs/swagger" in the "nest-cli.json",
 // because nest-cli.json is resolving "@nestjs/swagger" plugin from

--- a/apps/api/v2/src/swagger/generate-swagger.ts
+++ b/apps/api/v2/src/swagger/generate-swagger.ts
@@ -8,8 +8,8 @@ import type {
   OperationObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 import "dotenv/config";
-import * as fs from "fs";
-import type { Server } from "http";
+import * as fs from "node:fs";
+import type { Server } from "node:http";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 

--- a/apps/api/v2/test/fixtures/repository/api-keys.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/api-keys.repository.fixture.ts
@@ -1,7 +1,7 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { TestingModule } from "@nestjs/testing";
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash } from "node:crypto";
 
 export class ApiKeysRepositoryFixture {
   private prismaReadClient: PrismaReadService["prisma"];

--- a/apps/api/v2/test/fixtures/repository/tokens.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/tokens.repository.fixture.ts
@@ -1,7 +1,7 @@
 import { PrismaReadService } from "@/modules/prisma/prisma-read.service";
 import { PrismaWriteService } from "@/modules/prisma/prisma-write.service";
 import { TestingModule } from "@nestjs/testing";
-import * as crypto from "crypto";
+import * as crypto from "node:crypto";
 import { DateTime } from "luxon";
 
 export class TokensRepositoryFixture {

--- a/apps/web/app/api/auth/two-factor/totp/setup/route.ts
+++ b/apps/web/app/api/auth/two-factor/totp/setup/route.ts
@@ -1,6 +1,6 @@
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
 import { parseRequestData } from "app/api/parseRequestData";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";

--- a/apps/web/app/api/csrf/route.ts
+++ b/apps/web/app/api/csrf/route.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import { NextResponse } from "next/server";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";

--- a/apps/web/app/api/recorded-daily-video/route.ts
+++ b/apps/web/app/api/recorded-daily-video/route.ts
@@ -1,5 +1,5 @@
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/apps/web/app/api/sync/helpscout/route.ts
+++ b/apps/web/app/api/sync/helpscout/route.ts
@@ -1,5 +1,5 @@
 import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { headers } from "next/headers";
 import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -15,7 +15,7 @@ import type { SSRConfig } from "next-i18next/dist/types/types";
 import { ThemeProvider } from "next-themes";
 import type { AppProps as NextAppProps, AppProps as NextJsAppProps } from "next/app";
 import { NuqsAdapter } from "nuqs/adapters/next/pages";
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 import type { PropsWithChildren, ReactNode } from "react";
 import { useEffect } from "react";
 

--- a/apps/web/lib/apps/[slug]/getStaticProps.ts
+++ b/apps/web/lib/apps/[slug]/getStaticProps.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
+import fs from "node:fs"
 import matter from "gray-matter";
-import path from "path";
+import path from "node:path"
 import { z } from "zod";
 
 import { getAppWithMetadata } from "@calcom/app-store/_appRegistry";

--- a/apps/web/lib/handleOrgRedirect.test.ts
+++ b/apps/web/lib/handleOrgRedirect.test.ts
@@ -1,5 +1,5 @@
 import type { GetServerSidePropsContext } from "next";
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import * as constants from "@calcom/lib/constants";

--- a/apps/web/lib/handleOrgRedirect.ts
+++ b/apps/web/lib/handleOrgRedirect.ts
@@ -1,5 +1,5 @@
-import type { ParsedUrlQuery } from "querystring";
-import { stringify } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
+import { stringify } from "node:querystring";
 
 import { SINGLE_ORG_SLUG } from "@calcom/lib/constants";
 import logger from "@calcom/lib/logger";

--- a/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
+++ b/apps/web/lib/reschedule/[uid]/getServerSideProps.ts
@@ -1,6 +1,6 @@
 // page can be a server component
 import type { GetServerSidePropsContext } from "next";
-import { URLSearchParams } from "url";
+import { URLSearchParams } from "node:url";
 import { z } from "zod";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";

--- a/apps/web/modules/auth/logout-view.tsx
+++ b/apps/web/modules/auth/logout-view.tsx
@@ -2,7 +2,7 @@
 
 import { signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 import { useEffect, useState } from "react";
 
 import { WEBSITE_URL } from "@calcom/lib/constants";

--- a/apps/web/next-i18next.config.ts
+++ b/apps/web/next-i18next.config.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path"
 
 import i18nConfig from "@calcom/config/next-i18next.config";
 

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import type { NextPageContext } from "next";
 import { SessionProvider } from "next-auth/react";
 import React from "react";

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,5 +1,5 @@
 import { platform } from "@todesktop/client-core";
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import { dir } from "i18next";
 import type { DocumentContext, DocumentProps } from "next/document";
 import Document, { Head, Html, Main, NextScript } from "next/document";

--- a/apps/web/playwright/fixtures/servers.ts
+++ b/apps/web/playwright/fixtures/servers.ts
@@ -1,4 +1,4 @@
-import type { Server } from "http";
+import type { Server } from "node:http";
 
 import { nextServer } from "../lib/next-server";
 

--- a/apps/web/playwright/lib/loadJSON.ts
+++ b/apps/web/playwright/lib/loadJSON.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs"
+import path from "node:path"
 
 /**
  *  Simple utility to load JSON files from the file system. Needed to avoid certain errors with:

--- a/apps/web/playwright/lib/next-server.ts
+++ b/apps/web/playwright/lib/next-server.ts
@@ -1,8 +1,8 @@
 import detect from "detect-port";
-import type { Server } from "http";
-import { createServer } from "http";
+import type { Server } from "node:http";
+import { createServer } from "node:http";
 import next from "next";
-import { parse } from "url";
+import { parse } from "node:url";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare let process: {

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -1,9 +1,9 @@
 import type { Frame, Page, Request as PlaywrightRequest } from "@playwright/test";
 import { expect } from "@playwright/test";
-import { createHash } from "crypto";
-import EventEmitter from "events";
-import type { IncomingMessage, ServerResponse } from "http";
-import { createServer } from "http";
+import { createHash } from "node:crypto";
+import EventEmitter from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import type { Messages } from "mailhog";
 import { totp } from "otplib";
 import { v4 as uuid } from "uuid";

--- a/apps/web/playwright/oauth-provider.e2e.ts
+++ b/apps/web/playwright/oauth-provider.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { createHash, randomBytes } from "crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";

--- a/apps/web/playwright/settings/upload-avatar.e2e.ts
+++ b/apps/web/playwright/settings/upload-avatar.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import path from "path";
+import path from "node:path"
 
 import { CAL_URL } from "@calcom/lib/constants";
 import { prisma } from "@calcom/prisma";

--- a/apps/web/playwright/signup.e2e.ts
+++ b/apps/web/playwright/signup.e2e.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 
 import { APP_NAME, IS_PREMIUM_USERNAME_ENABLED, IS_MAILHOG_ENABLED } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";

--- a/apps/web/scripts/check-missing-translations.ts
+++ b/apps/web/scripts/check-missing-translations.ts
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const TEMPLATE_LANGUAGE = "en";
 const SPECIFIC_LOCALES = process.argv.slice(2) || [];

--- a/apps/web/scripts/copy-app-store-static.js
+++ b/apps/web/scripts/copy-app-store-static.js
@@ -1,7 +1,7 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 const glob = require("glob");
-const crypto = require("crypto");
+const crypto = require("node:crypto");
 
 const copyAppStoreStatic = () => {
   // Get all static files from app-store packages

--- a/apps/web/scripts/create-sentry-release.js
+++ b/apps/web/scripts/create-sentry-release.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execSync } = require("node:child_process");
 
 const CLIENT_FILES_PATH = ".next/static/chunks";
 

--- a/apps/web/scripts/ts-check-changed-files.ts
+++ b/apps/web/scripts/ts-check-changed-files.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync } from "node:child_process";
 
 type Err = {
   stdout: string;

--- a/apps/web/server/lib/[user]/getServerSideProps.ts
+++ b/apps/web/server/lib/[user]/getServerSideProps.ts
@@ -1,6 +1,6 @@
 import type { EmbedProps } from "app/WithEmbedSSR";
 import type { GetServerSideProps } from "next";
-import { encode } from "querystring";
+import { encode } from "node:querystring";
 import type { z } from "zod";
 
 import { orgDomainConfig } from "@calcom/features/ee/organizations/lib/orgDomains";

--- a/apps/web/test/jest-setup.js
+++ b/apps/web/test/jest-setup.js
@@ -1,6 +1,6 @@
 // This is a workaround for https://github.com/jsdom/jsdom/issues/2524#issuecomment-902027138
 
 // See https://github.com/microsoft/accessibility-insights-web/blob/40416a4ae6b91baf43102f58e069eff787de4de2/src/tests/unit/jest-setup.ts
-const { TextEncoder, TextDecoder } = require("util");
+const { TextEncoder, TextDecoder } = require("node:util");
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;

--- a/apps/web/test/lib/getSchedule/selectedSlots.test.ts
+++ b/apps/web/test/lib/getSchedule/selectedSlots.test.ts
@@ -7,7 +7,7 @@ import {
   type ScenarioData,
 } from "../../utils/bookingScenario/bookingScenario";
 
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import { describe, test, beforeEach, vi } from "vitest";
 import type { z } from "zod";
 

--- a/biome.json
+++ b/biome.json
@@ -91,7 +91,7 @@
       "linter": {
         "rules": {
           "nursery": {
-            "useQwikValidLexicalScope": "warn",
+            "useQwikValidLexicalScope": "off",
             "useExplicitType": "warn",
             "noReactForwardRef": "warn",
             "noTernary": "warn",

--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,7 @@
       "!!**/dist",
       "!!**/build",
       "!!**/public",
+      "!!**/*.d.ts",
       "!!public",
       "!!apps/web/public/embed",
       "!!packages/prisma/zod",
@@ -110,7 +111,8 @@
           },
           "style": {
             "useExportsLast": "warn",
-            "noProcessEnv": "warn"
+            "noProcessEnv": "warn",
+            "useNodejsImportProtocol": "error"
           },
           "complexity": {
             "noExcessiveLinesPerFunction": "warn"

--- a/i18n-unused.config.js
+++ b/i18n-unused.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 
 /**
  * # Regex for translation keys

--- a/packages/app-store-cli/src/build.ts
+++ b/packages/app-store-cli/src/build.ts
@@ -1,9 +1,9 @@
 import chokidar from "chokidar";
-import fs from "fs";
+import fs from "node:fs"
 // eslint-disable-next-line no-restricted-imports
 import { debounce } from "lodash";
-import { spawnSync } from "child_process";
-import path from "path";
+import { spawnSync } from "node:child_process";
+import path from "node:path"
 import type { AppMeta } from "@calcom/types/App";
 import { AppMetaSchema } from "@calcom/types/AppMetaSchema";
 

--- a/packages/app-store-cli/src/components/AppCreateUpdateForm.tsx
+++ b/packages/app-store-cli/src/components/AppCreateUpdateForm.tsx
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs"
 import { Box, Newline, Text, useApp } from "ink";
 import SelectInput from "ink-select-input";
 import TextInput from "ink-text-input";

--- a/packages/app-store-cli/src/constants.ts
+++ b/packages/app-store-cli/src/constants.ts
@@ -1,5 +1,5 @@
-import os from "os";
-import path from "path";
+import os from "node:os";
+import path from "node:path"
 
 export const APP_STORE_PATH = path.join(__dirname, "..", "..", "app-store");
 export const TEMPLATES_PATH = path.join(APP_STORE_PATH, "templates");

--- a/packages/app-store-cli/src/core.ts
+++ b/packages/app-store-cli/src/core.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs"
+import path from "node:path"
 
 import { APP_STORE_PATH, TEMPLATES_PATH, IS_WINDOWS_PLATFORM } from "./constants";
 import execSync from "./utils/execSync";

--- a/packages/app-store-cli/src/utils/execSync.ts
+++ b/packages/app-store-cli/src/utils/execSync.ts
@@ -1,4 +1,4 @@
-import child_process from "child_process";
+import child_process from "node:child_process";
 
 const execSync = async (cmd: string) => {
   const silent = process.env.DEBUG === "1" ? false : true;

--- a/packages/app-store-cli/src/utils/getApp.ts
+++ b/packages/app-store-cli/src/utils/getApp.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs"
+import path from "node:path"
 
 import { APP_STORE_PATH, TEMPLATES_PATH } from "../constants";
 import { getAppName } from "./getAppName";

--- a/packages/app-store-cli/src/utils/getAppName.ts
+++ b/packages/app-store-cli/src/utils/getAppName.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path"
 
 import { APP_STORE_PATH } from "../constants";
 

--- a/packages/app-store-cli/src/utils/templates.ts
+++ b/packages/app-store-cli/src/utils/templates.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs"
+import path from "node:path"
 
 import { TEMPLATES_PATH } from "../constants";
 import { getAppName } from "./getAppName";

--- a/packages/app-store/basecamp3/api/add.ts
+++ b/packages/app-store/basecamp3/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/app-store/btcpayserver/api/webhook.ts
+++ b/packages/app-store/btcpayserver/api/webhook.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 import type { NextApiRequest, NextApiResponse } from "next";
 import getRawBody from "raw-body";
 import { z } from "zod";

--- a/packages/app-store/dailyvideo/lib/scripts/deleteRecordings.ts
+++ b/packages/app-store/dailyvideo/lib/scripts/deleteRecordings.ts
@@ -170,8 +170,8 @@ async function getAllRecordingsOlderThan6Months(): Promise<Recording[]> {
 }
 
 async function saveRecordingsToJson(recordings: Recording[]): Promise<void> {
-  const fs = await import("fs/promises");
-  const path = await import("path");
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
 
   const simplifiedRecordings = recordings.map((recording) => ({
     id: recording.id,
@@ -316,8 +316,8 @@ async function deleteRecordingsFromJson(dryRun = false): Promise<void> {
     process.exit(1);
   }
 
-  const fs = await import("fs/promises");
-  const path = await import("path");
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
 
   const filePath = path.join(process.cwd(), "recordings_older_than_6_months.json");
 
@@ -415,7 +415,7 @@ async function deleteRecordingsFromJson(dryRun = false): Promise<void> {
 }
 
 async function mainDelete(): Promise<void> {
-  const readline = (await import("readline")).createInterface({
+  const readline = (await import("node:readline")).createInterface({
     input: process.stdin,
     output: process.stdout,
   });

--- a/packages/app-store/feishucalendar/api/add.ts
+++ b/packages/app-store/feishucalendar/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 import { z } from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";

--- a/packages/app-store/hitpay/api/webhook.ts
+++ b/packages/app-store/hitpay/api/webhook.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type z from "zod";
 

--- a/packages/app-store/huddle01video/api/add.ts
+++ b/packages/app-store/huddle01video/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/app-store/intercom/api/add.ts
+++ b/packages/app-store/intercom/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 

--- a/packages/app-store/jelly/api/add.ts
+++ b/packages/app-store/jelly/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 import { z } from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";

--- a/packages/app-store/larkcalendar/api/add.ts
+++ b/packages/app-store/larkcalendar/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 import { z } from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";

--- a/packages/app-store/nextcloudtalk/api/add.ts
+++ b/packages/app-store/nextcloudtalk/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/app-store/nextcloudtalk/lib/VideoApiAdapter.ts
+++ b/packages/app-store/nextcloudtalk/lib/VideoApiAdapter.ts
@@ -1,4 +1,4 @@
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 

--- a/packages/app-store/office365calendar/api/add.ts
+++ b/packages/app-store/office365calendar/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 

--- a/packages/app-store/office365video/api/add.ts
+++ b/packages/app-store/office365video/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 

--- a/packages/app-store/stripepayment/api/callback.ts
+++ b/packages/app-store/stripepayment/api/callback.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import type { Prisma } from "@calcom/prisma/client";
 

--- a/packages/app-store/stripepayment/lib/client/createPaymentLink.ts
+++ b/packages/app-store/stripepayment/lib/client/createPaymentLink.ts
@@ -1,4 +1,4 @@
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBSITE_URL } from "@calcom/lib/constants";
 

--- a/packages/app-store/stripepayment/lib/client/createPaymentLink.ts
+++ b/packages/app-store/stripepayment/lib/client/createPaymentLink.ts
@@ -1,6 +1,8 @@
-import { stringify } from "node:querystring";
 
 import { WEBSITE_URL } from "@calcom/lib/constants";
+
+// biome-ignore lint/style/useNodejsImportProtocol: No node env
+import { stringify } from "querystring";
 
 export type Maybe<T> = T | undefined | null;
 

--- a/packages/app-store/tandemvideo/api/add.ts
+++ b/packages/app-store/tandemvideo/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";

--- a/packages/app-store/webex/api/add.ts
+++ b/packages/app-store/webex/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/app-store/zohocalendar/api/add.ts
+++ b/packages/app-store/zohocalendar/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/app-store/zohocalendar/api/callback.ts
+++ b/packages/app-store/zohocalendar/api/callback.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { renewSelectedCalendarCredentialId } from "@calcom/lib/connectedCalendar";
 import { WEBAPP_URL } from "@calcom/lib/constants";

--- a/packages/app-store/zohocalendar/lib/CalendarService.ts
+++ b/packages/app-store/zohocalendar/lib/CalendarService.ts
@@ -1,4 +1,4 @@
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import dayjs from "@calcom/dayjs";
 import { getLocation } from "@calcom/lib/CalEventParser";

--- a/packages/app-store/zohocrm/api/_getAdd.ts
+++ b/packages/app-store/zohocrm/api/_getAdd.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 

--- a/packages/app-store/zoomvideo/api/add.ts
+++ b/packages/app-store/zoomvideo/api/add.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import { WEBAPP_URL_FOR_OAUTH } from "@calcom/lib/constants";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";

--- a/packages/embeds/embed-core/vite.config.js
+++ b/packages/embeds/embed-core/vite.config.js
@@ -3,7 +3,7 @@ import EnvironmentPlugin from "vite-plugin-environment";
 
 import viteBaseConfig, { embedCoreEnvVars } from "../vite.config";
 
-const path = require("path");
+const path = require("node:path");
 const { defineConfig } = require("vite");
 module.exports = defineConfig((configEnv) => {
   /** @type {import('vite').UserConfig} */

--- a/packages/embeds/embed-react/vite.config.js
+++ b/packages/embeds/embed-react/vite.config.js
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import path from "path";
+import path from "node:path"
 import { defineConfig } from "vite";
 
 import viteBaseConfig from "../vite.config";

--- a/packages/embeds/embed-snippet/vite.config.js
+++ b/packages/embeds/embed-snippet/vite.config.js
@@ -1,6 +1,6 @@
 import viteBaseConfig from "../vite.config";
 
-const path = require("path");
+const path = require("node:path");
 const { defineConfig } = require("vite");
 
 module.exports = defineConfig({

--- a/packages/embeds/vite.config.js
+++ b/packages/embeds/vite.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 require("dotenv").config({ path: path.join(__dirname, "..", "..", ".env") });
 process.env.EMBED_PUBLIC_VERCEL_URL = process.env.VERCEL_URL;
 process.env.EMBED_PUBLIC_WEBAPP_URL = process.env.NEXT_PUBLIC_WEBAPP_URL;

--- a/packages/features/auth/lib/sendVerificationRequest.ts
+++ b/packages/features/auth/lib/sendVerificationRequest.ts
@@ -1,9 +1,9 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import Handlebars from "handlebars";
 import type { SendVerificationRequestParams } from "next-auth/providers/email";
 import type { TransportOptions } from "nodemailer";
 import nodemailer from "nodemailer";
-import path from "path";
+import path from "node:path"
 
 import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
 import { serverConfig } from "@calcom/lib/serverConfig";

--- a/packages/features/auth/lib/verifyCodeUnAuthenticated.ts
+++ b/packages/features/auth/lib/verifyCodeUnAuthenticated.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { hashEmail } from "@calcom/lib/server/PiiHasher";

--- a/packages/features/auth/lib/verifyEmail.ts
+++ b/packages/features/auth/lib/verifyEmail.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash } from "node:crypto";
 import { totp } from "otplib";
 
 import {

--- a/packages/features/bookings/lib/reschedule/determineReschedulePreventionRedirect.ts
+++ b/packages/features/bookings/lib/reschedule/determineReschedulePreventionRedirect.ts
@@ -1,4 +1,4 @@
-import { URLSearchParams } from "url";
+import { URLSearchParams } from "node:url";
 
 import { getFullName } from "@calcom/features/form-builder/utils";
 import { ENV_PAST_BOOKING_RESCHEDULE_CHANGE_TEAM_IDS } from "@calcom/lib/constants";

--- a/packages/features/bookings/lib/service/InstantBookingCreateService.ts
+++ b/packages/features/bookings/lib/service/InstantBookingCreateService.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import short from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 

--- a/packages/features/bot-detection/BotDetectionService.test.ts
+++ b/packages/features/bot-detection/BotDetectionService.test.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from "http";
+import type { IncomingHttpHeaders } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";

--- a/packages/features/bot-detection/BotDetectionService.ts
+++ b/packages/features/bot-detection/BotDetectionService.ts
@@ -1,5 +1,5 @@
 import { checkBotId } from "botid/server";
-import type { IncomingHttpHeaders } from "http";
+import type { IncomingHttpHeaders } from "node:http";
 
 import type { EventTypeRepository } from "@calcom/features/eventtypes/repositories/eventTypeRepository";
 import type { FeaturesRepository } from "@calcom/features/flags/features.repository";

--- a/packages/features/ee/api-keys/lib/apiKeys.ts
+++ b/packages/features/ee/api-keys/lib/apiKeys.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash } from "node:crypto";
 
 // Hash the API key to check against when veriying it. so we don't have to store the key in plain text.
 export const hashAPIKey = (apiKey: string): string => createHash("sha256").update(apiKey).digest("hex");

--- a/packages/features/ee/common/server/private-api-utils.ts
+++ b/packages/features/ee/common/server/private-api-utils.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 
 export const generateNonce = (): string => {
   return crypto.randomBytes(16).toString("hex");

--- a/packages/features/ee/organizations/lib/orgDomains.ts
+++ b/packages/features/ee/organizations/lib/orgDomains.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 
 import { IS_PRODUCTION, WEBSITE_URL, SINGLE_ORG_SLUG } from "@calcom/lib/constants";
 import { ALLOWED_HOSTNAMES, RESERVED_SUBDOMAINS, WEBAPP_URL } from "@calcom/lib/constants";

--- a/packages/features/ee/organizations/lib/server/orgCreationUtils.ts
+++ b/packages/features/ee/organizations/lib/server/orgCreationUtils.ts
@@ -1,4 +1,4 @@
-import { lookup } from "dns";
+import { lookup } from "node:dns";
 import { type TFunction } from "i18next";
 
 import { sendAdminOrganizationNotification } from "@calcom/emails/organization-email-service";

--- a/packages/features/ee/teams/lib/getTeamMemberEmailFromCrm.ts
+++ b/packages/features/ee/teams/lib/getTeamMemberEmailFromCrm.ts
@@ -1,4 +1,4 @@
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 
 /* eslint-disable */
 import { getCRMContactOwnerForRRLeadSkip } from "@calcom/app-store/_utils/CRMRoundRobinSkip";

--- a/packages/features/ee/teams/services/teamService.ts
+++ b/packages/features/ee/teams/services/teamService.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 
 import { getTeamBillingServiceFactory } from "@calcom/ee/billing/di/containers/Billing";
 import { deleteWorkfowRemindersOfRemovedMember } from "@calcom/features/ee/teams/lib/deleteWorkflowRemindersOfRemovedMember";

--- a/packages/features/filters/lib/getTeamsFiltersFromQuery.ts
+++ b/packages/features/filters/lib/getTeamsFiltersFromQuery.ts
@@ -1,4 +1,4 @@
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 import { z } from "zod";
 
 // Take array as a string and return zod array

--- a/packages/features/insights/services/InsightsRoutingService.integration-test.ts
+++ b/packages/features/insights/services/InsightsRoutingService.integration-test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { v4 as uuid } from "uuid";
 import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
 

--- a/packages/features/routing-forms/lib/getRoutedUrl.test.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.test.ts
@@ -1,6 +1,6 @@
 import "@calcom/lib/__mocks__/logger";
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import type { GetServerSidePropsContext } from "next";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/features/routing-forms/lib/getRoutedUrl.ts
+++ b/packages/features/routing-forms/lib/getRoutedUrl.ts
@@ -1,7 +1,7 @@
 // !IMPORTANT! changes to this file requires publishing new version of platform libraries in order for the changes to be applied to APIV2
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import type { GetServerSidePropsContext } from "next";
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { compile } from "handlebars";
 
 import type { TGetTranscriptAccessLink } from "@calcom/app-store/dailyvideo/zod";

--- a/packages/features/webhooks/lib/service/WebhookService.ts
+++ b/packages/features/webhooks/lib/service/WebhookService.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 
 import { WebhookTriggerEvents } from "@calcom/prisma/enums";
 

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,9 +1,7 @@
-
 import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps";
 
-const stringify = (obj: Record<string, string>): string =>
+const stringify = (obj: Record<string, string | number | number[]>): string =>
   new URLSearchParams(obj).toString();
-
 
 export const getAppOnboardingUrl = ({
   slug,

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,4 +1,4 @@
-import { stringify } from "querystring";
+import { stringify } from "node:querystring";
 
 import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps";
 

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -15,7 +15,7 @@ export const getAppOnboardingUrl = ({
   teamId?: number;
 }): string => {
   const params: { [key: string]: string | number | number[] } = { slug };
-  if (!!teamId) {
+  if (!teamId) {
     params.teamId = teamId;
   }
   const query = stringify(params);

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -15,7 +15,7 @@ export const getAppOnboardingUrl = ({
   teamId?: number;
 }): string => {
   const params: { [key: string]: string | number | number[] } = { slug };
-  if (!teamId) {
+  if (teamId) {
     params.teamId = teamId;
   }
   const query = stringify(params);

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,7 +1,5 @@
-import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps";
-
-const stringify = (obj: Record<string, string | number | number[]>): string =>
-  new URLSearchParams(obj).toString();
+// biome-ignore lint/style/useNodejsImportProtocol: Vite env
+import { stringify } from "querystring";
 
 export const getAppOnboardingUrl = ({
   slug,

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,3 +1,5 @@
+import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps"
+
 // biome-ignore lint/style/useNodejsImportProtocol: Vite env
 import { stringify } from "querystring";
 

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,6 +1,9 @@
-import { stringify } from "node:querystring";
 
 import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps";
+
+const stringify = (obj: Record<string, string>) =>
+  new URLSearchParams(obj).toString();
+
 
 export const getAppOnboardingUrl = ({
   slug,

--- a/packages/lib/apps/getAppOnboardingUrl.ts
+++ b/packages/lib/apps/getAppOnboardingUrl.ts
@@ -1,7 +1,7 @@
 
 import type { AppOnboardingSteps } from "@calcom/lib/apps/appOnboardingSteps";
 
-const stringify = (obj: Record<string, string>) =>
+const stringify = (obj: Record<string, string>): string =>
   new URLSearchParams(obj).toString();
 
 
@@ -13,7 +13,7 @@ export const getAppOnboardingUrl = ({
   slug: string;
   step: AppOnboardingSteps;
   teamId?: number;
-}) => {
+}): string => {
   const params: { [key: string]: string | number | number[] } = { slug };
   if (!!teamId) {
     params.teamId = teamId;

--- a/packages/lib/crypto.ts
+++ b/packages/lib/crypto.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 
 const ALGORITHM = "aes256";
 const INPUT_ENCODING = "utf8";

--- a/packages/lib/hooks/useParamsWithFallback.ts
+++ b/packages/lib/hooks/useParamsWithFallback.ts
@@ -2,7 +2,7 @@
 
 import { useRouter as useCompatRouter } from "next/compat/router";
 import { useParams } from "next/navigation";
-import type { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "node:querystring";
 
 interface Params {
   [key: string]: string | string[];

--- a/packages/lib/logger.server.ts
+++ b/packages/lib/logger.server.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs"
 
 import logger from "./logger";
 

--- a/packages/lib/pkce.ts
+++ b/packages/lib/pkce.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 export function verifyCodeChallenge(
   codeVerifier: string,

--- a/packages/lib/server/perfObserver.ts
+++ b/packages/lib/server/perfObserver.ts
@@ -1,4 +1,4 @@
-import { PerformanceObserver } from "perf_hooks";
+import { PerformanceObserver } from "node:perf_hooks";
 
 import logger from "../logger";
 
@@ -23,4 +23,4 @@ if (process.env.NODE_ENV !== "production") {
 
 export default perfObserver;
 
-export { performance } from "perf_hooks";
+export { performance } from "node:perf_hooks";

--- a/packages/lib/server/service/VerificationTokenService.ts
+++ b/packages/lib/server/service/VerificationTokenService.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash } from "node:crypto";
 
 import { VerificationTokenRepository } from "../repository/verificationToken";
 

--- a/packages/platform/atoms/scripts/dev-on.js
+++ b/packages/platform/atoms/scripts/dev-on.js
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, "../package.json");

--- a/packages/platform/atoms/vite.config.ts
+++ b/packages/platform/atoms/vite.config.ts
@@ -1,6 +1,6 @@
 import react from "@vitejs/plugin-react-swc";
-import path from "path";
-import { resolve } from "path";
+import path from "node:path"
+import { resolve } from "node:path";
 import { defineConfig, loadEnv } from "vite";
 import dts from "vite-plugin-dts";
 

--- a/packages/platform/examples/base/playwright.config.ts
+++ b/packages/platform/examples/base/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
-import path from "path";
+import path from "node:path"
 
 const envPath = process.env.CI ? path.resolve(__dirname, ".env") : path.resolve(__dirname, ".env.local");
 

--- a/packages/platform/libraries/i18n.ts
+++ b/packages/platform/libraries/i18n.ts
@@ -7,7 +7,7 @@ import logger from "@calcom/lib/logger";
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { i18n } = require("@calcom/config/next-i18next.config");
-const path = require("path");
+const path = require("node:path");
 const translationsPath = path.resolve(__dirname, "../../../../apps/web/public/static/locales/en/common.json");
 const englishTranslations: Record<string, string> = require(translationsPath);
 /* eslint-enable @typescript-eslint/no-require-imports */

--- a/packages/platform/libraries/scripts/local.js
+++ b/packages/platform/libraries/scripts/local.js
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/platform/libraries/scripts/postpublish.js
+++ b/packages/platform/libraries/scripts/postpublish.js
@@ -1,7 +1,7 @@
-import { spawn } from "child_process";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import { spawn } from "node:child_process";
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url";
 
 import { getCurrentVersion } from "./prepublish.js";
 

--- a/packages/platform/libraries/scripts/prepublish.js
+++ b/packages/platform/libraries/scripts/prepublish.js
@@ -1,7 +1,7 @@
-import fs from "fs";
-import https from "https";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs"
+import https from "node:https";
+import path from "node:path"
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/platform/libraries/vite.config.js
+++ b/packages/platform/libraries/vite.config.js
@@ -1,9 +1,9 @@
 // vite.config.ts
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
-import path from "path";
-import { dirname } from "path";
-import { fileURLToPath } from "url";
+import { resolve } from "node:path";
+import path from "node:path"
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 

--- a/packages/trpc/server/routers/viewer/admin/createSelfHostedLicenseKey.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/createSelfHostedLicenseKey.handler.ts
@@ -1,4 +1,4 @@
-import * as crypto from "crypto";
+import * as crypto from "node:crypto";
 import { z } from "zod";
 
 import { CALCOM_PRIVATE_API_ROUTE } from "@calcom/lib/constants";

--- a/packages/trpc/server/routers/viewer/attributes/findTeamMembersMatchingAttributeLogic.handler.ts
+++ b/packages/trpc/server/routers/viewer/attributes/findTeamMembersMatchingAttributeLogic.handler.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from "http";
+import type { ServerResponse } from "node:http";
 import type { NextApiResponse } from "next";
 
 import { findTeamMembersMatchingAttributeLogic } from "@calcom/features/routing-forms/lib/findTeamMembersMatchingAttributeLogic";

--- a/packages/trpc/server/routers/viewer/me/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/get.handler.ts
@@ -19,7 +19,7 @@ type MeOptions = {
 };
 
 export const getHandler = async ({ ctx, input }: MeOptions) => {
-  const crypto = await import("crypto");
+  const crypto = await import("node:crypto");
 
   const { user: sessionUser, session } = ctx;
 

--- a/packages/trpc/server/routers/viewer/oAuth/addClient.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/addClient.handler.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash } from "node:crypto";
 
 import { prisma } from "@calcom/prisma";
 import { Prisma } from "@calcom/prisma/client";

--- a/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 
 import dayjs from "@calcom/dayjs";
 import { prisma } from "@calcom/prisma";

--- a/packages/trpc/server/routers/viewer/organizations/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/create.handler.ts
@@ -1,4 +1,4 @@
-import { lookup } from "dns";
+import { lookup } from "node:dns";
 
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { isNotACompanyEmail } from "@calcom/ee/organizations/lib/server/orgCreationUtils";

--- a/packages/trpc/server/routers/viewer/organizations/setPassword.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/setPassword.handler.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import { verifyPassword } from "@calcom/features/auth/lib/verifyPassword";
 import { hashPassword } from "@calcom/lib/auth/hashPassword";

--- a/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/organizations/verifyCode.handler.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import { IS_PRODUCTION } from "@calcom/lib/constants";

--- a/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
+++ b/packages/trpc/server/routers/viewer/routing-forms/findTeamMembersMatchingAttributeLogicOfRoute.handler.ts
@@ -3,7 +3,7 @@
  * Also, it is applicable only for sub-teams. Regular teams and user Routing Forms don't hit this endpoint.
  * Live mode uses findTeamMembersMatchingAttributeLogicOfRoute fn directly
  */
-import type { ServerResponse } from "http";
+import type { ServerResponse } from "node:http";
 import type { NextApiResponse } from "next";
 
 import { enrichHostsWithDelegationCredentials } from "@calcom/app-store/delegationCredential";

--- a/packages/trpc/server/routers/viewer/slots/types.ts
+++ b/packages/trpc/server/routers/viewer/slots/types.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import { z } from "zod";
 
 import { timeZoneSchema } from "@calcom/lib/dayjs/timeZone.schema";

--- a/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
+++ b/packages/trpc/server/routers/viewer/teams/inviteMember/utils.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "node:crypto";
 import type { TFunction } from "i18next";
 
 import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";

--- a/packages/trpc/server/routers/viewer/workflows/verifyEmailCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/workflows/verifyEmailCode.handler.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import { totpRawCheck } from "@calcom/lib/totp";
 import { prisma } from "@calcom/prisma";

--- a/packages/types/next.d.ts
+++ b/packages/types/next.d.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import type { Session } from "next-auth";
 
 import "./next-auth";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import type { Frame, PlaywrightTestConfig } from "@playwright/test";
 import { devices, expect } from "@playwright/test";
 import dotEnv from "dotenv";
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 

--- a/scripts/seed-app-store.ts
+++ b/scripts/seed-app-store.ts
@@ -3,7 +3,7 @@
  * This file is deprecated. The only use of this file is to seed the database for E2E tests. Each test should take care of seeding it's own data going forward.
  */
 import dotEnv from "dotenv";
-import path from "path";
+import path from "node:path"
 
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 import prisma from "@calcom/prisma";

--- a/scripts/seed-utils.ts
+++ b/scripts/seed-utils.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { uuid } from "short-uuid";
 import type z from "zod";
 

--- a/tests/libs/__mocks__/prisma.ts
+++ b/tests/libs/__mocks__/prisma.ts
@@ -1,6 +1,6 @@
 import { type DMMF } from "@prisma/client/runtime/client";
 import { getDMMF } from "@prisma/internals";
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { beforeEach, vi } from "vitest";
 import { createPrismock } from "prismock/build/main/lib/client";
 
@@ -84,7 +84,7 @@ vi.mock("@calcom/prisma", async (importOriginal) => {
   const PrismockClientClass = createPrismock(
     PrismaWithDMMF as unknown as typeof Prisma & { dmmf: DMMF.Document }
   );
-  
+
   prismockInstance = new PrismockClientClass();
 
   if (!prismockInstance.$queryRaw) {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
## What does this PR do?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all Node.js core module imports to the node: protocol across apps, packages, tests, and scripts. This makes imports consistent, improves tooling compatibility, and aligns with our lint rules.

- **Refactors**
  - Replaced imports like fs, path, http, crypto, url, dns, events, worker_threads, querystring with node: equivalents (with exceptions in non-Node contexts).
  - Updated dynamic imports in scripts to use node: (fs/promises, path, readline).
  - Enforced via Biome: useNodejsImportProtocol set to error; ignored *.d.ts; disabled Qwik lexical scope rule.
  - Adjusted next-i18next patch to use node:fs and node:path.
  - Kept querystring in getAppOnboardingUrl and Stripe client util with linter overrides for non-Node environments.
  - No functional changes.

<sup>Written for commit 817f958f6283d522c4daac19eb7d2235ccef3e39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

