### PR TITLE
fix: prevent disabled apps from appearing in app store category pages

### DIFF
--- a/apps/web/lib/apps/categories/[category]/getStaticProps.ts
+++ b/apps/web/lib/apps/categories/[category]/getStaticProps.ts
@@ -10,6 +10,7 @@ export const getStaticProps = async (category: AppCategories) => {
       categories: {
         has: category,
       },
+      enabled: true,
     },
     select: {
       slug: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop showing disabled apps on app store category pages by filtering for enabled apps only. This ensures category pages list only active apps.

<sup>Written for commit 666d62c1563a640097d352a3e9f6c321436dd9c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

