### PR TITLE
chore: Update CODEOWNERS for GitHub actions/workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+.github/actions/**/* @calcom/Foundation
+.github/workflows/**/* @calcom/Foundation
 /**/package.json @calcom/Foundation
 /apps/api/**/* @calcom/Foundation
 /apps/web/**/layout.tsx @calcom/Consumer @calcom/Foundation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add CODEOWNERS entries for .github/actions and .github/workflows to route changes to @calcom/Foundation. This clarifies ownership and ensures CI-related updates get reviewed by the right team.

<sup>Written for commit 89c584349b5d69e2e6498ae1d9b46cc45c52563a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

