### PR TITLE
feat: add source: 'onboarding' metadata to subscriptions from onboarding v3

### DIFF
--- a/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
+++ b/packages/features/ee/organizations/lib/OrganizationPaymentService.ts
@@ -274,11 +274,12 @@ export class OrganizationPaymentService {
       })
     );
 
-    const subscriptionData = ORG_TRIAL_DAYS
-      ? {
-          trial_period_days: ORG_TRIAL_DAYS,
-        }
-      : undefined;
+    const subscriptionData = {
+      ...(ORG_TRIAL_DAYS && { trial_period_days: ORG_TRIAL_DAYS }),
+      metadata: {
+        source: "onboarding",
+      },
+    };
 
     return this.billingService.createSubscriptionCheckout({
       customerId: stripeCustomerId,
@@ -292,7 +293,7 @@ export class OrganizationPaymentService {
         pricePerSeat: config.pricePerSeat,
         billingPeriod: config.billingPeriod,
       },
-      ...(subscriptionData && { subscriptionData }),
+      subscriptionData,
     });
   }
 

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -97,6 +97,9 @@ export const generateTeamCheckoutSession = async ({
     },
     subscription_data: {
       trial_period_days: 14, // Add a 14-day trial
+      metadata: {
+        ...(isOnboarding && { source: "onboarding" }),
+      },
     },
     metadata: {
       type: CHECKOUT_SESSION_TYPES.TEAM_CREATION,


### PR DESCRIPTION
## What does this PR do?

Adds `source: "onboarding"` metadata to Stripe subscriptions when users sign up to a team or organization from the onboarding v3 flow. This helps track which subscriptions originated from the onboarding flow for analytics and debugging purposes.

**Changes:**
- **Teams**: Adds `source: "onboarding"` to `subscription_data.metadata` when `isOnboarding` is true
- **Organizations**: Adds `source: "onboarding"` to subscription metadata for all organization onboarding subscriptions

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - no documentation changes needed.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. **For Teams (onboarding v3)**:
   - Go through the team creation flow from onboarding v3 (`/onboarding/teams/details`)
   - Complete the Stripe checkout
   - Verify in Stripe dashboard that the subscription has `metadata.source = "onboarding"`

2. **For Organizations (onboarding v3)**:
   - Go through the organization creation flow from onboarding v3
   - Complete the Stripe checkout
   - Verify in Stripe dashboard that the subscription has `metadata.source = "onboarding"`

**Environment variables needed:**
- `STRIPE_TEAM_MONTHLY_PRICE_ID`
- `STRIPE_ORG_MONTHLY_PRICE_ID`
- Standard Stripe configuration

## Human Review Checklist

- [ ] Verify that `isOnboarding` flag correctly identifies onboarding v3 team signups vs other team creation paths
- [ ] Confirm that `OrganizationPaymentService.createSubscription` is only called from onboarding flows (otherwise non-onboarding org subscriptions would also get this metadata)
- [ ] Verify the empty metadata object `{}` when `isOnboarding` is false for teams is acceptable behavior

---

Link to Devin run: https://app.devin.ai/sessions/eb76f0a24ea447a983f1c90a6227234c
Requested by: @sean-brydon