### PR TITLE
fix(apps): Use Tailwind line-clamp-3 for app card description truncation

### DIFF
--- a/apps/web/modules/apps/components/AppCard.tsx
+++ b/apps/web/modules/apps/components/AppCard.tsx
@@ -128,14 +128,8 @@ export function AppCard({ app, credentials, searchText, userAdminTeams }: AppCar
             <span className="pl-1 text-subtle">{props.reviews} reviews</span>
           </div> */}
       <p
-        className="text-default mt-2 grow text-sm"
+        className="text-default mt-2 grow text-sm line-clamp-3"
         dangerouslySetInnerHTML={{ __html: markdownToSafeHTML(app.description) }}
-        style={{
-          overflow: "hidden",
-          display: "-webkit-box",
-          WebkitBoxOrient: "vertical",
-          WebkitLineClamp: "3",
-        }}
       />
 
       <div className="mt-5 flex max-w-full flex-row justify-between gap-2">


### PR DESCRIPTION
## Summary
Fixes long app descriptions not being truncated properly in the app card component.

## Problem
The inline style approach using `WebkitLineClamp: "3"` (as a string) and related properties wasn't working reliably for text truncation.

## Solution
Replace inline styles with Tailwind's `line-clamp-3` utility class, which properly handles:
- `-webkit-line-clamp: 3`
- `-webkit-box-orient: vertical`
- `display: -webkit-box`
- `overflow: hidden`

This is the recommended approach per Tailwind's documentation and has better cross-browser support.

## Test Plan
1. Go to `/apps`
2. Check apps with long descriptions (Tandem, Zoom, Discord)
3. Verify descriptions are properly truncated to 3 lines

Closes #23659

🤖 Generated with [Claude Code](https://claude.com/claude-code)