### PR TITLE
chore: api v2 generate swagger only in dev

### DIFF
--- a/apps/api/v2/src/main.ts
+++ b/apps/api/v2/src/main.ts
@@ -6,7 +6,7 @@ import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
-import "dotenv/config";
+
 import { WinstonModule } from "nest-winston";
 import * as qs from "qs";
 
@@ -15,7 +15,6 @@ import type { AppConfig } from "@/config/type";
 import { AppModule } from "./app.module";
 import { bootstrap } from "./bootstrap";
 import { loggerConfig } from "./lib/logger";
-import { generateSwaggerForApp } from "./swagger/generate-swagger";
 
 run().catch((error: Error) => {
   console.error("Failed to start Cal Platform API", { error: error.stack });
@@ -28,8 +27,14 @@ async function run(): Promise<void> {
 
   try {
     bootstrap(app);
-    const port = app.get(ConfigService<AppConfig, true>).get("api.port", { infer: true });
-    generateSwaggerForApp(app);
+    const config = app.get(ConfigService<AppConfig, true>);
+    const port = config.get("api.port", { infer: true });
+
+    if (config.get("env.type", { infer: true }) === "development") {
+      const { generateSwaggerForApp } = await import("./swagger/generate-swagger");
+      generateSwaggerForApp(app);
+    }
+
     await app.listen(port);
     logger.log(`Application started on port: ${port}`);
   } catch (error) {


### PR DESCRIPTION

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate Swagger docs only in development for API v2. This prevents loading Swagger in non-dev and reduces production startup overhead.

- **Refactors**
  - Gate Swagger generation with env.type === "development" and lazy-load the generator.
  - Remove top-level dotenv and Swagger imports; reuse ConfigService for env and port.

<sup>Written for commit e8cada6019b7a08ddbdf6f7fa7085a0d12f9c396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

