### PR TITLE
fix: allow deleting first time slot in availability schedule

### DIFF
--- a/packages/features/schedules/components/Schedule.tsx
+++ b/packages/features/schedules/components/Schedule.tsx
@@ -279,34 +279,32 @@ export const DayRanges = <TFieldValues extends FieldValues>({
                 />
               )}
             />
-            {index === 0 && (
-              <Button
-                disabled={disabled}
-                data-testid="add-time-availability"
-                tooltip={labels?.addTime ?? t("add_time_availability")}
-                className="text-default"
-                type="button"
-                color="minimal"
-                variant="icon"
-                StartIcon="plus"
-                onClick={() => {
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  const slotRange: any = getDateSlotRange(
-                    getValues(`${name}.${fields.length - 1}`),
-                    getValues(`${name}.0`)
-                  );
+            <Button
+              disabled={disabled}
+              data-testid="add-time-availability"
+              tooltip={labels?.addTime ?? t("add_time_availability")}
+              className="text-default"
+              type="button"
+              color="minimal"
+              variant="icon"
+              StartIcon="plus"
+              onClick={() => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const slotRange: any = getDateSlotRange(
+                  getValues(`${name}.${fields.length - 1}`),
+                  getValues(`${name}.0`)
+                );
 
-                  if (slotRange?.append) {
-                    append(slotRange.append);
-                  }
+                if (slotRange?.append) {
+                  append(slotRange.append);
+                }
 
-                  if (slotRange?.prepend) {
-                    prepend(slotRange.prepend);
-                  }
-                }}
-              />
-            )}
-            {index !== 0 && (
+                if (slotRange?.prepend) {
+                  prepend(slotRange.prepend);
+                }
+              }}
+            />
+            {fields.length > 1 && (
               <RemoveTimeButton index={index} remove={remove} className="text-default border-none" />
             )}
           </div>


### PR DESCRIPTION
Fixes #26448

Previously, users could not delete the first time slot in their availability schedule. The trash icon only appeared on slots 2+, while the '+' button only appeared on the first slot.

Changes:
- Show '+' button on all time slots for easier adding
- Show delete button on all slots when there are 2+ slots
- Prevent deletion when only 1 slot remains (must have at least one)

This improves UX by allowing users to remove any time slot they want, not just the ones after the first.

## What does this PR do?

Allows users to delete the first time slot in their availability schedule when multiple slots exist.

- Fixes #26448

## Demo (For contributors especially)

#### Before:
- Slots 2 and 3 have delete (trash) icons
- Slot 1 has NO delete icon, only a '+' button

#### After:
- All slots have both '+' and delete icons when there are 2+ slots
- Cannot delete when only 1 slot remains

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no docs changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. Existing tests cover the component; manual testing performed.

## How should this be tested?

1. Go to Settings > Availability
2. Select any schedule
3. Add multiple time slots (e.g., 3 slots) for any day
4. Verify ALL slots now show delete buttons
5. Delete the first slot - should work
6. Verify you cannot delete when only 1 slot remains

No special environment variables needed.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] N/A - simple conditional change, no complex logic needing comments
- [x] My changes generate no new warnings
