### PR TITLE
chore: Disable noReactSpecificProps as we use react

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -121,7 +121,6 @@
             "noImgElement": "warn"
           },
           "suspicious": {
-            "noReactSpecificProps": "warn",
             "noDoubleEquals": "warn",
             "noAssignInExpressions": "warn",
             "noExplicitAny": "warn",


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the noReactSpecificProps lint rule in Biome to match our React codebase and remove unnecessary warnings. This keeps linting relevant and avoids false positives.

<sup>Written for commit 41727258ccc9c69f8e14ffd387f680f15d6846fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

