### PR TITLE
feat: add BUILD_FROM_BRANCH option to release-docker workflow

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -17,9 +17,13 @@ on:
   # in case manual trigger is needed
   workflow_dispatch:
     inputs:
+      BUILD_FROM_BRANCH:
+        description: "Build from the selected branch instead of a tag"
+        type: boolean
+        default: false
       RELEASE_TAG:
-        description: "Tag to build (e.g., v6.0.5)"
-        required: true
+        description: "Tag to build (e.g., v6.0.5) - required if BUILD_FROM_BRANCH is false"
+        required: false
       PUSH_IMAGE:
         description: "Push the Docker image to DockerHub"
         type: boolean
@@ -30,15 +34,28 @@ jobs:
     name: "Release AMD64"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - name: Validate inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH == false && inputs.RELEASE_TAG == ''
+        run: |
+          echo "::error::RELEASE_TAG is required when BUILD_FROM_BRANCH is false"
+          exit 1
+
       - name: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.RELEASE_TAG || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH) && github.ref || inputs.RELEASE_TAG || github.ref }}
 
       - name: "Determine tag"
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
+            if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
+              # Extract branch name and short SHA for the tag
+              BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+              SHORT_SHA=$(git rev-parse --short HEAD)
+              echo "RELEASE_TAG=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_ENV
+            else
+              echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
+            fi
           else
             echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           fi
@@ -84,15 +101,28 @@ jobs:
     name: "Release ARM"
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Validate inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH == false && inputs.RELEASE_TAG == ''
+        run: |
+          echo "::error::RELEASE_TAG is required when BUILD_FROM_BRANCH is false"
+          exit 1
+
       - name: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.RELEASE_TAG || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH) && github.ref || inputs.RELEASE_TAG || github.ref }}
 
       - name: "Determine tag"
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
+            if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
+              # Extract branch name and short SHA for the tag
+              BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+              SHORT_SHA=$(git rev-parse --short HEAD)
+              echo "RELEASE_TAG=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_ENV
+            else
+              echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
+            fi
           else
             echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -51,8 +51,10 @@ jobs:
             if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
               # Extract branch name and short SHA for the tag
               BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+              # Sanitize branch name: replace slashes with dashes for valid Docker tag
+              SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
               SHORT_SHA=$(git rev-parse --short HEAD)
-              echo "RELEASE_TAG=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_ENV
+              echo "RELEASE_TAG=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_ENV
             else
               echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
             fi
@@ -118,8 +120,10 @@ jobs:
             if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
               # Extract branch name and short SHA for the tag
               BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+              # Sanitize branch name: replace slashes with dashes for valid Docker tag
+              SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
               SHORT_SHA=$(git rev-parse --short HEAD)
-              echo "RELEASE_TAG=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_ENV
+              echo "RELEASE_TAG=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_ENV
             else
               echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
             fi

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -30,9 +30,12 @@ on:
         default: true
 
 jobs:
-  release-amd64:
-    name: "Release AMD64"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  prepare:
+    name: "Prepare Release"
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      release_tag: ${{ steps.determine-tag.outputs.release_tag }}
+      checkout_ref: ${{ steps.determine-tag.outputs.checkout_ref }}
     steps:
       - name: Validate inputs
         if: github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH == false && inputs.RELEASE_TAG == ''
@@ -45,8 +48,19 @@ jobs:
         with:
           ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH) && github.ref || inputs.RELEASE_TAG || github.ref }}
 
-      - name: "Determine tag"
+      - name: "Determine tag and ref"
+        id: determine-tag
         run: |
+          # Determine checkout ref
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "checkout_ref=${{ inputs.RELEASE_TAG }}" >> $GITHUB_OUTPUT
+          else
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
+
+          # Determine release tag
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
               # Extract branch name and short SHA for the tag
@@ -54,13 +68,25 @@ jobs:
               # Sanitize branch name: replace slashes with dashes for valid Docker tag
               SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
               SHORT_SHA=$(git rev-parse --short HEAD)
-              echo "RELEASE_TAG=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_ENV
+              echo "release_tag=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_OUTPUT
             else
-              echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
+              echo "release_tag=${{ inputs.RELEASE_TAG }}" >> $GITHUB_OUTPUT
             fi
           else
-            echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            echo "release_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
+
+  release-amd64:
+    name: "Release AMD64"
+    needs: prepare
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Build and test Docker image
         uses: ./.github/actions/docker-build-and-test
@@ -101,35 +127,15 @@ jobs:
 
   release-arm:
     name: "Release ARM"
+    needs: prepare
     runs-on: ubuntu-24.04-arm
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
     steps:
-      - name: Validate inputs
-        if: github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH == false && inputs.RELEASE_TAG == ''
-        run: |
-          echo "::error::RELEASE_TAG is required when BUILD_FROM_BRANCH is false"
-          exit 1
-
       - name: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH) && github.ref || inputs.RELEASE_TAG || github.ref }}
-
-      - name: "Determine tag"
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
-              # Extract branch name and short SHA for the tag
-              BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-              # Sanitize branch name: replace slashes with dashes for valid Docker tag
-              SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
-              SHORT_SHA=$(git rev-parse --short HEAD)
-              echo "RELEASE_TAG=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_ENV
-            else
-              echo "RELEASE_TAG=${{ inputs.RELEASE_TAG }}" >> $GITHUB_ENV
-            fi
-          else
-            echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          fi
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Build and test Docker image
         uses: ./.github/actions/docker-build-and-test


### PR DESCRIPTION
## What does this PR do?

Adds a new `BUILD_FROM_BRANCH` option to the release-docker workflow that allows building Docker images from the selected branch in the workflow_dispatch dropdown, instead of always requiring a tag.

This enables testing new code that isn't tagged yet by using the workflow_dispatch functionality to build from any branch.

**Changes:**
- Added `BUILD_FROM_BRANCH` boolean input (default: false)
- Made `RELEASE_TAG` optional (only required when `BUILD_FROM_BRANCH` is false)
- Added input validation to fail early if neither option is properly set
- When building from branch, the Docker tag is generated as `{sanitized-branch-name}-{short-sha}`
- Branch names with slashes (e.g., `feature/something`) are sanitized to dashes for valid Docker tags
- Extracted common logic into a `prepare` job to avoid code duplication between AMD64 and ARM jobs

## Updates since last revision

- Added branch name sanitization to handle slashes in branch names (e.g., `feature/my-branch` becomes `feature-my-branch-abc1234`)
- Refactored workflow to use a shared `prepare` job that handles validation and tag determination, with outputs consumed by both `release-amd64` and `release-arm` jobs

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, tested by running the workflow.

## How should this be tested?

1. Go to Actions → Release Docker → Run workflow
2. Select a branch from the dropdown (try one with slashes like `feature/something`)
3. Check `BUILD_FROM_BRANCH` checkbox
4. Leave `RELEASE_TAG` empty
5. Run the workflow and verify it checks out the selected branch and generates a tag like `feature-something-abc1234`

**Alternative test (validation):**
1. Run workflow with `BUILD_FROM_BRANCH` unchecked and `RELEASE_TAG` empty
2. Verify the workflow fails with error "RELEASE_TAG is required when BUILD_FROM_BRANCH is false"

## Human Review Checklist

- [ ] Verify job outputs (`release_tag`, `checkout_ref`) are correctly passed from `prepare` to build jobs
- [ ] Confirm the prepare job correctly determines values for all scenarios (push to tag, workflow_dispatch with BUILD_FROM_BRANCH, workflow_dispatch with RELEASE_TAG)
- [ ] Check that the `RELEASE_TAG` env var set at job level is accessible in the `docker-build-and-test` action
- [x] ~~Consider if branch names with slashes (e.g., `feature/something`) will produce valid Docker tags~~ - Addressed: slashes are now replaced with dashes
- [ ] Consider if other invalid Docker tag characters could appear in branch names

---

Link to Devin run: https://app.devin.ai/sessions/fac5927de8314c3ba7ed6e6d5fa7e8df
Requested by: @keithwillcode