### PR TITLE
fix: remove installation requirement from trusted bot check

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,13 +20,16 @@ jobs:
           script: |
             const adder = context.payload.sender.login;
             const senderType = context.payload.sender.type;
+            const senderId = context.payload.sender.id;
             const pr = context.payload.pull_request;
+
+            console.log(`Sender: ${adder} (type: ${senderType}, id: ${senderId})`);
 
             const trustedBotLogins = ['graphite-app[bot]'];
             let isAuthorized = false;
 
             if (senderType === 'Bot' && trustedBotLogins.includes(adder)) {
-              console.log(`Label added by trusted GitHub App: ${adder}`);
+              console.log(`Authorized: trusted GitHub App`);
               isAuthorized = true;
             }
 

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -44,7 +44,7 @@ jobs:
                 return;
               }
 
-              console.log(`Label added by ${adder} (${perm.permission})`);
+              console.log(`Label added by ${adder}`);
             }
 
             // Find the latest pr.yml run for this PR's head SHA

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,12 +21,11 @@ jobs:
             const adder = context.payload.sender.login;
             const senderType = context.payload.sender.type;
             const pr = context.payload.pull_request;
-            const installation = context.payload.installation;
 
             const trustedBotLogins = ['graphite-app[bot]'];
             let isAuthorized = false;
 
-            if (senderType === 'Bot' && installation && trustedBotLogins.includes(adder)) {
+            if (senderType === 'Bot' && trustedBotLogins.includes(adder)) {
               console.log(`Label added by trusted GitHub App: ${adder}`);
               isAuthorized = true;
             }

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,10 +20,9 @@ jobs:
           script: |
             const adder = context.payload.sender.login;
             const senderType = context.payload.sender.type;
-            const senderId = context.payload.sender.id;
             const pr = context.payload.pull_request;
 
-            console.log(`Sender: ${adder} (type: ${senderType}, id: ${senderId})`);
+            console.log(`Sender: ${adder} (type: ${senderType})`);
 
             const trustedBotLogins = ['graphite-app[bot]'];
             let isAuthorized = false;


### PR DESCRIPTION
## What does this PR do?

Fixes the `graphite-app[bot]` authorization failure in the `run-ci.yml` workflow.

The previous implementation required the `installation` object to be present in the webhook payload when checking for trusted bots:
```javascript
if (senderType === 'Bot' && installation && trustedBotLogins.includes(adder))
```

However, the `installation` object is not present in `pull_request_target` `labeled` event payloads when GitHub Apps add labels. This caused `graphite-app[bot]` to fail the bot check and fall through to the human permission check, which fails for bots.

The fix removes the `installation` requirement and relies on:
- `sender.type === 'Bot'`
- `sender.login` matching the trusted bot list (`graphite-app[bot]`)

This is secure because the sender fields come from GitHub's webhook payload and cannot be forged by contributors.

### Updates since last revision

Added extra logging to help debug future issues:
- Logs sender login, type, and id at the start of the workflow
- This will help verify the sender type when Graphite triggers the workflow

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, tested after merge.

## How should this be tested?

Since `run-ci.yml` uses `pull_request_target`, the workflow YAML runs from the base branch (`main`). This means the fix can only be tested after merging.

**After merging**, have Graphite add a `run-ci` or `ready-for-e2e` label to a PR and verify:
1. The workflow logs show `Sender: graphite-app[bot] (type: Bot, id: ...)`
2. The workflow logs show `Authorized: trusted GitHub App`
3. CI triggers successfully without permission errors

## Human Review Checklist

- [ ] Verify the security model is acceptable: trusting `sender.type === 'Bot'` + known bot login from GitHub's webhook payload
- [ ] Confirm the trusted bot list remains tight (only `graphite-app[bot]`)
- [ ] Note: Cannot be tested until merged due to `pull_request_target` behavior

---

Link to Devin run: https://app.devin.ai/sessions/437e4ef5d03e454d8a97cb59a03782a5
Requested by: keith@cal.com (@keithwillcode)