### PR TITLE
test: add unit tests for refactored slot services

### DIFF
--- a/packages/features/slots/services/AvailabilityService.ts
+++ b/packages/features/slots/services/AvailabilityService.ts
@@ -591,7 +591,7 @@ export class AvailableSlotsService {
         id: user.id,
         email: user.email,
       }));
-      const eventTimeZone = eventType.schedule?.timeZone ?? input.timeZone ?? "UTC";
+      const eventTimeZone = eventType.schedule?.timeZone ?? usersWithCredentials[0]?.timeZone ?? "UTC";
       busyTimesFromLimitsMap = await this.getBusyTimesFromLimitsForUsers(
         usersForLimits,
         bookingLimits,
@@ -617,7 +617,7 @@ export class AvailableSlotsService {
         id: user.id,
         email: user.email,
       }));
-      const eventTimeZone = eventType.schedule?.timeZone ?? input.timeZone ?? "UTC";
+      const eventTimeZone = eventType.schedule?.timeZone ?? usersWithCredentials[0]?.timeZone ?? "UTC";
       teamBookingLimitsMap = await this.getBusyTimesFromTeamLimitsForUsers(
         usersForTeamLimits,
         teamBookingLimits,

--- a/packages/features/slots/services/__tests__/LimitEnforcementService.test.ts
+++ b/packages/features/slots/services/__tests__/LimitEnforcementService.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import dayjs from "@calcom/dayjs";
+import type { UserAvailabilityService } from "@calcom/features/availability/lib/getUserAvailability";
+import type { CheckBookingLimitsService } from "@calcom/features/bookings/lib/checkBookingLimits";
+import type { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import type { BusyTimesService } from "@calcom/features/busyTimes/services/getBusyTimes";
+
+import { LimitEnforcementService } from "../LimitEnforcementService";
+
+describe("LimitEnforcementService", () => {
+  let mockBusyTimesService: BusyTimesService;
+  let mockUserAvailabilityService: UserAvailabilityService;
+  let mockCheckBookingLimitsService: CheckBookingLimitsService;
+  let mockBookingRepo: BookingRepository;
+  let service: LimitEnforcementService;
+
+  const mockUsers = [
+    { id: 1, email: "user1@test.com" },
+    { id: 2, email: "user2@test.com" },
+  ];
+
+  const mockEventType = {
+    id: 1,
+    length: 30,
+  };
+
+  beforeEach(() => {
+    mockBusyTimesService = {
+      getStartEndDateforLimitCheck: vi.fn().mockReturnValue({
+        limitDateFrom: dayjs("2024-01-01"),
+        limitDateTo: dayjs("2024-01-31"),
+      }),
+      getBusyTimesForLimitChecks: vi.fn().mockResolvedValue([]),
+      getBusyTimes: vi.fn(),
+    } as unknown as BusyTimesService;
+
+    mockUserAvailabilityService = {
+      getPeriodStartDatesBetween: vi.fn().mockReturnValue([dayjs("2024-01-15")]),
+    } as unknown as UserAvailabilityService;
+
+    mockCheckBookingLimitsService = {
+      checkBookingLimit: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CheckBookingLimitsService;
+
+    mockBookingRepo = {
+      getTotalBookingDuration: vi.fn().mockResolvedValue(0),
+      getAllAcceptedTeamBookingsOfUsers: vi.fn().mockResolvedValue([]),
+    } as unknown as BookingRepository;
+
+    service = new LimitEnforcementService({
+      busyTimesService: mockBusyTimesService,
+      userAvailabilityService: mockUserAvailabilityService,
+      checkBookingLimitsService: mockCheckBookingLimitsService,
+      bookingRepo: mockBookingRepo,
+    });
+  });
+
+  describe("getBusyTimesFromLimitsForUsers", () => {
+    it("should return empty map when no booking or duration limits are set", async () => {
+      const result = await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        null,
+        null,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(result.size).toBe(0);
+      expect(mockBusyTimesService.getBusyTimesForLimitChecks).not.toHaveBeenCalled();
+    });
+
+    it("should call getBusyTimesForLimitChecks when booking limits are set", async () => {
+      const bookingLimits = { PER_DAY: 5 };
+
+      await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        null,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userIds: [1, 2],
+          eventTypeId: 1,
+          bookingLimits,
+        })
+      );
+    });
+
+    it("should return busy times for users who have reached their booking limit", async () => {
+      const bookingLimits = { PER_DAY: 2 };
+      const existingBookings = [
+        {
+          id: 1,
+          userId: 1,
+          start: dayjs("2024-01-15T10:00:00Z").toDate(),
+          end: dayjs("2024-01-15T10:30:00Z").toDate(),
+        },
+        {
+          id: 2,
+          userId: 1,
+          start: dayjs("2024-01-15T11:00:00Z").toDate(),
+          end: dayjs("2024-01-15T11:30:00Z").toDate(),
+        },
+      ];
+
+      vi.mocked(mockBusyTimesService.getBusyTimesForLimitChecks).mockResolvedValue(existingBookings);
+
+      const result = await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        null,
+        dayjs("2024-01-15"),
+        dayjs("2024-01-15"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(result.has(1)).toBe(true);
+      expect(result.get(1)?.length).toBeGreaterThan(0);
+    });
+
+    it("should handle duration limits", async () => {
+      const durationLimits = { PER_DAY: 60 };
+
+      await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        null,
+        durationLimits,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          durationLimits,
+        })
+      );
+    });
+
+    it("should mark period as busy when duration exceeds limit", async () => {
+      const durationLimits = { PER_DAY: 60 };
+      const existingBookings = [
+        {
+          id: 1,
+          userId: 1,
+          start: dayjs("2024-01-15T10:00:00Z").toDate(),
+          end: dayjs("2024-01-15T11:00:00Z").toDate(),
+        },
+      ];
+
+      vi.mocked(mockBusyTimesService.getBusyTimesForLimitChecks).mockResolvedValue(existingBookings);
+
+      const result = await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        null,
+        durationLimits,
+        dayjs("2024-01-15"),
+        dayjs("2024-01-15"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(result.has(1)).toBe(true);
+    });
+
+    it("should use checkBookingLimitsService for yearly limits", async () => {
+      const bookingLimits = { PER_YEAR: 100 };
+
+      vi.mocked(mockUserAvailabilityService.getPeriodStartDatesBetween).mockReturnValue([
+        dayjs("2024-01-01"),
+      ]);
+
+      await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        null,
+        dayjs("2024-01-01"),
+        dayjs("2024-12-31"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(mockCheckBookingLimitsService.checkBookingLimit).toHaveBeenCalled();
+    });
+
+    it("should mark period as busy when yearly limit check throws", async () => {
+      const bookingLimits = { PER_YEAR: 100 };
+
+      vi.mocked(mockUserAvailabilityService.getPeriodStartDatesBetween).mockReturnValue([
+        dayjs("2024-01-01"),
+      ]);
+      vi.mocked(mockCheckBookingLimitsService.checkBookingLimit).mockRejectedValue(
+        new Error("Limit exceeded")
+      );
+
+      const result = await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        null,
+        dayjs("2024-01-01"),
+        dayjs("2024-12-31"),
+        30,
+        mockEventType,
+        "UTC"
+      );
+
+      expect(result.has(1)).toBe(true);
+      expect(result.get(1)?.length).toBeGreaterThan(0);
+    });
+
+    it("should handle rescheduleUid parameter", async () => {
+      const bookingLimits = { PER_DAY: 5 };
+      const rescheduleUid = "reschedule-123";
+
+      await service.getBusyTimesFromLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        null,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        30,
+        mockEventType,
+        "UTC",
+        rescheduleUid
+      );
+
+      expect(mockBusyTimesService.getBusyTimesForLimitChecks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rescheduleUid,
+        })
+      );
+    });
+  });
+
+  describe("getBusyTimesFromTeamLimitsForUsers", () => {
+    it("should fetch team bookings and apply limits", async () => {
+      const bookingLimits = { PER_DAY: 5 };
+      const teamId = 123;
+
+      await service.getBusyTimesFromTeamLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        teamId,
+        false,
+        "UTC"
+      );
+
+      expect(mockBookingRepo.getAllAcceptedTeamBookingsOfUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          users: mockUsers,
+          teamId,
+          includeManagedEvents: false,
+        })
+      );
+    });
+
+    it("should include managed events when flag is set", async () => {
+      const bookingLimits = { PER_DAY: 5 };
+      const teamId = 123;
+
+      await service.getBusyTimesFromTeamLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        teamId,
+        true,
+        "UTC"
+      );
+
+      expect(mockBookingRepo.getAllAcceptedTeamBookingsOfUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeManagedEvents: true,
+        })
+      );
+    });
+
+    it("should return busy times when team booking limit is reached", async () => {
+      const bookingLimits = { PER_DAY: 2 };
+      const teamBookings = [
+        {
+          id: 1,
+          userId: 1,
+          startTime: dayjs("2024-01-15T10:00:00Z").toDate(),
+          endTime: dayjs("2024-01-15T10:30:00Z").toDate(),
+          eventTypeId: 1,
+          title: "Meeting 1",
+        },
+        {
+          id: 2,
+          userId: 1,
+          startTime: dayjs("2024-01-15T11:00:00Z").toDate(),
+          endTime: dayjs("2024-01-15T11:30:00Z").toDate(),
+          eventTypeId: 1,
+          title: "Meeting 2",
+        },
+      ];
+
+      vi.mocked(mockBookingRepo.getAllAcceptedTeamBookingsOfUsers).mockResolvedValue(teamBookings);
+
+      const result = await service.getBusyTimesFromTeamLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        dayjs("2024-01-15"),
+        dayjs("2024-01-15"),
+        123,
+        false,
+        "UTC"
+      );
+
+      expect(result.has(1)).toBe(true);
+    });
+
+    it("should handle rescheduleUid for team limits", async () => {
+      const bookingLimits = { PER_DAY: 5 };
+      const rescheduleUid = "reschedule-456";
+
+      await service.getBusyTimesFromTeamLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        dayjs("2024-01-01"),
+        dayjs("2024-01-31"),
+        123,
+        false,
+        "UTC",
+        rescheduleUid
+      );
+
+      expect(mockBookingRepo.getAllAcceptedTeamBookingsOfUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludedUid: rescheduleUid,
+        })
+      );
+    });
+
+    it("should use checkBookingLimitsService for yearly team limits", async () => {
+      const bookingLimits = { PER_YEAR: 100 };
+
+      vi.mocked(mockUserAvailabilityService.getPeriodStartDatesBetween).mockReturnValue([
+        dayjs("2024-01-01"),
+      ]);
+
+      await service.getBusyTimesFromTeamLimitsForUsers(
+        mockUsers,
+        bookingLimits,
+        dayjs("2024-01-01"),
+        dayjs("2024-12-31"),
+        123,
+        true,
+        "UTC"
+      );
+
+      expect(mockCheckBookingLimitsService.checkBookingLimit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamId: 123,
+          includeManagedEvents: true,
+        })
+      );
+    });
+  });
+});

--- a/packages/features/slots/services/__tests__/SlotFilteringService.test.ts
+++ b/packages/features/slots/services/__tests__/SlotFilteringService.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { SlotFilteringService } from "../SlotFilteringService";
+
+describe("SlotFilteringService", () => {
+  const service = new SlotFilteringService();
+
+  describe("filterSlotsByRequestedDateRange", () => {
+    it("should return slots unchanged when timeZone is undefined", () => {
+      const slotsMappedToDate = {
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+        "2024-01-16": [{ time: "2024-01-16T10:00:00Z" }],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00Z",
+        endTime: "2024-01-16T23:59:59Z",
+        timeZone: undefined,
+      });
+
+      expect(result).toEqual(slotsMappedToDate);
+    });
+
+    it("should filter out dates outside the requested range", () => {
+      const slotsMappedToDate = {
+        "2024-01-14": [{ time: "2024-01-14T10:00:00Z" }],
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+        "2024-01-16": [{ time: "2024-01-16T10:00:00Z" }],
+        "2024-01-17": [{ time: "2024-01-17T10:00:00Z" }],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00Z",
+        endTime: "2024-01-16T23:59:59Z",
+        timeZone: "UTC",
+      });
+
+      expect(result).toEqual({
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+        "2024-01-16": [{ time: "2024-01-16T10:00:00Z" }],
+      });
+    });
+
+    it("should handle single day range", () => {
+      const slotsMappedToDate = {
+        "2024-01-14": [{ time: "2024-01-14T10:00:00Z" }],
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+        "2024-01-16": [{ time: "2024-01-16T10:00:00Z" }],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00Z",
+        endTime: "2024-01-15T23:59:59Z",
+        timeZone: "UTC",
+      });
+
+      expect(result).toEqual({
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+      });
+    });
+
+    it("should handle timezone conversion correctly", () => {
+      const slotsMappedToDate = {
+        "2024-01-14": [{ time: "2024-01-14T10:00:00Z" }],
+        "2024-01-15": [{ time: "2024-01-15T10:00:00Z" }],
+        "2024-01-16": [{ time: "2024-01-16T10:00:00Z" }],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00-05:00",
+        endTime: "2024-01-16T23:59:59-05:00",
+        timeZone: "America/New_York",
+      });
+
+      expect(Object.keys(result)).toContain("2024-01-15");
+      expect(Object.keys(result)).toContain("2024-01-16");
+    });
+
+    it("should preserve slot data including attendees and bookingUid", () => {
+      const slotsMappedToDate = {
+        "2024-01-15": [
+          { time: "2024-01-15T10:00:00Z", attendees: 5, bookingUid: "abc123" },
+          { time: "2024-01-15T11:00:00Z", attendees: 3 },
+        ],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00Z",
+        endTime: "2024-01-15T23:59:59Z",
+        timeZone: "UTC",
+      });
+
+      expect(result["2024-01-15"]).toEqual([
+        { time: "2024-01-15T10:00:00Z", attendees: 5, bookingUid: "abc123" },
+        { time: "2024-01-15T11:00:00Z", attendees: 3 },
+      ]);
+    });
+
+    it("should return empty object when no dates match", () => {
+      const slotsMappedToDate = {
+        "2024-01-10": [{ time: "2024-01-10T10:00:00Z" }],
+        "2024-01-11": [{ time: "2024-01-11T10:00:00Z" }],
+      };
+
+      const result = service.filterSlotsByRequestedDateRange({
+        slotsMappedToDate,
+        startTime: "2024-01-15T00:00:00Z",
+        endTime: "2024-01-16T23:59:59Z",
+        timeZone: "UTC",
+      });
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("getAllDatesWithBookabilityStatus", () => {
+    it("should mark available dates as bookable", () => {
+      const availableDates = ["2024-01-15", "2024-01-16", "2024-01-17"];
+
+      const result = service.getAllDatesWithBookabilityStatus(availableDates);
+
+      expect(result["2024-01-15"]).toEqual({ isBookable: true });
+      expect(result["2024-01-16"]).toEqual({ isBookable: true });
+      expect(result["2024-01-17"]).toEqual({ isBookable: true });
+    });
+
+    it("should fill in intermediate dates as not bookable", () => {
+      const availableDates = ["2024-01-15", "2024-01-18"];
+
+      const result = service.getAllDatesWithBookabilityStatus(availableDates);
+
+      expect(result["2024-01-15"]).toEqual({ isBookable: true });
+      expect(result["2024-01-16"]).toEqual({ isBookable: false });
+      expect(result["2024-01-17"]).toEqual({ isBookable: false });
+      expect(result["2024-01-18"]).toEqual({ isBookable: true });
+    });
+
+    it("should handle single date", () => {
+      const availableDates = ["2024-01-15"];
+
+      const result = service.getAllDatesWithBookabilityStatus(availableDates);
+
+      expect(result).toEqual({
+        "2024-01-15": { isBookable: true },
+      });
+    });
+
+    it("should handle consecutive dates correctly", () => {
+      const availableDates = ["2024-01-15", "2024-01-16"];
+
+      const result = service.getAllDatesWithBookabilityStatus(availableDates);
+
+      expect(Object.keys(result).length).toBe(2);
+      expect(result["2024-01-15"]).toEqual({ isBookable: true });
+      expect(result["2024-01-16"]).toEqual({ isBookable: true });
+    });
+
+    it("should handle sparse availability with multiple gaps", () => {
+      const availableDates = ["2024-01-15", "2024-01-17", "2024-01-20"];
+
+      const result = service.getAllDatesWithBookabilityStatus(availableDates);
+
+      expect(result["2024-01-15"]).toEqual({ isBookable: true });
+      expect(result["2024-01-16"]).toEqual({ isBookable: false });
+      expect(result["2024-01-17"]).toEqual({ isBookable: true });
+      expect(result["2024-01-18"]).toEqual({ isBookable: false });
+      expect(result["2024-01-19"]).toEqual({ isBookable: false });
+      expect(result["2024-01-20"]).toEqual({ isBookable: true });
+    });
+  });
+});

--- a/packages/features/slots/services/__tests__/SlotReservationService.test.ts
+++ b/packages/features/slots/services/__tests__/SlotReservationService.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { ISelectedSlotRepository } from "@calcom/features/selectedSlots/repositories/ISelectedSlotRepository";
+
+import { SlotReservationService } from "../SlotReservationService";
+
+describe("SlotReservationService", () => {
+  let mockSelectedSlotRepo: ISelectedSlotRepository;
+  let service: SlotReservationService;
+
+  beforeEach(() => {
+    mockSelectedSlotRepo = {
+      findManyUnexpiredSlots: vi.fn(),
+      deleteManyExpiredSlots: vi.fn(),
+      upsert: vi.fn(),
+      deleteByUid: vi.fn(),
+    };
+    service = new SlotReservationService(mockSelectedSlotRepo);
+  });
+
+  describe("getReservedSlotsAndCleanupExpired", () => {
+    const mockUsers = [
+      { id: 1, email: "user1@test.com", timeZone: "UTC", credentials: [], selectedCalendars: [] },
+      { id: 2, email: "user2@test.com", timeZone: "UTC", credentials: [], selectedCalendars: [] },
+    ];
+
+    it("should return slots selected by other users (not the current booker)", async () => {
+      const bookerClientUid = "booker-123";
+      const unexpiredSlots = [
+        { uid: "booker-123", slotUtcStartDate: new Date(), slotUtcEndDate: new Date(), eventTypeId: 1 },
+        { uid: "other-user-456", slotUtcStartDate: new Date(), slotUtcEndDate: new Date(), eventTypeId: 1 },
+        { uid: "other-user-789", slotUtcStartDate: new Date(), slotUtcEndDate: new Date(), eventTypeId: 1 },
+      ];
+
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue(unexpiredSlots);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 0 });
+
+      const result = await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid,
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.every((slot) => slot.uid !== bookerClientUid)).toBe(true);
+      expect(result.map((s) => s.uid)).toEqual(["other-user-456", "other-user-789"]);
+    });
+
+    it("should return all slots when bookerClientUid is undefined", async () => {
+      const unexpiredSlots = [
+        { uid: "user-123", slotUtcStartDate: new Date(), slotUtcEndDate: new Date(), eventTypeId: 1 },
+        { uid: "user-456", slotUtcStartDate: new Date(), slotUtcEndDate: new Date(), eventTypeId: 1 },
+      ];
+
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue(unexpiredSlots);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 0 });
+
+      const result = await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid: undefined,
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(result).toHaveLength(2);
+    });
+
+    it("should return empty array when no unexpired slots exist", async () => {
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue([]);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 0 });
+
+      const result = await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid: "booker-123",
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should call findManyUnexpiredSlots with correct user IDs", async () => {
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue([]);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 0 });
+
+      await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid: "booker-123",
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(mockSelectedSlotRepo.findManyUnexpiredSlots).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userIds: [1, 2],
+        })
+      );
+    });
+
+    it("should cleanup expired slots after fetching", async () => {
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue([]);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 5 });
+
+      await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid: "booker-123",
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(mockSelectedSlotRepo.deleteManyExpiredSlots).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventTypeId: 1,
+        })
+      );
+    });
+
+    it("should handle null response from findManyUnexpiredSlots", async () => {
+      vi.mocked(mockSelectedSlotRepo.findManyUnexpiredSlots).mockResolvedValue(null as unknown as []);
+      vi.mocked(mockSelectedSlotRepo.deleteManyExpiredSlots).mockResolvedValue({ count: 0 });
+
+      const result = await service.getReservedSlotsAndCleanupExpired({
+        bookerClientUid: "booker-123",
+        usersWithCredentials: mockUsers as Parameters<
+          typeof service.getReservedSlotsAndCleanupExpired
+        >[0]["usersWithCredentials"],
+        eventTypeId: 1,
+      });
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

This PR adds unit tests for the refactored slot services and fixes a timezone fallback regression identified during code review.

**Changes:**
1. **Timezone fallback fix** in `AvailabilityService.ts`: Restored the original timezone fallback behavior from `input.timeZone` back to `usersWithCredentials[0]?.timeZone` for booking limit calculations. This affects both `busyTimesFromLimitsMap` and `teamBookingLimitsMap` computations.

2. **New tests for SlotFilteringService** (11 tests):
   - Date range filtering with timezone handling
   - Bookability status calculations for date ranges
   - Edge cases: single day, empty results, preserving slot data

3. **New tests for SlotReservationService** (6 tests):
   - Filtering slots by booker client UID
   - Cleanup of expired slots
   - Handling null/empty responses

4. **New tests for LimitEnforcementService** (13 tests):
   - Booking limits (per day, per year)
   - Duration limits
   - Team booking limits
   - Reschedule UID handling

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the tests locally:
```bash
TZ=UTC yarn test packages/features/slots/services/__tests__ --run
```

All 30 tests should pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] **Verify timezone fallback change**: The change from `input.timeZone` to `usersWithCredentials[0]?.timeZone` restores the original behavior from main. Confirm this is the intended fallback for booking limit timezone calculations.
- [ ] **Review test coverage**: Check if edge cases are adequately covered, particularly for the LimitEnforcementService which has complex limit calculation logic.

---

Link to Devin run: https://app.devin.ai/sessions/6478048dbf224dc488467bee461e5637
Requested by: @sean-brydon