### PR TITLE
fix(oauth): unify token endpoint + document v2 endpoints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,109 @@
+# OAuth Improvements - Final Status
+
+## Completed Work (This Branch)
+
+### Commits (9 total)
+1. `b8a4e2caee` fix(oauth): unify token endpoint to support refresh_token grant
+2. `6b3e62321e` docs(oauth): expose /authorize and /exchange endpoints in OpenAPI
+3. `98e5fe728d` security(oauth): harden JWT handling with explicit algorithm
+4. `b01f66ab0b` feat(oauth): add redirectUris array field to OAuthClient
+5. `49c590907e` feat(oauth): add allowedScopes field to OAuthClient
+6. `a788954881` feat(oauth): implement multiple redirect URIs validation
+7. `8fea023aec` feat(oauth): enforce allowedScopes validation
+8. `776bdf78a9` security(oauth): comprehensive security hardening
+9. `98b6d95eb1` docs(oauth): add OAuth 2.0 documentation
+
+### Features Implemented
+- **PR1**: Unified `/token` endpoint with refresh_token support
+- **PR3**: OAuth v2 endpoints documented in OpenAPI
+- **PR4a+b**: Multiple redirect URIs (schema + validation)
+- **PR6a+b**: Scope enforcement (schema + validation)
+- **Security**: Timing-safe comparison, JWT algorithm fix, centralized constants
+- **Docs**: OAuth 2.0 documentation at `docs/api-reference/v1/oauth.mdx`
+
+### Key Files Modified
+- `packages/prisma/schema.prisma` - Added `redirectUris`, `allowedScopes`
+- `packages/lib/crypto.ts` - Added `timingSafeCompare`, `generateSecret`, `hashSecretKey`
+- `packages/features/oauth/services/OAuthService.ts` - Security hardening
+- `packages/features/oauth/lib/constants.ts` - New file for centralized constants
+- `packages/features/auth/lib/oAuthAuthorization.ts` - JWT algorithm fix
+- `apps/web/app/api/auth/oauth/token/route.ts` - Multi-URI validation
+- `packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.ts` - Scope enforcement
+
+## Relationship with PR #25556
+
+PR #25556 (OAuth developer settings with approval workflow) adds:
+- `OAuthClientApprovalStatus` enum (PENDING, APPROVED, REJECTED)
+- `approvalStatus` field
+- `userId` (creator relation)
+- `websiteUrl` field
+- Admin/developer UI for OAuth client management
+- Email notifications
+
+**These changes are independent and can merge in either order.**
+
+When both merge, resolve schema conflict by combining all fields:
+```prisma
+model OAuthClient {
+  clientId       String                    @id @unique
+  redirectUri    String
+  redirectUris   String[]                  @default([])        // from this branch
+  clientSecret   String?
+  clientType     OAuthClientType           @default(CONFIDENTIAL)
+  name           String
+  logo           String?
+  websiteUrl     String?                                        // from #25556
+  allowedScopes  AccessScope[]             @default([READ_BOOKING, READ_PROFILE])  // from this branch
+  accessCodes    AccessCode[]
+  approvalStatus OAuthClientApprovalStatus @default(PENDING)    // from #25556
+  userId         Int?                                           // from #25556
+  user           User?                     @relation(...)       // from #25556
+  createdAt      DateTime                  @default(now())      // from #25556
+
+  @@index([userId])
+}
+```
+
+## PR5b: Approval Status Gating (After #25556 Merges)
+
+After PR #25556 merges, add approval status gating to `generateAuthCode.handler.ts`:
+
+```typescript
+// Add to select:
+select: {
+  clientId: true,
+  redirectUri: true,
+  name: true,
+  clientType: true,
+  allowedScopes: true,
+  approvalStatus: true,  // ADD THIS
+  userId: true,          // ADD THIS
+},
+
+// Add after client lookup (before scope validation):
+if (client.approvalStatus === "REJECTED") {
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message: "OAuth client has been rejected",
+  });
+}
+
+if (client.approvalStatus === "PENDING" && client.userId !== ctx.user.id) {
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message: "OAuth client is pending approval",
+  });
+}
+```
+
+This allows:
+- APPROVED clients: Anyone can authorize
+- PENDING clients: Only the creator can authorize (for testing)
+- REJECTED clients: No one can authorize
+
+## Next Steps
+
+1. Create PR from this branch for review
+2. Wait for #25556 to merge
+3. Apply PR5b gating logic (small follow-up PR)
+4. Resolve any schema conflicts during merge

--- a/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
+++ b/apps/api/v2/src/modules/oauth-clients/controllers/oauth-flow/oauth-flow.controller.ts
@@ -24,9 +24,9 @@ import {
 } from "@nestjs/common";
 import {
   ApiTags as DocsTags,
-  ApiExcludeEndpoint as DocsExcludeEndpoint,
   ApiHeader as DocsHeader,
   ApiOperation,
+  ApiResponse,
 } from "@nestjs/swagger";
 import { Response as ExpressResponse } from "express";
 
@@ -49,7 +49,16 @@ export class OAuthFlowController {
   @Post("/authorize")
   @HttpCode(HttpStatus.OK)
   @UseGuards(NextAuthGuard)
-  @DocsExcludeEndpoint()
+  @DocsTags("OAuth Flow")
+  @ApiOperation({
+    summary: "Authorize an OAuth client",
+    description:
+      "Creates an authorization code for the signed-in user and redirects back to the provided redirectUri.",
+  })
+  @ApiResponse({
+    status: 302,
+    description: "Redirects to the provided redirectUri with a code query parameter.",
+  })
   async authorize(
     @Param("clientId") clientId: string,
     @Body() body: OAuthAuthorizeInput,
@@ -83,7 +92,20 @@ export class OAuthFlowController {
 
   @Post("/exchange")
   @HttpCode(HttpStatus.OK)
-  @DocsExcludeEndpoint()
+  @DocsTags("OAuth Flow")
+  @DocsHeader({
+    name: "Authorization",
+    description: "Bearer <authorization_code> from the authorize endpoint.",
+    required: true,
+  })
+  @ApiOperation({
+    summary: "Exchange authorization code for tokens",
+    description: `Use the authorization code to obtain access and refresh tokens. ${TOKENS_DOCS}`,
+  })
+  @ApiResponse({
+    status: 200,
+    type: KeysResponseDto,
+  })
   async exchange(
     @Headers("Authorization") authorization: string,
     @Param("clientId") clientId: string,

--- a/apps/web/app/api/auth/oauth/refreshToken/route.ts
+++ b/apps/web/app/api/auth/oauth/refreshToken/route.ts
@@ -19,7 +19,7 @@ async function handler(req: NextRequest) {
   const { client_id, client_secret, grant_type, refresh_token } = await parseUrlFormData(req);
 
   if (!process.env.CALENDSO_ENCRYPTION_KEY) {
-    return NextResponse.json({ message: "CALENDSO_ENCRYPTION_KEY is not set" }, { status: 500 });
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
   }
 
   if (!client_id) {
@@ -55,7 +55,9 @@ async function handler(req: NextRequest) {
       return NextResponse.json({ error: "invalid_request" }, { status: 400 });
     }
 
-    decodedRefreshToken = jwt.verify(refreshTokenValue, secretKey) as OAuthTokenPayload;
+    decodedRefreshToken = jwt.verify(refreshTokenValue, secretKey, {
+      algorithms: ["HS256"],
+    }) as OAuthTokenPayload;
   } catch {
     return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
   }
@@ -85,10 +87,12 @@ async function handler(req: NextRequest) {
   };
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: ACCESS_TOKEN_EXPIRES_IN,
   });
 
   const refresh_token_new = jwt.sign(payloadRefreshToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   });
 

--- a/apps/web/app/api/auth/oauth/refreshToken/route.ts
+++ b/apps/web/app/api/auth/oauth/refreshToken/route.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+import { OAUTH_TOKEN_EXPIRY } from "@calcom/features/oauth/lib/constants";
 import { OAuthClientRepository } from "@calcom/features/oauth/repositories/OAuthClientRepository";
 import { OAuthService } from "@calcom/features/oauth/services/OAuthService";
 import prisma from "@calcom/prisma";
@@ -7,9 +9,6 @@ import { parseUrlFormData } from "app/api/parseRequestData";
 import jwt from "jsonwebtoken";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
-const ACCESS_TOKEN_EXPIRES_IN = 1800; // 30 minutes
-const REFRESH_TOKEN_EXPIRES_IN = 30 * 24 * 60 * 60; // 30 days
 
 /**
  * @deprecated Use POST /api/auth/oauth/token with grant_type=refresh_token instead.
@@ -88,12 +87,12 @@ async function handler(req: NextRequest) {
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.ACCESS_TOKEN,
   });
 
   const refresh_token_new = jwt.sign(payloadRefreshToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.REFRESH_TOKEN,
   });
 
   return NextResponse.json(
@@ -101,7 +100,7 @@ async function handler(req: NextRequest) {
       access_token,
       token_type: "bearer",
       refresh_token: refresh_token_new,
-      expires_in: ACCESS_TOKEN_EXPIRES_IN,
+      expires_in: OAUTH_TOKEN_EXPIRY.ACCESS_TOKEN,
     },
     {
       status: 200,

--- a/apps/web/app/api/auth/oauth/token/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/oauth/token/__tests__/route.test.ts
@@ -597,7 +597,9 @@ describe("POST /api/auth/oauth/token", () => {
         expires_in: 1800,
       });
 
-      expect(mockJwt.verify).toHaveBeenCalledWith("valid_refresh_token", "test_encryption_key");
+      expect(mockJwt.verify).toHaveBeenCalledWith("valid_refresh_token", "test_encryption_key", {
+        algorithms: ["HS256"],
+      });
     });
 
     it("should reject refresh_token without client_id", async () => {

--- a/apps/web/app/api/auth/oauth/token/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/oauth/token/__tests__/route.test.ts
@@ -1,5 +1,5 @@
+import { generateSecret, timingSafeCompare } from "@calcom/lib/crypto";
 import { verifyCodeChallenge } from "@calcom/lib/pkce";
-import { generateSecret } from "@calcom/trpc/server/routers/viewer/oAuth/addClient.handler";
 import jwt from "jsonwebtoken";
 // Import mocked dependencies after mocks are set up
 import { NextRequest } from "next/server";
@@ -55,8 +55,9 @@ vi.mock("@calcom/lib/pkce", () => ({
   verifyCodeChallenge: vi.fn(),
 }));
 
-vi.mock("@calcom/trpc/server/routers/viewer/oAuth/addClient.handler", () => ({
+vi.mock("@calcom/lib/crypto", () => ({
   generateSecret: vi.fn(),
+  timingSafeCompare: vi.fn(() => true),
 }));
 
 vi.mock("jsonwebtoken", () => ({
@@ -107,6 +108,7 @@ vi.mock("app/api/parseRequestData", () => ({
 
 const mockVerifyCodeChallenge = vi.mocked(verifyCodeChallenge);
 const mockGenerateSecret = vi.mocked(generateSecret);
+const mockTimingSafeCompare = vi.mocked(timingSafeCompare);
 const mockJwt = vi.mocked(jwt);
 
 // Set up environment
@@ -354,6 +356,7 @@ describe("POST /api/auth/oauth/token", () => {
         mockConfidentialClient as Awaited<ReturnType<typeof prismaMock.oAuthClient.findFirst>>
       );
       mockGenerateSecret.mockReturnValue(["different_hashed_secret", "wrong_secret"]);
+      mockTimingSafeCompare.mockReturnValue(false);
 
       const tokenRequest = createTokenRequest({
         grant_type: "authorization_code",
@@ -702,6 +705,7 @@ describe("POST /api/auth/oauth/token", () => {
         mockConfidentialClient as Awaited<ReturnType<typeof prismaMock.oAuthClient.findFirst>>
       );
       mockGenerateSecret.mockReturnValue(["different_hash", "wrong_secret"]);
+      mockTimingSafeCompare.mockReturnValue(false);
 
       const tokenRequest = createTokenRequest({
         grant_type: "refresh_token",

--- a/apps/web/app/api/auth/oauth/token/route.ts
+++ b/apps/web/app/api/auth/oauth/token/route.ts
@@ -1,3 +1,4 @@
+import { OAUTH_TOKEN_EXPIRY } from "@calcom/features/oauth/lib/constants";
 import { AccessCodeRepository } from "@calcom/features/oauth/repositories/AccessCodeRepository";
 import { OAuthClientRepository } from "@calcom/features/oauth/repositories/OAuthClientRepository";
 import { OAuthService } from "@calcom/features/oauth/services/OAuthService";
@@ -8,9 +9,6 @@ import { parseUrlFormData } from "app/api/parseRequestData";
 import jwt from "jsonwebtoken";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
-const ACCESS_TOKEN_EXPIRES_IN = 1800; // 30 minutes
-const REFRESH_TOKEN_EXPIRES_IN = 30 * 24 * 60 * 60; // 30 days
 
 function isValidRedirectUri(
   redirectUri: string,
@@ -26,7 +24,7 @@ function isValidRedirectUri(
 
 function createTokenResponse(access_token: string, refresh_token: string) {
   return NextResponse.json(
-    { access_token, token_type: "bearer", refresh_token, expires_in: ACCESS_TOKEN_EXPIRES_IN },
+    { access_token, token_type: "bearer", refresh_token, expires_in: OAUTH_TOKEN_EXPIRY.ACCESS_TOKEN },
     {
       status: 200,
       headers: {
@@ -102,12 +100,12 @@ async function handleAuthorizationCode(
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.ACCESS_TOKEN,
   });
 
   const refresh_token = jwt.sign(payloadRefreshToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.REFRESH_TOKEN,
   });
 
   return createTokenResponse(access_token, refresh_token);
@@ -176,12 +174,12 @@ async function handleRefreshToken(
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.ACCESS_TOKEN,
   });
 
   const refresh_token_new = jwt.sign(payloadRefreshToken, secretKey, {
     algorithm: "HS256",
-    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+    expiresIn: OAUTH_TOKEN_EXPIRY.REFRESH_TOKEN,
   });
 
   return createTokenResponse(access_token, refresh_token_new);

--- a/apps/web/app/api/auth/oauth/token/route.ts
+++ b/apps/web/app/api/auth/oauth/token/route.ts
@@ -1,32 +1,39 @@
-import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import { parseUrlFormData } from "app/api/parseRequestData";
-import jwt from "jsonwebtoken";
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-
 import { AccessCodeRepository } from "@calcom/features/oauth/repositories/AccessCodeRepository";
 import { OAuthClientRepository } from "@calcom/features/oauth/repositories/OAuthClientRepository";
 import { OAuthService } from "@calcom/features/oauth/services/OAuthService";
 import prisma from "@calcom/prisma";
 import type { OAuthTokenPayload } from "@calcom/types/oauth";
+import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
+import { parseUrlFormData } from "app/api/parseRequestData";
+import jwt from "jsonwebtoken";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
-async function handler(req: NextRequest) {
-  const { code, client_id, client_secret, grant_type, redirect_uri, code_verifier } = await parseUrlFormData(
-    req
+const ACCESS_TOKEN_EXPIRES_IN = 1800; // 30 minutes
+const REFRESH_TOKEN_EXPIRES_IN = 30 * 24 * 60 * 60; // 30 days
+
+function createTokenResponse(access_token: string, refresh_token: string) {
+  return NextResponse.json(
+    { access_token, token_type: "bearer", refresh_token, expires_in: ACCESS_TOKEN_EXPIRES_IN },
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json;charset=UTF-8",
+        "Cache-Control": "no-store",
+        Pragma: "no-cache",
+      },
+    }
   );
+}
 
-  if (!process.env.CALENDSO_ENCRYPTION_KEY) {
-    return NextResponse.json({ message: "CALENDSO_ENCRYPTION_KEY is not set" }, { status: 500 });
-  }
-
-  if (!client_id || !code || !redirect_uri) {
-    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
-  }
-
-  if (grant_type !== "authorization_code") {
-    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
-  }
-
+async function handleAuthorizationCode(
+  client_id: string,
+  client_secret: string | undefined,
+  code: string,
+  redirect_uri: string,
+  code_verifier: string | undefined,
+  secretKey: string
+) {
   const oAuthClientRepository = new OAuthClientRepository(prisma);
   const accessCodeRepository = new AccessCodeRepository(prisma);
 
@@ -60,8 +67,6 @@ async function handler(req: NextRequest) {
     return NextResponse.json({ error: pkceError.error }, { status: pkceError.status });
   }
 
-  const secretKey = process.env.CALENDSO_ENCRYPTION_KEY;
-
   const payloadAuthToken: OAuthTokenPayload = {
     userId: accessCode.userId,
     teamId: accessCode.teamId,
@@ -83,27 +88,119 @@ async function handler(req: NextRequest) {
     }),
   };
 
-  const accessTokenExpiresIn = 1800; // 30 minutes
-
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
-    expiresIn: accessTokenExpiresIn,
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
   });
 
   const refresh_token = jwt.sign(payloadRefreshToken, secretKey, {
-    expiresIn: 30 * 24 * 60 * 60, // 30 days
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   });
 
-  return NextResponse.json(
-    { access_token, token_type: "bearer", refresh_token, expires_in: accessTokenExpiresIn },
-    {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json;charset=UTF-8",
-        "Cache-Control": "no-store",
-        Pragma: "no-cache",
-      },
+  return createTokenResponse(access_token, refresh_token);
+}
+
+async function handleRefreshToken(
+  client_id: string,
+  client_secret: string | undefined,
+  refresh_token: string | undefined,
+  authHeader: string | null,
+  secretKey: string
+) {
+  const oAuthClientRepository = new OAuthClientRepository(prisma);
+
+  const client = await oAuthClientRepository.findByClientId(client_id);
+
+  if (!client) {
+    return NextResponse.json({ error: "invalid_client" }, { status: 401 });
+  }
+
+  const isValidClient = OAuthService.validateClient(client, client_secret);
+
+  if (!isValidClient) {
+    return NextResponse.json({ error: "invalid_client" }, { status: 401 });
+  }
+
+  let decodedRefreshToken: OAuthTokenPayload;
+
+  try {
+    const refreshTokenValue = refresh_token || authHeader?.split(" ")[1] || "";
+
+    if (!refreshTokenValue) {
+      return NextResponse.json({ error: "invalid_request" }, { status: 400 });
     }
-  );
+
+    decodedRefreshToken = jwt.verify(refreshTokenValue, secretKey) as OAuthTokenPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
+  }
+
+  if (!decodedRefreshToken || decodedRefreshToken.token_type !== "Refresh Token") {
+    return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
+  }
+
+  if (decodedRefreshToken.clientId !== client_id) {
+    return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
+  }
+
+  const payloadAuthToken: OAuthTokenPayload = {
+    userId: decodedRefreshToken.userId,
+    teamId: decodedRefreshToken.teamId,
+    scope: decodedRefreshToken.scope,
+    token_type: "Access Token",
+    clientId: client_id,
+  };
+
+  const payloadRefreshToken: OAuthTokenPayload = {
+    userId: decodedRefreshToken.userId,
+    teamId: decodedRefreshToken.teamId,
+    scope: decodedRefreshToken.scope,
+    token_type: "Refresh Token",
+    clientId: client_id,
+  };
+
+  const access_token = jwt.sign(payloadAuthToken, secretKey, {
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  });
+
+  const refresh_token_new = jwt.sign(payloadRefreshToken, secretKey, {
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+  });
+
+  return createTokenResponse(access_token, refresh_token_new);
+}
+
+async function handler(req: NextRequest) {
+  const { code, client_id, client_secret, grant_type, redirect_uri, code_verifier, refresh_token } =
+    await parseUrlFormData(req);
+
+  if (!process.env.CALENDSO_ENCRYPTION_KEY) {
+    return NextResponse.json({ message: "CALENDSO_ENCRYPTION_KEY is not set" }, { status: 500 });
+  }
+
+  const secretKey = process.env.CALENDSO_ENCRYPTION_KEY;
+
+  if (!client_id) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  if (grant_type === "authorization_code") {
+    if (!code || !redirect_uri) {
+      return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+    }
+    return handleAuthorizationCode(client_id, client_secret, code, redirect_uri, code_verifier, secretKey);
+  }
+
+  if (grant_type === "refresh_token") {
+    return handleRefreshToken(
+      client_id,
+      client_secret,
+      refresh_token,
+      req.headers.get("authorization"),
+      secretKey
+    );
+  }
+
+  return NextResponse.json({ error: "unsupported_grant_type" }, { status: 400 });
 }
 
 export const POST = defaultResponderForAppDir(handler);

--- a/apps/web/app/api/auth/oauth/token/route.ts
+++ b/apps/web/app/api/auth/oauth/token/route.ts
@@ -89,10 +89,12 @@ async function handleAuthorizationCode(
   };
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: ACCESS_TOKEN_EXPIRES_IN,
   });
 
   const refresh_token = jwt.sign(payloadRefreshToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   });
 
@@ -129,7 +131,9 @@ async function handleRefreshToken(
       return NextResponse.json({ error: "invalid_request" }, { status: 400 });
     }
 
-    decodedRefreshToken = jwt.verify(refreshTokenValue, secretKey) as OAuthTokenPayload;
+    decodedRefreshToken = jwt.verify(refreshTokenValue, secretKey, {
+      algorithms: ["HS256"],
+    }) as OAuthTokenPayload;
   } catch {
     return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
   }
@@ -159,10 +163,12 @@ async function handleRefreshToken(
   };
 
   const access_token = jwt.sign(payloadAuthToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: ACCESS_TOKEN_EXPIRES_IN,
   });
 
   const refresh_token_new = jwt.sign(payloadRefreshToken, secretKey, {
+    algorithm: "HS256",
     expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   });
 
@@ -174,7 +180,7 @@ async function handler(req: NextRequest) {
     await parseUrlFormData(req);
 
   if (!process.env.CALENDSO_ENCRYPTION_KEY) {
-    return NextResponse.json({ message: "CALENDSO_ENCRYPTION_KEY is not set" }, { status: 500 });
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
   }
 
   const secretKey = process.env.CALENDSO_ENCRYPTION_KEY;

--- a/apps/web/app/api/auth/oauth/token/route.ts
+++ b/apps/web/app/api/auth/oauth/token/route.ts
@@ -12,6 +12,18 @@ import { NextResponse } from "next/server";
 const ACCESS_TOKEN_EXPIRES_IN = 1800; // 30 minutes
 const REFRESH_TOKEN_EXPIRES_IN = 30 * 24 * 60 * 60; // 30 days
 
+function isValidRedirectUri(
+  redirectUri: string,
+  clientRedirectUri: string,
+  clientRedirectUris: string[]
+): boolean {
+  // Use redirectUris array if it has items, otherwise fall back to single redirectUri
+  if (clientRedirectUris.length > 0) {
+    return clientRedirectUris.includes(redirectUri);
+  }
+  return clientRedirectUri === redirectUri;
+}
+
 function createTokenResponse(access_token: string, refresh_token: string) {
   return NextResponse.json(
     { access_token, token_type: "bearer", refresh_token, expires_in: ACCESS_TOKEN_EXPIRES_IN },
@@ -43,7 +55,7 @@ async function handleAuthorizationCode(
     return NextResponse.json({ error: "invalid_client" }, { status: 401 });
   }
 
-  if (client.redirectUri !== redirect_uri) {
+  if (!isValidRedirectUri(redirect_uri, client.redirectUri, client.redirectUris)) {
     return NextResponse.json({ error: "invalid_grant" }, { status: 400 });
   }
 

--- a/apps/web/playwright/oauth-provider.e2e.ts
+++ b/apps/web/playwright/oauth-provider.e2e.ts
@@ -1,9 +1,8 @@
-import { expect } from "@playwright/test";
-import { createHash, randomBytes } from "node:crypto";
-
+import { randomBytes } from "node:crypto";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import { generateSecret } from "@calcom/lib/crypto";
 import { prisma } from "@calcom/prisma";
-import { generateSecret } from "@calcom/trpc/server/routers/viewer/oAuth/addClient.handler";
+import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
 

--- a/docs/api-reference/v1/oauth.mdx
+++ b/docs/api-reference/v1/oauth.mdx
@@ -1,0 +1,142 @@
+---
+title: "OAuth 2.0"
+---
+
+<Warning>
+**API v1 is deprecated and will be discontinued on February 15, 2026.** Please migrate to [API v2](/api-reference/v2/introduction) as soon as possible.
+</Warning>
+
+Cal.com supports OAuth 2.0 for third-party applications to access user data with their consent. This guide covers the authorization code flow with PKCE support.
+
+## OAuth Flow Overview
+
+1. **Authorization Request**: Your app redirects users to Cal.com's authorization page
+2. **User Consent**: User approves or denies access to their Cal.com data
+3. **Authorization Code**: Cal.com redirects back with an authorization code
+4. **Token Exchange**: Your app exchanges the code for access and refresh tokens
+5. **API Access**: Use access tokens to make authenticated API requests
+
+## Client Types
+
+### PUBLIC Clients (PKCE Required)
+For browser-based or mobile apps that cannot securely store a client secret.
+- **PKCE is mandatory** with `S256` challenge method
+- No client secret required
+
+### CONFIDENTIAL Clients
+For server-side applications that can securely store a client secret.
+- Client secret required for token exchange
+- PKCE optional but recommended for enhanced security
+
+## Endpoints
+
+### Authorization Endpoint
+```
+GET /auth/oauth2/authorize
+```
+
+Query Parameters:
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `client_id` | Yes | Your OAuth client ID |
+| `redirect_uri` | Yes | Must match a registered redirect URI |
+| `response_type` | Yes | Must be `code` |
+| `scope` | No | Space-separated list of requested scopes |
+| `state` | Recommended | CSRF protection token |
+| `code_challenge` | PUBLIC clients | Base64-URL-encoded SHA-256 hash of code_verifier |
+| `code_challenge_method` | PUBLIC clients | Must be `S256` |
+
+### Token Endpoint
+```
+POST /api/auth/oauth/token
+Content-Type: application/x-www-form-urlencoded
+```
+
+#### Authorization Code Exchange
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `grant_type` | Yes | Must be `authorization_code` |
+| `code` | Yes | Authorization code from callback |
+| `client_id` | Yes | Your OAuth client ID |
+| `redirect_uri` | Yes | Must match the authorization request |
+| `client_secret` | CONFIDENTIAL | Required for confidential clients |
+| `code_verifier` | PUBLIC | The original random string used to generate code_challenge |
+
+#### Refresh Token Exchange
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `grant_type` | Yes | Must be `refresh_token` |
+| `refresh_token` | Yes | The refresh token |
+| `client_id` | Yes | Your OAuth client ID |
+| `client_secret` | CONFIDENTIAL | Required for confidential clients |
+
+### Token Response
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "token_type": "bearer",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
+  "expires_in": 1800
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `access_token` | JWT for API authentication (30 minute expiry) |
+| `token_type` | Always `bearer` |
+| `refresh_token` | JWT for obtaining new access tokens (30 day expiry) |
+| `expires_in` | Access token lifetime in seconds |
+
+## Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `READ_BOOKING` | Read access to user's bookings |
+| `READ_PROFILE` | Read access to user's profile information |
+
+Requested scopes must be within the client's `allowedScopes`. Requests for unauthorized scopes will be rejected.
+
+## PKCE Implementation
+
+For PUBLIC clients (and recommended for all clients):
+
+1. Generate a random `code_verifier` (43-128 characters)
+2. Create `code_challenge` = BASE64URL(SHA256(code_verifier))
+3. Include `code_challenge` and `code_challenge_method=S256` in authorization request
+4. Include `code_verifier` in token exchange request
+
+```javascript
+// Example PKCE generation
+const codeVerifier = crypto.randomBytes(32).toString('base64url');
+const codeChallenge = crypto
+  .createHash('sha256')
+  .update(codeVerifier)
+  .digest('base64url');
+```
+
+## Error Responses
+
+Token endpoint errors follow RFC 6749:
+
+| Error | Description |
+|-------|-------------|
+| `invalid_request` | Missing required parameter or malformed request |
+| `invalid_client` | Client authentication failed |
+| `invalid_grant` | Authorization code/refresh token invalid or expired |
+| `unsupported_grant_type` | Grant type not supported |
+
+## Security Best Practices
+
+1. **Always use HTTPS** for all OAuth endpoints
+2. **Validate the `state` parameter** to prevent CSRF attacks
+3. **Store tokens securely** - never expose in client-side code or logs
+4. **Use short-lived access tokens** with refresh token rotation
+5. **Implement PKCE** even for confidential clients when possible
+6. **Validate redirect URIs** exactly match registered URIs
+
+## Multiple Redirect URIs
+
+OAuth clients can register multiple redirect URIs. During authorization, the `redirect_uri` parameter must exactly match one of the registered URIs.

--- a/packages/features/auth/lib/oAuthAuthorization.ts
+++ b/packages/features/auth/lib/oAuthAuthorization.ts
@@ -1,12 +1,16 @@
-import jwt from "jsonwebtoken";
-
 import prisma from "@calcom/prisma";
 import type { OAuthTokenPayload } from "@calcom/types/oauth";
+import jwt from "jsonwebtoken";
 
 export default async function isAuthorized(token: string, requiredScopes: string[] = []) {
+  const secretKey = process.env.CALENDSO_ENCRYPTION_KEY;
+  if (!secretKey) {
+    return null;
+  }
+
   let decodedToken: OAuthTokenPayload;
   try {
-    decodedToken = jwt.verify(token, process.env.CALENDSO_ENCRYPTION_KEY || "") as OAuthTokenPayload;
+    decodedToken = jwt.verify(token, secretKey, { algorithms: ["HS256"] }) as OAuthTokenPayload;
   } catch {
     return null;
   }

--- a/packages/features/oauth/lib/constants.ts
+++ b/packages/features/oauth/lib/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * OAuth token expiration constants
+ */
+export const OAUTH_TOKEN_EXPIRY = {
+  /** Access token expires in 30 minutes */
+  ACCESS_TOKEN: 1800,
+  /** Refresh token expires in 30 days */
+  REFRESH_TOKEN: 30 * 24 * 60 * 60,
+} as const;

--- a/packages/features/oauth/repositories/OAuthClientRepository.ts
+++ b/packages/features/oauth/repositories/OAuthClientRepository.ts
@@ -10,6 +10,7 @@ export class OAuthClientRepository {
       },
       select: {
         redirectUri: true,
+        redirectUris: true,
         clientSecret: true,
         clientType: true,
       },

--- a/packages/features/oauth/services/OAuthService.ts
+++ b/packages/features/oauth/services/OAuthService.ts
@@ -1,5 +1,5 @@
+import { generateSecret, timingSafeCompare } from "@calcom/lib/crypto";
 import { verifyCodeChallenge } from "@calcom/lib/pkce";
-import { generateSecret } from "@calcom/trpc/server/routers/viewer/oAuth/addClient.handler";
 
 interface OAuthClient {
   clientType: "CONFIDENTIAL" | "PUBLIC";
@@ -24,7 +24,7 @@ export class OAuthService {
       if (!client_secret) return false;
 
       const [hashedSecret] = generateSecret(client_secret);
-      if (client.clientSecret !== hashedSecret) return false;
+      if (!client.clientSecret || !timingSafeCompare(client.clientSecret, hashedSecret)) return false;
     }
 
     return true; // PUBLIC has no client_secret

--- a/packages/lib/crypto.ts
+++ b/packages/lib/crypto.ts
@@ -1,4 +1,4 @@
-import crypto from "node:crypto";
+import crypto, { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 
 const ALGORITHM = "aes256";
 const INPUT_ENCODING = "utf8";
@@ -12,7 +12,7 @@ const IV_LENGTH = 16; // AES blocksize
  *
  * @returns Encrypted value using key
  */
-export const symmetricEncrypt = function (text: string, key: string) {
+export const symmetricEncrypt = (text: string, key: string) => {
   const _key = Buffer.from(key, "latin1");
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, _key, iv);
@@ -28,7 +28,7 @@ export const symmetricEncrypt = function (text: string, key: string) {
  * @param text Value to decrypt
  * @param key Key used to decrypt value must be 32 bytes for AES256 encryption algorithm
  */
-export const symmetricDecrypt = function (text: string, key: string) {
+export const symmetricDecrypt = (text: string, key: string) => {
   const _key = Buffer.from(key, "latin1");
 
   const components = text.split(":");
@@ -38,4 +38,30 @@ export const symmetricDecrypt = function (text: string, key: string) {
   deciphered += decipher.final(INPUT_ENCODING);
 
   return deciphered;
+};
+
+/**
+ * Hash a secret key using SHA-256
+ */
+export const hashSecretKey = (secret: string): string => createHash("sha256").update(secret).digest("hex");
+
+/**
+ * Generate a random secret and its hash
+ * @returns [hashedSecret, plainSecret]
+ */
+export const generateSecret = (secret = randomBytes(32).toString("hex")): [string, string] => [
+  hashSecretKey(secret),
+  secret,
+];
+
+/**
+ * Timing-safe string comparison to prevent timing attacks
+ */
+export const timingSafeCompare = (a: string, b: string): boolean => {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
 };

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1764,6 +1764,7 @@ enum OAuthClientType {
 model OAuthClient {
   clientId     String          @id @unique
   redirectUri  String
+  redirectUris String[]        @default([])
   clientSecret String?
   clientType   OAuthClientType @default(CONFIDENTIAL)
   name         String

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1762,15 +1762,16 @@ enum OAuthClientType {
 }
 
 model OAuthClient {
-  clientId     String          @id @unique
-  redirectUri  String
-  redirectUris String[]        @default([])
-  clientSecret String?
-  clientType   OAuthClientType @default(CONFIDENTIAL)
-  name         String
-  logo         String?
-  isTrusted    Boolean         @default(false)
-  accessCodes  AccessCode[]
+  clientId      String          @id @unique
+  redirectUri   String
+  redirectUris  String[]        @default([])
+  clientSecret  String?
+  clientType    OAuthClientType @default(CONFIDENTIAL)
+  name          String
+  logo          String?
+  isTrusted     Boolean         @default(false)
+  allowedScopes AccessScope[]   @default([READ_BOOKING, READ_PROFILE])
+  accessCodes   AccessCode[]
 }
 
 model AccessCode {

--- a/packages/trpc/server/routers/viewer/oAuth/addClient.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/addClient.handler.ts
@@ -1,7 +1,8 @@
-import { randomBytes, createHash } from "node:crypto";
+import { randomBytes } from "node:crypto";
 
+import { generateSecret } from "@calcom/lib/crypto";
 import { prisma } from "@calcom/prisma";
-import { Prisma } from "@calcom/prisma/client";
+import type { Prisma } from "@calcom/prisma/client";
 
 import type { TAddClientInputSchema } from "./addClient.schema";
 
@@ -44,8 +45,3 @@ export const addClientHandler = async ({ input }: AddClientOptions) => {
     isPkceEnabled: enablePkce,
   };
 };
-
-const hashSecretKey = (apiKey: string): string => createHash("sha256").update(apiKey).digest("hex");
-
-// Generate a random secret
-export const generateSecret = (secret = randomBytes(32).toString("hex")) => [hashSecretKey(secret), secret];

--- a/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.ts
+++ b/packages/trpc/server/routers/viewer/oAuth/generateAuthCode.handler.ts
@@ -27,11 +27,21 @@ export const generateAuthCodeHandler = async ({ ctx, input }: AddClientOptions) 
       redirectUri: true,
       name: true,
       clientType: true,
+      allowedScopes: true,
     },
   });
 
   if (!client) {
     throw new TRPCError({ code: "UNAUTHORIZED", message: "Client ID not valid" });
+  }
+
+  // Validate requested scopes are within client's allowed scopes
+  const invalidScopes = scopes.filter((scope) => !client.allowedScopes.includes(scope as AccessScope));
+  if (invalidScopes.length > 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Requested scopes not allowed: ${invalidScopes.join(", ")}`,
+    });
   }
 
   if (client.clientType === "PUBLIC") {


### PR DESCRIPTION
## Summary

Comprehensive OAuth improvements for cal.com:

1. **Unified token endpoint** (`/api/auth/oauth/token`) - Now accepts `refresh_token` grant type. Fixes #24016
2. **Multiple redirect URIs** - Added `redirectUris` field to OAuthClient schema
3. **Scope enforcement** - Added `allowedScopes` field and validation in authorization flow
4. **Security hardening** - Timing-safe comparison, explicit JWT algorithm (HS256)
5. **API documentation** - OAuth v2 endpoints documented in OpenAPI

## Changes

| File | Description |
|------|-------------|
| `apps/web/app/api/auth/oauth/token/route.ts` | Accept `refresh_token` grant, multi-URI validation |
| `packages/prisma/schema.prisma` | Add `redirectUris`, `allowedScopes` fields |
| `packages/lib/crypto.ts` | Add `timingSafeCompare`, `generateSecret` functions |
| `packages/features/oauth/services/OAuthService.ts` | Use timing-safe comparison |
| `packages/features/auth/lib/oAuthAuthorization.ts` | Explicit HS256 algorithm |
| `docs/api-reference/v1/oauth.mdx` | OAuth 2.0 documentation |

## Migrations

```sql
-- Add redirectUris
ALTER TABLE "OAuthClient" ADD COLUMN "redirectUris" TEXT[] DEFAULT '{}';

-- Add allowedScopes  
ALTER TABLE "OAuthClient" ADD COLUMN "allowedScopes" TEXT[] DEFAULT '{READ_BOOKING,READ_PROFILE}';
```

## Rollback

```sql
ALTER TABLE "OAuthClient" DROP COLUMN "redirectUris";
ALTER TABLE "OAuthClient" DROP COLUMN "allowedScopes";
```

## Testing

- [x] 24 unit tests for token endpoint (all passing)
- [x] 13 unit tests for generateAuthCode handler (all passing)
- [x] Tested locally with mock data

## Related

- Fixes #24016 (refresh token support via unified endpoint)
- Related to #25556 (OAuth developer settings - separate PR for approval workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)