### PR TITLE
feat: add Cubic AI to Devin review integration workflow

### DIFF
--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -1,0 +1,111 @@
+name: Cubic AI to Devin Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trigger-devin:
+    name: Trigger Devin to Address Cubic AI Review
+    # Only run if the review is from cubic-dev-ai bot and contains the AI prompt
+    if: github.event.review.user.login == 'cubic-dev-ai[bot]'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Extract AI prompt from Cubic review
+        id: extract-prompt
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reviewBody = context.payload.review.body || '';
+            
+            // Look for the AI prompt section in Cubic's review
+            // Format: <details><summary>Prompt for AI agents (all issues)</summary>
+            //         ```text
+            //         ... prompt content ...
+            //         ```
+            //         </details>
+            const promptMatch = reviewBody.match(/<details>\s*<summary>Prompt for AI agents[^<]*<\/summary>\s*```(?:text)?\s*([\s\S]*?)```\s*<\/details>/i);
+            
+            if (!promptMatch || !promptMatch[1]) {
+              console.log('No AI prompt found in review body');
+              console.log('Review body:', reviewBody);
+              core.setOutput('has-prompt', 'false');
+              return;
+            }
+            
+            const prompt = promptMatch[1].trim();
+            console.log('Extracted prompt:', prompt);
+            
+            // Save prompt to file to avoid shell escaping issues
+            const fs = require('fs');
+            fs.writeFileSync('/tmp/cubic-prompt.txt', prompt);
+            
+            core.setOutput('has-prompt', 'true');
+
+      - name: Create Devin session
+        if: steps.extract-prompt.outputs.has-prompt == 'true'
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+        run: |
+          CUBIC_PROMPT=$(cat /tmp/cubic-prompt.txt)
+          
+          # Build the full prompt for Devin
+          FULL_PROMPT="You are addressing code review feedback from Cubic AI on PR #${{ github.event.pull_request.number }} in repository ${{ github.repository }}.
+
+          Your tasks:
+          1. Clone the repository ${{ github.repository }} locally.
+          2. Check out the PR branch and review the current code.
+          3. Read and understand the Cubic AI review feedback below.
+          4. Address each issue identified by Cubic AI by making the necessary code changes.
+          5. Commit your changes with clear commit messages referencing the issues fixed.
+          6. Push your changes to the PR branch.
+
+          Cubic AI Review Feedback:
+          ${CUBIC_PROMPT}
+
+          Rules and Guidelines:
+          1. Make minimal, focused changes that directly address the feedback.
+          2. Follow the existing code style and conventions in the repository.
+          3. Test your changes if possible before pushing.
+          4. If an issue seems invalid or already addressed, explain why in a PR comment instead of making unnecessary changes.
+          5. Never ask for user confirmation. Never wait for user messages."
+
+          # Call Devin API
+          RESPONSE=$(curl -s -X POST "https://api.devin.ai/v1/sessions" \
+            -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg prompt "$FULL_PROMPT" \
+              --arg title "Cubic AI Review: PR #${{ github.event.pull_request.number }}" \
+              '{
+                prompt: $prompt,
+                title: $title,
+                tags: ["cubic-ai-review", "pr-${{ github.event.pull_request.number }}"]
+              }')")
+          
+          echo "Devin API Response: $RESPONSE"
+          
+          # Extract session URL if available
+          SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
+          if [ -n "$SESSION_URL" ]; then
+            echo "Devin session created: $SESSION_URL"
+            echo "SESSION_URL=$SESSION_URL" >> $GITHUB_ENV
+          fi
+
+      - name: Post comment with Devin session link
+        if: steps.extract-prompt.outputs.has-prompt == 'true' && env.SESSION_URL != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sessionUrl = process.env.SESSION_URL;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `### Devin AI is addressing Cubic AI's review feedback\n\nA Devin session has been created to address the issues identified by Cubic AI.\n\n[View Devin Session](${sessionUrl})`
+            });

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   trigger-devin:

--- a/.github/workflows/cubic-devin-review.yml
+++ b/.github/workflows/cubic-devin-review.yml
@@ -87,9 +87,7 @@ jobs:
                 tags: ["cubic-ai-review", "pr-${{ github.event.pull_request.number }}"]
               }')")
           
-          echo "Devin API Response: $RESPONSE"
-          
-          # Extract session URL if available
+          # Extract session URL if available (avoid logging full response to prevent exposing sensitive data)
           SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // .session_url // empty')
           if [ -n "$SESSION_URL" ]; then
             echo "Devin session created: $SESSION_URL"


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow that automatically triggers Devin AI to address code review feedback from Cubic AI (`cubic-dev-ai[bot]`).

**How it works:**
1. Triggers on `pull_request_review` events (not every comment)
2. Job-level `if` condition immediately skips unless the review is from `cubic-dev-ai[bot]` - **no CI minutes consumed for other reviews**
3. Extracts the AI prompt from Cubic's review body (the `<details><summary>Prompt for AI agents` section)
4. Creates a Devin session via the Devin API with the extracted prompt
5. Posts a comment on the PR with a link to the Devin session

## Updates since last revision

- Fixed permission issue: Changed `pull-requests: read` to `pull-requests: write` to allow posting comments on PRs
- Fixed security issue: Removed debug log that output the full Devin API response, which could expose sensitive session tokens or authentication data in CI logs. The session URL is still logged when successfully extracted.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - workflow only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - GitHub Actions workflow, tested by triggering with Cubic AI review.

## How should this be tested?

1. **Setup required:** Add `DEVIN_API_KEY` secret to the repository (Settings → Secrets and variables → Actions)
2. Create a PR and wait for Cubic AI to post a review with the "Prompt for AI agents" section
3. Verify the workflow triggers and creates a Devin session
4. Verify a comment is posted on the PR with the Devin session link

**Alternative validation:**
- Create a test PR and manually trigger a `pull_request_review` event with a mock Cubic AI payload to verify the regex extraction works

## Human Review Checklist

- [x] ~~**Permission issue:** The workflow has `pull-requests: read` but attempts to post a comment. Should this be `pull-requests: write`?~~ Fixed - now uses `pull-requests: write`
- [x] ~~**Security issue:** Logging full Devin API response could expose sensitive data~~ Fixed - removed debug log, only session URL is logged
- [x] Verify the regex pattern matches Cubic AI's actual review format (based on [this example](https://github.com/calcom/cal.com/pull/26615#pullrequestreview-3643738346))
- [x] Confirm `DEVIN_API_KEY` secret will be added to the repository
- [x] Consider if additional error handling is needed for Devin API failures (currently minimal)

---

Link to Devin run: https://app.devin.ai/sessions/3d9895cea4644f8d98d1cdb7ac19f019
Requested by: @keithwillcode