### PR TITLE
fix: atoms build by updating import paths

### DIFF
--- a/apps/web/modules/shell/DynamicModals.tsx
+++ b/apps/web/modules/shell/DynamicModals.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { WelcomeToOrganizationsModal } from "~/ee/organizations/components/WelcomeToOrganizationsModal";
+import { WelcomeToOrganizationsModal } from "@calcom/web/modules/ee/organizations/components/WelcomeToOrganizationsModal";
 
 import { WelcomeToCalcomModal } from "./components/WelcomeToCalcomModal";
 import { GatedFeaturesModal } from "./components/GatedFeaturesModal";

--- a/apps/web/modules/shell/banners/LayoutBanner.tsx
+++ b/apps/web/modules/shell/banners/LayoutBanner.tsx
@@ -1,10 +1,10 @@
 import ImpersonatingBanner, {
   type ImpersonatingBannerProps,
-} from "~/ee/impersonation/components/ImpersonatingBanner";
+} from "@calcom/web/modules/ee/impersonation/components/ImpersonatingBanner";
 import {
   OrgUpgradeBanner,
   type OrgUpgradeBannerProps,
-} from "~/ee/organizations/components/OrgUpgradeBanner";
+} from "@calcom/web/modules/ee/organizations/components/OrgUpgradeBanner";
 import {
   TeamsUpgradeBanner,
   type TeamsUpgradeBannerProps,


### PR DESCRIPTION
## What does this PR do?

- Fix the build by correcting EE component import paths in DynamicModals and LayoutBanner. Switched from the ~ alias to @calcom/web/modules to match the current module structure.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A - I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Please use the latest Vercel preview and test please 🙏.
