### PR TITLE
fix: add @calcom/trpc#build dependency to @calcom/web#dev task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -458,6 +458,10 @@
       "cache": false,
       "outputs": ["dist/**", "build/**"]
     },
+    "@calcom/web#dev": {
+      "dependsOn": ["@calcom/trpc#build", "//#env-check:common", "//#env-check:app-store"],
+      "cache": false
+    },
     "dev": {
       "dependsOn": ["//#env-check:common", "//#env-check:app-store"],
       "cache": false


### PR DESCRIPTION
## What does this PR do?

After PR #26082 refactored tRPC to split the build into server and react phases, the client-side code now imports `AppRouter` from generated type declarations (`packages/trpc/types/server/routers/_app`) instead of directly from server source. Since the `types/` directory is gitignored, a fresh clone or clean state won't have these types until you manually run `yarn workspace @calcom/trpc build`.

This PR adds `@calcom/trpc#build` as a dependency of the `@calcom/web#dev` task so that types are automatically generated before the dev server starts.

This is consistent with how `type-check` and `type-check:ci` tasks already depend on `@calcom/trpc#build`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - this is a build configuration change.

## How should this be tested?

1. Fresh clone the repo (or delete `packages/trpc/types/` directory)
2. Run `yarn dev`
3. Verify that the trpc types are generated before the web dev server starts
4. Confirm no type errors related to missing `AppRouter` types

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

<!-- Link to Devin run: https://app.devin.ai/sessions/65628076a44f4355a338df3cb4c893e4 -->
<!-- Requested by: sean@cal.com (@sean-brydon) -->