### PR TITLE
fix: correctly assign billing period from Stripe subscription in team upgrade

### DIFF
--- a/apps/web/app/api/teams/[team]/upgrade/route.ts
+++ b/apps/web/app/api/teams/[team]/upgrade/route.ts
@@ -44,7 +44,7 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<Params
     const price = subscription.items.data[0]?.price as Stripe.Price | undefined;
     const stripeInterval = price?.recurring?.interval;
     const billingPeriod = stripeInterval === "year" ? BillingPeriod.ANNUALLY : BillingPeriod.MONTHLY;
-    const pricePerSeat = price?.unit_amount ? price.unit_amount / 100 : null;
+    const pricePerSeat = price?.unit_amount ?? null;
     const paidSeats = subscription.items.data[0]?.quantity ?? null;
     const subscriptionStart = subscription.current_period_start
       ? new Date(subscription.current_period_start * 1000)

--- a/apps/web/app/api/teams/[team]/upgrade/route.ts
+++ b/apps/web/app/api/teams/[team]/upgrade/route.ts
@@ -105,7 +105,7 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<Params
       create: {
         teamId: team.id,
         subscriptionId: subscription.id,
-        subscriptionItemId: subscription.items.data[0].id,
+        subscriptionItemId: subscription.items.data[0]?.id ?? "",
         customerId:
           typeof checkoutSession.customer === "string"
             ? checkoutSession.customer

--- a/packages/features/ee/billing/repository/billing/IBillingRepository.ts
+++ b/packages/features/ee/billing/repository/billing/IBillingRepository.ts
@@ -34,6 +34,11 @@ export interface IBillingRepositoryConstructorArgs {
   isOrganization: boolean;
 }
 
+export enum BillingPeriod {
+  MONTHLY = "MONTHLY",
+  ANNUALLY = "ANNUALLY",
+}
+
 export interface IBillingRepositoryCreateArgs {
   teamId: number;
   subscriptionId: string;
@@ -41,6 +46,9 @@ export interface IBillingRepositoryCreateArgs {
   customerId: string;
   planName: Plan;
   status: SubscriptionStatus;
+  billingPeriod?: BillingPeriod;
+  pricePerSeat?: number;
+  paidSeats?: number;
   subscriptionStart?: Date;
   subscriptionTrialEnd?: Date;
   subscriptionEnd?: Date;

--- a/packages/prisma/migrations/20260108110350_add_billing_fields_to_team_billing/migration.sql
+++ b/packages/prisma/migrations/20260108110350_add_billing_fields_to_team_billing/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "public"."TeamBilling" ADD COLUMN     "billingPeriod" "public"."BillingPeriod",
+ADD COLUMN     "paidSeats" INTEGER,
+ADD COLUMN     "pricePerSeat" DOUBLE PRECISION;

--- a/packages/prisma/migrations/20260108110350_add_billing_fields_to_team_billing/migration.sql
+++ b/packages/prisma/migrations/20260108110350_add_billing_fields_to_team_billing/migration.sql
@@ -1,4 +1,4 @@
 -- AlterTable
 ALTER TABLE "public"."TeamBilling" ADD COLUMN     "billingPeriod" "public"."BillingPeriod",
 ADD COLUMN     "paidSeats" INTEGER,
-ADD COLUMN     "pricePerSeat" DOUBLE PRECISION;
+ADD COLUMN     "pricePerSeat" INTEGER;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2918,7 +2918,7 @@ model TeamBilling {
   status               String
   planName             String
   billingPeriod        BillingPeriod?
-  pricePerSeat         Float?
+  pricePerSeat         Int?
   paidSeats            Int?
   subscriptionStart    DateTime?
   subscriptionTrialEnd DateTime?

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2912,11 +2912,14 @@ model TeamBilling {
   teamId Int    @unique
   team   Team?  @relation("TeamBilling", fields: [teamId], references: [id], onDelete: Cascade)
 
-  subscriptionId       String    @unique
+  subscriptionId       String         @unique
   subscriptionItemId   String
   customerId           String
   status               String
   planName             String
+  billingPeriod        BillingPeriod?
+  pricePerSeat         Float?
+  paidSeats            Int?
   subscriptionStart    DateTime?
   subscriptionTrialEnd DateTime?
   subscriptionEnd      DateTime?


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where annual team plans were incorrectly created as monthly team billing records when Stripe upselling is enabled. The billing period is now correctly extracted from the Stripe subscription's `price.recurring.interval` field.

**Changes:**
- Added `billingPeriod`, `pricePerSeat`, and `paidSeats` fields to the `TeamBilling` model
- Modified the team upgrade route to extract billing period from Stripe subscription price
- Added upsert logic to create/update `TeamBilling` records with correct billing period after checkout

## Updates since last revision

- Changed `pricePerSeat` to store cents (INTEGER) instead of dollars (FLOAT) - stores raw Stripe `unit_amount` value directly for precision

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - backend change only.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a team and go through the Stripe checkout flow with an **annual** plan
2. After successful checkout, verify the `TeamBilling` record in the database has:
   - `billingPeriod` = `ANNUALLY` (not `MONTHLY`)
   - `pricePerSeat` populated with the price **in cents** (e.g., 1500 for $15.00)
   - `paidSeats` populated with the quantity from the subscription
3. Repeat with a **monthly** plan and verify `billingPeriod` = `MONTHLY`

**Environment variables needed:**
- Stripe test keys configured
- Valid Stripe price IDs for both monthly and annual team plans

## Human Review Checklist

- [ ] Verify the billing period detection logic: `year` → `ANNUALLY`, default → `MONTHLY`
- [ ] Check if the duplicate `BillingPeriod` enum in `IBillingRepository.ts` should instead import from `@calcom/prisma/enums`
- [ ] Confirm hardcoded `status: "ACTIVE"` and `planName: "TEAM"` are correct for this flow
- [ ] Verify upsert handles edge cases (null customer ID, missing subscription items)
- [ ] Confirm `pricePerSeat` storing cents (not dollars) aligns with how other billing code handles prices

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

Link to Devin run: https://app.devin.ai/sessions/03322b0751d3494eb7776bb155f8fbb1
Requested by: @sean-brydon