### PR TITLE
fix: refresh token endpoint for companion

### DIFF
--- a/companion/services/oauthService.ts
+++ b/companion/services/oauthService.ts
@@ -526,15 +526,19 @@ export class CalComOAuthService {
       refresh_token: refreshToken,
     };
 
-    const tokenEndpoint = `${this.config.calcomBaseUrl}/api/auth/oauth/token`;
+    const refreshTokenEndpoint = `${this.config.calcomBaseUrl}/api/auth/oauth/refreshToken`;
 
     if (this.isRunningInIframe()) {
-      const tokens = await this.exchangeCodeForTokensViaExtension(tokenRequest, tokenEndpoint);
+      const tokens = await this.exchangeCodeForTokensViaExtension(
+        tokenRequest,
+        refreshTokenEndpoint
+      );
       await this.syncTokensToExtension(tokens);
       return tokens;
     }
 
-    return this.exchangeCodeForTokensDirect(tokenRequest, tokenEndpoint);
+    const result = await this.exchangeCodeForTokensDirect(tokenRequest, refreshTokenEndpoint);
+    return result;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

The companion called the wrong endpoint for refreshing the OAuth token. The correct endpoint is `app.cal.com/api/auth/oauth/refreshToken`
