### PR TITLE
fix(insights): fix chart x-axis labels showing in wrong language

### DIFF
--- a/packages/features/insights/server/insightsDateUtils.ts
+++ b/packages/features/insights/server/insightsDateUtils.ts
@@ -136,7 +136,7 @@ export const formatPeriod = ({
       const shouldShowMonth = wholeStart.isSame(start, "day") || start.date() === 1;
 
       if (shouldShowMonth) {
-        return omitYear ? start.format("MMM D") : start.format("MMM D, YYYY");
+        return omitYear ? start.locale("en").format("MMM D") : start.locale("en").format("MMM D, YYYY");
       } else {
         return omitYear ? start.format("D") : start.format("D, YYYY");
       }
@@ -144,22 +144,22 @@ export const formatPeriod = ({
     case "week": {
       const startFormat = "MMM D";
       let endFormat = "MMM D";
-      if (start.format("MMM") === end.format("MMM")) {
+      if (start.locale("en").format("MMM") === end.locale("en").format("MMM")) {
         endFormat = "D";
       }
 
       if (start.format("YYYY") !== end.format("YYYY")) {
-        return `${start.format(`${startFormat} , YYYY`)} - ${end.format(`${endFormat}, YYYY`)}`;
+        return `${start.locale("en").format(`${startFormat} , YYYY`)} - ${end.locale("en").format(`${endFormat}, YYYY`)}`;
       }
 
       if (omitYear) {
-        return `${start.format(startFormat)} - ${end.format(endFormat)}`;
+        return `${start.locale("en").format(startFormat)} - ${end.locale("en").format(endFormat)}`;
       } else {
-        return `${start.format(startFormat)} - ${end.format(endFormat)}, ${end.format("YYYY")}`;
+        return `${start.locale("en").format(startFormat)} - ${end.locale("en").format(endFormat)}, ${end.format("YYYY")}`;
       }
     }
     case "month": {
-      return omitYear ? start.format("MMM") : start.format("MMM YYYY");
+      return omitYear ? start.locale("en").format("MMM") : start.locale("en").format("MMM YYYY");
     }
     case "year": {
       return start.format("YYYY");
@@ -186,24 +186,24 @@ export const formatPeriodFull = ({
 
   switch (timeView) {
     case "day": {
-      return omitYear ? start.format("MMM D") : start.format("MMM D, YYYY");
+      return omitYear ? start.locale("en").format("MMM D") : start.locale("en").format("MMM D, YYYY");
     }
     case "week": {
       const startFormat = "MMM D";
       const endFormat = "MMM D";
 
       if (start.format("YYYY") !== end.format("YYYY")) {
-        return `${start.format(`${startFormat}, YYYY`)} - ${end.format(`${endFormat}, YYYY`)}`;
+        return `${start.locale("en").format(`${startFormat}, YYYY`)} - ${end.locale("en").format(`${endFormat}, YYYY`)}`;
       }
 
       if (omitYear) {
-        return `${start.format(startFormat)} - ${end.format(endFormat)}`;
+        return `${start.locale("en").format(startFormat)} - ${end.locale("en").format(endFormat)}`;
       } else {
-        return `${start.format(startFormat)} - ${end.format(endFormat)}, ${end.format("YYYY")}`;
+        return `${start.locale("en").format(startFormat)} - ${end.locale("en").format(endFormat)}, ${end.format("YYYY")}`;
       }
     }
     case "month": {
-      return omitYear ? start.format("MMM") : start.format("MMM YYYY");
+      return omitYear ? start.locale("en").format("MMM") : start.locale("en").format("MMM YYYY");
     }
     case "year": {
       return start.format("YYYY");


### PR DESCRIPTION
## What does this PR do?

Chart X-axis month labels were displaying in Spanish ("Ene", "Dic")  instead of English ("Jan", "Dec") on production, even when the app's  global language was set to English.

- Fixes #26499
- Fixes [CAL-7031](https://linear.app/calcom/issue/CAL-7031/chart-x-axis-month-labels-render-in-non-english-locale-on-production)

### Cause
- The `formatPeriod()` and `formatPeriodFull()` functions were using  `start.format("MMM")` without explicitly specifying a locale.
- This happens because Day.js locale is global and mutable, so month formatting (MMM) can inherit the server’s active locale unless explicitly specified. 

### Solution
added explicit `.locale("en")` to all month name formatting calls (MMM format) to ensure X-axis labels always display in english.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):
<img width="1909" height="977" alt="Screenshot 2026-01-06 164224" src="https://github.com/user-attachments/assets/3450f741-f15a-4fc7-af25-dfec83f319c1" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- All 49 unit tests pass: TZ=UTC yarn vitest run packages/features/insights/server/__tests__/events.test.ts