### PR TITLE
refactor(web): remove ~ alias and use @calcom/web/modules directly

### DIFF
--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/embed/page.tsx
@@ -9,7 +9,7 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/[type]/getServerSideProps";
 
-import TypePage, { type PageProps as ClientPageProps } from "~/users/views/users-type-public-view";
+import TypePage, { type PageProps as ClientPageProps } from "@calcom/web/modules/users/views/users-type-public-view";
 
 export const generateMetadata = async () => {
   return {

--- a/apps/web/app/(booking-page-wrapper)/[user]/[type]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/[type]/page.tsx
@@ -11,8 +11,8 @@ import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/[type]/getServerSideProps";
 
-import type { PageProps as LegacyPageProps } from "~/users/views/users-type-public-view";
-import LegacyPage from "~/users/views/users-type-public-view";
+import type { PageProps as LegacyPageProps } from "@calcom/web/modules/users/views/users-type-public-view";
+import LegacyPage from "@calcom/web/modules/users/views/users-type-public-view";
 
 export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/[user]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/embed/page.tsx
@@ -6,7 +6,7 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/getServerSideProps";
 
-import User, { type PageProps as ClientPageProps } from "~/users/views/users-public-view";
+import User, { type PageProps as ClientPageProps } from "@calcom/web/modules/users/views/users-public-view";
 
 export const generateMetadata = async () => {
   return {

--- a/apps/web/app/(booking-page-wrapper)/[user]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/[user]/page.tsx
@@ -9,8 +9,8 @@ import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/[user]/getServerSideProps";
 
-import type { PageProps as LegacyPageProps } from "~/users/views/users-public-view";
-import LegacyPage from "~/users/views/users-public-view";
+import type { PageProps as LegacyPageProps } from "@calcom/web/modules/users/views/users-public-view";
+import LegacyPage from "@calcom/web/modules/users/views/users-public-view";
 
 export const generateMetadata = async ({ params, searchParams }: PageProps) => {
   const props = await getData(

--- a/apps/web/app/(booking-page-wrapper)/booking-successful/[uid]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking-successful/[uid]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams } from "next/navigation";
 
 import dayjs from "@calcom/dayjs";
-import { DecoyBookingSuccessCard } from "~/bookings/components/DecoyBookingSuccessCard";
+import { DecoyBookingSuccessCard } from "@calcom/web/modules/bookings/components/DecoyBookingSuccessCard";
 import { useDecoyBooking } from "@calcom/features/bookings/Booker/components/hooks/useDecoyBooking";
 
 export default function BookingSuccessful() {

--- a/apps/web/app/(booking-page-wrapper)/booking/[uid]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking/[uid]/embed/page.tsx
@@ -7,11 +7,11 @@ import { loadTranslations } from "@calcom/lib/server/i18n";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import OldPage from "~/bookings/views/bookings-single-view";
+import OldPage from "@calcom/web/modules/bookings/views/bookings-single-view";
 import {
   getServerSideProps,
   type PageProps as ClientPageProps,
-} from "~/bookings/views/bookings-single-view.getServerSideProps";
+} from "@calcom/web/modules/bookings/views/bookings-single-view.getServerSideProps";
 
 export const metadata = {
   robots: {

--- a/apps/web/app/(booking-page-wrapper)/booking/[uid]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking/[uid]/page.tsx
@@ -10,11 +10,11 @@ import { BookingStatus } from "@calcom/prisma/enums";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import OldPage from "~/bookings/views/bookings-single-view";
+import OldPage from "@calcom/web/modules/bookings/views/bookings-single-view";
 import {
   getServerSideProps,
   type PageProps as ClientPageProps,
-} from "~/bookings/views/bookings-single-view.getServerSideProps";
+} from "@calcom/web/modules/bookings/views/bookings-single-view.getServerSideProps";
 
 const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
 

--- a/apps/web/app/(booking-page-wrapper)/booking/dry-run-successful/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/booking/dry-run-successful/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import BookingDryRunSuccessView from "~/bookings/views/booking-dry-run-success-view";
+import BookingDryRunSuccessView from "@calcom/web/modules/bookings/views/booking-dry-run-success-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(booking-page-wrapper)/d/[link]/[slug]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/d/[link]/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 import { type PageProps } from "@lib/d/[link]/[slug]/getServerSideProps";
 
-import Type from "~/d/[link]/d-type-view";
+import Type from "@calcom/web/modules/d/[link]/d-type-view";
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const _params = await params;

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/[type]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/[type]/embed/page.tsx
@@ -8,10 +8,10 @@ import { loadTranslations } from "@calcom/lib/server/i18n";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/[type]/getServerSideProps";
 
-import type { PageProps as TeamTypePageProps } from "~/team/type-view";
-import TeamTypePage from "~/team/type-view";
-import UserTypePage from "~/users/views/users-type-public-view";
-import type { PageProps as UserTypePageProps } from "~/users/views/users-type-public-view";
+import type { PageProps as TeamTypePageProps } from "@calcom/web/modules/team/type-view";
+import TeamTypePage from "@calcom/web/modules/team/type-view";
+import UserTypePage from "@calcom/web/modules/users/views/users-type-public-view";
+import type { PageProps as UserTypePageProps } from "@calcom/web/modules/users/views/users-type-public-view";
 
 const getData = withEmbedSsrAppDir<ClientPageProps>(getServerSideProps);
 

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/[type]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/[type]/page.tsx
@@ -10,10 +10,10 @@ import { loadTranslations } from "@calcom/lib/server/i18n";
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/[type]/getServerSideProps";
 
-import type { PageProps as TeamTypePageProps } from "~/team/type-view";
-import TeamTypePage from "~/team/type-view";
-import UserTypePage from "~/users/views/users-type-public-view";
-import type { PageProps as UserTypePageProps } from "~/users/views/users-type-public-view";
+import type { PageProps as TeamTypePageProps } from "@calcom/web/modules/team/type-view";
+import TeamTypePage from "@calcom/web/modules/team/type-view";
+import UserTypePage from "@calcom/web/modules/users/views/users-type-public-view";
+import type { PageProps as UserTypePageProps } from "@calcom/web/modules/users/views/users-type-public-view";
 
 export type OrgTypePageProps = UserTypePageProps | TeamTypePageProps;
 const getData = withAppDirSsr<OrgTypePageProps>(getServerSideProps);

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/embed/page.tsx
@@ -5,10 +5,10 @@ import { cookies, headers } from "next/headers";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/getServerSideProps";
 
-import type { PageProps as TeamPageProps } from "~/team/team-view";
-import TeamPage from "~/team/team-view";
-import UserPage from "~/users/views/users-public-view";
-import type { PageProps as UserPageProps } from "~/users/views/users-public-view";
+import type { PageProps as TeamPageProps } from "@calcom/web/modules/team/team-view";
+import TeamPage from "@calcom/web/modules/team/team-view";
+import UserPage from "@calcom/web/modules/users/views/users-public-view";
+import type { PageProps as UserPageProps } from "@calcom/web/modules/users/views/users-public-view";
 
 const getData = withEmbedSsrAppDir<ClientPageProps>(getServerSideProps);
 

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/[user]/page.tsx
@@ -9,10 +9,10 @@ import { getOrgOrTeamAvatar } from "@calcom/lib/defaultAvatarImage";
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/[user]/getServerSideProps";
 
-import type { PageProps as TeamPageProps } from "~/team/team-view";
-import TeamPage from "~/team/team-view";
-import UserPage from "~/users/views/users-public-view";
-import type { PageProps as UserPageProps } from "~/users/views/users-public-view";
+import type { PageProps as TeamPageProps } from "@calcom/web/modules/team/team-view";
+import TeamPage from "@calcom/web/modules/team/team-view";
+import UserPage from "@calcom/web/modules/users/views/users-public-view";
+import type { PageProps as UserPageProps } from "@calcom/web/modules/users/views/users-public-view";
 
 export type OrgPageProps = UserPageProps | TeamPageProps;
 const getData = withAppDirSsr<OrgPageProps>(getServerSideProps);

--- a/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/org/[orgSlug]/instant-meeting/team/[slug]/[type]/page.tsx
@@ -8,8 +8,8 @@ import { getOrgFullOrigin } from "@calcom/features/ee/organizations/lib/orgDomai
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/org/[orgSlug]/instant-meeting/team/[slug]/[type]/getServerSideProps";
 
-import type { Props } from "~/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-meeting-view";
-import Page from "~/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-meeting-view";
+import type { Props } from "@calcom/web/modules/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-meeting-view";
+import Page from "@calcom/web/modules/org/[orgSlug]/instant-meeting/team/[slug]/[type]/instant-meeting-view";
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const context = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/embed/page.tsx
@@ -8,7 +8,7 @@ import { loadTranslations } from "@calcom/lib/server/i18n";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
 
-import TypePage, { type PageProps as ClientPageProps } from "~/team/type-view";
+import TypePage, { type PageProps as ClientPageProps } from "@calcom/web/modules/team/type-view";
 
 export const generateMetadata = async () => {
   return {

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/page.tsx
@@ -12,8 +12,8 @@ import { prisma } from "@calcom/prisma";
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/team/[slug]/[type]/getServerSideProps";
 
-import LegacyPage from "~/team/type-view";
-import type { PageProps as LegacyPageProps } from "~/team/type-view";
+import LegacyPage from "@calcom/web/modules/team/type-view";
+import type { PageProps as LegacyPageProps } from "@calcom/web/modules/team/type-view";
 
 import CachedTeamBooker, {
   generateMetadata as generateCachedMetadata,

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/pageWithCachedData.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/[type]/pageWithCachedData.tsx
@@ -18,7 +18,7 @@ import { BookingStatus, RedirectType } from "@calcom/prisma/enums";
 import { buildLegacyCtx, buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { handleOrgRedirect } from "@lib/handleOrgRedirect";
 
-import CachedClientView, { type TeamBookingPageProps } from "~/team/type-view-cached";
+import CachedClientView, { type TeamBookingPageProps } from "@calcom/web/modules/team/type-view-cached";
 
 import { getCachedTeamData, getEnrichedEventType, getCRMData, shouldUseApiV2ForTeamSlots } from "./queries";
 

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/embed/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/embed/page.tsx
@@ -5,7 +5,7 @@ import { cookies, headers } from "next/headers";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/team/[slug]/getServerSideProps";
 
-import TeamPage, { type PageProps as ClientPageProps } from "~/team/team-view";
+import TeamPage, { type PageProps as ClientPageProps } from "@calcom/web/modules/team/team-view";
 
 export const generateMetadata = async () => {
   return {

--- a/apps/web/app/(booking-page-wrapper)/team/[slug]/page.tsx
+++ b/apps/web/app/(booking-page-wrapper)/team/[slug]/page.tsx
@@ -9,8 +9,8 @@ import { getOrgOrTeamAvatar } from "@calcom/lib/defaultAvatarImage";
 import { buildLegacyCtx, decodeParams } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/team/[slug]/getServerSideProps";
 
-import type { PageProps } from "~/team/team-view";
-import LegacyPage from "~/team/team-view";
+import type { PageProps } from "@calcom/web/modules/team/team-view";
+import LegacyPage from "@calcom/web/modules/team/team-view";
 
 export const generateMetadata = async ({ params, searchParams }: _PageProps) => {
   const { team, markdownStrippedBio, isSEOIndexable, currentOrgDomain } = await getData(

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDir.tsx
@@ -1,7 +1,7 @@
 import { ShellMainAppDirBackButton } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppDirBackButton";
 import classNames from "classnames";
 
-import type { LayoutProps } from "~/shell/Shell";
+import type { LayoutProps } from "@calcom/web/modules/shell/Shell";
 
 // Copied from `ShellMain` but with a different `ShellMainAppDirBackButton` import
 // for client/server component separation

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirBackButton.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/ShellMainAppDirBackButton.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 
 import { Button } from "@calcom/ui/components/button";
 
-import type { LayoutProps } from "~/shell/Shell";
+import type { LayoutProps } from "@calcom/web/modules/shell/Shell";
 
 export const ShellMainAppDirBackButton = ({ backPath }: { backPath: LayoutProps["backPath"] }) => {
   const router = useRouter();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
@@ -15,7 +15,7 @@ import { AvailabilitySliderTable } from "@calcom/web/modules/timezone-buddy/comp
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { AvailabilityList, AvailabilityCTA } from "~/availability/availability-view";
+import { AvailabilityList, AvailabilityCTA } from "@calcom/web/modules/availability/availability-view";
 
 import { ShellMainAppDir } from "../ShellMainAppDir";
 

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/skeleton.tsx
@@ -5,7 +5,7 @@ import { ShellMainAppDir } from "app/(use-page-wrapper)/(main-nav)/ShellMainAppD
 import SkeletonLoader from "@calcom/features/availability/components/SkeletonLoader";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import { AvailabilityCTA } from "~/availability/availability-view";
+import { AvailabilityCTA } from "@calcom/web/modules/availability/availability-view";
 
 export default function AvailabilityLoader() {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/bookings/[status]/page.tsx
@@ -13,8 +13,8 @@ import { MembershipRole } from "@calcom/prisma/enums";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { validStatuses } from "~/bookings/lib/validStatuses";
-import BookingsList from "~/bookings/views/bookings-view";
+import { validStatuses } from "@calcom/web/modules/bookings/lib/validStatuses";
+import BookingsList from "@calcom/web/modules/bookings/views/bookings-view";
 
 const querySchema = z.object({
   status: z.enum(validStatuses),

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -13,7 +13,7 @@ import { eventTypesRouter } from "@calcom/trpc/server/routers/viewer/eventTypes/
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import EventTypes, { EventTypesCTA } from "~/event-types/views/event-types-listing-view";
+import EventTypes, { EventTypesCTA } from "@calcom/web/modules/event-types/views/event-types-listing-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/layout.tsx
@@ -6,7 +6,7 @@ import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 const Layout = async ({ children }: { children: React.ReactNode }) => {
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -9,7 +9,7 @@ import { ErrorWithCode } from "@calcom/lib/errors";
 import prisma from "@calcom/prisma";
 import { MembershipRole } from "@calcom/prisma/enums";
 
-import { TeamsListing } from "~/ee/teams/components/TeamsListing";
+import { TeamsListing } from "@calcom/web/modules/ee/teams/components/TeamsListing";
 
 import { TeamsCTA } from "./CTA";
 

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/skeleton.tsx
@@ -5,7 +5,7 @@ import { TeamsCTA } from "app/(use-page-wrapper)/(main-nav)/teams/CTA";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
+import SkeletonLoaderTeamList from "@calcom/web/modules/ee/teams/components/SkeletonloaderTeamList";
 
 export const TeamsListSkeleton = () => {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/apps/(homepage)/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/(homepage)/page.tsx
@@ -9,7 +9,7 @@ import type { AppCategories } from "@calcom/prisma/enums";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import AppsPage from "~/apps/apps-view";
+import AppsPage from "@calcom/web/modules/apps/apps-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/apps/[slug]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { getStaticProps } from "@lib/apps/[slug]/getStaticProps";
 
-import AppView from "~/apps/[slug]/slug-view";
+import AppView from "@calcom/web/modules/apps/[slug]/slug-view";
 
 const paramsSchema = z.object({
   slug: z.string(),

--- a/apps/web/app/(use-page-wrapper)/apps/[slug]/setup/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/[slug]/setup/page.tsx
@@ -7,7 +7,7 @@ import { getServerSideProps } from "@calcom/app-store/_pages/setup/_getServerSid
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import SetupView, { type PageProps as ClientPageProps } from "~/apps/[slug]/setup/setup-view";
+import SetupView, { type PageProps as ClientPageProps } from "@calcom/web/modules/apps/[slug]/setup/setup-view";
 
 export const generateMetadata = async ({ params: _params }: ServerPageProps) => {
   const params = await _params;

--- a/apps/web/app/(use-page-wrapper)/apps/categories/[category]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/categories/[category]/page.tsx
@@ -6,7 +6,7 @@ import { AppCategories } from "@calcom/prisma/enums";
 
 import { getStaticProps } from "@lib/apps/categories/[category]/getStaticProps";
 
-import CategoryPage from "~/apps/categories/[category]/category-view";
+import CategoryPage from "@calcom/web/modules/apps/categories/[category]/category-view";
 
 const querySchema = z.object({
   category: z.enum(Object.values(AppCategories) as [AppCategories, ...AppCategories[]]),

--- a/apps/web/app/(use-page-wrapper)/apps/categories/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/categories/page.tsx
@@ -5,7 +5,7 @@ import { cookies, headers } from "next/headers";
 import { getServerSideProps } from "@lib/apps/categories/getServerSideProps";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import Page from "~/apps/categories/categories-view";
+import Page from "@calcom/web/modules/apps/categories/categories-view";
 
 const getData = withAppDirSsr(getServerSideProps);
 

--- a/apps/web/app/(use-page-wrapper)/apps/installation/[[...step]]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/installation/[[...step]]/page.tsx
@@ -6,8 +6,8 @@ import { cookies, headers } from "next/headers";
 import { getServerSideProps } from "@lib/apps/installation/[[...step]]/getServerSideProps";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import type { OnboardingPageProps } from "~/apps/installation/[[...step]]/step-view";
-import Page from "~/apps/installation/[[...step]]/step-view";
+import type { OnboardingPageProps } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
+import Page from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 export const generateMetadata = async ({ params }: PageProps) => {
   const stepParam = (await params).step;

--- a/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/installed/[category]/page.tsx
@@ -12,7 +12,7 @@ import { calendarsRouter } from "@calcom/trpc/server/routers/viewer/calendars/_r
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import InstalledApps from "~/apps/installed/[category]/installed-category-view";
+import InstalledApps from "@calcom/web/modules/apps/installed/[category]/installed-category-view";
 
 const querySchema = z.object({
   category: z.nativeEnum(AppCategories),

--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/[[...pages]]/Forms.tsx
@@ -7,7 +7,7 @@ import { useFormContext } from "react-hook-form";
 
 import { isFallbackRoute } from "@calcom/app-store/routing-forms/lib/isFallbackRoute";
 import type { RoutingFormWithResponseCount } from "@calcom/app-store/routing-forms/types/types";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { FilterResults } from "@calcom/features/filters/components/FilterResults";
 import { TeamsFilter } from "@calcom/features/filters/components/TeamsFilter";
 import { getTeamsFiltersFromQuery } from "@calcom/features/filters/lib/getTeamsFiltersFromQuery";
@@ -34,11 +34,11 @@ import {
   FormActionsProvider,
 } from "@calcom/web/components/apps/routing-forms/FormActions";
 
-import { useHasPaidPlan } from "~/billing/hooks/useHasPaidPlan";
-import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
-import { CreateButtonWithTeamsList } from "~/ee/teams/components/createButton/CreateButtonWithTeamsList";
-import { ShellMain } from "~/shell/Shell";
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import { useHasPaidPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
+import SkeletonLoaderTeamList from "@calcom/web/modules/ee/teams/components/SkeletonloaderTeamList";
+import { CreateButtonWithTeamsList } from "@calcom/web/modules/ee/teams/components/createButton/CreateButtonWithTeamsList";
+import { ShellMain } from "@calcom/web/modules/shell/Shell";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 function NewFormButton({ setNewFormDialogState }: { setNewFormDialogState: SetNewFormDialogState }) {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/apps/routing-forms/forms/layout.tsx
@@ -6,7 +6,7 @@ import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 import FormProvider from "../[...pages]/FormProvider";
 

--- a/apps/web/app/(use-page-wrapper)/auth/forgot-password/[id]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/forgot-password/[id]/page.tsx
@@ -7,8 +7,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/forgot-password/[id]/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/auth/forgot-password/[id]/forgot-password-single-view";
-import SetNewUserPassword from "~/auth/forgot-password/[id]/forgot-password-single-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/auth/forgot-password/[id]/forgot-password-single-view";
+import SetNewUserPassword from "@calcom/web/modules/auth/forgot-password/[id]/forgot-password-single-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ id: string }> }) => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/forgot-password/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/forgot-password/page.tsx
@@ -8,7 +8,7 @@ import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import ForgotPassword from "~/auth/forgot-password/forgot-password-view";
+import ForgotPassword from "@calcom/web/modules/auth/forgot-password/forgot-password-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/login/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/login/page.tsx
@@ -7,8 +7,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/login/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/auth/login-view";
-import Login from "~/auth/login-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/auth/login-view";
+import Login from "@calcom/web/modules/auth/login-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/logout/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/logout/page.tsx
@@ -4,7 +4,7 @@ import { cookies, headers } from "next/headers";
 
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
-import Logout from "~/auth/logout-view";
+import Logout from "@calcom/web/modules/auth/logout-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/oauth2/authorize/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/oauth2/authorize/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import Page from "~/auth/oauth2/authorize-view";
+import Page from "@calcom/web/modules/auth/oauth2/authorize-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/platform/authorize/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/platform/authorize/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import Page from "~/auth/platform/authorize-view";
+import Page from "@calcom/web/modules/auth/platform/authorize-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/saml-idp/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/saml-idp/page.tsx
@@ -2,7 +2,7 @@ import type { PageProps } from "app/_types";
 import { notFound } from "next/navigation";
 import { z } from "zod";
 
-import SamlIdpClient from "~/auth/saml-idp/saml-idp-view";
+import SamlIdpClient from "@calcom/web/modules/auth/saml-idp/saml-idp-view";
 
 const querySchema = z.object({
   code: z.string(),

--- a/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/setup/page.tsx
@@ -9,8 +9,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/setup/getServerSideProps";
 
-import Setup from "~/auth/setup-view";
-import type { PageProps as ClientPageProps } from "~/auth/setup-view";
+import Setup from "@calcom/web/modules/auth/setup-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/auth/setup-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/signin/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/signin/page.tsx
@@ -9,8 +9,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/signin/getServerSideProps";
 
-import SignIn from "~/auth/signin-view";
-import type { PageProps as ClientPageProps } from "~/auth/signin-view";
+import SignIn from "@calcom/web/modules/auth/signin-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/auth/signin-view";
 
 const getData = withAppDirSsr<ClientPageProps>(getServerSideProps);
 const ServerPage = async ({ params, searchParams }: ServerPageProps) => {

--- a/apps/web/app/(use-page-wrapper)/auth/sso/[provider]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/sso/[provider]/page.tsx
@@ -6,8 +6,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/sso/[provider]/getServerSideProps";
 
-import type { SSOProviderPageProps } from "~/auth/sso/provider-view";
-import SSOProviderView from "~/auth/sso/provider-view";
+import type { SSOProviderPageProps } from "@calcom/web/modules/auth/sso/provider-view";
+import SSOProviderView from "@calcom/web/modules/auth/sso/provider-view";
 
 const getData = withAppDirSsr<SSOProviderPageProps>(getServerSideProps);
 const ServerPage = async ({ params, searchParams }: PageProps) => {

--- a/apps/web/app/(use-page-wrapper)/auth/sso/direct/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/sso/direct/page.tsx
@@ -6,8 +6,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/sso/direct/getServerSideProps";
 
-import type { SSODirectPageProps } from "~/auth/sso/direct-view";
-import SSODirectView from "~/auth/sso/direct-view";
+import type { SSODirectPageProps } from "@calcom/web/modules/auth/sso/direct-view";
+import SSODirectView from "@calcom/web/modules/auth/sso/direct-view";
 
 const getData = withAppDirSsr<SSODirectPageProps>(getServerSideProps);
 const ServerPage = async ({ params, searchParams }: PageProps) => {

--- a/apps/web/app/(use-page-wrapper)/auth/verify-email-change/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/verify-email-change/page.tsx
@@ -7,8 +7,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 
 import { getServerSideProps } from "@server/lib/auth/verify-email-change/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/auth/verify-email-change-view";
-import VerifyEmailChange from "~/auth/verify-email-change-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/auth/verify-email-change-view";
+import VerifyEmailChange from "@calcom/web/modules/auth/verify-email-change-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/verify-email/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/verify-email/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import VerifyEmailPage from "~/auth/verify-email-view";
+import VerifyEmailPage from "@calcom/web/modules/auth/verify-email-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/auth/verify/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/verify/page.tsx
@@ -2,7 +2,7 @@ import type { PageProps as _PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { z } from "zod";
 
-import VerifyPage from "~/auth/verify-view";
+import VerifyPage from "@calcom/web/modules/auth/verify-view";
 
 const querySchema = z.object({
   stripeCustomerId: z.string().optional(),

--- a/apps/web/app/(use-page-wrapper)/availability/[schedule]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/availability/[schedule]/page.tsx
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { availabilityRouter } from "@calcom/trpc/server/routers/viewer/availability/_router";
 import { travelSchedulesRouter } from "@calcom/trpc/server/routers/viewer/travelSchedules/_router";
 
-import { AvailabilitySettingsWebWrapper } from "~/availability/[schedule]/schedule-view";
+import { AvailabilitySettingsWebWrapper } from "@calcom/web/modules/availability/[schedule]/schedule-view";
 
 const querySchema = z.object({
   schedule: z

--- a/apps/web/app/(use-page-wrapper)/availability/[schedule]/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/availability/[schedule]/skeleton.tsx
@@ -2,7 +2,7 @@
 
 import { SkeletonText, SkeletonContainer, SkeletonButton } from "@calcom/ui/components/skeleton";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export function AvailabilityScheduleSkeleton() {
   return (

--- a/apps/web/app/(use-page-wrapper)/availability/troubleshoot/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/availability/troubleshoot/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import Troubleshoot from "~/availability/troubleshoot/troubleshoot-view";
+import Troubleshoot from "@calcom/web/modules/availability/troubleshoot/troubleshoot-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/connect-and-join/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/connect-and-join/page.tsx
@@ -1,8 +1,8 @@
 import { _generateMetadata } from "app/_utils";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 
-import LegacyPage from "~/connect-and-join/connect-and-join-view";
+import LegacyPage from "@calcom/web/modules/connect-and-join/connect-and-join-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/error.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/error.tsx
@@ -3,7 +3,7 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function Error() {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/skeleton.tsx
@@ -7,7 +7,7 @@ import {
   SkeletonAvatar,
 } from "@calcom/ui/components/skeleton";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export const EventTypeEditPageSkeleton = () => {
   const backButtonSkeleton = (

--- a/apps/web/app/(use-page-wrapper)/getting-started/[[...step]]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/getting-started/[[...step]]/page.tsx
@@ -12,7 +12,7 @@ import { meRouter } from "@calcom/trpc/server/routers/viewer/me/_router";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import Page from "~/getting-started/[[...step]]/onboarding-view";
+import Page from "@calcom/web/modules/getting-started/[[...step]]/onboarding-view";
 
 export const generateMetadata = async ({ params }: ServerPageProps) => {
   const stepParam = (await params).step;

--- a/apps/web/app/(use-page-wrapper)/insights/UpgradeTipWrapper.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/UpgradeTipWrapper.tsx
@@ -8,7 +8,7 @@ import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { Icon } from "@calcom/ui/components/icon";
 
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 export default function UpgradeTipWrapper({ children }: { children: React.ReactNode }) {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/insights/call-history/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/call-history/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import InsightsCallHistoryPage from "~/insights/views/insights-call-history-view";
+import InsightsCallHistoryPage from "@calcom/web/modules/insights/views/insights-call-history-view";
 
 import { checkInsightsPagePermission } from "../checkInsightsPagePermission";
 

--- a/apps/web/app/(use-page-wrapper)/insights/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/layout.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import { CTA_CONTAINER_CLASS_NAME } from "@calcom/features/data-table/lib/utils";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 import UpgradeTipWrapper from "./UpgradeTipWrapper";
 

--- a/apps/web/app/(use-page-wrapper)/insights/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata } from "app/_utils";
 
 import prisma from "@calcom/prisma";
 
-import InsightsPage from "~/insights/views/insights-view";
+import InsightsPage from "@calcom/web/modules/insights/views/insights-view";
 
 import { checkInsightsPagePermission } from "./checkInsightsPagePermission";
 

--- a/apps/web/app/(use-page-wrapper)/insights/router-position/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/router-position/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import InsightsVirtualQueuesPage from "~/insights/views/insights-virtual-queues-view";
+import InsightsVirtualQueuesPage from "@calcom/web/modules/insights/views/insights-virtual-queues-view";
 
 import { checkInsightsPagePermission } from "../checkInsightsPagePermission";
 

--- a/apps/web/app/(use-page-wrapper)/insights/routing/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/insights/routing/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata } from "app/_utils";
 
 import { prisma } from "@calcom/prisma";
 
-import InsightsRoutingPage from "~/insights/views/insights-routing-view";
+import InsightsRoutingPage from "@calcom/web/modules/insights/views/insights-routing-view";
 
 import { checkInsightsPagePermission } from "../checkInsightsPagePermission";
 

--- a/apps/web/app/(use-page-wrapper)/maintenance/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/maintenance/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata } from "app/_utils";
 
 import { APP_NAME } from "@calcom/lib/constants";
 
-import LegacyPage from "~/maintenance/maintenance-view";
+import LegacyPage from "@calcom/web/modules/maintenance/maintenance-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/more/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/more/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import Page from "~/more/more-page-view";
+import Page from "@calcom/web/modules/more/more-page-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/getting-started/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/getting-started/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OnboardingView } from "~/onboarding/getting-started/onboarding-view";
+import { OnboardingView } from "@calcom/web/modules/onboarding/getting-started/onboarding-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/brand/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/brand/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OrganizationBrandView } from "~/onboarding/organization/brand/organization-brand-view";
+import { OrganizationBrandView } from "@calcom/web/modules/onboarding/organization/brand/organization-brand-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/details/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/details/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OrganizationDetailsView } from "~/onboarding/organization/details/organization-details-view";
+import { OrganizationDetailsView } from "@calcom/web/modules/onboarding/organization/details/organization-details-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/invite/email/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/invite/email/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OrganizationInviteEmailView } from "~/onboarding/organization/invite/email/organization-invite-email-view";
+import { OrganizationInviteEmailView } from "@calcom/web/modules/onboarding/organization/invite/email/organization-invite-email-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/invite/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/invite/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OrganizationInviteView } from "~/onboarding/organization/invite/organization-invite-view";
+import { OrganizationInviteView } from "@calcom/web/modules/onboarding/organization/invite/organization-invite-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/organization/teams/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/organization/teams/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { OrganizationTeamsView } from "~/onboarding/organization/teams/organization-teams-view";
+import { OrganizationTeamsView } from "@calcom/web/modules/onboarding/organization/teams/organization-teams-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/personal/calendar/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/personal/calendar/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { PersonalCalendarView } from "~/onboarding/personal/calendar/personal-calendar-view";
+import { PersonalCalendarView } from "@calcom/web/modules/onboarding/personal/calendar/personal-calendar-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/personal/profile/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/personal/profile/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { PersonalSettingsView } from "~/onboarding/personal/settings/personal-settings-view";
+import { PersonalSettingsView } from "@calcom/web/modules/onboarding/personal/settings/personal-settings-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/personal/settings/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/personal/settings/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { PersonalSettingsView } from "~/onboarding/personal/settings/personal-settings-view";
+import { PersonalSettingsView } from "@calcom/web/modules/onboarding/personal/settings/personal-settings-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/teams/details/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/teams/details/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { TeamDetailsView } from "~/onboarding/teams/details/team-details-view";
+import { TeamDetailsView } from "@calcom/web/modules/onboarding/teams/details/team-details-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/teams/invite/email/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/teams/invite/email/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { TeamInviteEmailView } from "~/onboarding/teams/invite/email/team-invite-email-view";
+import { TeamInviteEmailView } from "@calcom/web/modules/onboarding/teams/invite/email/team-invite-email-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/onboarding/teams/invite/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/onboarding/teams/invite/page.tsx
@@ -7,7 +7,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { TeamInviteEmailView } from "~/onboarding/teams/invite/email/team-invite-email-view";
+import { TeamInviteEmailView } from "@calcom/web/modules/onboarding/teams/invite/email/team-invite-email-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/refer/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/refer/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 
 import { IS_DUB_REFERRALS_ENABLED } from "@calcom/lib/constants";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 import { DubReferralsPage } from "./DubReferralsPage";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/AdminLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/AdminLayoutAppDirClient.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import type { UserPermissionRole } from "@calcom/prisma/enums";
 import { ErrorBoundary } from "@calcom/ui/components/errorBoundary";
 
-import type Shell from "~/shell/Shell";
+import type Shell from "@calcom/web/modules/shell/Shell";
 
 export type AdminLayoutProps = {
   children: React.ReactNode;

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/apps/[category]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/apps/[category]/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getTranslate } from "app/_utils";
 
-import AdminAppsList from "~/apps/components/AdminAppsList";
+import AdminAppsList from "@calcom/web/modules/apps/components/AdminAppsList";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ category: string }> }) =>

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/impersonation/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/impersonation/page.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import ImpersonationView from "~/settings/admin/impersonation-view";
+import ImpersonationView from "@calcom/web/modules/settings/admin/impersonation-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/lockedSMS/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/lockedSMS/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import LockedSMSView from "~/settings/admin/locked-sms-view";
+import LockedSMSView from "@calcom/web/modules/settings/admin/locked-sms-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/oAuth/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/oAuth/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import LegacyPage from "~/settings/admin/oauth-view";
+import LegacyPage from "@calcom/web/modules/settings/admin/oauth-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/organizations/[id]/edit/page.tsx
@@ -2,8 +2,8 @@ import { type Params } from "app/_types";
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { z } from "zod";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import { OrgForm } from "~/ee/organizations/admin/AdminOrgEditPage";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import { OrgForm } from "@calcom/web/modules/ee/organizations/admin/AdminOrgEditPage";
 import { getOrganizationRepository } from "@calcom/features/ee/organizations/di/OrganizationRepository.container";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/organizations/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/organizations/page.tsx
@@ -1,8 +1,8 @@
 import { _generateMetadata } from "app/_utils";
 import { getTranslate } from "app/_utils";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import AdminOrgTable from "~/ee/organizations/admin/AdminOrgPage";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import AdminOrgTable from "@calcom/web/modules/ee/organizations/admin/AdminOrgPage";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/playground/date-range-filter/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/playground/date-range-filter/page.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 
 import { ColumnFilterType, DataTableProvider } from "@calcom/features/data-table";
 import type { DateRangeFilterOptions } from "@calcom/features/data-table/lib/types";
-import { DateRangeFilter } from "~/data-table/components/filters/DateRangeFilter";
+import { DateRangeFilter } from "@calcom/web/modules/data-table/components/filters/DateRangeFilter";
 
 type DemoRow = {
   id: number;

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
@@ -2,8 +2,8 @@ import { type Params } from "app/_types";
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { z } from "zod";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import { UsersEditView } from "~/ee/users/views/users-edit-view";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import { UsersEditView } from "@calcom/web/modules/ee/users/views/users-edit-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { prisma } from "@calcom/prisma";

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/add/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/add/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import UsersAddView from "~/ee/users/views/users-add-view";
+import UsersAddView from "@calcom/web/modules/ee/users/views/users-add-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import UsersListingView from "~/ee/users/views/users-listing-view";
+import UsersListingView from "@calcom/web/modules/ee/users/views/users-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { Button } from "@calcom/ui/components/button";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/workspace-platforms/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/workspace-platforms/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import WorkspacePlatformsPage from "~/ee/organizations/admin/WorkspacePlatformPage";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import WorkspacePlatformsPage from "@calcom/web/modules/ee/organizations/admin/WorkspacePlatformPage";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
@@ -29,7 +29,7 @@ import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
 import { VerticalTabItem } from "@calcom/ui/components/navigation";
 import { Skeleton } from "@calcom/ui/components/skeleton";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 const getTabs = (orgBranding: OrganizationBranding | null) => {
   const tabs: VerticalTabItemProps[] = [

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/billing/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/billing/page.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import BillingView from "~/settings/billing/billing-view";
+import BillingView from "@calcom/web/modules/settings/billing/billing-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/settings/developer/api-keys-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/settings/developer/api-keys-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
@@ -9,7 +9,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import ApiKeysView from "~/settings/developer/api-keys-view";
+import ApiKeysView from "@calcom/web/modules/settings/developer/api-keys-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/webhooks/views/webhooks-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/webhooks/views/webhooks-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/page.tsx
@@ -9,7 +9,7 @@ import { webhookRouter } from "@calcom/trpc/server/routers/viewer/webhook/_route
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import WebhooksView from "~/webhooks/views/webhooks-view";
+import WebhooksView from "@calcom/web/modules/webhooks/views/webhooks-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/[id]/page.tsx
@@ -4,7 +4,7 @@ import { _generateMetadata } from "app/_utils";
 import { WebhookRepository } from "@calcom/features/webhooks/lib/repository/WebhookRepository";
 import { APP_NAME } from "@calcom/lib/constants";
 
-import { EditWebhookView } from "~/webhooks/views/webhook-edit-view";
+import { EditWebhookView } from "@calcom/web/modules/webhooks/views/webhook-edit-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ id: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/new/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/new/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/webhooks/views/webhook-new-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/webhooks/views/webhook-new-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/new/page.tsx
@@ -5,7 +5,7 @@ import { APP_NAME } from "@calcom/lib/constants";
 import { appsRouter } from "@calcom/trpc/server/routers/viewer/apps/_router";
 import { webhookRouter } from "@calcom/trpc/server/routers/viewer/webhook/_router";
 
-import { NewWebhookView } from "~/webhooks/views/webhook-new-view";
+import { NewWebhookView } from "@calcom/web/modules/webhooks/views/webhook-new-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/appearance/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/appearance/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/settings/my-account/appearance-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/settings/my-account/appearance-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/appearance/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/appearance/page.tsx
@@ -11,7 +11,7 @@ import { getCachedHasTeamPlan } from "@calcom/web/app/cache/membership";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import AppearancePage from "~/settings/my-account/appearance-view";
+import AppearancePage from "@calcom/web/modules/settings/my-account/appearance-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/settings/my-account/general-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/settings/my-account/general-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/general/page.tsx
@@ -9,7 +9,7 @@ import { getTravelSchedule } from "@calcom/web/app/cache/travelSchedule";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import GeneralView from "~/settings/my-account/general-view";
+import GeneralView from "@calcom/web/modules/settings/my-account/general-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/out-of-office/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/out-of-office/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import OutOfOfficeView from "~/settings/my-account/out-of-office-view";
+import OutOfOfficeView from "@calcom/web/modules/settings/my-account/out-of-office-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/profile/loading.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/profile/loading.tsx
@@ -1,4 +1,4 @@
-import { SkeletonLoader } from "~/settings/my-account/profile-skeleton";
+import { SkeletonLoader } from "@calcom/web/modules/settings/my-account/profile-skeleton";
 
 export default function Loading() {
   return <SkeletonLoader />;

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/profile/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/profile/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 
 import { meRouter } from "@calcom/trpc/server/routers/viewer/me/_router";
 
-import ProfileView from "~/settings/my-account/profile-view";
+import ProfileView from "@calcom/web/modules/settings/my-account/profile-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/push-notifications/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/my-account/push-notifications/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import PushNotificationsView from "~/settings/my-account/push-notifications-view";
+import PushNotificationsView from "@calcom/web/modules/settings/my-account/push-notifications-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/attributes/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/attributes/page.tsx
@@ -6,7 +6,7 @@ import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permi
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { MembershipRole } from "@calcom/prisma/enums";
 
-import OrgSettingsAttributesPage from "~/ee/organizations/attributes/attributes-list-view";
+import OrgSettingsAttributesPage from "@calcom/web/modules/ee/organizations/attributes/attributes-list-view";
 
 import { validateUserHasOrg } from "../../actions/validateUserHasOrg";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/billing/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/billing/page.tsx
@@ -4,7 +4,7 @@ import { getTranslate } from "app/_utils";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { MembershipRole } from "@calcom/prisma/enums";
 
-import BillingView from "~/settings/billing/billing-view";
+import BillingView from "@calcom/web/modules/settings/billing/billing-view";
 
 import { validateUserHasOrgPerms } from "../../actions/validateUserHasOrgPerms";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/delegation-credential/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/delegation-credential/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import DelegationCredentialList from "~/ee/organizations/delegationCredential";
+import DelegationCredentialList from "@calcom/web/modules/ee/organizations/delegationCredential";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { MembershipRole } from "@calcom/prisma/enums";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/dsync/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/dsync/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import DirectorySyncTeamView from "~/ee/dsync/views/team-dsync-view";
+import DirectorySyncTeamView from "@calcom/web/modules/ee/dsync/views/team-dsync-view";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/guest-notifications/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/guest-notifications/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { redirect } from "next/navigation";
 
-import GuestNotificationsView from "~/ee/organizations/guest-notifications";
+import GuestNotificationsView from "@calcom/web/modules/ee/organizations/guest-notifications";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/privacy/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/privacy/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { redirect } from "next/navigation";
 
-import PrivacyView from "~/ee/organizations/privacy";
+import PrivacyView from "@calcom/web/modules/ee/organizations/privacy";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/sso/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/(org-admin-only)/sso/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { redirect } from "next/navigation";
 
-import OrgSSOView from "~/ee/sso/views/orgs-sso-view";
+import OrgSSOView from "@calcom/web/modules/ee/sso/views/orgs-sso-view";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/admin-api/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/admin-api/page.tsx
@@ -2,7 +2,7 @@ import { getTranslate, _generateMetadata } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import { AdminAPIView } from "~/ee/organizations/admin-api";
+import { AdminAPIView } from "@calcom/web/modules/ee/organizations/admin-api";
 
 import { validateUserHasOrg } from "../actions/validateUserHasOrg";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/general/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/general/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import LegacyPage from "~/ee/organizations/general";
+import LegacyPage from "@calcom/web/modules/ee/organizations/general";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/profile/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/profile/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { redirect } from "next/navigation";
 
-import LegacyPage from "~/ee/organizations/profile";
+import LegacyPage from "@calcom/web/modules/ee/organizations/profile";
 import { Resource } from "@calcom/features/pbac/domain/types/permission-registry";
 import { getResourcePermissions } from "@calcom/features/pbac/lib/resource-permissions";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/(main-page)/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/(main-page)/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { redirect } from "next/navigation";
 
-import { OtherTeamsListing } from "~/ee/organizations/components/OtherTeamsListing";
+import { OtherTeamsListing } from "@calcom/web/modules/ee/organizations/components/OtherTeamsListing";
 import { getOrganizationRepository } from "@calcom/features/ee/organizations/di/OrganizationRepository.container";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/(main-page)/skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/(main-page)/skeleton.tsx
@@ -3,7 +3,7 @@
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
+import SkeletonLoaderTeamList from "@calcom/web/modules/ee/teams/components/SkeletonloaderTeamList";
 
 export function SkeletonLoader() {
   const { t } = useLocale();

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/appearance/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import LegacyPage from "~/ee/teams/views/team-appearance-view";
+import LegacyPage from "@calcom/web/modules/ee/teams/views/team-appearance-view";
 
 import { validateUserHasOrg } from "../../../../actions/validateUserHasOrg";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/members/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 
 import LegacyPage, {
   TeamMembersCTA,
-} from "~/ee/organizations/other-team-members-view";
+} from "@calcom/web/modules/ee/organizations/other-team-members-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import { validateUserHasOrg } from "../../../../actions/validateUserHasOrg";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/organizations/teams/other/[id]/profile/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import LegacyPage from "~/ee/organizations/other-team-profile-view";
+import LegacyPage from "@calcom/web/modules/ee/organizations/other-team-profile-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 import { validateUserHasOrg } from "../../../../actions/validateUserHasOrg";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/impersonation/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/impersonation/page.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import ProfileImpersonationViewWrapper from "~/settings/security/impersonation-view";
+import ProfileImpersonationViewWrapper from "@calcom/web/modules/settings/security/impersonation-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/password/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/password/page.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import PasswordViewWrapper from "~/settings/security/password-view";
+import PasswordViewWrapper from "@calcom/web/modules/settings/security/password-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/sso/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/sso/page.tsx
@@ -1,7 +1,7 @@
 import { _generateMetadata } from "app/_utils";
 import { getTranslate } from "app/_utils";
 
-import SAMLSSO from "~/ee/sso/views/user-sso-view";
+import SAMLSSO from "@calcom/web/modules/ee/sso/views/user-sso-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/two-factor-auth/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/security/two-factor-auth/page.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import TwoFactorAuthView from "~/settings/security/two-factor-auth-view";
+import TwoFactorAuthView from "@calcom/web/modules/settings/security/two-factor-auth-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/appearance/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/teams/[id]/appearance/page.tsx
@@ -2,7 +2,7 @@ import { _generateMetadata, getTranslate } from "app/_utils";
 
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
-import LegacyPage from "~/ee/teams/views/team-appearance-view";
+import LegacyPage from "@calcom/web/modules/ee/teams/views/team-appearance-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ id: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/license-key/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/license-key/new/page.tsx
@@ -8,7 +8,7 @@ import type { inferSSRProps } from "@calcom/types/inferSSRProps";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/settings/license-key/new/getServerSideProps";
 
-import CreateANewLicenseKeyForm, { LayoutWrapper } from "~/settings/license-key/new/new-view";
+import CreateANewLicenseKeyForm, { LayoutWrapper } from "@calcom/web/modules/settings/license-key/new/new-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-admin-only)/appearance/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-admin-only)/appearance/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import Page from "~/ee/organizations/appearance";
+import Page from "@calcom/web/modules/ee/organizations/appearance";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/[id]/members/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/[id]/members/layout.tsx
@@ -2,7 +2,7 @@ import { getTranslate } from "app/_utils";
 
 import { CTA_CONTAINER_CLASS_NAME } from "@calcom/features/data-table/lib/utils";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const t = await getTranslate();

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
@@ -15,7 +15,7 @@ import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/or
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { MembersView } from "~/members/members-view";
+import { MembersView } from "@calcom/web/modules/members/members-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/about/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/about/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/about-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/about-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/add-teams/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/add-teams/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/add-teams-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/add-teams-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/handover/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/handover/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/onboarding-handover";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/onboarding-handover";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/onboard-members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/onboard-members/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/onboard-members-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/onboard-members-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/page.tsx
@@ -1,8 +1,8 @@
 import { _generateMetadata } from "app/_utils";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/create-new-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/create-new-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/resume/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/resume/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import ResumeOnboardingPage, { LayoutWrapper } from "~/ee/organizations/new/resume-view";
+import ResumeOnboardingPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/resume-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/new/status/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/new/status/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage, { LayoutWrapper } from "~/ee/organizations/new/payment-status-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/ee/organizations/new/payment-status-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/billing/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/billing/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import PlatformBillingUpgrade from "~/settings/platform/billing/billing-view";
+import PlatformBillingUpgrade from "@calcom/web/modules/settings/platform/billing/billing-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/managed-users/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/managed-users/page.tsx
@@ -7,7 +7,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import ManagedUsersView from "~/settings/platform/managed-users/managed-users-view";
+import ManagedUsersView from "@calcom/web/modules/settings/platform/managed-users/managed-users-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/members/layout.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/members/layout.tsx
@@ -3,7 +3,7 @@ import { getTranslate } from "app/_utils";
 import { CTA_CONTAINER_CLASS_NAME } from "@calcom/features/data-table/lib/utils";
 import { Button } from "@calcom/ui/components/button";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const t = await getTranslate();

--- a/apps/web/app/(use-page-wrapper)/settings/platform/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/members/page.tsx
@@ -1,7 +1,7 @@
 import { createRouterCaller } from "app/_trpc/context";
 import { _generateMetadata } from "app/_utils";
 
-import PlatformMembersView from "~/ee/platform/views/members";
+import PlatformMembersView from "@calcom/web/modules/ee/platform/views/members";
 import { viewerOrganizationsRouter } from "@calcom/trpc/server/routers/viewer/organizations/_router";
 
 export const generateMetadata = async () =>

--- a/apps/web/app/(use-page-wrapper)/settings/platform/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/new/page.tsx
@@ -3,12 +3,12 @@ import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import LegacyPage, { LayoutWrapper } from "~/settings/platform/new/create-new-view";
+import LegacyPage, { LayoutWrapper } from "@calcom/web/modules/settings/platform/new/create-new-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/[clientId]/edit/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/[clientId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import EditView from "~/settings/platform/oauth-clients/[clientId]/edit/edit-view";
+import EditView from "@calcom/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ clientId: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/[clientId]/edit/webhooks/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/[clientId]/edit/webhooks/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import EditWebhooksView from "~/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view";
+import EditWebhooksView from "@calcom/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ clientId: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/create/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/oauth-clients/create/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import CreateNewView from "~/settings/platform/oauth-clients/create-new-view";
+import CreateNewView from "@calcom/web/modules/settings/platform/oauth-clients/create-new-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import PlatformView from "~/settings/platform/platform-view";
+import PlatformView from "@calcom/web/modules/settings/platform/platform-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/platform/plans/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/platform/plans/page.tsx
@@ -7,7 +7,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import PlatformPlansView from "~/settings/platform/plans/platform-plans-view";
+import PlatformPlansView from "@calcom/web/modules/settings/platform/plans/platform-plans-view";
 
 export const generateMetadata = async () => {
   return await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/teams/[id]/event-type/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/[id]/event-type/page.tsx
@@ -10,7 +10,7 @@ import { MembershipRole } from "@calcom/prisma/enums";
 
 import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 
-import { CreateTeamEventType, LayoutWrapper } from "~/settings/teams/[id]/event-types-view";
+import { CreateTeamEventType, LayoutWrapper } from "@calcom/web/modules/settings/teams/[id]/event-types-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ id: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/teams/[id]/onboard-members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/[id]/onboard-members/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import AddNewTeamMembers, { LayoutWrapper } from "~/settings/teams/[id]/onboard-members-view";
+import AddNewTeamMembers, { LayoutWrapper } from "@calcom/web/modules/settings/teams/[id]/onboard-members-view";
 
 export const generateMetadata = async ({ params }: { params: Promise<{ id: string }> }) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/settings/teams/new/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/teams/new/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import CreateNewTeamView, { LayoutWrapper } from "~/settings/teams/new/create-new-team-view";
+import CreateNewTeamView, { LayoutWrapper } from "@calcom/web/modules/settings/teams/new/create-new-team-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/signup/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/signup/page.tsx
@@ -6,8 +6,8 @@ import { cookies, headers } from "next/headers";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/signup/getServerSideProps";
 
-import type { SignupProps } from "~/signup-view";
-import Signup from "~/signup-view";
+import type { SignupProps } from "@calcom/web/modules/signup-view";
+import Signup from "@calcom/web/modules/signup-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/upgrade/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/upgrade/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import LegacyPage from "~/upgrade/upgrade-view";
+import LegacyPage from "@calcom/web/modules/upgrade/upgrade-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/video/[uid]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/video/[uid]/page.tsx
@@ -8,8 +8,8 @@ import { APP_NAME, SEO_IMG_OGIMG_VIDEO, WEBSITE_URL } from "@calcom/lib/constant
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/video/[uid]/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/videos/views/videos-single-view";
-import VideosSingleView from "~/videos/views/videos-single-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/videos/views/videos-single-view";
+import VideosSingleView from "@calcom/web/modules/videos/views/videos-single-view";
 
 export const generateMetadata = async () => {
   const t = await getTranslate();

--- a/apps/web/app/(use-page-wrapper)/video/meeting-ended/[uid]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/video/meeting-ended/[uid]/page.tsx
@@ -6,8 +6,8 @@ import { cookies, headers } from "next/headers";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/video/meeting-ended/[uid]/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/videos/views/videos-meeting-ended-single-view";
-import MeetingEnded from "~/videos/views/videos-meeting-ended-single-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/videos/views/videos-meeting-ended-single-view";
+import MeetingEnded from "@calcom/web/modules/videos/views/videos-meeting-ended-single-view";
 
 export const generateMetadata = async ({ params }: ServerPageProps) =>
   await _generateMetadata(

--- a/apps/web/app/(use-page-wrapper)/video/meeting-not-started/[uid]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/video/meeting-not-started/[uid]/page.tsx
@@ -11,8 +11,8 @@ import { prisma } from "@calcom/prisma";
 import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/video/meeting-not-started/[uid]/getServerSideProps";
 
-import type { PageProps as ClientPageProps } from "~/videos/views/videos-meeting-not-started-single-view";
-import MeetingNotStarted from "~/videos/views/videos-meeting-not-started-single-view";
+import type { PageProps as ClientPageProps } from "@calcom/web/modules/videos/views/videos-meeting-not-started-single-view";
+import MeetingNotStarted from "@calcom/web/modules/videos/views/videos-meeting-not-started-single-view";
 
 const querySchema = z.object({
   uid: z.string(),

--- a/apps/web/app/(use-page-wrapper)/video/no-meeting-found/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/video/no-meeting-found/page.tsx
@@ -1,6 +1,6 @@
 import { _generateMetadata } from "app/_utils";
 
-import NoMeetingFound from "~/videos/views/videos-no-meeting-found-single-view";
+import NoMeetingFound from "@calcom/web/modules/videos/views/videos-no-meeting-found-single-view";
 
 export const generateMetadata = async () =>
   await _generateMetadata(

--- a/apps/web/components/EnterprisePage.tsx
+++ b/apps/web/components/EnterprisePage.tsx
@@ -5,8 +5,8 @@ import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { Icon } from "@calcom/ui/components/icon";
 
-import Shell from "~/shell/Shell";
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import Shell from "@calcom/web/modules/shell/Shell";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 export default function EnterprisePage() {
   const { t } = useLocale();

--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -16,7 +16,7 @@ import Head from "next/head";
 import Script from "next/script";
 
 import "@calcom/embed-core/src/embed-iframe";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { IS_CALCOM, WEBAPP_URL } from "@calcom/lib/constants";
 import { getCalcomUrl } from "@calcom/lib/getCalcomUrl";
 import { buildCanonical } from "@calcom/lib/next-seo.config";

--- a/apps/web/components/PageWrapperAppDir.tsx
+++ b/apps/web/components/PageWrapperAppDir.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@calcom/embed-core/src/embed-iframe";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 
 import AppProviders from "@lib/app-providers-app-dir";
 

--- a/apps/web/components/apps/App.tsx
+++ b/apps/web/components/apps/App.tsx
@@ -1,7 +1,7 @@
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 import type { AppPageProps } from "./AppPage";
 import { AppPage } from "./AppPage";

--- a/apps/web/components/apps/installation/AccountsStepCard.tsx
+++ b/apps/web/components/apps/installation/AccountsStepCard.tsx
@@ -8,7 +8,7 @@ import classNames from "@calcom/ui/classNames";
 import { Avatar } from "@calcom/ui/components/avatar";
 import { StepCard } from "@calcom/ui/components/card";
 
-import type { TTeams } from "~/apps/installation/[[...step]]/step-view";
+import type { TTeams } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 export type PersonalAccountProps = Pick<User, "id" | "avatarUrl" | "name"> & { alreadyInstalled: boolean };
 

--- a/apps/web/components/apps/installation/ConfigureStepCard.tsx
+++ b/apps/web/components/apps/installation/ConfigureStepCard.tsx
@@ -21,7 +21,7 @@ import { Icon } from "@calcom/ui/components/icon";
 import EventTypeAppSettingsWrapper from "@components/apps/installation/EventTypeAppSettingsWrapper";
 import EventTypeConferencingAppSettings from "@components/apps/installation/EventTypeConferencingAppSettings";
 
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import type { TEventType, TEventTypesForm, TEventTypeGroup } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 export type TFormType = {
   id: number;

--- a/apps/web/components/apps/installation/EventTypeAppSettingsWrapper.tsx
+++ b/apps/web/components/apps/installation/EventTypeAppSettingsWrapper.tsx
@@ -6,7 +6,7 @@ import useAppsData from "@calcom/features/apps/hooks/useAppsData";
 
 import type { ConfigureStepCardProps } from "@components/apps/installation/ConfigureStepCard";
 
-import type { TEventType } from "~/apps/installation/[[...step]]/step-view";
+import type { TEventType } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 type EventTypeAppSettingsWrapperProps = Pick<
   ConfigureStepCardProps,

--- a/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
+++ b/apps/web/components/apps/installation/EventTypeConferencingAppSettings.tsx
@@ -14,9 +14,9 @@ import { QueryCell } from "@lib/QueryCell";
 
 import type { TFormType } from "@components/apps/installation/ConfigureStepCard";
 
-import type { TEventType } from "~/apps/installation/[[...step]]/step-view";
-import Locations from "~/event-types/components/locations/Locations";
-import type { TLocationOptions, TEventTypeLocation } from "~/event-types/components/locations/Locations";
+import type { TEventType } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
+import Locations from "@calcom/web/modules/event-types/components/locations/Locations";
+import type { TLocationOptions, TEventTypeLocation } from "@calcom/web/modules/event-types/components/locations/Locations";
 
 const LocationsWrapper = ({
   eventType,

--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { ScrollableArea } from "@calcom/ui/components/scrollable";
 
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import type { TEventType, TEventTypesForm, TEventTypeGroup } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 type EventTypesCardProps = {
   userName: string;

--- a/apps/web/components/apps/layouts/AppsLayout.tsx
+++ b/apps/web/components/apps/layouts/AppsLayout.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 type AppsLayoutProps = {
   children: React.ReactNode;

--- a/apps/web/components/apps/layouts/InstalledAppsLayout.tsx
+++ b/apps/web/components/apps/layouts/InstalledAppsLayout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import AppCategoryNavigation from "@calcom/app-store/_components/AppCategoryNavigation";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function InstalledAppsLayout({
   children,

--- a/apps/web/components/apps/routing-forms/SingleForm.tsx
+++ b/apps/web/components/apps/routing-forms/SingleForm.tsx
@@ -7,7 +7,7 @@ import type { UseFormReturn } from "react-hook-form";
 
 import { InfoLostWarningDialog } from "@calcom/app-store/routing-forms/components/InfoLostWarningDialog";
 import type { RoutingFormWithResponseCount } from "@calcom/app-store/routing-forms/types/types";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";

--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { z } from "zod";
 
 import { MeetingSessionDetailsDialog } from "@calcom/web/modules/ee/video/components/MeetingSessionDetailsDialog";
-import ViewRecordingsDialog from "~/ee/video/components/ViewRecordingsDialog";
+import ViewRecordingsDialog from "@calcom/web/modules/ee/video/components/ViewRecordingsDialog";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/components/settings/CustomEmailTextField.tsx
+++ b/apps/web/components/settings/CustomEmailTextField.tsx
@@ -13,7 +13,7 @@ import {
 } from "@calcom/ui/components/dropdown";
 import { InputError, Input } from "@calcom/ui/components/form";
 
-import type { FormValues } from "~/settings/my-account/profile-view";
+import type { FormValues } from "@calcom/web/modules/settings/my-account/profile-view";
 
 type CustomEmailTextFieldProps = {
   formMethods: UseFormReturn<FormValues>;

--- a/apps/web/components/settings/TravelScheduleModal.tsx
+++ b/apps/web/components/settings/TravelScheduleModal.tsx
@@ -10,7 +10,7 @@ import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogClose } from "@calcom/ui/components/dialog";
 import { Label, SettingsToggle, DateRangePicker, DatePicker } from "@calcom/ui/components/form";
 
-import type { FormValues } from "~/settings/my-account/general-view";
+import type { FormValues } from "@calcom/web/modules/settings/my-account/general-view";
 
 interface TravelScheduleModalProps {
   open: boolean;

--- a/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
+++ b/apps/web/lib/apps/installation/[[...step]]/getServerSideProps.ts
@@ -15,8 +15,8 @@ import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { eventTypeBookingFields } from "@calcom/prisma/zod-utils";
 
-import { STEPS } from "~/apps/installation/[[...step]]/constants";
-import type { OnboardingPageProps, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import { STEPS } from "@calcom/web/modules/apps/installation/[[...step]]/constants";
+import type { OnboardingPageProps, TEventTypeGroup } from "@calcom/web/modules/apps/installation/[[...step]]/step-view";
 
 const getUser = async (userId: number) => {
   const userRepo = new UserRepository(prisma);

--- a/apps/web/modules/apps/categories/[category]/category-view.tsx
+++ b/apps/web/modules/apps/categories/[category]/category-view.tsx
@@ -8,7 +8,7 @@ import { SkeletonText } from "@calcom/ui/components/skeleton";
 
 import type { CategoryDataProps } from "@lib/apps/categories/[category]/getStaticProps";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function Apps({ apps, category }: CategoryDataProps) {
   const { t, isLocaleReady } = useLocale();

--- a/apps/web/modules/apps/categories/categories-view.tsx
+++ b/apps/web/modules/apps/categories/categories-view.tsx
@@ -9,7 +9,7 @@ import { SkeletonText } from "@calcom/ui/components/skeleton";
 
 import type { getServerSideProps } from "@lib/apps/categories/getServerSideProps";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export type PageProps = inferSSRProps<typeof getServerSideProps>;
 

--- a/apps/web/modules/apps/installation/[[...step]]/step-view.tsx
+++ b/apps/web/modules/apps/installation/[[...step]]/step-view.tsx
@@ -32,7 +32,7 @@ import { ConfigureStepCard } from "@components/apps/installation/ConfigureStepCa
 import { EventTypesStepCard } from "@components/apps/installation/EventTypesStepCard";
 import { StepHeader } from "@components/apps/installation/StepHeader";
 
-import { STEPS } from "~/apps/installation/[[...step]]/constants";
+import { STEPS } from "@calcom/web/modules/apps/installation/[[...step]]/constants";
 
 export type TEventType = EventTypeAppSettingsComponentProps["eventType"] &
   Pick<

--- a/apps/web/modules/auth/setup-view.tsx
+++ b/apps/web/modules/auth/setup-view.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
-import AdminAppsList from "~/apps/components/AdminAppsList";
+import AdminAppsList from "@calcom/web/modules/apps/components/AdminAppsList";
 import { APP_NAME } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { inferSSRProps } from "@calcom/types/inferSSRProps";

--- a/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingCalendarContainer.tsx
@@ -4,7 +4,7 @@ import { useReactTable, getCoreRowModel, getSortedRowModel } from "@tanstack/rea
 import React, { useMemo, useEffect } from "react";
 
 import dayjs from "@calcom/dayjs";
-import { DataTableFilters } from "~/data-table/components/filters";
+import { DataTableFilters } from "@calcom/web/modules/data-table/components/filters";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
@@ -13,13 +13,13 @@ import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { Icon } from "@calcom/ui/components/icon";
 
-import { useBookingCalendarData } from "~/bookings/hooks/useBookingCalendarData";
-import { useBookingFilters } from "~/bookings/hooks/useBookingFilters";
-import { useCalendarAllowedFilters } from "~/bookings/hooks/useCalendarAllowedFilters";
-import { useCalendarAutoSelector } from "~/bookings/hooks/useCalendarAutoSelector";
-import { useCalendarNavigationCapabilities } from "~/bookings/hooks/useCalendarNavigationCapabilities";
-import { useCurrentWeekStart } from "~/bookings/hooks/useCurrentWeekStart";
-import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
+import { useBookingCalendarData } from "@calcom/web/modules/bookings/hooks/useBookingCalendarData";
+import { useBookingFilters } from "@calcom/web/modules/bookings/hooks/useBookingFilters";
+import { useCalendarAllowedFilters } from "@calcom/web/modules/bookings/hooks/useCalendarAllowedFilters";
+import { useCalendarAutoSelector } from "@calcom/web/modules/bookings/hooks/useCalendarAutoSelector";
+import { useCalendarNavigationCapabilities } from "@calcom/web/modules/bookings/hooks/useCalendarNavigationCapabilities";
+import { useCurrentWeekStart } from "@calcom/web/modules/bookings/hooks/useCurrentWeekStart";
+import { useFacetedUniqueValues } from "@calcom/web/modules/bookings/hooks/useFacetedUniqueValues";
 
 import { buildFilterColumns, getFilterColumnVisibility } from "../columns/filterColumns";
 import { getWeekStart } from "../lib/weekUtils";

--- a/apps/web/modules/bookings/components/BookingList.tsx
+++ b/apps/web/modules/bookings/components/BookingList.tsx
@@ -2,7 +2,7 @@
 
 import type { Table as ReactTable } from "@tanstack/react-table";
 
-import { DataTableWrapper } from "~/data-table/components";
+import { DataTableWrapper } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 

--- a/apps/web/modules/bookings/components/BookingListContainer.tsx
+++ b/apps/web/modules/bookings/components/BookingListContainer.tsx
@@ -9,7 +9,7 @@ import {
   useDataTable,
   useDisplayedFilterCount,
 } from "@calcom/features/data-table";
-import { DataTableSegment, DataTableFilters } from "~/data-table/components";
+import { DataTableSegment, DataTableFilters } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import useMeQuery from "@calcom/trpc/react/hooks/useMeQuery";
@@ -19,13 +19,13 @@ import { Button } from "@calcom/ui/components/button";
 import { ToggleGroup } from "@calcom/ui/components/form";
 import { WipeMyCalActionButton } from "@calcom/web/components/apps/wipemycalother/wipeMyCalActionButton";
 
-import { useBookingFilters } from "~/bookings/hooks/useBookingFilters";
-import { useBookingListColumns } from "~/bookings/hooks/useBookingListColumns";
-import { useBookingListData } from "~/bookings/hooks/useBookingListData";
-import { useBookingStatusTab } from "~/bookings/hooks/useBookingStatusTab";
-import { useFacetedUniqueValues } from "~/bookings/hooks/useFacetedUniqueValues";
-import { useListAutoSelector } from "~/bookings/hooks/useListAutoSelector";
-import { useListNavigationCapabilities } from "~/bookings/hooks/useListNavigationCapabilities";
+import { useBookingFilters } from "@calcom/web/modules/bookings/hooks/useBookingFilters";
+import { useBookingListColumns } from "@calcom/web/modules/bookings/hooks/useBookingListColumns";
+import { useBookingListData } from "@calcom/web/modules/bookings/hooks/useBookingListData";
+import { useBookingStatusTab } from "@calcom/web/modules/bookings/hooks/useBookingStatusTab";
+import { useFacetedUniqueValues } from "@calcom/web/modules/bookings/hooks/useFacetedUniqueValues";
+import { useListAutoSelector } from "@calcom/web/modules/bookings/hooks/useListAutoSelector";
+import { useListNavigationCapabilities } from "@calcom/web/modules/bookings/hooks/useListNavigationCapabilities";
 
 import {
   BookingDetailsSheetStoreProvider,

--- a/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
+++ b/apps/web/modules/ee/api-keys/components/ApiKeyDialogForm.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import dayjs from "@calcom/dayjs";
-import type { TApiKeys } from "~/ee/api-keys/components/ApiKeyListItem";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import type { TApiKeys } from "@calcom/web/modules/ee/api-keys/components/ApiKeyListItem";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { API_NAME_LENGTH_MAX_LIMIT } from "@calcom/lib/constants";
 import { IS_CALCOM } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";

--- a/apps/web/modules/ee/dsync/components/GroupTeamMappingTable.tsx
+++ b/apps/web/modules/ee/dsync/components/GroupTeamMappingTable.tsx
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 
 import { DataTableProvider } from "@calcom/features/data-table/DataTableProvider";
-import { DataTable, DataTableToolbar } from "~/data-table/components";
+import { DataTable, DataTableToolbar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 

--- a/apps/web/modules/ee/organizations/admin-api.tsx
+++ b/apps/web/modules/ee/organizations/admin-api.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { Icon } from "@calcom/ui/components/icon";
 
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 export const AdminAPIView = () => {
   const { t } = useLocale();

--- a/apps/web/modules/ee/organizations/appearance.tsx
+++ b/apps/web/modules/ee/organizations/appearance.tsx
@@ -6,8 +6,8 @@ import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import BrandColorsForm from "~/ee/common/components/BrandColorsForm";
-import { AppearanceSkeletonLoader } from "~/ee/common/components/CommonSkeletonLoaders";
+import BrandColorsForm from "@calcom/web/modules/ee/common/components/BrandColorsForm";
+import { AppearanceSkeletonLoader } from "@calcom/web/modules/ee/common/components/CommonSkeletonLoaders";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import ThemeLabel from "@calcom/features/settings/ThemeLabel";
 import { DEFAULT_LIGHT_BRAND_COLOR, DEFAULT_DARK_BRAND_COLOR } from "@calcom/lib/constants";

--- a/apps/web/modules/ee/organizations/attributes/attributes-create-view.tsx
+++ b/apps/web/modules/ee/organizations/attributes/attributes-create-view.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";

--- a/apps/web/modules/ee/organizations/attributes/attributes-edit-view.tsx
+++ b/apps/web/modules/ee/organizations/attributes/attributes-edit-view.tsx
@@ -4,7 +4,7 @@ import { useParams } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";

--- a/apps/web/modules/ee/organizations/attributes/attributes-list-view.tsx
+++ b/apps/web/modules/ee/organizations/attributes/attributes-list-view.tsx
@@ -3,7 +3,7 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/organizations/general.tsx
+++ b/apps/web/modules/ee/organizations/general.tsx
@@ -6,11 +6,11 @@ import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { TimezoneSelect } from "@calcom/features/components/timezone-select";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import { DisableAutofillOnBookingPageSwitch } from "~/ee/organizations/components/DisableAutofillOnBookingPageSwitch";
-import { DisablePhoneOnlySMSNotificationsSwitch } from "~/ee/organizations/components/DisablePhoneOnlySMSNotificationsSwitch";
-import { LockEventTypeSwitch } from "~/ee/organizations/components/LockEventTypeSwitch";
-import { NoSlotsNotificationSwitch } from "~/ee/organizations/components/NoSlotsNotificationSwitch";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import { DisableAutofillOnBookingPageSwitch } from "@calcom/web/modules/ee/organizations/components/DisableAutofillOnBookingPageSwitch";
+import { DisablePhoneOnlySMSNotificationsSwitch } from "@calcom/web/modules/ee/organizations/components/DisablePhoneOnlySMSNotificationsSwitch";
+import { LockEventTypeSwitch } from "@calcom/web/modules/ee/organizations/components/LockEventTypeSwitch";
+import { NoSlotsNotificationSwitch } from "@calcom/web/modules/ee/organizations/components/NoSlotsNotificationSwitch";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { nameOfDay } from "@calcom/lib/weekday";

--- a/apps/web/modules/ee/organizations/guest-notifications.tsx
+++ b/apps/web/modules/ee/organizations/guest-notifications.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { trpc } from "@calcom/trpc/react";
 import { SkeletonContainer, SkeletonText, SkeletonButton } from "@calcom/ui/components/skeleton";
 
-import DisableGuestBookingEmailsSetting from "~/ee/organizations/components/DisableGuestBookingEmailsSetting";
+import DisableGuestBookingEmailsSetting from "@calcom/web/modules/ee/organizations/components/DisableGuestBookingEmailsSetting";
 
 const SkeletonLoader = () => {
   return (

--- a/apps/web/modules/ee/organizations/new/about-view.tsx
+++ b/apps/web/modules/ee/organizations/new/about-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AboutOrganizationForm } from "~/ee/organizations/components/AboutOrganizationForm";
+import { AboutOrganizationForm } from "@calcom/web/modules/ee/organizations/components/AboutOrganizationForm";
 
 import { OrganizationWizardLayout } from "./_components/OrganizationWizardLayout";
 

--- a/apps/web/modules/ee/organizations/new/create-new-view.tsx
+++ b/apps/web/modules/ee/organizations/new/create-new-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CreateANewOrganizationForm } from "~/ee/organizations/components/CreateANewOrganizationForm";
+import { CreateANewOrganizationForm } from "@calcom/web/modules/ee/organizations/components/CreateANewOrganizationForm";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 import { useGetUserAttributes } from "@calcom/web/components/settings/platform/hooks/useGetUserAttributes";

--- a/apps/web/modules/ee/organizations/new/onboarding-handover.tsx
+++ b/apps/web/modules/ee/organizations/new/onboarding-handover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AdminOnboardingHandover } from "~/ee/organizations/components/AdminOnboardingHandover";
+import { AdminOnboardingHandover } from "@calcom/web/modules/ee/organizations/components/AdminOnboardingHandover";
 import { WizardLayout } from "@calcom/ui/components/layout";
 
 export const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/apps/web/modules/ee/organizations/new/payment-status-view.tsx
+++ b/apps/web/modules/ee/organizations/new/payment-status-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import PaymentStatusView from "~/ee/organizations/new/_components/PaymentStatusView";
+import PaymentStatusView from "@calcom/web/modules/ee/organizations/new/_components/PaymentStatusView";
 
 import { OrganizationWizardLayout } from "./_components/OrganizationWizardLayout";
 

--- a/apps/web/modules/ee/organizations/other-team-members-view.tsx
+++ b/apps/web/modules/ee/organizations/other-team-members-view.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import MemberListItem from "~/ee/organizations/components/MemberListItem";
+import MemberListItem from "@calcom/web/modules/ee/organizations/components/MemberListItem";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useParamsWithFallback } from "@calcom/lib/hooks/useParamsWithFallback";
 import { CreationSource } from "@calcom/prisma/enums";
@@ -17,8 +17,8 @@ import { Button } from "@calcom/ui/components/button";
 import { showToast } from "@calcom/ui/components/toast";
 import { revalidateTeamsList } from "@calcom/web/app/(use-page-wrapper)/(main-nav)/teams/actions";
 
-import MakeTeamPrivateSwitch from "~/ee/teams/components/MakeTeamPrivateSwitch";
-import MemberInvitationModal from "~/ee/teams/components/MemberInvitationModal";
+import MakeTeamPrivateSwitch from "@calcom/web/modules/ee/teams/components/MakeTeamPrivateSwitch";
+import MemberInvitationModal from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 type Members = RouterOutputs["viewer"]["organizations"]["listOtherTeamMembers"]["rows"];
 type Team = RouterOutputs["viewer"]["organizations"]["getOtherTeam"];

--- a/apps/web/modules/ee/organizations/privacy.tsx
+++ b/apps/web/modules/ee/organizations/privacy.tsx
@@ -4,13 +4,13 @@ import { usePathname } from "next/navigation";
 
 import { DataTableProvider } from "@calcom/features/data-table";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
-import OrgAutoJoinSetting from "~/ee/organizations/components/OrgAutoJoinSetting";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
+import OrgAutoJoinSetting from "@calcom/web/modules/ee/organizations/components/OrgAutoJoinSetting";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 
-import { BlocklistTable } from "~/ee/organizations/privacy/blocklist-table";
-import MakeTeamPrivateSwitch from "~/ee/teams/components/MakeTeamPrivateSwitch";
+import { BlocklistTable } from "@calcom/web/modules/ee/organizations/privacy/blocklist-table";
+import MakeTeamPrivateSwitch from "@calcom/web/modules/ee/teams/components/MakeTeamPrivateSwitch";
 
 const PrivacyView = ({
   permissions,

--- a/apps/web/modules/ee/organizations/privacy/blocklist-table.tsx
+++ b/apps/web/modules/ee/organizations/privacy/blocklist-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { DataTableToolbar } from "~/data-table/components";
+import { DataTableToolbar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Button } from "@calcom/ui/components/button";
 import { ToggleGroup } from "@calcom/ui/components/form";

--- a/apps/web/modules/ee/organizations/privacy/components/blocked-entries-table.tsx
+++ b/apps/web/modules/ee/organizations/privacy/components/blocked-entries-table.tsx
@@ -5,7 +5,7 @@ import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/rea
 import { useMemo, useState } from "react";
 
 import { useDataTable } from "@calcom/features/data-table";
-import { DataTableWrapper } from "~/data-table/components";
+import { DataTableWrapper } from "@calcom/web/modules/data-table/components";
 import { IS_CALCOM } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/organizations/privacy/components/pending-reports-table.tsx
+++ b/apps/web/modules/ee/organizations/privacy/components/pending-reports-table.tsx
@@ -5,7 +5,7 @@ import { getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/rea
 import { useMemo, useState } from "react";
 
 import { useDataTable } from "@calcom/features/data-table";
-import { DataTableWrapper } from "~/data-table/components";
+import { DataTableWrapper } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/organizations/profile.tsx
+++ b/apps/web/modules/ee/organizations/profile.tsx
@@ -6,7 +6,7 @@ import { useEffect, useLayoutEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { subdomainSuffix } from "@calcom/features/ee/organizations/lib/orgDomains";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";

--- a/apps/web/modules/ee/platform/components/CreateANewPlatformForm.tsx
+++ b/apps/web/modules/ee/platform/components/CreateANewPlatformForm.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { uuid } from "short-uuid";
 
-import { deriveOrgNameFromEmail, deriveSlugFromEmail } from "~/ee/organizations/components/CreateANewOrganizationForm";
+import { deriveOrgNameFromEmail, deriveSlugFromEmail } from "@calcom/web/modules/ee/organizations/components/CreateANewOrganizationForm";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import slugify from "@calcom/lib/slugify";
 import { UserPermissionRole } from "@calcom/prisma/enums";

--- a/apps/web/modules/ee/sso/components/SSOConfiguration.tsx
+++ b/apps/web/modules/ee/sso/components/SSOConfiguration.tsx
@@ -3,7 +3,7 @@
 import ConnectionInfo from "./ConnectionInfo";
 import OIDCConnection from "./OIDCConnection";
 import SAMLConnection from "./SAMLConnection";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Alert } from "@calcom/ui/components/alert";

--- a/apps/web/modules/ee/support/components/ContactMenuItem.tsx
+++ b/apps/web/modules/ee/support/components/ContactMenuItem.tsx
@@ -3,7 +3,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Icon } from "@calcom/ui/components/icon";
 import { useHasPaidPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
 
-import { UpgradeTeamsBadgeWebWrapper } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
+import { UpgradeTeamsBadgeWebWrapper } from "@calcom/web/modules/billing/components/UpgradeTeamsBadgeWebWrapper";
 
 import FreshChatMenuItem from "../lib/freshchat/FreshChatMenuItem";
 import HelpscoutMenuItem from "../lib/helpscout/HelpscoutMenuItem";

--- a/apps/web/modules/ee/support/lib/intercom/provider.tsx
+++ b/apps/web/modules/ee/support/lib/intercom/provider.tsx
@@ -10,7 +10,7 @@ import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import { useHasPaidPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
 import { useBootIntercom } from "@calcom/web/modules/ee/support/lib/intercom/useIntercom";
 
-import { IntercomContactForm } from "~/ee/support/components/IntercomContactForm";
+import { IntercomContactForm } from "@calcom/web/modules/ee/support/components/IntercomContactForm";
 
 declare global {
   interface Window {

--- a/apps/web/modules/ee/teams/components/AddNewTeamMembers.tsx
+++ b/apps/web/modules/ee/teams/components/AddNewTeamMembers.tsx
@@ -22,7 +22,7 @@ import { SkeletonButton, SkeletonContainer, SkeletonText } from "@calcom/ui/comp
 import { showToast } from "@calcom/ui/components/toast";
 import InviteLinkSettingsModal from "@calcom/web/modules/ee/teams/components/InviteLinkSettingsModal";
 
-import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
+import { MemberInvitationModalWithoutMembers } from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 type TeamMember = RouterOutputs["viewer"]["teams"]["listMembers"]["members"][number];
 

--- a/apps/web/modules/ee/teams/components/DeleteBulkTeamMembers.tsx
+++ b/apps/web/modules/ee/teams/components/DeleteBulkTeamMembers.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/teams/components/EventTypesList.tsx
+++ b/apps/web/modules/ee/teams/components/EventTypesList.tsx
@@ -2,7 +2,7 @@ import type { Table } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import { useState, Fragment } from "react";
 
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
+++ b/apps/web/modules/ee/teams/components/MemberInvitationModal.tsx
@@ -4,7 +4,7 @@ import type { FormEvent } from "react";
 import { useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import TeamInviteFromOrg from "~/ee/organizations/components/TeamInviteFromOrg";
+import TeamInviteFromOrg from "@calcom/web/modules/ee/organizations/components/TeamInviteFromOrg";
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
 import type { PendingMember } from "@calcom/features/ee/teams/lib/types";

--- a/apps/web/modules/ee/teams/components/MemberList.tsx
+++ b/apps/web/modules/ee/teams/components/MemberList.tsx
@@ -25,7 +25,7 @@ import {
   useColumnFilters,
   convertFacetedValuesToMap,
 } from "@calcom/features/data-table";
-import { DataTableToolbar, DataTableFilters, DataTableWrapper, DataTableSelectionBar } from "~/data-table/components";
+import { DataTableToolbar, DataTableFilters, DataTableWrapper, DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";

--- a/apps/web/modules/ee/teams/components/TeamAvailabilityModal.tsx
+++ b/apps/web/modules/ee/teams/components/TeamAvailabilityModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import dayjs from "@calcom/dayjs";
 import { TimezoneSelect } from "@calcom/features/components/timezone-select";
 import type { ITimezone } from "@calcom/features/components/timezone-select";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { CURRENT_TIMEZONE } from "@calcom/lib/timezoneConstants";

--- a/apps/web/modules/ee/teams/components/TeamListItem.tsx
+++ b/apps/web/modules/ee/teams/components/TeamListItem.tsx
@@ -30,7 +30,7 @@ import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { revalidateTeamsList } from "@calcom/web/app/(use-page-wrapper)/(main-nav)/teams/actions";
 
-import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
+import { MemberInvitationModalWithoutMembers } from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 import InviteLinkSettingsModal from "./InviteLinkSettingsModal";
 import { TeamRole } from "./TeamPill";

--- a/apps/web/modules/ee/teams/components/TeamsListing.tsx
+++ b/apps/web/modules/ee/teams/components/TeamsListing.tsx
@@ -13,8 +13,8 @@ import { Label } from "@calcom/ui/components/form";
 import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
 
-import SkeletonLoaderTeamList from "~/ee/teams/components/SkeletonloaderTeamList";
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import SkeletonLoaderTeamList from "@calcom/web/modules/ee/teams/components/SkeletonloaderTeamList";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 import TeamList from "./TeamList";
 

--- a/apps/web/modules/ee/teams/views/team-appearance-view.tsx
+++ b/apps/web/modules/ee/teams/views/team-appearance-view.tsx
@@ -5,8 +5,8 @@ import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import BrandColorsForm from "~/ee/common/components/BrandColorsForm";
-import { AppearanceSkeletonLoader } from "~/ee/common/components/CommonSkeletonLoaders";
+import BrandColorsForm from "@calcom/web/modules/ee/common/components/BrandColorsForm";
+import { AppearanceSkeletonLoader } from "@calcom/web/modules/ee/common/components/CommonSkeletonLoaders";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import ThemeLabel from "@calcom/features/settings/ThemeLabel";
 import { APP_NAME } from "@calcom/lib/constants";

--- a/apps/web/modules/ee/teams/views/team-members-view.tsx
+++ b/apps/web/modules/ee/teams/views/team-members-view.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from "react";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import type { MemberPermissions } from "@calcom/web/modules/users/components/UserTable/types";
 
-import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
+import { MemberInvitationModalWithoutMembers } from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 import MemberList from "../components/MemberList";
 

--- a/apps/web/modules/ee/teams/views/team-settings-view.tsx
+++ b/apps/web/modules/ee/teams/views/team-settings-view.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import { AppearanceSkeletonLoader } from "~/ee/common/components/CommonSkeletonLoaders";
+import { AppearanceSkeletonLoader } from "@calcom/web/modules/ee/common/components/CommonSkeletonLoaders";
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useParamsWithFallback } from "@calcom/lib/hooks/useParamsWithFallback";

--- a/apps/web/modules/ee/users/components/UsersTable.tsx
+++ b/apps/web/modules/ee/users/components/UsersTable.tsx
@@ -24,7 +24,7 @@ import { Icon } from "@calcom/ui/components/icon";
 import { DropdownActions, Table } from "@calcom/ui/components/table";
 import { showToast } from "@calcom/ui/components/toast";
 
-import { withLicenseRequired } from "~/ee/common/components/LicenseRequired";
+import { withLicenseRequired } from "@calcom/web/modules/ee/common/components/LicenseRequired";
 
 const { Cell, ColumnTitle, Header, Row } = Table;
 

--- a/apps/web/modules/ee/users/views/users-add-view.tsx
+++ b/apps/web/modules/ee/users/views/users-add-view.tsx
@@ -6,7 +6,7 @@ import { getParserWithGeneric } from "@calcom/prisma/zod-utils";
 import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { userBodySchema } from "@calcom/features/ee/users/schemas/userBodySchema";
 import { UserForm } from "../components/UserForm";
 

--- a/apps/web/modules/ee/video/components/ViewRecordingsDialog.tsx
+++ b/apps/web/modules/ee/video/components/ViewRecordingsDialog.tsx
@@ -5,7 +5,7 @@ import { Suspense, useEffect, useState } from "react";
 
 import dayjs from "@calcom/dayjs";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RecordingItemSchema } from "@calcom/prisma/zod-utils";
 import type { RouterOutputs } from "@calcom/trpc/react";

--- a/apps/web/modules/ee/workflows/components/EmptyScreen.tsx
+++ b/apps/web/modules/ee/workflows/components/EmptyScreen.tsx
@@ -4,7 +4,7 @@ import { EmptyScreen as ClassicEmptyScreen } from "@calcom/ui/components/empty-s
 import { Icon } from "@calcom/ui/components/icon";
 import type { IconName } from "@calcom/ui/components/icon";
 
-import { CreateButtonWithTeamsList } from "~/ee/teams/components/createButton/CreateButtonWithTeamsList";
+import { CreateButtonWithTeamsList } from "@calcom/web/modules/ee/teams/components/createButton/CreateButtonWithTeamsList";
 
 import { WorkflowCreationDialog, useWorkflowCreation } from "./WorkflowCreationDialog";
 

--- a/apps/web/modules/ee/workflows/components/VoiceSelectionDialog.tsx
+++ b/apps/web/modules/ee/workflows/components/VoiceSelectionDialog.tsx
@@ -3,7 +3,7 @@ import { usePathname } from "next/navigation";
 import { useMemo, useState, useCallback } from "react";
 
 import { DataTableProvider } from "@calcom/features/data-table";
-import { DataTableWrapper } from "~/data-table/components";
+import { DataTableWrapper } from "@calcom/web/modules/data-table/components";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import { useVoicePreview } from "@calcom/features/ee/workflows/hooks/useVoicePreview";
 import { useLocale } from "@calcom/lib/hooks/useLocale";

--- a/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
+++ b/apps/web/modules/ee/workflows/views/WorkflowPage.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { Toaster } from "sonner";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import {
   isSMSAction,
   isSMSOrWhatsappAction,

--- a/apps/web/modules/ee/workflows/views/WorkflowsPage.tsx
+++ b/apps/web/modules/ee/workflows/views/WorkflowsPage.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import type { WorkflowRepository } from "@calcom/features/ee/workflows/repositories/WorkflowRepository";
 import { FilterResults } from "@calcom/features/filters/components/FilterResults";
 import { TeamsFilter } from "@calcom/features/filters/components/TeamsFilter";
@@ -26,7 +26,7 @@ import {
 } from "@calcom/web/modules/ee/workflows/components/WorkflowCreationDialog";
 import WorkflowList from "@calcom/web/modules/ee/workflows/components/WorkflowListPage";
 
-import { CreateButtonWithTeamsList } from "~/ee/teams/components/createButton/CreateButtonWithTeamsList";
+import { CreateButtonWithTeamsList } from "@calcom/web/modules/ee/teams/components/createButton/CreateButtonWithTeamsList";
 
 type PageProps = {
   filteredList?: Awaited<ReturnType<typeof WorkflowRepository.getFilteredList>>;

--- a/apps/web/modules/event-types/components/tabs/ai/AIEventController.tsx
+++ b/apps/web/modules/event-types/components/tabs/ai/AIEventController.tsx
@@ -8,7 +8,7 @@ import { getTemplateFieldsSchema } from "@calcom/features/calAIPhone/getTemplate
 import { templateFieldsMap } from "@calcom/features/calAIPhone/template-fields-map";
 import type { TemplateType } from "@calcom/features/calAIPhone/zod-utils";
 import PhoneInput from "@calcom/features/components/phone-input";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import type { EventTypeSetup, FormValues } from "@calcom/features/eventtypes/lib/types";
 import { ComponentForField } from "@calcom/features/form-builder/FormBuilderField";
 import { useLocale } from "@calcom/lib/hooks/useLocale";

--- a/apps/web/modules/event-types/components/tabs/instant/InstantEventController.tsx
+++ b/apps/web/modules/event-types/components/tabs/instant/InstantEventController.tsx
@@ -5,7 +5,7 @@ import { components } from "react-select";
 import type { OptionProps, SingleValueProps } from "react-select";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
 import type { EventTypeSetup, FormValues, AvailabilityOption } from "@calcom/features/eventtypes/lib/types";
 import { subscriberUrlReserved } from "@calcom/features/webhooks/lib/subscriberUrlReserved";
@@ -24,9 +24,9 @@ import { Select } from "@calcom/ui/components/form";
 import { SettingsToggle } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 
-import { WebhookForm } from "~/webhooks/components";
-import type { TWebhook, WebhookFormSubmitData } from "~/webhooks/components/WebhookForm";
-import WebhookListItem from "~/webhooks/components/WebhookListItem";
+import { WebhookForm } from "@calcom/web/modules/webhooks/components";
+import type { TWebhook, WebhookFormSubmitData } from "@calcom/web/modules/webhooks/components/WebhookForm";
+import WebhookListItem from "@calcom/web/modules/webhooks/components/WebhookListItem";
 
 type InstantEventControllerProps = {
   eventType: EventTypeSetup;

--- a/apps/web/modules/event-types/components/tabs/webhooks/EventWebhooksTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/webhooks/EventWebhooksTab.tsx
@@ -17,9 +17,9 @@ import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 import { showToast } from "@calcom/ui/components/toast";
 import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/event-types/[type]/actions";
 
-import { WebhookForm } from "~/webhooks/components";
-import EventTypeWebhookListItem from "~/webhooks/components/EventTypeWebhookListItem";
-import type { TWebhook, WebhookFormSubmitData } from "~/webhooks/components/WebhookForm";
+import { WebhookForm } from "@calcom/web/modules/webhooks/components";
+import EventTypeWebhookListItem from "@calcom/web/modules/webhooks/components/EventTypeWebhookListItem";
+import type { TWebhook, WebhookFormSubmitData } from "@calcom/web/modules/webhooks/components/WebhookForm";
 
 export const EventWebhooksTab = ({ eventType }: Pick<EventTypeSetupProps, "eventType">) => {
   const { t } = useLocale();

--- a/apps/web/modules/event-types/components/tabs/workflows/EventWorkflowsTab.tsx
+++ b/apps/web/modules/event-types/components/tabs/workflows/EventWorkflowsTab.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import useLockedFieldsManager from "@calcom/features/ee/managed-event-types/hooks/useLockedFieldsManager";
 import { getActionIcon } from "@calcom/features/ee/workflows/lib/getActionIcon";
 import type { FormValues } from "@calcom/features/eventtypes/lib/types";
@@ -23,8 +23,8 @@ import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { revalidateEventTypeEditPage } from "@calcom/web/app/(use-page-wrapper)/event-types/[type]/actions";
 
-import SkeletonLoader from "~/ee/workflows/components/SkeletonLoaderEventWorkflowsTab";
-import type { WorkflowType } from "~/ee/workflows/components/WorkflowListPage";
+import SkeletonLoader from "@calcom/web/modules/ee/workflows/components/SkeletonLoaderEventWorkflowsTab";
+import type { WorkflowType } from "@calcom/web/modules/ee/workflows/components/WorkflowListPage";
 
 type PartialWorkflowType = Pick<
   WorkflowType,

--- a/apps/web/modules/insights/views/insights-call-history-view.tsx
+++ b/apps/web/modules/insights/views/insights-call-history-view.tsx
@@ -10,7 +10,7 @@ import {
   convertFacetedValuesToMap,
   useDataTable,
 } from "@calcom/features/data-table";
-import { DataTableWrapper, DataTableToolbar, DataTableFilters } from "~/data-table/components";
+import { DataTableWrapper, DataTableToolbar, DataTableFilters } from "@calcom/web/modules/data-table/components";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import type { CallDetailsState, CallDetailsAction } from "@calcom/features/ee/workflows/lib/types";

--- a/apps/web/modules/insights/views/insights-view.tsx
+++ b/apps/web/modules/insights/views/insights-view.tsx
@@ -8,7 +8,7 @@ import {
   ColumnFilterType,
   type FilterableColumn,
 } from "@calcom/features/data-table";
-import { DataTableFilters, DateRangeFilter } from "~/data-table/components";
+import { DataTableFilters, DateRangeFilter } from "@calcom/web/modules/data-table/components";
 import type { FilterType } from "@calcom/types/data-table";
 import { useDataTable } from "@calcom/features/data-table/hooks/useDataTable";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";

--- a/apps/web/modules/members/members-view.tsx
+++ b/apps/web/modules/members/members-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { checkAdminOrOwner } from "@calcom/features/auth/lib/checkAdminOrOwner";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { UserListTable } from "@calcom/web/modules/users/components/UserTable/UserListTable";
 import type { UserListTableProps } from "@calcom/web/modules/users/components/UserTable/UserListTable";

--- a/apps/web/modules/more/more-page-view.tsx
+++ b/apps/web/modules/more/more-page-view.tsx
@@ -2,8 +2,8 @@
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 
-import Shell from "~/shell/Shell";
-import { MobileNavigationMoreItems } from "~/shell/navigation/Navigation";
+import Shell from "@calcom/web/modules/shell/Shell";
+import { MobileNavigationMoreItems } from "@calcom/web/modules/shell/navigation/Navigation";
 
 export default function MorePage() {
   const { t } = useLocale();

--- a/apps/web/modules/settings/billing/billing-view.tsx
+++ b/apps/web/modules/settings/billing/billing-view.tsx
@@ -8,7 +8,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
 
-import BillingCredits from "~/settings/billing/components/BillingCredits";
+import BillingCredits from "@calcom/web/modules/settings/billing/components/BillingCredits";
 
 interface CtaRowProps {
   title: string;

--- a/apps/web/modules/settings/billing/components/BillingCredits.tsx
+++ b/apps/web/modules/settings/billing/components/BillingCredits.tsx
@@ -23,7 +23,7 @@ import { ProgressBar } from "@calcom/ui/components/progress-bar";
 import { showToast } from "@calcom/ui/components/toast";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 
-import { MemberInvitationModalWithoutMembers } from "~/ee/teams/components/MemberInvitationModal";
+import { MemberInvitationModalWithoutMembers } from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 import { BillingCreditsSkeleton } from "./BillingCreditsSkeleton";
 

--- a/apps/web/modules/settings/developer/api-keys-view.tsx
+++ b/apps/web/modules/settings/developer/api-keys-view.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from "react";
 
-import type { TApiKeys } from "~/ee/api-keys/components/ApiKeyListItem";
-import LicenseRequired from "~/ee/common/components/LicenseRequired";
+import type { TApiKeys } from "@calcom/web/modules/ee/api-keys/components/ApiKeyListItem";
+import LicenseRequired from "@calcom/web/modules/ee/common/components/LicenseRequired";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import ApiKeyDialogForm from "~/ee/api-keys/components/ApiKeyDialogForm";
-import ApiKeyListItem from "~/ee/api-keys/components/ApiKeyListItem";
+import ApiKeyDialogForm from "@calcom/web/modules/ee/api-keys/components/ApiKeyDialogForm";
+import ApiKeyListItem from "@calcom/web/modules/ee/api-keys/components/ApiKeyListItem";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { APP_NAME } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";

--- a/apps/web/modules/settings/my-account/appearance-view.tsx
+++ b/apps/web/modules/settings/my-account/appearance-view.tsx
@@ -27,7 +27,7 @@ import { SettingsToggle, ColorPicker, Form } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 import { useCalcomTheme } from "@calcom/ui/styles";
 
-import { UpgradeTeamsBadgeWebWrapper } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
+import { UpgradeTeamsBadgeWebWrapper } from "@calcom/web/modules/billing/components/UpgradeTeamsBadgeWebWrapper";
 
 const useBrandColors = (
   currentTheme: string | null,

--- a/apps/web/modules/settings/my-account/holidays-view.tsx
+++ b/apps/web/modules/settings/my-account/holidays-view.tsx
@@ -16,7 +16,7 @@ import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonContainer, SkeletonText } from "@calcom/ui/components/skeleton";
 import { showToast } from "@calcom/ui/components/toast";
 
-import { OutOfOfficeToggleGroup } from "~/settings/outOfOffice/OutOfOfficeToggleGroup";
+import { OutOfOfficeToggleGroup } from "@calcom/web/modules/settings/outOfOffice/OutOfOfficeToggleGroup";
 
 function HolidaysCTA() {
   const { t } = useLocale();

--- a/apps/web/modules/settings/my-account/out-of-office-view.tsx
+++ b/apps/web/modules/settings/my-account/out-of-office-view.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState } from "react";
 
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 
-import type { BookingRedirectForm } from "~/settings/outOfOffice/types";
+import type { BookingRedirectForm } from "@calcom/web/modules/settings/outOfOffice/types";
 
-import { CreateOrEditOutOfOfficeEntryModal } from "~/settings/outOfOffice/CreateOrEditOutOfOfficeModal";
-import OutOfOfficeEntriesList from "~/settings/outOfOffice/OutOfOfficeEntriesList";
-import { OutOfOfficeTab } from "~/settings/outOfOffice/OutOfOfficeToggleGroup";
+import { CreateOrEditOutOfOfficeEntryModal } from "@calcom/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal";
+import OutOfOfficeEntriesList from "@calcom/web/modules/settings/outOfOffice/OutOfOfficeEntriesList";
+import { OutOfOfficeTab } from "@calcom/web/modules/settings/outOfOffice/OutOfOfficeToggleGroup";
 
 import { HolidaysView } from "./holidays-view";
 

--- a/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
+++ b/apps/web/modules/settings/outOfOffice/CreateOrEditOutOfOfficeModal.tsx
@@ -20,11 +20,11 @@ import { Switch } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 import { useHasTeamPlan } from "@calcom/web/modules/billing/hooks/useHasPaidPlan";
 
-import { UpgradeTeamsBadgeWebWrapper as UpgradeTeamsBadge } from "~/billing/components/UpgradeTeamsBadgeWebWrapper";
-import { OutOfOfficeTab } from "~/settings/outOfOffice/OutOfOfficeToggleGroup";
+import { UpgradeTeamsBadgeWebWrapper as UpgradeTeamsBadge } from "@calcom/web/modules/billing/components/UpgradeTeamsBadgeWebWrapper";
+import { OutOfOfficeTab } from "@calcom/web/modules/settings/outOfOffice/OutOfOfficeToggleGroup";
 
-export type { BookingRedirectForm } from "~/settings/outOfOffice/types";
-import type { BookingRedirectForm } from "~/settings/outOfOffice/types";
+export type { BookingRedirectForm } from "@calcom/web/modules/settings/outOfOffice/types";
+import type { BookingRedirectForm } from "@calcom/web/modules/settings/outOfOffice/types";
 
 type Option = { value: number; label: string };
 

--- a/apps/web/modules/settings/outOfOffice/OutOfOfficeEntriesList.tsx
+++ b/apps/web/modules/settings/outOfOffice/OutOfOfficeEntriesList.tsx
@@ -18,7 +18,7 @@ import {
   useFilterValue,
   ZDateRangeFilterValue,
 } from "@calcom/features/data-table";
-import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment } from "~/data-table/components";
+import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment } from "@calcom/web/modules/data-table/components";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import ServerTrans from "@calcom/lib/components/ServerTrans";

--- a/apps/web/modules/settings/platform/billing/billing-view.tsx
+++ b/apps/web/modules/settings/platform/billing/billing-view.tsx
@@ -15,8 +15,8 @@ import { useUnsubscribeTeamToStripe } from "@lib/hooks/settings/platform/billing
 import NoPlatformPlan from "@components/settings/platform/dashboard/NoPlatformPlan";
 import { useGetUserAttributes } from "@components/settings/platform/hooks/useGetUserAttributes";
 
-import { CtaRow } from "~/settings/billing/billing-view";
-import Shell from "~/shell/Shell";
+import { CtaRow } from "@calcom/web/modules/settings/billing/billing-view";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 declare global {
   interface Window {

--- a/apps/web/modules/settings/platform/managed-users/managed-users-view.tsx
+++ b/apps/web/modules/settings/platform/managed-users/managed-users-view.tsx
@@ -10,7 +10,7 @@ import { PlatformManagedUsersTable } from "@calcom/web/modules/users/components/
 
 import { useOAuthClients } from "@lib/hooks/settings/platform/oauth-clients/useOAuthClients";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 type OAuthClientOption = { label: string; value: string };
 

--- a/apps/web/modules/settings/platform/new/create-new-view.tsx
+++ b/apps/web/modules/settings/platform/new/create-new-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CreateANewPlatformForm } from "~/ee/platform/components/CreateANewPlatformForm";
+import { CreateANewPlatformForm } from "@calcom/web/modules/ee/platform/components/CreateANewPlatformForm";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Alert } from "@calcom/ui/components/alert";
 import { WizardLayout } from "@calcom/ui/components/layout";

--- a/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-view.tsx
@@ -16,7 +16,7 @@ import { useGetUserAttributes } from "@components/settings/platform/hooks/useGet
 import type { FormValues } from "@components/settings/platform/oauth-clients/oauth-client-form";
 import { OAuthClientForm as EditOAuthClientForm } from "@components/settings/platform/oauth-clients/oauth-client-form";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function EditOAuthClient() {
   const { t } = useLocale();

--- a/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/[clientId]/edit/edit-webhooks-view.tsx
@@ -17,8 +17,8 @@ import {
 import NoPlatformPlan from "@components/settings/platform/dashboard/NoPlatformPlan";
 import { useGetUserAttributes } from "@components/settings/platform/hooks/useGetUserAttributes";
 
-import Shell from "~/shell/Shell";
-import { WebhookForm } from "~/webhooks/components";
+import Shell from "@calcom/web/modules/shell/Shell";
+import { WebhookForm } from "@calcom/web/modules/webhooks/components";
 
 export default function EditOAuthClientWebhooks() {
   const { t } = useLocale();

--- a/apps/web/modules/settings/platform/oauth-clients/create-new-view.tsx
+++ b/apps/web/modules/settings/platform/oauth-clients/create-new-view.tsx
@@ -15,7 +15,7 @@ import { useGetUserAttributes } from "@components/settings/platform/hooks/useGet
 import type { FormValues } from "@components/settings/platform/oauth-clients/oauth-client-form";
 import { OAuthClientForm } from "@components/settings/platform/oauth-clients/oauth-client-form";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function CreateOAuthClient() {
   const router = useRouter();

--- a/apps/web/modules/settings/platform/plans/platform-plans-view.tsx
+++ b/apps/web/modules/settings/platform/plans/platform-plans-view.tsx
@@ -6,7 +6,7 @@ import NoPlatformPlan from "@components/settings/platform/dashboard/NoPlatformPl
 import { useGetUserAttributes } from "@components/settings/platform/hooks/useGetUserAttributes";
 import { PlatformPricing } from "@components/settings/platform/pricing/platform-pricing";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export default function PlatformPlans() {
   const { t } = useLocale();

--- a/apps/web/modules/settings/platform/platform-view.tsx
+++ b/apps/web/modules/settings/platform/platform-view.tsx
@@ -17,7 +17,7 @@ import { OAuthClientsList } from "@components/settings/platform/dashboard/oauth-
 import { useGetUserAttributes } from "@components/settings/platform/hooks/useGetUserAttributes";
 import { PlatformPricing } from "@components/settings/platform/pricing/platform-pricing";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 const queryClient = new QueryClient();
 

--- a/apps/web/modules/shell/DynamicModals.tsx
+++ b/apps/web/modules/shell/DynamicModals.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { WelcomeToOrganizationsModal } from "~/ee/organizations/components/WelcomeToOrganizationsModal";
+import { WelcomeToOrganizationsModal } from "@calcom/web/modules/ee/organizations/components/WelcomeToOrganizationsModal";
 
 import { WelcomeToCalcomModal } from "./components/WelcomeToCalcomModal";
 import { GatedFeaturesModal } from "./components/GatedFeaturesModal";

--- a/apps/web/modules/shell/banners/LayoutBanner.tsx
+++ b/apps/web/modules/shell/banners/LayoutBanner.tsx
@@ -1,10 +1,10 @@
 import ImpersonatingBanner, {
   type ImpersonatingBannerProps,
-} from "~/ee/impersonation/components/ImpersonatingBanner";
+} from "@calcom/web/modules/ee/impersonation/components/ImpersonatingBanner";
 import {
   OrgUpgradeBanner,
   type OrgUpgradeBannerProps,
-} from "~/ee/organizations/components/OrgUpgradeBanner";
+} from "@calcom/web/modules/ee/organizations/components/OrgUpgradeBanner";
 import {
   TeamsUpgradeBanner,
   type TeamsUpgradeBannerProps,

--- a/apps/web/modules/timezone-buddy/components/AvailabilitySliderTable.tsx
+++ b/apps/web/modules/timezone-buddy/components/AvailabilitySliderTable.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import dayjs from "@calcom/dayjs";
 import { DataTableProvider } from "@calcom/features/data-table/DataTableProvider";
-import { DataTable, DataTableToolbar } from "~/data-table/components";
+import { DataTable, DataTableToolbar } from "@calcom/web/modules/data-table/components";
 import { useDataTable } from "@calcom/features/data-table/hooks";
 import type { DateRange } from "@calcom/features/schedules/lib/date-ranges";
 import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
@@ -21,7 +21,7 @@ import { UserAvatar } from "@calcom/ui/components/avatar";
 import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 
-import { UpgradeTip } from "~/shell/UpgradeTip";
+import { UpgradeTip } from "@calcom/web/modules/shell/UpgradeTip";
 
 import { createTimezoneBuddyStore, TBContext } from "../store";
 import { AvailabilityEditSheet } from "./AvailabilityEditSheet";

--- a/apps/web/modules/upgrade/upgrade-view.tsx
+++ b/apps/web/modules/upgrade/upgrade-view.tsx
@@ -9,7 +9,7 @@ import { Button } from "@calcom/ui/components/button";
 import { EmptyScreen } from "@calcom/ui/components/empty-screen";
 import { showToast } from "@calcom/ui/components/toast";
 
-import Shell from "~/shell/Shell";
+import Shell from "@calcom/web/modules/shell/Shell";
 
 export type OrgUpgradeBannerProps = {
   data: RouterOutputs["viewer"]["me"]["getUserTopBanners"]["orgUpgradeBanner"];

--- a/apps/web/modules/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
+++ b/apps/web/modules/users/components/UserTable/BulkActions/DeleteBulkUsers.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@calcom/features/components/controlled-dialog";
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { DialogTrigger, ConfirmationDialogContent } from "@calcom/ui/components/dialog";

--- a/apps/web/modules/users/components/UserTable/BulkActions/EventTypesList.tsx
+++ b/apps/web/modules/users/components/UserTable/BulkActions/EventTypesList.tsx
@@ -2,7 +2,7 @@ import type { Table } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import { useState, Fragment } from "react";
 
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { SchedulingType } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/modules/users/components/UserTable/BulkActions/MassAssignAttributes.tsx
+++ b/apps/web/modules/users/components/UserTable/BulkActions/MassAssignAttributes.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useState, useMemo, type PropsWithChildren } 
 import type { Dispatch, SetStateAction } from "react";
 
 import { type ColumnFilter } from "@calcom/features/data-table";
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { Attribute as _Attribute, AttributeOption } from "@calcom/prisma/client";
 import { trpc } from "@calcom/trpc/react";

--- a/apps/web/modules/users/components/UserTable/BulkActions/TeamList.tsx
+++ b/apps/web/modules/users/components/UserTable/BulkActions/TeamList.tsx
@@ -2,7 +2,7 @@ import type { Table } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
-import { DataTableSelectionBar } from "~/data-table/components";
+import { DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import classNames from "@calcom/ui/classNames";

--- a/apps/web/modules/users/components/UserTable/InviteMemberModal.tsx
+++ b/apps/web/modules/users/components/UserTable/InviteMemberModal.tsx
@@ -7,7 +7,7 @@ import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
 import usePlatformMe from "@calcom/web/components/settings/platform/hooks/usePlatformMe";
 
-import MemberInvitationModal from "~/ee/teams/components/MemberInvitationModal";
+import MemberInvitationModal from "@calcom/web/modules/ee/teams/components/MemberInvitationModal";
 
 import type { UserTableAction } from "./types";
 

--- a/apps/web/modules/users/components/UserTable/PlatformManagedUsersTable.tsx
+++ b/apps/web/modules/users/components/UserTable/PlatformManagedUsersTable.tsx
@@ -9,7 +9,7 @@ import {
   useColumnFilters,
   useDataTable,
 } from "@calcom/features/data-table";
-import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment, DataTableSelectionBar } from "~/data-table/components";
+import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment, DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useLocale } from "@calcom/lib/hooks/useLocale";

--- a/apps/web/modules/users/components/UserTable/UserListTable.tsx
+++ b/apps/web/modules/users/components/UserTable/UserListTable.tsx
@@ -17,7 +17,7 @@ import {
   convertFacetedValuesToMap,
   useDataTable,
 } from "@calcom/features/data-table";
-import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment, DataTableSelectionBar } from "~/data-table/components";
+import { DataTableWrapper, DataTableToolbar, DataTableFilters, DataTableSegment, DataTableSelectionBar } from "@calcom/web/modules/data-table/components";
 import { useSegments } from "@calcom/features/data-table/hooks/useSegments";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import {

--- a/apps/web/modules/users/components/UserTable/UserListTableSkeleton.tsx
+++ b/apps/web/modules/users/components/UserTable/UserListTableSkeleton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DataTableSkeleton } from "~/data-table/components";
+import { DataTableSkeleton } from "@calcom/web/modules/data-table/components";
 import { CTA_CONTAINER_CLASS_NAME } from "@calcom/features/data-table/lib/utils";
 import { SkeletonButton, SkeletonContainer, SkeletonText } from "@calcom/ui/components/skeleton";
 

--- a/apps/web/modules/webhooks/components/CreateNewWebhookButton.tsx
+++ b/apps/web/modules/webhooks/components/CreateNewWebhookButton.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { MembershipRole } from "@calcom/prisma/enums";
 
-import { CreateButtonWithTeamsList } from "~/ee/teams/components/createButton/CreateButtonWithTeamsList";
+import { CreateButtonWithTeamsList } from "@calcom/web/modules/ee/teams/components/createButton/CreateButtonWithTeamsList";
 
 export const CreateNewWebhookButton = () => {
   const router = useRouter();

--- a/apps/web/modules/webhooks/components/WebhookForm.tsx
+++ b/apps/web/modules/webhooks/components/WebhookForm.tsx
@@ -19,7 +19,7 @@ import { Label } from "@calcom/ui/components/form";
 import { TextField } from "@calcom/ui/components/form";
 import { Switch } from "@calcom/ui/components/form";
 
-import { TimeTimeUnitInput } from "~/ee/workflows/components/TimeTimeUnitInput";
+import { TimeTimeUnitInput } from "@calcom/web/modules/ee/workflows/components/TimeTimeUnitInput";
 
 import WebhookTestDisclosure from "./WebhookTestDisclosure";
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~/*": ["modules/*"],
       "@components/*": ["components/*"],
       "@pages/*": ["pages/*"],
       "@lib/*": ["lib/*"],


### PR DESCRIPTION
## What does this PR do?

Removes the `~` path alias from `apps/web/tsconfig.json` and replaces all `~/...` imports with `@calcom/web/modules/...` imports.

This improves compatibility with bundlers like Vite (used by the atoms package) that don't automatically respect TypeScript path mappings. When atoms imports files from `apps/web/modules/`, and those files use `~/...` imports, Vite can't resolve them because it doesn't know about the `~` alias. Using explicit `@calcom/web/modules/...` paths makes imports work consistently across all bundlers.

Related to the atoms build failure in #26176.

**Link to Devin run:** https://app.devin.ai/sessions/0b579847f5474245827cfe70c4d83a78
**Requested by:** benny@cal.com (@hbjORbj)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Verify no `~/` imports remain in `apps/web`:
   ```bash
   grep -r "from ['\"]~/" apps/web --include="*.ts" --include="*.tsx"
   ```
   Should return no results.

2. Verify the `~` alias is removed from `apps/web/tsconfig.json`

3. Run the atoms build to confirm it no longer fails on `~` imports:
   ```bash
   cd packages/platform/atoms && yarn build
   ```

4. Run type checks and lint to ensure no regressions

## Human Review Checklist

- [ ] Verify the `~/*` path mapping is removed from `apps/web/tsconfig.json`
- [ ] Spot check a few modified files to ensure imports look correct
- [ ] Confirm no other tsconfig paths were accidentally modified

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings