### PR TITLE
chore: Implement back fill and populate new records

### DIFF
--- a/apps/web/app/api/teams/api/create/route.ts
+++ b/apps/web/app/api/teams/api/create/route.ts
@@ -60,6 +60,8 @@ async function handler(request: NextRequest) {
     if (checkoutSessionSubscription) {
       const billingService = getBillingProviderService();
       const { subscriptionStart } = billingService.extractSubscriptionDates(checkoutSessionSubscription);
+      const { billingPeriod, pricePerSeat } =
+        billingService.extractBillingMetadata(checkoutSessionSubscription);
 
       const teamBillingServiceFactory = getTeamBillingServiceFactory();
       const teamBillingService = teamBillingServiceFactory.init(finalizedTeam);
@@ -72,6 +74,8 @@ async function handler(request: NextRequest) {
         status: SubscriptionStatus.ACTIVE,
         planName: Plan.TEAM,
         subscriptionStart,
+        billingPeriod,
+        pricePerSeat,
       });
     }
 

--- a/apps/web/app/api/teams/create/route.ts
+++ b/apps/web/app/api/teams/create/route.ts
@@ -95,6 +95,7 @@ async function getHandler(req: NextRequest) {
   if (checkoutSession && subscription) {
     const billingProviderService = getBillingProviderService();
     const { subscriptionStart } = billingProviderService.extractSubscriptionDates(subscription);
+    const { billingPeriod, pricePerSeat } = billingProviderService.extractBillingMetadata(subscription);
     const teamBillingServiceFactory = getTeamBillingServiceFactory();
     const teamBillingService = teamBillingServiceFactory.init(team);
     await teamBillingService.saveTeamBilling({
@@ -106,6 +107,8 @@ async function getHandler(req: NextRequest) {
       status: SubscriptionStatus.ACTIVE,
       planName: Plan.TEAM,
       subscriptionStart,
+      billingPeriod,
+      pricePerSeat,
     });
   }
 

--- a/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
+++ b/packages/features/ee/billing/api/webhook/_invoice.paid.org.ts
@@ -125,6 +125,7 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
     const stripeSubscription = await stripe.subscriptions.retrieve(paymentSubscriptionId);
     const billingService = getBillingProviderService();
     const { subscriptionStart } = billingService.extractSubscriptionDates(stripeSubscription);
+    const { billingPeriod, pricePerSeat } = billingService.extractBillingMetadata(stripeSubscription);
 
     const teamBillingServiceFactory = getTeamBillingServiceFactory();
     const teamBillingService = teamBillingServiceFactory.init(organization);
@@ -137,6 +138,8 @@ const handler = async (data: SWHMap["invoice.paid"]["data"]) => {
       status: SubscriptionStatus.ACTIVE,
       planName: Plan.ORGANIZATION,
       subscriptionStart,
+      billingPeriod,
+      pricePerSeat,
     });
 
     logger.debug(`Marking onboarding as complete for organization ${organization.id}`);

--- a/packages/features/ee/billing/repository/billing/IBillingRepository.ts
+++ b/packages/features/ee/billing/repository/billing/IBillingRepository.ts
@@ -44,4 +44,6 @@ export interface IBillingRepositoryCreateArgs {
   subscriptionStart?: Date;
   subscriptionTrialEnd?: Date;
   subscriptionEnd?: Date;
+  billingPeriod?: string | null;
+  pricePerSeat?: number | null;
 }

--- a/packages/prisma/migrations/20260106125614_add_billing_period_and_seat/migration.sql
+++ b/packages/prisma/migrations/20260106125614_add_billing_period_and_seat/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "public"."OrganizationBilling" ADD COLUMN     "billingPeriod" "public"."BillingPeriod",
+ADD COLUMN     "pricePerSeat" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "public"."TeamBilling" ADD COLUMN     "billingPeriod" "public"."BillingPeriod",
+ADD COLUMN     "pricePerSeat" DOUBLE PRECISION;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2908,7 +2908,7 @@ model TeamBilling {
   teamId Int    @unique
   team   Team?  @relation("TeamBilling", fields: [teamId], references: [id], onDelete: Cascade)
 
-  subscriptionId       String    @unique
+  subscriptionId       String         @unique
   subscriptionItemId   String
   customerId           String
   status               String
@@ -2916,6 +2916,8 @@ model TeamBilling {
   subscriptionStart    DateTime?
   subscriptionTrialEnd DateTime?
   subscriptionEnd      DateTime?
+  billingPeriod        BillingPeriod?
+  pricePerSeat         Float?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -2926,7 +2928,7 @@ model OrganizationBilling {
   teamId Int    @unique
   team   Team   @relation("OrganizationBilling", fields: [teamId], references: [id], onDelete: Cascade)
 
-  subscriptionId       String    @unique
+  subscriptionId       String         @unique
   subscriptionItemId   String
   customerId           String
   status               String
@@ -2934,6 +2936,8 @@ model OrganizationBilling {
   subscriptionStart    DateTime?
   subscriptionTrialEnd DateTime?
   subscriptionEnd      DateTime?
+  billingPeriod        BillingPeriod?
+  pricePerSeat         Float?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/scripts/backfill-team-billing.ts
+++ b/scripts/backfill-team-billing.ts
@@ -1,0 +1,479 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Backfill Team Billing Records
+ *
+ * This script creates/updates TeamBilling and OrganizationBilling records for teams
+ * that have Stripe subscriptions but missing or incomplete billing data.
+ *
+ * Rate Limits:
+ * - Stripe API: 100 requests/second (live mode), 25 requests/second (test mode)
+ * - Default script rate: ~40 requests/second (2.5x safety margin for live mode)
+ * - Configurable via --delay-requests flag
+ *
+ * Performance (100k teams with default settings):
+ * - Batch size: 50 teams
+ * - Processing rate: ~40 teams/second
+ * - Estimated time: ~42 minutes
+ *
+ * Usage:
+ *   yarn workspace @calcom/prisma backfill-team-billing --dry-run
+ *   yarn workspace @calcom/prisma backfill-team-billing
+ *   yarn workspace @calcom/prisma backfill-team-billing --batch-size 100 --delay-requests 15
+ */
+
+import "dotenv/config";
+import process from "node:process";
+import { getBillingProviderService } from "@calcom/ee/billing/di/containers/Billing";
+import { Plan } from "@calcom/ee/billing/repository/billing/IBillingRepository";
+import stripe from "@calcom/features/ee/payments/server/stripe";
+import type { SubLogger } from "@calcom/lib/logger";
+import logger from "@calcom/lib/logger";
+import { prisma } from "@calcom/prisma";
+import { Prisma } from "@calcom/prisma/client";
+import type Stripe from "stripe";
+
+const log: SubLogger = logger.getSubLogger({ prefix: ["backfill-team-billing"] });
+
+interface ScriptOptions {
+  dryRun: boolean;
+  batchSize: number;
+  delayBetweenBatches: number;
+  delayBetweenRequests: number;
+}
+
+interface Stats {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  total: number;
+}
+
+interface TeamWithMetadata {
+  id: number;
+  name: string;
+  isOrganization: boolean;
+  metadata: {
+    subscriptionId?: string;
+    subscriptionItemId?: string;
+    paymentId?: string;
+  };
+}
+
+const DEFAULT_OPTIONS: ScriptOptions = {
+  dryRun: false,
+  batchSize: 50, // 50 teams per batch
+  delayBetweenBatches: 1000, // 1 second between batches
+  delayBetweenRequests: 25, // 25ms between Stripe calls = ~40 req/s (well under 100 req/s limit)
+};
+
+function parseArgs(): ScriptOptions {
+  const args = process.argv.slice(2);
+  const options = { ...DEFAULT_OPTIONS };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--batch-size" && args[i + 1]) {
+      options.batchSize = parseInt(args[i + 1], 10);
+      i++;
+    } else if (arg === "--delay-batches" && args[i + 1]) {
+      options.delayBetweenBatches = parseInt(args[i + 1], 10);
+      i++;
+    } else if (arg === "--delay-requests" && args[i + 1]) {
+      options.delayBetweenRequests = parseInt(args[i + 1], 10);
+      i++;
+    }
+  }
+
+  return options;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchSubscriptionFromStripe(subscriptionId: string): Promise<Stripe.Subscription | null> {
+  try {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    return subscription;
+  } catch (error) {
+    if (error instanceof Error) {
+      // Check for rate limit error
+      if ("statusCode" in error && (error as Stripe.errors.StripeError).statusCode === 429) {
+        log.warn(`Rate limited on subscription ${subscriptionId}, waiting 10 seconds...`);
+        await sleep(10000);
+        // Retry once
+        return fetchSubscriptionFromStripe(subscriptionId);
+      }
+      log.error(`Error fetching subscription ${subscriptionId}: ${error.message}`);
+    }
+    return null;
+  }
+}
+
+async function createBillingRecord(
+  team: TeamWithMetadata,
+  subscription: Stripe.Subscription,
+  dryRun: boolean
+): Promise<boolean> {
+  try {
+    const billingService = getBillingProviderService();
+    const { subscriptionStart, subscriptionTrialEnd, subscriptionEnd } =
+      billingService.extractSubscriptionDates(subscription);
+    const { billingPeriod, pricePerSeat } = billingService.extractBillingMetadata(subscription);
+
+    const subscriptionItemId = subscription.items.data[0]?.id;
+    if (!subscriptionItemId) {
+      log.warn(`No subscription item found for team ${team.id}`);
+      return false;
+    }
+
+    const billingData = {
+      teamId: team.id,
+      subscriptionId: subscription.id,
+      subscriptionItemId,
+      customerId: subscription.customer as string,
+      status: billingService.mapStripeStatusToCalStatus({
+        stripeStatus: subscription.status,
+        subscriptionId: subscription.id,
+      }),
+      planName: team.isOrganization ? Plan.ORGANIZATION : Plan.TEAM,
+      subscriptionStart,
+      subscriptionTrialEnd,
+      subscriptionEnd,
+      billingPeriod,
+      pricePerSeat,
+    };
+
+    if (dryRun) {
+      log.info(
+        `[DRY RUN] Would create ${team.isOrganization ? "OrganizationBilling" : "TeamBilling"} for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+      return true;
+    }
+
+    if (team.isOrganization) {
+      await prisma.organizationBilling.create({
+        data: billingData,
+      });
+      log.info(
+        `Created OrganizationBilling for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+    } else {
+      await prisma.teamBilling.create({
+        data: billingData,
+      });
+      log.info(
+        `Created TeamBilling for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+    }
+
+    return true;
+  } catch (error) {
+    if (error instanceof Error) {
+      log.error(`Failed to create billing record for team ${team.id}: ${error.message}`);
+    }
+    return false;
+  }
+}
+
+async function updateBillingRecord(
+  team: TeamWithMetadata,
+  subscription: Stripe.Subscription,
+  dryRun: boolean
+): Promise<boolean> {
+  try {
+    const billingService = getBillingProviderService();
+    const { billingPeriod, pricePerSeat } = billingService.extractBillingMetadata(subscription);
+
+    if (dryRun) {
+      log.info(
+        `[DRY RUN] Would update ${team.isOrganization ? "OrganizationBilling" : "TeamBilling"} for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+      return true;
+    }
+
+    if (team.isOrganization) {
+      await prisma.organizationBilling.update({
+        where: { teamId: team.id },
+        data: {
+          billingPeriod,
+          pricePerSeat,
+        },
+      });
+      log.info(
+        `Updated OrganizationBilling for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+    } else {
+      await prisma.teamBilling.update({
+        where: { teamId: team.id },
+        data: {
+          billingPeriod,
+          pricePerSeat,
+        },
+      });
+      log.info(
+        `Updated TeamBilling for team ${team.id} (${team.name}): ${billingPeriod}, $${pricePerSeat}/seat`
+      );
+    }
+
+    return true;
+  } catch (error) {
+    if (error instanceof Error) {
+      log.error(`Failed to update billing record for team ${team.id}: ${error.message}`);
+    }
+    return false;
+  }
+}
+
+async function fetchTeamsBatch(
+  cursor: number | null,
+  batchSize: number
+): Promise<{ teams: TeamWithMetadata[]; nextCursor: number | null }> {
+  const teams = await prisma.team.findMany({
+    where: {
+      metadata: {
+        path: ["subscriptionId"],
+        not: Prisma.JsonNull,
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      isOrganization: true,
+      metadata: true,
+    },
+    take: batchSize,
+    ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    orderBy: {
+      id: "asc",
+    },
+  });
+
+  const nextCursor = teams.length === batchSize ? teams[teams.length - 1].id : null;
+
+  const teamData = teams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    isOrganization: team.isOrganization,
+    metadata: team.metadata as {
+      subscriptionId?: string;
+      subscriptionItemId?: string;
+      paymentId?: string;
+    },
+  }));
+
+  return { teams: teamData, nextCursor };
+}
+
+async function countTeamsWithSubscriptions(): Promise<number> {
+  return await prisma.team.count({
+    where: {
+      metadata: {
+        path: ["subscriptionId"],
+        not: Prisma.JsonNull,
+      },
+    },
+  });
+}
+
+async function checkExistingBillingRecord(
+  team: TeamWithMetadata
+): Promise<"missing" | "exists-incomplete" | "exists-complete"> {
+  if (team.isOrganization) {
+    const existing = await prisma.organizationBilling.findUnique({
+      where: { teamId: team.id },
+      select: {
+        billingPeriod: true,
+        pricePerSeat: true,
+      },
+    });
+
+    if (!existing) return "missing";
+    if (existing.billingPeriod === null || existing.pricePerSeat === null) {
+      return "exists-incomplete";
+    }
+    return "exists-complete";
+  }
+
+  const existing = await prisma.teamBilling.findUnique({
+    where: { teamId: team.id },
+    select: {
+      billingPeriod: true,
+      pricePerSeat: true,
+    },
+  });
+
+  if (!existing) return "missing";
+  if (existing.billingPeriod === null || existing.pricePerSeat === null) {
+    return "exists-incomplete";
+  }
+  return "exists-complete";
+}
+
+async function processBatch(teams: TeamWithMetadata[], options: ScriptOptions, stats: Stats): Promise<void> {
+  for (const team of teams) {
+    const subscriptionId = team.metadata.subscriptionId;
+
+    if (!subscriptionId) {
+      stats.skipped++;
+      log.debug(`Skipping team ${team.id} - no subscriptionId in metadata`);
+      continue;
+    }
+
+    // Check if billing record exists and is complete
+    const recordStatus = await checkExistingBillingRecord(team);
+
+    if (recordStatus === "exists-complete") {
+      stats.skipped++;
+      log.debug(`Skipping team ${team.id} (${team.name}) - billing record already complete`);
+      continue;
+    }
+
+    // Rate limiting
+    await sleep(options.delayBetweenRequests);
+
+    // Fetch subscription from Stripe
+    const subscription = await fetchSubscriptionFromStripe(subscriptionId);
+
+    if (!subscription) {
+      stats.failed++;
+      log.warn(`Failed to fetch subscription for team ${team.id} (${team.name})`);
+      continue;
+    }
+
+    let success = false;
+
+    if (recordStatus === "missing") {
+      success = await createBillingRecord(team, subscription, options.dryRun);
+      if (success) {
+        stats.created++;
+      } else {
+        stats.failed++;
+      }
+    } else if (recordStatus === "exists-incomplete") {
+      success = await updateBillingRecord(team, subscription, options.dryRun);
+      if (success) {
+        stats.updated++;
+      } else {
+        stats.failed++;
+      }
+    }
+  }
+}
+
+function printSummary(stats: Stats, startTime: number): void {
+  const elapsed = Date.now() - startTime;
+  const elapsedMinutes = Math.floor(elapsed / 60000);
+  const elapsedSeconds = Math.floor((elapsed % 60000) / 1000);
+
+  log.info("");
+  log.info("========================================");
+  log.info("Backfill Summary");
+  log.info("========================================");
+  log.info(`  Created: ${stats.created} (new billing records)`);
+  log.info(`  Updated: ${stats.updated} (incomplete records)`);
+  log.info(`  Skipped: ${stats.skipped} (already complete)`);
+  log.info(`  Failed: ${stats.failed}`);
+  log.info(`  Total: ${stats.total}`);
+  log.info(`  Time taken: ${elapsedMinutes}m ${elapsedSeconds}s`);
+  log.info("========================================");
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  const startTime = Date.now();
+
+  log.info("========================================");
+  log.info("Starting Team Billing Backfill");
+  log.info("========================================");
+  log.info(`Dry run: ${options.dryRun}`);
+  log.info(`Batch size: ${options.batchSize}`);
+  log.info(`Delay between batches: ${options.delayBetweenBatches}ms`);
+  log.info(`Delay between requests: ${options.delayBetweenRequests}ms`);
+  log.info(`DATABASE_URL set: ${!!process.env.DATABASE_URL}`);
+  log.info(`STRIPE_PRIVATE_KEY set: ${!!process.env.STRIPE_PRIVATE_KEY}`);
+  log.info("");
+
+  // Count total teams with subscriptions
+  log.info("Counting teams with subscriptions...");
+  const totalTeams = await countTeamsWithSubscriptions();
+  log.info(`Found ${totalTeams} teams with subscriptionId in metadata\n`);
+
+  const stats: Stats = {
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    total: totalTeams,
+  };
+
+  // Process teams using cursor-based pagination
+  let cursor: number | null = null;
+  let batchNumber = 0;
+  const estimatedBatches = Math.ceil(totalTeams / options.batchSize);
+
+  log.info(`Processing ~${estimatedBatches} batches...\n`);
+
+  while (true) {
+    batchNumber++;
+
+    // Fetch next batch of teams
+    const { teams, nextCursor } = await fetchTeamsBatch(cursor, options.batchSize);
+
+    if (teams.length === 0) {
+      break;
+    }
+
+    log.info(`Processing batch ${batchNumber} (${teams.length} teams)...`);
+
+    await processBatch(teams, options, stats);
+
+    // Print progress every 5 batches
+    if (batchNumber % 5 === 0) {
+      const processedCount = stats.created + stats.updated + stats.skipped + stats.failed;
+      const progress = (processedCount / totalTeams) * 100;
+      const elapsed = Date.now() - startTime;
+      const elapsedMinutes = Math.floor(elapsed / 60000);
+
+      log.info("========================================");
+      log.info(`Progress: ${processedCount}/${totalTeams} teams (${progress.toFixed(1)}%)`);
+      log.info(`Elapsed: ${elapsedMinutes}m`);
+      log.info(
+        `Created: ${stats.created}, updated: ${stats.updated}, skipped: ${stats.skipped}, failed: ${stats.failed}`
+      );
+      log.info("========================================");
+    }
+
+    // Move cursor to next batch
+    cursor = nextCursor;
+
+    // Break if no more teams
+    if (!nextCursor) {
+      break;
+    }
+
+    // Delay between batches
+    await sleep(options.delayBetweenBatches);
+  }
+
+  printSummary(stats, startTime);
+
+  if (options.dryRun) {
+    log.info("\n⚠️  This was a DRY RUN - no changes were made to the database");
+  }
+}
+
+// Run the script
+main()
+  .then(() => {
+    log.info("\n✅ Script completed successfully");
+    process.exit(0);
+  })
+  .catch((error) => {
+    log.error("\n❌ Script failed with error:", error);
+    process.exit(1);
+  });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add billingPeriod and pricePerSeat to team and organization billing, and populate them for new and existing records. Values are extracted from Stripe subscriptions.

- **New Features**
  - Store billingPeriod and pricePerSeat in TeamBilling and OrganizationBilling.
  - Extract billingPeriod (monthly/annually) and seat price from Stripe subscription items.
  - Persist these fields during team creation and on invoice.paid for organizations.

- **Migration**
  - Run database migration to add the new columns.
  - Optional: Backfill existing records with the script: yarn workspace @calcom/prisma backfill-team-billing

<sup>Written for commit 56387c1b035b0d2cc333a355d52f81c6f1e6cfdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

