### PR TITLE
docs: add OAuth documentation and expose v2 endpoints

### DIFF
--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -94,13 +94,16 @@ export class OAuthFlowController {
     description: `Exchange the authorization code received from the authorize endpoint for access and refresh tokens. ${TOKENS_DOCS}`,
   })
   async exchange(
-    @Headers("Authorization") authorization: string,
+    @Headers("Authorization") authorization: string | undefined,
     @Param("clientId") clientId: string,
     @Body() body: ExchangeAuthorizationCodeInput
   ): Promise<KeysResponseDto> {
-    const authorizeEndpointCode = authorization.replace("Bearer ", "").trim();
+    if (!authorization || !authorization.startsWith("Bearer ")) {
+      throw new BadRequestException("Missing or invalid 'Authorization: Bearer <code>' header.");
+    }
+    const authorizeEndpointCode = authorization.slice(7).trim();
     if (!authorizeEndpointCode) {
-      throw new BadRequestException("Missing 'Bearer' Authorization header.");
+      throw new BadRequestException("Authorization code is empty.");
     }
 
     const tokens = await this.oAuthFlowService.exchangeAuthorizationToken(

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -22,12 +22,7 @@ import {
   Response,
   UseGuards,
 } from "@nestjs/common";
-import {
-  ApiTags as DocsTags,
-  ApiExcludeEndpoint as DocsExcludeEndpoint,
-  ApiHeader as DocsHeader,
-  ApiOperation,
-} from "@nestjs/swagger";
+import { ApiTags as DocsTags, ApiHeader as DocsHeader, ApiOperation } from "@nestjs/swagger";
 import { Response as ExpressResponse } from "express";
 
 import { SUCCESS_STATUS, X_CAL_SECRET_KEY } from "@calcom/platform-constants";
@@ -49,7 +44,12 @@ export class OAuthFlowController {
   @Post("/authorize")
   @HttpCode(HttpStatus.OK)
   @UseGuards(NextAuthGuard)
-  @DocsExcludeEndpoint()
+  @DocsTags("Platform / OAuth")
+  @ApiOperation({
+    summary: "Authorize a user",
+    description:
+      "Initiate the OAuth authorization flow. The user must have an active Cal.com session. On success, redirects to the provided redirectUri with an authorization code.",
+  })
   async authorize(
     @Param("clientId") clientId: string,
     @Body() body: OAuthAuthorizeInput,
@@ -83,7 +83,16 @@ export class OAuthFlowController {
 
   @Post("/exchange")
   @HttpCode(HttpStatus.OK)
-  @DocsExcludeEndpoint()
+  @DocsTags("Platform / OAuth")
+  @DocsHeader({
+    name: "Authorization",
+    description: "Bearer <authorization_code> from the authorize redirect.",
+    required: true,
+  })
+  @ApiOperation({
+    summary: "Exchange authorization code for tokens",
+    description: `Exchange the authorization code received from the authorize endpoint for access and refresh tokens. ${TOKENS_DOCS}`,
+  })
   async exchange(
     @Headers("Authorization") authorization: string,
     @Param("clientId") clientId: string,

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -210,6 +210,7 @@
         "platform/introduction",
         "platform/setup",
         "platform/quickstart",
+        "oauth",
         {
           "group": "Atoms",
           "icon": "atom",

--- a/docs/oauth.mdx
+++ b/docs/oauth.mdx
@@ -1,0 +1,44 @@
+---
+title: OAuth
+description: Authorize apps and platform integrations with Cal.com accounts.
+icon: "key"
+---
+
+Cal.com OAuth lets your app request access to a user's Cal.com account and call API v2 on their behalf.
+For a high-level overview, see the help article: https://cal.com/help/apps-and-integrations/oauth.
+
+## Get an OAuth client
+- Platform customers can create a client in the dashboard: https://app.cal.com/settings/platform/oauth-clients/create.
+- If you do not yet have a platform subscription, start here: https://app.cal.com/settings/platform/new.
+
+## OAuth flow (API v2)
+1. Authorize the user (requires an active Cal.com session):
+   `POST https://api.cal.com/v2/oauth/{clientId}/authorize` with body `{"redirectUri":"https://your.app/oauth/callback"}`.
+   The response is a 302 redirect to your `redirectUri` with `code=...`.
+2. Exchange the code for tokens:
+   `POST https://api.cal.com/v2/oauth/{clientId}/exchange` with header `Authorization: Bearer <code>`
+   and body `{"clientSecret":"<client secret>"}`.
+3. Refresh tokens:
+   `POST https://api.cal.com/v2/oauth/{clientId}/refresh` with header
+   `x-cal-secret-key: <client secret>` and body `{"refreshToken":"<refresh token>"}`.
+
+Access tokens are valid for 60 minutes and refresh tokens for 1 year. Store them server-side.
+
+## Manage clients and users
+Use API v2 to create and manage OAuth clients and managed users:
+- `POST /v2/oauth-clients`
+- `GET /v2/oauth-clients`
+- `PATCH /v2/oauth-clients/{clientId}`
+- `DELETE /v2/oauth-clients/{clientId}`
+- `POST /v2/oauth-clients/{clientId}/users`
+
+See the full [API reference](/api-reference/v2).
+
+## Badges
+Use the official "Continue with Cal.com" badge in your auth UI:
+
+<img src="https://app.cal.com/continue-with-calcom-coss-ui.svg" alt="Continue with Cal.com" />
+
+```html
+<img src="https://app.cal.com/continue-with-calcom-coss-ui.svg" alt="Continue with Cal.com" />
+```


### PR DESCRIPTION
## Summary
- Add `docs/oauth.mdx` with OAuth flow guide, self-serve platform paths, and official badge snippet
- Add oauth to Platform navigation in `docs/mint.json`
- Remove `@DocsExcludeEndpoint` from `/authorize` and `/exchange` endpoints to expose them in OpenAPI
- Add proper API documentation decorators under "Platform / OAuth" tag

## Test plan
- [ ] Verify `docs/oauth.mdx` renders correctly in Mintlify
- [ ] Confirm oauth appears in Platform navigation
- [ ] After swagger regeneration, verify `/authorize` and `/exchange` appear in API reference

Closes #26469, #26470, #26471

