### PR TITLE
fix: Update Dockerfile since /tests directory no longer exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ COPY .yarn ./.yarn
 COPY apps/web ./apps/web
 COPY apps/api/v2 ./apps/api/v2
 COPY packages ./packages
-COPY tests ./tests
 
 RUN yarn config set httpTimeout 1200000
 RUN npx turbo prune --scope=@calcom/web --scope=@calcom/trpc --docker


### PR DESCRIPTION
## What does this PR do?

Fixes the failing Docker build workflow by removing the `COPY tests ./tests` line from the Dockerfile. The `/tests` directory at the root level has been removed from the repository, causing the Docker build to fail when trying to copy a non-existent directory.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - the Docker build workflow itself will verify this fix.

## How should this be tested?

The Docker build workflow (Release Docker AMD64) should now pass. No manual testing required - the CI workflow that was failing will validate this fix.