### PR TITLE
fix: add waitFor calls to prevent flaky time slot selection tests

### DIFF
--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -107,28 +107,34 @@ export function createHttpServer(opts: { requestHandler?: RequestHandler } = {})
 
 export async function selectFirstAvailableTimeSlotNextMonth(page: Page | Frame) {
   // Wait for the booker to be ready before interacting
-  await page.getByTestId("incrementMonth").waitFor();
-  await page.getByTestId("incrementMonth").click();
+  const incrementMonth = page.getByTestId("incrementMonth");
+  await incrementMonth.waitFor();
+  await incrementMonth.click();
 
   // Wait for available day to appear after month increment
-  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).waitFor();
-  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).click();
+  const firstAvailableDay = page.locator('[data-testid="day"][data-disabled="false"]').nth(0);
+  await firstAvailableDay.waitFor();
+  await firstAvailableDay.click();
 
-  await page.locator('[data-testid="time"]').nth(0).waitFor();
-  await page.locator('[data-testid="time"]').nth(0).click();
+  const firstTimeSlot = page.locator('[data-testid="time"]').nth(0);
+  await firstTimeSlot.waitFor();
+  await firstTimeSlot.click();
 }
 
 export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
   // Wait for the booker to be ready before interacting
-  await page.getByTestId("incrementMonth").waitFor();
-  await page.getByTestId("incrementMonth").click();
+  const incrementMonth = page.getByTestId("incrementMonth");
+  await incrementMonth.waitFor();
+  await incrementMonth.click();
 
   // Wait for available day to appear after month increment
-  await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).waitFor();
-  await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();
+  const secondAvailableDay = page.locator('[data-testid="day"][data-disabled="false"]').nth(1);
+  await secondAvailableDay.waitFor();
+  await secondAvailableDay.click();
 
-  await page.locator('[data-testid="time"]').nth(0).waitFor();
-  await page.locator('[data-testid="time"]').nth(0).click();
+  const firstTimeSlot = page.locator('[data-testid="time"]').nth(0);
+  await firstTimeSlot.waitFor();
+  await firstTimeSlot.click();
 }
 
 export async function bookEventOnThisPage(page: Page) {

--- a/apps/web/playwright/lib/testUtils.ts
+++ b/apps/web/playwright/lib/testUtils.ts
@@ -106,21 +106,28 @@ export function createHttpServer(opts: { requestHandler?: RequestHandler } = {})
 }
 
 export async function selectFirstAvailableTimeSlotNextMonth(page: Page | Frame) {
-  // Let current month dates fully render.
+  // Wait for the booker to be ready before interacting
+  await page.getByTestId("incrementMonth").waitFor();
   await page.getByTestId("incrementMonth").click();
 
-  // Waiting for full month increment
+  // Wait for available day to appear after month increment
+  await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).waitFor();
   await page.locator('[data-testid="day"][data-disabled="false"]').nth(0).click();
 
+  await page.locator('[data-testid="time"]').nth(0).waitFor();
   await page.locator('[data-testid="time"]').nth(0).click();
 }
 
 export async function selectSecondAvailableTimeSlotNextMonth(page: Page) {
-  // Let current month dates fully render.
+  // Wait for the booker to be ready before interacting
+  await page.getByTestId("incrementMonth").waitFor();
   await page.getByTestId("incrementMonth").click();
 
+  // Wait for available day to appear after month increment
+  await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).waitFor();
   await page.locator('[data-testid="day"][data-disabled="false"]').nth(1).click();
 
+  await page.locator('[data-testid="time"]').nth(0).waitFor();
   await page.locator('[data-testid="time"]').nth(0).click();
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes flaky E2E test "Booking should be rescheduleable for a user that was moved to an organization through non-org domain" by adding explicit `waitFor()` calls before clicking elements in the time slot selection utility functions.

The test was failing intermittently with a timeout error waiting for `getByTestId('incrementMonth')` to be clickable. The root cause was that the booker component hadn't fully loaded before the test tried to interact with it.

Flaky test report: https://calcom.github.io/test-results-2/reports/feat/billing-proration-dal/20823899989/1/#?q=s%3Aflaky&testId=f4724bc808c14ce428b3-17f7bfc76c96eeef1b94

## Updates since last revision

- Refactored to use locator variables instead of repeating selectors, making the code cleaner and more maintainable

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - test utility change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

This fix addresses test flakiness, which is inherently difficult to reproduce locally. The change follows the established pattern already used in `booking-pages.e2e.ts:430` where `waitFor()` is called before clicking the incrementMonth button.

To verify:
1. Run the reschedule E2E tests multiple times: `PLAYWRIGHT_HEADLESS=1 yarn e2e reschedule.e2e.ts`
2. The test "Booking should be rescheduleable for a user that was moved to an organization through non-org domain" should pass consistently

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

---

> **Reviewer Note**: This PR also applies the same fix to `selectSecondAvailableTimeSlotNextMonth` for consistency, even though the flaky test only used the first function.

### Human Review Checklist
- [ ] Verify `waitFor()` calls are placed before each `click()` action
- [ ] Confirm locator variables are correctly defined and reused

### Link to Devin run
https://app.devin.ai/sessions/2f2e562ccb12492790d9a57fc1ec8b65

### Requested by
@keithwillcode