### PR TITLE
feat: add team name badge to event type

### DIFF
--- a/packages/features/eventtypes/components/EventTypeLayout.tsx
+++ b/packages/features/eventtypes/components/EventTypeLayout.tsx
@@ -8,6 +8,7 @@ import type { EventTypeSetupProps } from "@calcom/features/eventtypes/lib/types"
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { SchedulingType } from "@calcom/prisma/enums";
 import classNames from "@calcom/ui/classNames";
+import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { ButtonGroup } from "@calcom/ui/components/buttonGroup";
 import { VerticalDivider } from "@calcom/ui/components/divider";
@@ -103,6 +104,13 @@ function EventTypeSingleLayout({
       backPath={teamId ? `/event-types?teamId=${teamId}` : "/event-types"}
       title={`${eventType.title} | ${t("event_type")}`}
       heading={eventType.title}
+      beforeCTAactions={
+        team?.name ? (
+          <Badge className="ml-4 hidden text-xs md:flex" variant="gray">
+            {team.name}
+          </Badge>
+        ) : null
+      }
       CTA={
         <div className="flex items-center justify-end">
           {!formMethods.getValues("metadata")?.managedEventConfig && (

--- a/packages/features/eventtypes/components/EventTypeLayout.tsx
+++ b/packages/features/eventtypes/components/EventTypeLayout.tsx
@@ -103,13 +103,15 @@ function EventTypeSingleLayout({
     <Shell
       backPath={teamId ? `/event-types?teamId=${teamId}` : "/event-types"}
       title={`${eventType.title} | ${t("event_type")}`}
-      heading={eventType.title}
-      beforeCTAactions={
-        team?.name ? (
-          <Badge className="ml-4 hidden text-xs md:flex" variant="gray">
-            {team.name}
-          </Badge>
-        ) : null
+      heading={
+        <div className="flex items-center gap-2">
+          <span>{eventType.title}</span>
+          {team?.name && (
+            <Badge className="text-xs" variant="gray">
+              {team.name}
+            </Badge>
+          )}
+        </div>
       }
       CTA={
         <div className="flex items-center justify-end">

--- a/packages/features/eventtypes/components/EventTypeLayout.tsx
+++ b/packages/features/eventtypes/components/EventTypeLayout.tsx
@@ -107,7 +107,7 @@ function EventTypeSingleLayout({
         <div className="flex items-center gap-2">
           <span>{eventType.title}</span>
           {team?.name && (
-            <Badge className="text-xs" variant="gray">
+            <Badge className="hidden text-xs md:flex" variant="gray">
               {team.name}
             </Badge>
           )}

--- a/packages/platform/atoms/src/components/ui/shell.tsx
+++ b/packages/platform/atoms/src/components/ui/shell.tsx
@@ -7,10 +7,7 @@ export const Shell = (props: LayoutProps) => {
     <div className={cn(props.headerClassName, "flex flex-col px-10 py-4")}>
       <div className="mb-6 flex items-center justify-between md:mb-6 md:mt-0 lg:mb-8">
         <div className="flex flex-col gap-0.5">
-          <div className="flex items-center">
-            <div>{props.heading}</div>
-            {props.beforeCTAactions}
-          </div>
+          <div>{props.heading}</div>
           <div className="text-default text-sm">{props.subtitle}</div>
         </div>
         <div>{props.CTA}</div>

--- a/packages/platform/atoms/src/components/ui/shell.tsx
+++ b/packages/platform/atoms/src/components/ui/shell.tsx
@@ -7,7 +7,10 @@ export const Shell = (props: LayoutProps) => {
     <div className={cn(props.headerClassName, "flex flex-col px-10 py-4")}>
       <div className="mb-6 flex items-center justify-between md:mb-6 md:mt-0 lg:mb-8">
         <div className="flex flex-col gap-0.5">
-          <div>{props.heading}</div>
+          <div className="flex items-center">
+            <div>{props.heading}</div>
+            {props.beforeCTAactions}
+          </div>
           <div className="text-default text-sm">{props.subtitle}</div>
         </div>
         <div>{props.CTA}</div>


### PR DESCRIPTION
## What does this PR do?

This PR adds a team badge in the event type settings page header, displaying the team name next to the event type title, matching the design pattern used in the Workflows page.

- Fixes #26532
- Fixes [CAL-7033](https://linear.app/calcom/issue/CAL-7033/add-team-badge-in-event-type-settings)

## Visual Demo

**Before:** 
<img width="1675" height="191" alt="image" src="https://github.com/user-attachments/assets/363b1a89-21d6-4d79-aa5b-4bbf9bca2330" />


**After:**
<img width="1675" height="191" alt="image" src="https://github.com/user-attachments/assets/7aa6157a-3572-4323-811b-d76a5706900d" />



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. **N/A - Visual UI enhancement**

## How should this be tested?

1. Log in to Cal.com
2. Navigate to a team event type settings page (`/event-types/[id]`)
3. Verify that a gray badge with the team name appears in the header 
4. Verify the badge is hidden on mobile and visible on desktop
5. Verify no badge appears for personal (non-team) event types
