### PR TITLE
fix(ui): Remove double hover effect on destructive dropdown items

### DIFF
--- a/packages/ui/components/dropdown/Dropdown.tsx
+++ b/packages/ui/components/dropdown/Dropdown.tsx
@@ -63,7 +63,7 @@ type DropdownMenuItemProps = ComponentProps<(typeof DropdownMenuPrimitive)["Chec
 export const DropdownMenuItem = forwardRef<HTMLDivElement, DropdownMenuItemProps>(
   ({ className = "", ...props }, forwardedRef) => (
     <DropdownMenuPrimitive.Item
-      className={`hover:bg-subtle hover:text-emphasis text-default text-sm ring-inset first-of-type:rounded-t-[inherit] last-of-type:rounded-b-[inherit] hover:ring-0 focus:outline-none focus:bg-subtle focus:text-emphasis ${className}`}
+      className={`hover:text-emphasis text-default text-sm ring-inset first-of-type:rounded-t-[inherit] last-of-type:rounded-b-[inherit] hover:ring-0 focus:outline-none focus:bg-subtle focus:text-emphasis ${className}`}
       {...props}
       ref={forwardedRef}
     />


### PR DESCRIPTION
## Summary

Fixes the double hover effect on destructive dropdown menu items where both the parent `DropdownMenuItem`'s subtle gray background and the child `DropdownItem`'s error red background appeared simultaneously on hover.

**Root cause:** `DropdownMenuItem` applied `hover:bg-subtle` unconditionally, conflicting with `DropdownItem`'s `hover:bg-error` for destructive items.

**Solution:** Remove `hover:bg-subtle` from `DropdownMenuItem`. The child `DropdownItem` component already handles hover backgrounds appropriately:
- Non-destructive items: `hover:bg-subtle`
- Destructive items: `hover:bg-error`

This is a minimal, targeted fix that doesn't affect other styling or behavior.

## Before/After

**Before:** Both backgrounds visible (gray + red layered)
**After:** Only the appropriate background (red for destructive, gray for non-destructive)

## Test plan

- [x] Tested destructive actions in dropdown menus (Delete, Leave team, etc.)
- [x] Verified non-destructive items still show subtle hover background
- [x] Confirmed focus styles are preserved for keyboard navigation

Closes #26256

🤖 Generated with [Claude Code](https://claude.com/claude-code)