### PR TITLE
refactor: convert PrismaAttributeToUserRepository to accept Prisma as dependency

### DIFF
--- a/packages/features/attributes/lib/getAttributes.ts
+++ b/packages/features/attributes/lib/getAttributes.ts
@@ -221,6 +221,7 @@ async function _getOrgMembershipToUserIdForTeam({ orgId, teamId }: { orgId: numb
 
 async function _queryAllData({ orgId, teamId }: { orgId: number; teamId: number }) {
   const attributeRepo = new PrismaAttributeRepository(prisma);
+  const attributeToUserRepo = new PrismaAttributeToUserRepository(prisma);
 
   const [orgMembershipToUserIdForTeamMembers, attributesOfTheOrg] = await Promise.all([
     _getOrgMembershipToUserIdForTeam({ orgId, teamId }),
@@ -230,7 +231,7 @@ async function _queryAllData({ orgId, teamId }: { orgId: number; teamId: number 
   const orgMembershipIds = Array.from(orgMembershipToUserIdForTeamMembers.keys());
 
   // Get all the attributes assigned to the members of the team
-  const attributesToUsersForTeam = await PrismaAttributeToUserRepository.findManyByOrgMembershipIds({
+  const attributesToUsersForTeam = await attributeToUserRepo.findManyByOrgMembershipIds({
     orgMembershipIds,
   });
 

--- a/packages/features/attributes/lib/utils.ts
+++ b/packages/features/attributes/lib/utils.ts
@@ -1,4 +1,5 @@
 import { PrismaAttributeToUserRepository } from "@calcom/features/attributes/repositories/PrismaAttributeToUserRepository";
+import prisma from "@calcom/prisma";
 
 export const getWhereClauseForAttributeOptionsManagedByCalcom = () => {
   // Neither created nor updated by DSync
@@ -10,7 +11,8 @@ export const getWhereClauseForAttributeOptionsManagedByCalcom = () => {
 };
 
 export const findAssignmentsForMember = async ({ memberId }: { memberId: number }) => {
-  const assignments = await PrismaAttributeToUserRepository.findManyIncludeAttribute({ memberId });
+  const attributeToUserRepo = new PrismaAttributeToUserRepository(prisma);
+  const assignments = await attributeToUserRepo.findManyIncludeAttribute({ memberId });
   return assignments.map((assignment) => ({
     ...assignment,
     attributeOption: {

--- a/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
+++ b/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
@@ -1,20 +1,37 @@
-import { prisma } from "@calcom/prisma";
-import type { Prisma } from "@calcom/prisma/client";
+import type { PrismaClient } from "@calcom/prisma";
+
+type AttributeToUserCreateManyInput = {
+  id?: string;
+  memberId: number;
+  attributeOptionId: string;
+  weight?: number;
+  createdById: number;
+  updatedById: number;
+  createdByDSyncId?: string | null;
+  updatedByDSyncId?: string | null;
+};
+
+type AttributeToUserWhereInput = {
+  memberId?: number | { in?: number[] };
+  attributeOptionId?: string | { in?: string[] };
+};
 
 export class PrismaAttributeToUserRepository {
-  static async createManySkipDuplicates(data: Prisma.AttributeToUserCreateManyInput[]) {
-    return await prisma.attributeToUser.createMany({ data, skipDuplicates: true });
+  constructor(private prismaClient: PrismaClient) {}
+
+  async createManySkipDuplicates(data: AttributeToUserCreateManyInput[]) {
+    return await this.prismaClient.attributeToUser.createMany({ data, skipDuplicates: true });
   }
 
-  static async deleteMany(where: Prisma.AttributeToUserWhereInput) {
+  async deleteMany(where: AttributeToUserWhereInput) {
     if (Object.keys(where).length === 0) {
       throw new Error("Empty where clause provided to deleteMany. Potential data loss risk.");
     }
-    return await prisma.attributeToUser.deleteMany({ where });
+    return await this.prismaClient.attributeToUser.deleteMany({ where });
   }
 
-  static async findManyIncludeAttribute(where: Prisma.AttributeToUserWhereInput) {
-    return await prisma.attributeToUser.findMany({
+  async findManyIncludeAttribute(where: AttributeToUserWhereInput) {
+    return await this.prismaClient.attributeToUser.findMany({
       where,
       include: {
         attributeOption: {
@@ -28,12 +45,12 @@ export class PrismaAttributeToUserRepository {
     });
   }
 
-  static async findManyByOrgMembershipIds({ orgMembershipIds }: { orgMembershipIds: number[] }) {
+  async findManyByOrgMembershipIds({ orgMembershipIds }: { orgMembershipIds: number[] }) {
     if (!orgMembershipIds.length) {
       return [];
     }
 
-    const attributesAssignedToTeamMembers = await prisma.attributeToUser.findMany({
+    const attributesAssignedToTeamMembers = await this.prismaClient.attributeToUser.findMany({
       where: {
         memberId: {
           in: orgMembershipIds,

--- a/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
+++ b/packages/features/attributes/repositories/PrismaAttributeToUserRepository.ts
@@ -1,36 +1,21 @@
 import type { PrismaClient } from "@calcom/prisma";
-
-type AttributeToUserCreateManyInput = {
-  id?: string;
-  memberId: number;
-  attributeOptionId: string;
-  weight?: number;
-  createdById: number;
-  updatedById: number;
-  createdByDSyncId?: string | null;
-  updatedByDSyncId?: string | null;
-};
-
-type AttributeToUserWhereInput = {
-  memberId?: number | { in?: number[] };
-  attributeOptionId?: string | { in?: string[] };
-};
+import type { Prisma } from "@calcom/prisma/generated/prisma/client";
 
 export class PrismaAttributeToUserRepository {
   constructor(private prismaClient: PrismaClient) {}
 
-  async createManySkipDuplicates(data: AttributeToUserCreateManyInput[]) {
+  async createManySkipDuplicates(data: Prisma.AttributeToUserCreateManyInput[]) {
     return await this.prismaClient.attributeToUser.createMany({ data, skipDuplicates: true });
   }
 
-  async deleteMany(where: AttributeToUserWhereInput) {
+  async deleteMany(where: Prisma.AttributeToUserWhereInput) {
     if (Object.keys(where).length === 0) {
       throw new Error("Empty where clause provided to deleteMany. Potential data loss risk.");
     }
     return await this.prismaClient.attributeToUser.deleteMany({ where });
   }
 
-  async findManyIncludeAttribute(where: AttributeToUserWhereInput) {
+  async findManyIncludeAttribute(where: Prisma.AttributeToUserWhereInput) {
     return await this.prismaClient.attributeToUser.findMany({
       where,
       include: {


### PR DESCRIPTION
## What does this PR do?

Converts `PrismaAttributeToUserRepository` from using static methods with a direct `prisma` import to using instance methods with `PrismaClient` injected via constructor. This follows the dependency injection pattern used by other repositories in the codebase (e.g., `UserRepository`, `TeamRepository`, `HostRepository`, `PrismaBookingReportRepository`).

**Changes:**
- Refactored `PrismaAttributeToUserRepository` to accept `PrismaClient` as a constructor parameter
- Converted all static methods to instance methods
- Updated `getAttributes.ts` and `utils.ts` to instantiate the repository with prisma
- Uses Prisma types from `@calcom/prisma/generated/prisma/client` (matching the pattern in `PrismaBookingReportRepository`)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - internal refactoring only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This is a refactoring change that maintains existing functionality:

1. Verify the application builds without type errors
2. Test attribute assignment functionality in the UI to ensure attributes can still be assigned to users
3. Verify that `getAttributesAssignmentData` and `findAssignmentsForMember` functions work correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

<!-- Link to Devin run: https://app.devin.ai/sessions/05a4d103535e4fad924aebc4b511ec73 -->
<!-- Requested by: @joeauyeung -->