### PR TITLE
chore: change API codeowner to Foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /**/package.json @calcom/Foundation
-/apps/api/**/* @calcom/API
+/apps/api/**/* @calcom/Foundation
 /apps/web/**/layout.tsx @calcom/Consumer @calcom/Foundation
 /apps/web/lib/csp.ts @calcom/Foundation
 /apps/web/lib/buildNonce.ts @calcom/Foundation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated CODEOWNERS to set Foundation as the owner for /apps/api/**/*. Ensures API PRs are routed to the Foundation team for review.

<sup>Written for commit cc331224ef3ba652c9c8346ec68663f04c43582a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

