### PR TITLE
chore: upgrade ts target (perf)

### DIFF
--- a/apps/api/v2/src/ee/calendars/services/gcal.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/gcal.service.ts
@@ -24,7 +24,7 @@ const CALENDAR_SCOPES = [
 
 @Injectable()
 export class GoogleCalendarService implements OAuthCalendarApp {
-  public readonly redirectUri = `${this.config.get("api.url")}/gcal/oauth/save`;
+  public readonly redirectUri: string;
   private gcalResponseSchema = z.object({ client_id: z.string(), client_secret: z.string() });
   private logger = new Logger("GcalService");
 
@@ -35,7 +35,9 @@ export class GoogleCalendarService implements OAuthCalendarApp {
     private readonly calendarsService: CalendarsService,
     private readonly tokensRepository: TokensRepository,
     private readonly selectedCalendarsRepository: SelectedCalendarsRepository
-  ) {}
+  ) {
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/gcal/oauth/save`;
+  }
 
   async connect(
     authorization: string,

--- a/apps/api/v2/src/ee/calendars/services/outlook.service.ts
+++ b/apps/api/v2/src/ee/calendars/services/outlook.service.ts
@@ -21,7 +21,7 @@ import {
 
 @Injectable()
 export class OutlookService implements OAuthCalendarApp {
-  private redirectUri = `${this.config.get("api.url")}/calendars/${OFFICE_365_CALENDAR}/save`;
+  private redirectUri: string;
 
   constructor(
     private readonly config: ConfigService,
@@ -29,7 +29,9 @@ export class OutlookService implements OAuthCalendarApp {
     private readonly credentialRepository: CredentialsRepository,
     private readonly tokensRepository: TokensRepository,
     private readonly selectedCalendarsRepository: SelectedCalendarsRepository
-  ) {}
+  ) {
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/calendars/${OFFICE_365_CALENDAR}/save`;
+  }
 
   async connect(
     authorization: string,

--- a/apps/api/v2/src/ee/gcal/gcal.controller.ts
+++ b/apps/api/v2/src/ee/gcal/gcal.controller.ts
@@ -43,15 +43,16 @@ const CALENDAR_SCOPES = [
 @ApiExcludeController(true)
 export class GcalController {
   private readonly logger = new Logger("Platform Gcal Provider");
+  private redirectUri: string;
 
   constructor(
     private readonly credentialRepository: CredentialsRepository,
     private readonly config: ConfigService,
     private readonly gcalService: GCalService,
     private readonly calendarsService: CalendarsService
-  ) {}
-
-  private redirectUri = `${this.config.get("api.url")}/gcal/oauth/save`;
+  ) {
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/gcal/oauth/save`;
+  }
 
   @Get("/oauth/auth-url")
   @HttpCode(HttpStatus.OK)

--- a/apps/api/v2/src/modules/conferencing/services/office365-video.service.ts
+++ b/apps/api/v2/src/modules/conferencing/services/office365-video.service.ts
@@ -19,14 +19,16 @@ const zoomAppKeysSchema = z.object({
 @Injectable()
 export class Office365VideoService {
   private logger = new Logger("Office365VideoService");
-  private redirectUri = `${this.config.get("api.url")}/conferencing/${OFFICE_365_VIDEO}/oauth/callback`;
+  private redirectUri: string;
   private scopes = ["OnlineMeetings.ReadWrite", "offline_access"];
 
   constructor(
     private readonly config: ConfigService,
     private readonly appsRepository: AppsRepository,
     private readonly credentialsRepository: CredentialsRepository
-  ) {}
+  ) {
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/conferencing/${OFFICE_365_VIDEO}/oauth/callback`;
+  }
 
   async getOffice365AppKeys() {
     const app = await this.appsRepository.getAppBySlug(OFFICE_365_VIDEO);

--- a/apps/api/v2/src/modules/conferencing/services/zoom-video.service.ts
+++ b/apps/api/v2/src/modules/conferencing/services/zoom-video.service.ts
@@ -19,13 +19,15 @@ const zoomAppKeysSchema = z.object({
 @Injectable()
 export class ZoomVideoService {
   private logger = new Logger("ZoomVideoService");
-  private redirectUri = `${this.config.get("api.url")}/conferencing/${ZOOM}/oauth/callback`;
+  private redirectUri: string;
 
   constructor(
     private readonly config: ConfigService,
     private readonly appsRepository: AppsRepository,
     private readonly credentialsRepository: CredentialsRepository
-  ) {}
+  ) {
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/conferencing/${ZOOM}/oauth/callback`;
+  }
 
   async getZoomAppKeys() {
     const app = await this.appsRepository.getAppBySlug(ZOOM);

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -51,10 +51,10 @@ export class StripeService {
     this.stripe = new Stripe(configService.get("stripe.apiKey", { infer: true }) ?? "", {
       apiVersion: "2020-08-27",
     });
-    this.redirectUri = `${this.config.get("api.url")}/stripe/save`;
-    this.webAppUrl = this.config.get("app.baseUrl");
-    this.environment = this.config.get("env.type");
-    this.teamMonthlyPriceId = this.config.get("stripe.teamMonthlyPriceId");
+    this.redirectUri = `${this.config.get("api.url") ?? ""}/stripe/save`;
+    this.webAppUrl = this.config.get("app.baseUrl") ?? "";
+    this.environment = this.config.get("env.type") ?? "";
+    this.teamMonthlyPriceId = this.config.get("stripe.teamMonthlyPriceId") ?? "";
   }
 
   getStripe() {

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -35,10 +35,10 @@ export type OAuthCallbackState = {
 @Injectable()
 export class StripeService {
   private stripe: Stripe;
-  private redirectUri = `${this.config.get("api.url")}/stripe/save`;
-  private webAppUrl = this.config.get("app.baseUrl");
-  private environment = this.config.get("env.type");
-  private teamMonthlyPriceId = this.config.get("stripe.teamMonthlyPriceId");
+  private redirectUri: string;
+  private webAppUrl: string;
+  private environment: string;
+  private teamMonthlyPriceId: string;
 
   constructor(
     configService: ConfigService<AppConfig>,
@@ -51,6 +51,10 @@ export class StripeService {
     this.stripe = new Stripe(configService.get("stripe.apiKey", { infer: true }) ?? "", {
       apiVersion: "2020-08-27",
     });
+    this.redirectUri = `${this.config.get("api.url")}/stripe/save`;
+    this.webAppUrl = this.config.get("app.baseUrl");
+    this.environment = this.config.get("env.type");
+    this.teamMonthlyPriceId = this.config.get("stripe.teamMonthlyPriceId");
   }
 
   getStripe() {

--- a/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.ts
+++ b/apps/api/v2/src/modules/teams/teams/controllers/teams.controller.ts
@@ -5,7 +5,6 @@ import { Roles } from "@/modules/auth/decorators/roles/roles.decorator";
 import { ApiAuthGuard } from "@/modules/auth/guards/api-auth/api-auth.guard";
 import { RolesGuard } from "@/modules/auth/guards/roles/roles.guard";
 import { UpdateOrgTeamDto } from "@/modules/organizations/teams/index/inputs/update-organization-team.input";
-import { OrgTeamOutputResponseDto } from "@/modules/organizations/teams/index/outputs/organization-team.output";
 import { CreateTeamInput } from "@/modules/teams/teams/inputs/create-team.input";
 import { CreateTeamOutput } from "@/modules/teams/teams/outputs/teams/create-team.output";
 import { GetTeamOutput } from "@/modules/teams/teams/outputs/teams/get-team.output";
@@ -97,7 +96,7 @@ export class TeamsController {
   @Delete("/:teamId")
   @ApiOperation({ summary: "Delete a team" })
   @Roles("TEAM_OWNER")
-  async deleteTeam(@Param("teamId", ParseIntPipe) teamId: number): Promise<OrgTeamOutputResponseDto> {
+  async deleteTeam(@Param("teamId", ParseIntPipe) teamId: number): Promise<UpdateTeamOutput> {
     const team = await this.teamsRepository.delete(teamId);
     return {
       status: SUCCESS_STATUS,

--- a/apps/api/v2/src/modules/teams/teams/services/teams.service.ts
+++ b/apps/api/v2/src/modules/teams/teams/services/teams.service.ts
@@ -10,14 +10,16 @@ import { slugify } from "@calcom/platform-libraries";
 
 @Injectable()
 export class TeamsService {
-  private isTeamBillingEnabled = this.configService.get("stripe.isTeamBillingEnabled");
+  private isTeamBillingEnabled: boolean;
 
   constructor(
     private readonly teamsRepository: TeamsRepository,
     private readonly teamsMembershipsRepository: TeamsMembershipsRepository,
     private readonly stripeService: StripeService,
     private readonly configService: ConfigService
-  ) {}
+  ) {
+    this.isTeamBillingEnabled = this.configService.get("stripe.isTeamBillingEnabled") ?? false;
+  }
 
   async createTeam(input: CreateTeamInput, ownerId: number) {
     const { autoAcceptCreator, ...teamData } = input;

--- a/apps/api/v2/src/modules/workflows/inputs/workflow-step.input.ts
+++ b/apps/api/v2/src/modules/workflows/inputs/workflow-step.input.ts
@@ -140,7 +140,7 @@ export class BaseFormWorkflowStepDto extends BaseWorkflowStepDto {
   @ApiProperty({ description: "Action to perform", example: EMAIL_HOST, enum: STEP_ACTIONS })
   @IsString()
   @IsIn(FORM_ALLOWED_STEP_ACTIONS)
-  action!: FormAllowedStepAction;
+  declare action: FormAllowedStepAction;
 }
 
 export class WorkflowEmailHostStepDto extends BaseWorkflowStepDto {

--- a/apps/api/v2/tsconfig.json
+++ b/apps/api/v2/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": ".",

--- a/biome.json
+++ b/biome.json
@@ -48,6 +48,9 @@
     ]
   },
   "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    },
     "formatter": {
       "arrowParentheses": "always",
       "bracketSpacing": true,

--- a/packages/app-store-cli/tsconfig.json
+++ b/packages/app-store-cli/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "noEmitOnError": false,
-    "target": "ES2020",
+    "target": "ES2022",
     "baseUrl": ".",
     "resolveJsonModule": true
   },

--- a/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
+++ b/packages/embeds/embed-core/src/FloatingButton/FloatingButton.ts
@@ -42,7 +42,7 @@ export class FloatingButton extends HTMLElement {
   }
 
   // Button added here triggers the modal on click. So, it has to have the same data attributes as the modal target as well
-  dataset!: DOMStringMap & FloatingButtonDataset & ModalTargetDatasetProps;
+  declare dataset: DOMStringMap & FloatingButtonDataset & ModalTargetDatasetProps;
   buttonWrapperStyleDisplay!: HTMLElement["style"]["display"];
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore

--- a/packages/embeds/embed-core/tsconfig.json
+++ b/packages/embeds/embed-core/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "jsx": "react",
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "esnext",
     "moduleResolution": "Node",
     "baseUrl": ".",

--- a/packages/embeds/embed-react/test/packaged/tsconfig.json
+++ b/packages/embeds/embed-react/test/packaged/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "module": "ESNext",
-    "target": "ES2015",
+    "target": "ES2022",
     "moduleResolution": "Node",
     "baseUrl": ".",
     "declaration": true,

--- a/packages/embeds/embed-react/tsconfig.json
+++ b/packages/embeds/embed-react/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "module": "ESNext",
-    "target": "ES2015",
+    "target": "ES2022",
     "moduleResolution": "Node",
     "baseUrl": ".",
     "declaration": true,

--- a/packages/embeds/embed-snippet/tsconfig.json
+++ b/packages/embeds/embed-snippet/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "jsx": "react",
-    "target": "ES2015",
+    "target": "ES2022",
     "baseUrl": ".",
     "module": "ESNext",
     "declaration": true,

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "jsx": "preserve",
     "resolveJsonModule": true
   },

--- a/packages/lib/tsconfig.test.json
+++ b/packages/lib/tsconfig.test.json
@@ -4,7 +4,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "esModuleInterop": true,
-    "target": "es5",
+    "target": "es2022",
     "jsx": "react-jsx",
     "resolveJsonModule": true
   },

--- a/packages/platform/constants/package.json
+++ b/packages/platform/constants/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-constants",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "private": true,

--- a/packages/platform/constants/tsconfig.json
+++ b/packages/platform/constants/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2022",
     "resolveJsonModule": true,
     "baseUrl": "./",
     "outDir": "./dist"

--- a/packages/platform/constants/tsconfig.json
+++ b/packages/platform/constants/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
+    "module": "CommonJS",
     "resolveJsonModule": true,
     "baseUrl": "./",
     "outDir": "./dist"

--- a/packages/platform/constants/tsconfig.json
+++ b/packages/platform/constants/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "baseUrl": "./",
     "outDir": "./dist"

--- a/packages/platform/enums/package.json
+++ b/packages/platform/enums/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-enums",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.ts",
   "types": "./dist/index.ts",
   "private": true,

--- a/packages/platform/enums/tsconfig.json
+++ b/packages/platform/enums/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "baseUrl": "./",

--- a/packages/platform/enums/tsconfig.json
+++ b/packages/platform/enums/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
+    "module": "CommonJS",
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "baseUrl": "./",

--- a/packages/platform/enums/tsconfig.json
+++ b/packages/platform/enums/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2022",
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "baseUrl": "./",

--- a/packages/platform/examples/base/tsconfig.json
+++ b/packages/platform/examples/base/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/platform/libraries/i18n.ts
+++ b/packages/platform/libraries/i18n.ts
@@ -1,16 +1,20 @@
 import { createInstance } from "i18next";
 import type { i18n as I18nInstance } from "i18next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { fetchWithTimeout } from "@calcom/lib/fetchWithTimeout";
 import logger from "@calcom/lib/logger";
 
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { i18n } = require("@calcom/config/next-i18next.config");
-const path = require("node:path");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const i18nConfig = require("@calcom/config/next-i18next.config");
+const { i18n } = i18nConfig;
 const translationsPath = path.resolve(__dirname, "../../../../apps/web/public/static/locales/en/common.json");
 const englishTranslations: Record<string, string> = require(translationsPath);
-/* eslint-enable @typescript-eslint/no-require-imports */
 
 const translationCache = new Map<string, Record<string, string>>([["en-common", englishTranslations]]);
 const i18nInstanceCache = new Map<string, I18nInstance>();

--- a/packages/platform/libraries/tsconfig.json
+++ b/packages/platform/libraries/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ES2021",
+    "target": "ES2022",
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "types": ["jest"],

--- a/packages/platform/libraries/tsconfig.json
+++ b/packages/platform/libraries/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "module": "CommonJS",
     "target": "ES2022",
     "jsx": "react-jsx",
     "resolveJsonModule": true,

--- a/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
@@ -319,7 +319,7 @@ export class RecurringBookingOutput_2024_08_13 extends BookingOutput_2024_08_13 
   })
   @IsObject()
   @Expose()
-  bookingFieldsResponses!: Record<string, unknown>;
+  declare bookingFieldsResponses: Record<string, unknown>;
 }
 
 export class GetSeatedBookingOutput_2024_08_13 extends BaseBookingOutput_2024_08_13 {

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/get-event-types-query.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/get-event-types-query.input.ts
@@ -2,7 +2,8 @@ import { ApiPropertyOptional } from "@nestjs/swagger";
 import { Transform } from "class-transformer";
 import { IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
 
-import { SkipTakePagination, SortOrder, SortOrderType } from "../../../pagination/pagination.input";
+import type { SortOrderType } from "../../../pagination/pagination.input";
+import { SkipTakePagination, SortOrder } from "../../../pagination/pagination.input";
 
 export class GetEventTypesQuery_2024_06_14 {
   @IsOptional()

--- a/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
@@ -46,7 +46,7 @@ export class NameDefaultFieldOutput_2024_06_14 extends NameDefaultFieldInput_202
   @DocsProperty({
     default: "name",
   })
-  type!: "name";
+  declare type: "name";
 
   @IsBoolean()
   @DocsProperty()
@@ -72,7 +72,7 @@ export class SplitNameDefaultFieldOutput_2024_06_14 extends SplitNameDefaultFiel
   @DocsProperty({
     default: "splitName",
   })
-  type!: "splitName";
+  declare type: "splitName";
 }
 
 export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2024_06_14 {
@@ -94,18 +94,18 @@ export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2
   @DocsProperty({
     default: "email",
   })
-  type!: "email";
+  declare type: "email";
 
   @IsBoolean()
   @DocsProperty()
-  required!: boolean;
+  declare required: boolean;
 
   @IsBoolean()
   @DocsProperty({
     description: `If true show under event type settings but don't show this booking field in the Booker. If false show in both. Can only be hidden
       for organization team event types when also providing attendee phone number booking field.`,
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class LocationDefaultFieldOutput_2024_06_14 {
@@ -161,7 +161,7 @@ export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleRea
   @DocsProperty({
     default: "rescheduleReason",
   })
-  slug!: "rescheduleReason";
+  declare slug: "rescheduleReason";
 
   @IsString()
   @DocsProperty({
@@ -171,24 +171,24 @@ export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleRea
 
   @IsBoolean()
   @DocsProperty()
-  required!: boolean;
+  declare required: boolean;
 
   @IsBoolean()
   @DocsProperty({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  label?: string;
+  declare label: string | undefined;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  placeholder?: string;
+  declare placeholder: string | undefined;
 
   @IsBoolean()
   @ApiProperty({
@@ -198,7 +198,7 @@ export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleRea
       For example, if URL contains query parameter `&rescheduleReason=busy`,\
       the reschedule reason field will be prefilled with this value and disabled.",
   })
-  disableOnPrefill!: boolean;
+  declare disableOnPrefill: boolean;
 }
 
 export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2024_06_14 {
@@ -214,7 +214,7 @@ export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2
   @DocsProperty({
     default: "title",
   })
-  slug!: "title";
+  declare slug: "title";
 
   @IsString()
   @DocsProperty({
@@ -224,24 +224,24 @@ export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2
 
   @IsBoolean()
   @DocsProperty()
-  required!: boolean;
+  declare required: boolean;
 
   @IsBoolean()
   @DocsProperty({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  label?: string;
+  declare label: string | undefined;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  placeholder?: string;
+  declare placeholder: string | undefined;
 
   @IsBoolean()
   @ApiProperty({
@@ -251,7 +251,7 @@ export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2
       For example, if URL contains query parameter `&title=masterclass`,\
       the title field will be prefilled with this value and disabled.",
   })
-  disableOnPrefill!: boolean;
+  declare disableOnPrefill: boolean;
 }
 
 export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2024_06_14 {
@@ -267,7 +267,7 @@ export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2
   @DocsProperty({
     default: "notes",
   })
-  slug!: "notes";
+  declare slug: "notes";
 
   @IsString()
   @DocsProperty({
@@ -277,24 +277,24 @@ export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2
 
   @IsBoolean()
   @DocsProperty()
-  required!: boolean;
+  declare required: boolean;
 
   @IsBoolean()
   @DocsProperty({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  label?: string;
+  declare label: string | undefined;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  placeholder?: string;
+  declare placeholder: string | undefined;
 
   @IsBoolean()
   @ApiProperty({
@@ -304,7 +304,7 @@ export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2
       For example, if URL contains query parameter `&notes=hello`,\
       the notes field will be prefilled with this value and disabled.",
   })
-  disableOnPrefill!: boolean;
+  declare disableOnPrefill: boolean;
 }
 
 export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput_2024_06_14 {
@@ -320,7 +320,7 @@ export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput
   @DocsProperty({
     default: "guests",
   })
-  slug!: "guests";
+  declare slug: "guests";
 
   @IsString()
   @DocsProperty({
@@ -330,24 +330,24 @@ export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput
 
   @IsBoolean()
   @DocsProperty()
-  required!: boolean;
+  declare required: boolean;
 
   @IsBoolean()
   @DocsProperty({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  label?: string;
+  declare label: string | undefined;
 
   @IsString()
   @IsOptional()
   @DocsProperty()
-  placeholder?: string;
+  declare placeholder: string | undefined;
 
   @IsBoolean()
   @ApiProperty({
@@ -357,7 +357,7 @@ export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput
       For example, if URL contains query parameter `&guests=lauris@cal.com`,\
       the guests field will be prefilled with this value and disabled.",
   })
-  disableOnPrefill!: boolean;
+  declare disableOnPrefill: boolean;
 }
 
 export class PhoneDefaultFieldOutput_2024_06_14 {
@@ -427,7 +427,7 @@ export class PhoneFieldOutput_2024_06_14 extends PhoneFieldInput_2024_06_14 {
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 {
@@ -444,7 +444,7 @@ export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
@@ -461,7 +461,7 @@ export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
@@ -478,7 +478,7 @@ export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
@@ -495,7 +495,7 @@ export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_14 {
@@ -512,7 +512,7 @@ export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_1
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
@@ -529,7 +529,7 @@ export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_2024_06_14 {
@@ -546,7 +546,7 @@ export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_202
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_06_14 {
@@ -563,7 +563,7 @@ export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput_2024_06_14 {
@@ -580,7 +580,7 @@ export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_06_14 {
@@ -597,7 +597,7 @@ export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class BooleanFieldOutput_2024_06_14 extends BooleanFieldInput_2024_06_14 {
@@ -614,7 +614,7 @@ export class BooleanFieldOutput_2024_06_14 extends BooleanFieldInput_2024_06_14 
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })
-  hidden!: boolean;
+  declare hidden: boolean;
 }
 
 export class OutputUnknownBookingField_2024_06_14 {

--- a/packages/platform/types/event-types/event-types_2024_06_14/outputs/event-type.output.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/outputs/event-type.output.ts
@@ -529,7 +529,7 @@ export class TeamEventTypeOutput_2024_06_14 extends BaseEventTypeOutput_2024_06_
   @IsOptional()
   @IsBoolean()
   @ApiPropertyOptional()
-  hideCalendarEventDetails?: boolean;
+  declare hideCalendarEventDetails: boolean | undefined;
 
   @ValidateNested()
   @Type(() => EventTypeTeam)

--- a/packages/platform/types/organizations/teams/outputs/team.output.ts
+++ b/packages/platform/types/organizations/teams/outputs/team.output.ts
@@ -9,5 +9,5 @@ export class OrgTeamOutputDto extends TeamOutputDto {
   @IsOptional()
   @Expose()
   @ApiPropertyOptional()
-  readonly parentId?: number;
+  declare readonly parentId: number | undefined;
 }

--- a/packages/platform/types/package.json
+++ b/packages/platform/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-types",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.js",
   "private": true,

--- a/packages/platform/types/tsconfig.json
+++ b/packages/platform/types/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/platform/types/tsconfig.json
+++ b/packages/platform/types/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
+    "module": "CommonJS",
     "resolveJsonModule": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/platform/types/tsconfig.json
+++ b/packages/platform/types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2022",
     "resolveJsonModule": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/platform/types/utils/RequiresOneOfPropertiesWhenNotDisabled.ts
+++ b/packages/platform/types/utils/RequiresOneOfPropertiesWhenNotDisabled.ts
@@ -31,7 +31,12 @@ export function RequiresAtLeastOnePropertyWhenNotDisabled(validationOptions?: Va
             return true;
           }
 
-          const otherProperties = Object.keys(obj).filter((key) => key !== "disabled");
+          // note(Devin): With ES2022 class fields, Object.keys() includes properties that are undefined
+          // (e.g., maximumActiveBookings, offerReschedule) because they're emitted as runtime class fields.
+          // We need to check for properties that have defined values, not just keys that exist.
+          const otherProperties = Object.entries(obj).filter(
+            ([key, value]) => key !== "disabled" && value !== undefined
+          );
           const hasAtLeastOneOtherProperty = otherProperties.length > 0;
 
           if (!hasAtLeastOneOtherProperty) {

--- a/packages/platform/types/utils/RequiresOneOfPropertiesWhenNotDisabled.ts
+++ b/packages/platform/types/utils/RequiresOneOfPropertiesWhenNotDisabled.ts
@@ -31,9 +31,6 @@ export function RequiresAtLeastOnePropertyWhenNotDisabled(validationOptions?: Va
             return true;
           }
 
-          // note(Devin): With ES2022 class fields, Object.keys() includes properties that are undefined
-          // (e.g., maximumActiveBookings, offerReschedule) because they're emitted as runtime class fields.
-          // We need to check for properties that have defined values, not just keys that exist.
           const otherProperties = Object.entries(obj).filter(
             ([key, value]) => key !== "disabled" && value !== undefined
           );

--- a/packages/platform/utils/package.json
+++ b/packages/platform/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-utils",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "private": true,

--- a/packages/platform/utils/tsconfig.json
+++ b/packages/platform/utils/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "types": ["jest"],
     "outDir": "./dist",

--- a/packages/platform/utils/tsconfig.json
+++ b/packages/platform/utils/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2022",
     "resolveJsonModule": true,
     "types": ["jest"],
     "outDir": "./dist",

--- a/packages/platform/utils/tsconfig.json
+++ b/packages/platform/utils/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
+    "module": "CommonJS",
     "resolveJsonModule": true,
     "types": ["jest"],
     "outDir": "./dist",

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -149,7 +149,20 @@ function withSlotsCache(
 }
 
 export class AvailableSlotsService {
-  constructor(public readonly dependencies: IAvailableSlotsService) {}
+  public getAvailableSlots: (
+    args: GetScheduleOptions
+  ) => Promise<IGetAvailableSlots>;
+
+
+  constructor(public readonly dependencies: IAvailableSlotsService) {
+    this.getAvailableSlots = withReporting(
+      withSlotsCache(
+        dependencies.redisClient,
+        this._getAvailableSlots.bind(this)
+      ),
+      "getAvailableSlots"
+    );
+  }
 
   private async _getReservedSlotsAndCleanupExpired({
     bookerClientUid,
@@ -1003,10 +1016,7 @@ export class AvailableSlotsService {
     "getRegularOrDynamicEventType"
   );
 
-  getAvailableSlots = withReporting(
-    withSlotsCache(this.dependencies.redisClient, this._getAvailableSlots.bind(this)),
-    "getAvailableSlots"
-  );
+
 
   async _getAvailableSlots({ input, ctx }: GetScheduleOptions): Promise<IGetAvailableSlots> {
     const {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "target": "es2022",
     "composite": false,
     "declaration": true,
     "declarationMap": true,

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "declaration": false,
     "declarationMap": false,
-    "target": "es5",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "ESNext",
-    "target": "ES5",
+    "target": "es2022",
     "jsx": "react-jsx"
   },
   "include": [".", "../types/next-auth.d.ts"],


### PR DESCRIPTION
## What does this PR do?

Upgrades the TypeScript target to ES2022 across the monorepo to reduce transpilation and improve performance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the TypeScript target to ES2022 across the monorepo to reduce transpilation and improve performance. Moved field initializations into constructors and switched to type-only class properties to align with ES2022 semantics.

- **Refactors**
  - Set compilerOptions.target to ES2022 in base and package tsconfigs (API v2, app-store-cli, embeds, platform, lib, trpc, Next.js/react-library).
  - Moved field initializations into constructors (AvailableSlotsService, calendar/conferencing services, Stripe, Gcal controller, Teams service).
  - Replaced definite assignment assertions with declare in platform outputs and selected API v2 DTOs to avoid runtime class fields under ES2022.
  - Decorators: use type-only import for SortOrderType and enable unsafeParameterDecoratorsEnabled in Biome.
  - Migrated platform packages to ESM (type=module) and updated platform-libraries i18n to ESM imports.

- **Bug Fixes**
  - Updated RequiresAtLeastOnePropertyWhenNotDisabled validator to count only defined values, since ES2022 emits undefined class fields at runtime.

<sup>Written for commit d01dac43899e3f80948dc4a6d61f3a227122783b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

### ES2022 Compatibility Fixes

The ES2022 target changes class field semantics, requiring the following fixes:

**TS2612 Errors (Property will overwrite base property):**
- `booking-fields.output.ts` - Added `declare` modifier to properties in 19 output classes
- `booking.output.ts` - Fixed `bookingFieldsResponses` in `RecurringBookingOutput_2024_08_13`
- `event-type.output.ts` - Fixed `hideCalendarEventDetails` in `TeamEventTypeOutput_2024_06_14`
- `team.output.ts` - Fixed `parentId` in `OrgTeamOutputDto`

**TS1272 Errors (Type imports with decorators):**
- `get-event-types-query.input.ts` - Changed to `import type` for `SortOrderType`

### CI Status
- Type check: ✓ Passing
- Linters: ✓ Passing
- Unit tests: ✓ Passing
- API v2 Unit tests: Pre-existing Jest configuration issues (unrelated to this PR)

---

**Link to Devin run:** https://app.devin.ai/sessions/9bf85eb1d10f4045b6ca88c0ef2c2085
**Requested by:** Volnei Munhoz (@volnei)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run `yarn type-check:ci --force` to verify no new type errors are introduced
2. Run `yarn lint` to verify linting passes
3. Run `yarn test` to verify unit tests pass
4. Build the API v2 app to verify the ES2022 target works correctly

## Human Review Checklist

- [ ] Verify the `declare` modifier changes don't affect runtime behavior of NestJS DTOs with decorators
- [ ] Verify the AvailableSlotsService constructor refactor maintains the same functionality
- [ ] Confirm API v2 Unit test failures are pre-existing and unrelated to these changes