### PR TITLE
refactor: Extract schedule determination to seperate fn

### DIFF
--- a/apps/web/modules/onboarding/hooks/useOnboardingCalendarEvents.ts
+++ b/apps/web/modules/onboarding/hooks/useOnboardingCalendarEvents.ts
@@ -2,17 +2,23 @@ import { useSession } from "next-auth/react";
 import { useMemo, useEffect } from "react";
 
 import dayjs from "@calcom/dayjs";
-import type { GetUserAvailabilityResult } from "@calcom/features/availability/lib/getUserAvailability";
+
 import type { CalendarEvent } from "@calcom/features/calendars/weeklyview/types/events";
 import { BookingStatus } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
+import type { RouterOutputs } from "@calcom/trpc/react";
 
 type UseOnboardingCalendarEventsProps = {
   startDate: Date;
   endDate: Date;
 };
 
-const emptyAvailabilityData = {
+type UseOnboardingCalendarEventsResult = {
+  events: CalendarEvent[];
+  isLoading: boolean;
+};
+
+const emptyAvailabilityData: RouterOutputs["viewer"]["availability"]["user"] = {
   busy: [],
   timeZone: "",
   dateRanges: [],
@@ -21,9 +27,12 @@ const emptyAvailabilityData = {
   dateOverrides: [],
   currentSeats: null,
   datesOutOfOffice: {},
-} as GetUserAvailabilityResult;
+};
 
-export const useOnboardingCalendarEvents = ({ startDate, endDate }: UseOnboardingCalendarEventsProps) => {
+export const useOnboardingCalendarEvents = ({
+  startDate,
+  endDate,
+}: UseOnboardingCalendarEventsProps): UseOnboardingCalendarEventsResult => {
   const { data: session } = useSession();
   const utils = trpc.useUtils();
 
@@ -65,7 +74,6 @@ export const useOnboardingCalendarEvents = ({ startDate, endDate }: UseOnboardin
         start: new Date(event.start),
         end: new Date(event.end),
         options: {
-          color: event.source ? undefined : undefined,
           status: BookingStatus.ACCEPTED,
         },
       };

--- a/packages/features/availability/lib/detectEventTypeScheduleForUser.test.ts
+++ b/packages/features/availability/lib/detectEventTypeScheduleForUser.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SCHEDULE_DATA, detectEventTypeScheduleForUser } from "./detectEventTypeScheduleForUser";
+import type { DetectEventTypeScheduleForUserInput } from "./detectEventTypeScheduleForUser";
+
+describe("detectEventTypeScheduleForUser", () => {
+  const mockUser = {
+    id: 1,
+    timeZone: "America/New_York",
+    defaultScheduleId: 100,
+    schedules: [
+      {
+        id: 100,
+        timeZone: "America/New_York",
+        availability: [],
+      },
+      {
+        id: 101,
+        timeZone: "Europe/London",
+        availability: [],
+      },
+    ],
+  };
+
+  const createInput = (
+    overrides: Partial<DetectEventTypeScheduleForUserInput> = {}
+  ): DetectEventTypeScheduleForUserInput => ({
+    user: mockUser,
+    eventType: null,
+    ...overrides,
+  });
+
+  it("should prioritize eventType.schedule if present", () => {
+    const eventTypeSchedule = {
+      id: 999,
+      timeZone: "Asia/Tokyo",
+      availability: [],
+    };
+
+    const input = createInput({
+      eventType: {
+        hosts: [],
+        timeZone: null,
+        schedule: eventTypeSchedule,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    expect(result.schedule).toEqual(expect.objectContaining({ id: 999, timeZone: "Asia/Tokyo" }));
+    expect(result.isTimezoneSet).toBe(true);
+    expect(result.isDefaultSchedule).toBe(false);
+  });
+
+  it("should prioritize host schedule if eventType.schedule is missing", () => {
+    const hostSchedule = {
+      id: 888,
+      timeZone: "Europe/Berlin",
+      availability: [],
+    };
+
+    const input = createInput({
+      eventType: {
+        hosts: [
+          {
+            user: { id: 1 },
+            schedule: hostSchedule,
+          },
+        ],
+        timeZone: null,
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    expect(result.schedule).toEqual(expect.objectContaining({ id: 888, timeZone: "Europe/Berlin" }));
+    expect(result.isTimezoneSet).toBe(true);
+    expect(result.isDefaultSchedule).toBe(false);
+  });
+
+  it("should prioritize user default schedule if neither event nor host schedule is present", () => {
+    const input = createInput({
+      eventType: {
+        hosts: [],
+        timeZone: null,
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    expect(result.schedule).toEqual(expect.objectContaining({ id: 100, timeZone: "America/New_York" }));
+    expect(result.isTimezoneSet).toBe(true);
+    // It matches the user's default schedule ID
+    expect(result.isDefaultSchedule).toBe(true);
+  });
+
+  it("should use user schedule if it acts as host schedule", () => {
+    // This covers the case where host schedule is explicitly set and matches a user schedule
+    const userSchedule = mockUser.schedules[1]; // id 101
+    const input = createInput({
+      eventType: {
+        hosts: [
+          {
+            user: { id: 1 },
+            schedule: userSchedule,
+          },
+        ],
+        timeZone: null,
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+    expect(result.schedule).toEqual(expect.objectContaining({ id: 101 }));
+    expect(result.isDefaultSchedule).toBe(false); // 101 is not default (100 is)
+  });
+
+  it("should use fallback schedule if no schedules are found", () => {
+    const userWithNoSchedules = {
+      ...mockUser,
+      schedules: [],
+      defaultScheduleId: null,
+    };
+
+    const input = createInput({
+      user: userWithNoSchedules,
+      eventType: {
+        hosts: [],
+        timeZone: null,
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    expect(result.schedule.id).toBe(0); // Default schedule ID
+    expect(result.schedule.availability?.[0]?.days).toEqual(DEFAULT_SCHEDULE_DATA.availability?.[0]?.days);
+    expect(result.isTimezoneSet).toBe(false); // Fallback schedule doesn't count as "set"
+    expect(result.isDefaultSchedule).toBe(false);
+  });
+
+  it("should use eventType timezone as fallback if schedule timezone is missing", () => {
+    const userWithNoSchedules = {
+      ...mockUser,
+      schedules: [],
+      defaultScheduleId: null,
+    };
+
+    const input = createInput({
+      user: userWithNoSchedules,
+      eventType: {
+        hosts: [],
+        timeZone: "Pacific/Honolulu",
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    // Schedule itself (fallback) has no timezone, so it picks up the fallback
+    expect(result.schedule.timeZone).toBe("Pacific/Honolulu");
+    expect(result.isTimezoneSet).toBe(false);
+  });
+
+  it("should use user timezone as fallback if everything else is missing", () => {
+    const userWithNoSchedules = {
+      ...mockUser,
+      schedules: [],
+      defaultScheduleId: null,
+      timeZone: "Africa/Cairo",
+    };
+
+    const input = createInput({
+      user: userWithNoSchedules,
+      eventType: {
+        hosts: [],
+        timeZone: null,
+        schedule: null,
+      },
+    });
+
+    const result = detectEventTypeScheduleForUser(input);
+
+    expect(result.schedule.timeZone).toBe("Africa/Cairo");
+    expect(result.isTimezoneSet).toBe(false);
+  });
+});

--- a/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
+++ b/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
@@ -1,0 +1,101 @@
+import type { GetUserAvailabilityInitialData } from "./getUserAvailability";
+
+export type ScheduleWithoutTimeZone = {
+  id: number;
+  availability?: {
+    days: number[];
+    startTime: Date;
+    endTime: Date;
+    date: Date | null;
+  }[];
+};
+
+export const DEFAULT_SCHEDULE_DATA: ScheduleWithoutTimeZone = {
+  availability: [
+    {
+      startTime: new Date("1970-01-01T09:00:00Z"),
+      endTime: new Date("1970-01-01T17:00:00Z"),
+      days: [1, 2, 3, 4, 5], // Monday to Friday
+      date: null,
+    },
+  ],
+  id: 0,
+};
+
+export type DetectEventTypeScheduleForUserInput = {
+  eventType?: {
+    hosts: {
+      user: {
+        id: number;
+      };
+      schedule:
+        | (ScheduleWithoutTimeZone & {
+            timeZone: string | null;
+          })
+        | null;
+    }[];
+    timeZone: string | null;
+    schedule:
+      | (ScheduleWithoutTimeZone & {
+          timeZone: string | null;
+        })
+      | null;
+  } | null;
+  user: {
+    schedules: NonNullable<GetUserAvailabilityInitialData["user"]>["schedules"];
+    defaultScheduleId: number | null;
+    timeZone: string;
+    id: number;
+  };
+};
+
+export type DetectEventTypeScheduleForUserOutput = {
+  isDefaultSchedule: boolean;
+  isTimezoneSet: boolean;
+  schedule: ScheduleWithoutTimeZone & {
+    timeZone: string;
+  };
+};
+
+export function detectEventTypeScheduleForUser({
+  eventType,
+  user,
+}: DetectEventTypeScheduleForUserInput): DetectEventTypeScheduleForUserOutput {
+  const userSchedule = user.schedules.filter(
+    (schedule) => !user?.defaultScheduleId || schedule.id === user?.defaultScheduleId
+  )[0];
+  const hostSchedule = eventType?.hosts?.find((host) => host.user.id === user.id)?.schedule;
+
+  // TODO: It uses default timezone of user. Should we use timezone of team ?
+  const fallbackTimezoneIfScheduleIsMissing = eventType?.timeZone || user.timeZone;
+
+  const fallbackSchedule = {
+    ...DEFAULT_SCHEDULE_DATA,
+    timeZone: fallbackTimezoneIfScheduleIsMissing,
+  };
+
+  let potentialSchedule = null;
+
+  if (eventType?.schedule) {
+    potentialSchedule = eventType.schedule;
+  } else if (hostSchedule) {
+    potentialSchedule = hostSchedule;
+  } else if (userSchedule) {
+    potentialSchedule = userSchedule;
+  }
+
+  const schedule = potentialSchedule ?? fallbackSchedule;
+
+  const isDefaultSchedule = !!(userSchedule && userSchedule.id === schedule?.id);
+
+  const isTimezoneSet = Boolean(potentialSchedule && potentialSchedule.timeZone !== null);
+
+  return {
+    isDefaultSchedule,
+    isTimezoneSet,
+    schedule: {
+      ...schedule,
+      timeZone: schedule.timeZone || fallbackTimezoneIfScheduleIsMissing,
+    },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted schedule selection into a dedicated function to simplify getUserAvailability and make timezone fallback logic clearer. No functional changes expected.

- **Refactors**
  - Added detectEventTypeScheduleForUser to choose schedule and report isDefaultSchedule/isTimezoneSet.
  - Introduced ScheduleWithoutTimeZone and DEFAULT_SCHEDULE_DATA.
  - Simplified timezone resolution, using delegated calendar TZ only when needed.
  - Made GetUserAvailabilityResult explicit and typed _getUserAvailability accordingly.
  - Imported WorkingHoursWithUserId and removed inline schedule logic and redundant debug logging.

<sup>Written for commit 6bf6b445ea2523348f1d1cae8bca5174f509d891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

