### PR TITLE
fix: remove shouldServeCache in getCalendarEvent getAvailability call

### DIFF
--- a/packages/features/calendars/lib/getCalendarsEvents.test.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.test.ts
@@ -274,7 +274,6 @@ describe("getCalendarsEvents", () => {
         "2010-12-01",
         "2010-12-04",
         [selectedCalendar],
-        undefined,
         false
       );
       expect(result).toEqual([
@@ -345,14 +344,12 @@ describe("getCalendarsEvents", () => {
         "2010-12-01",
         "2010-12-04",
         [selectedGoogleCalendar],
-        undefined,
         false
       );
       expect(getOfficeAvailabilitySpy).toHaveBeenCalledWith(
         "2010-12-01",
         "2010-12-04",
         [selectedOfficeCalendar],
-        undefined,
         false
       );
       expect(result).toEqual([
@@ -396,7 +393,7 @@ describe("getCalendarsEvents", () => {
 
       const result = await getCalendarsEvents(credentials, startDate, endDate, []);
 
-      expect(getAvailabilitySpy).toHaveBeenCalledWith(startDate, endDate, [], undefined, true);
+      expect(getAvailabilitySpy).toHaveBeenCalledWith(startDate, endDate, [], true);
       expect(result).toEqual([[]]);
     });
   });

--- a/packages/features/calendars/lib/getCalendarsEvents.ts
+++ b/packages/features/calendars/lib/getCalendarsEvents.ts
@@ -151,7 +151,6 @@ const getCalendarsEvents = async (
       dateFrom,
       dateTo,
       passedSelectedCalendars,
-      shouldServeCache,
       allowFallbackToPrimary
     );
     performance.mark("eventBusyDatesEnd");


### PR DESCRIPTION
## What does this PR do?

shouldServeCache is not used in calendar services getAvailability, so this PR removes the unused parameter from the `getCalendarsEvents.ts` call.

### Updates since last revision

Updated the unit test expectations in `getCalendarsEvents.test.ts` to remove the `undefined` parameter that was previously expected for `shouldServeCache`. This aligns the tests with the implementation change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the unit tests for the affected file:
```bash
TZ=UTC yarn test packages/features/calendars/lib/getCalendarsEvents.test.ts
```

All 17 tests should pass.

## Human Review Checklist

- [ ] Verify that removing `shouldServeCache` parameter doesn't break any other callers of `getAvailability` in the codebase
- [ ] Confirm the test expectations correctly match the new function signature