### PR TITLE
fix: Matched colour of icons across website

### DIFF
--- a/apps/web/app/(use-page-wrapper)/insights/UpgradeTipWrapper.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/UpgradeTipWrapper.tsx
@@ -15,17 +15,17 @@ export default function UpgradeTipWrapper({ children }: { children: React.ReactN
   const session = useSession();
   const features = [
     {
-      icon: <Icon name="users" className="h-5 w-5" />,
+      icon: <Icon name="users" className="h-5 w-5 text-red-500" />,
       title: t("view_bookings_across"),
       description: t("view_bookings_across_description"),
     },
     {
-      icon: <Icon name="refresh-ccw" className="h-5 w-5" />,
+      icon: <Icon name="refresh-ccw" className="h-5 w-5 text-blue-500" />,
       title: t("identify_booking_trends"),
       description: t("identify_booking_trends_description"),
     },
     {
-      icon: <Icon name="user-plus" className="h-5 w-5" />,
+      icon: <Icon name="user-plus" className="h-5 w-5 text-green-500" />,
       title: t("spot_popular_event_types"),
       description: t("spot_popular_event_types_description"),
     },


### PR DESCRIPTION
fixes #26395


###Before 

<img width="1637" height="235" alt="image" src="https://github.com/user-attachments/assets/265c64ef-221c-4fd0-a8da-167019ffe321" />


###After


<img width="1637" height="897" alt="image" src="https://github.com/user-attachments/assets/04fa04d0-b2d1-4fe7-b35b-500bf17ebf97" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized icon colors in the Insights Upgrade tip to match the site palette and improve visual consistency.

- **UI Improvements**
  - users icon: red-500
  - refresh-ccw icon: blue-500
  - user-plus icon: green-500

<sup>Written for commit 8860dc7f4084d7ea0d362cd8099eb9588a9d3385. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



