### PR TITLE
refactor: move WebWrapper files from @calcom/atoms to @calcom/web to fix circular dependency

### DIFF
--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
@@ -6,7 +6,7 @@ import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 
-import { EventTypeWebWrapper } from "@calcom/atoms/event-types/wrappers/EventTypeWebWrapper";
+import { EventTypeWebWrapper } from "@calcom/web/modules/event-types/wrappers/EventTypeWebWrapper";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import { getEventTypePermissions } from "@calcom/features/pbac/lib/event-type-permissions";
 import { eventTypesRouter } from "@calcom/trpc/server/routers/viewer/eventTypes/_router";

--- a/apps/web/modules/event-types/components/locations/Locations.tsx
+++ b/apps/web/modules/event-types/components/locations/Locations.tsx
@@ -7,7 +7,6 @@ import type { UseFormGetValues, UseFormSetValue, Control, FormState } from "reac
 
 import type { EventLocationType } from "@calcom/app-store/locations";
 import { getEventLocationType, MeetLocationType } from "@calcom/app-store/locations";
-import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import type { LocationCustomClassNames } from "@calcom/features/eventtypes/components/locations/types";
 import type { LocationFormValues, EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types";
 import CheckboxField from "@calcom/features/form/components/CheckboxField";
@@ -45,6 +44,7 @@ type LocationsProps = {
   locationOptions: TLocationOptions;
   prefillLocation?: SingleValueLocationOption;
   customClassNames?: LocationCustomClassNames;
+  isPlatform?: boolean;
 };
 
 const getLocationFromType = (type: EventLocationType["type"], locationOptions: TLocationOptions) => {
@@ -94,6 +94,7 @@ const Locations: React.FC<LocationsProps> = ({
   eventType,
   prefillLocation,
   customClassNames,
+  isPlatform = false,
   ...props
 }) => {
   const { t } = useLocale();
@@ -162,8 +163,6 @@ const Locations: React.FC<LocationsProps> = ({
       }
     }
   }, [prefillLocation, seatsEnabled, validLocations, append]);
-
-  const isPlatform = useIsPlatform();
 
   return (
     <div className={classNames("w-full", customClassNames?.container)}>

--- a/apps/web/modules/event-types/components/tabs/availability/EventAvailabilityTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/availability/EventAvailabilityTab.tsx
@@ -5,7 +5,7 @@ import { Controller, useFormContext } from "react-hook-form";
 import type { OptionProps, SingleValueProps } from "react-select";
 import { components } from "react-select";
 
-import type { GetAllSchedulesByUserIdQueryType } from "@calcom/atoms/event-types/wrappers/EventAvailabilityTabWebWrapper";
+import type { GetAllSchedulesByUserIdQueryType } from "@calcom/web/modules/event-types/wrappers/EventAvailabilityTabWebWrapper";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import dayjs from "@calcom/dayjs";
 import { SelectSkeletonLoader } from "@calcom/features/availability/components/SkeletonLoader";

--- a/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/setup/EventSetupTab.tsx
@@ -3,7 +3,6 @@ import { Controller, useFormContext } from "react-hook-form";
 import type { UseFormGetValues, UseFormSetValue, Control, FormState } from "react-hook-form";
 import type { MultiValue } from "react-select";
 
-import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
 import type { LocationCustomClassNames } from "@calcom/features/eventtypes/components/locations/types";
 import type {
@@ -65,10 +64,11 @@ export const EventSetupTab = (
     hasOrgBranding: boolean;
     orgId?: number;
     localeOptions?: { value: string; label: string }[];
+    isPlatform?: boolean;
   }
 ) => {
   const { t } = useLocale();
-  const isPlatform = useIsPlatform();
+  const isPlatform = props.isPlatform ?? false;
   const formMethods = useFormContext<FormValues>();
   const { eventType, team, urlPrefix, hasOrgBranding, customClassNames, orgId } = props;
 

--- a/apps/web/modules/event-types/wrappers/EventAdvancedWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventAdvancedWebWrapper.tsx
@@ -1,7 +1,8 @@
 import { localeOptions } from "@calcom/lib/i18n";
 import { trpc } from "@calcom/trpc/react";
-import type { EventAdvancedBaseProps } from "@calcom/web/modules/event-types/components/tabs/advanced/EventAdvancedTab";
-import { EventAdvancedTab } from "@calcom/web/modules/event-types/components/tabs/advanced/EventAdvancedTab";
+
+import type { EventAdvancedBaseProps } from "../components/tabs/advanced/EventAdvancedTab";
+import { EventAdvancedTab } from "../components/tabs/advanced/EventAdvancedTab";
 
 const EventAdvancedWebWrapper = ({ ...props }: EventAdvancedBaseProps) => {
   const connectedCalendarsQuery = trpc.viewer.calendars.connectedCalendars.useQuery();

--- a/apps/web/modules/event-types/wrappers/EventAvailabilityTabWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventAvailabilityTabWebWrapper.tsx
@@ -6,7 +6,8 @@ import type { EventTypeSetup, FormValues } from "@calcom/features/eventtypes/lib
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
-import { EventAvailabilityTab } from "@calcom/web/modules/event-types/components/tabs/availability/EventAvailabilityTab";
+
+import { EventAvailabilityTab } from "../components/tabs/availability/EventAvailabilityTab";
 
 export type EventAvailabilityTabWebWrapperProps = {
   eventType: EventTypeSetup;

--- a/apps/web/modules/event-types/wrappers/EventLimitsTabWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventLimitsTabWebWrapper.tsx
@@ -1,0 +1,8 @@
+import { EventLimitsTab } from "../components/tabs/limits/EventLimitsTab";
+import type { EventLimitsTabProps } from "../components/tabs/limits/EventLimitsTab";
+
+const EventLimitsTabWebWrapper = (props: EventLimitsTabProps) => {
+  return <EventLimitsTab {...props} />;
+};
+
+export default EventLimitsTabWebWrapper;

--- a/apps/web/modules/event-types/wrappers/EventRecurringWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventRecurringWebWrapper.tsx
@@ -1,0 +1,8 @@
+import type { EventRecurringTabProps } from "../components/tabs/recurring/EventRecurringTab";
+import { EventRecurringTab } from "../components/tabs/recurring/EventRecurringTab";
+
+const EventRecurringWebWrapper = (props: EventRecurringTabProps) => {
+  return <EventRecurringTab {...props} />;
+};
+
+export default EventRecurringWebWrapper;

--- a/apps/web/modules/event-types/wrappers/EventSetupTabWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventSetupTabWebWrapper.tsx
@@ -3,8 +3,9 @@ import { useSession } from "next-auth/react";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { localeOptions } from "@calcom/lib/i18n";
-import type { EventSetupTabProps } from "@calcom/web/modules/event-types/components/tabs/setup/EventSetupTab";
-import { EventSetupTab } from "@calcom/web/modules/event-types/components/tabs/setup/EventSetupTab";
+
+import type { EventSetupTabProps } from "../components/tabs/setup/EventSetupTab";
+import { EventSetupTab } from "../components/tabs/setup/EventSetupTab";
 
 const EventSetupTabWebWrapper = (props: EventSetupTabProps) => {
   const orgBranding = useOrgBranding();
@@ -18,6 +19,7 @@ const EventSetupTabWebWrapper = (props: EventSetupTabProps) => {
       hasOrgBranding={!!orgBranding}
       orgId={session.data?.user.org?.id}
       localeOptions={localeOptions}
+      isPlatform={false}
       {...props}
     />
   );

--- a/apps/web/modules/event-types/wrappers/EventTeamAssignmentTabWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventTeamAssignmentTabWebWrapper.tsx
@@ -1,7 +1,7 @@
 import {
   EventTeamAssignmentTab,
   type EventTeamAssignmentTabBaseProps,
-} from "@calcom/web/modules/event-types/components/tabs/assignment/EventTeamAssignmentTab";
+} from "../components/tabs/assignment/EventTeamAssignmentTab";
 
 const EventTeamAssignmentTabWebWrapper = (
   props: Omit<EventTeamAssignmentTabBaseProps, "isSegmentApplicable">

--- a/apps/web/modules/event-types/wrappers/EventTypeWebWrapper.tsx
+++ b/apps/web/modules/event-types/wrappers/EventTypeWebWrapper.tsx
@@ -20,14 +20,15 @@ import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
 import { showToast } from "@calcom/ui/components/toast";
+
 import { revalidateTeamEventTypeCache } from "@calcom/web/app/(booking-page-wrapper)/team/[slug]/[type]/actions";
 import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/event-types/[type]/actions";
 
 import { TRPCClientError } from "@trpc/react-query";
 
-import { useEventTypeForm } from "../hooks/useEventTypeForm";
-import { useHandleRouteChange } from "../hooks/useHandleRouteChange";
-import { useTabsNavigations } from "../hooks/useTabsNavigations";
+import { useEventTypeForm } from "@calcom/atoms/event-types/hooks/useEventTypeForm";
+import { useHandleRouteChange } from "@calcom/atoms/event-types/hooks/useHandleRouteChange";
+import { useTabsNavigations } from "@calcom/atoms/event-types/hooks/useTabsNavigations";
 
 type EventPermissions = {
   eventTypes: {
@@ -54,55 +55,50 @@ const AssignmentWarningDialog = dynamic(
 
 const EventSetupTab = dynamic(
   () =>
-    // import web wrapper when it's ready
     import("./EventSetupTabWebWrapper").then((mod) => mod),
   { loading: () => null }
 );
 
 const EventAvailabilityTab = dynamic(() =>
-  // import web wrapper when it's ready
   import("./EventAvailabilityTabWebWrapper").then((mod) => mod)
 );
 
 const EventTeamAssignmentTab = dynamic(() => import("./EventTeamAssignmentTabWebWrapper").then((mod) => mod));
 
 const EventLimitsTab = dynamic(() =>
-  // import web wrapper when it's ready
   import("./EventLimitsTabWebWrapper").then((mod) => mod)
 );
 
 const EventAdvancedTab = dynamic(() =>
-  // import web wrapper when it's ready
   import("./EventAdvancedWebWrapper").then((mod) => mod)
 );
 
 const EventInstantTab = dynamic(() =>
-  import("@calcom/web/modules/event-types/components/tabs/instant/EventInstantTab").then(
+  import("../components/tabs/instant/EventInstantTab").then(
     (mod) => mod.EventInstantTab
   )
 );
 
 const EventRecurringTab = dynamic(() =>
-  // import web wrapper when it's ready
   import("./EventRecurringWebWrapper").then((mod) => mod)
 );
 
 const EventAppsTab = dynamic(() =>
-  import("@calcom/web/modules/event-types/components/tabs/apps/EventAppsTab").then((mod) => mod.EventAppsTab)
+  import("../components/tabs/apps/EventAppsTab").then((mod) => mod.EventAppsTab)
 );
 
 const EventWorkflowsTab = dynamic(
-  () => import("@calcom/web/modules/event-types/components/tabs/workflows/EventWorkflowsTab")
+  () => import("../components/tabs/workflows/EventWorkflowsTab")
 );
 
 const EventWebhooksTab = dynamic(() =>
-  import("@calcom/web/modules/event-types/components/tabs/webhooks/EventWebhooksTab").then(
+  import("../components/tabs/webhooks/EventWebhooksTab").then(
     (mod) => mod.EventWebhooksTab
   )
 );
 
 const EventAITab = dynamic(() =>
-  import("@calcom/web/modules/event-types/components/tabs/ai/EventAITab").then((mod) => mod.EventAITab)
+  import("../components/tabs/ai/EventAITab").then((mod) => mod.EventAITab)
 );
 
 export type EventTypeWebWrapperProps = {

--- a/apps/web/modules/event-types/wrappers/index.ts
+++ b/apps/web/modules/event-types/wrappers/index.ts
@@ -1,0 +1,12 @@
+export { default as EventSetupTabWebWrapper } from "./EventSetupTabWebWrapper";
+export { default as EventAdvancedWebWrapper } from "./EventAdvancedWebWrapper";
+export { default as EventLimitsTabWebWrapper } from "./EventLimitsTabWebWrapper";
+export { default as EventRecurringWebWrapper } from "./EventRecurringWebWrapper";
+export { default as EventAvailabilityTabWebWrapper } from "./EventAvailabilityTabWebWrapper";
+export { default as EventTeamAssignmentTabWebWrapper } from "./EventTeamAssignmentTabWebWrapper";
+export { EventTypeWebWrapper } from "./EventTypeWebWrapper";
+export type { EventTypeWebWrapperProps } from "./EventTypeWebWrapper";
+export type {
+  EventAvailabilityTabWebWrapperProps,
+  GetAllSchedulesByUserIdQueryType,
+} from "./EventAvailabilityTabWebWrapper";

--- a/packages/platform/atoms/event-types/wrappers/EventLimitsTabWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventLimitsTabWebWrapper.tsx
@@ -1,8 +1,0 @@
-import { EventLimitsTab } from "@calcom/web/modules/event-types/components/tabs/limits/EventLimitsTab";
-import type { EventLimitsTabProps } from "@calcom/web/modules/event-types/components/tabs/limits/EventLimitsTab";
-
-const EventLimitsTabWebWrapper = (props: EventLimitsTabProps) => {
-  return <EventLimitsTab {...props} />;
-};
-
-export default EventLimitsTabWebWrapper;

--- a/packages/platform/atoms/event-types/wrappers/EventRecurringWebWrapper.tsx
+++ b/packages/platform/atoms/event-types/wrappers/EventRecurringWebWrapper.tsx
@@ -1,8 +1,0 @@
-import type { EventRecurringTabProps } from "@calcom/web/modules/event-types/components/tabs/recurring/EventRecurringTab";
-import { EventRecurringTab } from "@calcom/web/modules/event-types/components/tabs/recurring/EventRecurringTab";
-
-const EventRecurringWebWrapper = (props: EventRecurringTabProps) => {
-  return <EventRecurringTab {...props} />;
-};
-
-export default EventRecurringWebWrapper;

--- a/packages/platform/atoms/package.json
+++ b/packages/platform/atoms/package.json
@@ -62,7 +62,6 @@
     "./destination-calendar/wrappers/DestinationCalendarSettingsWebWrapper": "./destination-calendar/wrappers/DestinationCalendarSettingsWebWrapper.tsx",
     "./dist/index.ts": "./index.ts",
     "./dist/index.d.ts": "./dist/index.d.ts",
-    "./event-types/wrappers/EventTypeWebWrapper": "./event-types/wrappers/EventTypeWebWrapper.tsx",
     "./globals.min.css": "./globals.min.css",
     "./hooks/bookings/useHandleBookEvent": "./hooks/bookings/useHandleBookEvent.ts",
     "./hooks/useAtomsContext": "./hooks/useAtomsContext.ts",


### PR DESCRIPTION
## What does this PR do?

This is the first step in breaking the circular dependency between `@calcom/atoms` and `@calcom/web`. The goal is to ensure `@calcom/atoms` has no knowledge of `@calcom/web`, while `@calcom/web` can import from `@calcom/atoms`.

Changes:
- Move `EventTypeWebWrapper` and related WebWrapper files from `@calcom/atoms` to `@calcom/web/modules/event-types/wrappers/`
- Update imports in moved files to use relative paths instead of `@calcom/web/modules/...`
- Modify `EventSetupTab` and `Locations` components to accept `isPlatform` as a prop instead of using the `useIsPlatform` hook
- Remove `EventTypeWebWrapper` export from `@calcom/atoms` package.json

Note: This is a partial fix. Additional work is needed to address remaining circular dependencies in PlatformWrapper files, BaseCalProvider.tsx, and shell.tsx.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactoring only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Verify the event types page loads correctly at `/event-types/[type]`
2. Verify event type setup, availability, limits, recurring, advanced, and other tabs render properly
3. Verify no TypeScript errors with `yarn type-check:ci --force`
4. Verify no lint errors with `yarn lint`

## Checklist for Human Review

- [ ] Verify the removed `@calcom/atoms` export doesn't break any external consumers
- [ ] Confirm the `isPlatform` prop is correctly passed as `false` in web context (see `EventSetupTabWebWrapper.tsx`)
- [ ] Note: `EventAvailabilityTab` still uses `useIsPlatform` hook - this inconsistency is intentional for this partial refactor
- [ ] Verify dynamic imports in `EventTypeWebWrapper.tsx` resolve correctly with relative paths

---

Link to Devin run: https://app.devin.ai/sessions/0d603dcf6d484e96860513f6f186a781
Requested by: benny@cal.com (@hbjORbj)