### PR TITLE
chore: Make booking-audit integration test utils reusable

### DIFF
--- a/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
+++ b/packages/features/booking-audit/lib/service/__tests__/integration-utils.ts
@@ -1,0 +1,184 @@
+import { prisma } from "@calcom/prisma";
+import { BookingStatus, MembershipRole } from "@calcom/prisma/enums";
+import type { FeatureId } from "@calcom/features/flags/config";
+import { FeaturesRepository } from "@calcom/features/flags/features.repository";
+
+export const generateUniqueId = () => {
+  const timestamp = Date.now();
+  const randomSuffix = Math.random().toString(36).substring(7);
+  return `${timestamp}-${randomSuffix}`;
+};
+
+export const createTestUser = async (overrides?: { email?: string; username?: string; name?: string }) => {
+  const uniqueId = generateUniqueId();
+  return prisma.user.create({
+    data: {
+      email: overrides?.email || `test-user-${uniqueId}@example.com`,
+      username: overrides?.username || `testuser-${uniqueId}`,
+      name: overrides?.name || "Test User",
+    },
+  });
+};
+
+export const createTestOrganization = async (overrides?: { name?: string; slug?: string }) => {
+  const uniqueId = generateUniqueId();
+  return prisma.team.create({
+    data: {
+      name: overrides?.name || `Test Org ${uniqueId}`,
+      slug: overrides?.slug || `test-org-${uniqueId}`,
+      isOrganization: true,
+    },
+  });
+};
+
+export const createTestMembership = async (
+  userId: number,
+  teamId: number,
+  overrides?: { role?: MembershipRole; accepted?: boolean }
+) => {
+  return prisma.membership.create({
+    data: {
+      userId,
+      teamId,
+      role: overrides?.role || MembershipRole.ADMIN,
+      accepted: overrides?.accepted ?? true,
+    },
+  });
+};
+
+export const createTestEventType = async (
+  userId: number,
+  overrides?: { title?: string; slug?: string; length?: number }
+) => {
+  const uniqueId = generateUniqueId();
+  return prisma.eventType.create({
+    data: {
+      title: overrides?.title || "Test Event Type",
+      slug: overrides?.slug || `test-event-${uniqueId}`,
+      length: overrides?.length || 60,
+      userId,
+    },
+  });
+};
+
+export const createTestBooking = async (
+  userId: number,
+  eventTypeId: number,
+  overrides?: {
+    uid?: string;
+    title?: string;
+    startTime?: Date;
+    endTime?: Date;
+    status?: BookingStatus;
+    attendees?: Array<{ email: string; name: string; timeZone: string }>;
+  }
+) => {
+  const uniqueId = generateUniqueId();
+  const startTime = overrides?.startTime || new Date();
+  const endTime = overrides?.endTime || new Date(startTime.getTime() + 60 * 60 * 1000);
+
+  return prisma.booking.create({
+    data: {
+      uid: overrides?.uid || `test-booking-${uniqueId}`,
+      title: overrides?.title || "Test Booking",
+      startTime,
+      endTime,
+      userId,
+      eventTypeId,
+      status: overrides?.status || BookingStatus.ACCEPTED,
+      attendees: {
+        create: overrides?.attendees || [],
+      },
+    },
+  });
+};
+
+export const enableFeatureForOrganization = async (organizationId: number, featureSlug: string) => {
+  await prisma.feature.upsert({
+    where: { slug: featureSlug },
+    create: {
+      slug: featureSlug,
+      enabled: true,
+      description: `Test feature: ${featureSlug}`,
+    },
+    update: {
+      enabled: true,
+    },
+  });
+
+  const featuresRepository = new FeaturesRepository(prisma);
+  await featuresRepository.setTeamFeatureState({
+    teamId: organizationId,
+    featureId: featureSlug as FeatureId,
+    state: "enabled",
+    assignedBy: "test-system",
+  });
+};
+
+export const cleanupTestData = async (testData: {
+  bookingUid?: string;
+  userUuids?: string[];
+  attendeeEmails?: string[];
+  eventTypeId?: number;
+  organizationId?: number;
+  userIds?: number[];
+  featureSlug?: string;
+}) => {
+  if (testData.bookingUid) {
+    await prisma.bookingAudit.deleteMany({
+      where: { bookingUid: testData.bookingUid },
+    });
+  }
+
+  if (testData.userUuids?.length || testData.attendeeEmails?.length) {
+    await prisma.auditActor.deleteMany({
+      where: {
+        OR: [
+          ...(testData.userUuids?.map((uuid) => ({ userUuid: uuid })) || []),
+          ...(testData.attendeeEmails?.map((email) => ({ email })) || []),
+        ],
+      },
+    });
+  }
+
+  if (testData.attendeeEmails?.length) {
+    await prisma.attendee.deleteMany({
+      where: { email: { in: testData.attendeeEmails } },
+    });
+  }
+
+  if (testData.bookingUid) {
+    await prisma.booking.deleteMany({
+      where: { uid: testData.bookingUid },
+    });
+  }
+
+  if (testData.eventTypeId) {
+    await prisma.eventType.deleteMany({
+      where: { id: testData.eventTypeId },
+    });
+  }
+
+  if (testData.organizationId) {
+    if (testData.featureSlug) {
+      await prisma.teamFeatures.deleteMany({
+        where: {
+          teamId: testData.organizationId,
+          featureId: testData.featureSlug,
+        },
+      });
+    }
+    await prisma.membership.deleteMany({
+      where: { teamId: testData.organizationId },
+    });
+    await prisma.team.deleteMany({
+      where: { id: testData.organizationId },
+    });
+  }
+
+  if (testData.userIds?.length) {
+    await prisma.user.deleteMany({
+      where: { id: { in: testData.userIds } },
+    });
+  }
+};


### PR DESCRIPTION
## What does this PR do?

Extracts reusable integration test utilities for booking-audit into a shared module, making it easier to write future audit tests without duplicating setup/cleanup code.

**Changes:**
- Moved test helpers (createTestUser, createTestOrganization, createTestMembership, createTestEventType, createTestBooking, enableFeatureForOrganization, cleanupTestData) into `__tests__/integration-utils.ts`
- Renamed test file to `__tests__/created-action.integration-test.ts` to better reflect its scope
- Updated imports to use the shared utilities
- Minor formatting cleanup (no behavioral changes to tests)

## Visual Demo (For contributors especially)

N/A - Test infrastructure refactor only, no UI changes.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the booking-audit integration tests to verify they still pass:
```bash
yarn test packages/features/booking-audit
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Human Review Checklist

- [ ] Verify the cleanup logic change in `cleanupTestData` - now uses `prisma.teamFeatures.deleteMany` instead of `featuresRepository.setTeamFeatureState` with state "inherit"
- [ ] Confirm all test utilities are properly exported from `integration-utils.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted reusable integration test utilities for booking-audit and updated the created-action test to use them. This cleans up test setup and makes future audit tests easier to write, with no behavior changes.

- **Refactors**
  - Moved user/org/event/booking setup and cleanup into __tests__/integration-utils.ts.
  - Updated created-action.integration-test.ts to import shared helpers.
  - Simplified feature enablement and cleanup logic.
  - No changes to production code or test assertions.

<sup>Written for commit e1f4470149be939095c66a3c215f2e909eba6fce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->