### PR TITLE
docs: add DTO location and naming conventions to knowledge base

### DIFF
--- a/agents/knowledge-base.md
+++ b/agents/knowledge-base.md
@@ -420,6 +420,30 @@ export interface BookingDTO {
 }
 ```
 
+### DTO Location and Naming
+
+**Location rules** (based on reuse, not code age):
+- DTOs reused across domains → `packages/lib/dto/`
+- DTOs internal to one domain → `packages/features/{domain}/dto/`
+
+**Naming conventions**:
+- Base entity: `{Entity}Dto` (e.g., `BookingDto`)
+- With relations: `{Entity}With{Relations}Dto` (e.g., `BookingWithAttendeesDto`)
+- For specific projections: `{Entity}For{Purpose}Dto` (e.g., `BookingForConfirmationDto`)
+- Avoid: `{Entity}Dto2`, `{Entity}DtoForHandler`, or other use-case-specific names
+
+**Enum/union pattern** – use string literal unions to stay ORM-agnostic:
+
+```typescript
+// ✅ Good - ORM-agnostic string literal union
+export type BookingStatusDto = "CANCELLED" | "ACCEPTED" | "REJECTED" | "PENDING";
+
+// ❌ Bad - importing Prisma enum
+import { BookingStatus } from "@calcom/prisma/client";
+```
+
+**Type safety** – never use `as any` in DTO mapping functions. If types don't align, fix the mapping explicitly.
+
 ### Prisma boundaries
 
 - **Allowed**: `packages/prisma`, repository implementations (`packages/features/**/repositories/*Repository.ts`), and low-level data access infrastructure.

--- a/agents/knowledge-base.md
+++ b/agents/knowledge-base.md
@@ -422,9 +422,10 @@ export interface BookingDTO {
 
 ### DTO Location and Naming
 
-**Location rules** (based on reuse, not code age):
-- DTOs reused across domains → `packages/lib/dto/`
-- DTOs internal to one domain → `packages/features/{domain}/dto/`
+**Location rules**:
+- **New features**: Always put DTOs in `packages/features/{domain}/dto/`
+- **Refactored code**: DTOs for code being migrated to the repository pattern go in `packages/lib/dto/`
+- **Truly global DTOs**: Only DTOs genuinely shared across multiple domains belong in `packages/lib/dto/` – keep this minimal
 
 **Naming conventions**:
 - Base entity: `{Entity}Dto` (e.g., `BookingDto`)

--- a/agents/knowledge-base.md
+++ b/agents/knowledge-base.md
@@ -422,10 +422,7 @@ export interface BookingDTO {
 
 ### DTO Location and Naming
 
-**Location rules**:
-- **New features**: Always put DTOs in `packages/features/{domain}/dto/`
-- **Refactored code**: DTOs for code being migrated to the repository pattern go in `packages/lib/dto/`
-- **Truly global DTOs**: Only DTOs genuinely shared across multiple domains belong in `packages/lib/dto/` – keep this minimal
+**Location**: All DTOs go in `packages/lib/dto/`
 
 **Naming conventions**:
 - Base entity: `{Entity}Dto` (e.g., `BookingDto`)


### PR DESCRIPTION
## What does this PR do?

Adds DTO (Data Transfer Object) location and naming conventions to the knowledge base, complementing the existing Repository + DTO Pattern section. This follows the team discussion on PR #25844 about establishing consistent patterns for DTOs.

**Conventions added:**
- **Location**: All DTOs go in `packages/lib/dto/`
- **Naming conventions**: `{Entity}Dto`, `{Entity}With{Relations}Dto`, `{Entity}For{Purpose}Dto`
- **Enum/union pattern**: Use string literal unions instead of Prisma enums to stay ORM-agnostic
- **Type safety**: No `as any` in DTO mapping functions

### Updates since last revision

- Simplified location rules: all DTOs now go in `packages/lib/dto/` (previously had split between domain-specific and shared paths)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - this is a knowledge base update for AI agents.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - documentation only.

## How should this be tested?

This is a documentation-only change. Review the conventions to ensure they align with team expectations from the PR #25844 discussion.

## Human Review Checklist

- [ ] Verify the simplified location rule (all DTOs in `packages/lib/dto/`) matches team consensus
- [ ] Confirm naming conventions are clear and follow existing patterns in the codebase

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/023b65f15a174608972938441f9d5520
Requested by: eunjae@cal.com (@eunjae-lee)