### PR TITLE
feat: add admin healthcheck page for self-hosted instances

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_actions/sendTestEmail.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_actions/sendTestEmail.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { serverConfig } from "@calcom/lib/serverConfig";
+import { UserPermissionRole } from "@calcom/prisma/enums";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
+import { cookies, headers } from "next/headers";
+import { createTransport } from "nodemailer";
+
+type SendTestEmailResult = {
+  success: boolean;
+  error?: string;
+};
+
+export async function sendTestEmail(recipientEmail: string): Promise<SendTestEmailResult> {
+  // Verify admin role
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+  const userRole = session?.user?.role;
+
+  if (userRole !== UserPermissionRole.ADMIN) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  // Check if email is configured
+  if (!serverConfig.from) {
+    return { success: false, error: "EMAIL_FROM is not configured" };
+  }
+
+  // Check if SMTP transport is configured (not sendmail)
+  const transport = serverConfig.transport;
+  if (typeof transport === "object" && "sendmail" in transport) {
+    return { success: false, error: "SMTP is not configured. Using sendmail fallback." };
+  }
+
+  try {
+    const transporter = createTransport(transport);
+
+    await transporter.sendMail({
+      from: serverConfig.from,
+      to: recipientEmail,
+      subject: "Cal.com Test Email - SMTP Configuration Verified",
+      text: `This is a test email from your Cal.com instance.
+
+If you received this email, your SMTP configuration is working correctly.
+
+Sent from: ${serverConfig.from}
+Timestamp: ${new Date().toISOString()}`,
+      html: `
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color: #292929;">Cal.com Test Email</h2>
+          <p>This is a test email from your Cal.com instance.</p>
+          <p style="color: #22c55e; font-weight: bold;">If you received this email, your SMTP configuration is working correctly.</p>
+          <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 20px 0;" />
+          <p style="color: #737373; font-size: 12px;">
+            Sent from: ${serverConfig.from}<br />
+            Timestamp: ${new Date().toISOString()}
+          </p>
+        </div>
+      `,
+    });
+
+    return { success: true };
+  } catch (error) {
+    let errorMessage = "Failed to send test email";
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    return { success: false, error: errorMessage };
+  }
+}

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_queries/index.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_queries/index.ts
@@ -1,0 +1,134 @@
+import { unstable_cache } from "next/cache";
+import process from "node:process";
+
+import prisma from "@calcom/prisma";
+
+const HEALTHCHECK_CACHE_TTL = 60; // 1 minute cache for health checks
+
+type AppStatus = {
+  slug: string;
+  dirName: string;
+  enabled: boolean;
+  categories: string[];
+};
+
+type HealthCheckData = {
+  apps: {
+    installed: AppStatus[];
+    total: number;
+  };
+  license: {
+    hasEnvKey: boolean;
+    hasDbKey: boolean;
+  };
+  email: {
+    hasEmailFrom: boolean;
+    hasSendgridApiKey: boolean;
+  };
+  redis: {
+    hasUpstashUrl: boolean;
+    hasUpstashToken: boolean;
+  };
+  database: {
+    connected: boolean;
+    error?: string;
+  };
+};
+
+async function getInstalledApps(): Promise<AppStatus[]> {
+  const apps = await prisma.app.findMany({
+    select: {
+      slug: true,
+      dirName: true,
+      enabled: true,
+      categories: true,
+    },
+    orderBy: {
+      slug: "asc",
+    },
+  });
+
+  return apps;
+}
+
+async function getLicenseKeyStatus(): Promise<{ hasEnvKey: boolean; hasDbKey: boolean }> {
+  const hasEnvKey = !!process.env.CALCOM_LICENSE_KEY;
+
+  let hasDbKey = false;
+  try {
+    const deployment = await prisma.deployment.findUnique({
+      where: { id: 1 },
+      select: { licenseKey: true },
+    });
+    hasDbKey = !!deployment?.licenseKey;
+  } catch {
+    // Deployment table might not exist in some setups
+    hasDbKey = false;
+  }
+
+  return { hasEnvKey, hasDbKey };
+}
+
+function getEmailConfigStatus(): { hasEmailFrom: boolean; hasSendgridApiKey: boolean } {
+  return {
+    hasEmailFrom: !!process.env.EMAIL_FROM,
+    hasSendgridApiKey: !!process.env.SENDGRID_API_KEY,
+  };
+}
+
+function getRedisConfigStatus(): { hasUpstashUrl: boolean; hasUpstashToken: boolean } {
+  return {
+    hasUpstashUrl: !!process.env.UPSTASH_REDIS_REST_URL,
+    hasUpstashToken: !!process.env.UPSTASH_REDIS_REST_TOKEN,
+  };
+}
+
+async function getDatabaseStatus(): Promise<{ connected: boolean; error?: string }> {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return { connected: true };
+  } catch (error) {
+    let errorMessage = "Unknown database error";
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    return {
+      connected: false,
+      error: errorMessage,
+    };
+  }
+}
+
+async function fetchHealthCheckData(): Promise<HealthCheckData> {
+  const [apps, license, database] = await Promise.all([
+    getInstalledApps(),
+    getLicenseKeyStatus(),
+    getDatabaseStatus(),
+  ]);
+
+  const email = getEmailConfigStatus();
+  const redis = getRedisConfigStatus();
+
+  return {
+    apps: {
+      installed: apps,
+      total: apps.length,
+    },
+    license,
+    email,
+    redis,
+    database,
+  };
+}
+
+const getHealthCheckData: () => Promise<HealthCheckData> = unstable_cache(
+  fetchHealthCheckData,
+  ["admin-healthcheck"],
+  {
+    revalidate: HEALTHCHECK_CACHE_TTL,
+    tags: ["admin-healthcheck"],
+  }
+);
+
+export type { AppStatus, HealthCheckData };
+export { getHealthCheckData };

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_repository/index.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/_repository/index.ts
@@ -1,0 +1,88 @@
+import type { IDeploymentRepository } from "@calcom/features/ee/deployment/repositories/IDeploymentRepository";
+import prisma from "@calcom/prisma";
+
+type AppStatus = {
+  slug: string;
+  dirName: string;
+  enabled: boolean;
+  categories: string[];
+};
+
+class HealthcheckRepository {
+  async listApps(): Promise<AppStatus[]> {
+    const apps = await prisma.app.findMany({
+      select: {
+        slug: true,
+        dirName: true,
+        enabled: true,
+        categories: true,
+      },
+      orderBy: {
+        slug: "asc",
+      },
+    });
+
+    return apps;
+  }
+
+  async getDeploymentLicenseKey(): Promise<string | null> {
+    try {
+      const deployment = await prisma.deployment.findUnique({
+        where: { id: 1 },
+        select: { licenseKey: true },
+      });
+      return deployment?.licenseKey || null;
+    } catch {
+      // Deployment table might not exist in some setups
+      return null;
+    }
+  }
+
+  async ping(): Promise<{ connected: boolean; error?: string }> {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return { connected: true };
+    } catch (error) {
+      let errorMessage = "Unknown database error";
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      return {
+        connected: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  getDeploymentRepository(): IDeploymentRepository {
+    return {
+      async getLicenseKeyWithId(id: number): Promise<string | null> {
+        try {
+          const deployment = await prisma.deployment.findUnique({
+            where: { id },
+            select: { licenseKey: true },
+          });
+          return deployment?.licenseKey || null;
+        } catch {
+          return null;
+        }
+      },
+      async getSignatureToken(id: number): Promise<string | null> {
+        try {
+          const deployment = await prisma.deployment.findUnique({
+            where: { id },
+            select: { signatureTokenEncrypted: true },
+          });
+          return deployment?.signatureTokenEncrypted || null;
+        } catch {
+          return null;
+        }
+      },
+    };
+  }
+}
+
+const healthcheckRepository: HealthcheckRepository = new HealthcheckRepository();
+
+export type { AppStatus };
+export { healthcheckRepository };

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+
+import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
+import { _generateMetadata, getTranslate } from "app/_utils";
+
+import HealthCheckView from "~/settings/admin/healthcheck-view";
+
+import { getHealthCheckData } from "./_queries";
+
+async function generateMetadata(): Promise<Metadata> {
+  return await _generateMetadata(
+    (t) => t("admin"),
+    (t) => t("healthcheck"),
+    undefined,
+    undefined,
+    "/settings/admin/healthcheck"
+  );
+}
+
+async function Page(): Promise<ReactElement> {
+  const t = await getTranslate();
+  const healthCheckData = await getHealthCheckData();
+
+  return (
+    <SettingsHeader title={t("admin")} description={t("healthcheck")}>
+      <HealthCheckView data={healthCheckData} />
+    </SettingsHeader>
+  );
+}
+
+export { generateMetadata };
+export default Page;

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
@@ -1,8 +1,7 @@
-import type { Metadata } from "next";
-import type { ReactElement } from "react";
-
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { _generateMetadata, getTranslate } from "app/_utils";
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
 
 import HealthCheckView from "~/settings/admin/healthcheck-view";
 

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/healthcheck/page.tsx
@@ -1,10 +1,14 @@
+import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
+import { buildLegacyRequest } from "@lib/buildLegacyCtx";
 import { _generateMetadata, getTranslate } from "app/_utils";
 import type { Metadata } from "next";
+import { cookies, headers } from "next/headers";
 import type { ReactElement } from "react";
 
 import HealthCheckView from "~/settings/admin/healthcheck-view";
 
+import { sendTestEmail } from "./_actions/sendTestEmail";
 import { getHealthCheckData } from "./_queries";
 
 async function generateMetadata(): Promise<Metadata> {
@@ -20,10 +24,12 @@ async function generateMetadata(): Promise<Metadata> {
 async function Page(): Promise<ReactElement> {
   const t = await getTranslate();
   const healthCheckData = await getHealthCheckData();
+  const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
+  const userEmail = session?.user?.email || undefined;
 
   return (
     <SettingsHeader title={t("admin")} description={t("healthcheck")}>
-      <HealthCheckView data={healthCheckData} />
+      <HealthCheckView data={healthCheckData} userEmail={userEmail} onSendTestEmail={sendTestEmail} />
     </SettingsHeader>
   );
 }

--- a/apps/web/modules/settings/admin/healthcheck-view.tsx
+++ b/apps/web/modules/settings/admin/healthcheck-view.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { BadgeProps } from "@calcom/ui/components/badge";
+import { Badge } from "@calcom/ui/components/badge";
+import { PanelCard } from "@calcom/ui/components/card";
+import { Icon } from "@calcom/ui/components/icon";
+
+import type { HealthCheckData } from "~/settings/(admin-layout)/admin/healthcheck/_queries";
+
+type StatusBadgeProps = {
+  configured: boolean;
+  configuredLabel?: string;
+  notConfiguredLabel?: string;
+};
+
+function StatusBadge({
+  configured,
+  configuredLabel = "Configured",
+  notConfiguredLabel = "Not Configured",
+}: StatusBadgeProps): ReactElement {
+  let variant: BadgeProps["variant"] = "orange";
+  let label = notConfiguredLabel;
+  if (configured) {
+    variant = "green";
+    label = configuredLabel;
+  }
+  return (
+    <Badge variant={variant} withDot>
+      {label}
+    </Badge>
+  );
+}
+
+type StatusRowProps = {
+  label: string;
+  configured: boolean;
+  configuredLabel?: string;
+  notConfiguredLabel?: string;
+};
+
+function StatusRow({
+  label,
+  configured,
+  configuredLabel,
+  notConfiguredLabel,
+}: StatusRowProps): ReactElement {
+  return (
+    <div className="flex items-center justify-between border-b border-subtle px-4 py-3 last:border-b-0">
+      <span className="text-default text-sm">{label}</span>
+      <StatusBadge
+        configured={configured}
+        configuredLabel={configuredLabel}
+        notConfiguredLabel={notConfiguredLabel}
+      />
+    </div>
+  );
+}
+
+function renderAppsList(
+  apps: HealthCheckData["apps"]["installed"],
+  t: (key: string) => string
+): ReactElement {
+  if (apps.length === 0) {
+    return <div className="text-subtle px-4 py-3 text-sm">{t("no_apps_installed")}</div>;
+  }
+
+  return (
+    <>
+      {apps.map((app) => (
+        <div key={app.slug} className="flex items-center justify-between px-4 py-3">
+          <div className="flex flex-col">
+            <span className="text-default text-sm font-medium">{app.slug}</span>
+            <span className="text-subtle text-xs">{app.categories.join(", ")}</span>
+          </div>
+          <Badge variant="green" withDot>
+            {t("enabled")}
+          </Badge>
+        </div>
+      ))}
+    </>
+  );
+}
+
+type HealthCheckViewProps = {
+  data: HealthCheckData;
+};
+
+function HealthCheckView({ data }: HealthCheckViewProps): ReactElement {
+  const { t } = useLocale();
+
+  const enabledApps = data.apps.installed.filter((app) => app.enabled);
+  const disabledApps = data.apps.installed.filter((app) => !app.enabled);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Database Status */}
+      <PanelCard title={t("database")}>
+        <StatusRow
+          label={t("connection_status")}
+          configured={data.database.connected}
+          configuredLabel={t("connected")}
+          notConfiguredLabel={t("disconnected")}
+        />
+        {data.database.error && (
+          <div className="border-subtle bg-error/10 border-t px-4 py-3">
+            <div className="text-error flex items-center gap-2 text-sm">
+              <Icon name="alert-circle" className="h-4 w-4" />
+              <span>{data.database.error}</span>
+            </div>
+          </div>
+        )}
+      </PanelCard>
+
+      {/* License Key Status */}
+      <PanelCard title={t("license")}>
+        <StatusRow label={t("environment_variable")} configured={data.license.hasEnvKey} />
+        <StatusRow label={t("database_configuration")} configured={data.license.hasDbKey} />
+      </PanelCard>
+
+      {/* Email Configuration */}
+      <PanelCard title={t("email_configuration")}>
+        <StatusRow label="EMAIL_FROM" configured={data.email.hasEmailFrom} />
+        <StatusRow label="SENDGRID_API_KEY" configured={data.email.hasSendgridApiKey} />
+      </PanelCard>
+
+      {/* Redis Configuration */}
+      <PanelCard title={t("redis_configuration")}>
+        <StatusRow label="UPSTASH_REDIS_REST_URL" configured={data.redis.hasUpstashUrl} />
+        <StatusRow label="UPSTASH_REDIS_REST_TOKEN" configured={data.redis.hasUpstashToken} />
+      </PanelCard>
+
+      {/* Installed Apps */}
+      <PanelCard title={t("installed_apps")} subtitle={`${enabledApps.length} ${t("enabled").toLowerCase()}`}>
+        <div className="divide-subtle divide-y">{renderAppsList(enabledApps, t)}</div>
+      </PanelCard>
+
+      {/* Disabled Apps */}
+      {disabledApps.length > 0 && (
+        <PanelCard
+          title={t("disabled_apps")}
+          subtitle={`${disabledApps.length} ${t("disabled").toLowerCase()}`}
+          collapsible
+          defaultCollapsed>
+          <div className="divide-subtle divide-y">
+            {disabledApps.map((app) => (
+              <div key={app.slug} className="flex items-center justify-between px-4 py-3">
+                <div className="flex flex-col">
+                  <span className="text-default text-sm font-medium">{app.slug}</span>
+                  <span className="text-subtle text-xs">{app.categories.join(", ")}</span>
+                </div>
+                <Badge variant="orange" withDot>
+                  {t("disabled")}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </PanelCard>
+      )}
+    </div>
+  );
+}
+
+export default HealthCheckView;

--- a/apps/web/modules/settings/admin/healthcheck-view.tsx
+++ b/apps/web/modules/settings/admin/healthcheck-view.tsx
@@ -3,9 +3,12 @@
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { BadgeProps } from "@calcom/ui/components/badge";
 import { Badge } from "@calcom/ui/components/badge";
+import { Button } from "@calcom/ui/components/button";
 import { PanelCard } from "@calcom/ui/components/card";
 import { Icon } from "@calcom/ui/components/icon";
+import { showToast } from "@calcom/ui/components/toast";
 import type { ReactElement } from "react";
+import { useState } from "react";
 
 type AppStatus = {
   slug: string;
@@ -149,136 +152,194 @@ function ApiHealthBadge({ status, t }: ApiHealthBadgeProps): ReactElement {
   );
 }
 
-function renderAppsList(
-  apps: HealthCheckData["apps"]["installed"],
-  t: (key: string) => string
-): ReactElement {
-  if (apps.length === 0) {
-    return <div className="text-subtle px-4 py-3 text-sm">{t("no_apps_installed")}</div>;
-  }
+type DatabaseSectionProps = { database: HealthCheckData["database"]; t: (key: string) => string };
 
+function DatabaseSection({ database, t }: DatabaseSectionProps): ReactElement {
   return (
-    <>
-      {apps.map((app) => (
-        <div key={app.slug} className="flex items-center justify-between px-4 py-3">
-          <div className="flex flex-col">
-            <span className="text-default text-sm font-medium">{app.slug}</span>
-            <span className="text-subtle text-xs">{app.categories.join(", ")}</span>
+    <PanelCard title={t("database")}>
+      <StatusRow
+        label={t("connection_status")}
+        configured={database.connected}
+        configuredLabel={t("connected")}
+        notConfiguredLabel={t("disconnected")}
+      />
+      {database.error && (
+        <div className="border-subtle bg-error/10 border-t px-4 py-3">
+          <div className="text-error flex items-center gap-2 text-sm">
+            <Icon name="circle-alert" className="h-4 w-4" />
+            <span>{database.error}</span>
           </div>
-          <Badge variant="green" withDot>
-            {t("enabled")}
-          </Badge>
         </div>
-      ))}
-    </>
+      )}
+    </PanelCard>
+  );
+}
+
+type ApiHealthSectionProps = { apiV1: ApiHealthStatus; apiV2: ApiHealthStatus; t: (key: string) => string };
+
+function ApiHealthSection({ apiV1, apiV2, t }: ApiHealthSectionProps): ReactElement {
+  return (
+    <PanelCard title={t("api_health")}>
+      <div className="flex items-center justify-between border-b border-subtle px-4 py-3">
+        <span className="text-default text-sm">API v1</span>
+        <ApiHealthBadge status={apiV1} t={t} />
+      </div>
+      {apiV1.error && (
+        <div className="border-subtle bg-error/10 border-b px-4 py-2">
+          <span className="text-error text-xs">{apiV1.error}</span>
+        </div>
+      )}
+      <div className="flex items-center justify-between border-b border-subtle px-4 py-3 last:border-b-0">
+        <span className="text-default text-sm">API v2</span>
+        <ApiHealthBadge status={apiV2} t={t} />
+      </div>
+      {apiV2.error && (
+        <div className="border-subtle bg-error/10 px-4 py-2">
+          <span className="text-error text-xs">{apiV2.error}</span>
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
+type LicenseSectionProps = { license: LicenseStatus; t: (key: string) => string };
+
+function LicenseSection({ license, t }: LicenseSectionProps): ReactElement {
+  return (
+    <PanelCard title={t("license")}>
+      <StatusRow label={t("environment_variable")} configured={license.hasEnvKey} />
+      <StatusRow label={t("database_configuration")} configured={license.hasDbKey} />
+      <StatusRow
+        label={t("license_validation")}
+        configured={license.isValid}
+        configuredLabel={t("valid")}
+        notConfiguredLabel={t("invalid")}
+      />
+      {!license.serverReachable && (license.hasEnvKey || license.hasDbKey) && (
+        <div className="border-subtle bg-error/10 border-t px-4 py-3">
+          <div className="text-error flex items-start gap-2 text-sm">
+            <Icon name="circle-alert" className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div className="flex flex-col gap-1">
+              <span className="font-medium">{t("license_server_unreachable")}</span>
+              <span className="text-subtle text-xs">
+                {t("license_server_unreachable_description", { url: license.serverUrl })}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
+type EmailSectionProps = {
+  email: HealthCheckData["email"];
+  userEmail?: string;
+  isSendingTestEmail: boolean;
+  onSendTestEmail?: () => Promise<void>;
+  t: (key: string) => string;
+};
+
+function EmailSection({
+  email,
+  userEmail,
+  isSendingTestEmail,
+  onSendTestEmail,
+  t,
+}: EmailSectionProps): ReactElement {
+  return (
+    <PanelCard title={t("email_configuration")}>
+      <StatusRow label="EMAIL_FROM" configured={email.hasEmailFrom} />
+      <div className="flex items-center justify-between border-b border-subtle px-4 py-3 last:border-b-0">
+        <span className="text-default text-sm">{t("email_provider")}</span>
+        <EmailProviderBadge provider={email.provider} t={t} />
+      </div>
+      {email.provider === "sendgrid" && (
+        <StatusRow label="SENDGRID_API_KEY" configured={email.hasSendgridApiKey} />
+      )}
+      {email.provider === "smtp" && (
+        <StatusRow label={t("smtp_configuration")} configured={email.hasSmtpConfig} />
+      )}
+      {email.provider !== "none" && onSendTestEmail && userEmail && (
+        <div className="border-subtle border-t px-4 py-3">
+          <Button
+            color="secondary"
+            size="sm"
+            loading={isSendingTestEmail}
+            onClick={onSendTestEmail}
+            StartIcon="mail">
+            {t("send_test_email")}
+          </Button>
+          <p className="text-subtle mt-2 text-xs">{t("send_test_email_description", { email: userEmail })}</p>
+        </div>
+      )}
+    </PanelCard>
   );
 }
 
 type HealthCheckViewProps = {
   data: HealthCheckData;
+  userEmail?: string;
+  onSendTestEmail?: (email: string) => Promise<{ success: boolean; error?: string }>;
 };
 
-function HealthCheckView({ data }: HealthCheckViewProps): ReactElement {
+function HealthCheckView({ data, userEmail, onSendTestEmail }: HealthCheckViewProps): ReactElement {
   const { t } = useLocale();
-
+  const [isSendingTestEmail, setIsSendingTestEmail] = useState(false);
   const enabledApps = data.apps.installed.filter((app) => app.enabled);
   const disabledApps = data.apps.installed.filter((app) => !app.enabled);
 
+  const handleSendTestEmail = async (): Promise<void> => {
+    if (!onSendTestEmail || !userEmail) return;
+    setIsSendingTestEmail(true);
+    try {
+      const result = await onSendTestEmail(userEmail);
+      if (result.success) {
+        showToast(t("test_email_sent"), "success");
+      } else {
+        showToast(result.error || t("test_email_failed"), "error");
+      }
+    } catch {
+      showToast(t("test_email_failed"), "error");
+    } finally {
+      setIsSendingTestEmail(false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-6">
-      {/* Database Status */}
-      <PanelCard title={t("database")}>
-        <StatusRow
-          label={t("connection_status")}
-          configured={data.database.connected}
-          configuredLabel={t("connected")}
-          notConfiguredLabel={t("disconnected")}
-        />
-        {data.database.error && (
-          <div className="border-subtle bg-error/10 border-t px-4 py-3">
-            <div className="text-error flex items-center gap-2 text-sm">
-              <Icon name="circle-alert" className="h-4 w-4" />
-              <span>{data.database.error}</span>
-            </div>
-          </div>
-        )}
-      </PanelCard>
-
-      {/* API Health Status */}
-      <PanelCard title={t("api_health")}>
-        <div className="flex items-center justify-between border-b border-subtle px-4 py-3">
-          <span className="text-default text-sm">API v1</span>
-          <ApiHealthBadge status={data.apiV1} t={t} />
-        </div>
-        {data.apiV1.error && (
-          <div className="border-subtle bg-error/10 border-b px-4 py-2">
-            <span className="text-error text-xs">{data.apiV1.error}</span>
-          </div>
-        )}
-        <div className="flex items-center justify-between border-b border-subtle px-4 py-3 last:border-b-0">
-          <span className="text-default text-sm">API v2</span>
-          <ApiHealthBadge status={data.apiV2} t={t} />
-        </div>
-        {data.apiV2.error && (
-          <div className="border-subtle bg-error/10 px-4 py-2">
-            <span className="text-error text-xs">{data.apiV2.error}</span>
-          </div>
-        )}
-      </PanelCard>
-
-      {/* License Key Status */}
-      <PanelCard title={t("license")}>
-        <StatusRow label={t("environment_variable")} configured={data.license.hasEnvKey} />
-        <StatusRow label={t("database_configuration")} configured={data.license.hasDbKey} />
-        <StatusRow
-          label={t("license_validation")}
-          configured={data.license.isValid}
-          configuredLabel={t("valid")}
-          notConfiguredLabel={t("invalid")}
-        />
-        {/* License server reachability alert */}
-        {!data.license.serverReachable && (data.license.hasEnvKey || data.license.hasDbKey) && (
-          <div className="border-subtle bg-error/10 border-t px-4 py-3">
-            <div className="text-error flex items-start gap-2 text-sm">
-              <Icon name="circle-alert" className="mt-0.5 h-4 w-4 flex-shrink-0" />
-              <div className="flex flex-col gap-1">
-                <span className="font-medium">{t("license_server_unreachable")}</span>
-                <span className="text-subtle text-xs">
-                  {t("license_server_unreachable_description", { url: data.license.serverUrl })}
-                </span>
-              </div>
-            </div>
-          </div>
-        )}
-      </PanelCard>
-
-      {/* Email Configuration */}
-      <PanelCard title={t("email_configuration")}>
-        <StatusRow label="EMAIL_FROM" configured={data.email.hasEmailFrom} />
-        <div className="flex items-center justify-between border-b border-subtle px-4 py-3 last:border-b-0">
-          <span className="text-default text-sm">{t("email_provider")}</span>
-          <EmailProviderBadge provider={data.email.provider} t={t} />
-        </div>
-        {data.email.provider === "sendgrid" && (
-          <StatusRow label="SENDGRID_API_KEY" configured={data.email.hasSendgridApiKey} />
-        )}
-        {data.email.provider === "smtp" && (
-          <StatusRow label="SMTP (EMAIL_SERVER_HOST/PORT)" configured={data.email.hasSmtpConfig} />
-        )}
-      </PanelCard>
-
-      {/* Redis Configuration */}
+      <DatabaseSection database={data.database} t={t} />
+      <ApiHealthSection apiV1={data.apiV1} apiV2={data.apiV2} t={t} />
+      <LicenseSection license={data.license} t={t} />
+      <EmailSection
+        email={data.email}
+        userEmail={userEmail}
+        isSendingTestEmail={isSendingTestEmail}
+        onSendTestEmail={handleSendTestEmail}
+        t={t}
+      />
       <PanelCard title={t("redis_configuration")}>
         <StatusRow label="UPSTASH_REDIS_REST_URL" configured={data.redis.hasUpstashUrl} />
         <StatusRow label="UPSTASH_REDIS_REST_TOKEN" configured={data.redis.hasUpstashToken} />
       </PanelCard>
-
-      {/* Installed Apps */}
       <PanelCard title={t("installed_apps")} subtitle={`${enabledApps.length} ${t("enabled").toLowerCase()}`}>
-        <div className="divide-subtle divide-y">{renderAppsList(enabledApps, t)}</div>
+        <div className="divide-subtle divide-y">
+          {enabledApps.length === 0 && (
+            <div className="text-subtle px-4 py-3 text-sm">{t("no_apps_installed")}</div>
+          )}
+          {enabledApps.map((app) => (
+            <div key={app.slug} className="flex items-center justify-between px-4 py-3">
+              <div className="flex flex-col">
+                <span className="text-default text-sm font-medium">{app.slug}</span>
+                <span className="text-subtle text-xs">{app.categories.join(", ")}</span>
+              </div>
+              <Badge variant="green" withDot>
+                {t("enabled")}
+              </Badge>
+            </div>
+          ))}
+        </div>
       </PanelCard>
-
-      {/* Disabled Apps */}
       {disabledApps.length > 0 && (
         <PanelCard
           title={t("disabled_apps")}

--- a/apps/web/modules/settings/admin/healthcheck-view.tsx
+++ b/apps/web/modules/settings/admin/healthcheck-view.tsx
@@ -7,6 +7,7 @@ import { Button } from "@calcom/ui/components/button";
 import { PanelCard } from "@calcom/ui/components/card";
 import { Icon } from "@calcom/ui/components/icon";
 import { showToast } from "@calcom/ui/components/toast";
+import type { TFunction } from "i18next";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
@@ -100,7 +101,7 @@ function StatusRow({ label, configured, configuredLabel, notConfiguredLabel }: S
   );
 }
 
-function getEmailProviderLabel(provider: "sendgrid" | "smtp" | "none", t: (key: string) => string): string {
+function getEmailProviderLabel(provider: "sendgrid" | "smtp" | "none", t: TFunction): string {
   if (provider === "sendgrid") {
     return "SendGrid";
   }
@@ -112,7 +113,7 @@ function getEmailProviderLabel(provider: "sendgrid" | "smtp" | "none", t: (key: 
 
 type EmailProviderBadgeProps = {
   provider: "sendgrid" | "smtp" | "none";
-  t: (key: string) => string;
+  t: TFunction;
 };
 
 function EmailProviderBadge({ provider, t }: EmailProviderBadgeProps): ReactElement {
@@ -129,7 +130,7 @@ function EmailProviderBadge({ provider, t }: EmailProviderBadgeProps): ReactElem
 
 type ApiHealthBadgeProps = {
   status: ApiHealthStatus;
-  t: (key: string) => string;
+  t: TFunction;
 };
 
 function ApiHealthBadge({ status, t }: ApiHealthBadgeProps): ReactElement {
@@ -152,7 +153,7 @@ function ApiHealthBadge({ status, t }: ApiHealthBadgeProps): ReactElement {
   );
 }
 
-type DatabaseSectionProps = { database: HealthCheckData["database"]; t: (key: string) => string };
+type DatabaseSectionProps = { database: HealthCheckData["database"]; t: TFunction };
 
 function DatabaseSection({ database, t }: DatabaseSectionProps): ReactElement {
   return (
@@ -175,7 +176,7 @@ function DatabaseSection({ database, t }: DatabaseSectionProps): ReactElement {
   );
 }
 
-type ApiHealthSectionProps = { apiV1: ApiHealthStatus; apiV2: ApiHealthStatus; t: (key: string) => string };
+type ApiHealthSectionProps = { apiV1: ApiHealthStatus; apiV2: ApiHealthStatus; t: TFunction };
 
 function ApiHealthSection({ apiV1, apiV2, t }: ApiHealthSectionProps): ReactElement {
   return (
@@ -202,7 +203,7 @@ function ApiHealthSection({ apiV1, apiV2, t }: ApiHealthSectionProps): ReactElem
   );
 }
 
-type LicenseSectionProps = { license: LicenseStatus; t: (key: string) => string };
+type LicenseSectionProps = { license: LicenseStatus; t: TFunction };
 
 function LicenseSection({ license, t }: LicenseSectionProps): ReactElement {
   return (
@@ -237,7 +238,7 @@ type EmailSectionProps = {
   userEmail?: string;
   isSendingTestEmail: boolean;
   onSendTestEmail?: () => Promise<void>;
-  t: (key: string) => string;
+  t: TFunction;
 };
 
 function EmailSection({


### PR DESCRIPTION
## What does this PR do?

Adds a new healthcheck page at `/settings/admin/healthcheck` for self-hosted Cal.com instances. This page provides administrators with a quick overview of system health across multiple dimensions.

**Health checks included:**
- **Database**: Connection status with error display if disconnected
- **API Health**: Checks API v1 and v2 endpoints with response time display
- **License Key**: Checks environment variable, database configuration, validates against Cal.com license server via `LicenseKeyService`, and detects if license server is unreachable (firewall alert)
- **Email**: Detects email provider (SendGrid vs SMTP), shows configuration status, and allows sending a test email
- **Redis**: Checks `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` configuration
- **Installed Apps**: Lists enabled and disabled apps from the database

**Implementation details:**
- Uses PanelCard components to group health checks into sections
- Data fetched via React Server Components with Next.js `unstable_cache` (60s TTL)
- Queries organized in `_queries` folder next to page logic
- `HealthcheckRepository` encapsulates all Prisma operations (follows "no Prisma outside repositories" constraint)
- Admin role verification at query level (defense-in-depth with layout protection)
- API health checks use 5-second timeout to prevent page hangs
- View refactored into smaller section components for maintainability

## Updates since last revision

- Added **Send Test Email** action to verify SMTP configuration works
  - Server action at `_actions/sendTestEmail.ts` with admin role verification
  - Sends test email to the logged-in admin's email address
  - Shows success/error toast feedback
- Refactored `healthcheck-view.tsx` into smaller section components (`DatabaseSection`, `ApiHealthSection`, `LicenseSection`, `EmailSection`)
- Fixed `TFunction` type for `t` prop in section components (resolved CI type check failures)
- Added new translation keys: `smtp_configuration`, `send_test_email`, `send_test_email_description`, `test_email_sent`, `test_email_failed`, `configured`

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - admin feature, no public docs needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Log in as an admin user
2. Navigate to `/settings/admin/healthcheck`
3. Verify each section displays correctly:
   - Database should show "Connected" if DB is working
   - API Health should show status for API v1 and v2 with response times
   - License section shows env var, DB key status, validation result, and firewall alert if license server unreachable
   - Email section shows detected provider (SendGrid/SMTP/Not Configured)
   - Redis section shows configuration status
   - Apps section lists installed apps with enabled/disabled status
4. **Test Send Test Email**: If SMTP is configured, click "Send Test Email" and verify you receive the email
5. **Test admin-only access**: Log in as a non-admin user and verify you're redirected away from the page
6. **Test firewall alert**: If `CALCOM_PRIVATE_API_ROUTE` points to an unreachable server, verify the firewall alert appears

**Translation keys needed** in `apps/web/public/static/locales/en/common.json`:
- `healthcheck`, `database`, `connection_status`, `connected`, `disconnected`
- `license`, `environment_variable`, `database_configuration`
- `license_validation`, `valid`, `invalid`
- `email_configuration`, `email_provider`, `not_configured`
- `redis_configuration`, `disabled_apps`, `no_apps_installed`
- `api_health`, `healthy`, `unreachable`
- `license_server_unreachable`, `license_server_unreachable_description`
- `smtp_configuration`, `send_test_email`, `send_test_email_description`, `test_email_sent`, `test_email_failed`, `configured`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] **Translation keys must be manually added** to `common.json` (lint-staged config blocks JSON commits in public directory)
- [ ] Verify API health check URLs (`${WEBAPP_URL}/api` and `${WEBAPP_URL}/api/v2/health`) work correctly in self-hosted deployments
- [ ] Verify license server reachability check correctly identifies firewall/network issues vs invalid license
- [ ] Test the 5-second timeout behavior for API health checks - ensure page doesn't hang
- [ ] Verify admin-only access works at both layout level AND query level (non-admin should be redirected)
- [ ] Review `HealthcheckRepository` implementation for correctness
- [ ] **Test Send Test Email** with both SendGrid and SMTP configurations
- [ ] Verify the test email server action properly validates admin role before sending
- [ ] Verify sendmail fallback detection works correctly (should show error if only sendmail is configured)

---

**Link to Devin run:** https://app.devin.ai/sessions/19e455f7922d452888b1f7c62d61cb7e
**Requested by:** @sean-brydon