### PR TITLE
fix: update bundle identifier

### DIFF
--- a/companion/app.json
+++ b/companion/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "deploymentTarget": "18.0",
-      "bundleIdentifier": "com.calcom.companion",
+      "bundleIdentifier": "com.cal.companion",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },


### PR DESCRIPTION
## What does this PR do?

- Updates the iOS bundle identifier to match the one created on the App Store Connect website.

