### PR TITLE
fix(ui): Make incomplete booking form mobile-responsive

### DIFF
--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/IncompleteBooking.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/[...pages]/IncompleteBooking.tsx
@@ -128,22 +128,22 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                   <div className="bg-default mt-2 rounded-xl px-2 py-2">
                     <Label>Credential to use</Label>
                     <Select
-                      size="sm"
-                      options={credentialOptions}
-                      value={selectedCredential}
-                      onChange={(option) => {
-                        if (!option) {
-                          return;
-                        }
-                        setSelectedCredential(option);
-                      }}
-                    />
-                  </div>
+                    size="sm"
+                    options={credentialOptions}
+                    value={selectedCredential}
+                    onChange={(option) => {
+                      if (!option) {
+                        return;
+                      }
+                      setSelectedCredential(option);
+                    }}
+                  />
+                </div>
                 </>
               )}
 
               <div className="bg-default mt-2 rounded-xl px-2 py-2">
-                <div className="grid grid-cols-5 gap-4">
+                <div className="hidden md:grid md:grid-cols-5 md:gap-4">
                   <Label>{t("field_name")}</Label>
                   <Label>{t("field_type")}</Label>
                   <Label>{t("value")}</Label>
@@ -155,22 +155,25 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                       salesforceWriteToRecordObject[key as keyof typeof salesforceWriteToRecordObject];
                     return (
                       <div
-                        className="mt-2 grid gap-4"
-                        style={{ gridTemplateColumns: "repeat(5, 1fr)" }}
+                        className="mt-2 border-subtle flex flex-col gap-3 rounded-lg border p-3 md:mt-2 md:grid md:grid-cols-5 md:gap-4 md:border-0 md:p-0"
                         key={key}>
                         <div className="w-full">
+                          <Label className="md:hidden">{t("field_name")}</Label>
                           <InputField value={key} readOnly />
                         </div>
                         <div className="w-full">
+                          <Label className="md:hidden">{t("field_type")}</Label>
                           <Select
                             value={fieldTypeOptions.find((option) => option.value === action.fieldType)}
                             isDisabled={true}
                           />
                         </div>
                         <div className="w-full">
+                          <Label className="md:hidden">{t("value")}</Label>
                           <InputField value={action.value as string} readOnly />
                         </div>
                         <div className="w-full">
+                          <Label className="md:hidden">{t("when_to_write")}</Label>
                           <Select
                             value={whenToWriteToRecordOptions.find(
                               (option) => option.value === action.whenToWrite
@@ -178,7 +181,7 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                             isDisabled={true}
                           />
                         </div>
-                        <div>
+                        <div className="flex justify-end md:justify-start">
                           <Button
                             StartIcon="trash"
                             variant="icon"
@@ -193,8 +196,9 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                       </div>
                     );
                   })}
-                  <div className="mt-2 grid grid-cols-5 gap-4">
+                  <div className="mt-2 border-subtle flex flex-col gap-4 rounded-lg border p-3 md:mt-2 md:grid md:grid-cols-5 md:gap-4 md:border-0 md:p-0">
                     <div>
+                      <Label className="md:hidden">{t("field_name")}</Label>
                       <InputField
                         size="sm"
                         value={newSalesforceAction.field}
@@ -207,6 +211,7 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                       />
                     </div>
                     <div>
+                      <Label className="md:hidden">{t("field_type")}</Label>
                       <Select
                         size="sm"
                         options={fieldTypeOptions}
@@ -223,6 +228,7 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                       />
                     </div>
                     <div>
+                      <Label className="md:hidden">{t("value")}</Label>
                       <InputField
                         size="sm"
                         value={newSalesforceAction.value}
@@ -235,6 +241,7 @@ function Page({ form }: { form: RoutingFormWithResponseCount }) {
                       />
                     </div>
                     <div>
+                      <Label className="md:hidden">{t("when_to_write")}</Label>
                       <Select
                         size="sm"
                         options={whenToWriteToRecordOptions}


### PR DESCRIPTION
## What does this PR do?
Optimized the Incomplete Booking Salesforce integration form for mobile devices.

- Fixes #26412
- Fixes [CAL-7012](https://linear.app/calcom/issue/CAL-7012/mobile-responsiveness-issues-in-incomplete-booking-salesforce)

Changes

- Hide header row on mobile and show only on md and above
- Convert rows to vertical, card-like layout on mobile
- Add inline labels for mobile accessibility
- Preserve 5-column grid layout on desktop
- Remove inline styles and align with existing responsive patterns

## Visual Demo 

#### Image Demo (if applicable):
- Before 
<img width="426" height="826" alt="Screenshot 2026-01-03 171228" src="https://github.com/user-attachments/assets/a0b80c6a-6f6e-4971-9c3a-350cc875975e" />

- After 
<img width="1919" height="966" alt="Screenshot 2026-01-03 164949" src="https://github.com/user-attachments/assets/5a289849-fdfb-483b-ba2a-78edc7923405" />
<img width="415" height="822" alt="Screenshot 2026-01-03 165027" src="https://github.com/user-attachments/assets/f2efcae8-4b11-41cb-99c9-172f5f9e3fb0" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
- Mobile view
- Desktop view 
