### PR TITLE
fix(ci): use env vars for input interpolation in workflow run steps

### DIFF
--- a/.github/workflows/cleanup-report.yml
+++ b/.github/workflows/cleanup-report.yml
@@ -34,12 +34,13 @@ jobs:
       - name: Cleanup HTML reports on PR close/merge
         env:
           BRANCH_REPORTS_DIR: reports/${{ github.event.pull_request.head.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [ -d "$BRANCH_REPORTS_DIR" ]; then
             rm -rf "$BRANCH_REPORTS_DIR"
             git add .
-            git commit -m "workflow: remove all reports for branch ${{ github.event.pull_request.head.ref }} (PR closed/merged)"
+            git commit -m "workflow: remove all reports for branch $HEAD_REF (PR closed/merged)"
             git push
           else
-            echo "No reports found for branch ${{ github.event.pull_request.head.ref }}. Nothing to clean up."
+            echo "No reports found for branch $HEAD_REF. Nothing to clean up."
           fi

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -56,14 +56,18 @@ jobs:
       - uses: ./.github/actions/yarn-install
 
       - name: Bump version
+        env:
+          VERSION: ${{ inputs.next_version }}
         run: |
           cd apps/web
-          yarn version ${{ inputs.next_version }}
+          yarn version "$VERSION"
 
       - name: Commit changes
+        env:
+          VERSION: ${{ inputs.next_version }}
         run: |
           git add .
-          git commit -m "chore: release v${{ inputs.next_version }}"
+          git commit -m "chore: release v$VERSION"
           git push
 
       - name: Draft release

--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -63,10 +63,12 @@ jobs:
       - name: Cleanup old HTML reports
         if: ${{ env.BRANCH_REPORTS_EXIST == 'true' }}
         timeout-minutes: 3
+        env:
+          HEAD_BRANCH: ${{ inputs.head_branch }}
         run: |
-          rm -rf $BRANCH_REPORTS_DIR
+          rm -rf "$BRANCH_REPORTS_DIR"
           git add .
-          git commit -m "workflow: remove all reports for branch ${{ inputs.head_branch }}"
+          git commit -m "workflow: remove all reports for branch $HEAD_BRANCH"
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:
@@ -76,9 +78,12 @@ jobs:
         timeout-minutes: 3
         # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
         # this is necessary when this job running at least twice at the same time (e.g. through two pushes at the same time)
+        env:
+          RUN_ID: ${{ inputs.source_run_id }}
+          RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
         run: |
           git add .
-          git commit -m "workflow: add HTML report for run-id ${{ inputs.source_run_id }} (attempt:  ${{ inputs.source_run_attempt }})"
+          git commit -m "workflow: add HTML report for run-id $RUN_ID (attempt: $RUN_ATTEMPT)"
 
           while true; do
             git pull --rebase


### PR DESCRIPTION
 ## What does this PR do?

Updates GitHub Actions workflows to pass inputs via environment variables instead of direct `${{ }}` interpolation in shell scripts. This follows GitHub's recommended practice for handling workflow inputs in `run:` steps.

### Changes

- **cleanup-report.yml**: Added `HEAD_REF` env var for branch name in commit message and echo
- **publish-report.yml**: Added `HEAD_BRANCH`, `RUN_ID`, `RUN_ATTEMPT` env vars for commit messages
- **draft-release.yml**: Added `VERSION` env var for yarn version command and commit message

### How to test

1. Trigger each workflow and verify they complete successfully
2. Check commit messages are correctly formatted with the expected values
3. Verify no functional changes to workflow behavior

### Background

Direct interpolation of `${{ inputs.* }}` and `${{ github.event.* }}` in shell scripts can cause issues with special characters in branch names or input values. Using environment variables ensures proper shell escaping and is the recommended pattern per [GitHub Actions documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

  ## Mandatory Tasks

  - [x] I have self-reviewed the code
  - [x] **N/A** I have updated the developer docs
  - [x] **N/A** I confirm automated tests are in place