### PR TITLE
fix(deps): replace gray-matter with yaml.load for js-yaml 4.x compatibility

### DIFF
--- a/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
+++ b/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../getStaticProps";
+
+describe("parseFrontmatter", () => {
+  describe("valid frontmatter parsing", () => {
+    it("parses frontmatter with items array", () => {
+      const source = `---
+items:
+  - 1.jpg
+  - 2.png
+---
+Some content here`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({ items: ["1.jpg", "2.png"] });
+      expect(result.content).toBe("Some content here");
+    });
+
+    it("parses frontmatter with description only", () => {
+      const source = `---
+description: A simple description
+---
+Content`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({ description: "A simple description" });
+      expect(result.content).toBe("Content");
+    });
+
+    it("parses items with iframe objects", () => {
+      const source = `---
+items:
+  - iframe: { src: https://youtube.com/embed/abc }
+  - 1.jpg
+---
+Content`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({
+        items: [{ iframe: { src: "https://youtube.com/embed/abc" } }, "1.jpg"],
+      });
+      expect(result.content).toBe("Content");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty data when no frontmatter present", () => {
+      const source = "Just plain text content";
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({});
+      expect(result.content).toBe("Just plain text content");
+    });
+
+    it("handles trailing spaces after frontmatter delimiters", () => {
+      const source = `---
+items:
+  - test.jpg
+---
+Content`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({ items: ["test.jpg"] });
+      expect(result.content).toBe("Content");
+    });
+
+    it("preserves blank line after frontmatter", () => {
+      const source = `---
+title: Test
+---
+
+Content`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({ title: "Test" });
+      expect(result.content).toBe("\nContent");
+    });
+
+    it("returns empty data for non-object frontmatter (array root)", () => {
+      const source = `---
+- item1
+- item2
+---
+Content`;
+
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({});
+      expect(result.content).toBe("Content");
+    });
+  });
+
+  describe("security (JSON_SCHEMA protection)", () => {
+    it("throws on unsafe YAML types", () => {
+      const source = `---
+date: !!js/date 2024-01-01
+---
+Content`;
+
+      expect(() => parseFrontmatter(source)).toThrow();
+    });
+  });
+});

--- a/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
+++ b/apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts
@@ -56,7 +56,7 @@ Content`;
       expect(result.content).toBe("Just plain text content");
     });
 
-    it("handles trailing spaces after frontmatter delimiters", () => {
+    it("parses simple frontmatter correctly", () => {
       const source = `---
 items:
   - test.jpg
@@ -97,13 +97,16 @@ Content`;
   });
 
   describe("security (JSON_SCHEMA protection)", () => {
-    it("throws on unsafe YAML types", () => {
+    it("returns empty data on unsafe YAML types", () => {
       const source = `---
 date: !!js/date 2024-01-01
 ---
 Content`;
 
-      expect(() => parseFrontmatter(source)).toThrow();
+      const result = parseFrontmatter(source);
+
+      expect(result.data).toEqual({});
+      expect(result.content).toBe("Content");
     });
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -91,7 +91,6 @@
     "classnames": "2.3.2",
     "dompurify": "3.3.1",
     "entities": "4.5.0",
-    "gray-matter": "4.0.3",
     "handlebars": "4.7.7",
     "i18next": "23.2.3",
     "ical.js": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,7 +3546,6 @@ __metadata:
     env-cmd: "npm:10.1.0"
     glob: "npm:10.4.5"
     google-auth-library: "npm:9.15.0"
-    gray-matter: "npm:4.0.3"
     handlebars: "npm:4.7.7"
     i18next: "npm:23.2.3"
     ical.js: "npm:1.5.0"


### PR DESCRIPTION
## What does this PR do?

Replaces `gray-matter` with a direct `yaml.load()` implementation to fix production 500 errors on app store pages caused by js-yaml 4.x incompatibility.

### Changes

  | Layer | File(s) | Change |
  |-------|---------|--------|
  | Lib | `getStaticProps.ts` | Add `parseFrontmatter()` function using js-yaml directly |
  | Lib | `getStaticProps.ts` | Use `JSON_SCHEMA` for additional security (blocks unsafe YAML types) |
  | Tests | `parseFrontmatter.test.ts` | Add unit tests for frontmatter parsing and security |
  | Deps | `package.json` | Remove `gray-matter` dependency |

### Background

PR #26390 updated `js-yaml` from 3.x to 4.1.1 to fix CWE-1321 (prototype pollution). However, `gray-matter@4.0.3` internally uses `yaml.safeLoad()` which was removed in js-yaml 4.x, causing 500 errors on all `/apps/*` pages.

This PR replaces the abandoned `gray-matter` package (last updated 2019) with a simple function that:
- Uses `yaml.load()` which is safe by default in js-yaml 4.x
- Uses `JSON_SCHEMA` to block unsafe YAML types
- Reduces bundle size

## Visual Demo

 **Before:**
<img width="688" height="338" alt="apps-before" src="https://github.com/user-attachments/assets/f7b2ff6e-6606-4a97-8345-0f1f383ac3ef" />

 **After:**
<img width="688" height="338" alt="apps-after" src="https://github.com/user-attachments/assets/5afcfc6d-2110-4b97-9023-be14e0d01299" />

### How to test

1. Run unit tests: `yarn test apps/web/lib/apps/[slug]/__tests__/parseFrontmatter.test.ts`
2. Start dev server: `yarn dev`
3. Visit `/apps/google-calendar` → page should load with images
4. Visit `/apps/zoom` → page should load correctly
5. Check console for no errors

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] **N/A** I have updated the developer docs
- [x] I confirm automated tests are in place