### PR TITLE
fix: prevent duplicate cancellation emails when workflow exists

### DIFF
--- a/packages/features/ee/workflows/lib/actionHelperFunctions.ts
+++ b/packages/features/ee/workflows/lib/actionHelperFunctions.ts
@@ -65,6 +65,34 @@ export function isTextMessageToSpecificNumber(action?: WorkflowActions) {
   return action === WorkflowActions.SMS_NUMBER || action === WorkflowActions.WHATSAPP_NUMBER;
 }
 
+export function isHostAction(action: WorkflowActions) {
+  return action === WorkflowActions.EMAIL_HOST;
+}
+
+export function hasCancellationWorkflowsForRecipients(
+  workflows: { trigger: WorkflowTriggerEvents; steps: { action: WorkflowActions }[] }[]
+): { attendee: boolean; host: boolean } {
+  let attendee = false;
+  let host = false;
+
+  for (const workflow of workflows) {
+    if (workflow.trigger !== WorkflowTriggerEvents.EVENT_CANCELLED) continue;
+
+    for (const step of workflow.steps) {
+      if (isAttendeeAction(step.action)) {
+        attendee = true;
+      }
+      if (isHostAction(step.action)) {
+        host = true;
+      }
+    }
+
+    if (attendee && host) break;
+  }
+
+  return { attendee, host };
+}
+
 export function getWhatsappTemplateForTrigger(trigger: WorkflowTriggerEvents): WorkflowTemplates {
   switch (trigger) {
     case "NEW_EVENT":


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate cancellation emails being sent when EVENT_CANCELLED workflows are configured.

When a user sets up a workflow for event cancellations, the system was sending both the workflow email AND the standard system cancellation email, resulting in duplicate notifications to attendees and hosts.

- Fixes #26417
- Fixes [CAL-7014](https://linear.app/calcom/issue/CAL-7014/standard-email-upon-cancellation-despite-workflow)

## Visual Demo (For contributors especially)

**Before Fix:**
https://www.loom.com/share/a2c40bb66bb1496db483ccab6f8d77f1

**After Fix:**
https://www.loom.com/share/19005d17a7244fa19db37d5ef20c22c3

Screenshot shows successful test - only custom workflow cancellation email received, no duplicate standard system email.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A** - No documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Setup:**
1. Create an event type
2. Create a workflow with trigger "When event is cancelled" 
3. Add workflow action: "Send email to attendee" with custom message
4. message template : custom
- email subject: 
```
Custom Cancellation: {EVENT_NAME} on {EVENT_DATE}
```
- Email body : 
``` 
Hi {ATTENDEE_NAME},

This is a CUSTOM cancellation email from the workflow system.

Event: {EVENT_NAME}
Original time: {EVENT_DATE} at {EVENT_TIME}

This email should be the ONLY cancellation email you receive.
```
5. Add workflow action: "Send email to host" with custom message
4. message template : custom
- email subject 
```
Reminder: {EVENT_NAME} - {EVENT_DATE_ddd, MMM D, YYYY h:mma}
```
- Email body
```
This is a CUSTOM host cancellation email from workflow.
You should only receive this email, not the standard system email.
```
6. Save the workflow and ensure it's active on your event type

**Test:**
1. Book a meeting using the event type
2. Cancel the booking from the dashboard
3. Check emails for both attendee and host
