### PR TITLE
feat: add organization banner to user profile page

### DIFF
--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -1,25 +1,24 @@
 "use client";
 
-import classNames from "classnames";
-import type { InferGetServerSidePropsType } from "next";
-import Link from "next/link";
-import { Toaster } from "sonner";
-
 import {
   sdkActionManager,
   useEmbedNonStylesConfig,
   useEmbedStyles,
   useIsEmbed,
 } from "@calcom/embed-core/embed-iframe";
-import { EventTypeDescriptionLazy as EventTypeDescription } from "@calcom/web/modules/event-types/components";
-import EmptyPage from "@calcom/web/modules/event-types/components/EmptyPage";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { UserAvatar } from "@calcom/ui/components/avatar";
 import { Icon } from "@calcom/ui/components/icon";
+import { OrgBanner } from "@calcom/ui/components/organization-banner";
 import { UnpublishedEntity } from "@calcom/ui/components/unpublished-entity";
-
+import { EventTypeDescriptionLazy as EventTypeDescription } from "@calcom/web/modules/event-types/components";
+import EmptyPage from "@calcom/web/modules/event-types/components/EmptyPage";
 import type { getServerSideProps } from "@server/lib/[user]/getServerSideProps";
+import classNames from "classnames";
+import type { InferGetServerSidePropsType } from "next";
+import Link from "next/link";
+import { Toaster } from "sonner";
 
 export type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 export function UserPage(props: PageProps) {
@@ -62,39 +61,49 @@ export function UserPage(props: PageProps) {
             isEmbed ? "border-booker border-booker-width  bg-default rounded-md" : "",
             "max-w-3xl px-4 py-24"
           )}>
-          <div className="border-subtle bg-default text-default mb-8 rounded-xl border p-4">
-            <UserAvatar
-              size="lg"
-              user={{
-                avatarUrl: user.avatarUrl,
-                profile: user.profile,
-                name: profile.name,
-                username: profile.username,
-              }}
-            />
-            <h1 className="font-cal text-emphasis mb-1 mt-4 text-xl" data-testid="name-title">
-              {profile.name}
-              {!isOrg && user.verified && (
-                <Icon
-                  name="badge-check"
-                  className="mx-1 -mt-1 inline h-6 w-6 fill-blue-500 text-white dark:text-black"
-                />
-              )}
-              {isOrg && (
-                <Icon
-                  name="badge-check"
-                  className="mx-1 -mt-1 inline h-6 w-6 fill-yellow-500 text-white dark:text-black"
-                />
-              )}
-            </h1>
-            {!isBioEmpty && (
-              <>
-                <div
-                  className="text-default wrap-break-word text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
-                  dangerouslySetInnerHTML={{ __html: props.safeBio }}
-                />
-              </>
+          <div className="border-subtle bg-default text-default mb-8 overflow-hidden rounded-xl border">
+            {isOrg && user.profile.organization?.bannerUrl && (
+              <OrgBanner
+                alt={user.profile.organization.name ?? "Organization banner"}
+                imageSrc={user.profile.organization.bannerUrl}
+                className="h-24 w-full object-cover"
+              />
             )}
+            <div className="p-4">
+              <UserAvatar
+                size="lg"
+                user={{
+                  avatarUrl: user.avatarUrl,
+                  profile: user.profile,
+                  name: profile.name,
+                  username: profile.username,
+                }}
+                className={isOrg && user.profile.organization?.bannerUrl ? "-mt-[50px]" : ""}
+              />
+              <h1 className="font-cal text-emphasis mb-1 mt-4 text-xl" data-testid="name-title">
+                {profile.name}
+                {!isOrg && user.verified && (
+                  <Icon
+                    name="badge-check"
+                    className="mx-1 -mt-1 inline h-6 w-6 fill-blue-500 text-white dark:text-black"
+                  />
+                )}
+                {isOrg && (
+                  <Icon
+                    name="badge-check"
+                    className="mx-1 -mt-1 inline h-6 w-6 fill-yellow-500 text-white dark:text-black"
+                  />
+                )}
+              </h1>
+              {!isBioEmpty && (
+                <>
+                  <div
+                    className="text-default wrap-break-word text-sm [&_a]:text-blue-500 [&_a]:underline [&_a]:hover:text-blue-600"
+                    dangerouslySetInnerHTML={{ __html: props.safeBio }}
+                  />
+                </>
+              )}
+            </div>
           </div>
 
           <div

--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -59,14 +59,14 @@ export function UserPage(props: PageProps) {
           className={classNames(
             shouldAlignCentrally ? "mx-auto" : "",
             isEmbed ? "border-booker border-booker-width  bg-default rounded-md" : "",
-            "max-w-3xl px-4 py-24"
+            "max-w-3xl px-4 py-12"
           )}>
           <div className="border-subtle bg-default text-default mb-8 overflow-hidden rounded-xl border">
             {isOrg && user.profile.organization?.bannerUrl && (
               <OrgBanner
                 alt={user.profile.organization.name ?? "Organization banner"}
                 imageSrc={user.profile.organization.bannerUrl}
-                className="h-24 w-full object-cover"
+                className="p-1 border-subtle rounded-xl w-full object-cover"
               />
             )}
             <div className="p-4">
@@ -78,9 +78,9 @@ export function UserPage(props: PageProps) {
                   name: profile.name,
                   username: profile.username,
                 }}
-                className={isOrg && user.profile.organization?.bannerUrl ? "-mt-[50px]" : ""}
+                className={isOrg && user.profile.organization?.bannerUrl ? "-mt-14" : ""}
               />
-              <h1 className="font-cal text-emphasis mb-1 mt-4 text-xl" data-testid="name-title">
+              <h1 className={classNames("font-cal text-emphasis mb-1 text-xl", isOrg && user.profile.organization?.bannerUrl ? "" : "mt-4")} data-testid="name-title">
                 {profile.name}
                 {!isOrg && user.verified && (
                   <Icon

--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -66,7 +66,7 @@ export function UserPage(props: PageProps) {
               <OrgBanner
                 alt={user.profile.organization.name ?? "Organization banner"}
                 imageSrc={user.profile.organization.bannerUrl}
-                className="p-1 border-subtle rounded-xl w-full object-cover"
+                className="p-1 border border-subtle rounded-xl w-full object-cover"
               />
             )}
             <div className="p-4">


### PR DESCRIPTION
## What does this PR do?

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/ab2745a8-7b2a-4b58-b963-e84413096019" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/9c78e947-5ef4-4b5f-8ac8-d3496d254399" />

 
Adds the organization banner to the `orgslug.cal.com/[username]` profile page. When a user belongs to an organization that has a banner configured, the banner is displayed at the top of the profile card with the avatar overlapping it using a negative margin-top of 50px.

## Visual Demo (For contributors especially)

**Reference design provided by requester:**

![Reference design](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfb0p1VEo4MFZNOWxldHVWViIsInVzZXJfaWQiOiJlbWFpbHw2NzZmMmQyOTMyMWE5NmU4OGU1MTg0ZTciLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfb0p1VEo4MFZNOWxldHVWVi8wYTBmZmY4NC00ODVmLTQzMTctOTYyMi1jMjRiYmVmMzdlZmQiLCJpYXQiOjE3Njc3MTc0MjEsImV4cCI6MTc2ODMyMjIyMX0._rKu1CW2AR6gg1CBLmmzmbdwyfc6nh_zWQOPCOPUbkI)

**Note:** Visual testing in a live environment is recommended to verify the implementation matches the design.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Navigate to an organization user's profile page (`orgslug.cal.com/[username]`)
2. Ensure the organization has a banner URL configured
3. Verify the banner displays at full width at the top of the profile card
4. Verify the avatar overlaps the banner with approximately 50px negative margin
5. Test with an org user that has no banner configured - should display normally without banner
6. Test with a non-org user - should display normally without banner

## Human Review Checklist

- [ ] Verify the `className` prop is properly passed through `UserAvatar` to the underlying `Avatar` component
- [ ] Verify the banner displays correctly and the avatar overlap looks as expected
- [ ] Verify non-org users and org users without banners still render correctly
- [ ] Verify the `bannerUrl` is available on `user.profile.organization` in production data

---

**Link to Devin run:** https://app.devin.ai/sessions/c4e0917a183548a1a38c3dc563b4e4fc
**Requested by:** @PeerRich