### PR TITLE
chore: biome ternary rules changes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -112,7 +112,7 @@
             "useQwikValidLexicalScope": "off",
             "useExplicitType": "info",
             "noReactForwardRef": "warn",
-            "noTernary": "warn",
+            "noTernary": "info",
             "noUnresolvedImports": "warn"
           },
           "correctness": {
@@ -130,7 +130,8 @@
           "style": {
             "useExportsLast": "warn",
             "noProcessEnv": "warn",
-            "useNodejsImportProtocol": "error"
+            "useNodejsImportProtocol": "error",
+            "noNestedTernary": "warn"
           },
           "complexity": {
             "noExcessiveLinesPerFunction": "warn"


### PR DESCRIPTION
## What does this PR do?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted Biome lint rules: demoted "noTernary" from warn to info and added "noNestedTernary" as warn. This reduces lint noise for simple ternaries while discouraging nested ternaries.

<sup>Written for commit 2b2d0b5f166e6b93e4249364d47dd1a127f01b15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

