### PR TITLE
fix: improve cleanup for managed event types and fix flaky api v2 e2e test

### DIFF
--- a/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
@@ -67,7 +67,7 @@ describe("Organizations Event Types Endpoints", () => {
 
     beforeAll(async () => {
       // Generate unique slug inside beforeAll to ensure uniqueness across test runs
-      managedEventTypeSlug = `organizations-event-types-managed-${randomString()}`;
+      managedEventTypeSlug = `organizations-event-types-managed-${Date.now()}-${randomString()}`;
       const moduleRef = await withApiAuth(
         userEmail,
         Test.createTestingModule({
@@ -306,7 +306,7 @@ describe("Organizations Event Types Endpoints", () => {
           },
         ],
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error - schedulingType is lowercase in API input
+        // @ts-ignore
         schedulingType: "collective",
         hosts: [
           {
@@ -1095,7 +1095,7 @@ describe("Organizations Event Types Endpoints", () => {
           },
         ],
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error - schedulingType is camelCase in API input
+        // @ts-ignore
         schedulingType: "roundRobin",
         hosts: [
           {
@@ -1374,25 +1374,21 @@ describe("Organizations Event Types Endpoints", () => {
       expect(updatedEventType.bookingRequiresAuthentication).toEqual(false);
     });
 
-    function evaluateHost(expected: Host, received: Host | undefined): void {
+    function evaluateHost(expected: Host, received: Host | undefined) {
       expect(expected.userId).toEqual(received?.userId);
       expect(expected.mandatory).toEqual(received?.mandatory);
       expect(expected.priority).toEqual(received?.priority);
     }
 
     afterAll(async () => {
-      // Delete user event types first (child event types of managed event types)
       await eventTypesRepositoryFixture.deleteAllUserEventTypes(teammate1.id);
       await eventTypesRepositoryFixture.deleteAllUserEventTypes(teammate2.id);
-      // Delete team event types before deleting the team
       await eventTypesRepositoryFixture.deleteAllTeamEventTypes(team.id);
       await eventTypesRepositoryFixture.deleteAllTeamEventTypes(falseTestTeam.id);
-      // Delete users after their event types are deleted
       await userRepositoryFixture.deleteByEmail(userAdmin.email);
       await userRepositoryFixture.deleteByEmail(teammate1.email);
       await userRepositoryFixture.deleteByEmail(teammate2.email);
       await userRepositoryFixture.deleteByEmail(falseTestUser.email);
-      // Delete teams and organizations
       await teamsRepositoryFixture.delete(team.id);
       await teamsRepositoryFixture.delete(falseTestTeam.id);
       await organizationsRepositoryFixture.delete(org.id);

--- a/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
+++ b/apps/api/v2/src/modules/organizations/event-types/organizations-member-team-admin-event-types.e2e-spec.ts
@@ -306,7 +306,7 @@ describe("Organizations Event Types Endpoints", () => {
           },
         ],
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error - schedulingType is lowercase in API input
         schedulingType: "collective",
         hosts: [
           {
@@ -1095,7 +1095,7 @@ describe("Organizations Event Types Endpoints", () => {
           },
         ],
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error - schedulingType is camelCase in API input
         schedulingType: "roundRobin",
         hosts: [
           {
@@ -1374,20 +1374,25 @@ describe("Organizations Event Types Endpoints", () => {
       expect(updatedEventType.bookingRequiresAuthentication).toEqual(false);
     });
 
-    function evaluateHost(expected: Host, received: Host | undefined) {
+    function evaluateHost(expected: Host, received: Host | undefined): void {
       expect(expected.userId).toEqual(received?.userId);
       expect(expected.mandatory).toEqual(received?.mandatory);
       expect(expected.priority).toEqual(received?.priority);
     }
 
     afterAll(async () => {
+      // Delete user event types first (child event types of managed event types)
+      await eventTypesRepositoryFixture.deleteAllUserEventTypes(teammate1.id);
+      await eventTypesRepositoryFixture.deleteAllUserEventTypes(teammate2.id);
+      // Delete team event types before deleting the team
+      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(team.id);
+      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(falseTestTeam.id);
+      // Delete users after their event types are deleted
       await userRepositoryFixture.deleteByEmail(userAdmin.email);
       await userRepositoryFixture.deleteByEmail(teammate1.email);
       await userRepositoryFixture.deleteByEmail(teammate2.email);
       await userRepositoryFixture.deleteByEmail(falseTestUser.email);
-      // Explicitly delete all team event types before deleting the team to ensure proper cleanup
-      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(team.id);
-      await eventTypesRepositoryFixture.deleteAllTeamEventTypes(falseTestTeam.id);
+      // Delete teams and organizations
       await teamsRepositoryFixture.delete(team.id);
       await teamsRepositoryFixture.delete(falseTestTeam.id);
       await organizationsRepositoryFixture.delete(org.id);

--- a/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
@@ -13,7 +13,7 @@ export class EventTypesRepositoryFixture {
     this.prismaWriteClient = module.get(PrismaWriteService).prisma;
   }
 
-  async getAllUserEventTypes(userId: number): Promise<EventType[]> {
+  async getAllUserEventTypes(userId: number) {
     return this.prismaWriteClient.eventType.findMany({
       where: {
         userId,
@@ -21,7 +21,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async getAllTeamEventTypes(teamId: number): Promise<(EventType & { hosts: unknown[] })[]> {
+  async getAllTeamEventTypes(teamId: number) {
     return this.prismaWriteClient.eventType.findMany({
       where: {
         teamId,
@@ -32,7 +32,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async create(data: Prisma.EventTypeCreateInput, userId: number): Promise<EventType> {
+  async create(data: Prisma.EventTypeCreateInput, userId: number) {
     return this.prismaWriteClient.eventType.create({
       data: {
         ...data,
@@ -50,15 +50,15 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async createTeamEventType(data: Prisma.EventTypeCreateInput): Promise<EventType> {
+  async createTeamEventType(data: Prisma.EventTypeCreateInput) {
     return this.prismaWriteClient.eventType.create({ data });
   }
 
-  async delete(eventTypeId: EventType["id"]): Promise<EventType> {
+  async delete(eventTypeId: EventType["id"]) {
     return this.prismaWriteClient.eventType.delete({ where: { id: eventTypeId } });
   }
 
-  async deleteAllTeamEventTypes(teamId: number): Promise<Prisma.BatchPayload> {
+  async deleteAllTeamEventTypes(teamId: number) {
     return this.prismaWriteClient.eventType.deleteMany({
       where: {
         teamId,
@@ -66,7 +66,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async deleteAllUserEventTypes(userId: number): Promise<Prisma.BatchPayload> {
+  async deleteAllUserEventTypes(userId: number) {
     return this.prismaWriteClient.eventType.deleteMany({
       where: {
         userId,
@@ -74,7 +74,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async findById(eventTypeId: EventType["id"]): Promise<EventType | null> {
+  async findById(eventTypeId: EventType["id"]) {
     return this.prismaReadClient.eventType.findUnique({ where: { id: eventTypeId } });
   }
 }

--- a/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
+++ b/apps/api/v2/test/fixtures/repository/event-types.repository.fixture.ts
@@ -13,7 +13,7 @@ export class EventTypesRepositoryFixture {
     this.prismaWriteClient = module.get(PrismaWriteService).prisma;
   }
 
-  async getAllUserEventTypes(userId: number) {
+  async getAllUserEventTypes(userId: number): Promise<EventType[]> {
     return this.prismaWriteClient.eventType.findMany({
       where: {
         userId,
@@ -21,7 +21,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async getAllTeamEventTypes(teamId: number) {
+  async getAllTeamEventTypes(teamId: number): Promise<(EventType & { hosts: unknown[] })[]> {
     return this.prismaWriteClient.eventType.findMany({
       where: {
         teamId,
@@ -32,7 +32,7 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async create(data: Prisma.EventTypeCreateInput, userId: number) {
+  async create(data: Prisma.EventTypeCreateInput, userId: number): Promise<EventType> {
     return this.prismaWriteClient.eventType.create({
       data: {
         ...data,
@@ -50,15 +50,15 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async createTeamEventType(data: Prisma.EventTypeCreateInput) {
+  async createTeamEventType(data: Prisma.EventTypeCreateInput): Promise<EventType> {
     return this.prismaWriteClient.eventType.create({ data });
   }
 
-  async delete(eventTypeId: EventType["id"]) {
+  async delete(eventTypeId: EventType["id"]): Promise<EventType> {
     return this.prismaWriteClient.eventType.delete({ where: { id: eventTypeId } });
   }
 
-  async deleteAllTeamEventTypes(teamId: number) {
+  async deleteAllTeamEventTypes(teamId: number): Promise<Prisma.BatchPayload> {
     return this.prismaWriteClient.eventType.deleteMany({
       where: {
         teamId,
@@ -66,7 +66,15 @@ export class EventTypesRepositoryFixture {
     });
   }
 
-  async findById(eventTypeId: EventType["id"]) {
+  async deleteAllUserEventTypes(userId: number): Promise<Prisma.BatchPayload> {
+    return this.prismaWriteClient.eventType.deleteMany({
+      where: {
+        userId,
+      },
+    });
+  }
+
+  async findById(eventTypeId: EventType["id"]): Promise<EventType | null> {
     return this.prismaReadClient.eventType.findUnique({ where: { id: eventTypeId } });
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR addresses flaky e2e tests in `organizations-member-team-admin-event-types.e2e-spec.ts` that have been failing intermittently in CI with cascading failures.

**Problem:** When the "should create a managed team event-type" test fails with a 400 Bad Request (likely due to slug validation finding existing data), the `managedEventType` variable remains undefined, causing 6 subsequent tests to fail.

**Root Cause:** The `afterAll` cleanup was not deleting child event types of managed event types. Managed event types create child event types for each host user (with `userId` set, not `teamId`), but `deleteAllTeamEventTypes(teamId)` only deletes event types where `teamId` matches. This could leave orphaned data between test runs.

**Solution:**
- Add `deleteAllUserEventTypes` method to `EventTypesRepositoryFixture` to delete user-owned event types
- Update `afterAll` cleanup order: delete user event types first, then team event types, then users, then teams/orgs
- Fix pre-existing lint issues (replace `@ts-ignore` with `@ts-expect-error`, add explicit return types)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A - test file changes only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run the e2e tests multiple times: `TZ=UTC yarn test:e2e --testPathPattern="organizations-member-team-admin-event-types"`
2. Verify tests pass consistently without the 400 Bad Request error
3. The cleanup order ensures child event types are deleted before their parent entities

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings

## Human Review Checklist

- [ ] Verify the cleanup order is correct: user event types → team event types → users → teams → orgs
- [ ] Confirm `deleteAllUserEventTypes` correctly targets child event types of managed event types
- [ ] Note: The flakiness is hard to reproduce locally, so this fix is based on analysis of the cleanup logic. Monitor CI runs to confirm effectiveness.
- [ ] Lint fixes (`@ts-expect-error` and return types) are correct

---
**Link to Devin run:** https://app.devin.ai/sessions/02a225b4bb084a5fbf05eebf8ad394e1
**Requested by:** @anikdhabal