### PR TITLE
fix(api-v2): handle non-JSON responses in license check

### DIFF
--- a/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
+++ b/apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts
@@ -239,7 +239,7 @@ export class ApiAuthStrategy extends PassportStrategy(BaseStrategy, "api-auth") 
     const isLicenseValid = await this.deploymentsService.checkLicense();
     if (!isLicenseValid) {
       throw new UnauthorizedException(
-        "ApiAuthStrategy - api key - Invalid or missing CALCOM_LICENSE_KEY environment variable"
+        "License validation failed. Check CALCOM_LICENSE_KEY and GET_LICENSE_KEY_URL configuration."
       );
     }
     const strippedApiKey = stripApiKey(apiKey, this.config.get<string>("api.keyPrefix"));

--- a/apps/api/v2/src/modules/deployments/deployments.service.spec.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.spec.ts
@@ -1,0 +1,209 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { Logger } from "@nestjs/common";
+
+import { DeploymentsService } from "./deployments.service";
+import { DeploymentsRepository } from "./deployments.repository";
+import { RedisService } from "@/modules/redis/redis.service";
+
+const mockFetch: jest.Mock = jest.fn();
+global.fetch = mockFetch;
+
+describe("DeploymentsService", () => {
+  let service: DeploymentsService;
+  let mockRedis: { get: jest.Mock; set: jest.Mock };
+  let mockConfigService: { get: jest.Mock };
+
+  beforeEach(async () => {
+    mockRedis = { get: jest.fn(), set: jest.fn() };
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === "api.licenseKey") return "test-license-key";
+        if (key === "api.licenseKeyUrl") return "https://example.com/license";
+        if (key === "e2e") return false;
+        return undefined;
+      }),
+    };
+    mockFetch.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeploymentsService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: DeploymentsRepository, useValue: { getDeployment: jest.fn() } },
+        { provide: RedisService, useValue: { redis: mockRedis } },
+      ],
+    }).compile();
+
+    service = module.get(DeploymentsService);
+    jest.spyOn(Logger.prototype, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("checkLicense - early returns", () => {
+    it("returns true when e2e mode is enabled", async () => {
+      mockConfigService.get.mockImplementation((key: string) => (key === "e2e" ? true : undefined));
+      expect(await service.checkLicense()).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns false when no license key is configured", async () => {
+      mockConfigService.get.mockImplementation((key: string) => (key === "e2e" ? false : undefined));
+      expect(await service.checkLicense()).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns cached result if available", async () => {
+      mockRedis.get.mockResolvedValue('{"status":true}');
+      expect(await service.checkLicense()).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns false when cached data is corrupted", async () => {
+      mockRedis.get.mockResolvedValue("invalid json{");
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ status: false }),
+      });
+      expect(await service.checkLicense()).toBe(false);
+    });
+  });
+
+  describe("checkLicense - HTTP response handling", () => {
+    beforeEach(() => {
+      mockRedis.get.mockResolvedValue(null);
+    });
+
+    it("returns false when response is not ok", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 401 });
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("returns false when response is HTML", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "text/html" }),
+      });
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("returns false when response has no content-type header", async () => {
+      mockFetch.mockResolvedValue({ ok: true, headers: new Headers({}) });
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("accepts application/json; charset=utf-8", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json; charset=utf-8" }),
+        json: () => Promise.resolve({ status: true }),
+      });
+      expect(await service.checkLicense()).toBe(true);
+    });
+  });
+
+  describe("checkLicense - JSON validation", () => {
+    beforeEach(() => {
+      mockRedis.get.mockResolvedValue(null);
+    });
+
+    it("returns false when status field is missing", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ foo: "bar" }),
+      });
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("returns false when status field is not boolean", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ status: "valid" }),
+      });
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("returns true when license is valid", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ status: true }),
+      });
+      expect(await service.checkLicense()).toBe(true);
+    });
+
+    it("returns false when license is invalid", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ status: false }),
+      });
+      expect(await service.checkLicense()).toBe(false);
+    });
+  });
+
+  describe("checkLicense - error handling", () => {
+    beforeEach(() => {
+      mockRedis.get.mockResolvedValue(null);
+    });
+
+    it("returns false on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+      expect(await service.checkLicense()).toBe(false);
+    });
+
+    it("returns false on timeout", async () => {
+      const abortError = new Error("Timeout");
+      abortError.name = "AbortError";
+      mockFetch.mockRejectedValue(abortError);
+      expect(await service.checkLicense()).toBe(false);
+    });
+  });
+
+  describe("checkLicense - caching behavior", () => {
+    beforeEach(() => {
+      mockRedis.get.mockResolvedValue(null);
+    });
+
+    it("caches valid license response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ status: true }),
+      });
+      await service.checkLicense();
+      expect(mockRedis.set).toHaveBeenCalled();
+    });
+
+    it("does not cache when response is not ok", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+      await service.checkLicense();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+
+    it("does not cache when content-type is not JSON", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "text/html" }),
+      });
+      await service.checkLicense();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+
+    it("does not cache when JSON structure is invalid", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({ invalid: "structure" }),
+      });
+      await service.checkLicense();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -73,7 +73,7 @@ export class DeploymentsService {
       }
 
       // Only cache valid responses
-      await this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
+      await this.redisService.redis.set(cacheKey, JSON.stringify(data), "PX", CACHING_TIME);
       return data.status;
     } catch (error) {
       this.logger.error(`License check failed: ${(error as Error).message}`);

--- a/apps/api/v2/src/modules/deployments/deployments.service.ts
+++ b/apps/api/v2/src/modules/deployments/deployments.service.ts
@@ -1,31 +1,33 @@
 import { DeploymentsRepository } from "@/modules/deployments/deployments.repository";
 import { RedisService } from "@/modules/redis/redis.service";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 const CACHING_TIME = 86400000; // 24 hours in milliseconds
+const FETCH_TIMEOUT = 10000; // 10 seconds
 
-const getLicenseCacheKey = (key: string) => `api-v2-license-key-goblin-url-${key}`;
+const getLicenseCacheKey = (key: string): string => `api-v2-license-key-goblin-url-${key}`;
 
 type LicenseCheckResponse = {
   status: boolean;
 };
 @Injectable()
 export class DeploymentsService {
+  private readonly logger = new Logger(DeploymentsService.name);
+
   constructor(
     private readonly deploymentsRepository: DeploymentsRepository,
     private readonly configService: ConfigService,
     private readonly redisService: RedisService
   ) {}
 
-  async checkLicense() {
+  async checkLicense(): Promise<boolean> {
     if (this.configService.get("e2e")) {
       return true;
     }
-    let licenseKey = this.configService.get("api.licenseKey");
 
+    let licenseKey = this.configService.get("api.licenseKey");
     if (!licenseKey) {
-      /** We try to check on DB only if env is undefined */
       const deployment = await this.deploymentsRepository.getDeployment();
       licenseKey = deployment?.licenseKey ?? undefined;
     }
@@ -33,15 +35,49 @@ export class DeploymentsService {
     if (!licenseKey) {
       return false;
     }
+
     const licenseKeyUrl = this.configService.get("api.licenseKeyUrl") + `/${licenseKey}`;
-    const cachedData = await this.redisService.redis.get(getLicenseCacheKey(licenseKey));
-    if (cachedData) {
-      return (JSON.parse(cachedData) as LicenseCheckResponse)?.status;
-    }
-    const response = await fetch(licenseKeyUrl, { mode: "cors" });
-    const data = (await response.json()) as LicenseCheckResponse;
     const cacheKey = getLicenseCacheKey(licenseKey);
-    this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
-    return data.status;
+
+    // Check cache first
+    const cachedData = await this.redisService.redis.get(cacheKey);
+    if (cachedData) {
+      try {
+        return (JSON.parse(cachedData) as LicenseCheckResponse)?.status ?? false;
+      } catch {
+        // Cache corrupted, continue to fetch
+      }
+    }
+
+    try {
+      const response = await fetch(licenseKeyUrl, {
+        mode: "cors",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT),
+      });
+
+      if (!response.ok) {
+        this.logger.error(`License server returned ${response.status}`);
+        return false;
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        this.logger.error(`License server returned ${contentType}, expected JSON`);
+        return false;
+      }
+
+      const data = await response.json();
+      if (typeof data?.status !== "boolean") {
+        this.logger.error("License server returned invalid JSON structure");
+        return false;
+      }
+
+      // Only cache valid responses
+      await this.redisService.redis.set(cacheKey, JSON.stringify(data), "EX", CACHING_TIME);
+      return data.status;
+    } catch (error) {
+      this.logger.error(`License check failed: ${(error as Error).message}`);
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #24856 - Self-hosted setup: /v2/event-types returns 500 – license check fails with HTML response

The `DeploymentsService.checkLicense()` method was crashing with `"Unexpected token '<'"` when the license server returned HTML instead of JSON. This caused 500 Internal Server Error on `/v2/event-types` and other API v2 endpoints for self-hosted deployments.

## Root Cause

The original code called `response.json()` directly without:
1. Checking if the response was successful (`response.ok`)
2. Validating the `Content-Type` header
3. Wrapping in try-catch for error handling

When the license server returned an error page (HTML), `JSON.parse` threw a `SyntaxError` which propagated as a 500 error.

## Changes

### `apps/api/v2/src/modules/deployments/deployments.service.ts`

- **Add 10-second timeout** using `AbortSignal.timeout()` to prevent hanging requests
- **Check `response.ok`** before attempting to parse JSON
- **Validate `Content-Type`** header contains `application/json`
- **Validate JSON structure** - `status` field must be a boolean
- **Wrap in try-catch** - return `false` on any error (fail-closed)
- **Only cache successful validations** - don't cache failures so retries work immediately after fixing config
- **Add logging** via NestJS Logger for debugging

### `apps/api/v2/src/modules/auth/strategies/api-auth/api-auth.strategy.ts`

- **Improve error message** with debugging hints for self-hosted admins:
  ```
  "License validation failed. Check CALCOM_LICENSE_KEY and GET_LICENSE_KEY_URL configuration."
  ```

### `apps/api/v2/src/modules/deployments/deployments.service.spec.ts` (new)

- **18 comprehensive unit tests** covering:
  - E2E mode bypass
  - Missing license key
  - Cached results / corrupted cache
  - HTTP error responses (4xx, 5xx)
  - HTML responses (text/html, missing Content-Type)
  - Invalid JSON structure (missing status, non-boolean status)
  - Valid/invalid license responses
  - Network errors and timeouts
  - Caching behavior (cache hits, no cache on failures)

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| License server returns HTML | 500 Internal Server Error | 401 Unauthorized (with helpful message) |
| License server unreachable | Hangs indefinitely | Timeout after 10s, returns 401 |
| License server returns 404 | 500 (JSON parse error) | 401 Unauthorized |
| Invalid license | May crash depending on response | 401 Unauthorized |
| Valid license | Works | Works (no change) |

## Test Plan

- [x] Unit tests pass (18 test cases)
- [ ] Manual test on self-hosted Docker deployment with:
  - Valid license key
  - Invalid license key
  - Unreachable license server (wrong `GET_LICENSE_KEY_URL`)
  - License server returning HTML error page

## Configuration Reference

For self-hosted deployments, ensure these environment variables are set:

```env
CALCOM_LICENSE_KEY=your-license-key
GET_LICENSE_KEY_URL=https://console.cal.com/api/license
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)