### PR TITLE
fix(ci): delete old prod build caches on cache miss

### DIFF
--- a/.github/workflows/production-build-without-database.yml
+++ b/.github/workflows/production-build-without-database.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 env:
   ALLOWED_HOSTNAMES: ${{ vars.CI_ALLOWED_HOSTNAMES }}
@@ -44,4 +45,26 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
       - uses: ./.github/actions/yarn-install
+      - name: Generate cache key
+        id: cache-key
+        uses: ./.github/actions/cache-build-key
+        with:
+          branch_key: ${{ github.head_ref || github.ref_name }}
+      - name: Check if production build cache exists
+        uses: actions/cache@v4
+        id: cache-check
+        with:
+          path: |
+            ${{ github.workspace }}/apps/web/.next
+            ${{ github.workspace }}/apps/web/public/embed
+            **/.turbo/**
+            **/dist/**
+          key: ${{ steps.cache-key.outputs.key }}
+          lookup-only: true
+      - name: Delete old production build caches for this branch
+        if: steps.cache-check.outputs.cache-hit != 'true'
+        uses: useblacksmith/cache-delete@v1
+        with:
+          key: prod-build-${{ github.head_ref || github.ref_name }}
+          prefix: "true"
       - uses: ./.github/actions/cache-build


### PR DESCRIPTION
## What does this PR do?

When there are code changes in a PR that result in a cache miss for the production build, this PR now deletes any previously cached builds for the current branch before rebuilding. This helps reduce cache storage usage by cleaning up stale caches as we go, rather than waiting until the PR is closed.

Previously, we only deleted branch caches when a PR was closed (in `delete-blacksmith-cache.yml`). This meant that if a PR had multiple commits with different source hashes, we'd accumulate multiple cached builds per branch.

**Changes:**
1. Generate the cache key using `cache-build-key` action
2. Check if the cache exists using `lookup-only: true`
3. If cache miss, delete old production build caches for the branch using prefix matching
4. Proceed with normal `cache-build` action

Also adds `actions: write` permission required for cache deletion.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow changes are tested by running the workflow itself.

## How should this be tested?

1. Create a PR with some code changes
2. Observe the production build workflow runs and caches the build
3. Make another code change that would result in a different source hash
4. Observe that the workflow:
   - Checks for cache (should miss due to different hash)
   - Deletes old caches for the branch (check Blacksmith cache storage)
   - Builds and caches the new build

## Human Review Checklist

- [ ] Verify the cache key generation matches what `cache-build` action generates internally (uses same `cache-build-key` action with same `branch_key` input)
- [ ] Confirm `actions: write` permission is acceptable for this reusable workflow
- [ ] Verify prefix matching (`prod-build-{branch}`) correctly targets only the current branch's caches

---

Link to Devin run: https://app.devin.ai/sessions/31f639efc2414e8eab74a6ec02f6f66b
Requested by: keith@cal.com (@keithwillcode)