### PR TITLE
fix: update E2E test to match German translation without '+' prefix

### DIFF
--- a/apps/web/playwright/event-types.e2e.ts
+++ b/apps/web/playwright/event-types.e2e.ts
@@ -1,8 +1,7 @@
-import type { Page } from "@playwright/test";
-import { expect } from "@playwright/test";
-
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { randomString } from "@calcom/lib/random";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { test } from "./lib/fixtures";
 import {
@@ -550,7 +549,7 @@ test.describe("Event Types tests", () => {
         await expect(page.locator(`text="Ihr Name"`).nth(0)).toBeVisible();
         await expect(page.locator(`text="E-Mail Adresse"`).nth(0)).toBeVisible();
         await expect(page.locator(`text="Zusätzliche Notizen"`).nth(0)).toBeVisible();
-        await expect(page.locator(`text="+ Weitere Gäste"`).nth(0)).toBeVisible();
+        await expect(page.locator(`text="Weitere Gäste"`).nth(0)).toBeVisible();
         await expect(page.locator(`text="Zurück"`).nth(0)).toBeVisible();
         await expect(page.locator(`text="Bestätigen"`).nth(0)).toBeVisible();
       });


### PR DESCRIPTION
## What does this PR do?

Updates the E2E test for German interface language to match the translation change made in #26582, which removed the "+" prefix from the `additional_guests` translation.

The test was expecting `"+ Weitere Gäste"` but the German translation was updated to `"Weitere Gäste"` (without the "+"), causing the E2E test to fail.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test-only change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the E2E test for the German interface language:
```bash
PLAYWRIGHT_HEADLESS=1 yarn e2e apps/web/playwright/event-types.e2e.ts --grep "user can change the interface language to any other language"
```

The test should now pass since it expects `"Weitere Gäste"` which matches the current German translation.

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

**Link to Devin run:** https://app.devin.ai/sessions/12389ae613e545d0a4fe06500942e463
**Requested by:** @eunjae-lee