### PR TITLE
feat: add type=module to platform packages for ESM migration

### DIFF
--- a/packages/platform/constants/package.json
+++ b/packages/platform/constants/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-constants",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "private": true,

--- a/packages/platform/enums/package.json
+++ b/packages/platform/enums/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-enums",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.ts",
   "types": "./dist/index.ts",
   "private": true,

--- a/packages/platform/libraries/i18n.ts
+++ b/packages/platform/libraries/i18n.ts
@@ -1,16 +1,20 @@
 import { createInstance } from "i18next";
 import type { i18n as I18nInstance } from "i18next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { fetchWithTimeout } from "@calcom/lib/fetchWithTimeout";
 import logger from "@calcom/lib/logger";
 
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { i18n } = require("@calcom/config/next-i18next.config");
-const path = require("node:path");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const i18nConfig = require("@calcom/config/next-i18next.config");
+const { i18n } = i18nConfig;
 const translationsPath = path.resolve(__dirname, "../../../../apps/web/public/static/locales/en/common.json");
 const englishTranslations: Record<string, string> = require(translationsPath);
-/* eslint-enable @typescript-eslint/no-require-imports */
 
 const translationCache = new Map<string, Record<string, string>>([["en-common", englishTranslations]]);
 const i18nInstanceCache = new Map<string, I18nInstance>();

--- a/packages/platform/libraries/tsconfig.json
+++ b/packages/platform/libraries/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@calcom/tsconfig/base.json",
   "compilerOptions": {
-    "module": "CommonJS",
     "target": "ES2022",
     "jsx": "react-jsx",
     "resolveJsonModule": true,

--- a/packages/platform/types/package.json
+++ b/packages/platform/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-types",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.js",
   "private": true,

--- a/packages/platform/utils/package.json
+++ b/packages/platform/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@calcom/platform-utils",
   "version": "0.0.0",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "private": true,


### PR DESCRIPTION
## What does this PR do?

This is a **stacked PR** on top of #26392 (ES2022 target upgrade) that adds `"type": "module"` to the platform packages and removes remaining CommonJS configuration as preparation for ESM migration.

**Changes:**
- Added `"type": "module"` to `@calcom/platform-constants`
- Added `"type": "module"` to `@calcom/platform-enums`
- Added `"type": "module"` to `@calcom/platform-types`
- Added `"type": "module"` to `@calcom/platform-utils`
- Removed `"module": "CommonJS"` from `@calcom/platform-libraries` tsconfig
- Converted `i18n.ts` from CommonJS `require()` calls to ESM-compatible approach using `createRequire`

**Context:** The base PR removed explicit `"module": "CommonJS"` from the constants, enums, types, and utils packages' tsconfigs. This PR takes the next step by declaring them as ES modules in package.json and also removes CommonJS from the libraries package.

**⚠️ Important:** This change may require additional configuration updates for:
- Jest test configuration in packages that have tests (enums, utils)
- Any consumers using `require()` to import these packages
- Import paths that may need explicit file extensions

<!-- Link to Devin run: https://app.devin.ai/sessions/9bf85eb1d10f4045b6ca88c0ef2c2085 -->
<!-- Requested by: Volnei Munhoz (@volnei) -->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Merge the base PR (#26392) first
2. Build the platform packages: `yarn turbo run build --filter=@calcom/platform-libraries --force`
3. Run API v2 tests to verify runtime compatibility
4. Check that Jest tests in `packages/platform/enums` and `packages/platform/utils` still pass

## Human Review Checklist

- [ ] Verify the `createRequire` pattern in `i18n.ts` works correctly at runtime for loading CommonJS config
- [ ] Verify all consumers of platform packages can handle ESM imports
- [ ] Check if Jest configuration needs updates for test scripts
- [ ] Confirm this is intentionally exploratory/draft work for ESM migration

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings