### PR TITLE
feat(ci): upgrade bundle analysis to modern App Router format

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd apps/web
           export NODE_OPTIONS="--max_old_space_size=8192"
-          npx -p nextjs-bundle-analysis@0.5.0 report
+          node scripts/analyze-bundle.js
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4
@@ -107,7 +107,7 @@ jobs:
         run: |
           cd apps/web/.next/analyze
 
-          # Read current bundle stats
+          # Read current bundle stats (new App Router format)
           if [ ! -f "__bundle_analysis.json" ]; then
             echo "::error::Current bundle analysis not found"
             echo "check-passed=false" >> $GITHUB_OUTPUT
@@ -115,8 +115,11 @@ jobs:
             exit 0
           fi
 
-          CURRENT_SHARED=$(cat __bundle_analysis.json | jq -r '.__global.gzip // 0')
+          # New format uses .shared.gzip for App Router shared bundle
+          CURRENT_SHARED=$(cat __bundle_analysis.json | jq -r '.shared.gzip // .__global.gzip // 0')
+          CURRENT_ROUTES=$(cat __bundle_analysis.json | jq -r '.summary.totalRoutes // 0')
           echo "Current shared bundle (gzip): $CURRENT_SHARED bytes"
+          echo "Current App Router routes: $CURRENT_ROUTES"
 
           # Check if base bundle exists
           if [ ! -f "base/__bundle_analysis.json" ]; then
@@ -124,16 +127,28 @@ jobs:
             echo "check-passed=true" >> $GITHUB_OUTPUT
             echo "increase-percent=0" >> $GITHUB_OUTPUT
 
-            # Write summary
-            echo "## Bundle Analysis" >> $GITHUB_STEP_SUMMARY
+            # Write summary with route breakdown
+            CURRENT_KB=$(echo "scale=2; $CURRENT_SHARED / 1024" | bc)
+            echo "## Bundle Analysis (App Router)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**First Load JS shared by all:** $(echo "scale=2; $CURRENT_SHARED / 1024" | bc) KB (gzip)" >> $GITHUB_STEP_SUMMARY
+            echo "**First Load JS shared by all:** ${CURRENT_KB} KB (gzip)" >> $GITHUB_STEP_SUMMARY
+            echo "**App Router routes:** $CURRENT_ROUTES" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Show top 5 largest routes
+            echo "### Top 5 Largest Routes" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Route | First Load (gzip) |" >> $GITHUB_STEP_SUMMARY
+            echo "|-------|-------------------|" >> $GITHUB_STEP_SUMMARY
+            cat __bundle_analysis.json | jq -r '.summary.largestRoutes[:5][] | "| \(.route) | \((.firstLoadGzip / 1024 * 100 | floor) / 100) KB |"' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "> No base branch bundle found for comparison." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
 
-          BASE_SHARED=$(cat base/__bundle_analysis.json | jq -r '.__global.gzip // 0')
+          # Read base bundle stats (support both old and new format)
+          BASE_SHARED=$(cat base/__bundle_analysis.json | jq -r '.shared.gzip // .__global.gzip // 0')
+          BASE_ROUTES=$(cat base/__bundle_analysis.json | jq -r '.summary.totalRoutes // 0')
           echo "Base shared bundle (gzip): $BASE_SHARED bytes"
 
           # Calculate percentage change
@@ -177,12 +192,22 @@ jobs:
           fi
 
           # Write summary
-          echo "## Bundle Analysis $STATUS_EMOJI" >> $GITHUB_STEP_SUMMARY
+          echo "## Bundle Analysis (App Router) $STATUS_EMOJI" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Metric | Base | Current | Change |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|------|---------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| First Load JS shared by all (gzip) | ${BASE_KB} KB | ${CURRENT_KB} KB | ${CHANGE_INDICATOR} |" >> $GITHUB_STEP_SUMMARY
+          echo "| App Router routes | ${BASE_ROUTES} | ${CURRENT_ROUTES} | - |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Show top 5 largest routes
+          echo "### Top 5 Largest Routes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Route | First Load (gzip) |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------------------|" >> $GITHUB_STEP_SUMMARY
+          cat __bundle_analysis.json | jq -r '.summary.largestRoutes[:5][] | "| \(.route) | \((.firstLoadGzip / 1024 * 100 | floor) / 100) KB |"' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
           if [ "$CHECK_FAILED" -eq 1 ]; then
             echo "**Status:** $STATUS_TEXT - Shared bundle increased by ${PERCENT_CHANGE}% (threshold: ${THRESHOLD}%)" >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -2,10 +2,14 @@ name: "Next.js Bundle Analysis"
 
 on:
   workflow_call:
+    outputs:
+      shared-bundle-increase-percent:
+        description: "Percentage increase in First Load JS shared by all"
+        value: ${{ jobs.analyze.outputs.shared-bundle-increase-percent }}
+      shared-bundle-check-passed:
+        description: "Whether the shared bundle size check passed (increase < 10%)"
+        value: ${{ jobs.analyze.outputs.shared-bundle-check-passed }}
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 permissions:
   actions: write
@@ -51,6 +55,9 @@ jobs:
     if: always()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    outputs:
+      shared-bundle-increase-percent: ${{ steps.compare.outputs.increase-percent }}
+      shared-bundle-check-passed: ${{ steps.compare.outputs.check-passed }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dangerous-git-checkout
@@ -67,3 +74,116 @@ jobs:
         with:
           name: bundle
           path: apps/web/.next/analyze/__bundle_analysis.json
+
+      - name: Download base branch bundle stats
+        uses: dawidd6/action-download-artifact@v6
+        if: success() && github.event.pull_request
+        id: download-base
+        continue-on-error: true
+        with:
+          workflow: nextjs-bundle-analysis.yml
+          # Try to get artifact from the exact base commit first, fall back to branch
+          commit: ${{ github.event.pull_request.base.sha }}
+          name: bundle
+          path: apps/web/.next/analyze/base
+          if_no_artifact_found: warn
+
+      - name: Download base branch bundle stats (fallback to branch)
+        uses: dawidd6/action-download-artifact@v6
+        if: success() && github.event.pull_request && steps.download-base.outcome == 'failure'
+        id: download-base-fallback
+        continue-on-error: true
+        with:
+          workflow: nextjs-bundle-analysis.yml
+          branch: ${{ github.event.pull_request.base.ref }}
+          name: bundle
+          path: apps/web/.next/analyze/base
+          if_no_artifact_found: warn
+
+      - name: Compare bundle sizes
+        id: compare
+        if: always()
+        run: |
+          cd apps/web/.next/analyze
+
+          # Read current bundle stats
+          if [ ! -f "__bundle_analysis.json" ]; then
+            echo "::error::Current bundle analysis not found"
+            echo "check-passed=false" >> $GITHUB_OUTPUT
+            echo "increase-percent=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_SHARED=$(cat __bundle_analysis.json | jq -r '.__global.gzip // 0')
+          echo "Current shared bundle (gzip): $CURRENT_SHARED bytes"
+
+          # Check if base bundle exists
+          if [ ! -f "base/__bundle_analysis.json" ]; then
+            echo "::notice::No base bundle found for comparison. Skipping size check."
+            echo "check-passed=true" >> $GITHUB_OUTPUT
+            echo "increase-percent=0" >> $GITHUB_OUTPUT
+
+            # Write summary
+            echo "## Bundle Analysis" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**First Load JS shared by all:** $(echo "scale=2; $CURRENT_SHARED / 1024" | bc) KB (gzip)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> No base branch bundle found for comparison." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          BASE_SHARED=$(cat base/__bundle_analysis.json | jq -r '.__global.gzip // 0')
+          echo "Base shared bundle (gzip): $BASE_SHARED bytes"
+
+          # Calculate percentage change
+          if [ "$BASE_SHARED" -eq 0 ]; then
+            echo "::warning::Base shared bundle is 0, cannot calculate percentage"
+            PERCENT_CHANGE=0
+          else
+            PERCENT_CHANGE=$(echo "scale=4; (($CURRENT_SHARED - $BASE_SHARED) / $BASE_SHARED) * 100" | bc)
+          fi
+
+          echo "Percentage change: $PERCENT_CHANGE%"
+          echo "increase-percent=$PERCENT_CHANGE" >> $GITHUB_OUTPUT
+
+          # Check if increase is >= 10%
+          THRESHOLD=10
+          CHECK_FAILED=$(echo "$PERCENT_CHANGE >= $THRESHOLD" | bc -l)
+
+          if [ "$CHECK_FAILED" -eq 1 ]; then
+            echo "check-passed=false" >> $GITHUB_OUTPUT
+            STATUS_EMOJI="🔴"
+            STATUS_TEXT="FAILED"
+          else
+            echo "check-passed=true" >> $GITHUB_OUTPUT
+            STATUS_EMOJI="✅"
+            STATUS_TEXT="PASSED"
+          fi
+
+          # Calculate sizes in KB
+          CURRENT_KB=$(echo "scale=2; $CURRENT_SHARED / 1024" | bc)
+          BASE_KB=$(echo "scale=2; $BASE_SHARED / 1024" | bc)
+          DIFF_BYTES=$((CURRENT_SHARED - BASE_SHARED))
+          DIFF_KB=$(echo "scale=2; $DIFF_BYTES / 1024" | bc)
+
+          # Determine change indicator
+          if [ "$DIFF_BYTES" -gt 0 ]; then
+            CHANGE_INDICATOR="📈 +${DIFF_KB} KB (+${PERCENT_CHANGE}%)"
+          elif [ "$DIFF_BYTES" -lt 0 ]; then
+            CHANGE_INDICATOR="📉 ${DIFF_KB} KB (${PERCENT_CHANGE}%)"
+          else
+            CHANGE_INDICATOR="No change"
+          fi
+
+          # Write summary
+          echo "## Bundle Analysis $STATUS_EMOJI" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Base | Current | Change |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------|---------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| First Load JS shared by all (gzip) | ${BASE_KB} KB | ${CURRENT_KB} KB | ${CHANGE_INDICATOR} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$CHECK_FAILED" -eq 1 ]; then
+            echo "**Status:** $STATUS_TEXT - Shared bundle increased by ${PERCENT_CHANGE}% (threshold: ${THRESHOLD}%)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Status:** $STATUS_TEXT" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -433,6 +433,7 @@ jobs:
         e2e-embed,
         e2e-embed-react,
         e2e-app-store,
+        analyze,
       ]
     if: always()
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -448,6 +449,12 @@ jobs:
           echo "A maintainer must review the code and add the 'run-ci' label to trigger CI checks."
           exit 1
         if: needs.trust-check.outputs.is-trusted != 'true' && needs.trust-check.result == 'success'
+      - name: Fail if bundle size increased too much
+        run: |
+          echo "::error::Bundle analysis failed - First Load JS shared by all increased by 10% or more."
+          echo "Please review your changes and reduce the bundle size impact."
+          exit 1
+        if: needs.analyze.outputs.shared-bundle-check-passed == 'false'
       - name: Fail if conditional jobs failed
         run: exit 1
         if: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -454,7 +454,7 @@ jobs:
           echo "::error::Bundle analysis failed - First Load JS shared by all increased by 10% or more."
           echo "Please review your changes and reduce the bundle size impact."
           exit 1
-        if: needs.analyze.outputs.shared-bundle-check-passed == 'false'
+        if: needs.analyze.result == 'success' && needs.analyze.outputs.shared-bundle-check-passed == 'false'
       - name: Fail if conditional jobs failed
         run: exit 1
         if: |

--- a/apps/web/scripts/analyze-bundle.js
+++ b/apps/web/scripts/analyze-bundle.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Modern Next.js Bundle Analysis Script for App Router
+ * 
+ * This script analyzes the Next.js build output to provide:
+ * - Shared bundle size (First Load JS shared by all)
+ * - Per-route bundle sizes for App Router pages
+ * - Comparison with base branch when available
+ * 
+ * Output: JSON file with bundle stats for CI comparison
+ */
+
+const process = require("node:process");
+const fs = require("node:fs");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+const NEXT_DIR = path.join(__dirname, '..', '.next');
+const OUTPUT_DIR = path.join(NEXT_DIR, 'analyze');
+
+function getFileSize(filePath) {
+  try {
+    const stats = fs.statSync(filePath);
+    return stats.size;
+  } catch {
+    return 0;
+  }
+}
+
+function getGzipSize(filePath) {
+  try {
+    const content = fs.readFileSync(filePath);
+    const gzipped = zlib.gzipSync(content);
+    return gzipped.length;
+  } catch {
+    return 0;
+  }
+}
+
+function loadJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function analyzeSharedBundle(buildManifest) {
+  const shared = { files: [], raw: 0, gzip: 0 };
+  const rootMainFiles = buildManifest.rootMainFiles || [];
+  
+  console.log('=== Shared Bundle (First Load JS shared by all) ===\n');
+  
+  for (const file of rootMainFiles) {
+    const filePath = path.join(NEXT_DIR, file);
+    const raw = getFileSize(filePath);
+    const gzip = getGzipSize(filePath);
+    
+    shared.files.push({ file: path.basename(file), raw, gzip });
+    shared.raw += raw;
+    shared.gzip += gzip;
+    
+    console.log(`  ${path.basename(file)}: ${(raw / 1024).toFixed(2)} KB (${(gzip / 1024).toFixed(2)} KB gzip)`);
+  }
+  
+  console.log(`\n  Total Shared: ${(shared.raw / 1024).toFixed(2)} KB (${(shared.gzip / 1024).toFixed(2)} KB gzip)\n`);
+  
+  return { shared, rootMainFiles };
+}
+
+function analyzeAppRouterRoutes(appBuildManifest, rootMainFiles, sharedGzip) {
+  const routes = {};
+  const routeStats = [];
+  
+  if (!appBuildManifest?.pages) {
+    return { routes, largestRoutes: [] };
+  }
+  
+  console.log('=== App Router Routes ===\n');
+  
+  for (const [route, chunks] of Object.entries(appBuildManifest.pages)) {
+    const isApiRoute = route.startsWith('/api/');
+    const uniqueChunks = chunks.filter(chunk => !rootMainFiles.includes(chunk));
+    
+    let routeRaw = 0;
+    let routeGzip = 0;
+    
+    for (const chunk of uniqueChunks) {
+      const filePath = path.join(NEXT_DIR, chunk);
+      routeRaw += getFileSize(filePath);
+      routeGzip += getGzipSize(filePath);
+    }
+    
+    routes[route] = {
+      raw: routeRaw,
+      gzip: routeGzip,
+      firstLoad: { raw: sharedGzip + routeRaw, gzip: sharedGzip + routeGzip },
+      uniqueChunks: uniqueChunks.length,
+      isApiRoute,
+    };
+    
+    if (!isApiRoute) {
+      routeStats.push({ route, gzip: routeGzip, firstLoad: sharedGzip + routeGzip });
+    }
+  }
+  
+  routeStats.sort((a, b) => b.firstLoad - a.firstLoad);
+  const largestRoutes = routeStats.slice(0, 10).map(r => ({
+    route: r.route,
+    firstLoadGzip: r.firstLoad,
+    uniqueGzip: r.gzip,
+  }));
+  
+  console.log('Top 10 Largest Routes (by First Load JS):\n');
+  for (const route of largestRoutes) {
+    console.log(`  ${route.route}`);
+    console.log(`    First Load: ${(route.firstLoadGzip / 1024).toFixed(2)} KB gzip`);
+    console.log(`    Unique: ${(route.uniqueGzip / 1024).toFixed(2)} KB gzip\n`);
+  }
+  
+  return { routes, largestRoutes };
+}
+
+function analyzePagesRouterPages(buildManifest) {
+  const pages = {};
+  
+  if (!buildManifest.pages) {
+    return pages;
+  }
+  
+  const pagesRouterPages = Object.keys(buildManifest.pages).filter(p => !p.startsWith('/_'));
+  
+  if (pagesRouterPages.length === 0) {
+    return pages;
+  }
+  
+  console.log('=== Pages Router (Legacy) ===\n');
+  
+  for (const page of pagesRouterPages) {
+    const chunks = buildManifest.pages[page];
+    let pageRaw = 0;
+    let pageGzip = 0;
+    
+    for (const chunk of chunks) {
+      const filePath = path.join(NEXT_DIR, chunk);
+      pageRaw += getFileSize(filePath);
+      pageGzip += getGzipSize(filePath);
+    }
+    
+    pages[page] = { raw: pageRaw, gzip: pageGzip };
+    console.log(`  ${page}: ${(pageRaw / 1024).toFixed(2)} KB (${(pageGzip / 1024).toFixed(2)} KB gzip)`);
+  }
+  
+  return pages;
+}
+
+function writeResults(results) {
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+  
+  const outputPath = path.join(OUTPUT_DIR, '__bundle_analysis.json');
+  fs.writeFileSync(outputPath, JSON.stringify(results, null, 2));
+  
+  console.log('\n=== Summary ===\n');
+  console.log(`  First Load JS shared by all: ${(results.shared.gzip / 1024).toFixed(2)} KB gzip`);
+  console.log(`  App Router routes: ${results.summary.totalRoutes}`);
+  console.log(`  Pages Router pages: ${results.summary.totalPages}`);
+  console.log(`\n  Output: ${outputPath}\n`);
+}
+
+function analyzeBundle() {
+  console.log('Analyzing Next.js bundle for App Router...\n');
+
+  const buildManifest = loadJson(path.join(NEXT_DIR, 'build-manifest.json'));
+  const appBuildManifest = loadJson(path.join(NEXT_DIR, 'app-build-manifest.json'));
+
+  if (!buildManifest) {
+    console.error('Error: build-manifest.json not found. Run `next build` first.');
+    process.exit(1);
+  }
+
+  const { shared, rootMainFiles } = analyzeSharedBundle(buildManifest);
+  const { routes, largestRoutes } = analyzeAppRouterRoutes(appBuildManifest, rootMainFiles, shared.gzip);
+  const pages = analyzePagesRouterPages(buildManifest);
+
+  const results = {
+    timestamp: new Date().toISOString(),
+    shared,
+    routes,
+    pages,
+    summary: {
+      totalRoutes: Object.keys(routes).length,
+      totalPages: Object.keys(pages).length,
+      largestRoutes,
+    },
+  };
+
+  writeResults(results);
+  return results;
+}
+
+// Run analysis
+analyzeBundle();


### PR DESCRIPTION
## What does this PR do?

Upgrades the Next.js bundle analysis workflow to properly support App Router by replacing the `nextjs-bundle-analysis` package (designed for Pages Router) with a custom script that parses Next.js build manifests directly.

**Changes:**
- Replaces `nextjs-bundle-analysis@0.5.0` with custom `apps/web/scripts/analyze-bundle.js`
- Parses `build-manifest.json` (`rootMainFiles`) for accurate shared bundle calculation
- Parses `app-build-manifest.json` for per-route breakdown
- Shows top 5 largest routes in the GitHub step summary
- Calculates gzip sizes directly from chunk files using Node.js zlib
- Supports both old format (`__global.gzip`) and new format (`.shared.gzip`) for backward compatibility
- Removes `push: branches: [main]` trigger to reduce clutter
- Fails the `required` job if shared bundle increases by ≥10%

### Updates since last revision
- **App Router upgrade**: Replaced `nextjs-bundle-analysis` package with custom script that properly analyzes App Router bundles
- Added per-route breakdown showing top 5 largest routes by First Load JS
- Added route count to summary output
- Backward compatible with old artifact format for comparison during transition

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - CI workflow tested by running in CI.

## How should this be tested?

1. Create a PR with this change
2. Verify the bundle analysis job runs and outputs a summary with:
   - "First Load JS shared by all" metric
   - "App Router routes" count
   - "Top 5 Largest Routes" table
3. Verify the `required` job passes when `analyze` job is skipped (no `ready-for-e2e` label)
4. The first run may show "No base bundle found for comparison" since the artifact format changed
5. After merging, subsequent PRs should compare against the new format artifacts

## Human Review Checklist

- [ ] Verify the custom script correctly calculates shared bundle size from `rootMainFiles`
- [ ] Confirm gzip calculation matches what Next.js reports (uses Node.js zlib.gzipSync)
- [ ] Check backward compatibility: jq fallback `.shared.gzip // .__global.gzip` handles old artifacts
- [ ] Verify the 10% threshold is appropriate for your needs
- [ ] Review the top 5 largest routes display for usefulness
- [ ] Confirm shell dependencies (`jq`, `bc`) are available on `blacksmith-4vcpu-ubuntu-2404` runner

---

Link to Devin run: https://app.devin.ai/sessions/8ba2d423cd874c68b37976f6339f63b3
Requested by: keith@cal.com (@keithwillcode)