### PR TITLE
fix: cancel running CI workflow before re-triggering and allow trusted GitHub Apps

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -23,31 +23,19 @@ jobs:
             const pr = context.payload.pull_request;
             const installation = context.payload.installation;
 
-            // Trusted GitHub App IDs that can add labels to trigger CI
-            // Graphite App: https://github.com/apps/graphite-app
-            const GRAPHITE_APP_ID = 15497;
-            const trustedAppIds = [GRAPHITE_APP_ID];
+            // Trusted GitHub App bot logins that can add labels to trigger CI
+            // These are verified by checking sender.type === 'Bot' AND presence of installation context
+            // The installation object is GitHub-generated and cannot be forged by contributors
+            const trustedBotLogins = ['graphite-app[bot]'];
 
             let isAuthorized = false;
 
-            // Check if this is a GitHub App (Bot) with an installation context
-            if (senderType === 'Bot' && installation?.id) {
-              try {
-                // Get the installation details to verify the app_id
-                const { data: installationData } = await github.rest.apps.getInstallation({
-                  installation_id: installation.id,
-                });
-
-                if (trustedAppIds.includes(installationData.app_id)) {
-                  console.log(`Label added by trusted GitHub App: ${adder} (app_id: ${installationData.app_id})`);
-                  isAuthorized = true;
-                } else {
-                  console.log(`GitHub App ${adder} (app_id: ${installationData.app_id}) is not in the trusted list`);
-                }
-              } catch (error) {
-                console.log(`Could not verify GitHub App installation: ${error.message}`);
-                // Fall through to human permission check
-              }
+            // Check if this is a trusted GitHub App (Bot) with an installation context
+            // The combination of sender.type === 'Bot' + installation context + known bot login
+            // provides sufficient verification since the payload comes from GitHub
+            if (senderType === 'Bot' && installation && trustedBotLogins.includes(adder)) {
+              console.log(`Label added by trusted GitHub App: ${adder}`);
+              isAuthorized = true;
             }
 
             // If not authorized by app check, verify human has write access

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -19,21 +19,52 @@ jobs:
         with:
           script: |
             const adder = context.payload.sender.login;
+            const senderType = context.payload.sender.type;
             const pr = context.payload.pull_request;
+            const installation = context.payload.installation;
 
-            // Verify label adder has write access
-            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: adder,
-            });
+            // Trusted GitHub App IDs that can add labels to trigger CI
+            // Graphite App: https://github.com/apps/graphite-app
+            const GRAPHITE_APP_ID = 15497;
+            const trustedAppIds = [GRAPHITE_APP_ID];
 
-            if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
-              core.setFailed(`${adder} does not have write access`);
-              return;
+            let isAuthorized = false;
+
+            // Check if this is a GitHub App (Bot) with an installation context
+            if (senderType === 'Bot' && installation?.id) {
+              try {
+                // Get the installation details to verify the app_id
+                const { data: installationData } = await github.rest.apps.getInstallation({
+                  installation_id: installation.id,
+                });
+
+                if (trustedAppIds.includes(installationData.app_id)) {
+                  console.log(`Label added by trusted GitHub App: ${adder} (app_id: ${installationData.app_id})`);
+                  isAuthorized = true;
+                } else {
+                  console.log(`GitHub App ${adder} (app_id: ${installationData.app_id}) is not in the trusted list`);
+                }
+              } catch (error) {
+                console.log(`Could not verify GitHub App installation: ${error.message}`);
+                // Fall through to human permission check
+              }
             }
 
-            console.log(`Label added by ${adder} (${perm.permission})`);
+            // If not authorized by app check, verify human has write access
+            if (!isAuthorized) {
+              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: adder,
+              });
+
+              if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
+                core.setFailed(`${adder} does not have write access`);
+                return;
+              }
+
+              console.log(`Label added by ${adder} (${perm.permission})`);
+            }
 
             // Find the latest pr.yml run for this PR's head SHA
             const { data: runs } = await github.rest.actions.listWorkflowRuns({

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,26 +21,19 @@ jobs:
             const adder = context.payload.sender.login;
             const pr = context.payload.pull_request;
 
-            // Trusted bots that can add labels to trigger CI
-            const trustedBots = ['graphite-app[bot]'];
+            // Verify label adder has write access
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: adder,
+            });
 
-            // Verify label adder has write access (skip for trusted bots)
-            if (!trustedBots.includes(adder)) {
-              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username: adder,
-              });
-
-              if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
-                core.setFailed(`${adder} does not have write access`);
-                return;
-              }
-
-              console.log(`Label added by ${adder} (${perm.permission})`);
-            } else {
-              console.log(`Label added by trusted bot: ${adder}`);
+            if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
+              core.setFailed(`${adder} does not have write access`);
+              return;
             }
+
+            console.log(`Label added by ${adder} (${perm.permission})`);
 
             // Find the latest pr.yml run for this PR's head SHA
             const { data: runs } = await github.rest.actions.listWorkflowRuns({

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,19 +21,26 @@ jobs:
             const adder = context.payload.sender.login;
             const pr = context.payload.pull_request;
 
-            // Verify label adder has write access
-            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: adder,
-            });
+            // Trusted bots that can add labels to trigger CI
+            const trustedBots = ['graphite-app[bot]'];
 
-            if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
-              core.setFailed(`${adder} does not have write access`);
-              return;
+            // Verify label adder has write access (skip for trusted bots)
+            if (!trustedBots.includes(adder)) {
+              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: adder,
+              });
+
+              if (!['admin', 'maintain', 'write'].includes(perm.permission)) {
+                core.setFailed(`${adder} does not have write access`);
+                return;
+              }
+
+              console.log(`Label added by ${adder} (${perm.permission})`);
+            } else {
+              console.log(`Label added by trusted bot: ${adder}`);
             }
-
-            console.log(`Label added by ${adder} (${perm.permission})`);
 
             // Find the latest pr.yml run for this PR's head SHA
             const { data: runs } = await github.rest.actions.listWorkflowRuns({
@@ -56,13 +63,52 @@ jobs:
 
             const latestRun = matchingRuns[0];
 
-            // Check if workflow is still running - can't re-run in-progress workflows
+            // If workflow is still running, cancel it first then re-run
             if (latestRun.status === 'in_progress' || latestRun.status === 'queued') {
-              core.setFailed(`Workflow is still running (status: ${latestRun.status}). Wait for it to complete or cancel it first.`);
-              return;
+              console.log(`Workflow is running (status: ${latestRun.status}). Cancelling it first...`);
+
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: latestRun.id,
+              });
+
+              // Wait for the workflow to be cancelled (poll with timeout)
+              const maxWaitTime = 60000; // 60 seconds
+              const pollInterval = 2000; // 2 seconds
+              const startTime = Date.now();
+
+              while (Date.now() - startTime < maxWaitTime) {
+                await new Promise(resolve => setTimeout(resolve, pollInterval));
+
+                const { data: updatedRun } = await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: latestRun.id,
+                });
+
+                if (updatedRun.status === 'completed') {
+                  console.log(`Workflow cancelled successfully (conclusion: ${updatedRun.conclusion})`);
+                  break;
+                }
+
+                console.log(`Waiting for workflow to cancel... (status: ${updatedRun.status})`);
+              }
+
+              // Check final status
+              const { data: finalRun } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: latestRun.id,
+              });
+
+              if (finalRun.status !== 'completed') {
+                core.setFailed(`Timed out waiting for workflow to cancel (status: ${finalRun.status})`);
+                return;
+              }
             }
 
-            console.log(`Re-running workflow ${latestRun.id} (was: ${latestRun.conclusion})`);
+            console.log(`Re-running workflow ${latestRun.id} (was: ${latestRun.conclusion || latestRun.status})`);
 
             // Re-run preserves original context (PR, SHA, etc.)
             await github.rest.actions.reRunWorkflow({

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -23,22 +23,14 @@ jobs:
             const pr = context.payload.pull_request;
             const installation = context.payload.installation;
 
-            // Trusted GitHub App bot logins that can add labels to trigger CI
-            // These are verified by checking sender.type === 'Bot' AND presence of installation context
-            // The installation object is GitHub-generated and cannot be forged by contributors
             const trustedBotLogins = ['graphite-app[bot]'];
-
             let isAuthorized = false;
 
-            // Check if this is a trusted GitHub App (Bot) with an installation context
-            // The combination of sender.type === 'Bot' + installation context + known bot login
-            // provides sufficient verification since the payload comes from GitHub
             if (senderType === 'Bot' && installation && trustedBotLogins.includes(adder)) {
               console.log(`Label added by trusted GitHub App: ${adder}`);
               isAuthorized = true;
             }
 
-            // If not authorized by app check, verify human has write access
             if (!isAuthorized) {
               const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,


### PR DESCRIPTION
## What does this PR do?

Improves the `run-ci.yml` workflow that triggers CI when `run-ci` or `ready-for-e2e` labels are added to PRs.

**1. Cancel and re-run instead of failing**: Previously, if a workflow was already running when the label was added, the job would fail with an error asking the user to wait or cancel manually. Now it automatically cancels the running workflow, waits for cancellation to complete (with a 60-second timeout), and then re-runs it.

**2. Allow trusted GitHub Apps to trigger CI**: Previously, GitHub Apps like `graphite-app[bot]` would fail the permission check because `getCollaboratorPermissionLevel` only works for human users. Now the workflow checks:
- `sender.type === 'Bot'`
- Presence of `installation` context in the payload
- Bot login matches a trusted list (`graphite-app[bot]`)

This combination provides sufficient verification since the payload (including `sender.type` and `installation`) comes from GitHub and cannot be forged by contributors.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, tested manually after merge.

## How should this be tested?

**Note**: Since `run-ci.yml` uses `pull_request_target`, GitHub runs the workflow YAML from the base branch (`main`). This means the new logic won't execute until this PR is merged.

**After merging**, test:
1. **Cancel and re-run**: Open a PR, let CI start running, add `run-ci` label while in progress - verify it cancels and re-runs
2. **Graphite integration**: Have Graphite add a `run-ci` or `ready-for-e2e` label - verify it triggers successfully without permission errors

## Human Review Checklist

- [ ] Verify the bot login string `graphite-app[bot]` matches what GitHub reports in the event payload
- [ ] Review the 60-second timeout and 2-second polling interval for the cancellation wait loop
- [ ] Confirm the security model is acceptable: trusting `sender.type === 'Bot'` + `installation` context + known bot login
- [ ] Note: Cannot be tested until merged due to `pull_request_target` behavior

---

Link to Devin run: https://app.devin.ai/sessions/437e4ef5d03e454d8a97cb59a03782a5
Requested by: keith@cal.com (@keithwillcode)