### PR TITLE
feat: add fab varients to conferencing and calendar page in mobile view

### DIFF
--- a/apps/web/components/apps/CalendarListContainer.tsx
+++ b/apps/web/components/apps/CalendarListContainer.tsx
@@ -70,7 +70,7 @@ const AddCalendarButton = () => {
   const { t } = useLocale();
   return (
     <>
-      <Button color="secondary" StartIcon="plus" href="/apps/categories/calendar">
+      <Button color="secondary" StartIcon="plus" size="sm" variant="fab" href="/apps/categories/calendar">
         {t("add_calendar")}
       </Button>
     </>

--- a/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewWebWrapper.tsx
+++ b/packages/platform/atoms/connect/conferencing-apps/ConferencingAppsViewWebWrapper.tsx
@@ -181,7 +181,7 @@ const AddConferencingButton = () => {
   const { t } = useLocale();
 
   return (
-    <Button color="secondary" StartIcon="plus" href="/apps/categories/conferencing">
+    <Button color="secondary" StartIcon="plus" size="sm" variant="fab" href="/apps/categories/conferencing">
       {t("add")}
     </Button>
   );


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #26406
- Fixes [CAL-7010](https://linear.app/calcom/issue/CAL-7010/feat-add-mobile-fab-buttons-to-calendars-and-conferencing-settings)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

before:

<img width="479" height="317" alt="Screenshot 2026-01-03 at 12 31 34 PM" src="https://github.com/user-attachments/assets/35f8032c-c766-4ecd-9a06-bb3724435540" />

<img width="488" height="517" alt="Screenshot 2026-01-03 at 12 32 10 PM" src="https://github.com/user-attachments/assets/87a2eb9f-0606-45e5-906a-4195c1a5e47d" />

after:

<img width="487" height="429" alt="Screenshot 2026-01-03 at 12 31 44 PM" src="https://github.com/user-attachments/assets/7a6cba7a-a8da-43d7-9efd-b3c58c07a759" />

<img width="491" height="484" alt="Screenshot 2026-01-03 at 12 32 22 PM" src="https://github.com/user-attachments/assets/be0c7dc1-a836-42f1-85cc-a58144d87953" />



## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the “Add Calendar” and “Add Conferencing” actions to small floating action buttons (FAB) on mobile to make them easier to find and tap. Implements Linear CAL-7010 by setting size=sm and variant=fab in the Calendars and Conferencing settings.

<sup>Written for commit 7ae38527398db8f352366202274ad45b7d8f0483. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

