### PR TITLE
feat: add all event-types and upcoming bookings to KBar

### DIFF
--- a/apps/web/modules/shell/Kbar.tsx
+++ b/apps/web/modules/shell/Kbar.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
+import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { isMac } from "@calcom/lib/isMac";
 import { trpc } from "@calcom/trpc/react";
@@ -93,7 +94,7 @@ function useEventTypesAction(): void {
   const router = useRouter();
   const { data } = trpc.viewer.eventTypes.getEventTypesFromGroup.useInfiniteQuery(
     {
-      limit: 10,
+      limit: 100,
       group: { teamId: null, parentId: null },
     },
     {
@@ -124,6 +125,45 @@ function useEventTypesAction(): void {
   useRegisterActions(actions);
 }
 
+function useUpcomingBookingsAction(): void {
+  const router = useRouter();
+
+  const { data } = trpc.viewer.bookings.get.useQuery(
+    {
+      filters: {
+        status: "upcoming",
+        afterStartDate: dayjs().startOf("day").toISOString(),
+      },
+      limit: 100,
+    },
+    {
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000,
+    }
+  );
+
+  const bookingActions: Action[] = useMemo(() => {
+    if (!data?.bookings) return [];
+
+    return data.bookings.map((booking) => {
+      const startTime = dayjs(booking.startTime);
+      const formattedDate = startTime.format("MMM D");
+      const formattedTime = startTime.format("h:mm A");
+      const attendeeNames = (booking.attendees ?? []).map((a) => a.name).join(" ");
+
+      return {
+        id: `booking-${booking.uid}`,
+        name: `${booking.title} - ${formattedDate} ${formattedTime}`,
+        section: { name: "upcoming", priority: 1 },
+        keywords: `booking ${booking.title} ${attendeeNames}`,
+        perform: () => router.push(`/booking/${booking.uid}`),
+      };
+    });
+  }, [data?.bookings, router]);
+
+  useRegisterActions(bookingActions);
+}
+
 const KBarRoot = ({ children }: { children: ReactNode }): JSX.Element => {
   const router = useRouter();
   const actions = useMemo(() => buildKbarActions(router.push), [router.push]);
@@ -141,6 +181,7 @@ function CommandKey(): JSX.Element {
 const KBarContent = (): JSX.Element => {
   const { t } = useLocale();
   useEventTypesAction();
+  useUpcomingBookingsAction();
 
   return (
     <KBarPortal>


### PR DESCRIPTION
## What does this PR do?

Enhances the CMD+K widget (KBar) by adding individual event types and upcoming bookings as searchable items:

- Increases event types limit from 10 to 100 to show more event types in search results
- Adds `useUpcomingBookingsAction` hook to fetch and display upcoming bookings
- Bookings display as "{title} - {date} {time}" format (e.g., "Team Meeting - Jan 5 2:00 PM")
- Clicking a booking navigates to `/booking/{uid}`
- **Upcoming bookings appear at the very top of KBar** using section priority (`priority: 1`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **N/A - UI enhancement**

## How should this be tested?

1. Open the CMD+K widget (press Cmd+K or Ctrl+K)
2. Verify upcoming bookings appear at the **very top** of the results list
3. Search for an event type name - individual event types should appear in results
4. Search for a booking title - individual upcoming bookings should appear with date/time
5. Click on an event type - should navigate to `/event-types/{id}`
6. Click on a booking - should navigate to `/booking/{uid}`

## Human Review Checklist

- [ ] Verify the booking URL format `/booking/${booking.uid}` is correct for viewing booking details
- [ ] Confirm the section priority (`priority: 1`) correctly places bookings at the top of KBar
- [ ] Consider if fetching 100 items for both event types and bookings is appropriate for performance
- [ ] Test that attendees with undefined values don't cause errors

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/cb4a0f8576c84b71a18cfd35fd2db17c
**Requested by:** peer@cal.com (@PeerRich)