### PR TITLE
fix(auth): make identityProviderId lookup case-insensitive

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -843,7 +843,10 @@ export const getOptions = ({
           },
           where: {
             identityProvider: idP,
-            identityProviderId: account.providerAccountId,
+            identityProviderId: {
+              equals: account.providerAccountId,
+              mode: "insensitive",
+            },
           },
         });
 


### PR DESCRIPTION
## What does this PR do?

Makes the `identityProviderId` lookup case-insensitive during SAML authentication. Fixes potential login failures caused when the IdP sends a NameID with different casing than what's stored in the database.

### Changes

- Updated `identityProviderId` query in signIn callback to use `mode: "insensitive"`
- Aligns with existing pattern used for email lookups in the same file

### How to test

1. Configure SAML SSO with an IdP (e.g., Okta)
2. Create a user with `identityProviderId` stored as `user@example.com`
3. Configure IdP to send NameID as `User@Example.com` (different casing)
4. Attempt SAML login → should succeed (previously returned `wrong-provider` error)

### Background

The existing user lookup by `identityProviderId` was case-sensitive, while the fallback lookup by email uses `mode: "insensitive"`. When an IdP sends a NameID with different casing, the first lookup fails, falls through to email lookup, but hits the catch-all `wrong-provider` error since there's no SAML→SAML conversion path.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] **N/A** I have updated the developer docs
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works