### PR TITLE
fix: Add uuid to mock session objects in organization validation tests

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/actions/validateUserHasOrg.test.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/actions/validateUserHasOrg.test.ts
@@ -38,6 +38,7 @@ describe("validateUserHasOrg", () => {
     hasValidLicense: true,
     user: {
       id: 123,
+      uuid: "test-uuid-123",
       email: "test@example.com",
       name: "Test User",
       org: {
@@ -87,6 +88,7 @@ describe("validateUserHasOrg", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,
@@ -132,6 +134,7 @@ describe("validateUserHasOrg", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,
@@ -159,6 +162,7 @@ describe("validateUserHasOrg", () => {
       const mockSession = createMockSession({
         user: {
           id: undefined as unknown as number,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: {

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/actions/validateUserHasOrgAdmin.test.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/actions/validateUserHasOrgAdmin.test.ts
@@ -44,6 +44,7 @@ describe("validateUserHasOrgAdmin", () => {
     hasValidLicense: true,
     user: {
       id: 123,
+      uuid: "test-uuid-123",
       email: "test@example.com",
       name: "Test User",
       org: {
@@ -95,6 +96,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: {
@@ -136,6 +138,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,
@@ -187,6 +190,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,
@@ -216,6 +220,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: {
@@ -260,6 +265,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,
@@ -324,6 +330,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: {
@@ -366,6 +373,7 @@ describe("validateUserHasOrgAdmin", () => {
       const mockSession = createMockSession({
         user: {
           id: 123,
+          uuid: "test-uuid-123",
           email: "test@example.com",
           name: "Test User",
           org: undefined,


### PR DESCRIPTION
## What does this PR do?

Fixes TypeScript type errors in organization validation test files caused by the parent PR #25963 which added `uuid` as a required field on `Session.user`.

After a recent merge brought in new test files (`validateUserHasOrg.test.ts` and `validateUserHasOrgAdmin.test.ts`), the mock session objects in these files were missing the required `uuid` property, causing 12 type errors during CI typecheck.

This PR adds `uuid: "test-uuid-123"` to all mock session user objects in both test files.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test file changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run `yarn type-check:ci --force` and verify no type errors related to `validateUserHasOrg.test.ts` or `validateUserHasOrgAdmin.test.ts`
2. The CI typecheck job should pass after this fix

## Human Review Checklist

- [ ] Verify `uuid` is added to all 12 mock session objects that were causing type errors (4 in `validateUserHasOrg.test.ts`, 8 in `validateUserHasOrgAdmin.test.ts`)
- [ ] Confirm the hardcoded test UUID value `"test-uuid-123"` is appropriate for test purposes (no test logic depends on unique UUIDs)

---

Link to Devin run: https://app.devin.ai/sessions/b0276d8c67b14ebc8588f6c1ef40594e
Requested by: hariom@cal.com (@hariombalhara)