### PR TITLE
docs: fix list numbering in Manual setup section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ for Logger level to be set at info, for example.
    - [Setup postgres DB with Northflank](https://northflank.com/guides/deploy-postgres-database-on-northflank)
    - [Setup postgres DB with render](https://render.com/docs/databases)
 
-1. Copy and paste your `DATABASE_URL` from `.env` to `.env.appStore`.
+2. Copy and paste your `DATABASE_URL` from `.env` to `.env.appStore`.
 
-1. Set up the database using the Prisma schema (found in `packages/prisma/schema.prisma`)
+3. Set up the database using the Prisma schema (found in `packages/prisma/schema.prisma`)
 
    In a development environment, run:
 
@@ -271,7 +271,7 @@ for Logger level to be set at info, for example.
    yarn workspace @calcom/prisma db-deploy
    ```
 
-1. Run [mailhog](https://github.com/mailhog/MailHog) to view emails sent during development
+4. Run [mailhog](https://github.com/mailhog/MailHog) to view emails sent during development
 
    > **_NOTE:_** Required when `E2E_TEST_MAILHOG_ENABLED` is "1"
 
@@ -280,7 +280,7 @@ for Logger level to be set at info, for example.
    docker run -d -p 8025:8025 -p 1025:1025 mailhog/mailhog
    ```
 
-1. Run (in development mode)
+5. Run (in development mode)
 
    ```sh
    yarn dev


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect list numbering in the "Manual setup" section of the README. Steps 2-5 were all incorrectly numbered as "1." instead of their proper sequential order (2, 3, 4, 5).

This is a minor documentation fix to improve readability for developers following the manual setup instructions.

## Visual Demo

#### Before:
```
1. Configure environment variables...
1. Copy and paste your DATABASE_URL...
1. Set up the database...
1. Run mailhog...
1. Run (in development mode)...
```

#### After:
```
1. Configure environment variables...
2. Copy and paste your DATABASE_URL...
3. Set up the database...
4. Run mailhog...
5. Run (in development mode)...
```

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A - This is a README fix only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A - Documentation change only.

## How should this be tested?

1. Open the README.md file
2. Navigate to the "Manual setup" section under "Development"
3. Verify that the numbered list now shows proper sequential numbering (1, 2, 3, 4, 5) instead of all items being numbered "1."

## Checklist

- [x] I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
