### PR TITLE
fix(companion): optimize iOS bookings and migrate booking actions to React Query

### DIFF
--- a/companion/app/(tabs)/(bookings)/booking-detail.ios.tsx
+++ b/companion/app/(tabs)/(bookings)/booking-detail.ios.tsx
@@ -60,7 +60,6 @@ const getMeetingUrl = (booking: Booking | null): string | null => {
 };
 
 export default function BookingDetailIOS() {
-  "use no memo";
   const { uid } = useLocalSearchParams<{ uid: string }>();
   const { userInfo } = useAuth();
 
@@ -82,7 +81,7 @@ export default function BookingDetailIOS() {
   }, [booking?.start, booking?.startTime]);
 
   // Get meeting URL for Join button
-  const meetingUrl = useMemo(() => getMeetingUrl(booking), [booking]);
+  const meetingUrl = useMemo(() => getMeetingUrl(booking ?? null), [booking]);
 
   // Handle join meeting
   const handleJoinMeeting = useCallback(() => {
@@ -111,89 +110,44 @@ export default function BookingDetailIOS() {
     });
   }, [booking, userInfo?.id, userInfo?.email]);
 
-  // Action handlers that use the booking data
-  const handleReschedule = useCallback(() => {
-    if (actionHandlersRef.current?.openRescheduleModal) {
-      actionHandlersRef.current.openRescheduleModal();
+  // Invoke a handler by name - only accesses ref at invocation time (event handler)
+  // This avoids creating closures that capture the ref during render
+  const invokeHandler = useCallback((handlerName: keyof ActionHandlers, errorMessage: string) => {
+    const handlers = actionHandlersRef.current;
+    if (handlers?.[handlerName]) {
+      (handlers[handlerName] as () => void)();
     } else {
-      Alert.alert("Error", "Unable to reschedule. Please try again.");
+      Alert.alert("Error", errorMessage);
     }
   }, []);
 
-  const handleEditLocation = useCallback(() => {
-    if (actionHandlersRef.current?.openEditLocationModal) {
-      actionHandlersRef.current.openEditLocationModal();
-    } else {
-      Alert.alert("Error", "Unable to edit location. Please try again.");
-    }
-  }, []);
-
-  const handleAddGuests = useCallback(() => {
-    if (actionHandlersRef.current?.openAddGuestsModal) {
-      actionHandlersRef.current.openAddGuestsModal();
-    } else {
-      Alert.alert("Error", "Unable to add guests. Please try again.");
-    }
-  }, []);
-
-  const handleViewRecordings = useCallback(() => {
-    if (actionHandlersRef.current?.openViewRecordingsModal) {
-      actionHandlersRef.current.openViewRecordingsModal();
-    } else {
-      Alert.alert("Error", "Unable to view recordings. Please try again.");
-    }
-  }, []);
-
-  const handleSessionDetails = useCallback(() => {
-    if (actionHandlersRef.current?.openMeetingSessionDetailsModal) {
-      actionHandlersRef.current.openMeetingSessionDetailsModal();
-    } else {
-      Alert.alert("Error", "Unable to view session details. Please try again.");
-    }
-  }, []);
-
-  const handleMarkNoShow = useCallback(() => {
-    if (actionHandlersRef.current?.openMarkNoShowModal) {
-      actionHandlersRef.current.openMarkNoShowModal();
-    } else {
-      Alert.alert("Error", "Unable to mark no-show. Please try again.");
-    }
-  }, []);
-
-  const handleReport = useCallback(() => {
-    Alert.alert("Report Booking", "Report booking functionality is not yet available");
-  }, []);
-
-  const handleCancel = useCallback(() => {
-    if (actionHandlersRef.current?.handleCancelBooking) {
-      actionHandlersRef.current.handleCancelBooking();
-    } else {
-      Alert.alert("Error", "Unable to cancel. Please try again.");
-    }
-  }, []);
-
-  // Define booking actions organized by sections
+  // Define and filter booking actions
+  // Actions store handler metadata instead of closures to avoid capturing ref during render
   const bookingActionsSections = useMemo(() => {
+    // Define all actions with handler metadata (not closures)
     const allEditEventActions = [
       {
         id: "reschedule",
         label: "Reschedule Booking",
         icon: "calendar" as const,
-        onPress: handleReschedule,
+        handlerName: "openRescheduleModal" as const,
+        errorMessage: "Unable to reschedule. Please try again.",
         gatingKey: "reschedule" as const,
       },
       {
         id: "edit-location",
         label: "Edit Location",
         icon: "location" as const,
-        onPress: handleEditLocation,
+        handlerName: "openEditLocationModal" as const,
+        errorMessage: "Unable to edit location. Please try again.",
         gatingKey: "changeLocation" as const,
       },
       {
         id: "add-guests",
         label: "Add Guests",
         icon: "person.badge.plus" as const,
-        onPress: handleAddGuests,
+        handlerName: "openAddGuestsModal" as const,
+        errorMessage: "Unable to add guests. Please try again.",
         gatingKey: "addGuests" as const,
       },
     ];
@@ -203,21 +157,24 @@ export default function BookingDetailIOS() {
         id: "view-recordings",
         label: "View Recordings",
         icon: "video" as const,
-        onPress: handleViewRecordings,
+        handlerName: "openViewRecordingsModal" as const,
+        errorMessage: "Unable to view recordings. Please try again.",
         gatingKey: "viewRecordings" as const,
       },
       {
         id: "session-details",
         label: "Meeting Session Details",
         icon: "info.circle" as const,
-        onPress: handleSessionDetails,
+        handlerName: "openMeetingSessionDetailsModal" as const,
+        errorMessage: "Unable to view session details. Please try again.",
         gatingKey: "meetingSessionDetails" as const,
       },
       {
         id: "mark-no-show",
         label: "Mark as No-Show",
         icon: "eye.slash" as const,
-        onPress: handleMarkNoShow,
+        handlerName: "openMarkNoShowModal" as const,
+        errorMessage: "Unable to mark no-show. Please try again.",
         gatingKey: "markNoShow" as const,
       },
     ];
@@ -227,7 +184,11 @@ export default function BookingDetailIOS() {
         id: "report",
         label: "Report Booking",
         icon: "flag" as const,
-        onPress: handleReport,
+        handlerName: null,
+        errorMessage: null,
+        customHandler: () => {
+          Alert.alert("Report Booking", "Report booking functionality is not yet available");
+        },
         destructive: true,
         gatingKey: null,
       },
@@ -235,12 +196,14 @@ export default function BookingDetailIOS() {
         id: "cancel",
         label: "Cancel Event",
         icon: "xmark.circle" as const,
-        onPress: handleCancel,
+        handlerName: "handleCancelBooking" as const,
+        errorMessage: "Unable to cancel. Please try again.",
         destructive: true,
         gatingKey: "cancel" as const,
       },
     ];
 
+    // Filter actions based on gating logic
     const filterAction = (action: { gatingKey: keyof typeof actions | null }) => {
       if (action.gatingKey === null) return true;
       const gating = actions[action.gatingKey];
@@ -252,17 +215,7 @@ export default function BookingDetailIOS() {
       afterEvent: allAfterEventActions.filter(filterAction),
       standalone: allStandaloneActions.filter(filterAction),
     };
-  }, [
-    actions,
-    handleReschedule,
-    handleEditLocation,
-    handleAddGuests,
-    handleViewRecordings,
-    handleSessionDetails,
-    handleMarkNoShow,
-    handleReport,
-    handleCancel,
-  ]);
+  }, [actions]);
 
   return (
     <>
@@ -308,7 +261,7 @@ export default function BookingDetailIOS() {
                 <Stack.Header.MenuAction
                   key={action.id}
                   icon={action.icon}
-                  onPress={action.onPress}
+                  onPress={() => invokeHandler(action.handlerName, action.errorMessage)}
                 >
                   {action.label}
                 </Stack.Header.MenuAction>
@@ -321,7 +274,7 @@ export default function BookingDetailIOS() {
                 <Stack.Header.MenuAction
                   key={action.id}
                   icon={action.icon}
-                  onPress={action.onPress}
+                  onPress={() => invokeHandler(action.handlerName, action.errorMessage)}
                 >
                   {action.label}
                 </Stack.Header.MenuAction>
@@ -334,7 +287,13 @@ export default function BookingDetailIOS() {
                 <Stack.Header.MenuAction
                   key={action.id}
                   icon={action.icon}
-                  onPress={action.onPress}
+                  onPress={() => {
+                    if (action.customHandler) {
+                      action.customHandler();
+                    } else if (action.handlerName && action.errorMessage) {
+                      invokeHandler(action.handlerName, action.errorMessage);
+                    }
+                  }}
                   destructive
                 >
                   {action.label}

--- a/companion/app/(tabs)/(bookings)/index.tsx
+++ b/companion/app/(tabs)/(bookings)/index.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { Text, TextInput, View } from "react-native";
 import { BookingListScreen } from "@/components/booking-list-screen/BookingListScreen";
 import { Header } from "@/components/Header";
@@ -11,16 +11,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AppPressable } from "@/components/AppPressable";
 import { useActiveBookingFilter } from "@/hooks/useActiveBookingFilter";
-import type { EventType } from "@/services/calcom";
-import { CalComAPIService } from "@/services/calcom";
-import { safeLogError } from "@/utils/safeLogger";
+import { useEventTypes } from "@/hooks";
 
 export default function Bookings() {
   const [searchQuery, setSearchQuery] = useState("");
-  const [eventTypes, setEventTypes] = useState<EventType[]>([]);
   const [selectedEventTypeId, setSelectedEventTypeId] = useState<number | null>(null);
   const [selectedEventTypeLabel, setSelectedEventTypeLabel] = useState<string | null>(null);
-  const [eventTypesLoading, setEventTypesLoading] = useState(false);
+
+  // Use React Query hook for event types (same as iOS for unified caching)
+  const { data: eventTypes = [], isLoading: eventTypesLoading } = useEventTypes();
 
   // Use the active booking filter hook
   const { activeFilter, filterOptions, filterParams, handleFilterChange } = useActiveBookingFilter(
@@ -36,26 +35,6 @@ export default function Bookings() {
   const handleSearch = (query: string) => {
     setSearchQuery(query);
   };
-
-  const fetchEventTypes = useCallback(async () => {
-    setEventTypesLoading(true);
-    try {
-      const types = await CalComAPIService.getEventTypes();
-      setEventTypes(types);
-      setEventTypesLoading(false);
-    } catch (err) {
-      safeLogError("Error fetching event types:", err);
-      // Error is logged but not displayed to user for event type filter
-      setEventTypesLoading(false);
-    }
-  }, []);
-
-  // Fetch event types on mount for dropdown
-  useEffect(() => {
-    if (eventTypes.length === 0) {
-      fetchEventTypes();
-    }
-  }, [eventTypes.length, fetchEventTypes]);
 
   const clearEventTypeFilter = () => {
     setSelectedEventTypeId(null);

--- a/companion/components/screens/EditLocationScreen.ios.tsx
+++ b/companion/components/screens/EditLocationScreen.ios.tsx
@@ -12,8 +12,8 @@ import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import { Alert, KeyboardAvoidingView, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUpdateLocation } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
-import { CalComAPIService } from "@/services/calcom";
 import { safeLogError } from "@/utils/safeLogger";
 
 // Location types configuration
@@ -96,7 +96,9 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
     const backgroundStyle = transparentBackground ? "bg-transparent" : "bg-[#F2F2F7]";
     const [selectedType, setSelectedType] = useState<LocationTypeId>("link");
     const [inputValue, setInputValue] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
+
+    // Use React Query mutation for automatic cache invalidation
+    const { mutate: updateLocation, isPending: isSaving } = useUpdateLocation();
 
     // Detect location type from current location but don't pre-fill the input
     useEffect(() => {
@@ -124,7 +126,7 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
       [selectedType]
     );
 
-    const handleSubmit = useCallback(async () => {
+    const handleSubmit = useCallback(() => {
       if (!booking || isSaving) return;
 
       const trimmedValue = inputValue.trim();
@@ -159,19 +161,24 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
           locationPayload = { type: "address", address: trimmedValue };
       }
 
-      setIsSaving(true);
-      try {
-        await CalComAPIService.updateLocationV2(booking.uid, locationPayload);
-        Alert.alert("Success", "Location updated successfully", [
-          { text: "OK", onPress: onSuccess },
-        ]);
-        setIsSaving(false);
-      } catch (error) {
-        safeLogError("[EditLocationScreen] Failed to update location:", error);
-        Alert.alert("Error", "Failed to update location. Please try again.");
-        setIsSaving(false);
-      }
-    }, [booking, selectedType, inputValue, onSuccess, isSaving]);
+      updateLocation(
+        {
+          uid: booking.uid,
+          location: locationPayload,
+        },
+        {
+          onSuccess: () => {
+            Alert.alert("Success", "Location updated successfully", [
+              { text: "OK", onPress: onSuccess },
+            ]);
+          },
+          onError: (error) => {
+            safeLogError("[EditLocationScreen] Failed to update location:", error);
+            Alert.alert("Error", "Failed to update location. Please try again.");
+          },
+        }
+      );
+    }, [booking, selectedType, inputValue, onSuccess, isSaving, updateLocation]);
 
     // Expose submit function to parent via ref
     useImperativeHandle(

--- a/companion/components/screens/EditLocationScreen.tsx
+++ b/companion/components/screens/EditLocationScreen.tsx
@@ -29,8 +29,8 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUpdateLocation } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
-import { CalComAPIService } from "@/services/calcom";
 import { safeLogError } from "@/utils/safeLogger";
 
 export const LOCATION_TYPES = {
@@ -113,7 +113,9 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
     const [selectedType, setSelectedType] = useState<LocationTypeId>("link");
     const [inputValue, setInputValue] = useState("");
     const [showTypePicker, setShowTypePicker] = useState(false);
-    const [isSaving, setIsSaving] = useState(false);
+
+    // Use React Query mutation for automatic cache invalidation
+    const { mutate: updateLocation, isPending: isSaving } = useUpdateLocation();
 
     // Detect location type from current location but don't pre-fill the input
     useEffect(() => {
@@ -130,7 +132,7 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
 
     const selectedTypeConfig = LOCATION_TYPES[selectedType];
 
-    const handleSubmit = useCallback(async () => {
+    const handleSubmit = useCallback(() => {
       if (!booking || isSaving) return;
 
       const trimmedValue = inputValue.trim();
@@ -164,19 +166,24 @@ export const EditLocationScreen = forwardRef<EditLocationScreenHandle, EditLocat
           locationPayload = { type: "address", address: trimmedValue };
       }
 
-      setIsSaving(true);
-      try {
-        await CalComAPIService.updateLocationV2(booking.uid, locationPayload);
-        Alert.alert("Success", "Location updated successfully", [
-          { text: "OK", onPress: onSuccess },
-        ]);
-        setIsSaving(false);
-      } catch (error) {
-        safeLogError("[EditLocationScreen] Failed to update location:", error);
-        Alert.alert("Error", "Failed to update location. Please try again.");
-        setIsSaving(false);
-      }
-    }, [booking, selectedType, inputValue, onSuccess, isSaving]);
+      updateLocation(
+        {
+          uid: booking.uid,
+          location: locationPayload,
+        },
+        {
+          onSuccess: () => {
+            Alert.alert("Success", "Location updated successfully", [
+              { text: "OK", onPress: onSuccess },
+            ]);
+          },
+          onError: (error) => {
+            safeLogError("[EditLocationScreen] Failed to update location:", error);
+            Alert.alert("Error", "Failed to update location. Please try again.");
+          },
+        }
+      );
+    }, [booking, selectedType, inputValue, onSuccess, isSaving, updateLocation]);
 
     useImperativeHandle(
       ref,

--- a/companion/components/screens/RescheduleScreen.ios.tsx
+++ b/companion/components/screens/RescheduleScreen.ios.tsx
@@ -31,7 +31,6 @@ export const RescheduleScreen = forwardRef<RescheduleScreenHandle, RescheduleScr
     { booking, onSuccess, onSavingChange, transparentBackground = false },
     ref
   ) {
-    "use no memo";
     const insets = useSafeAreaInsets();
     const backgroundStyle = transparentBackground ? "bg-transparent" : "bg-[#F2F2F7]";
     const [selectedDateTime, setSelectedDateTime] = useState<Date>(new Date());

--- a/companion/components/screens/RescheduleScreen.ios.tsx
+++ b/companion/components/screens/RescheduleScreen.ios.tsx
@@ -10,8 +10,8 @@ import { Ionicons } from "@expo/vector-icons";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import { Alert, KeyboardAvoidingView, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useRescheduleBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
-import { CalComAPIService } from "@/services/calcom";
 import { safeLogError, safeLogInfo } from "@/utils/safeLogger";
 
 export interface RescheduleScreenProps {
@@ -36,7 +36,9 @@ export const RescheduleScreen = forwardRef<RescheduleScreenHandle, RescheduleScr
     const backgroundStyle = transparentBackground ? "bg-transparent" : "bg-[#F2F2F7]";
     const [selectedDateTime, setSelectedDateTime] = useState<Date>(new Date());
     const [reason, setReason] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
+
+    // Use React Query mutation for automatic cache invalidation
+    const { mutate: rescheduleBooking, isPending: isSaving } = useRescheduleBooking();
 
     useEffect(() => {
       if (booking?.startTime) {
@@ -52,7 +54,7 @@ export const RescheduleScreen = forwardRef<RescheduleScreenHandle, RescheduleScr
       onSavingChange?.(isSaving);
     }, [isSaving, onSavingChange]);
 
-    const handleSubmit = useCallback(async () => {
+    const handleSubmit = useCallback(() => {
       if (!booking || isSaving) return;
 
       if (selectedDateTime <= new Date()) {
@@ -60,22 +62,25 @@ export const RescheduleScreen = forwardRef<RescheduleScreenHandle, RescheduleScr
         return;
       }
 
-      setIsSaving(true);
-      try {
-        await CalComAPIService.rescheduleBooking(booking.uid, {
+      rescheduleBooking(
+        {
+          uid: booking.uid,
           start: selectedDateTime.toISOString(),
           reschedulingReason: reason.trim() || undefined,
-        });
-        Alert.alert("Success", "Booking rescheduled successfully", [
-          { text: "OK", onPress: onSuccess },
-        ]);
-        setIsSaving(false);
-      } catch (error) {
-        safeLogError("[RescheduleScreen] Failed to reschedule:", error);
-        Alert.alert("Error", "Failed to reschedule booking. Please try again.");
-        setIsSaving(false);
-      }
-    }, [booking, selectedDateTime, reason, onSuccess, isSaving]);
+        },
+        {
+          onSuccess: () => {
+            Alert.alert("Success", "Booking rescheduled successfully", [
+              { text: "OK", onPress: onSuccess },
+            ]);
+          },
+          onError: (error) => {
+            safeLogError("[RescheduleScreen] Failed to reschedule:", error);
+            Alert.alert("Error", "Failed to reschedule booking. Please try again.");
+          },
+        }
+      );
+    }, [booking, selectedDateTime, reason, onSuccess, isSaving, rescheduleBooking]);
 
     const handleDateSelected = useCallback(
       (date: Date) => {

--- a/companion/hooks/useBookings.ts
+++ b/companion/hooks/useBookings.ts
@@ -226,6 +226,47 @@ export function useDeclineBooking() {
 }
 
 /**
+ * Hook to update the location of a booking
+ *
+ * @returns Mutation function and state
+ *
+ * @example
+ * ```tsx
+ * const { mutate: updateLocation, isPending } = useUpdateLocation();
+ *
+ * updateLocation({
+ *   uid: 'abc-123',
+ *   location: { type: 'link', link: 'https://meet.example.com' }
+ * });
+ * ```
+ */
+export function useUpdateLocation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      uid,
+      location,
+    }: {
+      uid: string;
+      location: { type: string; [key: string]: string };
+    }) => CalComAPIService.updateLocationV2(uid, location),
+    onSuccess: (_, variables) => {
+      // Invalidate all booking queries
+      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
+
+      // Also invalidate the specific booking detail
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.bookings.detail(variables.uid),
+      });
+    },
+    onError: (_error) => {
+      console.error("Failed to update location");
+    },
+  });
+}
+
+/**
  * Hook to prefetch bookings (useful for navigation)
  *
  * @returns Function to prefetch bookings

--- a/companion/hooks/useBookings.ts
+++ b/companion/hooks/useBookings.ts
@@ -117,6 +117,46 @@ export function useCancelBooking() {
 }
 
 /**
+ * Hook to mark an attendee as no-show (absent)
+ *
+ * @returns Mutation function and state
+ *
+ * @example
+ * ```tsx
+ * const { mutate: markNoShow, isPending } = useMarkNoShow();
+ *
+ * markNoShow({ uid: 'abc-123', attendeeEmail: 'attendee@example.com', absent: true });
+ * ```
+ */
+export function useMarkNoShow() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      uid,
+      attendeeEmail,
+      absent,
+    }: {
+      uid: string;
+      attendeeEmail: string;
+      absent: boolean;
+    }) => CalComAPIService.markAbsent(uid, attendeeEmail, absent),
+    onSuccess: (_, variables) => {
+      // Invalidate all booking queries to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
+
+      // Also invalidate the specific booking detail
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.bookings.detail(variables.uid),
+      });
+    },
+    onError: (_error) => {
+      console.error("Failed to mark attendee as no-show");
+    },
+  });
+}
+
+/**
  * Hook to reschedule a booking
  *
  * @returns Mutation function and state

--- a/companion/hooks/useBookings.ts
+++ b/companion/hooks/useBookings.ts
@@ -267,6 +267,42 @@ export function useUpdateLocation() {
 }
 
 /**
+ * Hook to add guests to a booking
+ *
+ * @returns Mutation function and state
+ *
+ * @example
+ * ```tsx
+ * const { mutate: addGuests, isPending } = useAddGuests();
+ *
+ * addGuests({
+ *   uid: 'abc-123',
+ *   guests: [{ email: 'guest@example.com', name: 'Guest Name' }]
+ * });
+ * ```
+ */
+export function useAddGuests() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ uid, guests }: { uid: string; guests: { email: string; name?: string }[] }) =>
+      CalComAPIService.addGuests(uid, guests),
+    onSuccess: (_, variables) => {
+      // Invalidate all booking queries
+      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
+
+      // Also invalidate the specific booking detail
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.bookings.detail(variables.uid),
+      });
+    },
+    onError: (_error) => {
+      console.error("Failed to add guests");
+    },
+  });
+}
+
+/**
  * Hook to prefetch bookings (useful for navigation)
  *
  * @returns Function to prefetch bookings


### PR DESCRIPTION


https://github.com/user-attachments/assets/75f7bd29-8f1d-4744-a899-92b39dcff33f




https://github.com/user-attachments/assets/99dabda8-8dcc-44e8-82db-b979b71501ab









## What does this PR do?

Fixes iOS bookings page slowness caused by redundant `/me` API calls, unifies data-fetching patterns between iOS and Android, and migrates booking detail screens and action screens to React Query for automatic cache invalidation.

### Part 1: iOS Bookings Page Slowness Fix
**Root cause**: Both `getEventTypes()` and `getBookings()` were calling `getCurrentUser()` directly, which always makes a fresh `/me` API call (bypassing the cached `getUserProfile()` function). iOS was affected more than Android because iOS eagerly loads event types at mount for native header menus, resulting in **4 API calls** on tab switch vs Android's **2 calls**.

**Changes**:
- Add in-flight promise deduplication to `getUserProfile()` to prevent concurrent callers from each making a `/me` API call
- Update `getEventTypes()` to use cached `getUserProfile()` instead of `getCurrentUser()`
- Update `getBookings()` to use cached `getUserProfile()` instead of `getCurrentUser()`
- Clear in-flight promise in `clearUserProfile()` for proper logout cleanup
- **Unify Android with iOS**: Replace manual `useState` + `useEffect` + `useCallback` with `useEventTypes()` React Query hook on Android

### Part 2: Booking Detail Screen Migration to React Query
**Problem**: Booking actions (reschedule, edit location, add guests, mark no-show) didn't automatically update the UI. Users had to navigate back to bookings list, reload, then return to see updated data.

**Changes**:
- Refactor `BookingDetailScreen.tsx` and `BookingDetailScreen.ios.tsx` to be presentational components
- Accept `booking`, `isLoading`, `error`, `refetch`, `isRefetching` props instead of fetching internally
- Update route files (`booking-detail.tsx`, `booking-detail.ios.tsx`) to use `useBookingByUid()` React Query hook
- Add `RefreshControl` for pull-to-refresh support on both platforms
- Eliminates duplicate API calls (route + screen were both fetching the same booking)

### Part 3: Reschedule Screen Migration to React Query Mutation
**Changes**:
- Migrate `RescheduleScreen.tsx` (web/extension), `RescheduleScreen.ios.tsx`, and `RescheduleScreen.android.tsx` to use `useRescheduleBooking()` mutation hook
- Replace direct `CalComAPIService.rescheduleBooking()` calls with React Query mutation
- Use `isPending` from mutation instead of manual `isSaving` state
- **Automatic cache invalidation**: When reschedule succeeds, the hook invalidates both `bookings.detail(uid)` and `bookings.all` query keys, triggering automatic refetch

### Part 4: Edit Location Screen Migration to React Query Mutation
**Changes**:
- Add `useUpdateLocation()` mutation hook to `useBookings.ts`
- Migrate `EditLocationScreen.tsx` (Android/Web) and `EditLocationScreen.ios.tsx` to use the mutation hook
- Replace direct `CalComAPIService.updateLocationV2()` calls with React Query mutation
- Use `isPending` from mutation instead of manual `isSaving` state
- **Automatic cache invalidation**: When location update succeeds, the hook invalidates both `bookings.detail(uid)` and `bookings.all` query keys

### Part 5: Add Guests Screen Migration to React Query Mutation
**Changes**:
- Add `useAddGuests()` mutation hook to `useBookings.ts`
- Migrate `AddGuestsScreen.tsx` to use the mutation hook
- Replace direct `CalComAPIService.addGuests()` call with React Query mutation
- Use `isPending` from mutation instead of manual `isSaving` state
- **Automatic cache invalidation**: When guests are added, the hook invalidates both `bookings.detail(uid)` and `bookings.all` query keys

**Link to Devin run**: https://app.devin.ai/sessions/a447b6cb7a8d4ff3bb5c6c96171f2f31
**Requested by**: Dhairyashil Shinde (@dhairyashiil)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - no docs changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

### Part 1: Bookings Page Performance
1. Build and run the companion app on iOS
2. Navigate to a different tab (e.g., Event Types or Availability)
3. Tap on the Bookings tab in the bottom navbar
4. Observe that the bookings page loads faster than before (previously had noticeable delay)
5. Verify bookings data still loads correctly and filtering works as expected
6. **Test on Android**: Verify the event type filter dropdown still works correctly after switching to `useEventTypes()` hook

### Part 2: Booking Detail & Pull-to-Refresh
1. Navigate to a booking detail page
2. Pull down to refresh - verify the booking data reloads
3. Perform a booking action (e.g., reschedule or cancel from another device/web)
4. Pull to refresh on the detail page - verify updated data appears
5. Test on both iOS and Android

### Part 3: Reschedule Action with Auto-Refresh
1. Navigate to a booking detail page
2. Tap "Reschedule" and select a new date/time
3. Confirm the reschedule
4. **Verify**: After success alert dismisses and you return to booking detail, the new date/time should be displayed automatically (no manual refresh needed)
5. Test on iOS, Android, and web/extension

### Part 4: Edit Location Action with Auto-Refresh
1. Navigate to a booking detail page
2. Tap "Edit Location" and enter a new location (test all types: link, phone, address)
3. Confirm the location update
4. **Verify**: After success alert dismisses and you return to booking detail, the new location should be displayed automatically (no manual refresh needed)
5. Test on iOS and Android

### Part 5: Add Guests Action with Auto-Refresh
1. Navigate to a booking detail page
2. Tap "Add Guests" and add one or more guests (email + optional name)
3. Confirm adding the guests
4. **Verify**: After success alert dismisses and you return to booking detail, the new guests should be displayed automatically (no manual refresh needed)
5. Test on iOS and Android

## Human Review Checklist

- [ ] Verify the in-flight promise deduplication logic correctly handles concurrent calls
- [ ] Confirm error handling properly clears `_userProfilePromise` on failure
- [ ] Check that `clearUserProfile()` properly clears both `_userProfile` and `_userProfilePromise`
- [ ] **Booking Detail**: Verify error messages display correctly (error type changed from `string` to `Error`)
- [ ] **Booking Detail**: Test pull-to-refresh works on both iOS and Android
- [ ] **Booking Detail**: Verify `useBookingByUid` handles undefined uid gracefully (from route params)
- [ ] **Reschedule**: Verify `isPending` from mutation behaves same as previous manual `isSaving` state
- [ ] **Reschedule**: Confirm cache invalidation triggers booking detail refetch after successful reschedule
- [ ] **Reschedule**: Test error handling shows alert correctly on failure
- [ ] **Edit Location**: Verify `useUpdateLocation` hook correctly handles all location types (link, phone, address)
- [ ] **Edit Location**: Confirm cache invalidation triggers booking detail refetch after successful location update
- [ ] **Edit Location**: Test error handling shows alert correctly on failure
- [ ] **Add Guests**: Verify `useAddGuests` hook correctly handles guest array with email and optional name
- [ ] **Add Guests**: Confirm cache invalidation triggers booking detail refetch after successfully adding guests
- [ ] **Add Guests**: Test error handling shows alert correctly on failure
- [ ] **Android**: Confirm `useEventTypes()` hook returns compatible data structure

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings