### PR TITLE
fix: skip stale run-ci label check on workflow re-runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,7 +98,7 @@ jobs:
             // git commit timestamps can be arbitrarily backdated by attackers
             if (pr.labels?.some(l => l.name === 'run-ci')) {
               // Skip stale check if this is a re-run (run_attempt > 1)
-              // Re-runs are explicitly triggered by maintainers via the run-ci.yml workflow
+              // Re-runs are explicitly triggered by maintainers
               const runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT || '1', 10);
               if (runAttempt > 1) {
                 console.log(`Re-run detected (attempt ${runAttempt}), trusting existing 'run-ci' label`);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,18 @@ jobs:
               return;
             }
 
-            // Check 3: Was 'run-ci' label added AFTER this SHA was pushed by someone with write access?
+            // Check 3: Was this push made by someone with write access?
+            // This handles cases where a maintainer merges main into a community PR
+            const sender = context.payload.sender;
+            if (sender && sender.login !== pr.user.login) {
+              if (await hasWriteAccess(sender.login)) {
+                console.log(`Push made by maintainer: ${sender.login}`);
+                core.setOutput('is-trusted', true);
+                return;
+              }
+            }
+
+            // Check 4: Was 'run-ci' label added AFTER this SHA was pushed by someone with write access?
             // This enables re-runs triggered by the run-ci.yml workflow
             // NOTE: We use workflow run created_at instead of commit timestamp because
             // git commit timestamps can be arbitrarily backdated by attackers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,22 +92,20 @@ jobs:
               return;
             }
 
-            // Check 3: Was this push made by someone with write access?
-            // This handles cases where a maintainer merges main into a community PR
-            const sender = context.payload.sender;
-            if (sender && sender.login !== pr.user.login) {
-              if (await hasWriteAccess(sender.login)) {
-                console.log(`Push made by maintainer: ${sender.login}`);
-                core.setOutput('is-trusted', true);
-                return;
-              }
-            }
-
-            // Check 4: Was 'run-ci' label added AFTER this SHA was pushed by someone with write access?
+            // Check 3: Was 'run-ci' label added AFTER this SHA was pushed by someone with write access?
             // This enables re-runs triggered by the run-ci.yml workflow
             // NOTE: We use workflow run created_at instead of commit timestamp because
             // git commit timestamps can be arbitrarily backdated by attackers
             if (pr.labels?.some(l => l.name === 'run-ci')) {
+              // Skip stale check if this is a re-run (run_attempt > 1)
+              // Re-runs are explicitly triggered by maintainers via the run-ci.yml workflow
+              const runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT || '1', 10);
+              if (runAttempt > 1) {
+                console.log(`Re-run detected (attempt ${runAttempt}), trusting existing 'run-ci' label`);
+                core.setOutput('is-trusted', true);
+                return;
+              }
+
               const events = await github.paginate(github.rest.issues.listEvents, {
                 owner,
                 repo,


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where CI workflows fail to run on community PRs after a maintainer merges main into the PR branch.

**Root cause**: When a maintainer merges main into a community PR branch, it creates a new SHA. The existing `run-ci` label timing check fails because the label was added BEFORE the new push, causing `labelTime > pushTime` to be false.

**Solution**: Skip the stale label check if `GITHUB_RUN_ATTEMPT > 1`. When a maintainer adds the `run-ci` label after syncing, the `run-ci.yml` workflow triggers a re-run via `reRunWorkflow`. On re-runs, `run_attempt` will be > 1, so we trust the existing label without checking timing.

This avoids the need to remove and re-add the `run-ci` label after syncing a community PR with main, while keeping the explicit approval flow intact.

